### PR TITLE
Update max target length check

### DIFF
--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -94,7 +94,8 @@ def validate_model_call_mode(s: str) -> None:
 def validate_prefill_and_target_lengths(max_prefill_length: int, max_target_length: int) -> None:
   if max_prefill_length <= 0:
     raise ValueError(f"Invalid max_prefill_predict_length {max_prefill_length}, it should be a positive number")
-  if max_target_length <= max_prefill_length:
+  if max_target_length < max_prefill_length:
+    # valid max_target_length = max_prefill_length for existing logit checks
     raise ValueError(
         f"Invalid max_target_length {max_target_length}, this should be sum of "
         f"max_prefill_predict_length ({max_prefill_length}) and max output length expected."


### PR DESCRIPTION
# Description

Update max target length check:
- Allow max_target_length = max_prefill_length to valid forward check unit tests. In this case, we could reuse all existing model test assets (which is the same length of prefill).
- This is to simply code changes and test assets update for existing models

# Tests
- before the change with error `ValueError: Invalid max_target_length 11, this should be sum of max_prefill_predict_length (11) and max output length expected` (one [example](https://screenshot.googleplex.com/BWG98mZNvMiYAUt))
- test locally: [link](https://paste.googleplex.com/4959563628150784)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
