### PR TITLE
WIP: Adding TransformerEngine support for Communication GeMM overlap for Tensor Parallelism

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -298,6 +298,28 @@ ici_autoregressive_parallelism: 1
 ici_pipeline_parallelism: 1
 ici_expert_parallelism: 1
 
+# Configs for TransformerEngine Communication-GeMM overlap
+comm_gemm_overlap: False
+overlap_config: {
+  "fc1_fprop": {
+      "method": "ring_exchange",  # "pipeline" for collective kernels instead of send/recv
+      "cga_size": 1,  # default is 2 for "pipeline"
+      "num_sm": 1,  # ignored for "ring_exchange", must be tuned for "pipeline"
+      "set_sm_margin": False,  # set to True for "pipeline"
+      "atomic_gemm": False,  # more performant when not using CUDA Graphs
+      "use_ce": True,  # ignored (always False) for "pipeline" method
+  },
+  "fc2_fprop": {
+      "method": "pipeline", #for collective kernels instead of send/recv
+      "num_splits": 4,  # independent of TP size for "pipeline"
+      "cga_size": 2,  # default is 2 for "pipeline"
+      "num_sm": 8,  # ignored for "ring_exchange", must be tuned for "pipeline"
+      "set_sm_margin": True,  # set to True for "pipeline"
+      "atomic_gemm": False,  # more performant when not using CUDA Graphs
+      "use_ce": False,  # ignored (always False) for "pipeline" method
+  },
+}
+
 # The number of TPU slices is automatically determined, you should not set this explicitly. For ahead of time compilation,
 # you should set compile_toplogy_num_slices, which will in turn set this value. For non-TPU environments this is set to 1.
 num_slices: -1

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -426,6 +426,7 @@ class AttentionOp(nn.Module):
         scale_factor=1.0 / math.sqrt(head_dim),
         transpose_batch_sequence=False,
         window_size=sliding_window_size,
+        context_parallel_axis="sequence",
     )
     return dpa_layer(query, key, value, mask=attn_mask)
 

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -104,6 +104,9 @@ class DenseGeneral(nn.Module):
   quant: Optional[Quant] = None
   use_bias: bool = False
   matmul_precision: str = "default"
+  comm_gemm_overlap: Optional[bool] = False
+  comm_gemm_overlap_type: Optional[str] = ""
+  mesh: Optional[Quant] = None
 
   @nn.compact
   def __call__(self, inputs: Array) -> Array:
@@ -125,6 +128,23 @@ class DenseGeneral(nn.Module):
         dot_general = dot_general_cls()
         return dot_general(inputs, kernel, ((axis, contract_ind), ((), ())), precision=None)
       return dot_general(inputs, kernel, ((axis, contract_ind), ((), ())), precision=matmul_precision)
+
+    def transformer_engine_comm_gemm_overlap(inputs, kernel, axis, contract_ind):
+      from transformer_engine.jax.gemm import gemm as te_gemm_impl
+      from functools import partial
+      from jax.sharding import NamedSharding
+      from jax.sharding import PartitionSpec as P
+
+      def te_gemm_with_overlap(A, B):
+          return te_gemm_impl(
+              x=A,
+              kernel=jax.lax.with_sharding_constraint(B, NamedSharding(self.mesh, P(None, "tensor_sequence"))) if self.comm_gemm_overlap_type=="fc1_fprop" else jax.lax.with_sharding_constraint(B, NamedSharding(self.mesh, P("tensor_sequence", None))),
+              comm_overlap_name=self.comm_gemm_overlap_type
+          )
+
+      collective_gemm = jax.jit(partial(te_gemm_with_overlap))
+      out = collective_gemm(inputs, kernel)
+      return out
 
     features = _canonicalize_tuple(self.features)
     axis = _canonicalize_tuple(self.axis)
@@ -151,6 +171,8 @@ class DenseGeneral(nn.Module):
     kernel = jnp.asarray(kernel, self.dtype)
 
     contract_ind = tuple(range(0, len(axis)))
+    if self.comm_gemm_overlap:
+      compute_dot_general = transformer_engine_comm_gemm_overlap
     output = compute_dot_general(inputs, kernel, axis, contract_ind)
 
     if self.use_bias:
@@ -196,6 +218,7 @@ class MlpBlock(nn.Module):
   use_bias: bool = False
   use_pre_norm: bool = False
   quant: Optional[Quant] = None
+  mesh: Optional = None
 
   def get_norm_layer(self):
     if self.config.decoder_block in ("default", "llama2", "mistral", "gemma"):
@@ -241,6 +264,7 @@ class MlpBlock(nn.Module):
         y = _convert_to_activation_function(act_fn)(x[:, :, idx, ...])
         activations.append(y)
     else:
+      comm_gemm_overlap = True
       for idx, act_fn in enumerate(self.activations):
         dense_name = "wi" if len(self.activations) == 1 else f"wi_{idx}"
         x = DenseGeneral(
@@ -253,7 +277,11 @@ class MlpBlock(nn.Module):
             quant=self.quant,
             use_bias=self.use_bias,
             matmul_precision=self.config.matmul_precision,
+            comm_gemm_overlap=self.config.comm_gemm_overlap,
+            comm_gemm_overlap_type="fc1_fprop",
+            mesh=self.mesh,
         )(inputs)
+        comm_gemm_overlap=False
         x = checkpoint_name(x, "mlp" + dense_name)
         if cfg.activations_in_float32:
           x = x.astype(jnp.float32)
@@ -277,6 +305,9 @@ class MlpBlock(nn.Module):
         quant=self.quant,
         use_bias=self.use_bias,
         matmul_precision=self.config.matmul_precision,
+        comm_gemm_overlap=self.config.comm_gemm_overlap,
+        comm_gemm_overlap_type="fc2_fprop",
+        mesh=self.mesh,
     )(x)
 
     output = checkpoint_name(output, "mlpwo")

--- a/MaxText/layers/llama2.py
+++ b/MaxText/layers/llama2.py
@@ -151,6 +151,7 @@ class LlamaDecoderLayer(nn.Module):
         name="mlp",
         config=cfg,
         quant=self.quant,
+        mesh=mesh,
     )(hidden_states, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
 

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -121,6 +121,7 @@ class DecoderLayer(nn.Module):
         name="mlp",
         config=cfg,
         quant=self.quant,
+        mesh=mesh,
     )(lnx, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_length", "activation_embed"))
 


### PR DESCRIPTION
# Description

This PR adds the API for a TransformerEngine API into MaxText. This feature enables communication-gemm overlap (AKA collective matmul).

- This feature improves the performance of LLM training by ~10% when using Tensor Parallelism
- More stable than XLA's pattern matcher and the custom call generates good schedules.

# Tests

I have tested this change on Llama2 and Llama3 workloads so far.
```
python3 /opt/workspace/maxtext_fork/MaxText/train.py \
    /opt/workspace/maxtext_fork/MaxText/configs/base.yml \
    model_name=${MODEL} \
    per_device_batch_size=0.25 \
    steps=15 \
    scan_layers=true \
    monitor_goodput=false \
    enable_goodput_recording=false \
    remat_policy=minimal_flash \
    attention=cudnn_flash_te \
    max_target_length=4096 \
    use_iota_embed=true \
    logits_dot_in_fp32=false\
    enable_checkpointing=false \
    ici_data_parallelism=1 \
    ici_fsdp_parallelism=2 \
    ici_tensor_parallelism=1 \
    ici_tensor_sequence_parallelism=4 \
    base_output_directory=local_train \
    dataset_path=local \
    dataset_type=synthetic \
    hardware=gpu_mpi \
    comm_gemm_overlap=true
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
