### PR TITLE
Print memory stats after start_step in train

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -1027,15 +1027,15 @@ def save_quantized_checkpoint_if_configured(config, params):
 
 
 def print_mem_stats(label: str):
-  print(f"\nMemstats: {label}:")
+  max_logging.log(f"\nMemstats: {label}:")
   try:
     for d in jax.local_devices():
       stats = d.memory_stats()
       used = round(stats["bytes_in_use"] / 2**30, 2)
       limit = round(stats["bytes_limit"] / 2**30, 2)
-      print(f"\tUsing (GB) {used} / {limit} ({used/limit:%}) on {d}")
+      max_logging.log(f"\tUsing (GB) {used} / {limit} ({used/limit:%}) on {d}")
   except (RuntimeError, KeyError, TypeError) as ex:
-    print(f"\tMemstats unavailable, error: {ex}")
+    max_logging.log(f"\tMemstats unavailable, error: {ex}")
 
 
 def print_system_information():

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -935,6 +935,9 @@ def train_loop(config, state=None):
         jax.block_until_ready(state)  # Block until current state finishes to end profile cleanly
       prof.deactivate()
 
+    if step == start_step:
+      max_utils.print_mem_stats("After params initialized")
+
   if checkpoint_manager is not None:
     checkpoint_manager.wait_until_finished()
   write_metrics(writer, local_metrics_file, running_gcs_metrics, metrics, config.steps - 1, config)  # final step metrics


### PR DESCRIPTION
# Description

Display the memory statistics (including percentages) for all utilized devices. In `max_utils.py`, replace `print` statements with `max_logging` to maintain consistency.

FIXES: b/385169408

# Tests

Ran tests on local v4-8 devbox and xpk workload on v5e-512 cluster.
<img width="561" alt="image" src="https://github.com/user-attachments/assets/ee0457fe-0a11-455b-ad82-2a9f133caa8e" />
![memstats](https://github.com/user-attachments/assets/4e7e4644-0d3b-4cee-bc90-d08914d6cc62)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
