### PR TITLE
Add qkv_proj to the saved name list

### DIFF
--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -310,10 +310,10 @@ class Decoder(nn.Module):
             "key_proj",
             "qkv_proj",
         )
-      elif cfg.remat_policy == "qkv_proj_offloaded":
+      elif cfg.remat_policy == "save_qkv_proj_offloaded":
         policy = jax.checkpoint_policies.save_and_offload_only_these_names(
             names_which_can_be_saved=[],
-            names_which_can_be_offloaded=["query_proj", "value_proj", "key_proj"],
+            names_which_can_be_offloaded=["query_proj", "value_proj", "key_proj", "qkv_proj"],
             offload_src="device",
             offload_dst="pinned_host",
         )


### PR DESCRIPTION
Update QKV offloading and rename remat policy.

- Add qkv_proj to offloadable names due to query/key/value fusion
- Rename remat_policy from qkv_proj_offloaded to save_qkv_proj_offloaded