### PR TITLE
Support safetensors checkpoints [Do not merge - WIP]

### DIFF
--- a/MaxText/layers/gemma2.py
+++ b/MaxText/layers/gemma2.py
@@ -97,6 +97,7 @@ class Gemma2DecoderLayer(nn.Module):
         kv_quant=quantizations.configure_kv_quant(cfg),
         attention_type=attentions.AttentionType.LOCAL_SLIDING,
         sliding_window_size=cfg.sliding_window_size,
+        attn_logits_soft_cap=cfg.attn_logits_soft_cap,
     )
 
     attention_lnx = attention_layer(
@@ -178,6 +179,7 @@ class Gemma2DecoderLayer(nn.Module):
         quant=self.quant,
         kv_quant=quantizations.configure_kv_quant(cfg),
         attention_type=attentions.AttentionType.GLOBAL,
+        attn_logits_soft_cap=cfg.attn_logits_soft_cap,
     )
 
     attention_lnx = attention_layer(


### PR DESCRIPTION
Prior to this PR, our checkpointing code only supports loading `.pth` files but - in support of Mixtral 8x22B - we had need to load a `safetensors` file (v0.3 of the Instruct checkpoint, published by Mistral). We additionally noted that - as with `.pth` files - safetensors checkpoints could be split across multiple files. This PR addresses both cases.

Note we also introduce a new required argument, `checkpoint-type`, taking values of `pth` or `safetensors`.

Some additional tweaks:
- Check vocab size is correct instead of slicing to what's specified
- Set CPU device count to 1 to fix an error we see with > 1