### PR TITLE
DPO

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -310,8 +310,14 @@ per_device_batch_size: 12.0
 expansion_factor_real_data: -1 # if -1 then all hosts will load real data, else total_hosts//expansion_factor_real_data will pull data from GCS.
 eval_per_device_batch_size: 0.0
 max_corpus_chars: 10_000_000
-train_data_column: 'text'
-eval_data_column: 'text'
+train_data_columns: ['text'] # for DPO dataset containing "chosen" and "rejected"
+eval_data_columns: ['text'] # for DPO dataset containing "chosen" and "rejected"
+
+# direct preference optimization (DPO)
+use_dpo: False 
+dpo_label_smoothing: 0.0
+dpo_beta: 0.1
+
 # dataset_type must be synthetic, hf, grain, tfds
 # details in: https://github.com/google/maxtext/blob/main/getting_started/Data_Input_Pipeline.md
 dataset_type: tfds

--- a/MaxText/configs/dpo.yml
+++ b/MaxText/configs/dpo.yml
@@ -1,0 +1,31 @@
+base_config: "base.yml"
+
+use_dpo: true
+train_data_columns: ['chosen', 'rejected']
+eval_data_columns: ['chosen', 'rejected']
+base_output_directory: 'gs://maxtext-external/logs'
+
+per_device_batch_size: 2.0
+steps: 10
+max_target_length: 512
+eval_interval: 5  # test eval once, in the middle of 10 training steps
+eval_steps: 2
+
+# TFDS Pipeline ----------------------
+dataset_type: tfds
+dataset_path: 'gs://maxtext-dataset/dpo/anthropic_rlhf'
+dataset_name: 'tfds:1.0.0'
+eval_dataset_name: 'tfds:1.0.0'
+eval_split: 'test'
+
+# HF Pipeline -------------------------
+hf_eval_split: 'test'
+
+gradient_clipping_threshold: 10.0
+learning_rate: 5.0e-7
+dpo_label_smoothing: 0.0
+dpo_beta: 0.1
+
+enable_goodput_recording: false
+monitor_goodput: false
+enable_checkpointing: true

--- a/MaxText/input_pipeline/_tfds_data_processing.py
+++ b/MaxText/input_pipeline/_tfds_data_processing.py
@@ -30,6 +30,7 @@ import sequence_packing
 from input_pipeline import _input_pipeline_utils
 
 AUTOTUNE = tf.data.experimental.AUTOTUNE
+tf.config.experimental.set_visible_devices([], "GPU")  # reserve GPU memory for JAX only
 
 
 def get_datasets(
@@ -72,7 +73,7 @@ def preprocessing_pipeline(
     global_batch_size: int,
     global_mesh,
     max_target_length: int,
-    data_column_name,
+    data_column_names,
     shuffle: bool = False,
     data_shuffle_seed=0,
     tokenize: bool = True,
@@ -84,19 +85,32 @@ def preprocessing_pipeline(
     shift: bool = True,
     drop_remainder: bool = True,
     prefetch_size=tf.data.experimental.AUTOTUNE,
+    use_dpo: bool = False,
 ):
   """pipeline for preprocessing TFDS dataset."""
-  dataset = dataset.map(lambda x: _input_pipeline_utils.normalize_features(x, data_column_name), num_parallel_calls=AUTOTUNE)
+  if not use_dpo:
+    assert len(data_column_names) == 1
+    dataset = dataset.map(
+        lambda x: _input_pipeline_utils.normalize_features(x, data_column_names[0]), num_parallel_calls=AUTOTUNE
+    )
+  else:
+    dataset = dataset.map(lambda x: {col: x[col] for col in data_column_names}, num_parallel_calls=AUTOTUNE)
 
+  data_column_names = data_column_names if use_dpo else ("inputs", "targets")
   if tokenize:
     tokenizer_model = _input_pipeline_utils.get_tokenizer(tokenizer_path, add_bos, add_eos)
-    dataset = dataset.map(lambda x: tokenizer.TokenizeOp(tokenizer=tokenizer_model, features=x), num_parallel_calls=AUTOTUNE)
+    data_keys = data_column_names
+    dataset = dataset.map(
+        lambda x: tokenizer.TokenizeOp(tokenizer=tokenizer_model, features=x, data_keys=data_keys),
+        num_parallel_calls=AUTOTUNE,
+    )
 
   if max_target_length > 0:
-    # We can take upto max_length+1 because there would be truncation by 1 token
-    # for both inputs and targets
+    # in pre-training we can take upto max_length+1 because there would be truncation by
+    # 1 token for both inputs and targets
+    extra_tokens = 1 if not use_dpo else 0
     dataset = dataset.map(
-        lambda x: _input_pipeline_utils.truncate_to_max_allowable_length(x, max_target_length + 1),
+        lambda x: _input_pipeline_utils.truncate_to_max_allowable_length(x, max_target_length + extra_tokens),
         num_parallel_calls=AUTOTUNE,
     )
 
@@ -107,23 +121,28 @@ def preprocessing_pipeline(
   dataset = dataset.repeat(num_epochs)
 
   # Shift inputs for teacher-forced training
-  if shift:
+  if shift and not use_dpo:
     dataset = dataset.map(
         _input_pipeline_utils.shift_data_by_truncation, num_parallel_calls=tf.data.AUTOTUNE, deterministic=True
     )
 
   # Perform greedy sequence packing and batching
   assert global_batch_size % global_mesh.size == 0, "Batch size should be divisible number of global devices."
-  if pack_examples:
+  if pack_examples and not use_dpo:
     dataset = sequence_packing.pack_dataset(dataset, max_target_length)
     dataset = dataset.batch(global_batch_size // jax.process_count(), drop_remainder=drop_remainder)
   else:
     # simple (static-shape) padded batching
     dataset = dataset.padded_batch(
         global_batch_size // jax.process_count(),
-        padded_shapes={"inputs": max_target_length, "targets": max_target_length},
-        padding_values={"inputs": 0, "targets": 0},
+        padded_shapes={k: max_target_length for k in data_column_names},
+        padding_values={k: 0 for k in data_column_names},
         drop_remainder=drop_remainder,
+    )
+    dataset = dataset.map(
+        lambda x: _input_pipeline_utils.add_segmentation_and_position(x, data_column_names),
+        num_parallel_calls=tf.data.AUTOTUNE,
+        deterministic=True,
     )
 
   if prefetch_size:
@@ -155,12 +174,13 @@ def make_tfds_train_iterator(
       global_batch_size=config.global_batch_size_to_load,
       global_mesh=global_mesh,
       max_target_length=config.max_target_length,
-      data_column_name=config.train_data_column,
+      data_column_names=config.train_data_columns,
       shuffle=config.enable_data_shuffling,
       data_shuffle_seed=config.data_shuffle_seed,
       tokenize=config.tokenize_train_data,
       add_bos=config.add_bos,
       add_eos=config.add_eos,
+      use_dpo=config.use_dpo,
   )
   return train_iter
 
@@ -185,12 +205,13 @@ def make_tfds_eval_iterator(
       global_batch_size=config.global_batch_size_to_load_eval,
       global_mesh=global_mesh,
       max_target_length=config.max_target_length,
-      data_column_name=config.eval_data_column,
+      data_column_names=config.eval_data_columns,
       shuffle=False,
       data_shuffle_seed=config.data_shuffle_seed,
       tokenize=config.tokenize_eval_data,
       add_bos=config.add_bos,
       add_eos=config.add_eos,
+      use_dpo=config.use_dpo,
   )
 
   return eval_iter

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -269,6 +269,130 @@ def record_activation_metrics(output_metrics, intermediate_outputs, config):
       output_metrics["scalar"][f"activ_stdev/layer_{layer_num:03d}"] = layer["activation_stdev"][0]
 
 
+def _split_dpo_state(state):
+  reference_params = state.params["reference_params"]
+  new_state = state.replace(params={k: v for k, v in state.params.items() if k != "reference_params"})
+  return new_state, reference_params
+
+
+def _merge_dpo_state(state, reference_params):
+  return state.replace(params=dict(state.params, reference_params=reference_params))
+
+
+def dpo_loss_fn(model, config, data, dropout_rng, params, reference_params, is_train=True):
+  """loss_fn for both train and eval.
+
+  Args:
+    model: A nn.Module
+    config: Config of parameters
+    data: Batch of data to apply to the model
+    dropout_rng: A key to use to generate rng for dropout
+    params: Model params
+    is_train: True for train_step and False for eval_step
+
+  Returns:
+    loss: average loss
+    aux: a dictionary including intermediate_outputs, total_loss, and total_weights
+  """
+  # inputs, targets, segments, positions = apply_args
+  rng1, aqt_rng = jax.random.split(dropout_rng)
+
+  # decimate proportion of data when per_device_batch_size<1
+  if is_train:
+    for k, v in data.items():
+      data[k] = v[: config.micro_batch_size_to_train_on, :]
+
+  # for DPO we don't support packed sequence (they shouldn't be present in the first place)
+  data["chosen_segmentation"] = (data["chosen_segmentation"] == 1).astype(jnp.int32)
+  data["rejected_segmentation"] = (data["rejected_segmentation"] == 1).astype(jnp.int32)
+  data["chosen_position"] = data["chosen_position"] * (data["chosen_segmentation"] == 1)
+  data["rejected_position"] = data["rejected_position"] * (data["rejected_segmentation"] == 1)
+
+  # concatenated model and reference model forward pass
+  inputs = jnp.concatenate([data["chosen"], data["rejected"]], 0)
+  inputs_position = jnp.concatenate([data["chosen_position"], data["rejected_position"]], 0)
+  inputs_segmentation = jnp.concatenate([data["chosen_segmentation"], data["rejected_segmentation"]], 0)
+
+  logits, intermediate_outputs = model.apply(
+      params,
+      inputs,
+      inputs_position,
+      decoder_segment_ids=inputs_segmentation,
+      enable_dropout=config.enable_dropout if is_train else False,
+      rngs={"dropout": rng1, "params": aqt_rng},
+      mutable="intermediates",
+  )
+  ref_logits = model.apply(
+      {"params": reference_params},
+      inputs,
+      inputs_position,
+      decoder_segment_ids=inputs_segmentation,
+      enable_dropout=False,
+      rngs={"dropout": rng1, "params": aqt_rng},
+  )
+  ref_logits = jax.lax.stop_gradient(ref_logits)
+
+  # extract token ids, segmentation and logits for chosen and rejected sequences
+  chosen_ids = data["chosen"][..., 1:]
+  rejected_ids = data["rejected"][..., 1:]
+  chosen_segmentation = data["chosen_segmentation"][..., 1:]
+  rejected_segmentation = data["rejected_segmentation"][..., 1:]
+  n_logits = logits.shape[-3] // 2  # [B, S, E] - [batch, sequence, embedding/vocab]
+  chosen_logits, rejected_logits = logits[:n_logits, :, :], logits[n_logits:, :, :]  # [B, S, E], [B, S, E]
+  chosen_ref_logits, rejected_ref_logits = ref_logits[:n_logits, :, :], ref_logits[n_logits:, :, :]  # [B, S, E], [B, S, E]
+
+  # common subsequence and padding mask
+  common_prefix_mask = jnp.cumsum(chosen_ids != rejected_ids, axis=-1) == 0  # [B, S]
+  valid_seq_mask = (chosen_segmentation != 0) & (rejected_segmentation != 0) & ~common_prefix_mask  # [B, S]
+
+  # compute logratios from the sequence-reduced observed token log-probability
+  chosen_logps_seq = jnp.take_along_axis(  # [B, S]
+      jax.nn.log_softmax(chosen_logits[..., :-1, :], axis=-1), chosen_ids[..., None], axis=-1
+  )[..., 0]
+  chosen_logps = jnp.sum(chosen_logps_seq * valid_seq_mask, axis=-1)  # [B]
+  chosen_ref_logps_seq = jnp.take_along_axis(  # [B, S]
+      jax.nn.log_softmax(chosen_ref_logits[..., :-1, :], axis=-1), chosen_ids[..., None], axis=-1
+  )[..., 0]
+  chosen_ref_logps = jnp.sum(chosen_ref_logps_seq * valid_seq_mask, axis=-1)  # [B]
+  chosen_logratios = chosen_logps - chosen_ref_logps  # [B]
+
+  rejected_logps_seq = jnp.take_along_axis(  # [B, S]
+      jax.nn.log_softmax(rejected_logits[..., :-1, :], axis=-1), rejected_ids[..., None], axis=-1
+  )[..., 0]
+  rejected_logps = jnp.sum(rejected_logps_seq * valid_seq_mask, axis=-1)  # [B]
+  rejected_ref_logps_seq = jnp.take_along_axis(  # [B, S]
+      jax.nn.log_softmax(rejected_ref_logits[..., :-1, :], axis=-1), rejected_ids[..., None], axis=-1
+  )[..., 0]
+  rejected_ref_logps = jnp.sum(rejected_ref_logps_seq * valid_seq_mask, axis=-1)  # [B]
+  rejected_logratios = rejected_logps - rejected_ref_logps  # [B]
+
+  # DPO loss from chosen and rejected logratios
+  LABEL_SMOOTHING, BETA = config.dpo_label_smoothing, config.dpo_beta
+  logratios_delta = BETA * (chosen_logratios - rejected_logratios)  # [B]
+  losses = (  # [B]
+      -jax.nn.log_sigmoid(BETA * logratios_delta) * (1 - LABEL_SMOOTHING)
+      - jax.nn.log_sigmoid(-BETA * logratios_delta) * LABEL_SMOOTHING
+  )
+  total_loss, total_weights = jnp.mean(losses), losses.shape[0]
+  loss = total_loss
+
+  moe_lb_loss = 0.0
+  if config.num_experts > 1:
+    nested_key = ("intermediates", "decoder", "layers", "moe_lb_loss")
+    total_moe_lb_loss = maxtext_utils.get_nested_value(intermediate_outputs, nested_key, 0.0)
+    moe_lb_loss = jnp.mean(jnp.array(total_moe_lb_loss))
+    loss += moe_lb_loss
+  reward_accuracy = jnp.mean(chosen_logratios > rejected_logratios)
+  aux = {
+      "intermediate_outputs": intermediate_outputs,
+      "total_loss": total_loss,
+      "total_weights": total_weights,
+      "moe_lb_loss": moe_lb_loss,
+      "reward_accuracy": reward_accuracy,
+  }
+  return loss, aux
+
+
 def loss_fn(model, config, data, dropout_rng, params, is_train=True):
   """loss_fn for both train and eval.
 
@@ -343,11 +467,20 @@ def train_step(model, config, state_mesh_shardings, state, data, dropout_rng):
     rng2: A new rng key that can be used in future calls.
 
   """
+  reference_params, reference_params_sharding, extra_dpo_args, _loss_fn = [], [], [], loss_fn
+  if config.use_dpo:
+    state, reference_params = _split_dpo_state(state)
+    state_mesh_shardings, reference_params_sharding = _split_dpo_state(state_mesh_shardings)
+    extra_dpo_args = [reference_params]
+    _loss_fn = dpo_loss_fn
+
   if config.gradient_accumulation_steps > 1:
 
     def accumulate_gradient(acc_grad_and_loss, data):
-      grad_func = jax.value_and_grad(loss_fn, argnums=4, has_aux=True)
-      (_, aux), cur_batch_gradient = grad_func(model, config, data, dropout_rng, state.params, is_train=True)
+      grad_func = jax.value_and_grad(_loss_fn, argnums=4, has_aux=True)
+      (_, aux), cur_batch_gradient = grad_func(
+          model, config, data, dropout_rng, state.params, *extra_dpo_args, is_train=True
+      )
       acc_grad_and_loss["loss"] += aux["total_loss"]
       acc_grad_and_loss["moe_lb_loss"] += aux["moe_lb_loss"]
       acc_grad_and_loss["grad"] = jax.tree_util.tree_map(
@@ -380,8 +513,12 @@ def train_step(model, config, state_mesh_shardings, state, data, dropout_rng):
       cast_params = jax.device_put(state.params, max_utils.with_memory_kind(state_mesh_shardings.params, "device"))
       cast_params = max_utils.cast_to_bf16(cast_params)
       state = state.replace(params=cast_params)
-    grad_func = jax.value_and_grad(loss_fn, argnums=4, has_aux=True)
-    (loss, aux), raw_grads = grad_func(model, config, data, dropout_rng, state.params, is_train=True)
+      if config.use_dpo:
+        reference_params = jax.device_put(reference_params, max_utils.with_memory_kind(reference_params_sharding, "device"))
+        reference_params = max_utils.cast_to_bf16(reference_params)
+        extra_dpo_args = [reference_params]
+    grad_func = jax.value_and_grad(_loss_fn, argnums=4, has_aux=True)
+    (loss, aux), raw_grads = grad_func(model, config, data, dropout_rng, state.params, *extra_dpo_args, is_train=True)
   intermediate_outputs = aux["intermediate_outputs"]
   total_weights = aux["total_weights"]
   moe_lb_loss = aux["moe_lb_loss"]
@@ -408,6 +545,8 @@ def train_step(model, config, state_mesh_shardings, state, data, dropout_rng):
     scalar_metrics["learning/grad_norm"] = max_utils.l2norm_pytree(grads)
     scalar_metrics["learning/raw_grad_norm"] = max_utils.l2norm_pytree(raw_grads)
     scalar_metrics["learning/param_norm"] = max_utils.l2norm_pytree(new_state.params)
+  if config.use_dpo:
+    scalar_metrics["learning/dpo_reward_accuracy"] = aux["reward_accuracy"]
   metrics = {
       "scalar": scalar_metrics,
       "scalars": {},
@@ -416,13 +555,23 @@ def train_step(model, config, state_mesh_shardings, state, data, dropout_rng):
   if config.record_internal_nn_metrics:
     record_activation_metrics(metrics, intermediate_outputs, config)
 
+  if config.use_dpo:
+    new_state = _merge_dpo_state(new_state, reference_params)
+
   return new_state, metrics
 
 
 def eval_step(model, config, state, data, dropout_rng):
   """eval_step no backprop and new state compared with train_step."""
-  eval_loss_fn = functools.partial(loss_fn, model, config, data, dropout_rng, is_train=False)
-  loss, aux = eval_loss_fn(state.params)
+
+  reference_params, extra_dpo_args, _loss_fn = [], [], loss_fn
+  if config.use_dpo:
+    state, reference_params = _split_dpo_state(state)
+    extra_dpo_args = [reference_params]
+    _loss_fn = dpo_loss_fn
+
+  eval_loss_fn = functools.partial(_loss_fn, model, config, data, dropout_rng, is_train=False)
+  loss, aux = eval_loss_fn(state.params, *extra_dpo_args)
   total_loss = aux["total_loss"]
   total_weights = aux["total_weights"]
   moe_lb_loss = aux["moe_lb_loss"]
@@ -434,6 +583,8 @@ def eval_step(model, config, state, data, dropout_rng):
           "evaluation/moe_lb_loss": moe_lb_loss,
       },
   }
+  if config.use_dpo:
+    metrics["scalar"]["evaluation/dpo_reward_accuracy"] = aux["reward_accuracy"]
 
   return metrics
 
@@ -560,6 +711,31 @@ def setup_train_loop(config):
   if not config.using_pipeline_parallelism:
     # The vocab tensor(s) of shape [vocab, embed] (and transpose) are not sharded by stage
     maxtext_utils.assert_params_sufficiently_sharded(state.params, mesh, config.sharding_tolerance)
+
+  if config.use_dpo:
+    abstract_state, _, _ = max_utils.get_abstract_state(model, tx, config, init_rng, mesh, is_training=True)
+    max_logging.log(f"Restoring reference parameters for DPO from '{os.path.join(str(config.checkpoint_dir), str(0))}'")
+    try:
+      step0_restored, _ = checkpointing.load_state_if_possible(
+          checkpoint_manager,
+          data_iterator,
+          load_parameters_from_path="",
+          load_full_state_from_path="",
+          abstract_unboxed_pre_state=abstract_state,
+          enable_single_replica_ckpt_restoring=False,
+          dataset_type=config.dataset_type,
+          step=0,
+      )
+    except FileNotFoundError:
+      step0_restored = None
+    if step0_restored is not None:
+      reference_params = step0_restored["items"].params["params"]
+      state = _merge_dpo_state(state, reference_params)
+    else:
+      max_logging.log(
+          f"Could not restore reference parameters for DPO from '{os.path.join(str(config.checkpoint_dir), str(0))}'"
+      )
+
   record_goodput(recorder, config, recorder.record_training_preparation_end_time if recorder else None)
   return (
       init_rng,
@@ -599,6 +775,13 @@ def train_loop(config, state=None):
       eval_data_iterator,
       state,
   ) = setup_train_loop(config)
+
+  if config.use_dpo:
+    if "reference_params" not in state.params:
+      reference_params = jax.tree.map(jnp.copy, state.params["params"])
+      state = _merge_dpo_state(state, reference_params)
+    state_mesh_shardings = _merge_dpo_state(state_mesh_shardings, state_mesh_shardings.params["params"])
+
   # pylint: disable=line-too-long
   (
       functional_train,
@@ -692,7 +875,8 @@ def train_loop(config, state=None):
     last_step_completion = new_time
 
     if checkpoint_manager is not None:
-      if save_checkpoint(checkpoint_manager, int(step), state, config.dataset_type, data_iterator, config):
+      state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]
+      if save_checkpoint(checkpoint_manager, int(step), state_to_save, config.dataset_type, data_iterator, config):
         max_logging.log(f"saved a checkpoint at step {step}")
 
       # Upon preemption, exit when and only when all ongoing saves are complete.
@@ -712,6 +896,7 @@ def train_loop(config, state=None):
               "eval/moe_lb_loss": 0.0,
           }
       }
+      eval_dpo_reward_accuracy = 0.0
       eval_step_count = 0
       # pylint: disable=not-callable
       for eval_batch in eval_data_iterator:
@@ -722,6 +907,7 @@ def train_loop(config, state=None):
         cumulative_eval_metrics["scalar"]["eval/total_loss"] += float(eval_metrics["scalar"]["evaluation/total_loss"])
         cumulative_eval_metrics["scalar"]["eval/total_weights"] += float(eval_metrics["scalar"]["evaluation/total_weights"])
         cumulative_eval_metrics["scalar"]["eval/moe_lb_loss"] += float(eval_metrics["scalar"]["evaluation/moe_lb_loss"])
+        eval_dpo_reward_accuracy += float(eval_metrics["scalar"].get("evaluation/dpo_reward_accuracy", 0.0))  # for dpo only
         max_logging.log(f"Completed eval step {eval_step_count}")
         eval_step_count += 1
       eval_loss = (
@@ -730,11 +916,14 @@ def train_loop(config, state=None):
           + cumulative_eval_metrics["scalar"]["eval/moe_lb_loss"] / eval_step_count
       )
       cumulative_eval_metrics["scalar"]["eval/avg_loss"] = eval_loss
+      if config.use_dpo:
+        cumulative_eval_metrics["scalar"]["eval/dpo_reward_accuracy"] = eval_dpo_reward_accuracy / eval_step_count
       write_metrics(
           writer, local_metrics_file, running_gcs_metrics, cumulative_eval_metrics, step, config, is_training=False
       )
       max_logging.log(
-          f"average loss after {step=}: {eval_step_count=}, {eval_loss=}, total_weights={cumulative_eval_metrics['scalar']['eval/total_weights']}"
+          f"average loss after {step=}: {eval_step_count=}, {eval_loss=},"
+          f" total_weights={cumulative_eval_metrics['scalar']['eval/total_weights']}"
       )
       if eval_loss <= config.target_eval_loss:
         max_logging.log(f"Early stop and exit loop after reaching {config.target_eval_loss=}")

--- a/end_to_end/tpu/test_dpo.sh
+++ b/end_to_end/tpu/test_dpo.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -xe
+
+RUN_NAME=dpo_$(date +%Y-%m-%d-%H-%M-%S)
+
+# get latest converted Gemma2 2B checkpoint from internal GCS bucket
+export GEMMA_2B_CKPT_PATH=$(gcloud storage ls gs://maxtext-gemma/gemma2/2b | sort -r | head -1)
+LOGS="gs://maxtext-external/logs"
+
+# tfds pipeline
+python MaxText/train.py MaxText/configs/dpo.yml tokenizer_path=assets/tokenizer.gemma \
+    run_name="$RUN_NAME-tfds" model_name=gemma2-2b base_output_directory=${LOGS} \
+    load_parameters_path=${GEMMA_2B_CKPT_PATH}/0/items \
+    per_device_batch_size=0.5 allow_split_physical_axes=True \
+    ici_data_parallelism=2 ici_tensor_parallelism=2 ici_fsdp_parallelism=1
+
+# grain pipeline
+mkdir -p /tmp/anthropic_rlhf || true
+gcloud storage cp -r gs://maxtext-dataset/dpo/anthropic_rlhf/array_record /tmp/anthropic_rlhf
+python MaxText/train.py MaxText/configs/dpo.yml tokenizer_path=assets/tokenizer.gemma \
+    run_name="$RUN_NAME-grain" model_name=gemma2-2b base_output_directory=${LOGS} \
+    load_parameters_path=${GEMMA_2B_CKPT_PATH}/0/items \
+    dataset_type=grain grain_worker_count=16 \
+    grain_train_files='/tmp/anthropic_rlhf/array_record/anthropic_rlhf_tfds-train.array_record*' \
+    grain_eval_files='/tmp/anthropic_rlhf/array_record/anthropic_rlhf_tfds-test.array_record*' \
+    per_device_batch_size=0.5 allow_split_physical_axes=True \
+    ici_data_parallelism=2 ici_tensor_parallelism=2 ici_fsdp_parallelism=1
+
+# hf pipeline
+python MaxText/train.py MaxText/configs/dpo.yml tokenizer_path='google/gemma-2-2b-it' \
+    run_name="$RUN_NAME-grain" model_name=gemma2-2b base_output_directory=${LOGS} \
+    load_parameters_path=${GEMMA_2B_CKPT_PATH}/0/items \
+    dataset_type=hf hf_access_token=$HF_TOKEN hf_path='Anthropic/hh-rlhf' \
+    per_device_batch_size=0.5 allow_split_physical_axes=True ici_tensor_parallelism=2 \
+    ici_data_parallelism=2 ici_tensor_parallelism=2 ici_fsdp_parallelism=1


### PR DESCRIPTION
Adding DPO training to the main `train.py` script via config options.

The main new configs are `use_dpo` and other `dpo_...` values. Also `train_data_columns` and 
`eval_data_columns` are now lists of string field `['text']` for LLM pre-training and `['chosen', 'rejected']` for DPO.

Currently, only pre-processed datasets are supported already containing the concatenated full prompts: 'chosen' and 'rejected', like in [https://huggingface.co/datasets/Anthropic/hh-rlhf](https://huggingface.co/datasets/Anthropic/hh-rlhf)

Grain, HF and TFDS data pipelines are all compatible.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
