### PR TITLE
Enable Goodput recording and monitoring by default

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -386,8 +386,8 @@ eval_steps: -1  # only run this number of batches for eval, for debugging use
 target_eval_loss: 0.  # early stop once reaching target eval_loss
 
 # Goodput parameters
-enable_goodput_recording: False
-monitor_goodput: False
+enable_goodput_recording: True
+monitor_goodput: True
 goodput_upload_interval_seconds: 60
 
 # Vertex AI Tensorboard Configurations - https://github.com/google/maxtext/tree/main/getting_started/Use_Vertex_AI_Tensorboard.md

--- a/MaxText/tests/train_gpu_smoke_test.py
+++ b/MaxText/tests/train_gpu_smoke_test.py
@@ -34,6 +34,8 @@ class Train(unittest.TestCase):
             r"dataset_path=gs://maxtext-dataset",
             "enable_checkpointing=False",
             "tokenizer_path=../assets/tokenizer.llama2",
+            "enable_goodput_recording=False",
+            "monitor_goodput=False",
         ]
     )
 

--- a/MaxText/tests/train_int8_smoke_test.py
+++ b/MaxText/tests/train_int8_smoke_test.py
@@ -46,6 +46,8 @@ class Train(unittest.TestCase):
             "enable_checkpointing=False",
             "quantization=int8",
             "tokenizer_path=../assets/tokenizer.llama2",
+            "enable_goodput_recording=False",
+            "monitor_goodput=False",
         ]
     )
 

--- a/MaxText/tests/train_smoke_test.py
+++ b/MaxText/tests/train_smoke_test.py
@@ -45,6 +45,8 @@ class Train(unittest.TestCase):
             "steps=10",
             "enable_checkpointing=False",
             "tokenizer_path=../assets/tokenizer.llama2",
+            "enable_goodput_recording=False",
+            "monitor_goodput=False",
         ]
     )
 

--- a/constraints_gpu.txt
+++ b/constraints_gpu.txt
@@ -66,7 +66,7 @@ mccabe==0.7.0
 mdurl==0.1.2
 ml-collections==0.1.1
 ml-dtypes==0.3.2
-ml_goodput_measurement==0.0.3
+ml_goodput_measurement==0.0.4
 mlperf-logging==3.0.0
 more-itertools==10.3.0
 msgpack==1.0.8


### PR DESCRIPTION
Turning `enable_goodput_recording` and `monitor_goodput` on by default.

Tested
 - [x] GCE ~1k steps [run](https://screenshot.googleplex.com/6wFY2wqp8YHMmDC)
 - [x] GKE ~1k steps [run](https://screenshot.googleplex.com/3TVyAVhSPx2KCFA), 
 - [x] Example [logs](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22us-central2%22%0Aresource.labels.cluster_name%3D%22dishaw-xpk-test-3%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fjobset_sigs_k8s_io%2Fjobset-name%3D%22dishaw-goodput-maxtext-job-12%22%20severity%3E%3DDEFAULT;storageScope=project;cursorTimestamp=2024-09-27T00:10:55.977598170Z;startTime=2024-09-25T16:06:01.570Z;endTime=2024-09-27T22:25:38.299Z?e=13803378&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)
