### PR TITLE
Rollback PR 976 due to TE version mismatch

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -368,8 +368,8 @@ class AttentionOp(nn.Module):
       model_mode: str = common_types.MODEL_MODE_TRAIN,
   ) -> Array:
     """CUDNN Flash Attention with Transformer Engine.
-    1. Stable API, supports GQA, supports SWA
-    2. head_dim=256 is now supported from TE 1.2 with cudnn 9.5.0
+    1. Stable API, supports GQA
+    2. Supports head_dim till 128; head_dim=256 support will be added soon
     """
     # These imports are only meant to work in a GPU build.
     from transformer_engine.jax.flax.transformer import DotProductAttention  # pytype: disable=import-error
@@ -379,16 +379,12 @@ class AttentionOp(nn.Module):
     # generate attn_mask
     attn_mask = self.generate_attention_mask(query, key, decoder_segment_ids, model_mode)
 
-    sliding_window_size = self.sliding_window_size
-    if self.attention_type == AttentionType.LOCAL_SLIDING:
-      sliding_window_size = [self.sliding_window_size, 0]
-
     dpa_layer = DotProductAttention(
         head_dim=head_dim,
         num_attention_heads=self.num_query_heads,
         num_gqa_groups=self.num_kv_heads,
         attn_mask_type="padding_causal",  # 'no_mask', 'padding', 'causal', or 'padding_causal'
-        attn_bias_type="no_bias",  # 'no_bias', 'pre_scale_bias' or 'post_scale_bias'
+        attn_bias_type="NO_BIAS",  # 'no_bias', 'pre_scale_bias' or 'post_scale_bias'
         attention_dropout=self.dropout_rate,
         dropout_rng_name="aqt",
         dtype=self.dtype,
@@ -396,7 +392,6 @@ class AttentionOp(nn.Module):
         qkv_layout="BSHD_BSHD_BSHD",  # 'BS3HD', 'BSHD_BS2HD' or 'BSHD_BSHD_BSHD'
         scale_factor=1.0 / math.sqrt(head_dim),
         transpose_batch_sequence=False,
-        window_size=sliding_window_size,
     )
     return dpa_layer(query, key, value, mask=attn_mask)
 


### PR DESCRIPTION
PR #976 requires transformer-engine head, whereas our tests run with an older TE pin. We will rollback #976 for now until we can pin to a newer TE