### PR TITLE
Notify on MaxText build failures

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -112,4 +112,9 @@ jobs:
       run: gcloud container images delete gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:gpu --force-delete-tags --quiet
     - name: Delete TPU image
       run: gcloud container images delete gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:tpu --force-delete-tags --quiet
+    - name: Notify failed build  # creates an issue or modifies last open existing issue for failed build
+      uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
+      if: failure() && github.event.pull_request == null
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The action will find the latest open issue with the label "build failed" and add a comment. If no such issue is open, it will instead open a new issue. We exclude failures on pull requests because they represent in-development work where failures are more expected.

Reference: https://github.com/jayqi/failed-build-issue-action

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
