### PR TITLE
Adds 405B script for GPU for consistency.

### DIFF
--- a/MaxText/configs/models/gpu/llama3.1_405b.yml
+++ b/MaxText/configs/models/gpu/llama3.1_405b.yml
@@ -1,0 +1,16 @@
+base_config: "base.yml"
+run_name: "gpu_train_test"
+# Args coming from the NVIDIA spreadsheet http://shortn/_AhULYn1mX4.
+hardware: "gpu"
+steps: 10
+model_name: "llama3.1-405b"
+enable_checkpointing: False
+#attention: "cudnn_flash_te"
+remat_policy: "full"
+use_iota_embed: True
+scan_layers: True
+dataset_type: "synthetic"
+async_checkpointing: False
+logits_dot_in_fp32: False
+per_device_batch_size: 1.0
+max_target_length: 4096


### PR DESCRIPTION
We had (https://github.com/AI-Hypercomputer/maxtext/pull/998) trying to follow the "correct" way to invoke the job but later found pretty much all the scripts are using models/gpu/MODEL_NAME.yml for run, and also in the tool integration. It's easier to keep the convention for 405B and we can refactor in the future.