### PR TITLE
Support `allow_split_physical_axes` for multislice hybrid meshes such as FSDP on ICI and DCN.

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -402,6 +402,7 @@ def create_device_mesh(config, devices=None):
         ici_parallelism,
         dcn_parallelism,
         devices,
+        allow_split_physical_axes=allow_split_physical_axes,
     )
   else:
     if allow_split_physical_axes:


### PR DESCRIPTION
allow_split_physical_axes is only supported for device meshes atm but we also should support this for hybrid meshes. This is useful when we want to use FSDP across DCN and ICI + split the physical axis.