### PR TITLE
Update expected threads to fix maxtext profiler failures

### DIFF
--- a/MaxText/tests/profiler_test.py
+++ b/MaxText/tests/profiler_test.py
@@ -66,8 +66,8 @@ class TpuJAXTest(unittest.TestCase):
       if "name" in event and event["name"] == "thread_name":
         thread_names.append((event["args"]["name"]))
     expected_threads = [
-        "TensorFlow Name Scope",
-        "TensorFlow Ops",
+        "Framework Name Scope",
+        "Framework Ops",
         "XLA Modules",
         "XLA Ops",
         "XLA TraceMe",


### PR DESCRIPTION
Update the expected_threads to match with the profiler [tests](https://github.com/tensorflow/profiler/blob/30f24addc62d41305ba8949fb94b11302fe5665e/plugin/tensorboard_plugin_profile/integration_tests/tpu/tensorflow/tpu_tf2_keras_test.py#L159-L160).

Recently, the package tensorboard-plugin-profile was updated from version 2.15.1 to 2.15.2. This update may have caused the maxtext-profiling tests to fail since July 15, 2024. This PR updates the expected_threads name to match with the new [updates](https://github.com/tensorflow/profiler/blob/30f24addc62d41305ba8949fb94b11302fe5665e/plugin/tensorboard_plugin_profile/integration_tests/tpu/tensorflow/tpu_tf2_keras_test.py#L159-L160). Local airflow tests passed with success in "run_models."