### PR TITLE
Fix lib version mismatch between orbax and grain

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jax>=0.4.30
 jaxlib>=0.4.30
-orbax-checkpoint>=0.5.12
+orbax-checkpoint>=0.5.12,<0.10.3
 absl-py
 array-record
 aqtp


### PR DESCRIPTION
# Description
Found version mismatch between grain and orbax, which would be solved by downgrading `orbax-checkpoint` to 0.10.2. Added the corresponding version range in `requirements.txt` 

```
Traceback (most recent call last):  
File "/home/lizhiyu/maxtext/MaxText/maxengine_server.py", line 21, in <module>    import pyconfig  
File "/home/lizhiyu/maxtext/MaxText/pyconfig.py", line 27, in <module>    from layers.attentions import AttentionType  
File "/home/lizhiyu/maxtext/MaxText/layers/attentions.py", line 35, in <module>    from layers import linears  
File "/home/lizhiyu/maxtext/MaxText/layers/linears.py", line 35, in <module>    import max_utils  
File "/home/lizhiyu/maxtext/MaxText/max_utils.py", line 22, in <module>    import checkpointing  
File "/home/lizhiyu/maxtext/MaxText/checkpointing.py", line 23, in <module>    import grain.python as grain  
File "/home/lizhiyu/.local/lib/python3.10/site-packages/grain/python.py", line 36, in <module>    from ._src.python.checkpoint_handlers import PyGrainCheckpointHandler  
File "/home/lizhiyu/.local/lib/python3.10/site-packages/grain/_src/python/checkpoint_handlers.py", line 100, in <module>    class PyGrainCheckpointSave(ocp.args.CheckpointArgs):  
File "/home/lizhiyu/.local/lib/python3.10/site-packages/orbax/checkpoint/checkpoint_args.py", line 117, in decorator    handler_type_registry.register_handler_type(handler_cls)  
File "/home/lizhiyu/.local/lib/python3.10/site-packages/orbax/checkpoint/_src/handlers/handler_type_registry.py", line 71, in register_handler_type    _GLOBAL_HANDLER_TYPE_REGISTRY.add(handler_cls.typestr(), handler_cls)AttributeError: type object 'PyGrainCheckpointHandler' has no attribute 'typestr'
```
# Tests

Tested locally

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
