### PR TITLE
Improve build caching for GPU build

### DIFF
--- a/maxtext_gpu_dependencies.Dockerfile
+++ b/maxtext_gpu_dependencies.Dockerfile
@@ -38,12 +38,13 @@ RUN mkdir -p /deps
 # Set the working directory in the container
 WORKDIR /deps
 
-# Copy all files from local workspace into docker container
-COPY . .
-RUN ls .
+# Copy setup files and dependency files separately for better caching
+COPY setup.sh ./
+COPY constraints_gpu.txt requirements.txt requirements_with_jax_stable_stack.txt ./
 
+# Install dependencies - these steps are cached unless the copied files change
 RUN echo "Running command: bash setup.sh MODE=$ENV_MODE JAX_VERSION=$ENV_JAX_VERSION DEVICE=${ENV_DEVICE}"
 RUN --mount=type=cache,target=/root/.cache/pip bash setup.sh MODE=${ENV_MODE} JAX_VERSION=${ENV_JAX_VERSION} DEVICE=${ENV_DEVICE}
 
-
-WORKDIR /deps
+# Now copy the remaining code (source files that may change frequently)
+COPY . .


### PR DESCRIPTION
Small improvement to caching for MaxText GPU builds. This reduces PR test time from ~24min to ~14min.

Before:

<img width="1696" alt="Screenshot 2024-12-28 at 7 52 59 PM" src="https://github.com/user-attachments/assets/0e62e237-69bd-47ff-ad3c-8126f5b6ee96" />

After:

<img width="1705" alt="Screenshot 2024-12-30 at 7 28 33 PM" src="https://github.com/user-attachments/assets/ff134ce9-ffbd-41b7-8ca3-cfa9dc3fbe5f" />


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
