### PR TITLE
Add on-device runner and v5e benchmark model configs

### DIFF
--- a/benchmarks/Getting_Started_Benchmarking.md
+++ b/benchmarks/Getting_Started_Benchmarking.md
@@ -10,20 +10,26 @@ Two approaches are here:
 - **benchmark_runner.py**: A cli interface to running a specific model recipe, on pathways or mcjax directly or with orchestration like xpk with one command.
 
 ```shell
-# McJax
+# McJax with XPK
 CLUSTER=my-cluster
 ZONE=my-zone
 PROJECT=my-project
-python3 benchmarks/benchmark_runner.py --project $PROJECT --zone $ZONE --cluster_name $CLUSTER --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5
+python3 benchmarks/benchmark_runner.py xpk --project $PROJECT --zone $ZONE --cluster_name $CLUSTER --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5
 ```
 
 ```shell
-# Pathways
+# Pathways with XPK
 export RUNNER=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/maxtext_jax_stable
 export PROXY_IMAGE=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/proxy_server:latest
 export SERVER_IMAGE=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/server:latest
 
-python3 benchmarks/benchmark_runner.py --project $PROJECT --zone $ZONE --cluster_name $CLUSTER --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5 --pathways_server_image="${SERVER_IMAGE}" --pathways_proxy_image="${PROXY_IMAGE}" --pathways_runner_image="${RUNNER}"
+python3 benchmarks/benchmark_runner.py xpk --project $PROJECT --zone $ZONE --cluster_name $CLUSTER --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5 --pathways_server_image="${SERVER_IMAGE}" --pathways_proxy_image="${PROXY_IMAGE}" --pathways_runner_image="${RUNNER}"
+```
+
+```shell
+# On-device
+# Run model benchmark on current device (must run same command on all workers).
+python3 benchmarks/benchmark_runner.py on-device --base_output_directory gs://maxtext-experiments-tpem/ --run_name="test-run" --num_steps=5
 ```
 
 - **maxtext_xpk_runner.py**: A pythonic way to run xpk workloads! With the magic of for looping and python code, run several xpk workloads across a sweep of parameters including libtpu version, gke clusters, and maxtext parameters with one python script.

--- a/benchmarks/maxtext_v5e_model_configs.py
+++ b/benchmarks/maxtext_v5e_model_configs.py
@@ -1,0 +1,223 @@
+"""
+ Copyright 2025 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+"""Shared Benchmark config for v5e orchestrations."""
+
+import xla_flags_library
+from maxtext_trillium_model_configs import MaxTextModel, _add_to_model_dictionary
+
+
+v5e_model_dict = {}
+
+default_16b_v5e_256 = _add_to_model_dictionary(
+  v5e_model_dict,
+  MaxTextModel(
+    model_name="default-16b-v5e-256",
+    model_type="default",
+    tuning_params={
+        "per_device_batch_size": 6,
+        "remat_policy": "full",
+        "global_parameter_scale": 16,
+        "max_target_length": 2048,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "reuse_example_batch": 1,
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+    },
+    xla_flags=(
+        xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+    ),
+	)
+)
+
+
+default_32b_v5e_256 = _add_to_model_dictionary(
+  v5e_model_dict,
+  MaxTextModel(
+    model_name="default-32b-v5e-256",
+    model_type="default",
+    tuning_params={
+        "per_device_batch_size": 4,
+        "remat_policy": "full",
+        "global_parameter_scale": 32,
+        "max_target_length": 2048,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "reuse_example_batch": 1,
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+    },
+    xla_flags=(
+        xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+    ),
+	)
+)
+
+
+default_64b_v5e_256 = _add_to_model_dictionary(
+  v5e_model_dict,
+  MaxTextModel(
+    model_name="default-64b-v5e-256",
+    model_type="default",
+    tuning_params={
+        "per_device_batch_size": 2,
+        "remat_policy": "full",
+        "global_parameter_scale": 64,
+        "max_target_length": 2048,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "reuse_example_batch": 1,
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+    },
+    xla_flags=(
+        xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+    ),
+	)
+)
+
+default_128b_v5e_256 = _add_to_model_dictionary(
+  v5e_model_dict,
+  MaxTextModel(
+    model_name="default-128b-v5e-256",
+    model_type="default",
+    tuning_params={
+        "ici_fsdp_parallelism": -1,
+        "ici_tensor_parallelism": 16,
+        "per_device_batch_size": 1,
+        "remat_policy": "qkv_proj_offloaded",
+        "global_parameter_scale": 128,
+        "max_target_length": 2048,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "fused_qkv": True,
+        "fused_mlp": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "reuse_example_batch": 1,
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+    },
+    xla_flags=(
+        xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+    ),
+	)
+)
+
+gpt_3_175b_v5e_256 = _add_to_model_dictionary(
+  v5e_model_dict,
+  MaxTextModel(
+    model_name="gpt-3-175b-v5e-256",
+    model_type="gpt3-175b",
+    tuning_params={
+        "ici_fsdp_parallelism": -1,
+        "ici_tensor_parallelism": 16,
+        "per_device_batch_size": 0.5,
+        "remat_policy": "full",
+        "max_target_length": 2048,
+        "attention": "flash",
+        "dataset_type": "synthetic",
+        "reuse_example_batch": 1,
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+    },
+    xla_flags=(
+        xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+    ),
+	)
+)
+
+llama2_7b_v5e_256 = _add_to_model_dictionary(
+  v5e_model_dict,
+  MaxTextModel(
+    model_name="llama2-7b-v5e-256",
+    model_type="llama2-7b",
+    tuning_params={
+        "ici_fsdp_parallelism": -1,
+        "per_device_batch_size": 4,
+        "remat_policy": "save_qkv_proj",
+        "max_target_length": 2048,
+        "use_iota_embed": True,
+        "tokenizer_path": "assets/tokenizer.llama2",
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "reuse_example_batch": 1,
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+    },
+    xla_flags=(
+        xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+    ),
+	)
+)
+
+llama2_13b_v5e_256 = _add_to_model_dictionary(
+  v5e_model_dict,
+  MaxTextModel(
+    model_name="llama2-13b-v5e-256",
+    model_type="llama2-13b",
+    tuning_params={
+        "ici_fsdp_parallelism": -1,
+        "per_device_batch_size": 8,
+        "remat_policy": "qkv_proj_offloaded",
+        "max_target_length": 2048,
+        "use_iota_embed": True,
+        "tokenizer_path": "assets/tokenizer.llama2",
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "reuse_example_batch": 1,
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+    },
+    xla_flags=(
+        xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+    ),
+	)
+)
+
+llama2_70b_v5e_256 = _add_to_model_dictionary(
+  v5e_model_dict,
+  MaxTextModel(
+    model_name="llama2-70b-v5e-256",
+    model_type="llama2-70b",
+    tuning_params={
+        "ici_fsdp_parallelism": -1,
+        "per_device_batch_size": 2,
+        "remat_policy": "qkv_proj_offloaded",
+        "max_target_length": 2048,
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "reuse_example_batch": 1,
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+    },
+    xla_flags=(
+        xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+    ),
+	)
+)

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -72,6 +72,7 @@ class WorkloadConfig:
   priority: str = "medium"
   xpk_path: str = '~/xpk'
   pathways_config: PathwaysConfig = None
+  run_name: str = None
 
 
 @dataclasses.dataclass
@@ -454,6 +455,16 @@ def xpk_benchmark_runner(
     if return_code != 0:
       print('Unable to run xpk workload: {xpk_workload_name}')
 
+def on_device_benchmark_runner(
+    workload_configs: list[WorkloadConfig],
+):
+  for wl_config in workload_configs:
+    user_command = build_user_command(
+      name=wl_config.run_name,
+      wl_config=wl_config
+    )
+    print(f'User command: {user_command}')
+    subprocess.run(user_command, shell=True, text=True)
 
 # Run maxtext_xpk_runner.py as a script for executing multiple workloads pythonically!
 def main() -> int:


### PR DESCRIPTION
# Description

Adding on-device runner to `benchmark_runner.py`. This will run the model benchmark on the current device rather than launching it as an xpk workload. The benchmark script must be ran on all workers. This will allow our XLML perf tests to run our latest benchmark model configs.

This change introduces a new command-line flag that specifies which runner to use (xpk, on-device). Usage is as follows:

xpk runner:
```
python3 benchmarks/benchmark_runner.py xpk --project=<project> --zone=<zone> --device_type=v5litepod-256 --num_slices=1  --cluster_name=<cluster> --base_output_directory=gs://<your-bucket> --model_name="default_16b_v5e_256" --base_docker_image maxtext_base_image
```

on-device runner:
```
python3 benchmarks/benchmark_runner.py on-device --base_output_directory=gs://<your-bucket> --model_name="default_16b_v5e_256" --run_name=test-run
```

# Tests

http://shortn/_grjxE2vPHD

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
