### PR TITLE
Add option to dump hlo 

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -379,6 +379,17 @@ skip_first_n_steps_for_profiler: 1
 profiler_steps: 5
 profile_cleanly: True # If set to true, adds a block_until_ready on train state which aligns the profile for each step.
 
+# Dump HLO options
+dump_hlo: False
+dump_hlo_local_dir: "/tmp/xla_dump/"
+dump_hlo_delete_local_after: True # Cleans local directory after its uploaded
+dump_hlo_gcs_dir: "" # Defaults to {base_output_directory}/{run_name}/xla_dump
+dump_hlo_module_name: "jit_train_step" # Filter uploading modules by this string. Set to empty string to remove any filter.
+dump_hlo_xla_flags: "" # Defaults to "--xla_dump_to={dump_hlo_local_dir} --xla_dump_hlo_module_re={dump_hlo_module_name} --xla_dump_large_constants"
+dump_hlo_upload_all: False # If true all hosts dump HLO, false only jax.process_index()==0
+# All hosts should have identical HLO for SPMD programs, however we have encountered some bugs
+# where this is not the case and it is helpful to compare HLO across hosts.
+
 # When dropout is false the model is a deterministic function of the
 # data_shuffle_seed and init_weights_seed (i.e. reproducible losses)
 enable_dropout: True

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -344,6 +344,9 @@ class _HyperParameters:
     max_logging.log(f"Updating keys from model: {keys_from_model}")
     validate_no_keys_overwritten_twice(keys_from_env_and_command_line, keys_from_model)
 
+    # This must be invoked before initializing the backend
+    raw_keys = validate_and_set_hlo_dump_defaults(raw_keys)
+
     # We initialize the jax distributed system here because it must be done before device backend is initialized.
     if raw_keys["jax_debug_log_modules"]:
       jax.config.update("jax_debug_log_modules", raw_keys["jax_debug_log_modules"])
@@ -403,6 +406,8 @@ class _HyperParameters:
     raw_keys["mlp_dim"] = 2**mlp_dim_scale * raw_keys["base_mlp_dim"]
     raw_keys["num_decoder_layers"] = 2**layer_scale * raw_keys["base_num_decoder_layers"]
 
+    # This is the first command that initializes the backend - it calls
+    # jax.devices()
     (
         raw_keys["global_batch_size_to_load"],
         raw_keys["global_batch_size_to_train_on"],
@@ -509,6 +514,26 @@ def create_parallelisms_list(raw_keys):
   ]
   raw_keys["ici_parallelism"] = ici_parallelism
   raw_keys["dcn_parallelism"] = dcn_parallelism
+  return raw_keys
+
+
+def validate_and_set_hlo_dump_defaults(raw_keys):
+  if not raw_keys["dump_hlo"]:
+    return raw_keys
+  if os.environ.get("XLA_FLAGS") and raw_keys["dump_hlo_xla_flags"]:
+    raise ValueError("You must set either XLA_FLAGS or dump_hlo_xla_flags to dump HLO, but not both.")
+  if not os.environ.get("XLA_FLAGS") and not raw_keys["dump_hlo_xla_flags"]:
+    raw_keys["dump_hlo_xla_flags"] = f"--xla_dump_to={raw_keys['dump_hlo_local_dir']} --xla_dump_large_constants"
+    if raw_keys["dump_hlo_module_name"]:
+      raw_keys["dump_hlo_xla_flags"] = (
+          f"{raw_keys['dump_hlo_xla_flags']} --xla_dump_hlo_module_re={raw_keys['dump_hlo_module_name']}"
+      )
+  if not raw_keys["dump_hlo_gcs_dir"]:
+    raw_keys["dump_hlo_gcs_dir"] = os.path.join(raw_keys["base_output_directory"], raw_keys["run_name"], "xla_dump")
+  else:
+    raw_keys["dump_hlo_gcs_dir"] = max_utils.add_trailing_slash(raw_keys["dump_hlo_gcs_dir"])
+  if not os.environ.get("XLA_FLAGS"):
+    os.environ["XLA_FLAGS"] = raw_keys["dump_hlo_xla_flags"]
   return raw_keys
 
 

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -886,6 +886,16 @@ def train_loop(config, state=None):
 
     write_metrics(writer, local_metrics_file, running_gcs_metrics, metrics, step, config)
 
+    if config.dump_hlo and step == start_step:
+      jax.block_until_ready(state)  # Ensure compilation has finished.
+      max_utils.upload_dump(
+          config.dump_hlo_local_dir,
+          config.dump_hlo_gcs_dir,
+          module_name=config.dump_hlo_module_name,
+          delete_local_after=config.dump_hlo_delete_local_after,
+          all_host_upload=config.dump_hlo_upload_all,
+      )
+
     if config.eval_interval > 0 and step > start_step and (step + 1) % config.eval_interval == 0:
       assert eval_data_iterator
       cumulative_eval_metrics = {
@@ -956,8 +966,8 @@ def main(argv: Sequence[str]) -> None:
   if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
     os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
   pyconfig.initialize(argv)
-  max_utils.print_system_information()
   config = pyconfig.config
+  max_utils.print_system_information()
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path
   vertex_tensorboard_manager = VertexTensorboardManager()

--- a/MaxText/train_compile.py
+++ b/MaxText/train_compile.py
@@ -183,6 +183,16 @@ def main(argv: Sequence[str]) -> None:
   print(f"Cost analysis: {compiled.cost_analysis()}")
   print(f"Memory analysis: {compiled.memory_analysis()}")
 
+  # Dump HLO if requested
+  if config.dump_hlo:
+    max_utils.upload_dump(
+        config.dump_hlo_local_dir,
+        config.dump_hlo_gcs_dir,
+        module_name=config.dump_hlo_module_name,
+        delete_local_after=config.dump_hlo_delete_local_after,
+        all_host_upload=config.dump_hlo_upload_all,
+    )
+
 
 if __name__ == "__main__":
   app.run(main)


### PR DESCRIPTION
# Description

* Add option to Dump HLO in MaxText
* This uploads soon after compilation for both train.py and train_compile, which is beneficial as compared to using --debug-dump-gcs on XPK which uploads only at the job end (which will never happen if the job hangs).
* This does have the drawback of assuming a GCS endpoint for the dump location, some code modification is required for arbitrary endpoints

# Tests

Ran a few manual tests of train.py different dump options on both local devbox and on a larger XPK job, as well as some local train_compile tests.
We can modify our hybrid sim flow to use this so it will be covered in e2e test. It is hard to test locally because
1) it is not hermetic - depending on the state of the jax cache and gcs buckets
2) The XLA flags does not play nicely with pytest, I think only one backend will be set with an intial set of XLA flags, we cannot use different flags in different tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
