### PR TITLE
add SWA support to cudnn flash attn API

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -368,23 +368,25 @@ class AttentionOp(nn.Module):
       model_mode: str = common_types.MODEL_MODE_TRAIN,
   ) -> Array:
     """CUDNN Flash Attention with Transformer Engine.
-    1. Stable API, supports GQA
-    2. Supports head_dim till 128; head_dim=256 support will be added soon
+    1. Stable API, supports GQA, supports SWA
+    2. Supports head_dim till 128; head_dim=256 will be supported from cudnn 9.6
+    3. Supports causal masking, TE will generate the needed mask for SWA, no need for additional mask generation
     """
     # These imports are only meant to work in a GPU build.
     from transformer_engine.jax.flax.transformer import DotProductAttention  # pytype: disable=import-error
 
     _, _, _, head_dim = query.shape  # pylint: disable=unused-variable
 
-    # generate attn_mask
-    attn_mask = self.generate_attention_mask(query, key, decoder_segment_ids, model_mode)
+    sliding_window_size = self.sliding_window_size
+    if self.attention_type == AttentionType.LOCAL_SLIDING:
+      sliding_window_size = [self.sliding_window_size, 0]
 
     dpa_layer = DotProductAttention(
         head_dim=head_dim,
         num_attention_heads=self.num_query_heads,
         num_gqa_groups=self.num_kv_heads,
-        attn_mask_type="padding_causal",  # 'no_mask', 'padding', 'causal', or 'padding_causal'
-        attn_bias_type="NO_BIAS",  # 'no_bias', 'pre_scale_bias' or 'post_scale_bias'
+        attn_mask_type="causal",  # 'no_mask', 'padding', 'causal', or 'padding_causal'
+        attn_bias_type="no_bias",  # 'no_bias', 'pre_scale_bias' or 'post_scale_bias'
         attention_dropout=self.dropout_rate,
         dropout_rng_name="aqt",
         dtype=self.dtype,
@@ -392,8 +394,9 @@ class AttentionOp(nn.Module):
         qkv_layout="BSHD_BSHD_BSHD",  # 'BS3HD', 'BSHD_BS2HD' or 'BSHD_BSHD_BSHD'
         scale_factor=1.0 / math.sqrt(head_dim),
         transpose_batch_sequence=False,
+        window_size=sliding_window_size,
     )
-    return dpa_layer(query, key, value, mask=attn_mask)
+    return dpa_layer(query, key, value)
 
   def compute_local_attention(
       self, attn_weights: Array, value: Array | KVTensor, q_seq_len: int, model_mode: str


### PR DESCRIPTION
Exposed the sliding window attention to the cudnn flash attn API.
1. Needed to support GEMMA2 models
2. The causal masking is taken care of by TE
3. `head_dim = 256` support should be available in the next cudnn release, no code change on MaxText would be required