### PR TITLE
Initialize jax distributed when checkpointing is enabled

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -229,8 +229,6 @@ def maybe_initialize_jax_distributed_system(raw_keys):
     max_logging.log("Jax distributed system initialized on CPUs!")
   elif (
       raw_keys["enable_checkpointing"]
-      and raw_keys["async_checkpointing"]
-      and raw_keys["compile_topology_num_slices"] == -1
       and not raw_keys["enable_single_controller"]
   ) or raw_keys["hardware"] == "gpu_multiprocess":
     max_logging.log("Attempting to initialize the jax distributed system...")


### PR DESCRIPTION
Nightly tests are failing due to jax.distributed not being initialized in the synchronous checkpointing case.