### PR TITLE
Fix multihost_job cloud logging in case of maintenance event + recovery

### DIFF
--- a/multihost_job.py
+++ b/multihost_job.py
@@ -136,6 +136,8 @@ mkdir -p {args.RUN_NAME}
 cd {args.RUN_NAME}
 {get_env_command_str(args.NUM_SLICES)}
 {setup_ops_str(args.RUN_NAME, log_name)}
+sudo python3 -m virtualenv venv
+source venv/bin/activate
 ulimit -n 100000
 (({download_from_gcs(zip_gcs_path)}
 tar xzf {zip_name}

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -222,10 +222,7 @@ def install_ops_script_str(run_name, log_name):
   fi
   sudo chmod 777 /etc/google-cloud-ops-agent/config.yaml
   if ! grep -q '/{run_name}/{log_name}' /etc/google-cloud-ops-agent/config.yaml; then
-    echo 'Matt not found'
     sudo echo \\"{create_ops_config_str(run_name, log_name)}\\" >> /etc/google-cloud-ops-agent/config.yaml
-  else
-    echo 'Matt already exists'
   fi
   sudo service google-cloud-ops-agent restart
 """
@@ -327,7 +324,6 @@ def main(raw_args=None) -> None:
   log_name = "main_command_log_slice_${SLICE_ID}_worker_${WORKER_ID}"
   zip_gcs_path = os.path.join(bucket_path, zip_name)
   write_startup_script(zip_gcs_path, zip_name, log_name, bucket_path, startup_script_file, args)
-  print(f"writing startup_script to {startup_script_file}")
 
   print("Running CQR command...")
   captured_output = run_create_resources(startup_script_file, args)

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -136,8 +136,6 @@ mkdir -p {args.RUN_NAME}
 cd {args.RUN_NAME}
 {get_env_command_str(args.NUM_SLICES)}
 {setup_ops_str(args.RUN_NAME, log_name)}
-sudo python3 -m virtualenv venv
-source venv/bin/activate
 ulimit -n 100000
 (({download_from_gcs(zip_gcs_path)}
 tar xzf {zip_name}

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -223,7 +223,12 @@ def install_ops_script_str(run_name, log_name):
     done
   fi
   sudo chmod 777 /etc/google-cloud-ops-agent/config.yaml
-  sudo echo \\"{create_ops_config_str(run_name, log_name)}\\" >> /etc/google-cloud-ops-agent/config.yaml
+  if ! grep -q '/{run_name}/{log_name}' /etc/google-cloud-ops-agent/config.yaml; then
+    echo 'Matt not found'
+    sudo echo \\"{create_ops_config_str(run_name, log_name)}\\" >> /etc/google-cloud-ops-agent/config.yaml
+  else
+    echo 'Matt already exists'
+  fi
   sudo service google-cloud-ops-agent restart
 """
 
@@ -324,6 +329,7 @@ def main(raw_args=None) -> None:
   log_name = "main_command_log_slice_${SLICE_ID}_worker_${WORKER_ID}"
   zip_gcs_path = os.path.join(bucket_path, zip_name)
   write_startup_script(zip_gcs_path, zip_name, log_name, bucket_path, startup_script_file, args)
+  print(f"writing startup_script to {startup_script_file}")
 
   print("Running CQR command...")
   captured_output = run_create_resources(startup_script_file, args)


### PR DESCRIPTION
Tested via creating a multihost_job, simulating a maintenance event, and confirming we can see the logs even after recovering from the simulated maintenance event:

Create multihost_job
```
python3 multihost_job.py --COMMAND="bash setup.sh && python3 MaxText/train.py MaxText/configs/base.yml run_name=mattdavidow-mhj-ops-2 steps=5000 base_output_directory=$bd dataset_path=$dataset" --TPU_TYPE=v4-16 --NUM_SLICES=1 --RUN_NAME=mattdavidow-mhj-ops-2 --BUCKET_NAME=gs://mattdavidow-maxtext-br --ENABLE_AUTOCHECKPOINT=true
```

Simulate a maintenance event:
```
worker=t1v-xxx
gcloud compute instances add-metadata $worker --metadata simulate-maintenance-event=TRUE
```

Cloud logging of auto-checkpoint saving: https://screenshot.googleplex.com/5oUab5nPQiZeFWu

Cloud logging after recovery: https://screenshot.googleplex.com/4CzYr5ywwyMYVZT

Prior to this change, cloud logging would not recover after the maintenace event so would look like https://screenshot.googleplex.com/Bzsif2VUf4uga3d - although we can confirm that training did resume by looking at tensorboard or the GCS log that is sent at the end (but cloud logging stopped working).