### PR TITLE
Pylint for forks, some condition as unit tests

### DIFF
--- a/.github/workflows/CPUTests.yml
+++ b/.github/workflows/CPUTests.yml
@@ -1,9 +1,9 @@
 name: Linter
 
 on:
+  pull_request:
   push:
-    branches:
-      - '**'
+    branches: [ "main" ]
 
 jobs:
   cpu:


### PR DESCRIPTION
# Description

Modifies the pylint check conditions to be the same as for the unit tests. Previously forks (such as PRs from external contributors), would skip the pylint check, thus some code could be submitted that does not pass our pylint and had to be fixed after being submitted. This should fix this case - now the pylint will run on these PRs and block submit, giving the PR author a nice message run "bash code_style.sh" to fix pylint.

Previously: Only for branch pushes, any branch
Proposed: For any pull request and only pushes to main branch

# Tests

This is how we we currently run our unit tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
