### PR TITLE
Integrate emergency checkpointer into standalone_checkpointer for CPUs.

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 """ Common Max Utils needed by multiple modules"""
+import shutil
 import checkpointing
 import common_types
 import functools
@@ -221,7 +222,13 @@ def maybe_initialize_jax_distributed_system(raw_keys):
     max_logging.log(
         "Attempting to initialize the jax distributed system for CPU backend..."
     )
-    initialize_jax_for_cpu()
+    # delete_all_local_things()
+    if not raw_keys['enable_emergency_checkpoint']:
+      initialize_jax_for_cpu()
+      max_logging.log("ROSHANI DEBUG 1a : No emergency Checkpoint Jax distributed system initialized on CPUs!")
+    else:
+      initialize_jax_for_cpu_with_emergency_checkpointing(raw_keys)
+      max_logging.log("ROSHANI DEBUG 1b : Emergency Checkpoint Jax distributed system initialized on CPUs!")
     max_logging.log("Jax distributed system initialized on CPUs!")
   elif (
       raw_keys["enable_checkpointing"]
@@ -269,6 +276,57 @@ def initialize_jax_for_cpu():
       num_processes=int(os.environ.get("JAX_PROCESS_COUNT")),
   )
 
+def initialize_jax_for_cpu_with_emergency_checkpointing(raw_keys):
+  """Initialize JAX distributed runtime for CPUs when emergency checkpointing is used.
+  Args:
+      raw_keys: user provided arguments
+  """
+  ID_FILE = "id_file.txt"
+  run_name = raw_keys["run_name"]
+  max_logging.log(f" ROSHANI DEBUG 5a CPUs: run_name {run_name}")
+  
+  local_id_file = epath.Path(raw_keys["local_checkpoint_directory"]) / ID_FILE
+
+  if local_id_file.exists():
+    max_logging.log("ROSHANI DEBUG 5b CPUs: An ID file from a previous run exists, initializing JAX distributed runtime using the saved ID.")
+    process_id = int(local_id_file.read_text())
+    coordinator_address_file = _get_coordinator_address_file(raw_keys)
+    
+    hostname = socket.gethostname()
+    IPAddr = socket.gethostbyname(hostname)
+       
+    if process_id == 0:
+      coordinator_address = _get_cpu_coordinator_address_for_emergency_checkpointing(raw_keys)
+      max_logging.log(f" ROSHANI DEBUG 3a, coordinator_address is {coordinator_address} ")
+      coordinator_address_file.write_text(coordinator_address)
+    else:
+      # time.sleep(10)
+      coordinator_address = _retrieve_coordinator_address(coordinator_address_file)
+      max_logging.log(f" ROSHANI DEBUG 3b, coordinator_address is {coordinator_address} ")
+    
+    num_processes = int(os.environ.get("JAX_PROCESS_COUNT"))
+    max_logging.log(f" ROSHANI DEBUG 4a CPUs: Using the saved process_id of {process_id} with hostname {hostname} IP {IPAddr} and the 0'th process's address {coordinator_address}"
+                    f" to initialize JAX distributed runtime ")
+    jax.distributed.initialize(coordinator_address=coordinator_address, process_id=process_id, num_processes=num_processes)
+  else:
+    max_logging.log(" ROSHANI DEBUG 4b CPUs: No ID file from a previous run exists, initializing JAX distributed runtime without args.")
+    initialize_jax_for_cpu()
+    process_id = jax._src.distributed.global_state.process_id  # pylint: disable=protected-access
+    max_logging.log(f" ROSHANI DEBUG 2, CPUs process id {process_id})") #, corresponding tpu process id would have been {tpu_pid}")
+    local_id_file.write_text(str(process_id))
+
+  ocp.multihost.utils.initialize_runtime_to_distributed_ids()
+    
+
+def delete_all_local_things():
+  max_logging.log(" ROSHANI DEBUG 6 Deleting local checkpoints and id files...")
+  files = os.listdir("/test-cache")
+  for f in files:
+    if f != 'remote' and f != 'id_file.txt':
+      shutil.rmtree(f'/test-cache/{f}')
+    if f == 'id_file.txt':
+      os.remove('/test-cache/id_file.txt')
+
 
 def initialize_jax_for_tpu_with_emergency_checkpointing(raw_keys):
   """Initialize JAX distributed runtime for TPUs when emergency checkpointing is used.
@@ -306,24 +364,32 @@ def initialize_jax_for_tpu_with_emergency_checkpointing(raw_keys):
 
   ocp.multihost.utils.initialize_runtime_to_distributed_ids()
 
-
 def _get_run_name(raw_keys):
   if raw_keys["run_name"] != "":
     return raw_keys["run_name"]
   return os.environ.get("JOBSET_NAME")
 
+def _get_replicated_job_name(raw_keys):
+  return os.environ.get("REPLICATED_JOB_NAME")
 
 def _get_coordinator_address_file(raw_keys):
   COORDINATOR_ADDRESS_FILE = "coordinator_address.txt"
   return epath.Path(os.path.join(raw_keys["base_output_directory"], _get_run_name(raw_keys), COORDINATOR_ADDRESS_FILE))
 
+def _get_cpu_coordinator_address_for_emergency_checkpointing(raw_keys):
+  # run_name = _get_run_name(raw_keys)
+  # replicated_job = _get_replicated_job_name(raw_keys)
+  # slice_id = 0
+  # worker_id = 0
+  hostname = socket.gethostname()
+  IPAddr = socket.gethostbyname(hostname)
+  return f"{IPAddr}:1234"
 
 def _get_coordinator_address_for_emergency_checkpointing(raw_keys):
   run_name = _get_run_name(raw_keys)
   slice_id = os.environ.get('MEGASCALE_SLICE_ID')
   worker_id = os.environ.get('TPU_WORKER_ID')
   return f"{run_name}-slice-job-{slice_id}-{worker_id}.{run_name}:8476"
-
 
 def _retrieve_coordinator_address(coordinator_address_file):
   for _ in range(30):

--- a/MaxText/standalone_checkpointer.py
+++ b/MaxText/standalone_checkpointer.py
@@ -29,6 +29,7 @@ from flax.linen import partitioning as nn_partitioning
 import jax
 from jax import numpy as jnp
 import numpy as np
+import orbax.checkpoint.experimental.emergency.checkpoint_manager as emergency_checkpoint_manager
 
 import checkpointing
 import max_utils
@@ -61,7 +62,8 @@ def checkpoint_loop(config, state=None):
         checkpoint_manager, None, config.load_parameters_path, config.load_full_state_path, unboxed_abstract_state
     )
     if state:
-      state = state["items"]
+      if not isinstance(checkpoint_manager, emergency_checkpoint_manager.CheckpointManager):
+        state = state["items"]
 
   jax.block_until_ready(state)
   checkpoint_load_end = datetime.datetime.now()

--- a/MaxText/standalone_checkpointer.py
+++ b/MaxText/standalone_checkpointer.py
@@ -61,9 +61,8 @@ def checkpoint_loop(config, state=None):
     state, _ = checkpointing.load_state_if_possible(
         checkpoint_manager, None, config.load_parameters_path, config.load_full_state_path, unboxed_abstract_state
     )
-    if state:
-      if not isinstance(checkpoint_manager, emergency_checkpoint_manager.CheckpointManager):
-        state = state["items"]
+    if state and not isinstance(checkpoint_manager, emergency_checkpoint_manager.CheckpointManager):
+      state = state["items"]
 
   jax.block_until_ready(state)
   checkpoint_load_end = datetime.datetime.now()

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -355,9 +355,6 @@ def setup_mesh_and_model(config):
   # Mesh definition
   devices_array = max_utils.create_device_mesh(config)
   mesh = Mesh(devices_array, config.mesh_axes)
-  
-  # if emergency_checkpoint_manager.should_restore_mesh_from_metadata(epath.Path(config.local_checkpoint_directory)):
-  #   mesh = emergency_checkpoint_manager.consistent_restore_mesh_from_metadata(epath.Path(config.local_checkpoint_directory), mesh)
 
   if emergency_checkpoint_manager.should_restore_mesh_from_metadata(epath.Path(config.checkpoint_dir)):
     mesh = emergency_checkpoint_manager.consistent_restore_mesh_from_metadata(epath.Path(config.checkpoint_dir), mesh)

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -355,6 +355,9 @@ def setup_mesh_and_model(config):
   # Mesh definition
   devices_array = max_utils.create_device_mesh(config)
   mesh = Mesh(devices_array, config.mesh_axes)
+  
+  # if emergency_checkpoint_manager.should_restore_mesh_from_metadata(epath.Path(config.local_checkpoint_directory)):
+  #   mesh = emergency_checkpoint_manager.consistent_restore_mesh_from_metadata(epath.Path(config.local_checkpoint_directory), mesh)
 
   if emergency_checkpoint_manager.should_restore_mesh_from_metadata(epath.Path(config.checkpoint_dir)):
     mesh = emergency_checkpoint_manager.consistent_restore_mesh_from_metadata(epath.Path(config.checkpoint_dir), mesh)


### PR DESCRIPTION
1. When local checkpoints are available for restore, alter mesh setup as follows.

- Ignore the JAX coordinator provided by XPK and override the JAX coordinator to be the pod containing process_id 0.
- Persist the IP address of this pod using socket APIs to GCS.
- Let other processes retrieve the address of this coordinator, similar to TPUs.

2. Restore state and not state["items"] if emergency checkpoint manager is enabled.

3. Some changes in Jax/Orbax are needed to get this working end-to-end on CPUs. Other changes are addressed in this PR.