### PR TITLE
Add mixtral-8x7B offline inference script

### DIFF
--- a/MaxText/inference_mlperf/README.md
+++ b/MaxText/inference_mlperf/README.md
@@ -1,7 +1,7 @@
-## Run offline performance benchmarks.
+# Run offline performance benchmarks.
 
 
-### Create TPU VM.
+## Create TPU VM.
 Follow these [instructions](https://cloud.google.com/tpu/docs/v5e-inference#tpu-vm) to create TPU v5e-8 VM and ssh into the VM
 
 
@@ -14,21 +14,36 @@ source .env/bin/activate
 ```
 sudo apt-get install python3-dev
 sudo apt-get install build-essential -y
-git clone https://github.com/mlcommons/inference.git
+git clone git@github.com:mlcommons/inference.git
 cd inference/
 cd loadgen/ && pip install .
 ```
 
 ### Download datasets
+
 ```
 export DATA_DISK_DIR=~/loadgen_run_data
 mkdir -p ${DATA_DISK_DIR}
 cd ${DATA_DISK_DIR}
+```
+
+#### LLama2-70b:
+
+```
 gsutil cp gs://cloud-tpu-inference-public/mlcommons/inference/language/llama2-70b/data/processed-openorca/open_orca_gpt4_tokenized_llama.calibration_1000.pkl .
 mv open_orca_gpt4_tokenized_llama.calibration_1000.pkl processed-calibration-data.pkl
 
 gsutil cp gs://cloud-tpu-inference-public/mlcommons/inference/language/llama2-70b/data/processed-openorca/open_orca_gpt4_tokenized_llama.sampled_24576.pkl .
 mv open_orca_gpt4_tokenized_llama.sampled_24576.pkl processed-data.pkl
+```
+
+#### Mixtral-8x7b:
+```
+wget https://inference.mlcommons-storage.org/mixtral_8x7b%2F2024.06.06_mixtral_15k_calibration_v4.pkl .
+mv mixtral_8x7b%2F2024.06.06_mixtral_15k_calibration_v4.pkl mixtral-processed-calibration-data.pkl
+
+wget https://inference.mlcommons-storage.org/mixtral_8x7b/09292024_mixtral_15k_mintoken2_v1.pkl .
+mv 09292024_mixtral_15k_mintoken2_v1.pkl mixtral-processed-data.pkl
 ```
 
 ### Install Maxtext 
@@ -42,11 +57,17 @@ pip install -r MaxText/inference_mlperf/requirements.txt
 
 ### Generate quantized checkpoint
 
+* Download HF checkpoints and convert to Maxtext/Orbax format:
+#### LLama2-70b:
 Steps to get a quantized llama2-70B checkpoint for v5e-8
 
 Note llama2-70B model takes about 140G of memory and will not fit into a v5e-8. It must be downloaded onto a large machine (such as v5p-8) and quantized to a smaller quantized checkpoint to be loaded onto a v5e-8 machine.
 
 * Obtain a llama2-70b checkpoint and convert it to a maxtext inference checkpoint. Please follow maxtext instructions specified here: https://github.com/google/maxtext/blob/main/getting_started/Run_Llama2.md
+
+#### Mixtral-8x7b:
+Run the mixtral-8x7B script to generate a new bf16 checkpoint - https://github.com/AI-Hypercomputer/maxtext/blob/main/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
+For example, here is a bf16 checkpoint generaed by the script -- "gs://ml-auto-solutions/output/multipod/maxtext/chained_tests_mixtral-8x7b_stable-2024-09-15-04-01-09/unscanned_ckpt/checkpoints/0/items"
 
 * Convert the checkpoint into a quantized checkpoint
 
@@ -70,6 +91,9 @@ cd maxtext && \
 python MaxText/decode.py MaxText/configs/base.yml tokenizer_path=${TOKENIZER_PATH} load_parameters_path=${LOAD_PARAMS_PATH} max_prefill_predict_length=1024 max_target_length=2048 model_name=llama2-70b ici_fsdp_parallelism=1 ici_autoregressive_parallelism=1 ici_tensor_parallelism=-1 scan_layers=false weight_dtype=bfloat16 per_device_batch_size=11 attention=dot_product quantization=int8 save_quantized_params_path=${SAVE_QUANT_PARAMS_PATH}
 ```
 
+
+
+
 Your checkpoint is generated at `$SAVE_QUANT_PARAMS_PATH`. This is used to set `load_parameters_path` param below in `MAXENGINE_ARGS` env variable. 
 
 ### HuggingFace login
@@ -79,6 +103,7 @@ huggingface-cli login --token $HUGGING_FACE_TOKEN
 ```
 
 ### Offline Server - Test Run
+#### LLama2-70b:
 ```
 cd ~/maxtext/MaxText/inference_mlperf
 export TOKENIZER_PATH="/home/${USER}/maxtext/assets/tokenizer.llama2
@@ -86,6 +111,15 @@ export BATCH_AND_PREFILL_LEN="1024,20"
 export MAXENGINE_ARGS="model_name=llama2-70b tokenizer_path=${TOKENIZER_PATH}  quantization=int8 quantize_kvcache=True load_parameters_path=${SAVE_QUANT_PARAMS_PATH} checkpoint_is_quantized=True"
 
 bash ./llama_offline_run.sh -p -t
+```
+#### Mixtral-8x7b:
+```
+cd ~/maxtext/MaxText/inference_mlperf
+export TOKENIZER_PATH="/home/${USER}/maxtext/assets/tokenizer.mistral-v1
+export BATCH_AND_PREFILL_LEN="2048,18"
+export MAXENGINE_ARGS="model_name=mixtral-8x7b tokenizer_path=${TOKENIZER_PATH}  quantization=int8 quantize_kvcache=True load_parameters_path=${SAVE_QUANT_PARAMS_PATH} checkpoint_is_quantized=True megablox=False capacity_factor=1 model_call_mode=inference"
+
+bash ./mixtral_offline_run.sh -p -t
 ```
 
 ### Offline Benchmarks
@@ -97,27 +131,46 @@ export MAXENGINE_ARGS="model_name=llama2-70b tokenizer_path=${TOKENIZER_PATH}  q
 ```
 
 #### For v6
+#### LLama2-70b:
 ```
 export BATCH_AND_PREFILL_LEN=“256,216|512,108|1024,54”
 export MAXENGINE_ARGS="model_name=llama2-70b tokenizer_path=${TOKENIZER_PATH}  quantization=int8 quantize_kvcache=True load_parameters_path=${SAVE_QUANT_PARAMS_PATH} checkpoint_is_quantized=True compute_axis_order=0,2,1,3 ar_cache_axis_order=0,2,1,3"
 ```
+#### Mixtral-8x7b:
+export BATCH_AND_PREFILL_LEN="256,144|512,72|2048,18"
+export MAXENGINE_ARGS="model_name=mixtral-8x7b tokenizer_path=${TOKENIZER_PATH}  quantization=int8 quantize_kvcache=True load_parameters_path=${SAVE_QUANT_PARAMS_PATH} checkpoint_is_quantized=True megablox=False capacity_factor=1 model_call_mode=inference compute_axis_order=0,2,1,3 ar_cache_axis_order=0,2,1,3"
 
 #### Run offline performance benchmark
-
+#### LLama2-70b:
 ```
 bash ./llama_offline_run.sh -p
 ```
+#### Mixtral-8x7b:
+```
+bash ./mixtral_offline_run.sh -p
+```
 
 #### Run offline accuracy benchmark
+#### LLama2-70b:
 ```
 bash ./llama_offline_run.sh -a
 ```
+#### Mixtral-8x7b:
+```
+bash ./mixtral_offline_run.sh -a
+```
 
 #### Run offline audit benchmark
+#### LLama2-70b:
 ```
 bash ./llama_offline_run.sh -d
 
 ```
+#### Mixtral-8x7b:
+```
+bash ./mixtral_offline_run.sh -d
+```
+
 
 ### Profiling
 

--- a/MaxText/inference_mlperf/mixtral_offline_run.sh
+++ b/MaxText/inference_mlperf/mixtral_offline_run.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+# Example:
+# bash mixtral_offline_run.sh -r test_int8_kv_216-108-54  -n
+
+# enable profiling using -p option and capture using
+# tensorboard --logdir /tmp/tensorboard/
+
+run_name="test_int8_kv_bs_216-108-54"
+dry_run=false
+skip_warmup=false
+test_run=false
+enable_profiler=false
+performance=true
+audit=false
+accuracy=false
+fast_eval=false
+
+for arg in "$@"; do
+  case $arg in
+    -n) dry_run=true ;;
+    -t) test_run=true ;;
+    -s) skip_warmup=true ;;
+    -p) enable_profiler=true ;;
+    -d) audit=true ;;
+    -a) accuracy=true ;;
+    -f) fast_eval=true ;;
+    -r=*|--run=*) run_name="${arg#*=}" ;;
+    -r|--run)
+      shift
+      run_name="$1"
+      ;;
+  esac
+  shift
+done
+
+
+if "$dry_run"; then
+    cmd=echo
+else
+    cmd=''
+fi
+
+SKIP_WARMUP_OPTION=""
+if "$skip_warmup"; then
+    SKIP_WARMUP_OPTION="--skip_warmup"
+fi
+
+PROFILER_OPTION=""
+if "$enable_profiler"; then
+    PROFILER_OPTION="--enable_profile"
+fi
+
+if [ -z "$TOKENIZER_PATH" ]; then
+  TOKENIZER_PATH=/home/${USER}/maxtext/assets/tokenizer.mistral-v1
+fi
+
+BATCH_STR=""
+if [ -z "$BATCH_AND_PREFILL_LEN" ];
+then
+  BATCH_AND_PREFILL_LEN="256,144|512,72|2048,18"
+fi
+
+if [ -z "$TOK_OUTLEN_MULTIPLIER" ];
+then
+  TOK_OUTLEN_MULTIPLIER="2.5"
+fi
+
+if [ -z "$MAXENGINE_ARGS" ];
+then
+  CHECKPOINT="gs://vipannalla-bkt/checkpoints/quantized/mixtral-8x7b-instruct/11-06-24"
+  BASE_CFG="model_name=mixtral-8x7b tokenizer_path=${TOKENIZER_PATH} load_parameters_path=${CHECKPOINT}"
+  QUANT_CFG="quantization=int8 quantize_kvcache=True checkpoint_is_quantized=True"
+  LAYOUT_CFG="compute_axis_order=0,2,1,3 ar_cache_axis_order=0,2,1,3"
+  MOE_CFG="megablox=False capacity_factor=1 model_call_mode=inference"
+  MAXENGINE_ARGS="${BASE_CFG} ${QUANT_CFG} ${LAYOUT_CFG} ${MOE_CFG}"
+fi
+
+if [ -z "$BASEDIR" ];
+then
+  BASEDIR=/home/${USER}/inference
+fi
+
+if [ -z "$DATA_DISK_DIR" ];
+then
+  DATA_DISK_DIR=/home/${USER}/loadgen_run_data
+fi
+
+export LOADGEN_RUN_TIMESTAMP=$(TZ=America/Los_Angeles date +%Y%m%d%H%M%S%Z)
+export API_URL=0.0.0.0:9000
+if "$test_run"; then
+  export DATASET_TYPE=test
+  export DATASET_PATH=${DATA_DISK_DIR}/mixtral-processed-data.pkl
+  export TOTAL_SAMPLE_COUNT=100
+  export USER_CONFIG=user${TOTAL_SAMPLE_COUNT}.conf
+else
+  export DATASET_TYPE=full
+  export DATASET_PATH=${DATA_DISK_DIR}/mixtral-processed-data.pkl
+  export TOTAL_SAMPLE_COUNT=15000
+  export USER_CONFIG=user.conf
+fi
+
+# LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
+# makes subsequent runs faster
+export JAX_COMPILATION_CACHE_DIR="/tmp/jax_cache2"
+export LIBTPU_INIT_ARGS="--xla_tpu_enable_windowed_einsum_for_reduce_scatter=false --xla_jf_spmd_threshold_for_windowed_einsum_mib=1000000"
+
+run_loadgen() {
+  OUTPUT_LOG_ID=mixtral-8x7b-${run_name}-${DATASET_TYPE}-${LOADGEN_RUN_TYPE}-${LOADGEN_RUN_TYPE}_${LOADGEN_RUN_TIMESTAMP}
+  OUTPUT_LOG_DIR=${DATA_DISK_DIR}/logs/${OUTPUT_LOG_ID}
+  mkdir -p ${OUTPUT_LOG_DIR} && cp ${USER_CONFIG} ${OUTPUT_LOG_DIR}
+  OUTPUT_ACCURACY_JSON_PATH=${OUTPUT_LOG_DIR}/mlperf_log_accuracy.json
+  MIXTRAL_COLS_RENAME="{\"tok_input_len\": \"tok_input_length\", \"tok_ref_output_len\": \"tok_output_length\"}"
+
+  echo "LOADGEN_RUN_TIMESTAMP: ${LOADGEN_RUN_TIMESTAMP}"
+  echo "DATASET_PATH: ${DATASET_PATH}"
+  echo "TOTAL_SAMPLE_COUNT: ${TOTAL_SAMPLE_COUNT}"
+  echo "OUTPUT_LOG_DIR: ${OUTPUT_LOG_DIR}"
+  echo "USER_CONFIG: ${USER_CONFIG}"
+  echo "BATCH_AND_PREFILL_LEN: ${BATCH_AND_PREFILL_LEN}"
+  echo "MAXENGINE_ARGS: ${MAXENGINE_ARGS}"
+
+  ${cmd} python -m offline_mode \
+    --mlperf_test_mode=${TEST_MODE} \
+    --input_mode tokenized \
+    --output_mode tokenized \
+    --mlperf_conf $BASEDIR/mlperf.conf \
+    --user_conf ${USER_CONFIG} \
+    --audit_conf ${AUDIT_CONF}  \
+    --total_sample_count ${TOTAL_SAMPLE_COUNT} \
+    --dataset_path ${DATASET_PATH} \
+    --prefill_lengths_and_batch_sizes ${BATCH_AND_PREFILL_LEN} \
+    --maxengine_args "${MAXENGINE_ARGS}" \
+    --output_log_dir ${OUTPUT_LOG_DIR} \
+    --tok_outlen_multiplier ${TOK_OUTLEN_MULTIPLIER} \
+    --rename_dataset_cols "${MIXTRAL_COLS_RENAME}" \
+    ${SKIP_WARMUP_OPTION} ${PROFILER_OPTION} 2>&1 | tee ${OUTPUT_LOG_DIR}/${LOADGEN_RUN_TYPE}_log.log
+}
+
+run_loadgen_performance () {
+  LOADGEN_RUN_TYPE=offline-performance
+  TEST_MODE="performance"
+  AUDIT_CONF="no_audit"
+  run_loadgen
+}
+
+run_loadgen_audit () {
+  LOADGEN_RUN_TYPE=offline-audit
+  TEST_MODE="performance"
+  AUDIT_CONF="$BASEDIR/compliance/nvidia/TEST06/audit.config"
+  run_loadgen
+}
+
+# TODO: currently only checks Q&A and Math samples and fails on CodeGen. Will fix that in future PR.
+run_loadgen_accuracy () {
+  LOADGEN_RUN_TYPE=offline-accuracy
+  TEST_MODE="accuracy"
+  AUDIT_CONF="no_audit"
+  run_loadgen
+
+  # Eval Run
+  if [ -e ${OUTPUT_ACCURACY_JSON_PATH} ]; then
+    if [ "${FAST_EVAL:-false}" = "true" ] || "$fast_eval"; then
+      EVAL_SCRIPT="evaluate-accuracy-fast.py"
+    else
+      EVAL_SCRIPT="evaluate-accuracy.py"
+    fi
+    
+    ${CMD} python3 ${EVAL_SCRIPT} \
+      --tokenizer-path ${TOKENIZER_PATH} \
+      --mlperf-accuracy-file ${OUTPUT_ACCURACY_JSON_PATH} \
+      --dataset-file ${DATASET_PATH} 2>&1 | tee ${OUTPUT_LOG_DIR}/evaluate_offline_accuracy_log.log
+  fi
+}
+
+performance=true
+if "$audit"; then
+  performance=false
+  echo
+  echo "Starting loadgen audit"
+  run_loadgen_audit
+fi
+
+if "$accuracy"; then
+  performance=false
+  echo
+  echo "Starting loadgen accuracy"
+  run_loadgen_accuracy
+fi
+
+if "$performance"; then
+  echo
+  echo "Starting loadgen performance run"
+  run_loadgen_performance
+fi

--- a/MaxText/inference_mlperf/user.conf
+++ b/MaxText/inference_mlperf/user.conf
@@ -5,6 +5,7 @@
 
 # Set performance_sample_count for each model.
 llama2-70b.*.performance_sample_count_override = 24576
+mixtral-8x7b.*.performance_sample_count_override = 15000
 *.Offline.min_duration = 600000
 
 
@@ -13,6 +14,7 @@ llama2-70b.*.performance_sample_count_override = 24576
 # than 24576 we limit the min_query_count to 24576 and otherwise we use
 # the dataset size as the limit
 llama2-70b.Offline.min_query_count = 24576
+mixtral-8x7b.Offline.min_query_count = 15000
 
 # These fields should be defined and overridden by user.conf.
 *.Offline.target_qps = 5.0

--- a/MaxText/inference_mlperf/user100.conf
+++ b/MaxText/inference_mlperf/user100.conf
@@ -6,6 +6,7 @@
 # Set performance_sample_count for each model.
 #llama2-70b.*.performance_sample_count_override = 24576
 llama2-70b.*.performance_sample_count_override = 100
+mixtral-8x7b.*.performance_sample_count_override = 100
 #*.Offline.min_duration = 600000
 *.Offline.min_duration = 60
 
@@ -16,6 +17,7 @@ llama2-70b.*.performance_sample_count_override = 100
 # the dataset size as the limit
 #llama2-70b.Offline.min_query_count = 24576
 llama2-70b.Offline.min_query_count = 100
+mixtral-8x7b.Offline.min_query_count = 100
 
 
 # These fields should be defined and overridden by user.conf.

--- a/MaxText/inference_mlperf/user5000.conf
+++ b/MaxText/inference_mlperf/user5000.conf
@@ -6,6 +6,7 @@
 # Set performance_sample_count for each model.
 #llama2-70b.*.performance_sample_count_override = 24576
 llama2-70b.*.performance_sample_count_override = 5000
+mixtral-8x7b.*.performance_sample_count_override = 5000
 #*.Offline.min_duration = 600000
 *.Offline.min_duration = 600
 
@@ -16,6 +17,7 @@ llama2-70b.*.performance_sample_count_override = 5000
 # the dataset size as the limit
 #llama2-70b.Offline.min_query_count = 24576
 llama2-70b.Offline.min_query_count = 5000
+mixtral-8x7b.Offline.min_query_count = 5000
 
 
 # These fields should be defined and overridden by user.conf.


### PR DESCRIPTION
Adding MLperf offline benchmarking script for Mixtral-8x7b, similar to LLama2-70b one. There are still some TODOs and need couple more iterations to get it to final state, but this PR is already too big. Let me land this first and build on top.

# Tests
Test run: ./mixtral_offline_run.sh -t -p
Full run: ./mixtral_offline_run.sh -p
Accuracy: ./mixtral_offline_run.sh -a (Only Rouge scores work right now, need to fix Math and CodeGen evaluation).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
