### PR TITLE
Recover, rename and move the test_profiler.py to end_to_end

### DIFF
--- a/end_to_end/test_profiler.py
+++ b/end_to_end/test_profiler.py
@@ -1,0 +1,80 @@
+"""
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Profiler tests for TPUs."""
+import glob
+import json
+import os
+import unittest
+
+from tensorboard_plugin_profile.convert import raw_to_tool_data
+
+
+class ProfilerTest(unittest.TestCase):
+  """Test for profile collected with JAX."""
+
+  def _get_session_snapshot(self):
+    """Gets a session snapshot of current session. assume only one session."""
+    profile_plugin_root = "tensorboard/plugins/profile"
+    # The session exists under a director whose name is time-dependent.
+    profile_session_glob = os.path.join(profile_plugin_root, "*", "*.xplane.pb")
+    return glob.glob(profile_session_glob)
+
+  def test_xplane_is_present(self):
+    files = self._get_session_snapshot()
+    self.assertEqual(len(files), 1)
+
+  def test_overview_page(self):
+    xspace_filenames = self._get_session_snapshot()
+    result, _ = raw_to_tool_data.xspace_to_tool_data(xspace_filenames, "overview_page^", {})
+    result = json.loads(result)
+    run_environment = result[2]
+    self.assertEqual(run_environment["p"]["host_count"], "1")
+    self.assertRegex(run_environment["p"]["device_type"], "TPU.*")
+
+  def test_op_profile(self):
+    xspace_filenames = self._get_session_snapshot()
+    result, _ = raw_to_tool_data.xspace_to_tool_data(xspace_filenames, "op_profile^", {})
+    result = json.loads(result)
+    self.assertIn("byCategory", result)
+    self.assertIn("metrics", result["byCategory"])
+    overall_metrics = result["byCategory"]["metrics"]
+    self.assertIn("flops", overall_metrics)
+    self.assertIn("bandwidthUtils", overall_metrics)
+    self.assertGreater(overall_metrics["flops"], 0)
+
+  def test_device_trace_contains_threads(self):
+    xspace_filenames = self._get_session_snapshot()
+    result, _ = raw_to_tool_data.xspace_to_tool_data(xspace_filenames, "trace_viewer^", {})
+    result = json.loads(result)
+    thread_names = []
+    for event in result["traceEvents"]:
+      if "name" in event and event["name"] == "thread_name":
+        thread_names.append((event["args"]["name"]))
+    expected_threads = [
+        "Framework Name Scope",
+        "Framework Ops",
+        "XLA Modules",
+        "XLA Ops",
+        "XLA TraceMe",
+        "Steps",
+    ]
+    # Ensure that thread_names contains at least all expected threads.
+    self.assertEqual(set(expected_threads) - set(thread_names), set())
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

The previous profiler_test.py doesn't follow the pytest standard, thus we had a refactor in https://github.com/AI-Hypercomputer/maxtext/pull/1142. However, it accidentally breaks the airflow DAG maxtext_profiling by this error:

```
ModuleNotFoundError: No module named 'profiler'
```

This PR restores the previous profiler_test before the refactor, and changed the file name and class name for better alignment. 

FIXES: [b/388640587](https://buganizer.corp.google.com/issues/388640587)

# Tests

Tested locally, running the tests to check local profile completeness.
<img width="478" alt="Screenshot 2025-01-09 at 3 50 37 PM" src="https://github.com/user-attachments/assets/2038ea57-2070-4378-bf28-8f44de936c96" />

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
