### PR TITLE
Added a custom_wheel mode for building the dependency image.

### DIFF
--- a/docker_build_dependency_image.sh
+++ b/docker_build_dependency_image.sh
@@ -21,6 +21,11 @@
 # bash docker_build_dependency_image.sh MODE=stable JAX_VERSION=0.4.13
 # Nightly build with JAX_VERSION for GPUs. Available versions listed at https://storage.googleapis.com/jax-releases/jax_nightly_releases.html:
 # bash docker_build_dependency_image.sh DEVICE=gpu MODE=nightly JAX_VERSION=0.4.36.dev20241109 # Note: this sets both jax-nightly and jaxlib-nightly 
+# MODE=custom_wheels is the same as nightly except that it reinstalls any
+# additional wheels that are present in the maxtext directory.
+# The main use case is to install custom jax or jaxlib wheels but it also
+# works with any custom wheels.
+# bash docker_build_dependency_image.sh MODE=custom_wheels
 
 # Enable "exit immediately if any command fails" option
 set -e
@@ -48,6 +53,11 @@ fi
 if [[ -z ${MODE} ]]; then
   export MODE=stable
   echo "Default MODE=${MODE}"
+elif [[ ${MODE} == "custom_wheels" ]] ; then
+  export MODE=nightly
+  export CUSTOM_JAX=1
+else
+  export CUSTOM_JAX=0
 fi
 
 if [[ -z ${DEVICE} ]]; then
@@ -96,6 +106,11 @@ if [[ -z ${LIBTPU_GCS_PATH+x} ]] ; then
 else
   docker build --network host --build-arg MODE=${MODE} --build-arg JAX_VERSION=$JAX_VERSION --build-arg LIBTPU_GCS_PATH=$LIBTPU_GCS_PATH -f ./maxtext_dependencies.Dockerfile -t ${LOCAL_IMAGE_NAME} .
   docker build --network host --build-arg CUSTOM_LIBTPU=true -f ./maxtext_libtpu_path.Dockerfile -t ${LOCAL_IMAGE_NAME} .
+fi
+
+if [[ ${CUSTOM_JAX} -eq 1 ]] ; then
+  echo "Installing custom jax and jaxlib"
+  docker build --network host -f ./maxtext_custom_wheels.Dockerfile -t ${LOCAL_IMAGE_NAME} .
 fi
 
 echo ""

--- a/maxtext_custom_wheels.Dockerfile
+++ b/maxtext_custom_wheels.Dockerfile
@@ -1,0 +1,6 @@
+ARG BASEIMAGE=maxtext_base_image
+FROM $BASEIMAGE
+
+# Requires wheels be in /deps. This means any custom wheels should be placed
+# in the maxtext directory.
+RUN python3 -m pip install --force-reinstall /deps/*.whl


### PR DESCRIPTION
This mode is the same as nightly except that after nightly is installed, any file in `maxtext/*.whl` is forcefully reinstalled.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.