### PR TITLE
Add option to profile periodically

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -386,6 +386,9 @@ skip_first_n_steps_for_profiler: 1
 # Profile for a small number of steps to avoid a large profile file size.
 profiler_steps: 5
 profile_cleanly: True # If set to true, adds a block_until_ready on train state which aligns the profile for each step.
+profile_periodically_period: -1 # If set to a positive integer, profile every profile_periodically_period steps.
+# This is useful to debug scenarios where performance is changing.
+
 
 # Dump HLO options
 dump_hlo: False

--- a/MaxText/inference_microbenchmark.py
+++ b/MaxText/inference_microbenchmark.py
@@ -84,8 +84,8 @@ def prefill_insert_benchmark_loop(
     config, engine, decode_state, params, total_slots, tokens, true_length, iters, profile_name
 ):
   """Inner loop for benchmarking prefill and insert step."""
-  prof = profiler.Profiler(config, profile_name)
-  prof.activate()
+  prof = profiler.Profiler(config)
+  prof.activate(optional_postfix=profile_name)
   start = datetime.datetime.now()
   rng = jax.random.PRNGKey(1234)
   for i in range(iters):
@@ -121,8 +121,8 @@ def prefill_insert_benchmark(config, engine, decode_state, params, total_slots, 
 
 def ar_benchmark_loop(config, engine, params, decode_state, iters, profile_name):
   """Inner loop for benchmarking ar step."""
-  prof = profiler.Profiler(config, profile_name)
-  prof.activate()
+  prof = profiler.Profiler(config)
+  prof.activate(optional_postfix=profile_name)
   start = datetime.datetime.now()
   rng = jax.random.PRNGKey(1234)
   for _ in range(iters):

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -85,6 +85,17 @@ def validate_profiler_type(s: str) -> None:
     raise ValueError("Invalid profiler type was passed. Valid options ", valid_profiler_types)
 
 
+def validate_periodic_profiler(profiler, profile_periodically_period, profiler_steps):
+  if profile_periodically_period <= 0:
+    return
+  if not profiler:
+    raise ValueError("Periodic profiler requested but no profiler was set, set it via profiler=xplane or profiler=nsys")
+  if profile_periodically_period < profiler_steps:
+    raise ValueError(
+        f"You must set the profile_periodically_period {profile_periodically_period} at least as long profiler_steps {profiler_steps}."
+    )
+
+
 def validate_model_call_mode(s: str) -> None:
   valid_model_call_modes = ("", "inference")
   if s not in valid_model_call_modes:  # currently supported attention
@@ -106,6 +117,7 @@ def validate_keys(keys):
   validate_attention_kernel(keys["attention"])
   validate_attention_type(keys["attention_type"])
   validate_profiler_type(keys["profiler"])
+  validate_periodic_profiler(keys["profiler"], keys["profile_periodically_period"], keys["profiler_steps"])
   validate_compute_axis_order(keys["compute_axis_order"])
   validate_kv_quant_axis(keys["kv_quant_axis"], keys["quantize_kvcache"])
   validate_model_call_mode(keys["model_call_mode"])


### PR DESCRIPTION
# Description

Add an option to collect a profile periodically, every N steps. This can help debug scenarios where performance is variable over time

This also cleans up the existing profiler_test file, which actually had dead code that was not being tested (the code was not functioning and did not have the @pytest labels)


FIXES: b/387539222


# Tests
Included some unit tests, and confirmed that running only a regular profile and also period profile works as expected on my single host dev machine.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
