### PR TITLE
Add smaler v5e topologies to train_compile

### DIFF
--- a/MaxText/accelerator_to_spec_map.py
+++ b/MaxText/accelerator_to_spec_map.py
@@ -45,6 +45,9 @@ UserFacingNameToSystemCharacteristics = {
     "v6e-128": SystemCharacteristics("tpu", "v6e:8x16", "default", (2, 2, 1), 128, (False, True, False)),
     "v6e-256": SystemCharacteristics("tpu", "v6e:16x16", "default", (2, 2, 1), 256, (True, True, False)),
     # v5e: one core per chip with 16 GB HBM
+    "v5e-1": SystemCharacteristics("tpu", "v5e:1x1", "default", (1, 1, 1), 1, (False, False, False)),
+    "v5e-4": SystemCharacteristics("tpu", "v5e:2x2", "default", (2, 2, 1), 4, (False, False, False)),
+    "v5e-8": SystemCharacteristics("tpu", "v5e:2x4", "default", (2, 2, 1), 8, (False, False, False)),
     "v5e-16": SystemCharacteristics("tpu", "v5e:4x4", "default", (2, 2, 1), 16, (False, False, False)),
     "v5e-32": SystemCharacteristics("tpu", "v5e:4x8", "default", (2, 2, 1), 32, (False, False, False)),
     "v5e-64": SystemCharacteristics("tpu", "v5e:8x8", "default", (2, 2, 1), 64, (False, False, False)),
@@ -169,4 +172,9 @@ UserFacingNameToSystemCharacteristics = {
 
 
 def get_system_characteristics(user_facing_name):
-  return UserFacingNameToSystemCharacteristics.get(user_facing_name)
+  system_characteristics = UserFacingNameToSystemCharacteristics.get(user_facing_name)
+  if system_characteristics is None:
+    raise ValueError(
+        f"Invalid compile topology: {user_facing_name}. Valid topology names: {UserFacingNameToSystemCharacteristics.keys()}"
+    )
+  return system_characteristics

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -717,8 +717,10 @@ def calculate_global_batch_sizes(
 
 
 def get_num_target_devices(raw_keys):
-  compile_topology = accelerator_to_spec_map.get_system_characteristics(raw_keys.get("compile_topology", ""))
-  if compile_topology is not None:
+  # In AOT case compile_topology is set (e.g. is not the empty string), and we determine the
+  # number of devices from the compile_topology. In non-AOT settings we simply can use jax.devices().
+  if raw_keys.get("compile_topology"):
+    compile_topology = accelerator_to_spec_map.get_system_characteristics(raw_keys["compile_topology"])
     devices_per_slice = compile_topology.devices_per_slice
     return int(devices_per_slice * raw_keys["compile_topology_num_slices"])
   else:

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -852,6 +852,7 @@ def train_loop(config, state=None):
   last_step_completion = datetime.datetime.now()
   prof = profiler.Profiler(config)
   for step in np.arange(start_step, config.steps):
+    max_utils.print_mem_stats(f"step {step}")
     if step == first_profiling_step:
       if config.profile_cleanly:
         jax.block_until_ready(state)  # Block until previous state finishes to start profile cleanly


### PR DESCRIPTION
# Description

* Add smaller v5e-1 through v5e-8 topologies to train_compile
* Add nicer error message when user enters an invalid compile_topology string option

# Tests

Ran train_compile with compile_topology=v5e-8 (success) and v5-7 (expected error message)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
