### PR TITLE
Add Dockerfile and entrypoint script for the maxengine-server image

### DIFF
--- a/inference/maxengine_server/Dockerfile
+++ b/inference/maxengine_server/Dockerfile
@@ -1,0 +1,46 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ubuntu:22.04
+# Use Ubuntu 22.04 from Docker Hub.
+# https://hub.docker.com/_/ubuntu/tags?page=1&name=22.04
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV MAXTEXT_VERSION=main
+
+RUN apt -y update && apt install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    python3.10 \
+    python3-pip
+
+RUN update-alternatives --install \
+    /usr/bin/python3 python3 /usr/bin/python3.10 1
+
+RUN git clone https://github.com/AI-Hypercomputer/maxtext.git && \
+git clone https://github.com/AI-Hypercomputer/JetStream.git
+
+RUN cd maxtext/ && \
+git checkout ${MAXTEXT_VERSION} && \
+bash setup.sh
+
+RUN cd /JetStream && \
+pip install -e .
+
+COPY maxengine_server_entrypoint.sh /usr/bin/
+
+RUN chmod +x /usr/bin/maxengine_server_entrypoint.sh
+
+ENTRYPOINT ["/usr/bin/maxengine_server_entrypoint.sh"]

--- a/inference/maxengine_server/README.md
+++ b/inference/maxengine_server/README.md
@@ -1,0 +1,14 @@
+## Build and upload Maxengine Server image
+
+These instructions are to build the Maxengine Server image, which calls an entrypoint script that invokes the [JetStream](https://github.com/AI-Hypercomputer/JetStream) inference server with the MaxText framework. 
+
+```
+docker build -t maxengine-server .
+docker tag maxengine-server us-docker.pkg.dev/${PROJECT_ID}/jetstream/maxengine-server:latest
+docker push us-docker.pkg.dev/${PROJECT_ID}/jetstream/maxengine-server:latest
+```
+
+If you would like to change the version of MaxText the image is built off of, change the `MAXTEXT_VERSION` environment variable:
+```
+ENV MAXTEXT_VERSION=<your desired commit hash, release, or tag>
+```

--- a/inference/maxengine_server/maxengine_server_entrypoint.sh
+++ b/inference/maxengine_server/maxengine_server_entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd /maxtext
+python3 MaxText/maxengine_server.py \
+MaxText/configs/base.yml $@


### PR DESCRIPTION
# Description

Adds a Dockerfile and entrypoint script to build the maxengine-server image for inference. This is to consolidate artifacts to build out the JetStream-MaxText artifact in the maxtext repository. Adding the Dockerfile here will help to build out our internal pipeline for model server image release, as right now, the components [here](https://github.com/GoogleCloudPlatform/ai-on-gke/tree/main/tutorials-and-examples/inference-servers/jetstream/maxtext/maxengine-server) are referenced as part of a tutorial. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
