### PR TITLE
Fix bug to suport non-2x max_target_length

### DIFF
--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -91,6 +91,16 @@ def validate_model_call_mode(s: str) -> None:
     raise ValueError(f"Invalid model call mode {s}. Valid options are {valid_model_call_modes}")
 
 
+def validate_prefill_and_target_lengths(max_prefill_length: int, max_target_length: int) -> None:
+  if max_prefill_length <= 0:
+    raise ValueError(f"Invalid max_prefill_predict_length {max_prefill_length}, it should be a positive number")
+  if max_target_length <= max_prefill_length:
+    raise ValueError(
+        f"Invalid max_target_length {max_target_length}, this should be sum of "
+        f"max_prefill_predict_length ({max_prefill_length}) and max output length expected."
+    )
+
+
 def validate_keys(keys):
   validate_attention_kernel(keys["attention"])
   validate_attention_type(keys["attention_type"])
@@ -98,6 +108,7 @@ def validate_keys(keys):
   validate_compute_axis_order(keys["compute_axis_order"])
   validate_kv_quant_axis(keys["kv_quant_axis"], keys["quantize_kvcache"])
   validate_model_call_mode(keys["model_call_mode"])
+  validate_prefill_and_target_lengths(keys["max_prefill_predict_length"], keys["max_target_length"])
 
   assert (keys["load_parameters_path"] == "" and keys["load_full_state_path"] == "") or keys[
       "enable_checkpointing"

--- a/MaxText/tests/moe_test.py
+++ b/MaxText/tests/moe_test.py
@@ -35,7 +35,7 @@ class TokenDroppingTest(unittest.TestCase):
         model_name="mixtral-8x7b",
         dtype="bfloat16",
         megablox=False,
-        max_target_length=4,
+        max_target_length=80,
         per_device_batch_size=1,
         capacity_factor=2,
     )


### PR DESCRIPTION
# Description

This PR fixes usecases where max_target_length is not equal to 2 times the max_prefill_length. For example, setting max_prefill_length = 1024 and max_target_length=3172 fails right now. With this PR, this usecase works fine. 

Also added a validation check in config to ensure max_target_length > max_prefill_length in pyconfigs.

# Tests
Manually ran inference benchmark to verify the fix
```
python MaxText/inference_microbenchmark.py MaxText/configs/base.yml tokenizer_path=assets/tokenizer.mistral-v3  model_name=mixtral-8x22b ici_fsdp_parallelism=1 ici_autoregressive_parallelism=1 ici_tensor_parallelism=-1 scan_layers=false weight_dtype=bfloat16 per_device_batch_size=1 attention=dot_product megablox=False capacity_factor=1 quantization=int8 quantize_kvcache=True checkpoint_is_quantized=True model_call_mode=inference  max_prefill_predict_length=1024 max_target_length=3172 
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
