### PR TITLE
Use python3 and fix bash syntax

### DIFF
--- a/end_to_end/test_jdi.sh
+++ b/end_to_end/test_jdi.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 echo "Running the jax.distributed.initialize test";
-python -c "import jax; jax.distributed.initialize()";
-if [["$?" -eq "0"]]
+python3 -c "import jax; jax.distributed.initialize()";
+if [[ "$?" -eq "0" ]]; then
   echo "Test exit status 0, success!"
 else
   echo "Non-zero exit status, test failed!"
+fi


### PR DESCRIPTION
Tested the script on a TPU VM.

$ bash test_jdi.sh
Running the jax.distributed.initialize test
Test exit status 0, success!