### PR TITLE
Better save message for async checkpoint saving

### DIFF
--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -112,6 +112,13 @@ def create_orbax_emergency_checkpoint_manager(
   return emergency_mngr
 
 
+def print_save_message(step, async_checkpointing):
+  if async_checkpointing:
+    max_logging.log(f"Started an asynchronous checkpoint save for step {step}")
+  else:
+    max_logging.log(f"Saved a checkpoint at step {step}.")
+
+
 def _find_idx(array: np.ndarray, replica_axis_idx: int):
   """Returns the index along given dimension that the current host belongs to."""
   idx = None

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -877,7 +877,7 @@ def train_loop(config, state=None):
     if checkpoint_manager is not None:
       state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]
       if save_checkpoint(checkpoint_manager, int(step), state_to_save, config.dataset_type, data_iterator, config):
-        max_logging.log(f"saved a checkpoint at step {step}")
+        checkpointing.print_save_message(step, config.async_checkpointing)
 
       # Upon preemption, exit when and only when all ongoing saves are complete.
       if checkpoint_manager.reached_preemption(step):


### PR DESCRIPTION
# Description

Add a more accurate logging message for saving a checkpoint with an async checkpointer
Before: saved a checkpoint at step {step}
After: Started an asynchronous checkpoint save for step {step}

# Tests

* Ran with an async checkpointer, saw expected message
* Ran with a sync checkpointer, saw expected message

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
