### PR TITLE
Fix typo in trillium llama2-70b script 

### DIFF
--- a/MaxText/configs/trillium/llama2_7b_4096.sh
+++ b/MaxText/configs/trillium/llama2_7b_4096.sh
@@ -1,4 +1,4 @@
-# Llama2-70b model.
+# Llama2-7b model.
 # This config will work out of the box for any number of trillium-256 slices.
 #
 # Command Flags:
@@ -7,7 +7,7 @@
 # RUN_NAME (Required, unless run_name is already set in base.yml or running with XPK/GKE)
 #
 # Example to invoke this script:
-# bash MaxText/configs/trillium/llama2_70b_4096.sh RUN_NAME="<your_run_name>" OUTPUT_PATH="gs://<your_output_path>" DATASET_PATH="gs://<your_dataset_path>"
+# bash MaxText/configs/trillium/llama2_7b_4096.sh RUN_NAME="<your_run_name>" OUTPUT_PATH="gs://<your_output_path>" DATASET_PATH="gs://<your_dataset_path>"
 #
 
 


### PR DESCRIPTION
# Description

Fix typo in Trillium llama2-70b script. Changed 70b to 7b. 

# Tests

This script is used for regression testing in XLML. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.