### PR TITLE
Add environment variable to change Jetstream version

### DIFF
--- a/inference/maxengine_server/Dockerfile
+++ b/inference/maxengine_server/Dockerfile
@@ -19,6 +19,7 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV MAXTEXT_VERSION=main
+ENV JETSTREAM_VERSION=main
 
 RUN apt -y update && apt install -y --no-install-recommends \
     ca-certificates \
@@ -37,6 +38,7 @@ git checkout ${MAXTEXT_VERSION} && \
 bash setup.sh
 
 RUN cd /JetStream && \
+git checkout ${JETSTREAM_VERSION} && \
 pip install -e .
 
 COPY maxengine_server_entrypoint.sh /usr/bin/


### PR DESCRIPTION
# Description

Adds an environment variable to change JetStream version in Docker builds in case JetStream repository is broken at HEAD. 

# Tests

Manually tested by building the Dockerfile and testing the maxengine_server.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
