### PR TITLE
Mlperf/4.1 grain

### DIFF
--- a/MaxText/configs/v5e/mlperf-grain-tpu.sh
+++ b/MaxText/configs/v5e/mlperf-grain-tpu.sh
@@ -1,0 +1,157 @@
+echo "Running mlperf-grain-tpu.sh"
+# 16B parameter model.
+# This config will work out of the box for any number of v5e-256 slices.
+#
+# Command Flags:
+# OUTPUT_PATH (Required, unless base_output_directory is already set in base.yml)
+# DATASET_PATH (Required, unless dataset_path is already set in base.yml)
+# RUN_NAME (Required, unless run_name is already set in base.yml or running with XPK/GKE)
+# PLATFORM (Optional, can be "gke" or "gce", default is "gce")
+#
+# Example to invoke this script:
+# bash MaxText/configs/v5e/16b.sh RUN_NAME="<your_run_name>" OUTPUT_PATH="gs://<your_output_path>" DATASET_PATH="gs://<your_dataset_path>" PLATFORM="gke"
+#
+# Example to AOT compile:
+# bash MaxText/configs/v5e/16b.sh EXECUTABLE=train_compile.py M_COMPILE_TOPOLOGY=v5e-256 M_COMPILE_TOPOLOGY_NUM_SLICES=2
+
+
+# Stop execution if any command exits with error
+set -e -x
+
+export PLATFORM="gce"
+export EXECUTABLE="train.py" # or train_compile.py
+
+# Set environment variables
+for ARGUMENT in "$@"; do
+    IFS='=' read -r KEY VALUE <<< "$ARGUMENT"
+    export "$KEY"="$VALUE"
+done
+
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
+if [[ -z "${PER_DEVICE_BATCH_SIZE}" ]]; then
+    export PER_DEVICE_BATCH_SIZE=1
+    echo "PER_DEVICE_BATCH_SIZE is not set, setting to 1"
+else
+    echo "PER_DEVICE_BATCH_SIZE is set to ${PER_DEVICE_BATCH_SIZE}"
+fi
+
+if [[ -z "${GRAIN_WORKER_COUNT}" ]]; then
+    export GRAIN_WORKER_COUNT=1
+    echo "GRAIN_WORKER_COUNT is not set, setting to 1"
+else
+    echo "GRAIN_WORKER_COUNT is set to ${GRAIN_WORKER_COUNT}"
+fi
+
+if [[ -z "${STEPS}" ]]; then
+    export STEPS=10
+    echo "STEPS is not set, setting to 10"
+else
+    echo "STEPS is set to ${STEPS}"
+fi
+
+if [[ -z "${ICI_DATA}" ]]; then
+    export ICI_DATA=1
+    echo "ICI_DATA is not set, setting to 1"
+else
+    echo "ICI_DATA is set to ${ICI_DATA}"
+fi
+
+if [[ -z "${ICI_FSDP}" ]]; then
+    export ICI_FSDP=-1
+    echo "ICI_FSDP is not set, setting to -1"
+else
+    echo "ICI_FSDP is set to ${ICI_FSDP}"
+fi
+
+if [[ -z "${ICI_TENSOR}" ]]; then
+    export ICI_TENSOR=1
+    echo "ICI_TENSOR is not set, setting to 1"
+else
+    echo "ICI_TENSOR is set to ${ICI_TENSOR}"
+fi
+
+if [[ -z "${DCN_DATA}" ]]; then
+    export DCN_DATA=-1
+    echo "DCN_DATA is not set, setting to -1"
+else
+    echo "DCN_DATA is set to ${DCN_DATA}"
+fi
+
+if [[ -z "${DCN_FSDP}" ]]; then
+    export DCN_FSDP=1
+    echo "DCN_FSDP is not set, setting to 1"
+else
+    echo "DCN_FSDP is set to ${DCN_FSDP}"
+fi
+
+if [[ -z "${DCN_TENSOR}" ]]; then
+    export DCN_TENSOR=1
+    echo "DCN_TENSOR is not set, setting to 1"
+else
+    echo "DCN_TENSOR is set to ${DCN_TENSOR}"
+fi
+
+if [[ -z "${NUM_SLICES}" ]]; then
+    export NUM_SLICES=-1
+    echo "NUM_SLICES is not set, setting to -1"
+else
+    echo "NUM_SLICES is set to ${NUM_SLICES}"
+fi
+
+# Set up network optimizations
+bash preflight.sh PLATFORM=$PLATFORM
+
+# using gcsfuse
+echo "Mounting bucket to /tmp/gcsfuse/"
+bash setup_gcsfuse.sh DATASET_GCS_BUCKET=mlperf-exp-us-east1-cp0 MOUNT_PATH=/tmp/gcsfuse
+DATASET_PATH=/tmp/gcsfuse
+
+# download tokenizer
+gsutil cp gs://mlperf-llm-public2/vocab/c4_en_301_5Mexp2_spm.model assets/
+
+# Train
+export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
+
+JAX_PLATFORMS=tpu python3 MaxText/$EXECUTABLE MaxText/configs/base.yml \
+    steps=$STEPS \
+    model_name=gpt3-175b \
+    per_device_batch_size=$PER_DEVICE_BATCH_SIZE \
+    enable_checkpointing=False \
+    base_output_directory=gs://aireenmei-multipod/cpu \
+    grain_train_files=/tmp/gcsfuse/array-record/c4/en/3.0.4/c4-train2*.array_record \
+    grain_eval_files=/tmp/gcsfuse/array-record/c4/en/3.0.5/c4-validation*.array_record \
+    add_bos=False \
+    add_eos=False \
+    tokenize_eval_data=False \
+    eval_data_column='ids' \
+    eval_interval=5 \
+    dataset_type=grain \
+    ici_data_parallelism=$ICI_DATA \
+    ici_fsdp_parallelism=$ICI_FSDP \
+    ici_tensor_parallelism=$ICI_TENSOR \
+    dcn_data_parallelism=$DCN_DATA \
+    dcn_fsdp_parallelism=$DCN_FSDP \
+    dcn_tensor_parallelism=$DCN_TENSOR \
+    num_slices=$NUM_SLICES \
+    tokenizer_path=assets/c4_en_301_5Mexp2_spm.model \
+    remat_policy=full \
+    attention=flash \
+    data_shuffle_seed=8745 \
+    quantization=int8 \
+    grain_worker_count=$GRAIN_WORKER_COUNT
+    #run_name=$(date +%m%d-%H%M)
+    #model_name=gpt3-175b \
+    
+    # grain_eval_files=/tmp/gcsfuse/array-record/c4/en/3.0.1/c4-validation* \
+    # grain_eval_files=/tmp/gcsfuse/maxtext-dataset/array-record/c4/en/3.0.5/*.array_record
+    # eval_per_device_batch_size=4 eval_interval=10 eval_steps=5 \
+    # tokenize_eval_data=False eval_data_column='ids'\
+
+#gsutil cp $HOME/gcsfuse.json ${OUTPUT_PATH}/${M_RUN_NAME}/

--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -156,6 +156,23 @@ class HFDataSource(grain.RandomAccessDataSource):
 
 ########## Functions used by Grain pipeline
 
+class ArrayRecordDataSourceWithPadding(grain.ArrayRecordDataSource):
+  """A class that will produce all-0 padding data when run out of real data"""
+  def __init__(self, paths, data_column_name, max_target_length):
+    super().__init__(paths)
+    self.out_of_data = False
+    self.data_column_name = data_column_name
+    self.max_target_length = max_target_length
+  
+  def __getitem__(self, index):
+    if index >= super().__len__():
+      if not self.out_of_data:
+        max_logging.log(f"Failed to retrive data for {index=}, you may run out of data, grain data loader will start producint all-0 padding data")
+        self.out_of_data = True
+      return {self.data_column_name: np.zeros(self.max_target_length, dtype=np.int32)}
+    else:
+      return super().__getitem__(index)
+
 @dataclasses.dataclass
 class ParseFeatures(grain.MapTransform):
   """Parse serialized example"""
@@ -172,7 +189,8 @@ class ParseFeatures(grain.MapTransform):
         self.data_column: tf.io.FixedLenSequenceFeature([], dtype=self.dtype, allow_missing=True)
         })
       return parsed
-
+    if isinstance(features, dict):
+      return features
     return _parse(features)
 
 @dataclasses.dataclass
@@ -183,6 +201,8 @@ class NormalizeFeatures(grain.MapTransform):
     self.tokenize = tokenize
 
   def map(self, features):
+    if isinstance(features[self.column_name], np.ndarray):
+      return {"inputs": features[self.column_name], "targets": features[self.column_name]}
     if self.tokenize:
       return {"inputs": features[self.column_name].numpy()[0].decode(), "targets": features[self.column_name].numpy()[0].decode()}
     else:
@@ -192,17 +212,12 @@ class NormalizeFeatures(grain.MapTransform):
 @dataclasses.dataclass
 class ReformatPacking(grain.MapTransform):
   """Reformat packing outputs."""
-
   def map(self, data):
-    return {
-        "inputs": data[0]["inputs"],
-        "targets": data[0]["targets"],
-        "inputs_segmentation": data[1]["inputs"],
-        "targets_segmentation": data[1]["targets"],
-        "inputs_position": data[2]["inputs"],
-        "targets_position": data[2]["targets"],
-    }
-
+    data["inputs_segmentation"] = data.pop("inputs_segment_ids")
+    data["targets_segmentation"] = data.pop("targets_segment_ids")
+    data["inputs_position"] = data.pop("inputs_positions")
+    data["targets_position"] = data.pop("targets_positions")
+    return data
 
 @dataclasses.dataclass
 class PadToMaxLength(grain.MapTransform):
@@ -227,6 +242,25 @@ class PadToMaxLength(grain.MapTransform):
       data[key] = _pad(data[key], self.max_length)
     return data
 
+def pad_to_batch_size(x, batch_size, axis=0):
+  if x.shape[0] < batch_size:
+    pad_widths = [(0, 0)] * len(x.shape)
+    pad_widths[axis] = (0, batch_size - x.shape[0])
+    x = np.pad(x, pad_widths, mode="constant", constant_values=x.dtype.type(0))
+  return x
+
+@dataclasses.dataclass
+class PadBatch(grain.MapTransform):
+  """Pad partial batch to full"""
+
+  def __init__(self, batch_size):
+    self.batch_size = batch_size
+
+  def map(self, data):
+    for k, _ in data.items():
+      data[k] = pad_to_batch_size(data[k], batch_size=self.batch_size)
+    return data
+
 
 def shift_right(x, axis=1):
   """Shift the input to the right by padding and slicing on axis."""
@@ -239,17 +273,23 @@ def shift_right(x, axis=1):
   padded = np.pad(x, pad_widths, mode="constant", constant_values=x.dtype.type(0))
   return padded[tuple(slices)]
 
+def shift_left(x, axis=1):
+  """Shift to the left and pad."""
+  pad_widths = [(0, 0)] * len(x.shape)
+  pad_widths[axis] = (0, 1)
+  slices = [
+      slice(None),
+  ] * len(x.shape)
+  slices[axis] = slice(1, None)
+  padded = np.pad(x, pad_widths, mode="constant", constant_values=x.dtype.type(0))
+  return padded[tuple(slices)]
 
 def shift_and_refine(x, axis=1):
-  """Shift inputs, set segmentation to 0 when target element is 0.
-  Replace EOS by 0 for packed inputs."""
-  x["inputs"] = shift_right(x["inputs"], axis=axis)
+  """Shift left and set segmentation to 0 when target element is 0."""
+  x["targets"] = shift_left(x["targets"], axis=axis)
   targets_nonzero = x["targets"] != 0
   x["inputs_segmentation"] *= targets_nonzero
   x["targets_segmentation"] *= targets_nonzero
-  # For packed targets, the first shifted token of a new sequence is made
-  # 0, rather than being the EOS token for the last sequence.
-  x["inputs"] *= x["inputs_segmentation"] == shift_right(x["inputs_segmentation"], axis=axis)
 
   return x
 

--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -164,12 +164,15 @@ class ArrayRecordDataSourceWithPadding(grain.ArrayRecordDataSource):
     self.data_column_name = data_column_name
     self.max_target_length = max_target_length
   
+  def __len__(self):
+    return super().__len__() + self.max_target_length
+  
   def __getitem__(self, index):
     if index >= super().__len__():
       if not self.out_of_data:
         max_logging.log(f"Failed to retrive data for {index=}, you may run out of data, grain data loader will start producint all-0 padding data")
         self.out_of_data = True
-      return {self.data_column_name: np.zeros(self.max_target_length, dtype=np.int32)}
+      return {self.data_column_name: np.zeros(self.max_target_length // 2, dtype=np.int32)}
     else:
       return super().__getitem__(index)
 

--- a/MaxText/input_pipeline/input_pipeline_interface.py
+++ b/MaxText/input_pipeline/input_pipeline_interface.py
@@ -124,11 +124,14 @@ def make_mixed_train_iterator(config, mesh):
   process_indices = get_process_loading_real_data(config, mesh)
   if config.expansion_factor_real_data != -1:  # assert number of hosts loading real data
     assert len(process_indices) == jax.process_count() // config.expansion_factor_real_data
+  if config.dataset_type == "grain":
+    train_iter, eval_iter = make_grain_iterator(config, mesh, process_indices)
+    if not train_iter:
+      train_iter = BadSyntheticDataIterator(config, mesh)
+    return train_iter, eval_iter
   if jax.process_index() in process_indices:
     if config.dataset_type == "tfds":
       return make_tfds_iterator(config, mesh, process_indices)
-    elif config.dataset_type == "grain":
-      return make_grain_iterator(config, mesh, process_indices)
     elif config.dataset_type == "hf":
       return make_hf_iterator(config, mesh, process_indices)
   else:

--- a/MaxText/multihost_dataloading.py
+++ b/MaxText/multihost_dataloading.py
@@ -93,7 +93,7 @@ def get_next_batch_sharded(local_iterator: Iterator, global_mesh: Mesh) -> jax.A
 class MultiHostDataLoadIterator:
   """fold get_next_batch_sharded into a iterator class"""
 
-  def __init__(self, dataloader: Union[tf.data.Dataset, grain.DataLoader], global_mesh: Mesh):
+  def __init__(self, dataloader: Union[tf.data.Dataset, Iterable], global_mesh: Mesh):
     self.global_mesh = global_mesh
     self.dataloader = dataloader
     if isinstance(self.dataloader, tf.data.Dataset):

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -375,8 +375,8 @@ class _HyperParameters:
       if raw_keys['overwrite_ckpt_step'] == -1:
         raw_keys['overwrite_ckpt_step'] = math.ceil(4000.0 * 1536 / global_batch_size)
     global_batch_size_to_train_on = calculate_global_batch_sizes(raw_keys)[1]
-    if raw_keys["dataset_type"] != "synthetic":
-      raw_keys["eval_interval"] = math.ceil(24567 / global_batch_size_to_train_on)
+    # if raw_keys["dataset_type"] != "synthetic":
+    #   raw_keys["eval_interval"] = math.ceil(24567 / global_batch_size_to_train_on)
 
   @staticmethod
   def update_model_vars(base_config_path, raw_keys, config_name: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ cloud-tpu-diagnostics
 datasets
 gcsfs
 google-cloud-storage
-grain-nightly
+#grain-nightly
 flax>=0.8.0
 ml-collections
 ml-goodput-measurement

--- a/setup.sh
+++ b/setup.sh
@@ -190,4 +190,6 @@ if [[ "$MODE" == "pinned" ]]; then
     pip3 install -U -r requirements.txt -c constraints_gpu.txt
 else
     pip3 install -U -r requirements.txt
+    gsutil cp gs://mlperf-exp-us-east1-cp0/grain-wheel/grain-0.2.2-cp310-cp310-linux_x86_64.whl ./
+    pip3 install grain-0.2.2-cp310-cp310-linux_x86_64.whl
 fi


### PR DESCRIPTION
* Use a custom grain wheel (Need to rebuild dependency image, see changes in requirements.txt and setup.sh)
* Add grain support for per_device_batch_size<1 while eval_per_device_batch_size>1
* Run on v5p-128 using xpk (per_device_batch_size=0.5, eval_per_device_batch_size=1), using the script in this PR. command: bash MaxText/configs/v5e/mlperf-grain-tpu.sh PER_DEVICE_BATCH_SIZE=0.5 GRAIN_WORKER_COUNT=1 ICI_TENSOR=16 PLATFORM=gke 
Results: https://cloudlogging.app.goo.gl/5BpmD9iCEm7uVGNx5 
* The padding batch for eval doesn't work well. Suggest to first test with eval off (eval_interval=-1), then try eval on. Eval may not terminate but hang on some slice sizes. I'll continue working on that.