### PR TITLE
Expose all SplashAttention tunable parameters in the workload.

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -462,5 +462,14 @@ ragged_block_size: 256
 # These can be tuned for specific hardware generations, and can be set up to
 # the model's sequence length.
 sa_block_q: 512
+sa_block_kv: 512
+sa_block_kv_compute: 512
 sa_block_q_dkv: 512
+sa_block_kv_dkv: 512
+sa_block_kv_dkv_compute: 512
 sa_block_q_dq: 512
+sa_block_kv_dq: 512
+sa_use_fused_bwd_kernel: False
+sa_q_layout: "HEAD_DIM_MINOR"
+sa_k_layout: "HEAD_DIM_MINOR"
+sa_v_layout: "HEAD_DIM_MINOR"


### PR DESCRIPTION
Full tunable parameters for SplashAttention are [here](https://github.com/jax-ml/jax/blob/0181cb396d9956ea96f1d1de9695ceecdb1c7c5e/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py#L472-L497)

Test plan: $ python3 MaxText/train.py MaxText/configs/base.yml   run_name=$YOUR_JOB_NAME   base_output_directory=gs://xiowei-bucket-ctmd   dataset_type=synthetic   steps=10

cc: @miladm 