### PR TITLE
Feature/gcp workload monitoring

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -460,9 +460,9 @@ goodput_upload_interval_seconds: 60
 enable_pathways_goodput: False
 
 # GCP workload monitoring
-report_heartbeat_metric_for_gcp_monitoring: True
+report_heartbeat_metric_for_gcp_monitoring: False
 heartbeat_reporting_interval_in_seconds: 5
-report_performance_metric_for_gcp_monitoring: True
+report_performance_metric_for_gcp_monitoring: False
 
 # Vertex AI Tensorboard Configurations - https://github.com/google/maxtext/tree/main/getting_started/Use_Vertex_AI_Tensorboard.md
 # Set to True for GCE, False if running via XPK

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -459,6 +459,9 @@ monitor_goodput: True
 goodput_upload_interval_seconds: 60
 enable_pathways_goodput: False
 
+# GCP workload monitoring
+report_heartbeat_metric_for_gcp_monitoring: False
+
 # Vertex AI Tensorboard Configurations - https://github.com/google/maxtext/tree/main/getting_started/Use_Vertex_AI_Tensorboard.md
 # Set to True for GCE, False if running via XPK
 use_vertex_tensorboard: False

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -460,7 +460,9 @@ goodput_upload_interval_seconds: 60
 enable_pathways_goodput: False
 
 # GCP workload monitoring
-report_heartbeat_metric_for_gcp_monitoring: False
+report_heartbeat_metric_for_gcp_monitoring: True
+heartbeat_reporting_interval_in_seconds: 5
+report_performance_metric_for_gcp_monitoring: True
 
 # Vertex AI Tensorboard Configurations - https://github.com/google/maxtext/tree/main/getting_started/Use_Vertex_AI_Tensorboard.md
 # Set to True for GCE, False if running via XPK

--- a/MaxText/monitoring/gcp_workload_monitor.py
+++ b/MaxText/monitoring/gcp_workload_monitor.py
@@ -1,0 +1,123 @@
+import datetime
+import os
+import time
+
+import max_logging
+import requests  # type: ignore[pyi-error]
+import jax
+
+from google.api import metric_pb2, monitored_resource_pb2
+from google.api_core.exceptions import GoogleAPIError
+from google.cloud import monitoring_v3
+from urllib3.util.retry import Retry
+
+
+_METADATA_SERVER_URL = "http://metadata.google.internal/computeMetadata/v1/"
+_METADATA_HEADERS = {"Metadata-Flavor": "Google"}
+
+
+def report_heartbeat_thread(stop_event):
+  timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%f")
+  zone = get_node_zone()
+  workload_id = os.getenv("JOB_NAME", f"maxtext-llama2-tpu-{timestamp}")
+  local_rank = os.getenv("LOCAL_RANK", "0")
+  global_rank = jax.process_index()
+  project_id = get_gcp_project_id()
+  while not stop_event.is_set():
+    report_heartbeat(workload_id, local_rank, str(global_rank), project_id, zone)
+    time.sleep(5)
+
+
+def report_heartbeat(workload_id: str, local_rank: str, global_rank: str, project_id: str, zone: str):
+  try:
+    now = time.time()
+    seconds = int(now)
+    nanos = int((now - seconds) * 10**9)
+
+    # Create a TimeSeries object for the heartbeat metric
+    series = monitoring_v3.TimeSeries(
+        metric=metric_pb2.Metric(
+            type="compute.googleapis.com/workload_process/heartbeat",
+            labels={
+                # TODO : "gpu_index" for now due to legacy reasons. To be renamed to "local_rank" when schema ready
+                "gpu_index": local_rank,
+                "instance_id": _get_gcp_metadata(category="instance", attribute="id"),
+            },
+        ),
+        resource=monitored_resource_pb2.MonitoredResource(
+            type="compute.googleapis.com/WorkloadProcess",
+            labels={
+                "project_id": project_id,
+                "location": zone,
+                "workload_id": workload_id,
+                "replica_id": "0",
+                "process_id": global_rank,
+            },
+        ),
+        points=[
+            monitoring_v3.Point(
+                interval=monitoring_v3.TimeInterval(end_time={"seconds": seconds, "nanos": nanos}),
+                value=monitoring_v3.TypedValue(bool_value=True),
+            ),
+        ],
+    )
+
+    # Send data to Google Cloud Monitoring
+    client = monitoring_v3.MetricServiceClient()
+    client.create_time_series(
+        request={"name": f"projects/{project_id}", "time_series": [series]},
+        timeout=30,
+    )
+    max_logging.log("Heartbeat metric successfully sent to GCP.")
+  except GoogleAPIError as e:
+    max_logging.log(f"Failed to send heartbeat to GCP: {e}")
+  except Exception as e:
+    max_logging.log(f"Unexpected error while sending heartbeat to GCP: {e}")
+
+
+def _get_gcp_metadata(category, attribute, timeout=5, retries=3):
+  """
+  Fetch the specified attribute from GCP metadata server.
+
+  Args:
+    category (str): The high-level metadata category (ex: 'instance', 'project').
+    attribute (str): The attribute to fetch under this category (ex: 'id', 'zone').
+    timeout (int): Timeout for the request in seconds.
+    retries (int): Number of retry attempts for transient failures.
+
+  Returns:
+    str: The metadata value as a string, or None if the request fails.
+  """
+  target_url = f"{_METADATA_SERVER_URL}{category}/{attribute}"
+
+  session = requests.Session()
+  retry_strategy = Retry(
+      total=retries,
+      backoff_factor=0.5,
+      # Retry on the following status codes
+      status_forcelist=[429, 500, 502, 503, 504],
+  )
+  adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
+  session.mount("http://", adapter)
+
+  try:
+    response = session.get(target_url, headers=_METADATA_HEADERS, timeout=timeout)
+    response.raise_for_status()
+    return response.text
+  except requests.exceptions.RequestException as e:
+    max_logging.log(f"Failed to retrieve metadata for {category}/{attribute}: {e}")
+    return None
+
+
+def get_gcp_project_id():
+  """Returns the project id of the current GCP project."""
+  return _get_gcp_metadata("project", "project-id")
+
+
+def get_node_zone():
+  """Returns the zone of the GCE instance."""
+  zone_path = _get_gcp_metadata("instance", "zone")
+  if zone_path is None:
+    return None
+  # example zone_path: "projects/123456789/zones/us-central1-a"
+  return zone_path.rsplit("/", 1)[-1]

--- a/MaxText/monitoring/gcp_workload_monitor.py
+++ b/MaxText/monitoring/gcp_workload_monitor.py
@@ -1,6 +1,8 @@
 import datetime
 import os
 import time
+import queue
+import threading
 
 import max_logging
 import requests  # type: ignore[pyi-error]
@@ -16,66 +18,146 @@ _METADATA_SERVER_URL = "http://metadata.google.internal/computeMetadata/v1/"
 _METADATA_HEADERS = {"Metadata-Flavor": "Google"}
 
 
-def report_heartbeat_thread(stop_event):
-  timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%f")
-  zone = get_node_zone()
-  workload_id = os.getenv("JOB_NAME", f"maxtext-llama2-tpu-{timestamp}")
-  local_rank = os.getenv("LOCAL_RANK", "0")
-  global_rank = jax.process_index()
-  project_id = get_gcp_project_id()
-  while not stop_event.is_set():
-    report_heartbeat(workload_id, local_rank, str(global_rank), project_id, zone)
-    time.sleep(5)
+class GCPWorkloadMonitor:
+  """Interface for reporting metrics to GCP for monitoring."""
+
+  def __init__(self, run_name: str):
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%f")
+    self.workload_id = f"{run_name if run_name else 'maxtext-unnamed'}-{timestamp}"
+    self.zone = get_node_zone()
+    self.project_id = get_gcp_project_id()
+    self.client = monitoring_v3.MetricServiceClient()
+    self.heartbeat_reporting_started = False
+    self.performance_reporting_started = False
+    self.termination_event = threading.Event()
+
+  def __del__(self):
+    self.termination_event.set()
+
+  def start_heartbeat_reporting_thread(self, interval: int):
+    """Starts a thread that reports heartbeat every {interval} seconds until termination event is set."""
+    if self.heartbeat_reporting_started:
+      raise RuntimeError("Heartbeat reporting thread already started")
+    max_logging.log("Starting background thread for reporting heartbeat for workload observability")
+    self.heartbeat_reporting_started = True
+    t = threading.Thread(target=self._report_heartbeat_thread, args=(interval,))
+    t.daemon = True
+    t.start()
+
+  def start_performance_reporting_thread(self, metrics_queue: queue.Queue):
+    """Starts a thread that reports performance metric sent to metrics_queue until termination event is set."""
+    if self.performance_reporting_started:
+      raise RuntimeError("Performance reporting thread already started")
+    max_logging.log("Starting background thread for reporting performance for workload observability")
+    self.performance_reporting_started = True
+    t = threading.Thread(target=self._report_performance_thread, args=(metrics_queue,))
+    t.daemon = True
+    t.start()
+
+  def _report_heartbeat_thread(self, interval: int):
+    """Reports heartbeat metric to GCP every {interval} seconds until termination event is set."""
+    local_rank = os.getenv("LOCAL_RANK", "0")
+    global_rank = jax.process_index()
+    while not self.termination_event.is_set():
+      self._report_heartbeat(local_rank, str(global_rank))
+      time.sleep(interval)
+
+  def _report_performance_thread(self, metrics_queue: queue.Queue):
+    """Reports performance metric to GCP whenever new metric arrives at the metrics_queue until termination event is set."""
+    while not self.termination_event.is_set():
+      try:
+        # adding a timeout of 1s to ensure we don't block indefinitely and miss the stop event
+        performance_metric = metrics_queue.get(timeout=1)
+        self._report_performance(performance_metric)
+      except queue.Empty:
+        continue
+
+  def _report_heartbeat(self, local_rank: str, global_rank: str):
+    """Reports heartbeat metric for the process specified by the given local rank & global rank."""
+    try:
+      now = time.time()
+      seconds = int(now)
+      nanos = int((now - seconds) * 10**9)
+
+      # Create a TimeSeries object for the heartbeat metric
+      series = monitoring_v3.TimeSeries(
+          metric=metric_pb2.Metric(
+              type="compute.googleapis.com/workload_process/heartbeat",
+              labels={
+                  "local_rank": local_rank,
+                  "instance_id": _get_gcp_metadata(category="instance", attribute="id"),
+              },
+          ),
+          resource=monitored_resource_pb2.MonitoredResource(
+              type="compute.googleapis.com/WorkloadProcess",
+              labels={
+                  "project_id": self.project_id,
+                  "location": self.zone,
+                  "workload_id": self.workload_id,
+                  "replica_id": "0",
+                  "process_id": global_rank,
+              },
+          ),
+          points=[
+              monitoring_v3.Point(
+                  interval=monitoring_v3.TimeInterval(end_time={"seconds": seconds, "nanos": nanos}),
+                  value=monitoring_v3.TypedValue(bool_value=True),
+              ),
+          ],
+      )
+
+      # Send data to Google Cloud Monitoring
+      self.client.create_time_series(
+          request={"name": f"projects/{self.project_id}", "time_series": [series]},
+          timeout=30,
+      )
+      max_logging.log("Heartbeat metric successfully sent to GCP.")
+    except GoogleAPIError as e:
+      max_logging.log(f"Failed to send heartbeat to GCP: {e}")
+    except Exception as e:
+      max_logging.log(f"Unexpected error while sending heartbeat to GCP: {e}")
+
+  def _report_performance(self, performance_metric):
+    """Reports performance metric to GCP."""
+    try:
+      now = time.time()
+      seconds = int(now)
+      nanos = int((now - seconds) * 10**9)
+
+      # Create a TimeSeries object for the performance metric
+      series = monitoring_v3.TimeSeries(
+          metric=metric_pb2.Metric(
+              type="compute.googleapis.com/workload/performance",
+          ),
+          resource=monitored_resource_pb2.MonitoredResource(
+              type="compute.googleapis.com/Workload",
+              labels={
+                  "location": self.zone,
+                  "workload_id": self.workload_id,
+                  "replica_id": "0",
+              },
+          ),
+          points=[
+              monitoring_v3.Point(
+                  interval=monitoring_v3.TimeInterval(end_time={"seconds": seconds, "nanos": nanos}),
+                  value=monitoring_v3.TypedValue(double_value=performance_metric),
+              ),
+          ],
+      )
+
+      # Send data to Google Cloud Monitoring
+      self.client.create_time_series(
+          request={"name": f"projects/{self.project_id}", "time_series": [series]},
+          timeout=30,
+      )
+      max_logging.log("Performance metric successfully sent to GCP.")
+    except GoogleAPIError as e:
+      max_logging.log(f"Failed to send performance to GCP: {e}")
+    except Exception as e:
+      max_logging.log(f"Unexpected error while sending performance to GCP: {e}")
 
 
-def report_heartbeat(workload_id: str, local_rank: str, global_rank: str, project_id: str, zone: str):
-  try:
-    now = time.time()
-    seconds = int(now)
-    nanos = int((now - seconds) * 10**9)
-
-    # Create a TimeSeries object for the heartbeat metric
-    series = monitoring_v3.TimeSeries(
-        metric=metric_pb2.Metric(
-            type="compute.googleapis.com/workload_process/heartbeat",
-            labels={
-                # TODO : "gpu_index" for now due to legacy reasons. To be renamed to "local_rank" when schema ready
-                "gpu_index": local_rank,
-                "instance_id": _get_gcp_metadata(category="instance", attribute="id"),
-            },
-        ),
-        resource=monitored_resource_pb2.MonitoredResource(
-            type="compute.googleapis.com/WorkloadProcess",
-            labels={
-                "project_id": project_id,
-                "location": zone,
-                "workload_id": workload_id,
-                "replica_id": "0",
-                "process_id": global_rank,
-            },
-        ),
-        points=[
-            monitoring_v3.Point(
-                interval=monitoring_v3.TimeInterval(end_time={"seconds": seconds, "nanos": nanos}),
-                value=monitoring_v3.TypedValue(bool_value=True),
-            ),
-        ],
-    )
-
-    # Send data to Google Cloud Monitoring
-    client = monitoring_v3.MetricServiceClient()
-    client.create_time_series(
-        request={"name": f"projects/{project_id}", "time_series": [series]},
-        timeout=30,
-    )
-    max_logging.log("Heartbeat metric successfully sent to GCP.")
-  except GoogleAPIError as e:
-    max_logging.log(f"Failed to send heartbeat to GCP: {e}")
-  except Exception as e:
-    max_logging.log(f"Unexpected error while sending heartbeat to GCP: {e}")
-
-
-def _get_gcp_metadata(category, attribute, timeout=5, retries=3):
+def _get_gcp_metadata(category: str, attribute: str, timeout=5, retries=3):
   """
   Fetch the specified attribute from GCP metadata server.
 
@@ -117,7 +199,5 @@ def get_gcp_project_id():
 def get_node_zone():
   """Returns the zone of the GCE instance."""
   zone_path = _get_gcp_metadata("instance", "zone")
-  if zone_path is None:
-    return None
   # example zone_path: "projects/123456789/zones/us-central1-a"
-  return zone_path.rsplit("/", 1)[-1]
+  return zone_path.rsplit("/", 1)[-1] if zone_path else None

--- a/getting_started/GCP_Workload_Monitoring.md
+++ b/getting_started/GCP_Workload_Monitoring.md
@@ -1,0 +1,26 @@
+# Enable GCP Workload Monitoring
+This guide provides an overview on how to enable GCP workload monitoring for your MaxText workload.
+
+## Overview
+Google offers a monitoring and alerting feature that is well suited for critical MaxText workloads sensitive to infrastructure changes.
+Once enabled, metrics will be automatically sent to [Cloud Monarch](https://research.google/pubs/monarch-googles-planet-scale-in-memory-time-series-database/) for monitoring.
+If a metric hits its pre-defined threshold, the Google Cloud on-call team will be alerted to see if any action is needed. 
+
+The feature currently supports heartbeat and performance (training step time in seconds) metrics. In the near future, support for the goodput metric will also be added.
+Users should work with their Customer Engineer (CE) and the Google team to define appropriate thresholds for the performance metrics.
+
+This guide layouts how to enable the feature for your MaxText workload.
+
+## Enabling GCP Workload Monitoring
+User can control which metric they want to report via config:
+
+### Heartbeat metric 
+- This metric will be a boolean flag.
+- To turn on this metric, set `report_heartbeat_metric_for_gcp_monitoring` to `True`
+- To control the frequency of heartbeat reporting (default is every 5 seconds), set `heartbeat_reporting_interval_in_seconds` to your desired value.
+
+### Performance metric
+- This metric will be a double, capturing the training step time in seconds.
+- To turn on this metric, set `report_performance_metric_for_gcp_monitoring` to `True`
+
+For an example, please refer to [base.yml](../MaxText/configs/base.yml).

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ datasets
 gcsfs
 google-cloud-aiplatform==1.61.0
 google-cloud-storage
+google-cloud-monitoring
+google-api-core
+google-api-python-client
 grain-nightly
 flax>=0.8.0
 ml-collections


### PR DESCRIPTION
# Description

Add option to enable GCP workload monitoring for MaxText workloads. 

- GCP workload monitoring sends performance metrics (heartbeat & training step times) to cloud monarch for monitoring such that if a metric hits its pre-defined threshold, oncalls will be notified to see if any actions are needed. This is ideal for critical workloads sensitive to infrastructure changes. 
- Each metric can be configured to be on or off based on configs. Examples are included in `MaxText/configs/base.yml`
- Documentation can be found at `getting_started/GCP_Workload_Monitoring.md`

# Tests

Tested on trillium TPU and confirmed metrics sent to cloud monarch successfully if configs are enabled. No metrics will be sent to cloud monarch if configs are set to False.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
