### PR TITLE
Support manual testing with XPK and improvements to the benchmark tool

### DIFF
--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -14,24 +14,21 @@
  limitations under the License.
  """
 
-""" Script to run a benchmark/benchmarks on exsiting xpk or QR nodes (to be implmented)
+""" Script to run a benchmark/benchmarks on existing xpk or QR nodes (to be implemented)
                           ***** IMPORTANT *****
-This script will run specific tuned workload on specified hardwear and software enviroments
+This script will run specific tuned workload on specified hardware and software environments
 Example usages:
   python3 benchmark_runner.py  --project=<my-project> --zone=<zone> \
     --cluster_name=<xpk_cluster_name> --base_output_directory=<output_gcloud_bucket> --device_type=v6e-256 --num_slices=1 --model_name="llama2_70b_4096" --libtpu_version=20241009 --base_docker_image=maxtext_base_image
 """
 import argparse
-import importlib
 
-import maxtext_trillium_model_configs
-from maxtext_xpk_runner import BenchmarkRunner
-from maxtext_xpk_runner import HWConfig
-from maxtext_xpk_runner import SWconfig
+from maxtext_trillium_model_configs import trillium_model_dict
 from maxtext_xpk_runner import PathwaysConfig
+from maxtext_xpk_runner import WorkloadConfig
 from maxtext_xpk_runner import xpk_benchmark_runner
-from maxtext_xpk_runner import XpkConfig
-
+from maxtext_xpk_runner import XpkClusterConfig
+from maxtext_xpk_runner import LibTpuType
 
 def add_shared_arguments(custom_parser: argparse.ArgumentParser):
   """Add shared arguments to the parser.
@@ -65,7 +62,7 @@ def add_shared_arguments(custom_parser: argparse.ArgumentParser):
       '--base_output_directory',
       type=str,
       default=None, required=True,
-      help='gcloud bucket to store arfifacts.',
+      help='gcloud bucket to store artifacts.',
   )
   custom_parser.add_argument(
       '--device_type',
@@ -82,45 +79,10 @@ def add_shared_arguments(custom_parser: argparse.ArgumentParser):
   custom_parser.add_argument(
       '--model_name',
       type=str,
-      choices=[
-          'gpt_3_175b',
-          'llama2_7b_4096',
-          'llama2_70b_4096',
-          'llama2_70b_4096_real_data',
-          'llama2_70b_4096_pw_long_run',
-          'llama2_70b_4096_real_data_pw_long_run',
-          'llama2_70b_4096_pw_rd_tfds',
-          'llama2_70b_4096_synthetic_pw_lr',
-          'llama2_70b_4096_synthetic',
-          'llama3_70b_8192',
-          'llama3_1_405b_8192_fsdp_dcn',
-          'mixtral_8x7b_dropped',
-          'mixtral_8x7b_dropped_int8',
-          'mixtral_8x7b_dropless',
-          'gemma2_9b_8192',
-          'gemma2_27b_8192',
-          'llama3_1_70b_129024',
-          'llama3_1_8b_8192',
-          'llama3_1_70b_8192',
-      ],
-      default='llama2_70b_4096',
+      choices=list(trillium_model_dict.keys()),
+      default=list(trillium_model_dict.keys())[0],
       help=(
-          'model to be benchmarked, supported models are gpt_3_175b '
-          'llama2_7b_4096 '
-          'llama2_70b_4096 '
-          'llama2_70b_4096_real_data '
-          'llama2_70b_4096_pw_long_run '
-          'llama2_70b_4096_real_data_pw_long_run '
-          'llama2_70b_4096_pw_rd_tfds '
-          'llama2_70b_4096_synthetic_pw_lr '
-          'llama2_70b_4096_synthetic '
-          'llama3_1_405b_8192_fsdp_dcn '
-          'mixtral_8x7b_dropped '
-          'mixtral_8x7b_dropped_int8 '
-          'mixtral_8x7b_dropless '
-          'gemma2_9b_8192 '
-          'gemma2_27b_8192 '
-          'command.'
+        f'model to be benchmarked, supported models are the command choices.'
       ),
   )
   custom_parser.add_argument(
@@ -174,6 +136,12 @@ def add_shared_arguments(custom_parser: argparse.ArgumentParser):
       help='Priority the XPK workload should run with.',
   )
   custom_parser.add_argument(
+      '--num_steps',
+      type=int,
+      default=20,
+      help='Number of steps to run the workload for.',
+  )
+  custom_parser.add_argument(
       '--max_restarts',
       type=int,
       default=0,
@@ -188,42 +156,38 @@ def main() -> None:
   add_shared_arguments(parser)
   options = parser.parse_args()
 
-  cluster_config = XpkConfig(
-      cluster_name=options.cluster_name,
-      project=options.project,
-      zone=options.zone,
-      num_slices=options.num_slices,
-      device_type=options.device_type,
-      base_output_directory=options.base_output_directory,
-      priority=options.priority,
-      max_restarts=options.max_restarts,
+  cluster_config = XpkClusterConfig(
+        cluster_name=options.cluster_name,
+        project=options.project,
+        zone=options.zone,
+        device_type=options.device_type
+      )
+
+  pw_config = None
+  if options.use_pathways:
+    pw_config = PathwaysConfig(
+      server_image=options.pathways_server_image,
+      proxy_image=options.pathways_proxy_image,
+      runner_image=options.pathways_runner_image,
+    )
+
+  assert trillium_model_dict.get(options.model_name) is not None, f'Invalid model name: {options.model_name}'
+  workload_config = WorkloadConfig(
+    model=trillium_model_dict.get(options.model_name),
+    num_slices=options.num_slices,
+    num_steps=options.num_steps,
+    device_type=options.device_type,
+    base_output_directory=options.base_output_directory,
+    priority=options.priority,
+    max_restarts=options.max_restarts,
+    libtpu_type=LibTpuType.NIGHTLY,
+    libtpu_nightly_version=options.libtpu_version,
+    base_docker_image=options.base_docker_image,
+    xpk_path=options.xpk_path,
+    pathways_config=pw_config
   )
 
-  v6e_env_configs = SWconfig(
-      base_docker_image=options.base_docker_image,
-      libtpu_version=options.libtpu_version,
-      pathways_config=PathwaysConfig(
-          use_pathways=options.use_pathways,
-          server_image=options.pathways_server_image,
-          proxy_image=options.pathways_proxy_image,
-          runner_image=options.pathways_runner_image,
-      ),
-  )
-
-  v6e_256_configs = HWConfig(
-      num_slices=options.num_slices, device_type=options.device_type
-  )
-
-  model_sets = importlib.import_module('maxtext_trillium_model_configs')
-  benchmark_model = getattr(model_sets, options.model_name)
-
-  model_runner = BenchmarkRunner(
-      model_name=benchmark_model,
-      software_config=v6e_env_configs,
-      hardware_config=v6e_256_configs,
-  )
-
-  xpk_benchmark_runner(cluster_config, [model_runner], options.xpk_path)
+  xpk_benchmark_runner(cluster_config, [workload_config])
 
 
 if __name__ == '__main__':

--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -19,6 +19,11 @@ import dataclasses
 import typing
 import xla_flags_library
 
+# TODO(vbarr@) Abstract software features like checkpointing,
+# real data / synthetic data out of this config
+# TODO(vbarr@) Make slice dependent configurations to allow for a model's tuning
+# to adjust at scales.
+
 
 @dataclasses.dataclass
 class MaxTextModel:
@@ -27,9 +32,17 @@ class MaxTextModel:
   tuning_params: dict[str, typing.Any]
   xla_flags: str
 
+trillium_model_dict = {}
 
-default_basic = MaxTextModel(
-    model_name="default-basic",
+# Run this for new definitions that should be part of the library.
+def _add_to_model_dictionary(model_dictionary: dict[str, MaxTextModel], maxtext_model: MaxTextModel)-> MaxTextModel:
+  model_dictionary[maxtext_model.model_name.replace('-', '_')] = maxtext_model
+  return maxtext_model
+
+default_basic_1 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="default-basic-1",
     model_type="default",
     tuning_params={
         "per_device_batch_size": 1,
@@ -43,37 +56,13 @@ default_basic = MaxTextModel(
         "profiler": "xplane",
     },
     xla_flags="",
-)
-
-# Test model for FSDP + TP.
-default_1 = MaxTextModel(
-    model_name="default-1",
-    model_type="default",
-    tuning_params={
-        "per_device_batch_size": 1,
-        "ici_fsdp_parallelism": 16,
-        "ici_tensor_parallelism": 16,
-        "dcn_pipeline_parallelism": 2,
-        "dcn_fsdp_parallelism": 1,
-        "remat_policy": "full",
-        "global_parameter_scale": 1,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-    ),
+  )
 )
 
 
-default_32 = MaxTextModel(
+default_32 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="default-32",
     model_type="default",
     tuning_params={
@@ -97,9 +86,13 @@ default_32 = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
-default_64 = MaxTextModel(
+
+default_64 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="default-64",
     model_type="default",
     tuning_params={
@@ -123,9 +116,13 @@ default_64 = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
-default_128 = MaxTextModel(
+
+default_128 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="default-128",
     model_type="default",
     tuning_params={
@@ -149,15 +146,19 @@ default_128 = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
-default_256 = MaxTextModel(
+
+# OOM, Not Optimized yet
+default_256 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="default-256",
     model_type="default",
     tuning_params={
         "per_device_batch_size": 1,
         "ici_fsdp_parallelism": -1,
-        # "dcn_fsdp_parallelism": 2,
         "dcn_fsdp_transpose_parallelism": -1,
         "remat_policy": "full",
         "global_parameter_scale": 256,
@@ -177,12 +178,14 @@ default_256 = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
-# TODO(b/368441022) DEFAULT_512 which requires host offloading for optimizer
-# state.
-# Currently OOM
-default_512 = MaxTextModel(
+
+# OOM, Not Optimized yet
+default_512 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="default-512",
     model_type="default",
     tuning_params={
@@ -208,10 +211,13 @@ default_512 = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
 
-gpt_3_175b = MaxTextModel(
+gpt_3_175b = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="gpt-3-175b",
     model_type="gpt3-175b",
     tuning_params={
@@ -235,9 +241,13 @@ gpt_3_175b = MaxTextModel(
         + xla_flags_library.DATA_PARALLEL_OVERLAP
         + xla_flags_library.DISABLE_BUNDLE_AWARE_COST_MODEL
     ),
+  )
 )
 
-llama2_7b_4096 = MaxTextModel(
+
+llama2_7b_4096 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama2-7b-4096",
     model_type="llama2-7b",
     tuning_params={
@@ -261,26 +271,30 @@ llama2_7b_4096 = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
 
-llama2_70b_4096_real_data = MaxTextModel(
-    model_name="llama2-70b-4096-rd",
+llama2_70b_4096 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama2-70b-4096",
     model_type="llama2-70b",
     tuning_params={
-        "per_device_batch_size": 7,
-        "ici_fsdp_parallelism": -1,
+        "per_device_batch_size": 4,
+        "ici_fsdp_parallelism": 1,
+        "ici_fsdp_transpose_parallelism": -1,
+        "ici_tensor_parallelism": 1,
         "remat_policy": "full",
         "max_target_length": 4096,
         "attention": "flash",
         "gcs_metrics": True,
         "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
         "reuse_example_batch": 1,
         "enable_checkpointing": False,
         "profiler": "xplane",
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "tfds",
-        "tokenizer_path": "assets/tokenizer.llama2",
         "sa_block_q": 1024,
         "sa_block_q_dkv": 2048,
         "sa_block_q_dq": 2048,
@@ -289,10 +303,185 @@ llama2_70b_4096_real_data = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
 
-llama2_70b_4096_real_data_pw_long_run = MaxTextModel(
+llama2_70b_4096_optimized = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama2_70b_4096_synthetic",
+    model_type="llama2-70b",
+    tuning_params={
+        "per_device_batch_size": 2,
+        "ici_fsdp_parallelism": 1,
+        "ici_fsdp_transpose_parallelism": -1,
+        "ici_tensor_parallelism": 1,
+        "remat_policy": "qkv_proj_offloaded",
+        "max_target_length": 4096,
+        "attention": "flash",
+        "gcs_metrics": True,
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+        "sa_block_q": 1024,
+        "sa_block_q_dkv": 2048,
+        "sa_block_q_dq": 2048,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.CF_FOR_ALL_GATHER
+    ),
+  )
+)
+
+
+# Enable SparseCore Offloading of AR in an optimized model.
+llama2_70b_4096_sc = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama2-70b-4096-sc",
+    model_type="llama2-70b",
+    tuning_params={
+        "per_device_batch_size": 2,
+        "ici_fsdp_parallelism": 1,
+        "ici_fsdp_transpose_parallelism": -1,
+        "ici_tensor_parallelism": 1,
+        "remat_policy": "qkv_proj_offloaded",
+        "max_target_length": 4096,
+        "attention": "flash",
+        "gcs_metrics": True,
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+        "sa_block_q": 1024,
+        "sa_block_q_dkv": 2048,
+        "sa_block_q_dq": 2048,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+    ),
+  )
+)
+
+
+llama2_70b_4096_sc_real_data_tfds = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama2-70b-4096-sc",
+    model_type="llama2-70b",
+    tuning_params={
+        "per_device_batch_size": 2,
+        "ici_fsdp_parallelism": 1,
+        "ici_fsdp_transpose_parallelism": -1,
+        "ici_tensor_parallelism": 1,
+        "remat_policy": "qkv_proj_offloaded",
+        "max_target_length": 4096,
+        "attention": "flash",
+        "gcs_metrics": True,
+        "use_iota_embed": True,
+        "dataset_path": "gs://trillium-storage-datasets-sr",
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+        "sa_block_q": 1024,
+        "sa_block_q_dkv": 2048,
+        "sa_block_q_dq": 2048,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+    ),
+  )
+)
+
+
+llama2_70b_4096_sc_real_data_grain = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama2-70b-4096",
+    model_type="llama2-70b",
+    tuning_params={
+        "per_device_batch_size": 2,
+        "ici_fsdp_parallelism": 1,
+        "ici_fsdp_transpose_parallelism": -1,
+        "ici_tensor_parallelism": 1,
+        "remat_policy": "qkv_proj_offloaded",
+        "max_target_length": 4096,
+        "attention": "flash",
+        "gcs_metrics": True,
+        "use_iota_embed": True,
+        "dataset_path": "gs://trillium-storage-datasets-sr",
+        "base_output_directory": (
+            "gs://trillium-storage-tests-nov24-sr/long-run-dec11"
+        ),
+        "enable_checkpointing": False,
+        "dataset_type": "grain",
+        "grain_train_files": "/tmp/dataset/array-record/c4/en/3.0.1/c4-train.array_record*",
+        "grain_worker_count": 24,
+        "profiler": "xplane",
+        "sa_block_q": 1024,
+        "sa_block_q_dkv": 2048,
+        "sa_block_q_dq": 2048,
+        "profile_cleanly": False,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+    ),
+  )
+)
+
+
+llama2_70b_4096_sc_real_data_grain_checkpoint = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama2-70b-4096",
+    model_type="llama2-70b",
+    tuning_params={
+        "per_device_batch_size": 2,
+        "ici_fsdp_parallelism": 1,
+        "ici_fsdp_transpose_parallelism": -1,
+        "ici_tensor_parallelism": 1,
+        "remat_policy": "qkv_proj_offloaded",
+        "max_target_length": 4096,
+        "attention": "flash",
+        "gcs_metrics": True,
+        "use_iota_embed": True,
+        "dataset_path": "gs://trillium-storage-datasets-sr",
+        "base_output_directory": (
+            "gs://trillium-storage-tests-nov24-sr/long-run-dec11"
+        ),
+        "checkpoint_period": 100,
+        "enable_checkpointing": True,
+        "async_checkpointing": True,
+        "dataset_type": "grain",
+        "grain_train_files": "/tmp/dataset/array-record/c4/en/3.0.1/c4-train.array_record*",
+        "grain_worker_count": 24,
+        "profiler": "xplane",
+        "sa_block_q": 1024,
+        "sa_block_q_dkv": 2048,
+        "sa_block_q_dq": 2048,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+    ),
+  )
+)
+
+
+llama2_70b_4096_real_data_pw_long_run = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama2-70b-4096-rd-pw-lr",
     model_type="llama2-70b",
     tuning_params={
@@ -329,64 +518,13 @@ llama2_70b_4096_real_data_pw_long_run = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
-# ici_fsdp_transpose_parallelism gives one TFLOP better performance.
-llama2_70b_4096 = MaxTextModel(
-    model_name="llama2-70b-4096",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 4,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "full",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-    ),
-)
-llama2_70b_4096_synthetic = MaxTextModel(
-    model_name="llama2_70b_4096_synthetic",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "qkv_proj_offloaded",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-    ),
-)
 
-llama2_70b_4096_synthetic_pw_lr = MaxTextModel(
+llama2_70b_4096_synthetic_pw_lr = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama2_70b_4096_synthetic_pw_lr",
     model_type="llama2-70b",
     tuning_params={
@@ -424,9 +562,13 @@ llama2_70b_4096_synthetic_pw_lr = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
-llama2_70b_4096_pw_long_run = MaxTextModel(
+
+llama2_70b_4096_pw_long_run = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama2-70b-4096-pw-lr",
     model_type="llama2-70b",
     tuning_params={
@@ -464,9 +606,13 @@ llama2_70b_4096_pw_long_run = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
-llama2_70b_4096_pw_rd_tfds = MaxTextModel(
+
+llama2_70b_4096_pw_rd_tfds = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama2_70b_4096_pw_rd_tfds",
     model_type="llama2-70b",
     tuning_params={
@@ -480,7 +626,6 @@ llama2_70b_4096_pw_rd_tfds = MaxTextModel(
         "gcs_metrics": True,
         "use_iota_embed": True,
         "dataset_path": "gs://trillium-storage-datasets-sr",
-        "enable_checkpointing": False,
         "profiler": "xplane",
         "sa_block_q": 1024,
         "sa_block_q_dkv": 2048,
@@ -502,10 +647,13 @@ llama2_70b_4096_pw_rd_tfds = MaxTextModel(
     xla_flags_library.DENSE_VMEM_LIMIT_FLAG
     + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
 
-llama3_8b_8192 = MaxTextModel(
+llama3_8b_8192 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama3-8b-8192",
     model_type="llama3-8b",
     tuning_params={
@@ -529,9 +677,13 @@ llama3_8b_8192 = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.CF_FOR_ALL_GATHER
     ),
+  )
 )
 
-llama3_70b_8192 = MaxTextModel(
+
+llama3_70b_8192 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama3-70b-8192",
     model_type="llama3-70b",
     tuning_params={
@@ -559,9 +711,13 @@ llama3_70b_8192 = MaxTextModel(
         + xla_flags_library.HOST_OFFLOAD_FLAGS
         + " --xla_tpu_scheduler_percent_shared_memory_limit=90"
     ),
+  )
 )
 
-llama3_1_405b_8192_fsdp_dcn = MaxTextModel(
+
+llama3_1_405b_8192_fsdp_dcn = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama3-1-405b-8192-fsdp-dcn",
     model_type="llama3.1-405b",
     tuning_params={
@@ -595,9 +751,13 @@ llama3_1_405b_8192_fsdp_dcn = MaxTextModel(
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.HOST_OFFLOAD_FLAGS
     ),
+  )
 )
 
-llama3_1_8b_8192 = MaxTextModel(
+
+llama3_1_8b_8192 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama3_1-8b-8192",
     model_type="llama3.1-8b",
     tuning_params={
@@ -636,9 +796,13 @@ llama3_1_8b_8192 = MaxTextModel(
         + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
         + xla_flags_library.HOST_OFFLOAD_FLAGS
     ),
+  )
 )
 
-llama3_1_70b_8192 = MaxTextModel(
+
+llama3_1_70b_8192 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama3_1-70b-8192",
     model_type="llama3.1-70b",
     tuning_params={
@@ -675,9 +839,13 @@ llama3_1_70b_8192 = MaxTextModel(
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.HOST_OFFLOAD_FLAGS
     ),
+  )
 )
 
-llama3_1_70b_129024 = MaxTextModel(
+
+llama3_1_70b_129024 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="llama3_1-70b-129024",
     model_type="llama3.1-70b",
     tuning_params={
@@ -715,12 +883,16 @@ llama3_1_70b_129024 = MaxTextModel(
         xla_flags_library.DENSE_VMEM_LIMIT_FLAG
         + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
         + xla_flags_library.DATA_PARALLEL_OVERLAP
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_1D_ALL_GATHER
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_GATHER
         + xla_flags_library.HOST_OFFLOAD_FLAGS
     ),
+  )
 )
 
-mixtral_8x7b_dropless = MaxTextModel(
+
+mixtral_8x7b_dropless = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="mixtral-8x7b",
     model_type="mixtral-8x7b",
     tuning_params={
@@ -747,9 +919,13 @@ mixtral_8x7b_dropless = MaxTextModel(
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.DATA_PARALLEL_OVERLAP
     ),
+  )
 )
 
-mixtral_8x7b_dropped = MaxTextModel(
+
+mixtral_8x7b_dropped = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="mixtral-8x7b",
     model_type="mixtral-8x7b",
     tuning_params={
@@ -778,9 +954,13 @@ mixtral_8x7b_dropped = MaxTextModel(
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.DATA_PARALLEL_OVERLAP
     ),
+  )
 )
 
-mixtral_8x7b_dropped_int8 = MaxTextModel(
+
+mixtral_8x7b_dropped_int8 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="mixtral-8x7b",
     model_type="mixtral-8x7b",
     tuning_params={
@@ -809,9 +989,13 @@ mixtral_8x7b_dropped_int8 = MaxTextModel(
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.DATA_PARALLEL_OVERLAP
     ),
+  )
 )
 
-gemma2_9b_8192 = MaxTextModel(
+
+gemma2_9b_8192 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="gemma2-9b-8192",
     model_type="gemma2-9b",
     tuning_params={
@@ -838,9 +1022,13 @@ gemma2_9b_8192 = MaxTextModel(
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
     ),
+  )
 )
 
-gemma2_27b_8192 = MaxTextModel(
+
+gemma2_27b_8192 = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
     model_name="gemma2-27b-8192",
     model_type="gemma2-27b",
     tuning_params={
@@ -867,37 +1055,5 @@ gemma2_27b_8192 = MaxTextModel(
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
     ),
+  )
 )
-
-# TODO(b/368441022) LLAMA3.1 8B, 70B, 405B
-# TODO(b/368441022) MaxDiffusion BEST
-# TODO(b/368441022) Determine largest batch per slice for non-optimized models
-# List of all models
-maxstar_models = [
-    default_basic,
-    default_32,
-    default_64,  # Not Optimizied yet
-    default_128,  # Not Optimizied yet
-    # default_256,  # OOM, Not Optimizied yet
-    # default_512,  # OOM, Not Optimizied yet
-    gpt_3_175b,
-    llama2_7b_4096,
-    llama2_70b_4096,
-    llama2_70b_4096_pw_long_run,
-    llama2_70b_4096_real_data,
-    llama2_70b_4096_real_data_pw_long_run,
-    llama2_70b_4096_pw_rd_tfds,
-    llama3_8b_8192,  # Not Optimizied yet
-    llama3_70b_8192,  # Not Optimizied yet
-    llama2_70b_4096_synthetic_pw_lr,
-    llama2_70b_4096_synthetic,
-    llama3_1_405b_8192_fsdp_dcn,
-    llama3_1_8b_8192,
-    llama3_1_70b_8192,
-    llama3_1_70b_129024,
-    mixtral_8x7b_dropped,
-    mixtral_8x7b_dropped_int8,
-    mixtral_8x7b_dropless,
-    gemma2_9b_8192,
-    gemma2_27b_8192,
-]

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -17,9 +17,16 @@
 """  This file contains data classes and runner logic to execute the XPK runs triggered by benchmarks/benchmark_runner.py"
 
 """
+# Improvements:
+# Toggle Vertex AI Experiment on/off.
+# Group libtpu / jax / jaxlib dependencies instead of just libtpu.
+# Split out maxtext command generation and xpk runner from this file.
+# Enable hlo dumps.
+
 import dataclasses
 import datetime
 import enum
+import os
 import random
 import string
 import subprocess
@@ -30,55 +37,51 @@ import time
 import maxtext_trillium_model_configs as model_configs
 
 # Assumes you built maxtext dep image.
-# Assumes you locally downloaded the libtpu wheel.
-BASE_DOCKER_IMAGE = 'maxtext_base_image'
-
+# Assumes you have xpk installed in a git clone repo of ~/{wl_config.xpk_path}/xpk.py
+_DEFAULT_MAXTEXT_BASE_DOCKER_IMAGE_NAME = 'maxtext_base_image'
 
 class LibTpuType(enum.Enum):
-  V6E_NIGHTLY_WHEEL = 'v6e-nightly-wheel'
   NIGHTLY = 'nightly-libtpu'
+  # In order to use a custom libtpu, put a libtpu.so file in your local
+  # working directory.
   CUSTOM = 'custom'
   MAXTEXT = 'maxtext-docker'
 
 
 @dataclasses.dataclass
-class XpkConfig:
-  cluster_name: str
-  project: str
-  zone: str
-  num_slices: str
-  device_type: str
-  base_output_directory: str
-  priority: str
-  max_restarts: int
-
-
-@dataclasses.dataclass
 class PathwaysConfig:
-  use_pathways: bool
   server_image: str
   proxy_image: str
   runner_image: str
 
 
+# TODO(@vbarr): Split out parameters related to XPK workload and a General workload
 @dataclasses.dataclass
-class HWConfig:
+class WorkloadConfig:
+  """Class representing for passing general workload parameters"""
+
+  model: model_configs.MaxTextModel
   num_slices: str
   device_type: str
-
-
-@dataclasses.dataclass
-class SWconfig:
-  libtpu_version: str
+  base_output_directory: str
   base_docker_image: str
-  pathways_config: PathwaysConfig
+  libtpu_type: LibTpuType
+  libtpu_nightly_version: str = None # A date in %Y%M%D format, 20241201
+  num_steps: int = 20
+  max_restarts: int = 0
+  priority: str = "medium"
+  xpk_path: str = '~/xpk'
+  pathways_config: PathwaysConfig = None
 
 
 @dataclasses.dataclass
-class BenchmarkRunner:
-  model_name: str
-  hardware_config: HWConfig
-  software_config: SWconfig
+class XpkClusterConfig:
+  """Holds details related to a XPK cluster to run workloads on."""
+
+  cluster_name: str
+  project: str
+  zone: str
+  device_type: str
 
 
 def chunks(lst: list, n: int):
@@ -269,60 +272,54 @@ def run_command_with_updates(command, task, verbose=True) -> int:
 
 def build_user_command(
     name: str,
-    model: model_configs.MaxTextModel,
-    num_slices: int,
-    num_steps: int,
-    libtpu_type: LibTpuType,
-    libtpu_date: str,
-    cluster_config: XpkConfig,
-    base_output_directory: str,
-    buffer_size: int,
-    pathways_config: PathwaysConfig = None,
+    wl_config: WorkloadConfig,
 ):
+  is_pw_enabled = wl_config.pathways_config is not None
+
   config_tuning_params = ''
-  for key, value in model.tuning_params.items():
+  for key, value in wl_config.model.tuning_params.items():
     config_tuning_params += f'{key}={value} '
 
   install_libtpu_cmd = ''
-  if pathways_config.use_pathways:
-    pass
-  elif libtpu_type == LibTpuType.NIGHTLY:
-    install_libtpu_cmd += (
-        f' pip install libtpu-nightly==0.1.dev{libtpu_date} -f'
-        ' https://storage.googleapis.com/libtpu-releases/index.html &&'
-    )
-  elif libtpu_type == LibTpuType.CUSTOM:
-    install_libtpu_cmd += f' mv libtpu.so /lib/ &&'
-  elif libtpu_type == LibTpuType.MAXTEXT:
-    install_libtpu_cmd += ''
-  # model.xla_flags += ' --megascale_verify_checksums=true'
-  # Enable chaotic good.
-  # model.xla_flags += ' --megascale_grpc_use_chaotic_good=true'
-  # model.xla_flags += ' --megascale_grpc_use_event_engine_allocator=true'
-  # model.xla_flags += ' --grpc_enable_tcp_recv_zerocopy=false'
-  # model.xla_flags += ' --grpc_enable_rpc_receive_coalescing=true'
-  # model.xla_flags += ' --grpc_experiments=tcp_rcv_lowat'
+  jax_platforms = None
+  vertex_tensorboard = None
+  # TODO() support modifying nightly / stable dependencies in pathway flow
+  if is_pw_enabled:
+    jax_platforms = 'proxy'
+  else:
+    if wl_config.libtpu_type == LibTpuType.NIGHTLY:
+      install_libtpu_cmd += (
+          f' pip install libtpu-nightly==0.1.dev{wl_config.libtpu_nightly_version} -f'
+          ' https://storage.googleapis.com/libtpu-releases/index.html &&'
+      )
+    elif wl_config.libtpu_type == LibTpuType.CUSTOM:
+      # In order to use a custom libtpu, put a libtpu.so file in your local
+      # working directory.
+      install_libtpu_cmd += ' mv libtpu.so /lib/ &&'
+    elif wl_config.libtpu_type == LibTpuType.MAXTEXT:
+      # Use the libtpu dependent built in the docker image provided.
+      install_libtpu_cmd += ''
 
-  # Use single quotes for LIBTPU_INIT_ARGS and escape inner single quotes
-  libtpu_flags = f"LIBTPU_INIT_ARGS='{model.xla_flags}'"
-  jax_platforms = 'proxy' if pathways_config.use_pathways else 'tpu,cpu'
-  vertex_tensorboard = 'vertex_tensorboard_project="" vertex_tensorboard_region=""' if pathways_config.use_pathways else ''
+    jax_platforms = 'tpu,cpu'
+    vertex_tensorboard = 'use_vertex_tensorboard=false vertex_tensorboard_project="" vertex_tensorboard_region=""'
+
+  assert jax_platforms is not None, 'Error in setting jax_platforms'
+
+  libtpu_flags = f'LIBTPU_INIT_ARGS=\'{wl_config.model.xla_flags}\''
 
   # Construct the command string with proper formatting and line continuations
   command = ' '.join([
       f'{install_libtpu_cmd}',
-      f'echo {libtpu_flags} &&' if not pathways_config.use_pathways else '',
-      f'export {libtpu_flags} &&' if not pathways_config.use_pathways else '',
+      f'echo {libtpu_flags} &&' if not is_pw_enabled else '',
+      f'export {libtpu_flags} &&' if not is_pw_enabled else '',
       'export ENABLE_PATHWAYS_PERSISTENCE=1 &&',
       f'export JAX_PLATFORMS={jax_platforms} &&',
-      f'export TPU_PREMAPPED_BUFFER_SIZE={buffer_size} &&',
-      f'echo {buffer_size} &&',
       'export ENABLE_PJRT_COMPATIBILITY=true &&',
       'python3 MaxText/train.py MaxText/configs/base.yml',
       f'{config_tuning_params}',
-      f'model_name={model.model_type}',
-      f'base_output_directory={base_output_directory}',
-      'use_vertex_tensorboard=false',
+      f'steps={wl_config.num_steps}',
+      f'model_name={wl_config.model.model_type}',
+      f'base_output_directory={wl_config.base_output_directory}',
       f'{vertex_tensorboard}',
       f'run_name={name}'
   ])
@@ -330,91 +327,83 @@ def build_user_command(
 
 
 def generate_xpk_workload_cmd(
-    model: model_configs.MaxTextModel,
-    cluster_config: XpkConfig,
-    num_slices: int,
-    libtpu_type: LibTpuType,
-    libtpu_version: str,
-    base_output_directory: str,
-    buffer_size: int,
-    xpk_path: str = '~/xpk',
-    pathways_config: PathwaysConfig = None,
+    cluster_config: XpkClusterConfig,
+    wl_config: WorkloadConfig,
 ):
-  """Generates a command to run a maxstar model on XPK."""
-  num_steps = 20
+  """Generates a command to run a maxtext model on XPK."""
+
+  is_pathways_enabled = wl_config.pathways_config is not None
+
   time.localtime()
-  N = 3
+  length_of_random_str = 3
   temp_post_fix = ''.join(
-      random.choice(string.ascii_lowercase + string.digits) for _ in range(N)
+      random.choice(string.ascii_lowercase + string.digits) for _ in range(length_of_random_str)
   )
 
-  name = (
-      f"{model.model_name.replace('_', '-')}-{cluster_config.num_slices}-{time.strftime('%m%d%H', time.localtime())}-{temp_post_fix}"
-  )
-  if pathways_config.use_pathways:
-    # Pathways run names are long and need to be shortened.
+  truncate_model_name = 12
+  truncate_prefix = 5
+  common_post_fix = f"-{wl_config.num_slices}-{time.strftime('%m%d%H', time.localtime())}-{temp_post_fix}"
+  common_prefix = os.environ['USER']
+  pw_prefix = "pw-"
+
+  if is_pathways_enabled:
     name = (
-        f"pw-{model.model_name.replace('_', '-')}-{cluster_config.num_slices}-{temp_post_fix}"
+        f"{pw_prefix}{wl_config.model.model_name.replace('_', '-')[:truncate_model_name - len(pw_prefix)]}"
     )
+  else:
+    name = (
+      f"{wl_config.model.model_name.replace('_', '-')[:truncate_model_name]}"
+    )
+  name = f"{common_prefix[:truncate_prefix]}-{name}{common_post_fix}"
 
   user_command = build_user_command(
-      name,
-      model,
-      num_slices,
-      num_steps,
-      libtpu_type,
-      libtpu_version,
-      cluster_config,
-      base_output_directory,
-      buffer_size,
-      pathways_config,
+      name=name,
+      wl_config=wl_config
   )
 
   additional_flags = ''
-  if libtpu_type == LibTpuType.CUSTOM:
+  if not is_pathways_enabled and wl_config.libtpu_type == LibTpuType.CUSTOM:
     additional_flags = '--env="TPU_LIBRARY_PATH=/lib/libtpu.so"'
-  # additional_flags = '--env="TPU_MEGACORE=megachip_tccontrol"'
 
-  perf_optimzation_dcn = (
-      'kubectl apply -f'
-      ' https://raw.githubusercontent.com/GoogleCloudPlatform/ai-on-gke/9ff340f07f70be0130454f9e7238551587242b75/scripts/network-setup/v6e-network-optimization.yaml'
-  )
-
+  docker_image_flag = ''
   # pathways-related flags
   pathways_specific_flags = ''
-  docker_image_flag = f'--base-docker-image="{BASE_DOCKER_IMAGE}"'
-  if pathways_config.use_pathways:
+  if is_pathways_enabled:
+    pw_config = wl_config.pathways_config
     pathways_specific_flags = (
         '--use-pathways'
-        f' --server-image={pathways_config.server_image}'
-        f' --proxy-server-image={pathways_config.proxy_image}'
+        f' --server-image={pw_config.server_image}'
+        f' --proxy-server-image={pw_config.proxy_image}'
         ' --termination-grace-period-seconds=300'
-        f' --pathways-gcs-location={base_output_directory}'
+        f' --pathways-gcs-location={wl_config.base_output_directory}'
         f' --restart-on-user-code-failure'
-        f' --debug-dump-gcs={base_output_directory}'
+        f' --debug-dump-gcs={wl_config.base_output_directory}'
     )
     docker_image_flag = (
-        f'--docker-image={pathways_config.runner_image}'
+        f'--docker-image={pw_config.runner_image}'
     )
+  else:
+    docker_image_flag = f'--base-docker-image="{wl_config.base_docker_image}"'
+
 
   print(f'User command: {user_command}')
   return (
       (
-          # f'{perf_optimzation_dcn} &&'
-          f'python3 {xpk_path}/xpk.py workload create'
+          f'python3 {wl_config.xpk_path}/xpk.py workload create'
           f' {pathways_specific_flags}'
           f' --cluster={cluster_config.cluster_name}'
           f' --project={cluster_config.project}'
           f' --zone={cluster_config.zone}'
           f' --device-type={cluster_config.device_type}'
-          f' --num-slices={cluster_config.num_slices}'
+          f' --num-slices={wl_config.num_slices}'
           f' --command="{user_command}"'
           f' {docker_image_flag}'
           ' --enable-debug-logs'
           f' --workload={name}'
-          f' --priority={cluster_config.priority}'
-          f' --max-restarts={cluster_config.max_restarts}'
+          f' --priority={wl_config.priority}'
+          f' --max-restarts={wl_config.max_restarts}'
           # ' --use-vertex-tensorboard'
+          # f' --experiment-name={test_purpose_name}'
           f' {additional_flags}'
       ),
       name,
@@ -422,14 +411,10 @@ def generate_xpk_workload_cmd(
 
 
 def run_xpk_workload(
-    model: model_configs.MaxTextModel,
-    cluster_config: XpkConfig,
-    num_slices: int,
-    libtpu_type: LibTpuType,
-    libtpu_version: str,
-    buffer_size: int,
+    cluster_config: XpkClusterConfig,
+    wl_config: WorkloadConfig,
 ):
-  """Runs a maxstar model on XPK.
+  """Runs a maxtext model on XPK.
 
   Args:
     model:
@@ -437,43 +422,141 @@ def run_xpk_workload(
 
   Returns:
   """
+  assert cluster_config.device_type == wl_config.device_type, f"The workload device size {wl_config.device_type}, and cluster device size {cluster_config.device_type} don't match."
   command, _ = generate_xpk_workload_cmd(
-      model, cluster_config, num_slices, libtpu_type, libtpu_version, base_output_directory=cluster_config.base_output_directory, buffer_size=buffer_size
+      cluster_config=cluster_config,
+      wl_config=wl_config
   )
-  return run_command_with_updates(command, 'Run XPK workload', cluster_config)
+  return run_command_with_updates(command, 'Run XPK workload')
 
 
 def xpk_benchmark_runner(
-    cluster_config: XpkConfig,
-    benchmarks: list[BenchmarkRunner],
-    xpk_path: str = '~/xpk',
+    cluster_config: XpkClusterConfig,
+    workload_configs: list[WorkloadConfig],
 ):
   xpk_workload_names = []
   xpk_workload_cmds = []
-  for benchmark in benchmarks:
+  for wl_config in workload_configs:
     command, name = generate_xpk_workload_cmd(
-        model=benchmark.model_name,
-        cluster_config=cluster_config,
-        num_slices=benchmark.hardware_config.num_slices,
-        libtpu_type=LibTpuType.NIGHTLY,
-        libtpu_version=benchmark.software_config.libtpu_version,
-        base_output_directory=cluster_config.base_output_directory,
-        buffer_size=4294967296,
-        xpk_path=xpk_path,
-        pathways_config=benchmark.software_config.pathways_config,
+      cluster_config=cluster_config,
+      wl_config=wl_config
     )
 
-    print(f"name of the workload is: {name}")
+    print(f"Name of the workload is: {name} \n")
     xpk_workload_names.append(name)
 
-    print(f"XPK command to be used is: {command}")
+    print(f"XPK command to be used is: {command} \n")
     xpk_workload_cmds.append(command)
 
-  returncodes = run_commands(
-      xpk_workload_cmds,
-      'Run XPK workloads',
-      xpk_workload_names,
-      batch=1,
-      dry_run=False,
+  # TODO(@vbarr) Support batch workloads.
+  for xpk_workload_name, xpk_workload_cmd in zip(xpk_workload_names, xpk_workload_cmds):
+    return_code = run_command_with_updates(xpk_workload_cmd, xpk_workload_name)
+    if return_code != 0:
+      print('Unable to run xpk workload: {xpk_workload_name}')
+
+
+# Run maxtext_xpk_runner.py as a script for executing multiple workloads pythonically!
+def main() -> int:
+  # Variables to configure:
+  output_bucket = 'gs://DIR'
+  base_docker_image = _DEFAULT_MAXTEXT_BASE_DOCKER_IMAGE_NAME
+
+  # Set up the clusters to run workloads on!
+  v5e_cluster_config = XpkClusterConfig(
+      cluster_name='v5e-256',
+      project='my-cool-project',
+      zone='us-central2-b',
+      device_type='v5litepod-256',
   )
-  print(f'Returncodes: {returncodes}')
+
+  v6e_cluster_config = XpkClusterConfig(
+      cluster_name='v6e-256',
+      project='my-cool-project',
+      zone='us-central2-b',
+      device_type='v6e-256',
+  )
+
+  xpk_workload_cmds = []
+  xpk_workload_names = []
+
+  list_of_models = [
+    model_configs.llama2_70b_4096_sc,
+    # model_configs.default_128
+  ]
+
+  # Loop possibilities:
+  # 1. Test different libtpu nightly versions.
+  #  for libtpu_type in [
+  #           LibTpuType.NIGHTLY
+  #       ]:
+  #     todays_date = time.strftime('%Y%m%d')
+  #    for date in ['20241201', '20241202', todays_date]:
+
+  # 2. Test different model configurations.
+  # for remat_policy in ['qkv_proj_offloaded', 'minimal']:
+  #   model.tuning_params['remat_policy'] = remat_policy
+
+  # 3. See other examples below
+
+  user = os.environ['USER']
+  base_output_dir = os.path.join(output_bucket,user)
+
+  for model in list_of_models:
+    # Run workloads on the below clusters
+    for cluster_config in [
+      # v5e_cluster_config,
+      # v6e_cluster_config,
+      v6e_cluster_config_yucmhab,
+      # another_config,
+    ]:
+      # Run workloads in the following slice configurations
+      for num_slices in [1,]:
+        # Use the libtpu dependencies from:
+        for libtpu_type in [
+            # LibTpuType.CUSTOM
+            LibTpuType.MAXTEXT
+            # LibTpuType.NIGHTLY
+        ]:
+          wl_config = WorkloadConfig(
+            model=model,
+            num_slices=num_slices,
+            device_type=cluster_config.device_type,
+            base_output_directory=base_output_dir,
+            priority="medium",
+            max_restarts=0,
+            libtpu_type=libtpu_type,
+            libtpu_nightly_version="",
+            base_docker_image=base_docker_image,
+            pathways_config=None
+          )
+          command, name = generate_xpk_workload_cmd(
+            cluster_config=cluster_config,
+            wl_config=wl_config
+          )
+
+          print(f"Name of the workload is: {name} \n")
+          xpk_workload_names.append(name)
+
+          print(f"XPK command to be used is: {command} \n")
+          xpk_workload_cmds.append(command)
+
+  for xpk_workload_name, xpk_workload_cmd in zip(xpk_workload_names, xpk_workload_cmds):
+    return_code = run_command_with_updates(xpk_workload_cmd, xpk_workload_name)
+    if return_code != 0:
+      print('Unable to run xpk workload: {xpk_workload_name}')
+
+  # Support Batch workloads one day. Note that this doesn't show the xpk logs per workload.
+  # They are saved to file instead.
+  # return_codes = run_commands(
+  #     xpk_workload_cmds,
+  #     'Run XPK workloads',
+  #     xpk_workload_names,
+  #     batch=1,  # Parallel execution of workloads is not supported in XPK yet.
+  #     dry_run=False,
+  # )
+ # print(f'Return_codes: {return_codes}')
+
+
+
+if __name__ == '__main__':
+  main()

--- a/benchmarks/xla_flags_library.py
+++ b/benchmarks/xla_flags_library.py
@@ -15,15 +15,26 @@
  """
 """This file contains commonly-used XLA Flags."""
 
+### NOTICE ###
+# These are potential optimization flags that are used within MaxText models.
+# They may or may not provide performance improvements in extended use cases
+# but provide a recommendation for potential grouping of xla flags and their
+# usage. Please refer to their usage for examples.
+
+# xla tpu scoped vmem defines the amount of vmem used for the current hlo op.
+# The remaining vmem is used for prefetching latter op needs.
+# These limits are experimentally recommended values for compute bound models.
 _DENSE_VMEM_LIMIT = 98304
 _MOE_VMEM_LIMIT = 81920
+
 DENSE_VMEM_LIMIT_FLAG = f" --xla_tpu_scoped_vmem_limit_kib={_DENSE_VMEM_LIMIT}"
 MOE_VMEM_LIMIT_FLAG = f" --xla_tpu_scoped_vmem_limit_kib={_MOE_VMEM_LIMIT}"
 CUSTOM_VMEM_LIMIT_FLAG = (
     lambda vmem_limit: f"--xla_tpu_scoped_vmem_limit_kib={vmem_limit}"
 )
 
-# Enabled by default but lets make sure.
+# Continuation Fusion (CF) for All Gather Collectives
+# Continuation Fusion is a form of parallelizing compute work with collectives.
 CF_FOR_ALL_GATHER = (
     " --xla_tpu_enable_async_collective_fusion=true"
     " --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true"
@@ -32,6 +43,8 @@ CF_FOR_ALL_GATHER = (
     " --xla_enable_async_all_gather=true"
 )
 
+# Continuation Fusion (CF)for All Reduce Collectives
+# Continuation Fusion is a form of parallelizing compute work with collectives.
 CF_FOR_ALL_REDUCE = (
     " --xla_tpu_enable_async_collective_fusion=true"
     " --xla_tpu_enable_async_collective_fusion_fuse_all_reduce=true"
@@ -40,6 +53,8 @@ CF_FOR_ALL_REDUCE = (
     " --xla_enable_async_all_reduce=true"
 )
 
+# Continuation Fusion (CF) for All Gather and All Reduce Collectives.
+# Continuation Fusion is a form of parallelizing compute work with collectives.
 CF_FOR_ALL_REDUCE_AND_ALL_GATHER = (
     " --xla_enable_async_all_reduce=true"
     " --xla_enable_async_all_gather=true"
@@ -49,9 +64,9 @@ CF_FOR_ALL_REDUCE_AND_ALL_GATHER = (
     " --xla_tpu_enable_async_collective_fusion_multiple_steps=true"
 )
 
-#Only ready for 1D All-Gather but should support 2D soon, and
-# hopefully All-Reduce soon.
-ENABLE_SPARSECORE_OFFLOADING_FOR_1D_ALL_GATHER = (
+# Enable SparseCore All Gather (SC AG).
+# Either one of CF AG or SC AR can be enabled at a time.
+ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_GATHER = (
     " --xla_sc_disable_megacore_partitioning=true"
     " --xla_tpu_enable_async_collective_fusion_fuse_all_gather=false"
     " --xla_tpu_enable_all_gather_offload_tracing=true"
@@ -60,12 +75,13 @@ ENABLE_SPARSECORE_OFFLOADING_FOR_1D_ALL_GATHER = (
     " --xla_sc_enable_instruction_fusion=false"
     " --xla_sc_disjoint_spmem=false"
     " --2a886c8_chip_config_name=megachip_tccontrol"
-    # Interesting flags to try:
-    # " --xla_tpu_enable_offloading_gather_to_sparsecore=true"
-    # " --xla_tpu_enable_offloading_reduce_to_sparsecore=true"
-    # " --xla_tpu_enable_offloading_scatter_to_sparsecore=true"
+    " --xla_tpu_enable_sparse_core_collective_offload_all_reduce=false"
 )
 
+# Enable SparseCore All Reduce (SC AR)
+# Either one of CF AR or SC AR can be enabled at a time.
+# This is useful for reducing the gradient reduction all-reduce time with
+# overlapping with compute during that time.
 ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE = (
     " --xla_sc_disable_megacore_partitioning=true"
     " --xla_tpu_enable_all_reduce_offload_tracing=true"
@@ -76,14 +92,15 @@ ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE = (
     " --2a886c8_chip_config_name=megachip_tccontrol"
 )
 
-# Better memory layout for all-reduce
+# Better memory layout for all-reduce (AR).
 LAYOUT_FOR_ALL_REDUCE_SCATTER = (
     " --xla_tpu_use_minor_sharding_for_major_trivial_input=true"
     " --xla_tpu_relayout_group_size_threshold_for_reduce_scatter=1"
     " --xla_tpu_assign_all_reduce_scatter_layout=true"
 )
 
-# Enable AR + DS = RS fusion
+# Enable Reduce Scatter (RS) Fusion in certain cases by merging
+# All-reduce (AR) and Dynamic-Slice (DS).
 REDUCE_SCATTER_FUSION = (
     " --xla_tpu_use_minor_sharding_for_major_trivial_input=true"
     " --xla_tpu_relayout_group_size_threshold_for_reduce_scatter=1"
@@ -98,7 +115,8 @@ DATA_PARALLEL_OVERLAP = (
     " --xla_tpu_data_parallel_opt_different_sized_ops=true"
 )
 
-# Host offloading Flags.
+# Host offloading Flags. These are optimizations recommended when using host
+# offloading.
 HOST_OFFLOAD_FLAGS = (
     " --xla_tpu_enable_all_experimental_scheduler_features=true"
     " --xla_tpu_enable_scheduler_memory_pressure_tracking=true"
@@ -113,7 +131,17 @@ HOST_OFFLOAD_FLAGS = (
     " --xla_latency_hiding_scheduler_rerun=2"
 )
 
-# Enable SDC Checker
+# Disable bundle-aware CostModel which was causing worse perf b/357103386.
+# Some fusions in the backward pass of the model were 3x slower without this.
+DISABLE_BUNDLE_AWARE_COST_MODEL = (
+    " --xla_tpu_use_bundle_aware_cost_model_for_fusions=false"
+)
+
+# Enable Silent Data Corruption (SDC) Checker
+# SDC Checker will check for chip / ici / hardware corruption events.
+# Below is a configuration of finding non-deterministic failures by
+# rerunning the HLO and LLO and verifying the results match each time.
+# Enabling this will reduce performance by a factor of 1/(repeat_count + 1).
 ENABLE_SDC_CHECKER = False
 SDC_CHECKER = (
     " --xla_tpu_enable_sdc_checker=true"
@@ -124,6 +152,7 @@ if ENABLE_SDC_CHECKER:
   ENABLE_DEBUG_LOGS = True
 
 # Enable Debug Logs
+# These are a set of debug logs recommended to be part of a workload.
 ENABLE_DEBUG_LOGS = False
 DEBUG_LOGS = {
     "TPU_STDERR_LOG_LEVEL": "0",
@@ -131,8 +160,3 @@ DEBUG_LOGS = {
     "TPU_MIN_LOG_LEVEL": "0",
     "TPU_VMODULE": "tpu_configuration_ops_impl=3",  # Enable TPU logging
 }
-
-# Disable bundle-aware CostModel which was causing worse perf b/357103386.
-DISABLE_BUNDLE_AWARE_COST_MODEL = (
-    " --xla_tpu_use_bundle_aware_cost_model_for_fusions=false"
-)


### PR DESCRIPTION
# Description

- Adds support for pythonically executing several xpk workloads looping on pythonic model configs, xpk cluster parameters, slice sizes, libtpu dependencies
- Adjust internal structions for passing arguments between classes using XpkClusterConfig and WorkloadConfig
- Update the xla flag library with latest flags and more details on their usage
- Update models in the trillium model config with latest models and simplify how they are compiled to one dictionary, link this directly to the benchmark runner model_name argument
- num_steps argument added to benchmark runner


# Tests

1. Run benchmark runner with mcjax:

```
python3 benchmarks/benchmark_runner.py --project tpu-prod-env-one-vm --zone us-east5 --cluster_name bodaborg-v6e-256-dnd-yucmhab --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5
```

2. Run benchmark runner with pathways:

```

export RUNNER=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/maxtext_jax_stable
export PROXY_IMAGE=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/proxy_server:latest
export SERVER_IMAGE=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/server:latest

python3 benchmarks/benchmark_runner.py --project tpu-prod-env-one-vm --zone us-east5 --cluster_name bodaborg-v6e-256-dnd-yucmhab --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5  
 --pathways_server_image="${SERVER_IMAGE}" --pathways_proxy_image="${PROXY_IMAGE}" --pathways_runner_image="${RUNNER}" 
```

3. Run maxtext_xpk_runner.py directly:

```
python3 benchmarks/maxtext_xpk_runner.py
```


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
