### PR TITLE
Make synthetic data more realistic

### DIFF
--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -888,10 +888,10 @@ def train_loop(config, state=None):
         state, metrics = p_train_step(state, example_batch, nextrng)
 
     step_time_delta = datetime.datetime.now() - last_step_completion
+    last_step_completion = datetime.datetime.now()
     record_scalar_metrics(metrics, step_time_delta, per_device_tflops, learning_rate_schedule(step), per_device_tokens)
     if performance_metric_queue:
       performance_metric_queue.put(step_time_delta.total_seconds())
-    last_step_completion = datetime.datetime.now()
 
     if checkpoint_manager is not None:
       state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]


### PR DESCRIPTION
# Description

We've been using the `synthetic` dataset type for performance testing, and we noticed that the fact that it generates all zeros gives a false performance boost.  Something along the line must be faster when all the tokens are zero, though I'm not sure what that would be.  We observed a 3% discrepancy on v5p TPUs and a 10% discrepancy on MI300X GPUs.

This PR modifies the synthetic data iterator to produce tokens which are uniformly chosen among the vocabulary size.  While I doubt it will matter, I also set "positions" to more realistic values.

To ensure that randomly generating the data doesn't introduce a performance penalty, I pre-generate the data and just reference it later.

This seems to make the lazy computations be forced at different times, which makes the logged `step_time_seconds` incorrect.  It was printing 0.2 second step times every 1.8 seconds of wall clock time, which should be impossible.  I include a small fix to correctly keep track of the entire step time.

This is my first contribution to this repo, so let me know if there's any procedures I should follow.

# Tests

With only the step time fix, I ran gemma-2b on v5p and saw an average of 299 tflops/sec/device.  After this PR, that number became 290.  To verify that the performance difference was only due to the zeros, I took all of my changes except changed `randint` to `zeros`, and this indeed gave 299.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
