### PR TITLE
Add new remat policy for save_dot_except_mlp with context

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -159,12 +159,14 @@ set_remat_policy_on_pipeline_iterations: True
 set_remat_policy_on_layers_per_stage: False
 
 
-# Choose 'remat_policy' between 'minimal', 'save_dot_except_mlpwi', 'save_dot_except_mlp', 'save_qkv_proj', 'qkv_proj_offloaded', 'custom' 'minimal_offloaded', 'save_out_proj' and 'full'.
+# Choose 'remat_policy' between 'minimal', 'save_dot_with_context_except_mlp', 'save_dot_except_mlpwi', 'save_dot_except_mlp',
+# 'save_qkv_proj', 'qkv_proj_offloaded', 'custom' 'minimal_offloaded', 'save_out_proj' and 'full'.
 # These options offer a trade-off between speed (fastest to slowest) and HBM usage (highest to lowest)
 remat_policy: 'full'
 # If custom_save_offload remat_policy is chosen, you can select tensors from the following list to offload on host memory, rematerialize or save on device memory.
 # Pick one of these options for following tensors: ['remat','device','offload']
 decoder_layer_input: 'device' # this tensor cannot be rematerialized - it serves as periodic checkpoints that act as the remat start points
+context: 'remat' # From https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/jax/attention.py#L581-L583
 mlpwi: 'remat'
 mlpwi_0: 'remat'
 mlpwi_1: 'remat'

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -302,6 +302,15 @@ class Decoder(nn.Module):
     if cfg.remat_policy != "none":
       if cfg.remat_policy == "minimal":
         policy = jax.checkpoint_policies.checkpoint_dots_with_no_batch_dims
+      elif cfg.remat_policy == "save_dot_with_context_except_mlp":
+        policy = jax.checkpoint_policies.save_only_these_names(
+            "query_proj",
+            "value_proj",
+            "key_proj",
+            "qkv_proj",
+            "context",
+            "out_proj",
+        )
       elif cfg.remat_policy == "save_dot_except_mlpwi":
         policy = jax.checkpoint_policies.save_only_these_names(
             "query_proj",

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -200,6 +200,7 @@ def validate_and_assign_remat_tensors(keys):
   # list of allowed tensors for custom remat policy
   tensors = [
       "decoder_layer_input",
+      "context",
       "mlpwi",
       "mlpwi_0",
       "mlpwi_1",


### PR DESCRIPTION
# Description

Add a remat option that uses save_dot_except_mlp while also saving context. Also add `context` as an option for custom remat policies. Went from 820 (save_dot_except_mlpwi) -> 879 TFLOPs/s/device using this remat policy on H200.

This change is needed to support reproducibility on the H200 workloads.

# Tests

- Ran successful training on both GPU and local TPU using this remat policy
- Ran successful training on local TPU using `context` with custom remat policy:
```
python3 MaxText/train.py MaxText/configs/base.yml \
        base_output_directory=gs://bvandermoon-multipod-maxtext \
        dataset_path=gs://max-datasets-rogue/ \
        steps=100 \
        per_device_batch_size=1 \
        dtype=bfloat16 \
        run_name=bvandermoon-10-1-2024-$RANDOM \
        remat_policy=custom \
        query_proj=device \
        value_proj=device \
        key_proj=device \
        qkv_proj=device \
        context=device \
        out_proj=device
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
