### PR TITLE
Router Sharding optimization

### DIFF
--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -68,7 +68,7 @@ class Gpt3LayerNorm(nn.Module):
   epsilon: float = 1e-6
   dtype: Any = jnp.float32
   weight_dtype: Any = jnp.float32
-  kernel_axes: Tuple[str, ...] = ()
+  kernel_axes: Tuple[Optional[str], ...] = ()
   scale_init: Initializer = nn.initializers.zeros
   use_bias: bool = True
   reductions_in_fp32: bool = False

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -55,13 +55,6 @@ DISPATCH = "dispatch"
 COMBINE = "combine"
 
 
-def _get_model_call_mode(config):
-  if config.model_cal_mode == "inference":
-    return "inference"
-  else:
-    return None
-
-
 def _convert_to_activation_function(fn_or_string: Union[str, Callable[..., Any]]) -> Callable[..., Any]:
   """Convert a string to an activation function."""
   if fn_or_string == "linear":
@@ -107,7 +100,7 @@ class DenseGeneral(nn.Module):
   weight_dtype: DType = jnp.float32
   dtype: DType = jnp.float32
   kernel_init: NdInitializer = nd_dense_init(1.0, "fan_in", "truncated_normal")
-  kernel_axes: Tuple[str, ...] = ()
+  kernel_axes: Tuple[Optional[str], ...] = ()
   quant: Optional[Quant] = None
   use_bias: bool = False
   matmul_precision: str = "default"
@@ -309,7 +302,7 @@ class MoeBlock(nn.Module):
   num_experts_per_tok: int
   mesh: Mesh
   kernel_init: NdInitializer
-  kernel_axes: Tuple[str, ...]
+  kernel_axes: Tuple[Optional[str], ...]
   weight_dtype: DType = jnp.float32
   dtype: DType = jnp.float32
   quant: Optional[Quant] = None
@@ -597,7 +590,8 @@ class MoeBlock(nn.Module):
     return kernel
 
   def dense_matmul(self, inputs, gate_logits, w0_kernel, w1_kernel, wo_kernel):
-    gate_logits = nn.with_logical_constraint(gate_logits, ("activation_batch", "activation_length", "activation_embed"))
+    # gate_logits: batch, length, expert
+    gate_logits = nn.with_logical_constraint(gate_logits, ("activation_batch", "activation_length", None))
     softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
     # shape of top_k_weights & top_k_indices: (batch, sequence, num_experts_per_tok)
     top_k_weights, top_k_indices = jax.lax.top_k(softmax_probs, self.num_experts_per_tok)
@@ -609,7 +603,10 @@ class MoeBlock(nn.Module):
       mask_axes = ("activation_batch", "activation_length", None, None)
       dispatch_mask = nn.with_logical_constraint(dispatch_mask, mask_axes)
       combine_mask = nn.with_logical_constraint(combine_mask, mask_axes)
-      loss = self.load_balance_loss(top_k_indices, softmax_probs)
+      if self.config.model_call_mode != "inference":
+        loss = self.load_balance_loss(top_k_indices, softmax_probs)
+      else:
+        loss = None
       inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_length", "activation_embed"))
       with jax.named_scope("dispatch"):
         dispatch = self.get_einsum(rhs_mesh_axes=mask_axes, einsum_name=DISPATCH)(

--- a/MaxText/layers/mistral.py
+++ b/MaxText/layers/mistral.py
@@ -135,7 +135,7 @@ class MistralDecoderLayer(nn.Module):
           num_experts_per_tok=cfg.num_experts_per_tok,
           mesh=mesh,
           kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
-          kernel_axes=("embed", "mlp"),
+          kernel_axes=("embed", None),
           dtype=cfg.dtype,
           weight_dtype=cfg.weight_dtype,
           quant=self.quant,

--- a/MaxText/layers/normalizations.py
+++ b/MaxText/layers/normalizations.py
@@ -14,7 +14,7 @@
 
 """Normalization Layers."""
 
-from typing import Any, Tuple
+from typing import Any, Tuple, Optional
 
 from flax import linen as nn
 from jax import lax
@@ -30,7 +30,7 @@ class RMSNorm(nn.Module):
   epsilon: float = 1e-6
   dtype: Any = jnp.float32
   weight_dtype: Any = jnp.float32
-  kernel_axes: Tuple[str, ...] = ()
+  kernel_axes: Tuple[Optional[str], ...] = ()
   scale_init: Initializer = nn.initializers.ones
 
   @nn.compact


### PR DESCRIPTION
# Description
Following the guide from the core ml performance team, add router sharding optimization for inferencing 11.20% gain in prefill (1024 length) step or 9.8% improvement throughputs.

Key intuition: change from pre matmul all-gather to a post matmul one, much smaller in size. The costs in HBM is almost negectable after replicating the small router_projection weight. 
* in router projection: router_logits = self.router_logits(router_input)
* without this change: all gather **router_input** with the communication int8[batch, seq_len, embed] or int8[1, 1024, 768]
* with this change: all gather **router_logits** instead, a much smaller tensor with the communication bf16[batch, seq_len, num_expert] or bf16[1, 1024, 8]
* Replicate router_projection weight [embed, num_expert] is trivial since the weight is usually smaller than the other mlp weight [embed, mlp] by an order of magnitude.

Performance in training:
It should improve MoE training if we use tensor parallelism as well. However, usually we use either FSDP or expert parallelism. The performance is the same, verified in real experiments.

# Tests
Tested in both inferencing and training. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
