### PR TITLE
Fix multihost_runner.py kill script for v6e TPUs

### DIFF
--- a/multihost_runner.py
+++ b/multihost_runner.py
@@ -162,7 +162,7 @@ def kill_existing_processes_str():
   return """#!/bin/bash
 _TPU_VERSION_NAME="${1}"
 device_name="accel"
-if [[ "${_TPU_VERSION_NAME}" =~ ^v5.* ]]; then
+if [[ "${_TPU_VERSION_NAME}" =~ ^v[56].* ]]; then
   device_name="vfio/"
 fi
 echo "Searching for existing processes on device ${device_name}..."


### PR DESCRIPTION
The script that searches for existing processes is hard coded for v5 TPUs. This tiny edit allows the runner to kill existing processes on v6e TPUs.