### PR TITLE
Scan and remat only the outer pipeline iteration loop over microbatches

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -144,10 +144,22 @@ num_pipeline_repeats: -1
 # num_pipeline_microbatches must be a multiple of the number of pipeline stages. By default it is set to the number of stages.
 # Note the microbatch_size is given by global_batch_size / num_pipeline_microbatches, where global_batch_size = per_device_batch_size * num_devices
 num_pipeline_microbatches: -1
-scan_pipeline_iterations: True # This can be set independently of scan_layers, which is relevant when num_layers_per_pipeline_stage > 1.
 pipeline_delay_activation_forwarding: False # This delays the activation forwarding one loop iteration simplifying XLA's task of overlapping since
 # the communication and compute in each iteration are now independent. However this comes at the cost of doubling the pipeline bubble,
 # and you must set the number of microbatches to at least 2 * num_stages (the minimum 2 * num_stages is set by default with this delay).
+
+# There are two loops for PP: 
+#  1)  Outer loop over microbatches (pipeline iterations)
+#  2)  Inner loop over layers (layers per stage)
+# We have observed extra remat when a remat policy and scanning is performed on both, and recommend the default
+# settings below of scanning and setting a remat policy only over the pipeline iterations.
+# It may be useful to do the reverse when the layers_per_stage is very large.
+# The below settings only have effect when using pipeline parallelism.
+scan_pipeline_iterations: True
+# The layers per stage scanning option is set by scan_layers, we recommend setting scan_layers=False
+set_remat_policy_on_pipeline_iterations: True
+set_remat_policy_on_layers_per_stage: False
+
 
 # Choose 'remat_policy' between 'minimal', 'save_dot_except_mlpwi', 'save_dot_except_mlp', 'save_qkv_proj', 'qkv_proj_offloaded', 'custom' 'minimal_offloaded', 'save_out_proj' and 'full'.
 # These options offer a trade-off between speed (fastest to slowest) and HBM usage (highest to lowest)
@@ -165,7 +177,7 @@ value_proj: 'remat'
 qkv_proj: 'remat'
 out_proj: 'remat'
 
-scan_layers: True
+scan_layers: True # We recommend setting this to false when using pipeline parallelism, instead scanning the PP iterations.
 param_scan_axis: 1
 
 # The attention parameter dictates the specific algorithm/methodology used to compute the attention scores

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -251,6 +251,21 @@ class Decoder(nn.Module):
     )
     return scan_fn(config=cfg, mesh=mesh, name="layers", quant=self.quant)
 
+  def get_pipeline_stage_module(self, base_stage, cfg, mesh):
+    if cfg.num_layers_per_pipeline_stage == 1:
+      stage_module = base_stage(config=cfg, mesh=mesh, quant=self.quant)
+    elif cfg.scan_layers:
+      stage_module = self.scan_decoder_layers(cfg, base_stage, cfg.num_layers_per_pipeline_stage, "layers_per_stage", mesh)
+    else:
+      stage_module = SequentialBlockDecoderLayers(
+          decoder_layer=base_stage,
+          num_decoder_layers=cfg.num_layers_per_pipeline_stage,
+          config=cfg,
+          mesh=mesh,
+          quant=self.quant,
+      )
+    return stage_module
+
   @nn.compact
   def __call__(
       self,
@@ -349,21 +364,8 @@ class Decoder(nn.Module):
         static_argnums=(4, 5),  # Deterministic and model mode are static arguments.
     )
     if cfg.using_pipeline_parallelism:
-      if cfg.num_layers_per_pipeline_stage == 1:
-        stage_module = BlockLayer(config=cfg, mesh=mesh, quant=self.quant)
-      elif cfg.scan_layers:
-        stage_module = self.scan_decoder_layers(
-            cfg, RemattedBlockLayer, cfg.num_layers_per_pipeline_stage, "layers_per_stage", mesh
-        )
-      elif not cfg.scan_layers:
-        stage_module = SequentialBlockDecoderLayers(
-            decoder_layer=RemattedBlockLayer,
-            num_decoder_layers=cfg.num_layers_per_pipeline_stage,
-            config=cfg,
-            mesh=mesh,
-            quant=self.quant,
-        )
-
+      base_stage = RemattedBlockLayer if cfg.set_remat_policy_on_layers_per_stage else BlockLayer
+      stage_module = self.get_pipeline_stage_module(base_stage, cfg, mesh)
       y = pipeline.Pipeline(config=cfg, mesh=mesh, layers=stage_module, remat_policy=policy)(
           y,
           decoder_segment_ids,

--- a/MaxText/tests/pipeline_parallelism_test.py
+++ b/MaxText/tests/pipeline_parallelism_test.py
@@ -227,6 +227,7 @@ class PipelineParallelismTest(unittest.TestCase):
             "num_layers_per_pipeline_stage=2",
             "num_pipeline_microbatches=8",
             "tokenizer_path=../assets/tokenizer.llama2",
+            "scan_layers=False",  # We see better performance only scanning the pipeline iterations.
         ]
     )
 
@@ -274,6 +275,7 @@ class PipelineParallelismTest(unittest.TestCase):
             "num_layers_per_pipeline_stage=8",
             "num_pipeline_microbatches=8",
             "tokenizer_path=../assets/tokenizer.llama2",
+            "scan_layers=False",  # We see better performance only scanning the pipeline iterations.
         ]
     )
 


### PR DESCRIPTION
We have observed extra remat when scanning + rematting both the outer pipeline loop and inner loop over stages, and strange undesirable behavior when scanning + rematting only the inner loop. We have found scanning + rematting the outer loop + saving the decoder layer inputs performs well, and is a common pattern among other pipeline implementations in other codebases.

Note this replaces https://github.com/AI-Hypercomputer/maxtext/pull/971

See b/373949783 for more.