### PR TITLE
Update orbax-checkpoint pin to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jax>=0.4.30
 jaxlib>=0.4.30
-orbax-checkpoint>=0.5.12,<0.10.3
+orbax-checkpoint>=0.5.12
 absl-py
 array-record
 aqtp


### PR DESCRIPTION
# Description

Remove orbax-checkpoint pin to use the latest for nightly tests.

FIXES: b/388236310


# Tests

Github actions tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
