### PR TITLE
Fix static references to data inputs, removing FutureWarning

### DIFF
--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -338,7 +338,7 @@ class Decoder(nn.Module):
         BlockLayer,
         prevent_cse=not cfg.scan_layers,
         policy=policy,
-        static_argnums=(-1, -2, -3, -4, -5),
+        static_argnums=(-1, -2),  # deterministic and model mode are static arguments
     )
     if cfg.using_pipeline_parallelism:
       if cfg.num_layers_per_pipeline_stage == 1:

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -461,8 +461,8 @@ def init_initial_state(model, tx, config, is_training, key):
   input_shape = (config.micro_batch_size_to_train_on, config.max_target_length)
   model_vars = model.init(
       {"params": key, "dropout": key, "aqt": key},
-      jnp.ones(input_shape, dtype=jnp.int32),
-      jnp.ones(input_shape, dtype=jnp.int32),
+      np.ones(input_shape, dtype=jnp.int32),
+      np.ones(input_shape, dtype=jnp.int32),
   )
   if is_training:
     return init_training_state(model.apply, model_vars, tx)
@@ -721,16 +721,16 @@ cross_entropy_with_logits.defvjp(_cross_entropy_with_logits_fwd, _cross_entropy_
 
 def get_abstract_state(model, tx, config, rng, mesh, is_training=True):
   """Get a shaped abstraction of the state (including optimizer)"""
-  init_state_partial = functools.partial(init_initial_state, model, tx, config, is_training)
+  init_state_partial = functools.partial(init_initial_state, model, tx, config, is_training, rng)
 
   with nn_partitioning.axis_rules(config.logical_axis_rules):
-    abstract_state = jax.eval_shape(init_state_partial, rng)
+    abstract_state = jax.eval_shape(init_state_partial)
 
   state_logical_annotations = nn.get_partition_spec(abstract_state)
 
   state_mesh_shardings = nn.logical_to_mesh_sharding(state_logical_annotations, mesh, config.logical_axis_rules)
 
-  abstract_sharded_state = jax.jit(init_state_partial, in_shardings=None, out_shardings=state_mesh_shardings).eval_shape(rng)
+  abstract_sharded_state = jax.jit(init_state_partial, in_shardings=None, out_shardings=state_mesh_shardings).eval_shape()
 
   unboxed_abstract_sharded_state = unbox_logicallypartioned(abstract_sharded_state)
   # Initialization


### PR DESCRIPTION
Fix static references to data inputs, fixing the following FutureWarning:
`FutureWarning: unhashable type: <class 'jax._src.interpreters.partial_eval.DynamicJaxprTracer'>` 

Internal bug: b/352603879