### PR TITLE
Adding section in the README to build Maxtext with MODE=stable_stack

### DIFF
--- a/getting_started/Run_MaxText_via_xpk.md
+++ b/getting_started/Run_MaxText_via_xpk.md
@@ -48,7 +48,7 @@ gcloud auth login
 
 * Run this command to configure docker to use docker-credential-gcloud for GCR registries:
 ```
-gcloud auth configure-docker
+gcloud auth configure-docker us-docker.pkg.dev
 ```
 
 * Test the installation by running
@@ -78,6 +78,25 @@ after which log out and log back in to the machine.
     # Default will pick stable versions of dependencies
     bash docker_build_dependency_image.sh
     ```
+
+    #### New: Build Maxtext Docker Image with JAX Stable Stack
+    We're excited to announce that you can build the Maxtext Docker image using the JAX Stable Stack base image. This provides a more reliable and consistent build environment.
+
+    ###### What is JAX Stable Stack?
+    JAX Stable Stack provides a consistent environment for Maxtext by bundling JAX with core packages like `orbax`, `flax`, and `optax`, along with Google Cloud utilities and other essential tools. These libraries are tested to ensure compatibility, providing a stable foundation for building and running Maxtext and eliminating potential conflicts due to incompatible package versions.
+
+    ###### How to Use It
+    To build the Maxtext Docker image with JAX Stable Stack, simply set the MODE to `stable_stack` and specify the desired `BASEIMAGE` in the `docker_build_dependency_image.sh` script:
+    
+    ```
+    # Example bash docker_build_dependency_image.sh MODE=stable_stack BASEIMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.33-rev1
+    bash docker_build_dependency_image.sh MODE=stable_stack BASEIMAGE={{JAX_STABLE_STACK_BASEIMAGE}}
+    ```
+
+    You can find a list of available JAX Stable Stack base images [here](us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu).
+
+    **Important Note:** The JAX Stable Stack is currently in the experimental phase. We encourage you to try it out and provide feedback.
+
 3. After building the dependency image `maxtext_base_image`, xpk can handle updates to the working directory when running `xpk workload create` and using `--base-docker-image`.
 
     See details on docker images in xpk here: https://github.com/google/xpk/blob/main/README.md#how-to-add-docker-images-to-a-xpk-workload


### PR DESCRIPTION
This commit updates the README file by adding a new section that guides users on how to build Maxtext using the `stable_stack` mode. This mode leverages the JAX Stable Stack Docker image, which provides a pre-configured and reliable environment with JAX and its core libraries, ensuring compatibility.