### PR TITLE
Fix HBM OOM in mixtral_8x7b_dropped_int8

### DIFF
--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -457,6 +457,7 @@ mixtral_8x7b_dropped = MaxTextModel(
         "sa_block_q_dq": 2048,
         "megablox": False,
         "capacity_factor": 1.25,
+        "tokenizer_path": "assets/tokenizer.mistral-v1",
     },
     xla_flags=(
         xla_flags_library.MOE_VMEM_LIMIT_FLAG
@@ -475,7 +476,6 @@ mixtral_8x7b_dropped_int8 = MaxTextModel(
         "remat_policy": "full",
         "attention": "flash",
         "gcs_metrics": True,
-        "use_iota_embed": True,
         "dataset_path": "gs://max-datasets-rogue",
         "dataset_type": "synthetic",
         "reuse_example_batch": 1,
@@ -487,6 +487,7 @@ mixtral_8x7b_dropped_int8 = MaxTextModel(
         "megablox": False,
         "capacity_factor": 1.25,
         "quantization": "int8",
+        "tokenizer_path": "assets/tokenizer.mistral-v1",
     },
     xla_flags=(
         xla_flags_library.MOE_VMEM_LIMIT_FLAG


### PR DESCRIPTION
Got HBM OOM in reproducing `mixtral_8x7b_dropped_int8` and able to fit after disabling `"use_iota_embed": True`.
Additionally, add the specific tokenizer for mixtral model for better understanding, it won't change any performance in synthetic dataset. 

Verified with the following command:
```
python3 benchmarks/benchmark_runner.py  --project=tpu-prod-env-automated --zone=us-east5-c --cluster_name=bodaborg-v6e-256 --base_output_directory=gs://lizhiyu-multipods/v6e-test --device_type=v6e-256 --num_slices=1 --model_name="mixtral_8x7b_dropped_int8" --libtpu_version=20241002
```