### PR TITLE
Disable memstats printing on Pathways when unavailable

### DIFF
--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -963,12 +963,13 @@ def train_loop(config, state=None):
     # pytype: disable=attribute-error
     compiled = p_train_step.lower(state, example_batch, nextrng).compile()
     compiled_stats = compiled.memory_analysis()
-    max_logging.log(
-        f"Output size: {compiled_stats.output_size_in_bytes}, "
-        f"temp size: {compiled_stats.temp_size_in_bytes}, "
-        f"argument size: {compiled_stats.argument_size_in_bytes}, "
-        f"host temp size: {compiled_stats.host_temp_size_in_bytes}, in bytes."
-    )
+    if compiled_stats is not None:
+      max_logging.log(
+          f"Output size: {compiled_stats.output_size_in_bytes}, "
+          f"temp size: {compiled_stats.temp_size_in_bytes}, "
+          f"argument size: {compiled_stats.argument_size_in_bytes}, "
+          f"host temp size: {compiled_stats.host_temp_size_in_bytes}, in bytes."
+      )
   return state
 
 


### PR DESCRIPTION
# Description

This PR prevents errors on Pathways by conditionally skipping memstats printing when they're unavailable. This addresses the issue of
```
AttributeError: 'NoneType' object has no attribute 'output_size_in_bytes'
```

FIXES: [b/388837290](https://buganizer.corp.google.com/issues/388837290)

# Tests

Tested by assigning `compiled_stats=None`, confirming that the logging message is skipped when memstats are unavailable.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
