### PR TITLE
Quantization fix for AQTEinsum 

### DIFF
--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -597,9 +597,9 @@ class MoeBlock(nn.Module):
         )
       with jax.named_scope("w_sum"):
         weights_axis = ("activation_batch", "activation_length", "activation_exp")
-        output = self.get_einsum(rhs_mesh_axes=weights_axis)(
-            "BSEM,BSE -> BSM", intermediate_layer.astype(jnp.float32), weights.astype(jnp.float32)
-        ).astype(self.dtype)
+        output = jnp.einsum("BSEM,BSE -> BSM", intermediate_layer.astype(jnp.float32), weights.astype(jnp.float32)).astype(
+            self.dtype
+        )
       return output, None
 
   @nn.compact

--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -142,7 +142,7 @@ class AqtQuantization:
     aqt_einsum = functools.partial(
         aqt_flax.AqtEinsum(
             cfg=self.quant_dg,
-            lhs_quant_mode=self.quant_mode,
+            rhs_quant_mode=self.quant_mode,
             lhs_freeze_mode=aqt_flax.FreezerMode.NONE,
             rhs_freeze_mode=aqt_flax.FreezerMode.CALIBRATION_AND_VALUE,
             rhs_axis_metadata_wrapper=rhs_axis_metadata_wrapper,
@@ -265,6 +265,8 @@ def _get_aqt_key_paths(aqt_vars):
       if "AqtDotGeneral" in d.key:
         pruned_keys.append(jax.tree_util.DictKey(key="kernel"))
         break
+      elif "AqtEinsum" in d.key:
+        continue
       else:
         assert "Aqt" not in d.key, f"Unexpected Aqt op {d.key} in {k}."
         pruned_keys.append(d)


### PR DESCRIPTION
3 fixes - 
i) rhs_quant_mode instead of lhs_quant_mode
ii) Ignoring 'AqtEinsum' in keys
iii) using jnp.einsum instead of AQTEinsum for elementwise operations.