### PR TITLE
Copy assets in runner_image separately 

### DIFF
--- a/maxtext_runner.Dockerfile
+++ b/maxtext_runner.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1.7-labs
+
 ARG BASEIMAGE=maxtext_base_image
 FROM $BASEIMAGE
 
@@ -6,7 +8,11 @@ FROM $BASEIMAGE
 # Set the working directory in the container
 WORKDIR /deps
 
-# Copy all files from local workspace into docker container
-COPY . .
+# Copy assets separately 
+COPY assets/ .
+COPY MaxText/test_assets/ MaxText/.
+
+# Copy all files except assets from local workspace into docker container
+COPY --exclude=assets --exclude=MaxText/test_assets . .
 
 WORKDIR /deps


### PR DESCRIPTION
# Description

Copy assets to runner image separately for better caching. 

- This reduces upload time of docker image from 42s to 5s. 

FIXES: b/383179757

# Tests

Tested locally using `bash docker_upload_runner.sh CLOUD_IMAGE_NAME=${USER}-${RANDOM}`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
