### PR TITLE
Support JAX_VERSION for nightly mode on GPU

### DIFF
--- a/docker_build_dependency_image.sh
+++ b/docker_build_dependency_image.sh
@@ -19,6 +19,8 @@
 # bash docker_build_dependency_image.sh DEVICE={{gpu|tpu}} MODE=stable_stack BASEIMAGE={{JAX_STABLE_STACK BASEIMAGE FROM ARTIFACT REGISTRY}}
 # bash docker_build_dependency_image.sh MODE=nightly
 # bash docker_build_dependency_image.sh MODE=stable JAX_VERSION=0.4.13
+# Nightly build with JAX_VERSION for GPUs. Available versions listed at https://storage.googleapis.com/jax-releases/jax_nightly_releases.html:
+# bash docker_build_dependency_image.sh DEVICE=gpu MODE=nightly JAX_VERSION=0.4.36.dev20241109 # Note: this sets both jax-nightly and jaxlib-nightly 
 
 # Enable "exit immediately if any command fails" option
 set -e


### PR DESCRIPTION
# Description

Allow users to pass in `JAX_VERSION` for nightly mode. This lets us select a specific nightly build for JAX, e.g. `JAX_VERSION=0.4.36.dev20241109` will use nightly versions of `jax` and `jaxlib` from 11/9/2024.

This currently only works for GPUs since the way we are installing nightly jaxlib for TPUs is a little different (and possibly outdated). But the same general pattern should also work for TPUs in the future.

# Tests

Successfully built a Docker image using `MODE=nightly` with `JAX_VERSION=0.4.36.dev20241109` and with `JAX_VERSION` unset

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
