### PR TITLE
Mattdavidow v5p 32b update

### DIFF
--- a/MaxText/configs/v5p/32b.sh
+++ b/MaxText/configs/v5p/32b.sh
@@ -40,7 +40,7 @@ if [ "$RUN_PREFLIGHT" = "true" ]; then
 fi
 
 # Train
-export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
+export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_sc_disable_megacore_partitioning=true --xla_tpu_use_tc_device_shape_on_sc=true --xla_tpu_enable_sparse_core_collective_offload_all_gather=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=false"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=15 per_device_batch_size=6 enable_checkpointing=false\
     remat_policy=minimal global_parameter_scale=32\

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ More details on reproducing these results can be found in [MaxText/configs/READM
 
 | No. of params | Accelerator Type | TFLOP/chip/sec | Model flops utilization (MFU) |
 |---|---|---|---|
-| 32B | v5p-128 | 3.28e+02 | 71.47% |
+| 32B | v5p-128 | 3.28e+02 | 67.76% |
 | 64B | v5p-128 | 3.23e+02 | 70.31% |
 | 128B | v5p-256 | 3.15e+02 | 68.68% |
 | 128B | v5p-512 | 3.15e+02 | 68.53% |


### PR DESCRIPTION
# Description

Update v5p 32b config with SC offloading flags. These configs were previously optimized with slightly different model dimensions ~1 year ago

(internal) See b/385207081 for more

# Tests
* Ran 1 slice:  67.77% MFU (311.1 TFLOPS)
* Ran 2 slice:  65.3% MFU (300 TFLOPS)
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
