### PR TITLE
Allows env var for logging level.

### DIFF
--- a/MaxText/inference_mlperf/offline_mode.py
+++ b/MaxText/inference_mlperf/offline_mode.py
@@ -47,7 +47,7 @@ import offline_inference
 
 _MLPERF_ID = "llama2-70b"
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=os.getenv("LOGLEVEL", "INFO"))
 
 sys.path.insert(0, os.getcwd())
 log = logging.getLogger("main2.py")


### PR DESCRIPTION
# Description
For offline mlperf runs we have a default log level of INFO. This change allows for a environment variable called `LOGLEVEL` to be used to control the logging level. 

# Tests

Local runs.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
