### PR TITLE
Correct vocab size for 8x22b

### DIFF
--- a/MaxText/llama_or_mistral_ckpt.py
+++ b/MaxText/llama_or_mistral_ckpt.py
@@ -134,7 +134,7 @@ MODEL_PARAMS_DICT = {
         "num_heads": 48,
         "num_kv_heads": 8,
         "dims_per_head": 128,
-        "vocab": 32000,
+        "vocab": 32768,
         "base_emb_dim": 6144,
         "base_mlp_dim": 16384,
         "num_experts": 8,


### PR DESCRIPTION
# Description

Correct vocab size from 32000 to 32768, which aligned with right model [config](https://github.com/AI-Hypercomputer/maxtext/blob/main/MaxText/configs/models/mixtral-8x22b.yml)