### PR TITLE
Name the initialize state module

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -626,6 +626,7 @@ def setup_initial_state(
         state = restored["items"]
     else:
       init_state_partial = functools.partial(init_initial_state, model, tx, config, is_training)
+      init_state_partial.__name__ = "initialize_state"
       # pylint: disable=not-callable
       state = jax.jit(
           init_state_partial,


### PR DESCRIPTION
Currently this module is named something like "unnamed_jit_function" when HLO dumped, this will rename it to "jit_initialize_state"