### PR TITLE
Pass config dtype into RotaryEmbedding

### DIFF
--- a/MaxText/inference_microbenchmark_sweep.py
+++ b/MaxText/inference_microbenchmark_sweep.py
@@ -25,10 +25,11 @@ import inference_microbenchmark
 import pyconfig
 
 try:
-    JaxRuntimeError = jax.errors.JaxRuntimeError  # added in JAX 0.4.34
+  JaxRuntimeError = jax.errors.JaxRuntimeError  # added in JAX 0.4.34
 except AttributeError:
-    from jax._src.lib import xla_extension
-    JaxRuntimeError = xla_extension.XlaRuntimeError
+  from jax._src.lib import xla_extension
+
+  JaxRuntimeError = xla_extension.XlaRuntimeError
 
 
 def main():

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -1163,6 +1163,7 @@ class Attention(nn.Module):
         min_timescale=self.config.rope_min_timescale,
         max_timescale=self.config.rope_max_timescale,
         embedding_dims=self.head_dim,
+        fprop_dtype=self.dtype,
         name="key_rotary",
     )(inputs=key, position=inputs_positions)
     return key
@@ -1213,6 +1214,7 @@ class Attention(nn.Module):
         min_timescale=self.config.rope_min_timescale,
         max_timescale=self.config.rope_max_timescale,
         embedding_dims=self.head_dim,
+        fprop_dtype=self.dtype,
         name="query_rotary",
     )(inputs=query, position=inputs_positions)
     key = self.key_rotary(key, inputs_positions)


### PR DESCRIPTION
### Notes
Use the same dtype before and after calling RotaryEmbedding. Related to [issue 595](https://github.com/AI-Hypercomputer/maxtext/issues/595).

Not passing dtype into RotaryEmbedding was causing the keys to be cast to bfloat16. This caused the linked issue where running decode with float32 was throwing this exception:
```
AssertionError: Key and Value Dtypes should match
```

Note that I applied the same change for the query since this was also being cast to bfloat16. Let me know if I should keep the query casting the same as it was.

### Testing
* Successfully ran decode with bfloat16/float32. I was able to see key/value (and query) dtype matching for both runs. I also saw them not matching before this change
```
key: Traced<ShapedArray(float32[4,1,16,128])>with<DynamicJaxprTrace(level=3/0)>
value: Traced<ShapedArray(float32[4,1,16,128])>with<DynamicJaxprTrace(level=3/0)>
```
* Successfully ran training with bfloat16/float32