### PR TITLE
Remove aqt einsum for dropping

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -94,6 +94,10 @@ kv_quant_dtype: "int8"
 checkpoint_is_quantized: False # Set to True if reading from a saved aqt quantized checkpoint
 # Saves params quantized on fly at following path
 save_quantized_params_path: ""
+#Used to configure the mode in which model is called
+# when left as is, corresponds to training
+# accepted values are "inference" 
+model_call_mode: ""
 
 # Shard the range finding operation for quantization. By default this is set to number of slices.
 quantization_local_shard_count: -1

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -85,12 +85,19 @@ def validate_profiler_type(s: str) -> None:
     raise ValueError("Invalid profiler type was passed. Valid options ", valid_profiler_types)
 
 
+def validate_model_call_mode(s: str) -> None:
+  valid_model_call_modes = ("", "inference")
+  if s not in valid_model_call_modes:  # currently supported attention
+    raise ValueError(f"Invalid model call mode {s}. Valid options are {valid_model_call_modes}")
+
+
 def validate_keys(keys):
   validate_attention_kernel(keys["attention"])
   validate_attention_type(keys["attention_type"])
   validate_profiler_type(keys["profiler"])
   validate_compute_axis_order(keys["compute_axis_order"])
   validate_kv_quant_axis(keys["kv_quant_axis"], keys["quantize_kvcache"])
+  validate_model_call_mode(keys["model_call_mode"])
 
   assert (keys["load_parameters_path"] == "" and keys["load_full_state_path"] == "") or keys[
       "enable_checkpointing"


### PR DESCRIPTION
i) Remove AQTEinsum for 1st step where inputs are masked with dispatch mask. This will lead to failure in loading weights that are pre-quantized without capacity_factor > 0. 
which should not be the case. As capacity factor is only forward pass, we should be able to load weights. 

ii) Remove AQTEinsum from last step where C axis is contracted, that is element wise op and AQT does not support the same. 

iii) Add math.ceil, so expert capacity per batch is never zero

iv) Add model_call_model in base.yml to selectively choose between training and inference


The correctness tests done - 
when given capacity_factor = 2 (which is almost dropless). The rouge scores for 8x22B are

{'rouge1': 44.5123, 'rouge2': 24.5477, 'rougeL': 31.3922, 'rougeLsum': 42.0639, 'gen_len': 1269606, 'gen_num': 1200}

as compared to capacity_factor = -1

{'rouge1': 44.1463, 'rouge2': 24.2765, 'rougeL': 31.2481, 'rougeLsum': 41.6197, 'gen_len': 1229222, 'gen_num': 1200} which makes sense.


tested 8x22B with capacity factor 1.5

{'rouge1': 43.9813, 'rouge2': 24.1528, 'rougeL': 30.8425, 'rougeLsum': 41.5053, 'gen_len': 1312280, 'gen_num': 1200}


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.