### PR TITLE
Use attn_mask_type of causal_padding for cudnn_flash_attention

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -383,7 +383,7 @@ class AttentionOp(nn.Module):
         head_dim=head_dim,
         num_attention_heads=self.num_query_heads,
         num_gqa_groups=self.num_kv_heads,
-        attn_mask_type="causal",  # 'causal' or 'padding'
+        attn_mask_type="padding_causal",  # 'no_mask', 'padding', 'causal', or 'padding_causal'
         attn_bias_type="NO_BIAS",  # 'no_bias', 'pre_scale_bias' or 'post_scale_bias'
         attention_dropout=self.dropout_rate,
         dropout_rng_name="aqt",


### PR DESCRIPTION
### Notes

Update attn_mask_type so that it is not ignored. Related to issue [878](https://github.com/AI-Hypercomputer/maxtext/issues/878).

Note that this change currently only impacts workloads using `cudnn_flash_te` attention.

### Testing

* Trained 10 steps on GPUs with `cudnn_flash_te` enabled. Saw the same high-level output (step time, loss, etc.) before and after this change
* Ran the logit checker with llama2-7b logits and the test succeeded:

![Screenshot 2024-10-01 at 2 06 07 PM](https://github.com/user-attachments/assets/d8c768f9-7eb6-40ed-8f9c-d8fb7ccbcf1f)


