### PR TITLE
Add a base image for GPU image build for MaxText unit tests.

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -51,6 +51,7 @@ jobs:
       device_type: gpu
       device_name: a100-40gb-4
       build_mode: pinned
+      base_image: gcr.io/tpu-prod-env-multipod/maxtext_gpu_jax_pinned:latest
 
   tpu_unit_tests:
     needs: tpu_image


### PR DESCRIPTION
# Description

Add a base image for GPU image build used in MaxText unit tests. 

This reduces the image build duration from 14 minutes to 40 seconds when caching doesn't happen.

Before:
<img width="1696" alt="pr_before" src="https://github.com/user-attachments/assets/30f99506-de93-423e-8499-6a5611acdad4" />

After:
![pr_after](https://github.com/user-attachments/assets/39e7e7a1-e6b8-46f2-8880-a36e79c157e0)

FIXES: b/393160598

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
