### PR TITLE
Fix JetStream and MaxText integration

### DIFF
--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -51,7 +51,7 @@ def main(config):
   sampled_tokens_list.append(first_token)
   for _ in steps:
     rng, rng_generate = jax.random.split(rng)
-    decode_state, sampled_tokens = engine.generate(params, decode_state, rng_generate)
+    decode_state, sampled_tokens = engine.generate(params, decode_state, rng=rng_generate)
     sampled_tokens_list.append(sampled_tokens)
 
   results = [sampled_tokens.get_result_at_slot(slot).tokens.item() for sampled_tokens in sampled_tokens_list]

--- a/MaxText/inference_microbenchmark.py
+++ b/MaxText/inference_microbenchmark.py
@@ -124,7 +124,7 @@ def ar_benchmark_loop(config, engine, params, decode_state, iters, profile_name)
   rng = jax.random.PRNGKey(1234)
   for _ in range(iters):
     rng, rng_generate = jax.random.split(rng)
-    decode_state, _ = engine.generate(params, decode_state, rng_generate)
+    decode_state, _ = engine.generate(params, decode_state, rng=rng_generate)
   jax.block_until_ready(decode_state)
   end = datetime.datetime.now()
   prof.deactivate()
@@ -136,7 +136,7 @@ def ar_benchmark(config, engine, params, decode_state, global_batch_size, cache_
   rng = jax.random.PRNGKey(1234)
   for _ in range(_WARMUP_ITERS):
     rng, rng_generate = jax.random.split(rng)
-    decode_state, _ = engine.generate(params, decode_state, rng_generate)
+    decode_state, _ = engine.generate(params, decode_state, rng=rng_generate)
   jax.block_until_ready(decode_state)
 
   time_in_s, decode_state = ar_benchmark_loop(config, engine, params, decode_state, iters, profile_name="autoregress")


### PR DESCRIPTION
Makes an rng an optional argument for several MaxEngine functions that are required and used by JetStream.
Defaults to a rng with key 0