### PR TITLE
Make run_name optional for on-device benchmark runner

### DIFF
--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -308,6 +308,11 @@ def build_user_command(
 
   libtpu_flags = f'LIBTPU_INIT_ARGS=\'{wl_config.model.xla_flags}\''
 
+  if name is None:
+    run_name_command=""
+  else:
+    run_name_command=f'run_name={name}'
+
   # Construct the command string with proper formatting and line continuations
   command = ' '.join([
       f'{install_libtpu_cmd}',
@@ -322,7 +327,7 @@ def build_user_command(
       f'model_name={wl_config.model.model_type}',
       f'base_output_directory={wl_config.base_output_directory}',
       f'{vertex_tensorboard}',
-      f'run_name={name}'
+      f'{run_name_command}'
   ])
   return command
 


### PR DESCRIPTION
# Description
Make run_name optional for on-device benchmark runner. This is needed for XLML tests which generate their own run_names via M_RUN_NAME.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
