### PR TITLE
Change awk regex command to capture the coordinate address properly

### DIFF
--- a/gpu_multi_process_run.sh
+++ b/gpu_multi_process_run.sh
@@ -124,7 +124,7 @@ resolve_coordinator_ip() {
   echo "Coordinator Address $JAX_COORDINATOR_ADDRESS"
 
   while [[ "$coordinator_found" = false && $lookup_attempt -le $max_coordinator_lookups ]]; do
-    coordinator_ip_address=$(nslookup "$JAX_COORDINATOR_ADDRESS" 2>/dev/null | awk '/^Address: / { print $2 }' | head -n 1)
+    coordinator_ip_address=$(nslookup "$JAX_COORDINATOR_ADDRESS" 2>/dev/null | awk '/Address: / { print $2 }' | head -n 1)
     if [[ -n "$coordinator_ip_address" ]]; then
       coordinator_found=true
       echo "Coordinator IP address: $coordinator_ip_address"


### PR DESCRIPTION
# Description

While running A3+ benchmarking using XPK, I noted "Failed to recognize coordinator address" happening. Upon investigating, I noted that this regex is not capturing the address properly. An example log message looks like: 

```
Server: 34.118.224.10 Address: 34.118.224.10#53 ...
```
and the "Address" part is in the middle, rather than beginning, which is captured by `^`. Thus we need to remove this.



FIXES: b/381196280

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
