### PR TITLE
Reduce disk usage for mixtral tests

### DIFF
--- a/end_to_end/tpu/mixtral/8x22b/1_test_mixtral.sh
+++ b/end_to_end/tpu/mixtral/8x22b/1_test_mixtral.sh
@@ -14,21 +14,30 @@ MODEL_VARIATION='8x22b'
 
 if [ -z "${BASE_OUTPUT_PATH}" ]; then
     # Non-Googlers please remember to point BASE_OUTPUT_PATH to GCS buckets that you own, this script uses internal buckets for testing.
-    export BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d)
+    export BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d)/
     echo "BASE_OUTPUT_PATH is not set, using BASE_OUTPUT_PATH = ${BASE_OUTPUT_PATH}"
 fi
+BASE_OUTPUT_PATH=gs://rdyro-mixtral-storage/logs/megamem-logs
 
 # Download checkpoint
 pip3 install torch
-MODEL_NAME=Mixtral-8x22B-Instruct-v0.1
-gcloud storage cp -r "gs://maxtext-external/$MODEL_NAME" /tmp
-                     
+MODEL_NAME="Mixtral-8x22B-Instruct-v0.1"
+
+PARAM_DIR="$HOME/tempdisk"
+mkdir -p "$PARAM_DIR"
+[[ ! -z $(ls "$PARAM_DIR") ]] && fusermount -u "$PARAM_DIR"
+gcsfuse --implicit-dirs maxtext-external "$PARAM_DIR"
+# alternatively: $ gcloud storage cp -r "gs://maxtext-external/$MODEL_NAME" $PARAM_DIR
+
 # Convert it to MaxText(orbax) format - scanned ckpt
-JAX_PLATFORMS=cpu python3 MaxText/llama_or_mistral_ckpt.py --base-model-path="/tmp/$MODEL_NAME" --model-size=mixtral-8x22b --maxtext-model-path=${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt/
+JAX_PLATFORMS=cpu python3 MaxText/llama_or_mistral_ckpt.py --base-model-path="$PARAM_DIR/$MODEL_NAME" --model-size=mixtral-8x22b --maxtext-model-path=${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt/
 echo "Wrote MaxText compatible scanned checkpoint to ${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt"
+
+# unmount the gcsfuse directory
+fusermount -u "$PARAM_DIR"
 
 # Generate unscanned ckpt for efficient decoding test
 export SCANNED_CHECKPOINT=${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt/0/items
 export RUN_NAME=unscanned_ckpt
-JAX_PLATFORMS=cpu python MaxText/generate_param_only_checkpoint.py MaxText/configs/base.yml async_checkpointing=false base_output_directory=${BASE_OUTPUT_PATH} load_parameters_path=${SCANNED_CHECKPOINT} run_name=${RUN_NAME} model_name='mixtral-8x22b' force_unroll=true megablox=false dtype=float16 weight_dtype=bfloat16 per_device_batch_size=1 max_target_length=1
+JAX_PLATFORMS=cpu python MaxText/generate_param_only_checkpoint.py MaxText/configs/base.yml async_checkpointing=false base_output_directory=${BASE_OUTPUT_PATH} load_parameters_path=${SCANNED_CHECKPOINT} run_name=${RUN_NAME} model_name='mixtral-8x22b' force_unroll=true dtype=bfloat16 weight_dtype=bfloat16
 echo "Wrote MaxText compatible unscanned checkpoint to ${BASE_OUTPUT_PATH}/${RUN_NAME}/checkpoints"

--- a/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
+++ b/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
@@ -14,17 +14,25 @@ MODEL_VARIATION='8x7b'
 
 if [ -z "${BASE_OUTPUT_PATH}" ]; then
     # Non-Googlers please remember to point BASE_OUTPUT_PATH to GCS buckets that you own, this script uses internal buckets for testing.
-    export BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d)
+    export BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d)/
     echo "BASE_OUTPUT_PATH is not set, using BASE_OUTPUT_PATH = ${BASE_OUTPUT_PATH}"
 fi
 
 # Download checkpoint
 pip3 install torch
-gcloud storage cp -r gs://maxtext-external/mixtral-8x7B-v0.1-Instruct /tmp
+MODEL_NAME="mixtral-8x7B-v0.1-Instruct"
+PARAM_DIR="$HOME/tempdisk"
+mkdir -p "$PARAM_DIR"
+[[ ! -z $(ls "$PARAM_DIR") ]] && fusermount -u "$PARAM_DIR"
+gcsfuse --implicit-dirs maxtext-external "$PARAM_DIR"
+# alternatively: gcloud storage cp -r "gs://maxtext-external/$MODEL_NAME" /tmp
 
 # Convert it to MaxText(orbax) format - scanned ckpt
-JAX_PLATFORMS=cpu python3 MaxText/llama_or_mistral_ckpt.py --base-model-path=/tmp/mixtral-8x7B-v0.1-Instruct --model-size=mixtral-8x7b --maxtext-model-path=${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt/
+JAX_PLATFORMS=cpu python3 MaxText/llama_or_mistral_ckpt.py --base-model-path="$PARAM_DIR/$MODEL_NAME" --model-size=mixtral-8x7b --maxtext-model-path=${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt/
 echo "Wrote MaxText compatible scanned checkpoint to ${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt"
+
+# unmount the gcsfuse directory
+fusermount -u "$PARAM_DIR"
 
 # Generate unscanned ckpt for efficient decoding test
 export SCANNED_CHECKPOINT=${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt/0/items


### PR DESCRIPTION
This PR modifies the parameter conversion mixtral tests to go through `gcsfuse` instead of disk for lower VM disk usage