### PR TITLE
Checkpoint  tfds data iterator

### DIFF
--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -53,7 +53,7 @@ def create_orbax_checkpoint_manager(
     orbax_logger: Optional[abstract_logger.AbstractLogger] = None,
     use_ocdbt: bool = True,
     use_zarr3: bool = True,
-    tfds_iter_checkpointing: Optional[bool] = False
+    tfds_iter_checkpointing: Optional[bool] = True
 ):
   """Returns specified Orbax (async or not) CheckpointManager or None if checkpointing is disabled."""
   if not enable_checkpointing:

--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -27,6 +27,8 @@ from multihost_dataloading import MultiHostDataLoadIterator
 import numpy as np
 import orbax.checkpoint as ocp
 import orbax.checkpoint.experimental.emergency.checkpoint_manager as emergency_checkpoint_manager
+import dataclasses
+import tensorflow as tf
 
 # pylint: disable=too-many-positional-arguments
 
@@ -51,6 +53,7 @@ def create_orbax_checkpoint_manager(
     orbax_logger: Optional[abstract_logger.AbstractLogger] = None,
     use_ocdbt: bool = True,
     use_zarr3: bool = True,
+    tfds_iter_checkpointing: Optional[bool] = False
 ):
   """Returns specified Orbax (async or not) CheckpointManager or None if checkpointing is disabled."""
   if not enable_checkpointing:
@@ -61,6 +64,8 @@ def create_orbax_checkpoint_manager(
 
   if dataset_type == "grain":
     item_names = ("items", "iter")
+  elif dataset_type == "tfds" and tfds_iter_checkpointing:
+    item_names = ("items", "iter")
   else:
     item_names = ("items",)
 
@@ -68,7 +73,11 @@ def create_orbax_checkpoint_manager(
   p.mkdir(exist_ok=True, parents=True)
   # we need to use ocdbt and zarr3 to control max file size in the checkpoint
   # omitting `iter` uses default handler for `iter`
-  item_handlers = {"items": PyTreeCheckpointHandler(use_ocdbt=use_ocdbt, use_zarr3=use_zarr3)}
+  if dataset_type == "tfds" and tfds_iter_checkpointing:
+    item_handlers = {"items": PyTreeCheckpointHandler(use_ocdbt=True, use_zarr3=True),
+                     'iter': TfdsCheckpointHandler()}
+  else:
+    item_handlers = {"items": PyTreeCheckpointHandler(use_ocdbt=use_ocdbt, use_zarr3=use_zarr3)}
   mngr = CheckpointManager(
       p,
       item_names=item_names,
@@ -149,6 +158,7 @@ def load_state_if_possible(
     abstract_unboxed_pre_state: train_state.TrainState,
     enable_single_replica_ckpt_restoring: Optional[bool] = False,
     dataset_type: Optional[str] = "tfds",
+    tfds_iter_checkpointing: Optional[bool] = True
 ):
   """Loads TrainState as possible from the inputs.
 
@@ -233,6 +243,17 @@ def load_state_if_possible(
             ),
             None,
         )
+      elif dataset_type == "tfds" and data_iterator is not None and tfds_iter_checkpointing:
+          return (
+              checkpoint_manager.restore(
+                  latest_step,
+                  args=ocp.args.Composite(
+                      items=ocp.args.PyTreeRestore(item=abstract_unboxed_pre_state, restore_args=restore_args),
+                      iter=TfdsCheckpointRestore(data_iterator.local_iterator),
+                  ),
+              ),
+              None,
+          )
       else:
         return (
             checkpoint_manager.restore(
@@ -314,3 +335,63 @@ def save_params_to_path(checkpoint_dir, params):
   save_args = orbax_utils.save_args_from_target({"params": params})
   orbax_checkpointer.save(checkpoint_dir, {"params": params}, save_args=save_args, force=True)
   print(f"Quantized params checkpoint saved at: {checkpoint_dir}")
+
+
+class TfdsCheckpointHandler():
+    """Orbax CheckpointHandler for a tfds data iterator (a TensorFlow NumpyIterator).
+    Implements ocp.CheckpointHandler"""
+
+    def save(
+            self,
+            directory: epath.Path,
+            item: Optional[tf.data.NumpyIterator] = None,
+            args: Any = None,
+    ):
+        """Saves iterator passed as item or args.item to directory"""
+        item = item or args.item  # for compatibility with older Orbax API
+        checkpoint = tf.train.Checkpoint(iterator=item)
+        # Align checkpoint count with that of checkpoint manager
+        checkpoint.save_counter.assign(args.step - 1)
+        checkpoint.save(directory / f'process_{jax.process_index()}-of-{jax.process_count()}' / 'ckpt')
+
+    def restore(self, directory: epath.Path, item: Optional[tf.data.NumpyIterator] = None,
+                args: Any = None) -> tf.data.NumpyIterator:
+        """Restores the iterator from the checkpoint in `directory`."""
+        item = item or args.item  # for compatibility with older Orbax API
+        checkpoint = tf.train.Checkpoint(iterator=item)
+        restore_path = tf.train.latest_checkpoint(directory / f'process_{jax.process_index()}-of-{jax.process_count()}')
+        checkpoint.restore(restore_path).expect_partial()
+        return item
+
+    def structure(self, directory: epath.Path) -> Any:
+        """Required by interface"""
+        return None
+
+    def metadata(self, directory: epath.Path) -> Optional[Any]:
+        """Required by interface"""
+        return None
+
+    def finalize(self, directory: epath.Path):
+        """Required by interface"""
+        pass
+
+    def close(self):
+        """Required by interface"""
+        pass
+
+
+try:
+    # Register the handler
+    @ocp.args.register_with_handler(TfdsCheckpointHandler, for_save=True)
+    @dataclasses.dataclass
+    class TfdsCheckpointSave(ocp.args.CheckpointArgs):
+        item: Any
+        step: int  
+
+    @ocp.args.register_with_handler(TfdsCheckpointHandler, for_restore=True)
+    @dataclasses.dataclass
+    class TfdsCheckpointRestore(ocp.args.CheckpointArgs):
+        item: Any
+
+except (ImportError, TypeError):
+    pass

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -43,6 +43,8 @@ async_checkpointing: True
 checkpoint_period: 10_000
 # enables one replica to read the ckpt then broadcast to the rest
 enable_single_replica_ckpt_restoring: False
+# enable checkpointing of tfds data iterator, for fully deterministic training.  saves large checkpoints.
+tfds_iter_checkpointing: True
 
 force_unroll: False # during generate_param_only_checkpoint should we unroll the loop?
 

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -553,6 +553,7 @@ def setup_initial_state(
         unboxed_abstract_state,
         config.enable_single_replica_ckpt_restoring,
         config.dataset_type,
+        config.tfds_iter_checkpointing
     )
 
     if restored:

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -231,6 +231,16 @@ def save_checkpoint(
             iter=grain.PyGrainCheckpointSave(data_iterator.local_iterator),
         ),
     )
+  elif dataset_type == "tfds" and config.tfds_iter_checkpointing:
+    return checkpoint_manager.save(
+      step,
+      args=orbax.checkpoint.args.Composite(
+        items=orbax.checkpoint.args.PyTreeSave(
+          item=state, save_args=save_args, ocdbt_target_data_file_size=chunk_byte_size
+        ),
+        iter=checkpointing.TfdsCheckpointSave(item=data_iterator.local_iterator, step=step),
+      ),
+    )
   else:
     return checkpoint_manager.save(
         step,
@@ -503,6 +513,7 @@ def setup_mesh_and_model(config):
         logger,
         use_ocdbt,
         use_zarr3,
+        config.tfds_iter_checkpointing
     )
 
   return init_rng, writer, checkpoint_manager, mesh, model, learning_rate_schedule, tx

--- a/getting_started/Data_Input_Pipeline.md
+++ b/getting_started/Data_Input_Pipeline.md
@@ -21,7 +21,7 @@ Currently MaxText has three data input pipelines:
 | -------- | --------------- | -------- | ----------- |
 | HuggingFace | datasets in HuggingFace Hub<br>local/Cloud Storage datasets in json, parquet, arrow, csv, txt | convenience<br>multiple formats | limit scalability using HuggingFace Hub<br>non-deterministic with preemption<br>(deterministic without preemption) |
 | Grain | ArrayRecord, available through Tensorflow Datasets | fully deterministic, regardless of preemption | only supports random access datasets |
-| TFDS | TFRecord, available through Tensorflow Datasets |  | only supports TFRecords<br>non-deterministic with preemption<br>(deterministic without preemption) |
+| TFDS | TFRecord, available through Tensorflow Datasets |  fully deterministic, regardless of preemption | only supports TFRecords<br>requires checkpointing data iterator for fully deterministic training<br> |
 
 ### Performance
 * Perf data for all 3 input pipeline: https://github.com/google/maxtext/blob/main/getting_started/Data_Input_Perf.md
@@ -119,7 +119,6 @@ grain_eval_files: '/tmp/gcsfuse/array-record/c4/en/3.0.1/c4-validation.array_rec
 ```
 
 ### TFDS pipeline
-
 1. Download the Allenai c4 dataset in TFRecord format to a GCS bucket (will cost about $100, [details](https://github.com/allenai/allennlp/discussions/5056))
 ```
 bash download_dataset.sh {GCS_PROJECT} {GCS_BUCKET_NAME}
@@ -135,3 +134,8 @@ eval_split: 'validation'
 # TFDS input pipeline only supports tokenizer in spm format
 tokenizer_path: "assets/tokenizer.llama2"
 ```
+3. Enable determinism (optional)
+```
+tfds_iter_checkpointing: True
+```
+Note that deteriminism with preemption requires checkpointing the data iterator, and the checkpoints will be larger in size. 

--- a/getting_started/Data_Input_Pipeline.md
+++ b/getting_started/Data_Input_Pipeline.md
@@ -21,7 +21,7 @@ Currently MaxText has three data input pipelines:
 | -------- | --------------- | -------- | ----------- |
 | HuggingFace | datasets in HuggingFace Hub<br>local/Cloud Storage datasets in json, parquet, arrow, csv, txt | convenience<br>multiple formats | limit scalability using HuggingFace Hub<br>non-deterministic with preemption<br>(deterministic without preemption) |
 | Grain | ArrayRecord, available through Tensorflow Datasets | fully deterministic, regardless of preemption | only supports random access datasets |
-| TFDS | TFRecord, available through Tensorflow Datasets |  fully deterministic, regardless of preemption | only supports TFRecords<br>requires checkpointing data iterator for fully deterministic training<br> |
+| TFDS | TFRecord, available through Tensorflow Datasets |  optionally fully deterministic, regardless of preemption | only supports TFRecords<br>requires checkpointing data iterator for fully deterministic training<br> |
 
 ### Performance
 * Perf data for all 3 input pipeline: https://github.com/google/maxtext/blob/main/getting_started/Data_Input_Perf.md


### PR DESCRIPTION
Enable deterministic training with preemption when using tfds pipeline by checkpointing data iterator. 

Creates a checkpoint handler for data iterator that implements orbax.checkpoint.CheckpointHandler, similar to https://github.com/google/grain/blob/main/grain/_src/python/checkpoint_handlers.py. Handler utilizes tf.train.Checkpoint to save and restore iterator.  

Makes checkpointing the data iterator optional, since this method will save large checkpoints. Adds a bool flag to base.yml 

Async checkpointing is handled at the level of the orbax checkpoint manager. 

Updates input pipeline description to reflect option to checkpoint tfds iterator. 