### PR TITLE
Initialize distributed IDs on CPU

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -316,6 +316,8 @@ def initialize_jax_for_cpu(raw_keys):
       num_processes=int(os.environ.get("JAX_PROCESS_COUNT")),
       initialization_timeout=raw_keys["jax_distributed_initialization_timeout"],
   )
+  ocp.multihost.initialize_runtime_to_distributed_ids()
+  ocp.multihost.initialize_distributed_to_device_ids()
 
 
 def initialize_jax_for_tpu_with_emergency_checkpointing(raw_keys):


### PR DESCRIPTION
# Description

Calling these methods when running on CPU allows for the emergency checkpointer to work on CPU for testing purposes, in combination with some changes to Orbax.

See b/388522113 and the document linked from there

# Tests

See the document linked from the above bug for the steps followed to test this change.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
  - Many of the unit tests appear to be failing when I run them without changes, and I don't have permission to run integration tests, so it's a bit hard to tell
- [x] I have made or will make corresponding changes to the doc if needed.
