### PR TITLE
Add prefill packing for offline inference

### DIFF
--- a/MaxText/inference_mlperf/llama_offline_run.sh
+++ b/MaxText/inference_mlperf/llama_offline_run.sh
@@ -11,6 +11,7 @@ dry_run=false
 skip_warmup=false
 test_run=false
 enable_profiler=false
+enable_batch_prefill=false
 performance=true
 audit=false
 accuracy=false
@@ -22,6 +23,7 @@ for arg in "$@"; do
     -t) test_run=true ;;
     -s) skip_warmup=true ;;
     -p) enable_profiler=true ;;
+    -c) enable_batch_prefill=true ;;
     -d) audit=true ;;
     -a) accuracy=true ;;
     -f) fast_eval=true ;;
@@ -49,6 +51,11 @@ fi
 PROFILER_OPTION=""
 if "$enable_profiler"; then
     PROFILER_OPTION="--enable_profile"
+fi
+
+BATCH_PREFILL_OPTION=""
+if "$enable_batch_prefill"; then
+    BATCH_PREFILL_OPTION="--enable_batch_prefill"
 fi
 
 if [ -z "$TOKENIZER_PATH" ]; then
@@ -90,7 +97,7 @@ export API_URL=0.0.0.0:9000
 if "$test_run"; then
   export DATASET_TYPE=test
   export DATASET_PATH=${DATA_DISK_DIR}/processed-data.pkl
-  export TOTAL_SAMPLE_COUNT=100
+  export TOTAL_SAMPLE_COUNT=1000
   export USER_CONFIG=user${TOTAL_SAMPLE_COUNT}.conf
 else
   export DATASET_TYPE=full
@@ -131,7 +138,7 @@ run_loadgen() {
     --maxengine_args "${MAXENGINE_ARGS}" \
     --output_log_dir ${OUTPUT_LOG_DIR} \
     --tok_outlen_multiplier ${TOK_OUTLEN_MULTIPLIER} \
-    ${SKIP_WARMUP_OPTION} ${PROFILER_OPTION} 2>&1 | tee ${OUTPUT_LOG_DIR}/${LOADGEN_RUN_TYPE}_log.log
+    ${SKIP_WARMUP_OPTION} ${PROFILER_OPTION} ${BATCH_PREFILL_OPTION} 2>&1 | tee ${OUTPUT_LOG_DIR}/${LOADGEN_RUN_TYPE}_log.log
 }
 
 run_loadgen_performance () {

--- a/MaxText/inference_mlperf/offline_inference.py
+++ b/MaxText/inference_mlperf/offline_inference.py
@@ -32,7 +32,6 @@ import logging
 from maxengine import set_engine_vars_from_base_engine
 
 log = logging.getLogger(__name__)
-log.setLevel(os.getenv("LOGLEVEL", "INFO"))
 
 
 @dataclasses.dataclass
@@ -55,7 +54,7 @@ class JetThread(threading.Thread):
 
 class OfflineInference:
 
-  def __init__(self, engine: engine_api.Engine, params, base_engine: engine_api.Engine):
+  def __init__(self, engine: engine_api.Engine, params, base_engine: engine_api.Engine, enable_batch_prefill: bool):
     self.live = False
     self.engine = engine
     self.decode_state = None
@@ -66,6 +65,7 @@ class OfflineInference:
       set_engine_vars_from_base_engine(engine, base_engine, rng)
     self.params = params
 
+    self.enable_batch_prefill = enable_batch_prefill
     self.batch_size = engine.max_concurrent_decodes
     self.max_decode_length = engine.config.max_target_length - engine.config.max_prefill_predict_length
     metadata = engine.get_tokenizer()
@@ -73,8 +73,10 @@ class OfflineInference:
     self.dummy = False
 
     self._cached_pref = {}
+    self._cached_pref_batch = {}
     self._cached_generate = None
     self.detokenize_backlog = queue.Queue(10)
+    self.prefill_buckets = defaultdict(list)
 
   def init_decode_state(self):
     if self.decode_state is None:
@@ -83,7 +85,6 @@ class OfflineInference:
   def warmup(self, max_length, warmup_samples):
     self.init_decode_state()
     interesting_buckets = [
-        32,
         64,
         128,
         256,
@@ -102,6 +103,24 @@ class OfflineInference:
           .lower(self.params, tokens=input_data, slot=0, true_length=length - 1, decode_state=self.decode_state)
           .compile()
       )
+    #   input_data_batch = jax.ShapeDtypeStruct((max_length,), jnp.dtype("int32"))
+    #   example_seq_len=16
+    #   num_prompts = max_length//length
+    #   self._cached_pref_batch[length] = (
+    #     jax.jit(self._prefill_insert_batch, donate_argnums=(4,))
+    #     .lower(
+    #       self.params,
+    #       tokens=input_data_batch,
+    #       slots=jnp.arange(0, example_seq_len),
+    #       num_prompts = 16,
+    #       decoder_positions = jnp.arange(0, max_length),
+    #       decoder_segment_ids = jnp.ones(max_length),
+    #       start_pos=jnp.arange(0, max_length, max_length//example_seq_len),
+    #       padded_lengths=jnp.arange(0, max_length, max_length//example_seq_len),
+    #       true_lengths=jnp.arange(0, max_length, max_length//example_seq_len),
+    #       decode_state=self.decode_state)
+    #     .compile()
+    #   )
     self.batch_inference(warmup_samples, desc="warmup")
     self._cached_generate = (
         jax.jit(self.engine.generate, donate_argnums=(1,)).lower(self.params, self.decode_state).compile()
@@ -110,8 +129,47 @@ class OfflineInference:
   def _prefill_insert(self, params, tokens, slot, true_length, decode_state):
     """return decodestate."""
     prefill_result, first_token = self.engine.prefill(params=params, padded_tokens=tokens, true_length=true_length)
-    decode_state = self.engine.insert(prefill_result, decode_state, slot=slot)
+    decode_state = self.engine.insert(prefill_result, decode_state, slot)
     return first_token, decode_state
+
+  def _prefill_insert_batch(
+      self,
+      params,
+      tokens,
+      slots,
+      num_prompts,
+      decoder_positions,
+      decoder_segment_ids,
+      start_pos,
+      padded_lengths,
+      true_lengths,
+      decode_state,
+  ):
+    """return decodestate."""
+    prefill_results, first_tokens = self.engine.prefill_concat(
+        params=params,
+        padded_tokens=tokens,
+        decoder_positions=decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        start_pos=start_pos,
+        true_lengths=true_lengths,
+        num_prompts=num_prompts,
+    )
+    # decode_state = jax.lax.fori_loop(
+    #   0, num_prompts,
+    #   lambda i, state: self.engine.insert(
+    #     prefill_results[i],
+    #     state,
+    #     slot=slots[i],
+    #     start_idx = start_pos[i],
+    #     seq_len = padded_lengths[i]),
+    #   decode_state
+    # )
+    for i in range(num_prompts):
+      decode_state = self.engine.insert_partial(
+          prefill_results[i], decode_state, slots[i], start_idx=start_pos[i].item(), seq_len=padded_lengths[i].item()
+      )
+    return first_tokens, decode_state
 
   def batch_inference_with_callback(
       self,
@@ -125,20 +183,73 @@ class OfflineInference:
     token.
     """
 
-    def prefill(slot, tokens, true_length):
+    def prefill(prefill_bucket, prefill_len):
       nonlocal self
       if self.dummy:
         log.info("dummy prefill")
         return 123
+      if not self.enable_batch_prefill or prefill_len * len(prefill_bucket) != 1024:
+        prefill_result = []
+        prefill_fn = self._prefill_insert
+        if (cached := self._cached_pref.get(prefill_len)) is not None:
+          prefill_fn = cached
+        for slot, row in prefill_bucket:
+          first_token, self.decode_state = prefill_fn(
+              self.params, tokens=row.tokens, slot=slot, true_length=row.true_length, decode_state=self.decode_state
+          )
+          prefill_result.append((first_token, slot, row))
+        return prefill_result
+      else:
+        prefill_fn = self._prefill_insert_batch
+        if (cached := self._cached_pref_batch.get(prefill_len)) is not None:
+          prefill_fn = cached
+        positions = np.concatenate([np.arange(0, row.tokens.shape[0]) for (slot, row) in prefill_bucket])
+        positions = jnp.array(positions)
 
-      prefill_fn = self._prefill_insert
-      if (cached := self._cached_pref.get(len(tokens))) is not None:
-        prefill_fn = cached
+        sequence_indicators = []
+        for idx, (slot, row) in enumerate(prefill_bucket):
+          zero_to_n = np.arange(0, row.tokens.shape[0])
+          ones_to_keep = zero_to_n < row.true_length
+          one_d_output = (zero_to_n < row.true_length).astype(int) * (idx * 2 + 1) + (zero_to_n >= row.true_length).astype(
+              int
+          ) * (idx + 1) * 2
+          sequence_indicators.append(one_d_output)
+        sequence_indicator = jnp.array(np.concatenate(sequence_indicators))
 
-      first_token, self.decode_state = prefill_fn(
-          self.params, tokens=tokens, slot=slot, true_length=true_length, decode_state=self.decode_state
-      )
-      return first_token
+        tokens = jnp.concat([row.tokens for (slot, row) in prefill_bucket])
+
+        slots = [slot for (slot, row) in prefill_bucket]
+        padded_lengths = [row.tokens.shape[0] for (slot, row) in prefill_bucket]
+        true_lengths = [row.true_length for (slot, row) in prefill_bucket]
+        start_pos = np.cumsum([0] + [row.tokens.shape[0] for (slot, row) in prefill_bucket])[:-1]
+        start_pos = start_pos.tolist()
+
+        # pad slots to keep static shape of jitted function input
+        def pad_num_prompts_len_array(array_to_pad, pad_len):
+          if len(array_to_pad) < pad_len:
+            array_to_pad.extend([0] * (pad_len - len(array_to_pad)))
+          return jnp.array(array_to_pad)
+
+        slots = pad_num_prompts_len_array(slots, 16)
+        padded_lengths = pad_num_prompts_len_array(padded_lengths, 16)
+        true_lengths = pad_num_prompts_len_array(true_lengths, 16)
+        start_pos = pad_num_prompts_len_array(start_pos, 16)
+
+        first_tokens, self.decode_state = prefill_fn(
+            self.params,
+            tokens=tokens,
+            slots=slots,
+            num_prompts=len(prefill_bucket),
+            decoder_positions=positions,
+            decoder_segment_ids=sequence_indicator,
+            start_pos=start_pos,
+            padded_lengths=padded_lengths,
+            true_lengths=true_lengths,
+            decode_state=self.decode_state,
+        )
+        prefill_result = [(first_tokens[idx], slot, row) for (idx, (slot, row)) in enumerate(prefill_bucket)]
+
+        return prefill_result
 
     empty_slots = list(range(self.batch_size))
     slot_to_id = {}
@@ -170,6 +281,7 @@ class OfflineInference:
           self.decode_state, result_tokens = gen_fn(self.params, self.decode_state)
           result_tokens_l.append(result_tokens)
       for i in range(5):
+        # result_tokens.copy_to_host_async()
         result_tokens = result_tokens_l[i].convert_to_numpy()
         self.detokenize_backlog.put((result_tokens, False, 0, 0), block=True)
         # log.info(f"Decode put result {i} to queue")
@@ -182,6 +294,7 @@ class OfflineInference:
         # log.info("Detokenize start")
         newly_empty = []
         result_tokens, is_first_token, row_id, _slot = self.detokenize_backlog.get(block=True)
+        # result_tokens = result_tokens.convert_to_numpy()
         # log.info("Detokenize get from queue")
         if is_first_token:
           first_token = result_tokens.data[0][0].item()
@@ -199,7 +312,7 @@ class OfflineInference:
             should_finish = emit_token(id_, token.item())
           if should_finish or length >= self.max_decode_length:
             newly_empty.append(slot)
-            log.info(f"Detokenize free up {slot}, length {length}")
+            log.debug(f"Detokenize free up {slot}, length {length}")
         # Add slots of those that are empty to empty
         for slot in newly_empty:
           del slot_to_id[slot]
@@ -215,6 +328,7 @@ class OfflineInference:
     )
     self.live = True
     detokenize_thread.start()
+    total_num_prefills = 0
     for row in data:
       while not empty_slots:
         # If slots are all full, decode until there are free slots
@@ -224,16 +338,36 @@ class OfflineInference:
         decode()
       # do one insert
       num_tokens = len(row.tokens)
-      num_prefills[num_tokens] = 0 if num_tokens not in num_prefills else num_prefills[num_tokens] + 1
+      num_prefills[num_tokens] = 1 if num_tokens not in num_prefills else num_prefills[num_tokens] + 1
       log.info(
           f"prefill-{desc}-{num_prefills} num_prefills {sum(num_prefills.values())} num_tokens {num_tokens} true_length {row.true_length} num_empty_slots {len(empty_slots)} num_decodes {num_decodes}"
       )
+      total_num_prefills += 1
+      log.info(f"Total num prefill: {total_num_prefills}")
       slot = empty_slots.pop()
-      first_token = prefill(slot, row.tokens, row.true_length)
-      self.detokenize_backlog.put((first_token, True, row.id, slot), block=True)
-
+      # directly prefill prompts with 64 or less tokens
+      if num_tokens == 64:
+        first_token, slot, row = prefill([(slot, row)], 64)[0]
+        self.detokenize_backlog.put((first_token, True, row.id, slot), block=True)
+        continue
+      self.prefill_buckets[num_tokens].append((slot, row))
+      prefill_buckets_len = {k: len(self.prefill_buckets[k]) for k in self.prefill_buckets}
+      log.debug(f"prefill buckets {prefill_buckets_len}")
+      if len(self.prefill_buckets[num_tokens]) * num_tokens == 1024:
+        prefill_results = prefill(self.prefill_buckets[num_tokens], num_tokens)
+        for first_token, slot, row in prefill_results:
+          log.debug(f"Put row of len {row.tokens.shape[0]} true length {row.true_length} slot {slot} to detokenize backlog")
+          self.detokenize_backlog.put((first_token, True, row.id, slot), block=True)
+        self.prefill_buckets[num_tokens] = []
+    # For leftover requests in buckets at the end of computation, do prefill individually.
+    for num_tokens in self.prefill_buckets.keys():
+      prefill_results = prefill(self.prefill_buckets[num_tokens], num_tokens)
+      for first_token, slot, row in prefill_results:
+        log.debug(f"Put row of len {row.tokens.shape[0]} true length {row.true_length} slot {slot} to detokenize backlog")
+        self.detokenize_backlog.put((first_token, True, row.id, slot), block=True)
+    self.prefill_buckets = defaultdict(list)
     while slot_to_id:
-      log.info(f"decode-{desc}-{num_decodes} num_filled_slots {len(slot_to_id)}")
+      log.debug(f"decode-{desc}-{num_decodes} num_filled_slots {len(slot_to_id)}")
       num_decodes += 1
       decode()
 
@@ -248,7 +382,7 @@ class OfflineInference:
     def callback(id_, token):
       nonlocal res
       if token == self.tokenizer.eos_id:
-        log.info(f"res[{id_}] eos")
+        log.debug(f"res[{id_}] eos")
       if not res[id_] or res[id_][-1] != self.tokenizer.eos_id:
         res[id_].append(token)
       return token == self.tokenizer.eos_id

--- a/MaxText/inference_mlperf/offline_mode.py
+++ b/MaxText/inference_mlperf/offline_mode.py
@@ -147,6 +147,13 @@ flags.DEFINE_bool(
 )
 
 flags.DEFINE_bool(
+    "enable_batch_prefill",
+    False,
+    "If set, enable batch prefilling.",
+    required=False,
+)
+
+flags.DEFINE_bool(
     "skip_warmup",
     False,
     "Skip warmup",
@@ -463,7 +470,7 @@ def main(argv):
         max_target_length=target_length,
         args_str=FLAGS.maxengine_args,
     )
-    offline_inf = offline_inference.OfflineInference(engine, params, base_engine)
+    offline_inf = offline_inference.OfflineInference(engine, params, base_engine, FLAGS.enable_batch_prefill)
     if params is None and offline_inf.params is not None:
       base_engine = engine
     params = offline_inf.params

--- a/MaxText/inference_mlperf/trillium/benchmarks_llama2-70b-trillium_2x4.sh
+++ b/MaxText/inference_mlperf/trillium/benchmarks_llama2-70b-trillium_2x4.sh
@@ -7,6 +7,7 @@
 run_name="trillium_llama2-70b"
 dry_run=false
 enable_profiler=false
+enable_batch_prefill=false
 enable_xla_flags=false
 single_bucket=false
 token_multiplier=3.0
@@ -36,6 +37,7 @@ for arg in "$@"; do
         -t) test_mode=true ;;
         -s) single_bucket=true ;;
         -x) enable_xla_flags=true ;;
+        -c) enable_batch_prefill=true ;;
         -r=*|--run=*) run_name="${arg#*=}" ;;
         -r|--run) shift; run_name="$1" ;;
         -m=*|--multiplier=*) token_multiplier="${arg#*=}" ;;
@@ -66,6 +68,10 @@ fi
 
 if "$test_mode"; then
     RUN_OPTIONS="${RUN_OPTIONS} -t "
+fi
+
+if "$enable_batch_prefill"; then
+    RUN_OPTIONS="${RUN_OPTIONS} -c "
 fi
 
 if "$single_bucket"; then
@@ -104,7 +110,7 @@ run_benchmark() {
     local type=$1
     case "$type" in
         "performance")
-            $cmd bash llama_offline_run.sh -r benchmarks_performance_${RUN_DESC} ${RUN_OPTIONS}
+            $cmd bash llama_offline_run.sh ${RUN_OPTIONS} -r benchmarks_performance_${RUN_DESC}
             ;;
         "audit")
             $cmd bash llama_offline_run.sh -r benchmarks_audit_${RUN_DESC} -d

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -45,6 +45,7 @@ import warnings
 warnings.simplefilter("ignore", category=FutureWarning)
 
 Prefix = Any
+PackedPrefix = Any
 Params = Any
 
 
@@ -310,6 +311,111 @@ class MaxEngine(engine_api.Engine):
         "tokens": first_generated_token,
     }, result
 
+  @functools.partial(jax.jit, static_argnums=(0,), static_argnames=("num_prompts",))
+  def prefill_concat(
+      self,
+      *,
+      params: Params,
+      existing_prefix: Optional[jax.Array] = None,
+      padded_tokens: jax.Array,
+      decoder_positions: jax.Array,
+      decoder_segment_ids: jax.Array,
+      start_pos: jax.Array,
+      true_lengths: jax.Array,
+      num_prompts: int,
+      sampler: Optional[Callable[[Any], Any]] = None,  # pylint: disable=unused-argument
+      rng: Optional[jax.random.PRNGKey] = None,
+  ) -> Tuple[PackedPrefix, engine_api.ResultTokens]:
+    """Computes a kv-cache for a new packed generate request, which is a
+    concatenation of several shorter prompts. Experimentation shows that
+    longer prefill sequences gives approximately 15% boost in time per prefilled
+    token.
+
+    Args:
+      params: Scalar multiplier.
+      existing_prefix: If provided, represents a prefix that has already been
+        processed by the underlying model.
+      padded_tokens: Logically appended tokens to any existing prefix, this is
+        what we compute prefill on.
+      decoder_positions: int values indicating the position of token in its
+        original sequence.
+      decoder_segment_ids: int values indicating which sequence the the token
+        originally belong to.
+      start_pos: Padded array indicating the start position of each of the prompts.
+      true_length: Padded array indicating the true lengths of each of the prompts.
+      num_prompts: the number of prompts packed in the entire sequence.
+    Returns:
+      kv_cache: For the resulting text.
+    """
+    if existing_prefix:
+      raise ValueError("We don't know what to do with existing_prefix")
+
+    if rng is None:
+      rng = jax.random.PRNGKey(0)
+    input_tokens = jnp.expand_dims(padded_tokens, 0)  # [BATCH, SEQUENCE]
+    decoder_positions = jnp.expand_dims(decoder_positions, 0)
+    decoder_segment_ids = jnp.expand_dims(decoder_segment_ids, 0)
+    rng, new_rng = jax.random.split(rng)
+    with self._mesh, nn_partitioning.axis_rules(self.config.logical_axis_rules):
+      flat_logits, new_vars = self.model.apply(
+          params,
+          input_tokens,
+          decoder_positions,
+          decoder_segment_ids=decoder_segment_ids,
+          enable_dropout=False,
+          model_mode=common_types.MODEL_MODE_PREFILL,
+          rngs={"params": new_rng},
+          mutable=["cache"],
+      )
+    cache = new_vars["cache"]
+    cache = self._maybe_stack_prefill_result_cache(cache)
+
+    def process_packed_logits_and_caches(packed_flat_logits, idx):
+      next_pos = jnp.full((1, 1), true_lengths[idx], dtype=jnp.int32)
+      generated_tokens = jnp.zeros((1, 1), dtype=jnp.int32)
+      selected_logits = jax.lax.dynamic_slice(
+          packed_flat_logits,
+          (0, start_pos[idx] + true_lengths[idx] - 1, 0),
+          (packed_flat_logits.shape[0], 1, packed_flat_logits.shape[2]),
+      )
+      selected_logits = jax.lax.with_sharding_constraint(selected_logits, self.replicated_sharding)
+      first_generated_token = inference_utils.sampling(
+          selected_logits,
+          rng,
+          self.config.decode_sampling_strategy,
+          topk=self.config.decode_sampling_top_k,
+          nucleus_topp=self.config.decode_sampling_nucleus_p,
+          temperature=self.config.decode_sampling_temperature,
+      )
+      all_valid = jnp.ones(first_generated_token.shape, dtype=jnp.int8)
+      result = engine_api.ResultTokens(
+          data=jnp.concatenate((first_generated_token, all_valid, generated_tokens), axis=1),
+          # Tokens are shape [batch, speculations], so when we concatenate
+          # tokens, validity and length along their index 1 dimension then they
+          # occupy 0:speculations.
+          tokens_idx=(0, 1),
+          # Validity occupies the same amount of space, but next in line.
+          valid_idx=(1, 2),
+          # And lengths is rank 1.
+          length_idx=(2, 3),
+          samples_per_slot=1,
+      )
+      return {
+          "logits": selected_logits,
+          "cache": cache,
+          "next_pos": next_pos,
+          "generated_tokens": generated_tokens,
+          "tokens": first_generated_token,
+      }, result
+
+    prefill_results = []
+    first_tokens = []
+    for idx in range(num_prompts):
+      prefill_result, first_token = process_packed_logits_and_caches(flat_logits, idx)
+      prefill_results.append(prefill_result)
+      first_tokens.append(first_token)
+    return prefill_results, first_tokens
+
   @functools.partial(jax.jit, static_argnums=(0,), donate_argnums=(2,))
   def generate(
       self,
@@ -386,7 +492,7 @@ class MaxEngine(engine_api.Engine):
       decode_state: DecodeState,
       slot: int,
   ) -> DecodeState:
-    """Insert into KV cache"""
+    """Insert a single computed prefill cache into KV cache."""
     unboxed_prefix = max_utils.unbox_logicallypartioned(prefix)
 
     unboxed_prefix["cache"] = self._maybe_unstack_prefill_result_cache(unboxed_prefix["cache"])
@@ -434,6 +540,123 @@ class MaxEngine(engine_api.Engine):
           "cached_prefill_key_scale",
           "cached_prefill_value_scale",
       ]:
+        return jax.lax.dynamic_update_index_in_dim(full_cache, partial_cache, slot, batch_idx)
+      else:
+        raise ValueError(f"We don't have a strategy for inserting {path_key}")
+
+    inserted_cache = jax.tree_util.tree_map_with_path(
+        copy,
+        unboxed_prefix["cache"],
+        decode_state["cache"],
+        self.kv_cache_annotations_named,
+    )
+    inserted_logits = jax.lax.dynamic_update_index_in_dim(decode_state["logits"], unboxed_prefix["logits"], slot, 0)
+    inserted_next_pos = jax.lax.dynamic_update_index_in_dim(decode_state["next_pos"], unboxed_prefix["next_pos"], slot, 0)
+    inserted_generated_tokens = jax.lax.dynamic_update_index_in_dim(
+        decode_state["generated_tokens"],
+        unboxed_prefix["generated_tokens"],
+        slot,
+        0,
+    )
+    inserted_tokens = jax.lax.dynamic_update_index_in_dim(decode_state["tokens"], unboxed_prefix["tokens"], slot, 0)
+
+    inserted_logits = jax.lax.with_sharding_constraint(inserted_logits, self.replicated_sharding)
+    inserted_generated_tokens = jax.lax.with_sharding_constraint(inserted_generated_tokens, self.replicated_sharding)
+    inserted_next_pos = jax.lax.with_sharding_constraint(inserted_next_pos, self.replicated_sharding)
+    inserted_tokens = jax.lax.with_sharding_constraint(inserted_tokens, self.replicated_sharding)
+    inserted_cache = jax.lax.with_sharding_constraint(inserted_cache, self.kv_cache_shardings)
+
+    return {
+        "logits": inserted_logits,
+        "cache": inserted_cache,
+        "next_pos": inserted_next_pos,
+        "generated_tokens": inserted_generated_tokens,
+        "tokens": inserted_tokens,
+    }
+
+  @functools.partial(
+      jax.jit,
+      static_argnums=(0,),
+      static_argnames=("seq_len",),
+      donate_argnums=(
+          1,
+          2,
+      ),
+  )
+  def insert_partial(
+      self,
+      prefix: Prefix,
+      decode_state: DecodeState,
+      slot: int,
+      *,
+      start_idx: int,
+      seq_len: int,
+  ) -> DecodeState:
+    """Insert a sequence of several prefixes into KV cache."""
+    unboxed_prefix = max_utils.unbox_logicallypartioned(prefix)
+
+    unboxed_prefix["cache"] = self._maybe_unstack_prefill_result_cache(unboxed_prefix["cache"])
+
+    # jax.debug.print("Inserting cache slot {} start_idx {} seq_len {}", slot, start_idx, seq_len)
+    # example = unboxed_prefix["cache"]["decoder"]['layers_0']['self_attention']['AttentionOp_0']
+    # for key in example.keys():
+    #   jax.debug.print("{} shape: {}", key, example[key].shape)
+    # jax.debug.print("-----------------------------")
+    # jax.debug.print(self.config.prefill_cache_axis_order)
+    def copy(path, partial_cache, full_cache, annotations):
+      path_key = path[-1].key
+      if path_key in [
+          "cache_ar_index",
+          "cached_ar_key",
+          "cached_ar_value",
+          "cached_ar_key_scale",
+          "cached_ar_value_scale",
+      ]:
+        return full_cache  # we don't even zero these out because we can mask them out.
+
+      batch_idx = -1
+      if "cache_batch" in annotations:
+        batch_idx = annotations.index("cache_batch")
+      elif "cache_scale_batch" in annotations:
+        batch_idx = annotations.index("cache_scale_batch")
+
+      if batch_idx < 0:
+        raise ValueError(f"Batch index {batch_idx=} shouldn't be less than zero for {path_key}, got {annotations=}")
+
+      if path_key == "cache_ar_segment_id":
+        ### goal: zero this out in case there is existing data
+        zeros = jnp.zeros((1, self.config.max_target_length - self.config.max_prefill_predict_length), dtype=jnp.int32)
+        return jax.lax.dynamic_update_index_in_dim(full_cache, zeros, slot, batch_idx)
+      elif path_key == "cache_prefill_segment_id":
+        zeros = jnp.zeros((1, self.config.max_prefill_predict_length), dtype=jnp.int32)
+        ## zero out in case prefill cache is too small to cover
+        full_cache = jax.lax.dynamic_update_index_in_dim(full_cache, zeros, slot, batch_idx)
+        ## copy prefill cache
+        partial_cache = jax.lax.dynamic_slice(partial_cache, (0, start_idx), (1, seq_len))
+        partial_cache = jnp.mod(partial_cache, 2)
+        full_cache = jax.lax.dynamic_update_index_in_dim(full_cache, partial_cache, slot, batch_idx)
+        return full_cache
+      elif path_key == "cached_ar_lengths":
+        return full_cache.at[slot].set(0)
+      elif path_key in [
+          "cached_prefill_key",
+          "cached_prefill_value",
+          "cached_prefill_key_scale",
+          "cached_prefill_value_scale",
+      ]:
+        seqlen_index = self.config.prefill_cache_axis_order.split(",").index("1")
+        start_indices = jnp.zeros(4, dtype=int)
+        start_indices = jax.lax.dynamic_update_slice(
+            start_indices, jnp.array(start_idx, dtype=int, ndmin=1), (seqlen_index,)
+        )
+        # start_indices[seqlen_index] = start_idx
+        slice_size = list(partial_cache.shape)
+        slice_size[seqlen_index] = seq_len
+
+        slice_size = tuple(slice_size)
+        partial_cache = jax.lax.dynamic_slice(partial_cache, start_indices, slice_size)
+        # jax.debug.print("start_indices: {}, slice_size: {}", start_indices, slice_size)
+
         return jax.lax.dynamic_update_index_in_dim(full_cache, partial_cache, slot, batch_idx)
       else:
         raise ValueError(f"We don't have a strategy for inserting {path_key}")


### PR DESCRIPTION
# Description

Concatenates the prefills of several prompts for higher MFU in prefills. For now, only support bucketized concatenation for fixed padded lengths (mainly 128, 256 and 512). 

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
