### PR TITLE
Update NCCL flags for A3 Mega with the network release of 6/27.

### DIFF
--- a/gpu_multi_process_run.sh
+++ b/gpu_multi_process_run.sh
@@ -66,6 +66,8 @@ set_nccl_gpudirect_tcpx_specific_configuration() {
       export NCCL_MIN_NCHANNELS=4
       export NCCL_TUNER_CONFIG_PATH=/usr/local/nvidia/lib64/a3plus_tuner_config.textproto
       export NCCL_TUNER_PLUGIN=libnccl-tuner.so
+      export NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE=/usr/local/nvidia/lib64/a3plus_guest_config.textproto
+      export NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS=600000
     fi
   else
     echo "NOT using GPUDirect"


### PR DESCRIPTION
The network release of 6/27 can be found in this doc: https://docs.google.com/document/d/1D5umT4-WDuNnYf3ieQ5SfLdmvGRPBQGLB662udzwz8I/edit?tab=t.0#bookmark=id.tezgud50glwu.