### PR TITLE
Fix bug in processing mixed precision quantization config

### DIFF
--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -153,6 +153,8 @@ class AqtQuantization:
     rhs_axis_metadata_wrapper = self._get_rhs_axis_metadata_wrapper(
         mesh_axes, is_tiled, replicate_scale=self.replicate_scale
     )
+    # module_path = "/".join(nn.module._context.module_stack[-1].path)
+    # print(f"quant_dg: {quant_dg}, is_tiled: {is_tiled}, module_path: {module_path}")
     aqt_dg_cls = functools.partial(
         aqt_flax.AqtDotGeneral,
         quant_dg,
@@ -247,7 +249,9 @@ def _get_mixed_precision_quant_config(mixed_precision_config):
   ret_config = {}
   default_mp_config = _get_default_mp_config(default=mixed_precision_config.get(DEFAULT, None))
   for layer_name_re, layer_quantization_config in mixed_precision_config.items():
-    quant_config = default_mp_config
+    # Make a copy of default_mp_config to avoid updaing original dict
+    quant_config = default_mp_config.copy()
+    # print(f"Mixed precision config: processing {layer_name_re} - {layer_quantization_config}, default config - {quant_config}")
     if layer_name_re != DEFAULT:
       for k in quant_config.keys():
         quant_config[k] = layer_quantization_config.get(k, default_mp_config[k])

--- a/MaxText/tests/quantizations_test.py
+++ b/MaxText/tests/quantizations_test.py
@@ -27,6 +27,7 @@ from aqt.jax.v2 import aqt_tensor
 from aqt.jax.v2 import calibration
 
 _QUERY_REGEX = ".*/query"
+_VALUE_REGEX = ".*/value"
 
 
 class QuantTestModule(nn.Module):
@@ -146,6 +147,11 @@ class QuantizationTest(unittest.TestCase):
     self.assertEqual(quant_cfg.fwd.dg_quantizer.lhs.numerics.bits, 8)
     self.assertEqual(quant_cfg.fwd.dg_quantizer.rhs.numerics.bits, 4)
     self.assertEqual(tile_size, 128)
+
+    quant_cfg, tile_size = quant.quant_dg[_VALUE_REGEX]
+    self.assertEqual(quant_cfg.fwd.dg_quantizer.lhs.numerics.bits, 8)
+    self.assertEqual(quant_cfg.fwd.dg_quantizer.rhs.numerics.bits, 4)
+    self.assertEqual(tile_size, -1)
 
   def test_remove_quantized_params(self):
     _params = {


### PR DESCRIPTION
# Description
Mixed precision quantization errors out due to incorrect processing of config file (b/375050000). This PR fixed the issue.



# Tests
Manually run
`python MaxText/decode.py MaxText/configs/base.yml tokenizer_path=assets/tokenizer.mistral-v1  max_prefill_predict_length=1024 max_target_length=2048 model_name=mixtral-8x7b ici_fsdp_parallelism=1 ici_autoregressive_parallelism=1 ici_tensor_parallelism=-1 scan_layers=false weight_dtype=bfloat16 per_device_batch_size=18 attention=dot_product megablox=False capacity_factor=1 quantization=intmp quant_cfg_path=/home/vipannalla_google_com/configs/int4_weight_only.json quantize_kvcache=True checkpoint_is_quantized=True compute_axis_order=0,2,1,3 ar_cache_axis_order=0,2,1,3 load_parameters_path=gs://vipannalla-bkt/checkpoints/quantized/mixtral-8x7b-instruct/int4w/12-20-2024 model_call_mode=inference`

Quantization config used: 
```
{
  "__default__": {"w_bits": 8, "a_bits": 8, "w_scale": 1.0, "a_scale": 1.0, "tile_size": -1},
  ".*/query": {"w_bits": 4, "tile_size": 256},
  ".*/key": {"w_bits": 4, "tile_size": 256},
  ".*/value": {"w_bits": 4, "tile_size": 256},
  ".*/out": {"w_bits": 4},
  ".*/gate": {"w_bits": 4},
  ".*/wi_0": {"w_bits": 4},
  ".*/wi_1": {"w_bits": 4},
  ".*/wo": {"w_bits": 4}
}
```
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
