### PR TITLE
gradient accumulation

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -298,6 +298,9 @@ init_weights_seed: 0
 # You may disable clipping by setting gradient_clipping_threshold to zero.
 gradient_clipping_threshold: 1.0
 
+# Use gradient accumulation to update the weight every x steps.
+gradient_accumulation_steps: 1
+
 # AdamW optimizer parameters
 # We use AdamW following Llama2's training details, see https://arxiv.org/pdf/2307.09288.pdf section 2.2
 opt_type: "adamw"  # one of "adam_pax" or "adamw"


### PR DESCRIPTION
Adding new feature `gradient accumulation` to only update weight for every x steps.

Example command without using `gradient accumulation`: 
```
python3 MaxText/train.py MaxText/configs/base.yml   base_output_directory=${MAXTEXT_OUTPUT_PATH} run_name=${RUN_NAME}    enable_checkpointing=false async_checkpointing=false    per_device_batch_size=1    skip_first_n_steps_for_profiler=5 steps=30    dataset_type=synthetic    profiler=xplane
```

Example command with using `gradient accumulation`: 
```
python3 MaxText/train.py MaxText/configs/base.yml   base_output_directory=${MAXTEXT_OUTPUT_PATH} run_name=${RUN_NAME}    enable_checkpointing=false async_checkpointing=false    per_device_batch_size=1    skip_first_n_steps_for_profiler=5 steps=30    dataset_type=synthetic    profiler=xplane gradient_accumulation_steps=10
```

[Result1](https://paste.googleplex.com/6037166750957568)
[Result2](https://paste.googleplex.com/6279556128571392)