### PR TITLE
Remove memory stat spam

### DIFF
--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -852,7 +852,6 @@ def train_loop(config, state=None):
   last_step_completion = datetime.datetime.now()
   prof = profiler.Profiler(config)
   for step in np.arange(start_step, config.steps):
-    max_utils.print_mem_stats(f"step {step}")
     if step == first_profiling_step:
       if config.profile_cleanly:
         jax.block_until_ready(state)  # Block until previous state finishes to start profile cleanly


### PR DESCRIPTION
# Description

Remove mem stat spam from every step, it should be identical for each step after the params have been initialized


Prior:
```
Memstats: step 0:
        Using (GB) 3.09 / 30.75 (10.048780%) on TPU_0(process=0,(0,0,0,0))
        Using (GB) 3.09 / 30.75 (10.048780%) on TPU_1(process=0,(1,0,0,0))
        Using (GB) 3.09 / 30.75 (10.048780%) on TPU_2(process=0,(0,1,0,0))
        Using (GB) 3.09 / 30.75 (10.048780%) on TPU_3(process=0,(1,1,0,0))

Memstats: After params initialized:
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_0(process=0,(0,0,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_1(process=0,(1,0,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_2(process=0,(0,1,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_3(process=0,(1,1,0,0))

Memstats: step 1:
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_0(process=0,(0,0,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_1(process=0,(1,0,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_2(process=0,(0,1,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_3(process=0,(1,1,0,0))
completed step: 0, seconds: 5.096, TFLOP/s/device: 33.940, Tokens/s/device: 4823.045, total_weights: 79694, loss: 10.869
To see full metrics 'tensorboard --logdir=gs://maxtext-experiments-multipod/mattdavidow-train-base/tensorboard/'

Memstats: step 2:
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_0(process=0,(0,0,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_1(process=0,(1,0,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_2(process=0,(0,1,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_3(process=0,(1,1,0,0))
completed step: 1, seconds: 1.178, TFLOP/s/device: 146.763, Tokens/s/device: 20855.964, total_weights: 79045, loss: 9.679

Memstats: step 3:
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_0(process=0,(0,0,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_1(process=0,(1,0,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_2(process=0,(0,1,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_3(process=0,(1,1,0,0))
```
        
        After
```
        
Memstats: After params initialized:
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_0(process=0,(0,0,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_1(process=0,(1,0,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_2(process=0,(0,1,0,0))
        Using (GB) 3.12 / 30.75 (10.146341%) on TPU_3(process=0,(1,1,0,0))
completed step: 0, seconds: 4.885, TFLOP/s/device: 35.403, Tokens/s/device: 5031.002, total_weights: 79694, loss: 10.869
To see full metrics 'tensorboard --logdir=gs://maxtext-experiments-multipod/mattdavidow-train-base/tensorboard/'
completed step: 1, seconds: 1.179, TFLOP/s/device: 146.701, Tokens/s/device: 20847.047, total_weights: 79045, loss: 9.679
completed step: 2, seconds: 0.218, TFLOP/s/device: 794.657, Tokens/s/device: 112925.608, total_weights: 79307, loss: 9.567
completed step: 3, seconds: 0.966, TFLOP/s/device: 179.009, Tokens/s/device: 25438.334, total_weights: 80116, loss: 9.135
completed step: 4, seconds: 1.172, TFLOP/s/device: 147.521, Tokens/s/device: 20963.702, total_weights: 78709, loss: 9.071
```
# Tests

Ran a smoke train command and confirmed only printing mem stats once after param initialization.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
