### PR TITLE
Align profiler start and end times with train_step via block_until_ready

### DIFF
--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -651,6 +651,7 @@ def train_loop(config, state=None):
   prof = profiler.Profiler(config)
   for step in np.arange(start_step, config.steps):
     if step == first_profiling_step:
+      jax.block_until_ready(state)  # Block until previous state finishes to start profile cleanly
       prof.activate()
 
     with jax.profiler.StepTraceAnnotation("train", step_num=step):
@@ -721,6 +722,7 @@ def train_loop(config, state=None):
         break
 
     if step == last_profiling_step:
+      jax.block_until_ready(state)  # Block until current state finishes to end profile cleanly
       prof.deactivate()
 
   if checkpoint_manager is not None:


### PR DESCRIPTION
Align profiler start and end times with train_step via block_until_ready

Example profile with this change (with default skip_first_n_steps_for_profiler=1, profiler_steps=5) 
(https://xprof.corp.google.com/trace_viewer/mattdavidow-7890031890416702717?hosts=t1v-n-c3cb1aa0-w-0&host_index=0&view_start=-1109.907&view_end=8543.576)
