### PR TITLE
Recommend using v5e instead of v4

### DIFF
--- a/getting_started/First_run.md
+++ b/getting_started/First_run.md
@@ -13,7 +13,7 @@ We recommend starting with a single host first and then moving to multihost.
 Local development is a convenient way to run MaxText on a single host. It doesn't scale to
 multiple hosts.
 
-1. [Create and SSH to the single-host VM of your choice.](https://cloud.google.com/tpu/docs/users-guide-tpu-vm#creating_a_cloud_tpu_vm_with_gcloud) We recommend a `v4-8`.
+1. [Create and SSH to the single-host VM of your choice.](https://cloud.google.com/tpu/docs/users-guide-tpu-vm#creating_a_cloud_tpu_vm_with_gcloud) We recommend a `v5litepod-8`.
 2. Clone MaxText onto that TPUVM.
 3. Within the root directory of that `git` repo, install dependencies and pre-commit hook by running:
 ```

--- a/getting_started/First_run.md
+++ b/getting_started/First_run.md
@@ -13,7 +13,7 @@ We recommend starting with a single host first and then moving to multihost.
 Local development is a convenient way to run MaxText on a single host. It doesn't scale to
 multiple hosts.
 
-1. [Create and SSH to the single-host VM of your choice.](https://cloud.google.com/tpu/docs/users-guide-tpu-vm#creating_a_cloud_tpu_vm_with_gcloud) We recommend a `v5litepod-8`.
+1. [Create and SSH to the single-host VM of your choice.](https://cloud.google.com/tpu/docs/users-guide-tpu-vm#creating_a_cloud_tpu_vm_with_gcloud). You can use any available single host TPU, such as `v5litepod-8`, `v5p-8` or `v4-8`.
 2. Clone MaxText onto that TPUVM.
 3. Within the root directory of that `git` repo, install dependencies and pre-commit hook by running:
 ```


### PR DESCRIPTION
# Description

I'm following the quickstart tutorial and the `v4-8` accelerator seems to be unavailable in most regions. I switched to `v5litepod-1` after a while. Now it works.

# Tests

I managed to complete the tutorial using v5litepod-1, 4 and 8, while v4 doesn't seem to work

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
