### PR TITLE
modified the dockerfile for better caching

### DIFF
--- a/maxtext_dependencies.Dockerfile
+++ b/maxtext_dependencies.Dockerfile
@@ -18,6 +18,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python
 # Set environment variables for Google Cloud SDK and Python 3.10
 ENV PATH="/usr/local/google-cloud-sdk/bin:/usr/local/bin/python3.10:${PATH}"
 
+# Set environment variables via build arguments
 ARG MODE
 ENV ENV_MODE=$MODE
 
@@ -35,11 +36,13 @@ RUN mkdir -p /deps
 # Set the working directory in the container
 WORKDIR /deps
 
-# Copy all files from local workspace into docker container
-COPY . .
-RUN ls .
+# Copy setup files and dependency files separately for better caching
+COPY setup.sh ./
+COPY constraints_gpu.txt requirements.txt requirements_with_jax_stable_stack.txt ./
 
+# Install dependencies - these steps are cached unless the copied files change
 RUN echo "Running command: bash setup.sh MODE=$ENV_MODE JAX_VERSION=$ENV_JAX_VERSION LIBTPU_GCS_PATH=${ENV_LIBTPU_GCS_PATH} DEVICE=${ENV_DEVICE}"
 RUN --mount=type=cache,target=/root/.cache/pip bash setup.sh MODE=${ENV_MODE} JAX_VERSION=${ENV_JAX_VERSION} LIBTPU_GCS_PATH=${ENV_LIBTPU_GCS_PATH} DEVICE=${ENV_DEVICE}
 
-WORKDIR /deps
+# Now copy the remaining code (source files that may change frequently)
+COPY . .

--- a/setup.sh
+++ b/setup.sh
@@ -86,6 +86,14 @@ fi
 # Save the script folder path of maxtext
 run_name_folder_path=$(pwd)
 
+# Install dependencies from requirements.txt
+cd $run_name_folder_path && pip install --upgrade pip
+if [[ "$MODE" == "pinned" ]]; then
+    pip3 install -U -r requirements.txt -c constraints_gpu.txt
+else
+    pip3 install -U -r requirements.txt
+fi
+
 # Uninstall existing jax, jaxlib and  libtpu-nightly
 pip3 show jax && pip3 uninstall -y jax
 pip3 show jaxlib && pip3 uninstall -y jaxlib
@@ -184,10 +192,3 @@ else
     exit 1
 fi
 
-# Install dependencies from requirements.txt
-cd $run_name_folder_path && pip install --upgrade pip
-if [[ "$MODE" == "pinned" ]]; then
-    pip3 install -U -r requirements.txt -c constraints_gpu.txt
-else
-    pip3 install -U -r requirements.txt
-fi


### PR DESCRIPTION
Split the copy operation into minimal setup and requirement.txt file and defer the full repo copy at the end.
This prevent full dependency rebuild every time a user makes local changes and wants to quickly build an re-run on a remote cluster.