### PR TITLE
Add Pathways Recipe Support for Scale Testing

### DIFF
--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -24,6 +24,33 @@ import xla_flags_library
 # TODO(vbarr@) Make slice dependent configurations to allow for a model's tuning
 # to adjust at scales.
 
+# The minimum set of tuning params required for pathways. Does not include
+# checkpointing params.
+BASE_PATHWAYS_TUNING_PARAMS = {
+    "checkpoint_storage_use_ocdbt": False,
+    "checkpoint_storage_use_zarr3": False,
+    "enable_pathways_goodput": True,
+    "enable_single_controller": True,
+    "metrics_file": "metrics.txt",
+    "goodput_upload_interval_seconds": 30,
+}
+
+# The set of tuning params required for long-running pathways jobs.
+PATHWAYS_LONG_RUN_CHECKPOINTING_TUNING_PARAMS = {
+    "enable_checkpointing": True,
+    "async_checkpointing": True,
+    "checkpoint_period": 100,
+    "enable_checkpoint_cloud_logger": True,
+}
+
+# The set of tuning params required for short-running pathways jobs.
+PATHWAYS_SHORT_RUN_CHECKPOINTING_TUNING_PARAMS = {
+    "enable_checkpointing": True,
+    "async_checkpointing": True,
+    "checkpoint_period": 20,
+    "enable_checkpoint_cloud_logger": True,
+}
+
 
 @dataclasses.dataclass
 class MaxTextModel:
@@ -32,800 +59,709 @@ class MaxTextModel:
   tuning_params: dict[str, typing.Any]
   xla_flags: str
 
+  # Additional pathways tuning params as necessary. Adding
+  # enable_single_controller=True to pathways_tuning_params is not necessary.
+  pathways_tuning_params: dict[str, typing.Any] = None
+
+  # XLA flags for pathways, if different from the default. Some flags may not
+  # be supported by pathways e.g. "--2a886c8_chip_config_name".
+  pathways_xla_flag_options: dict[str, typing.Any] = None
+
+
 trillium_model_dict = {}
 
+
 # Run this for new definitions that should be part of the library.
-def _add_to_model_dictionary(model_dictionary: dict[str, MaxTextModel], maxtext_model: MaxTextModel)-> MaxTextModel:
-  model_dictionary[maxtext_model.model_name.replace('-', '_')] = maxtext_model
+def _add_to_model_dictionary(
+    model_dictionary: dict[str, MaxTextModel], maxtext_model: MaxTextModel
+) -> MaxTextModel:
+  model_dictionary[maxtext_model.model_name.replace("-", "_")] = maxtext_model
   return maxtext_model
 
+
 default_basic_1 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="default-basic-1",
-    model_type="default",
-    tuning_params={
-        "per_device_batch_size": 1,
-        "remat_policy": "full",
-        "global_parameter_scale": 1,
-        "attention": "flash",
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-    },
-    xla_flags="",
-  )
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="default-basic-1",
+        model_type="default",
+        tuning_params={
+            "per_device_batch_size": 1,
+            "remat_policy": "full",
+            "global_parameter_scale": 1,
+            "attention": "flash",
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+        },
+        xla_flags="",
+    ),
 )
 
-
-default_basic_1_pw = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="default-basic-1-pw",
-    model_type="default",
-    tuning_params={
-        "per_device_batch_size": 1,
-        "remat_policy": "full",
-        "global_parameter_scale": 1,
-        "attention": "flash",
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        # "profiler": "xplane",
-
-        # Additional tuning params for pathways long running test.
-        "enable_checkpointing": True,
-        "async_checkpointing": True,
-        "checkpoint_period": 100,
-        "checkpoint_storage_use_ocdbt": False,
-        "checkpoint_storage_use_zarr3": False,
-        "metrics_file": "metrics.txt",
-        "goodput_upload_interval_seconds": 30,
-        # "enable_pathways_goodput": True,
-        "enable_checkpoint_cloud_logger": True,
-        "enable_single_controller": True,
-    },
-    xla_flags="",
-  )
-)
 
 default_32 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="default-32",
-    model_type="default",
-    tuning_params={
-        "per_device_batch_size": 13,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "full",
-        "global_parameter_scale": 32,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 1024,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="default-32",
+        model_type="default",
+        tuning_params={
+            "per_device_batch_size": 13,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "full",
+            "global_parameter_scale": 32,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 1024,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+        ),
     ),
-  )
 )
 
 
 default_64 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="default-64",
-    model_type="default",
-    tuning_params={
-        "per_device_batch_size": 6,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "full",
-        "global_parameter_scale": 64,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="default-64",
+        model_type="default",
+        tuning_params={
+            "per_device_batch_size": 6,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "full",
+            "global_parameter_scale": 64,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+        ),
     ),
-  )
 )
 
 
 default_128 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="default-128",
-    model_type="default",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "full",
-        "global_parameter_scale": 128,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="default-128",
+        model_type="default",
+        tuning_params={
+            "per_device_batch_size": 2,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "full",
+            "global_parameter_scale": 128,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+        ),
     ),
-  )
 )
 
 
 # OOM, Not Optimized yet
 default_256 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="default-256",
-    model_type="default",
-    tuning_params={
-        "per_device_batch_size": 1,
-        "ici_fsdp_parallelism": -1,
-        "dcn_fsdp_transpose_parallelism": -1,
-        "remat_policy": "full",
-        "global_parameter_scale": 256,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="default-256",
+        model_type="default",
+        tuning_params={
+            "per_device_batch_size": 1,
+            "ici_fsdp_parallelism": -1,
+            "dcn_fsdp_transpose_parallelism": -1,
+            "remat_policy": "full",
+            "global_parameter_scale": 256,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+        ),
     ),
-  )
 )
 
 
 # OOM, Not Optimized yet
 default_512 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="default-512",
-    model_type="default",
-    tuning_params={
-        "per_device_batch_size": 1,
-        "ici_fsdp_parallelism": -1,
-        # "dcn_fsdp_parallelism": 2,
-        "dcn_fsdp_parallelism": -1,
-        "remat_policy": "full",
-        "global_parameter_scale": 512,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="default-512",
+        model_type="default",
+        tuning_params={
+            "per_device_batch_size": 1,
+            "ici_fsdp_parallelism": -1,
+            # "dcn_fsdp_parallelism": 2,
+            "dcn_fsdp_parallelism": -1,
+            "remat_policy": "full",
+            "global_parameter_scale": 512,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+        ),
     ),
-  )
 )
 
 
 gpt_3_175b = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="gpt-3-175b",
-    model_type="gpt3-175b",
-    tuning_params={
-        "per_device_batch_size": 3,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "full",
-        "attention": "flash",
-        "quantization": "int8",
-        "gcs_metrics": True,
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.DATA_PARALLEL_OVERLAP
-        + xla_flags_library.DISABLE_BUNDLE_AWARE_COST_MODEL
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="gpt-3-175b",
+        model_type="gpt3-175b",
+        tuning_params={
+            "per_device_batch_size": 3,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "full",
+            "attention": "flash",
+            "quantization": "int8",
+            "gcs_metrics": True,
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+            + xla_flags_library.DISABLE_BUNDLE_AWARE_COST_MODEL
+        ),
     ),
-  )
 )
 
 
 llama2_7b_4096 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2-7b-4096",
-    model_type="llama2-7b",
-    tuning_params={
-        "per_device_batch_size": 12,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "full",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama2-7b-4096",
+        model_type="llama2-7b",
+        tuning_params={
+            "per_device_batch_size": 12,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "full",
+            "max_target_length": 4096,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+        ),
     ),
-  )
-)
-
-llama2_7b_4096_pw = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2-7b-4096-pw",
-    model_type="llama2-7b",
-    tuning_params={
-        "per_device_batch_size": 4,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "full",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-        "steps": 1000000,
-
-        # Additional tuning params for pathways long running test.
-        "enable_checkpointing": True,
-        "async_checkpointing": True,
-        "checkpoint_period": 100,
-        "checkpoint_storage_use_ocdbt": False,
-        "checkpoint_storage_use_zarr3": False,
-        "metrics_file": "metrics.txt",
-        "goodput_upload_interval_seconds": 30,
-        # "enable_pathways_goodput": True,
-        "enable_checkpoint_cloud_logger": True,
-        "enable_single_controller": True,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-    ),
-  )
 )
 
 
 llama2_70b_4096 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2-70b-4096",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 4,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "full",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama2-70b-4096",
+        model_type="llama2-70b",
+        tuning_params={
+            "per_device_batch_size": 4,
+            "ici_fsdp_parallelism": 1,
+            "ici_fsdp_transpose_parallelism": -1,
+            "ici_tensor_parallelism": 1,
+            "remat_policy": "full",
+            "max_target_length": 4096,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+        ),
     ),
-  )
 )
 
 
 llama2_70b_4096_optimized = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2_70b_4096_synthetic",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "qkv_proj_offloaded",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama2_70b_4096_synthetic",
+        model_type="llama2-70b",
+        tuning_params={
+            "per_device_batch_size": 2,
+            "ici_fsdp_parallelism": 1,
+            "ici_fsdp_transpose_parallelism": -1,
+            "ici_tensor_parallelism": 1,
+            "remat_policy": "qkv_proj_offloaded",
+            "max_target_length": 4096,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+        ),
     ),
-  )
 )
 
 
 # Enable SparseCore Offloading of AR in an optimized model.
 llama2_70b_4096_sc = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2-70b-4096-sc",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "qkv_proj_offloaded",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama2-70b-4096-sc",
+        model_type="llama2-70b",
+        tuning_params={
+            "per_device_batch_size": 2,
+            "ici_fsdp_parallelism": 1,
+            "ici_fsdp_transpose_parallelism": -1,
+            "ici_tensor_parallelism": 1,
+            "remat_policy": "qkv_proj_offloaded",
+            "max_target_length": 4096,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
     ),
-  )
 )
 
 
 llama2_70b_4096_sc_real_data_tfds = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2-70b-4096-sc",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "qkv_proj_offloaded",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://trillium-storage-datasets-sr",
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama2-70b-4096-sc",
+        model_type="llama2-70b",
+        tuning_params={
+            "per_device_batch_size": 2,
+            "ici_fsdp_parallelism": 1,
+            "ici_fsdp_transpose_parallelism": -1,
+            "ici_tensor_parallelism": 1,
+            "remat_policy": "qkv_proj_offloaded",
+            "max_target_length": 4096,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://trillium-storage-datasets-sr",
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
     ),
-  )
 )
 
 
 llama2_70b_4096_sc_real_data_grain = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2-70b-4096",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "qkv_proj_offloaded",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://trillium-storage-datasets-sr",
-        "base_output_directory": (
-            "gs://trillium-storage-tests-nov24-sr/long-run-dec11"
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama2-70b-4096",
+        model_type="llama2-70b",
+        tuning_params={
+            "per_device_batch_size": 2,
+            "ici_fsdp_parallelism": 1,
+            "ici_fsdp_transpose_parallelism": -1,
+            "ici_tensor_parallelism": 1,
+            "remat_policy": "qkv_proj_offloaded",
+            "max_target_length": 4096,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://trillium-storage-datasets-sr",
+            "base_output_directory": (
+                "gs://trillium-storage-tests-nov24-sr/long-run-dec11"
+            ),
+            "enable_checkpointing": False,
+            "dataset_type": "grain",
+            "grain_train_files": (
+                "/tmp/dataset/array-record/c4/en/3.0.1/c4-train.array_record*"
+            ),
+            "grain_worker_count": 24,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+            "profile_cleanly": False,
+        },
+        pathways_tuning_params=PATHWAYS_LONG_RUN_CHECKPOINTING_TUNING_PARAMS,
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
         ),
-        "enable_checkpointing": False,
-        "dataset_type": "grain",
-        "grain_train_files": "/tmp/dataset/array-record/c4/en/3.0.1/c4-train.array_record*",
-        "grain_worker_count": 24,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-        "profile_cleanly": False,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
     ),
-  )
 )
 
 
 llama2_70b_4096_sc_real_data_grain_checkpoint = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2-70b-4096",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "qkv_proj_offloaded",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://trillium-storage-datasets-sr",
-        "base_output_directory": (
-            "gs://trillium-storage-tests-nov24-sr/long-run-dec11"
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama2-70b-4096",
+        model_type="llama2-70b",
+        tuning_params={
+            "per_device_batch_size": 2,
+            "ici_fsdp_parallelism": 1,
+            "ici_fsdp_transpose_parallelism": -1,
+            "ici_tensor_parallelism": 1,
+            "remat_policy": "qkv_proj_offloaded",
+            "max_target_length": 4096,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://trillium-storage-datasets-sr",
+            "base_output_directory": (
+                "gs://trillium-storage-tests-nov24-sr/long-run-dec11"
+            ),
+            "checkpoint_period": 100,
+            "enable_checkpointing": True,
+            "async_checkpointing": True,
+            "dataset_type": "grain",
+            "grain_train_files": (
+                "/tmp/dataset/array-record/c4/en/3.0.1/c4-train.array_record*"
+            ),
+            "grain_worker_count": 24,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        pathways_tuning_params=PATHWAYS_LONG_RUN_CHECKPOINTING_TUNING_PARAMS,
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
         ),
-        "checkpoint_period": 100,
-        "enable_checkpointing": True,
-        "async_checkpointing": True,
-        "dataset_type": "grain",
-        "grain_train_files": "/tmp/dataset/array-record/c4/en/3.0.1/c4-train.array_record*",
-        "grain_worker_count": 24,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
     ),
-  )
 )
 
-
-llama2_70b_4096_real_data_pw_long_run = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2-70b-4096-rd-pw-lr",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 4,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "full",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "reuse_example_batch": 0,
-        "profiler": "xplane",
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "tfds",
-        "tokenizer_path": "assets/tokenizer.llama2",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-        "steps": 1000000,
-
-        # Additional tuning params for pathways long running test.
-        "enable_checkpointing": True,
-        "async_checkpointing": True,
-        "checkpoint_period": 100,
-        "checkpoint_storage_use_ocdbt": False,
-        "checkpoint_storage_use_zarr3": False,
-        "metrics_file": "metrics.txt",
-        "goodput_upload_interval_seconds": 30,
-        "enable_pathways_goodput": True,
-        "enable_checkpoint_cloud_logger": True,
-        "enable_single_controller": True,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
+llama2_70b_4096_real_data_long_run = _add_to_model_dictionary(
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama2-70b-4096-rd-lr",
+        model_type="llama2-70b",
+        tuning_params={
+            "per_device_batch_size": 4,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "full",
+            "max_target_length": 4096,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "reuse_example_batch": 0,
+            "profiler": "xplane",
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "tfds",
+            "tokenizer_path": "assets/tokenizer.llama2",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        pathways_tuning_params=PATHWAYS_LONG_RUN_CHECKPOINTING_TUNING_PARAMS,
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
     ),
-  )
-)
-
-
-llama2_70b_4096_synthetic_pw_lr = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2_70b_4096_synthetic_pw_lr",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "qkv_proj_offloaded",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        # "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-        "steps": 1000000,
-
-        # Additional tuning params for pathways long running test.
-        "enable_checkpointing": True,
-        "async_checkpointing": True,
-        "checkpoint_period": 100,
-        "checkpoint_storage_use_ocdbt": False,
-        "checkpoint_storage_use_zarr3": False,
-        "metrics_file": "metrics.txt",
-        "goodput_upload_interval_seconds": 30,
-        "enable_pathways_goodput": True,
-        "enable_checkpoint_cloud_logger": True,
-        "enable_single_controller": True,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-    ),
-  )
-)
-
-
-llama2_70b_4096_pw_long_run = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2-70b-4096-pw-lr",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 4,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "full",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-        "steps": 1000000,
-
-        # Additional tuning params for pathways long running test.
-        "enable_checkpointing": True,
-        "async_checkpointing": True,
-        "checkpoint_period": 100,
-        "checkpoint_storage_use_ocdbt": False,
-        "checkpoint_storage_use_zarr3": False,
-        "metrics_file": "metrics.txt",
-        "goodput_upload_interval_seconds": 30,
-        "enable_pathways_goodput": True,
-        "enable_checkpoint_cloud_logger": True,
-        "enable_single_controller": True,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-    ),
-  )
-)
-
-
-llama2_70b_4096_pw_rd_tfds = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama2_70b_4096_pw_rd_tfds",
-    model_type="llama2-70b",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_parallelism": 1,
-        "ici_fsdp_transpose_parallelism": -1,
-        "ici_tensor_parallelism": 1,
-        "remat_policy": "qkv_proj_offloaded",
-        "max_target_length": 4096,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://trillium-storage-datasets-sr",
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-
-        # Additional tuning params for pathways long running test.
-        "enable_checkpointing": True,
-        "async_checkpointing": True,
-        "checkpoint_period": 100,
-        "checkpoint_storage_use_ocdbt": False,
-        "checkpoint_storage_use_zarr3": False,
-        "metrics_file": "metrics.txt",
-        "goodput_upload_interval_seconds": 30,
-        "enable_pathways_goodput": True,
-        "enable_checkpoint_cloud_logger": True,
-        "enable_single_controller": True,
-    },
-    xla_flags=(
-    xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-    + xla_flags_library.CF_FOR_ALL_GATHER
-    ),
-  )
 )
 
 
 llama3_8b_8192 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama3-8b-8192",
-    model_type="llama3-8b",
-    tuning_params={
-        "per_device_batch_size": 8,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "full",
-        "max_target_length": 8192,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama3-8b-8192",
+        model_type="llama3-8b",
+        tuning_params={
+            "per_device_batch_size": 8,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "full",
+            "max_target_length": 8192,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
     ),
-  )
 )
 
 
 llama3_70b_8192 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama3-70b-8192",
-    model_type="llama3-70b",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "full",
-        "optimizer_memory_host_offload": True,
-        "gradient_clipping_threshold": 0,
-        "max_target_length": 8192,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.HOST_OFFLOAD_FLAGS
-        + " --xla_tpu_scheduler_percent_shared_memory_limit=90"
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama3-70b-8192",
+        model_type="llama3-70b",
+        tuning_params={
+            "per_device_batch_size": 2,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "full",
+            "optimizer_memory_host_offload": True,
+            "gradient_clipping_threshold": 0,
+            "max_target_length": 8192,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.HOST_OFFLOAD_FLAGS
+            + " --xla_tpu_scheduler_percent_shared_memory_limit=90"
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
     ),
-  )
 )
 
 
 llama3_1_405b_8192_fsdp_dcn = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama3-1-405b-8192-fsdp-dcn",
-    model_type="llama3.1-405b",
-    tuning_params={
-        "per_device_batch_size": 1,
-        "ici_fsdp_parallelism": 64,
-        "ici_tensor_parallelism": 4,
-        "dcn_fsdp_parallelism": 2,
-        "allow_split_physical_axes": True,
-        "custom_mesh": "hybrid_ring_64x4",
-        "remat_policy": "custom",
-        "decoder_layer_input": "offload",
-        "query_proj": "offload",
-        "key_proj": "offload",
-        "value_proj": "offload",
-        "out_proj": "offload",
-        "max_target_length": 8192,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 1024,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.HOST_OFFLOAD_FLAGS
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama3-1-405b-8192-fsdp-dcn",
+        model_type="llama3.1-405b",
+        tuning_params={
+            "per_device_batch_size": 1,
+            "ici_fsdp_parallelism": 64,
+            "ici_tensor_parallelism": 4,
+            "dcn_fsdp_parallelism": 2,
+            "allow_split_physical_axes": True,
+            "custom_mesh": "hybrid_ring_64x4",
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "query_proj": "offload",
+            "key_proj": "offload",
+            "value_proj": "offload",
+            "out_proj": "offload",
+            "max_target_length": 8192,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.HOST_OFFLOAD_FLAGS
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
     ),
-  )
 )
 
 llama3_1_405b_8192_pure_fsdp_ici = _add_to_model_dictionary(
@@ -861,47 +797,61 @@ llama3_1_405b_8192_pure_fsdp_ici = _add_to_model_dictionary(
 )
 
 llama3_1_8b_8192 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama3_1-8b-8192",
-    model_type="llama3.1-8b",
-    tuning_params={
-        "per_device_batch_size": 4,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "custom",
-        "decoder_layer_input": "offload",
-        "out_proj": "offload",
-        "query_proj": "offload",
-        "key_proj": "offload",
-        "value_proj": "offload",
-        "max_target_length": 8192,
-        "attention": "flash",
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "enable_checkpointing": False,
-        "sa_block_q": 2048,
-        "sa_block_kv": 2048,
-        "sa_block_kv_compute": 2048,
-        "sa_block_q_dkv": 2048,
-        "sa_block_kv_dkv": 2048,
-        "sa_block_kv_dkv_compute": 2048,
-        "sa_block_q_dq": 2048,
-        "sa_block_kv_dq": 2048,
-        "sa_use_fused_bwd_kernel": True,
-        "profiler": "xplane",
-        "skip_first_n_steps_for_profiler": 10,
-        "profiler_steps": 5,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
-        + xla_flags_library.DATA_PARALLEL_OVERLAP
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
-        + xla_flags_library.HOST_OFFLOAD_FLAGS
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama3_1-8b-8192",
+        model_type="llama3.1-8b",
+        tuning_params={
+            "per_device_batch_size": 4,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "out_proj": "offload",
+            "query_proj": "offload",
+            "key_proj": "offload",
+            "value_proj": "offload",
+            "max_target_length": 8192,
+            "attention": "flash",
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "enable_checkpointing": False,
+            "sa_block_q": 2048,
+            "sa_block_kv": 2048,
+            "sa_block_kv_compute": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_kv_dkv": 2048,
+            "sa_block_kv_dkv_compute": 2048,
+            "sa_block_q_dq": 2048,
+            "sa_block_kv_dq": 2048,
+            "sa_use_fused_bwd_kernel": True,
+            "profiler": "xplane",
+            "skip_first_n_steps_for_profiler": 10,
+            "profiler_steps": 5,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+            + xla_flags_library.HOST_OFFLOAD_FLAGS
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
     ),
-  )
 )
 
 
@@ -952,307 +902,502 @@ llama3_1_8b_8192_no_collective_matmul = _add_to_model_dictionary(
 
 
 llama3_1_70b_8192 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama3_1-70b-8192",
-    model_type="llama3.1-70b",
-    tuning_params={
-        "per_device_batch_size": 4,
-        "ici_fsdp_parallelism": -1,
-        "remat_policy": "custom",
-        "decoder_layer_input": "offload",
-        "query_proj": "offload",
-        "key_proj": "offload",
-        "value_proj": "offload",
-        "max_target_length": 8192,
-        "attention": "flash",
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "enable_checkpointing": False,
-        "sa_block_q": 2048,
-        "sa_block_kv": 2048,
-        "sa_block_kv_compute": 2048,
-        "sa_block_q_dkv": 2048,
-        "sa_block_kv_dkv": 2048,
-        "sa_block_kv_dkv_compute": 2048,
-        "sa_block_q_dq": 2048,
-        "sa_block_kv_dq": 2048,
-        "sa_use_fused_bwd_kernel": True,
-        "profiler": "xplane",
-        "skip_first_n_steps_for_profiler": 10,
-        "profiler_steps": 5,
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
-        + xla_flags_library.DATA_PARALLEL_OVERLAP
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.HOST_OFFLOAD_FLAGS
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama3_1-70b-8192",
+        model_type="llama3.1-70b",
+        tuning_params={
+            "per_device_batch_size": 4,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "query_proj": "offload",
+            "key_proj": "offload",
+            "value_proj": "offload",
+            "max_target_length": 8192,
+            "attention": "flash",
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "enable_checkpointing": False,
+            "sa_block_q": 2048,
+            "sa_block_kv": 2048,
+            "sa_block_kv_compute": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_kv_dkv": 2048,
+            "sa_block_kv_dkv_compute": 2048,
+            "sa_block_q_dq": 2048,
+            "sa_block_kv_dq": 2048,
+            "sa_use_fused_bwd_kernel": True,
+            "profiler": "xplane",
+            "skip_first_n_steps_for_profiler": 10,
+            "profiler_steps": 5,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.HOST_OFFLOAD_FLAGS
+        ),
     ),
-  )
 )
 
 
-llama3_1_70b_129024 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="llama3_1-70b-129024",
-    model_type="llama3.1-70b",
-    tuning_params={
-        "per_device_batch_size": 0.125,
-        "ici_fsdp_parallelism": -1,
-        "ici_sequence_parallelism": 8,
-        "remat_policy": "custom",
-        "decoder_layer_input": "offload",
-        "out_proj": "offload",
-        "query_proj": "offload",
-        "key_proj": "offload",
-        "value_proj": "offload",
-        "max_target_length": 129024,
-        "attention": "flash",
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "enable_checkpointing": False,
-        "sa_block_q": 2048,
-        "sa_block_kv": 2048,
-        "sa_block_kv_compute": 2048,
-        "sa_block_q_dkv": 2048,
-        "sa_block_kv_dkv": 2048,
-        "sa_block_kv_dkv_compute": 2048,
-        "sa_block_q_dq": 2048,
-        "sa_block_kv_dq": 2048,
-        "sa_use_fused_bwd_kernel": True,
-        "profiler": "xplane",
-        "skip_first_n_steps_for_profiler": 10,
-        "profiler_steps": 5,
-        "allow_split_physical_axes": True,
-        "custom_mesh": "hybrid_ring_32x8",
-    },
-    xla_flags=(
-        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
-        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
-        + xla_flags_library.DATA_PARALLEL_OVERLAP
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_GATHER
-        + xla_flags_library.HOST_OFFLOAD_FLAGS
+llama3_1_70b_8192_lr_real_data = _add_to_model_dictionary(
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama3_1-70b-8192-pw-lr-rd",
+        model_type="llama3.1-70b",
+        tuning_params={
+            "per_device_batch_size": 4,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "query_proj": "offload",
+            "key_proj": "offload",
+            "value_proj": "offload",
+            "max_target_length": 8192,
+            "attention": "flash",
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "enable_checkpointing": False,
+            "sa_block_q": 2048,
+            "sa_block_kv": 2048,
+            "sa_block_kv_compute": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_kv_dkv": 2048,
+            "sa_block_kv_dkv_compute": 2048,
+            "sa_block_q_dq": 2048,
+            "sa_block_kv_dq": 2048,
+            "sa_use_fused_bwd_kernel": True,
+            "profiler": "xplane",
+            "skip_first_n_steps_for_profiler": 10,
+            "profiler_steps": 5,
+        },
+        pathways_tuning_params=PATHWAYS_LONG_RUN_CHECKPOINTING_TUNING_PARAMS,
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.HOST_OFFLOAD_FLAGS
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
     ),
-  )
+)
+
+llama3_1_70b_8192_iter_real_data_and_checkpointing_tfds = _add_to_model_dictionary(
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama3_1-70b-8192",
+        model_type="llama3.1-70b",
+        tuning_params={
+            "per_device_batch_size": 2,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "query_proj": "offload",
+            "key_proj": "offload",
+            "value_proj": "offload",
+            "max_target_length": 8192,
+            "attention": "flash",
+            "use_iota_embed": True,
+            "dataset_path": "gs://trillium-scale-datasets-q1-25-west",
+            "dataset_type": "tfds",
+            "enable_checkpointing": True,
+            "async_checkpointing": True,
+            "checkpoint_period": 20,
+            "enable_checkpoint_cloud_logger": True,
+            "sa_block_q": 2048,
+            "sa_block_kv": 2048,
+            "sa_block_kv_compute": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_kv_dkv": 2048,
+            "sa_block_kv_dkv_compute": 2048,
+            "sa_block_q_dq": 2048,
+            "sa_block_kv_dq": 2048,
+            "sa_use_fused_bwd_kernel": True,
+            "gcs_metrics": True,
+            "profiler": "xplane",
+            "skip_first_n_steps_for_profiler": 10,
+            "profiler_steps": 5,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.HOST_OFFLOAD_FLAGS
+            + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+            + " --xla_tpu_iova_dma_chunk_size_bytes=104857"
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        }
+    ),
+)
+
+llama3_1_70b_8192_iter_synth_data_and_checkpointing = _add_to_model_dictionary(
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama3_1-70b-8192-synth",
+        model_type="llama3.1-70b",
+        tuning_params={
+            "per_device_batch_size": 2,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "query_proj": "offload",
+            "key_proj": "offload",
+            "value_proj": "offload",
+            "max_target_length": 8192,
+            "attention": "flash",
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "enable_checkpointing": True,
+            "async_checkpointing": True,
+            "checkpoint_period": 20,
+            "enable_checkpoint_cloud_logger": True,
+            "sa_block_q": 2048,
+            "sa_block_kv": 2048,
+            "sa_block_kv_compute": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_kv_dkv": 2048,
+            "sa_block_kv_dkv_compute": 2048,
+            "sa_block_q_dq": 2048,
+            "sa_block_kv_dq": 2048,
+            "sa_use_fused_bwd_kernel": True,
+            "gcs_metrics": True,
+            "profiler": "xplane",
+            "skip_first_n_steps_for_profiler": 10,
+            "profiler_steps": 5,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.HOST_OFFLOAD_FLAGS
+            + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+            + " --xla_tpu_iova_dma_chunk_size_bytes=104857"
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        }
+    ),
+)
+
+llama3_1_70b_129024 = _add_to_model_dictionary(
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="llama3_1-70b-129024",
+        model_type="llama3.1-70b",
+        tuning_params={
+            "per_device_batch_size": 0.125,
+            "ici_fsdp_parallelism": -1,
+            "ici_sequence_parallelism": 8,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "out_proj": "offload",
+            "query_proj": "offload",
+            "key_proj": "offload",
+            "value_proj": "offload",
+            "max_target_length": 129024,
+            "attention": "flash",
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "enable_checkpointing": False,
+            "sa_block_q": 2048,
+            "sa_block_kv": 2048,
+            "sa_block_kv_compute": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_kv_dkv": 2048,
+            "sa_block_kv_dkv_compute": 2048,
+            "sa_block_q_dq": 2048,
+            "sa_block_kv_dq": 2048,
+            "sa_use_fused_bwd_kernel": True,
+            "profiler": "xplane",
+            "skip_first_n_steps_for_profiler": 10,
+            "profiler_steps": 5,
+            "allow_split_physical_axes": True,
+            "custom_mesh": "hybrid_ring_32x8",
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+            + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_GATHER
+            + xla_flags_library.HOST_OFFLOAD_FLAGS
+        ),
+        pathways_xla_flag_options={
+            xla_flags_library.REMOVE: [
+                "--2a886c8_chip_config_name=megachip_tccontrol"
+            ],
+            xla_flags_library.ADD_SERVER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_PROXY: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+            xla_flags_library.ADD_WORKER: (
+                xla_flags_library.ENHANCED_LAUNCH_BARRIER
+            ),
+        },
+    ),
 )
 
 
 mixtral_8x7b_dropless = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="mixtral_8x7b_dropless",
-    model_type="mixtral-8x7b",
-    tuning_params={
-        "per_device_batch_size": 12,
-        "ici_fsdp_parallelism": -1,
-        "max_target_length": 4096,
-        "remat_policy": "full",
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 2048,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-        "megablox": True,
-        "sparse_matmul": True,
-    },
-    xla_flags=(
-        xla_flags_library.MOE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.DATA_PARALLEL_OVERLAP
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="mixtral_8x7b_dropless",
+        model_type="mixtral-8x7b",
+        tuning_params={
+            "per_device_batch_size": 12,
+            "ici_fsdp_parallelism": -1,
+            "max_target_length": 4096,
+            "remat_policy": "full",
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+            "megablox": True,
+            "sparse_matmul": True,
+        },
+        xla_flags=(
+            xla_flags_library.MOE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+        ),
     ),
-  )
 )
 
 
 mixtral_8x7b_dropped = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="mixtral_8x7b_dropped",
-    model_type="mixtral-8x7b",
-    tuning_params={
-        "per_device_batch_size": 12,
-        "ici_fsdp_parallelism": -1,
-        "max_target_length": 4096,
-        "remat_policy": "custom",
-        "decoder_layer_input": "offload",
-        "out_proj": "offload",
-        "query_proj": "offload",
-        "key_proj": "offload",
-        "value_proj": "offload",
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 2048,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-        "megablox": False,
-        "sparse_matmul": False,
-        "capacity_factor": 1.25,
-        "tokenizer_path": "assets/tokenizer.mistral-v1",
-    },
-    xla_flags=(
-        xla_flags_library.MOE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.DATA_PARALLEL_OVERLAP
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="mixtral_8x7b_dropped",
+        model_type="mixtral-8x7b",
+        tuning_params={
+            "per_device_batch_size": 12,
+            "ici_fsdp_parallelism": -1,
+            "max_target_length": 4096,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "out_proj": "offload",
+            "query_proj": "offload",
+            "key_proj": "offload",
+            "value_proj": "offload",
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+            "megablox": False,
+            "sparse_matmul": False,
+            "capacity_factor": 1.25,
+            "tokenizer_path": "assets/tokenizer.mistral-v1",
+        },
+        xla_flags=(
+            xla_flags_library.MOE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+        ),
     ),
-  )
 )
 
 
 mixtral_8x7b_dropped_int8 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="mixtral_8x7b_dropped_int8",
-    model_type="mixtral-8x7b",
-    tuning_params={
-        "per_device_batch_size": 8,
-        "ici_fsdp_parallelism": -1,
-        "max_target_length": 4096,
-        "remat_policy": "full",
-        "attention": "flash",
-        "gcs_metrics": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 2048,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-        "megablox": False,
-        "sparse_matmul": False,
-        "capacity_factor": 1.25,
-        "quantization": "int8",
-        "tokenizer_path": "assets/tokenizer.mistral-v1",
-    },
-    xla_flags=(
-        xla_flags_library.MOE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.DATA_PARALLEL_OVERLAP
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="mixtral_8x7b_dropped_int8",
+        model_type="mixtral-8x7b",
+        tuning_params={
+            "per_device_batch_size": 8,
+            "ici_fsdp_parallelism": -1,
+            "max_target_length": 4096,
+            "remat_policy": "full",
+            "attention": "flash",
+            "gcs_metrics": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+            "megablox": False,
+            "sparse_matmul": False,
+            "capacity_factor": 1.25,
+            "quantization": "int8",
+            "tokenizer_path": "assets/tokenizer.mistral-v1",
+        },
+        xla_flags=(
+            xla_flags_library.MOE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+        ),
     ),
-  )
 )
 
 mixtral_8x22b_dropped = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="mixtral_8x22b_dropped",
-    model_type="mixtral-8x22b",
-    tuning_params={
-        "per_device_batch_size": 8,
-        "max_target_length": 4096,
-        "ici_fsdp_parallelism": 64,
-        "ici_expert_parallelism": 4,
-        "remat_policy": "custom",
-        "decoder_layer_input": "offload",
-        "out_proj": "offload",
-        "query_proj": "offload",
-        "key_proj": "offload",
-        "value_proj": "offload",
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "sa_block_q": 2048,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-        "megablox": False,
-        "sparse_matmul": False,
-        "capacity_factor": 1.25,
-        "tokenizer_path": "assets/tokenizer.mistral-v3",
-        "dtype": "bfloat16",
-        "weight_dtype": "bfloat16",
-        "allow_split_physical_axes": True,
-        "custom_mesh": "hybrid_ring_64x4",
-    },
-    xla_flags=(
-        xla_flags_library.MOE_VMEM_LIMIT_FLAG
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.DATA_PARALLEL_OVERLAP
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="mixtral_8x22b_dropped",
+        model_type="mixtral-8x22b",
+        tuning_params={
+            "per_device_batch_size": 8,
+            "max_target_length": 4096,
+            "ici_fsdp_parallelism": 64,
+            "ici_expert_parallelism": 4,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "out_proj": "offload",
+            "query_proj": "offload",
+            "key_proj": "offload",
+            "value_proj": "offload",
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+            "megablox": False,
+            "sparse_matmul": False,
+            "capacity_factor": 1.25,
+            "tokenizer_path": "assets/tokenizer.mistral-v3",
+            "dtype": "bfloat16",
+            "weight_dtype": "bfloat16",
+            "allow_split_physical_axes": True,
+            "custom_mesh": "hybrid_ring_64x4",
+        },
+        xla_flags=(
+            xla_flags_library.MOE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+        ),
     ),
-  )
 )
 
 gemma2_9b_8192 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="gemma2-9b-8192",
-    model_type="gemma2-9b",
-    tuning_params={
-        "per_device_batch_size": 3,
-        "ici_fsdp_transpose_parallelism": 256,
-        "remat_policy": "full",
-        "max_target_length": 8192,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "tokenizer_path": "assets/tokenizer.llama2",
-        "sa_block_q": 2048,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.CUSTOM_VMEM_LIMIT_FLAG(114688)
-        + xla_flags_library.REDUCE_SCATTER_FUSION
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="gemma2-9b-8192",
+        model_type="gemma2-9b",
+        tuning_params={
+            "per_device_batch_size": 3,
+            "ici_fsdp_transpose_parallelism": 256,
+            "remat_policy": "full",
+            "max_target_length": 8192,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "tokenizer_path": "assets/tokenizer.llama2",
+            "sa_block_q": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.CUSTOM_VMEM_LIMIT_FLAG(114688)
+            + xla_flags_library.REDUCE_SCATTER_FUSION
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+        ),
     ),
-  )
 )
 
 
 gemma2_27b_8192 = _add_to_model_dictionary(
-  trillium_model_dict,
-  MaxTextModel(
-    model_name="gemma2-27b-8192",
-    model_type="gemma2-27b",
-    tuning_params={
-        "per_device_batch_size": 2,
-        "ici_fsdp_transpose_parallelism": 256,
-        "remat_policy": "full",
-        "max_target_length": 8192,
-        "attention": "flash",
-        "gcs_metrics": True,
-        "use_iota_embed": True,
-        "dataset_path": "gs://max-datasets-rogue",
-        "dataset_type": "synthetic",
-        "reuse_example_batch": 1,
-        "enable_checkpointing": False,
-        "profiler": "xplane",
-        "tokenizer_path": "assets/tokenizer.llama2",
-        "sa_block_q": 2048,
-        "sa_block_q_dkv": 2048,
-        "sa_block_q_dq": 2048,
-    },
-    xla_flags=(
-        xla_flags_library.CUSTOM_VMEM_LIMIT_FLAG(122880)
-        + xla_flags_library.REDUCE_SCATTER_FUSION
-        + xla_flags_library.CF_FOR_ALL_GATHER
-        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="gemma2-27b-8192",
+        model_type="gemma2-27b",
+        tuning_params={
+            "per_device_batch_size": 2,
+            "ici_fsdp_transpose_parallelism": 256,
+            "remat_policy": "full",
+            "max_target_length": 8192,
+            "attention": "flash",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "tokenizer_path": "assets/tokenizer.llama2",
+            "sa_block_q": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.CUSTOM_VMEM_LIMIT_FLAG(122880)
+            + xla_flags_library.REDUCE_SCATTER_FUSION
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+        ),
     ),
-  )
 )

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -35,10 +35,12 @@ import tempfile
 import time
 
 import maxtext_trillium_model_configs as model_configs
+import xla_flags_library as xla_flags
 
 # Assumes you built maxtext dep image.
 # Assumes you have xpk installed in a git clone repo of ~/{wl_config.xpk_path}/xpk.py
 _DEFAULT_MAXTEXT_BASE_DOCKER_IMAGE_NAME = 'maxtext_base_image'
+
 
 class LibTpuType(enum.Enum):
   NIGHTLY = 'nightly-libtpu'
@@ -275,15 +277,72 @@ def run_command_with_updates(command, task, verbose=True) -> int:
     return 0
 
 
+def _get_config_tuning_params(wl_config: WorkloadConfig):
+  """Get config tuning parameters for the workload.
+
+  Args:
+    wl_config: Workload configuration.
+
+  Returns:
+    A string of config tuning parameters.
+  """
+  is_pw_enabled = wl_config.pathways_config is not None
+
+  config_tuning_params = ''
+  unified_tuning_params = wl_config.model.tuning_params.copy()  # Create a copy
+
+  # Overwrite the tuning params with pathways specific tuning params if present.
+  # otherwise add them to the dictionary. If pathays tuning params are not
+  # present, add the default pathways tuning params.
+  if is_pw_enabled:
+    if wl_config.model.pathways_tuning_params is None:
+      print(
+          'WARNING: Pathways tuning params are not present for model:'
+          f' {wl_config.model.model_name}, Adding the following base params to'
+          f' support pathways: {model_configs.BASE_PATHWAYS_TUNING_PARAMS}'
+      )
+      wl_config.model.pathways_tuning_params = (
+          model_configs.BASE_PATHWAYS_TUNING_PARAMS
+      )
+
+    # Automatically inject Base Pathways tuning params if not present. The user
+    # can override these values if they want, but if not present, we will add
+    # them to the dictionary.
+    for key, value in model_configs.BASE_PATHWAYS_TUNING_PARAMS.items():
+      if key not in wl_config.model.pathways_tuning_params:
+        wl_config.model.pathways_tuning_params[key] = value
+
+      print(
+          f'WARNING: {key} is not present in pathways tuning'
+          f' params for model: {wl_config.model.model_name}, Adding the'
+          f' param {key}={value} to support pathways.'
+      )
+
+    print(
+        f'Pathways tuning params for model: {wl_config.model.model_name} are:'
+        f' {wl_config.model.pathways_tuning_params}'
+    )
+    for key, value in wl_config.model.pathways_tuning_params.items():
+      unified_tuning_params[key] = value
+
+  print(
+      f'Unified tuning params for model are:'
+      f' {unified_tuning_params}'
+  )
+
+  for key, value in unified_tuning_params.items():
+    config_tuning_params += f'{key}={value} '
+
+  return config_tuning_params
+
+
 def build_user_command(
     name: str,
     wl_config: WorkloadConfig,
 ):
   is_pw_enabled = wl_config.pathways_config is not None
 
-  config_tuning_params = ''
-  for key, value in wl_config.model.tuning_params.items():
-    config_tuning_params += f'{key}={value} '
+  config_tuning_params = _get_config_tuning_params(wl_config)
 
   install_libtpu_cmd = ''
   jax_platforms = None
@@ -336,6 +395,94 @@ def build_user_command(
   return command
 
 
+def _get_pathways_proxy_flags(wl_config: WorkloadConfig):
+  """Get the pathways proxy flags for the workload and removes any extras."""
+  # Add in the xla flags alongside the proxy flags from the pathways config.
+  pw_config = wl_config.pathways_config
+
+  # Get proxy and xla flag string from model config
+  proxy_flags_string = pw_config.proxy_flags
+  xla_flags_string = wl_config.model.xla_flags
+
+  # Split both proxy_flags_string and xla_flags_string into lists of flags
+  proxy_flags_list = proxy_flags_string.strip().split()
+  xla_flags_list = xla_flags_string.strip().split()
+
+  # Combine the two lists of flags into a single list
+  proxy_flags = proxy_flags_list + xla_flags_list
+
+  # Remove the flags that are specified to be removed.
+  if (
+      wl_config.model.pathways_xla_flag_options
+      and xla_flags.REMOVE in wl_config.model.pathways_xla_flag_options
+  ):
+    flags_to_remove = wl_config.model.pathways_xla_flag_options[
+        xla_flags.REMOVE
+    ]
+    updated_proxy_flags = []
+    for flag in proxy_flags:
+      if flag not in flags_to_remove:
+        updated_proxy_flags.append(flag)
+    proxy_flags = updated_proxy_flags
+
+  # Add the flags that are specified to be added.
+  if (
+      wl_config.model.pathways_xla_flag_options
+      and xla_flags.ADD_PROXY in wl_config.model.pathways_xla_flag_options
+  ):
+    flags_to_add = wl_config.model.pathways_xla_flag_options[
+        xla_flags.ADD_PROXY
+    ]
+    proxy_flags.append(flags_to_add)
+
+  # Join the list of flags back into a single string, space-separated
+  return ' '.join(proxy_flags)
+
+
+def _get_pathways_worker_flags(wl_config: WorkloadConfig):
+  """Get the pathways worker flags for the workload and removes any extras."""
+  # Add in the xla flags alongside the worker flags from the pathways config.
+  pw_config = wl_config.pathways_config
+
+  # Get worker and xla flag string from model config
+  worker_flags = pw_config.worker_flags
+
+  # Add the flags that are specified to be added.
+  if (
+      wl_config.model.pathways_xla_flag_options
+      and xla_flags.ADD_WORKER in wl_config.model.pathways_xla_flag_options
+  ):
+    flags_to_add = wl_config.model.pathways_xla_flag_options[
+        xla_flags.ADD_WORKER
+    ]
+    worker_flags += flags_to_add
+
+  # Join the list of flags back into a single string, space-separated
+  return worker_flags
+
+
+def _get_pathways_server_flags(wl_config: WorkloadConfig):
+  """Get the pathways server flags for the workload and removes any extras."""
+  # Add in the xla flags alongside the server flags from the pathways config.
+  pw_config = wl_config.pathways_config
+
+  # Get server and xla flag string from model config
+  server_flags = pw_config.server_flags
+
+  # Add the flags that are specified to be added.
+  if (
+      wl_config.model.pathways_xla_flag_options
+      and xla_flags.ADD_SERVER in wl_config.model.pathways_xla_flag_options
+  ):
+    flags_to_add = wl_config.model.pathways_xla_flag_options[
+        xla_flags.ADD_SERVER
+    ]
+    server_flags += flags_to_add
+
+  # Join the list of flags back into a single string, space-separated
+  return server_flags
+
+
 def _get_pathways_specific_flags(wl_config: WorkloadConfig):
   pw_config = wl_config.pathways_config
   if pw_config is None:
@@ -357,18 +504,23 @@ def _get_pathways_specific_flags(wl_config: WorkloadConfig):
       else ''
   )
 
-  proxy_flags = pw_config.proxy_flags + wl_config.model.xla_flags
+  proxy_flags = _get_pathways_proxy_flags(wl_config)
+  worker_flags = _get_pathways_worker_flags(wl_config)
+  server_flags = _get_pathways_server_flags(wl_config)
+
+  # restart on all exit codes.
+  restart_codes = f"\"{','.join(str(code) for code in list(range(1, 256)))}\""
 
   pathways_specific_flags = (
       f' {server_image_flag} '
       f' {proxy_server_image_flag} '
       f' {remote_python_sidecar_image_flag} '
       f' --termination-grace-period-seconds=300 '
+      f' --restart-on-exit-codes={restart_codes} '
       f' --pathways-gcs-location={wl_config.base_output_directory} '
-      f' --restart-on-user-code-failure'
-      f' --custom-pathways-server-args="{pw_config.server_flags}" '
+      f' --custom-pathways-server-args="{server_flags}" '
       f' --custom-pathways-proxy-server-args="{proxy_flags}" '
-      f' --custom-pathways-worker-args="{pw_config.worker_flags}" '
+      f' --custom-pathways-worker-args="{worker_flags}" '
   )
   return pathways_specific_flags
 

--- a/benchmarks/recipes/pw_long_running_recipe.py
+++ b/benchmarks/recipes/pw_long_running_recipe.py
@@ -1,0 +1,144 @@
+"""
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import datetime
+import sys
+import os
+import args_helper as helper
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+import maxtext_trillium_model_configs as model_configs
+import maxtext_xpk_runner as mxr
+
+PROXY_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_proxy_server:latest"
+SERVER_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_server:latest"
+RUNNER = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/maxtext_jax_stable:latest"
+
+# Cluster Params
+CLUSTER = "v6e-256-cluster"
+PROJECT = "tpu-prod-env-cluster"
+ZONE = "us-east5-b"
+REGION = "us-east5"
+COUNTRY = "us"
+DEVICE_TYPE = "v6e-256"
+
+# Other parameters (MUST BE SET BY USER)
+XPK_PATH = "../xpk"  # We're running this script from the maxtext directory
+USER = os.environ["USER"]
+BASE_OUTPUT_DIRECTORY = (
+    f"gs://{USER}-{PROJECT}-{COUNTRY}/pw_mcjax_benchmarking/"
+)
+
+MAX_RESTARTS = 10_000
+BENCHMARK_STEPS=10_000_000
+
+
+def main() -> int:
+  # V6e cluster config
+  cluster_config = mxr.XpkClusterConfig(
+      cluster_name=CLUSTER,
+      project=PROJECT,
+      zone=ZONE,
+      device_type=DEVICE_TYPE,
+  )
+
+  # Handle command line arguments using args_helper
+  should_continue = helper.handle_cmd_args(
+      cluster_config, helper.DELETE, xpk_path=XPK_PATH
+  )
+
+  if not should_continue:
+    return 0
+
+  model_list = [
+      # model_configs.llama3_1_70b_8192_pw_lr_real_data,
+      # model_configs.llama3_1_8b_8192,
+      model_configs.llama3_1_70b_8192_iter_synth_data_and_checkpointing,
+  ]
+  pathways_config = mxr.PathwaysConfig(
+      server_image=SERVER_IMAGE,
+      proxy_server_image=PROXY_IMAGE,
+      runner_image=RUNNER,
+
+      # User can add additional flags here.
+      server_flags="--enable_metrics_collection=false",
+      proxy_flags="--enable_metrics_collection=false",
+      worker_flags="--enable_metrics_collection=false",
+  )
+  num_slices_list = [
+      2
+  ]
+
+  xpk_workload_cmds = []
+  xpk_workload_names = []
+
+  for model in model_list:
+    # Run workloads on the below clusters
+    for cluster_config in [
+        cluster_config,
+    ]:
+
+      # Make modifications to the model config here to add in any additional
+      # flags or changes to the model config.
+      model.tuning_params["use_vertex_tensorboard"] = True
+      model.tuning_params["vertex_tensorboard_project"] = PROJECT
+      model.tuning_params["vertex_tensorboard_location"] = REGION
+
+      # Run workloads in the following slice configurations
+      for num_slices in num_slices_list:
+        wl_config = mxr.WorkloadConfig(
+            model=model,
+            num_slices=num_slices,
+            device_type=cluster_config.device_type,
+            base_output_directory=BASE_OUTPUT_DIRECTORY,
+            max_restarts=MAX_RESTARTS,
+            libtpu_type=None,
+            libtpu_nightly_version="",
+            base_docker_image=None,
+            pathways_config=pathways_config,
+            xpk_path=XPK_PATH,
+            num_steps=BENCHMARK_STEPS,
+            priority="medium",
+        )
+        command, name = mxr.generate_xpk_workload_cmd(
+            cluster_config=cluster_config, wl_config=wl_config
+        )
+
+        print(f"Name of the workload is: {name} \n")
+        xpk_workload_names.append(name)
+
+        print(f"XPK command to be used is: {command} \n")
+        xpk_workload_cmds.append(command)
+
+  for xpk_workload_name, xpk_workload_cmd in zip(
+      xpk_workload_names, xpk_workload_cmds
+  ):
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    print(
+        f"[{timestamp}] Running workload: {xpk_workload_name} with command:"
+        f" {xpk_workload_cmd}"
+    )
+    return_code = mxr.run_command_with_updates(
+        xpk_workload_cmd, xpk_workload_name
+    )
+    if return_code != 0:
+      print(f"Unable to run xpk workload: {xpk_workload_name}")
+
+
+if __name__ == "__main__":
+  main()

--- a/benchmarks/recipes/pw_mcjax_benchmark_recipe.py
+++ b/benchmarks/recipes/pw_mcjax_benchmark_recipe.py
@@ -1,0 +1,152 @@
+"""
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+"""Used to perf benchmarks between Pathways and McJax."""
+
+import datetime
+import sys
+import os
+import args_helper as helper
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+import maxtext_trillium_model_configs as model_configs
+import maxtext_xpk_runner as mxr
+
+PROXY_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_proxy_server:latest"
+SERVER_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_server:latest"
+RUNNER = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/maxtext_jax_stable:latest"
+
+# Cluster Params
+CLUSTER = "v6e-256-cluster"
+PROJECT = "tpu-prod-env-cluster"
+ZONE = "us-east5-b"
+REGION = "us-east5"
+COUNTRY = "us"
+DEVICE_TYPE = "v6e-256"
+
+# Other parameters (MUST BE SET BY USER)
+XPK_PATH = "../xpk"  # We're running this script from the maxtext directory
+USER = os.environ["USER"]
+BASE_OUTPUT_DIRECTORY = (
+    f"gs://{USER}-{PROJECT}-{COUNTRY}/pw_mcjax_benchmarking/"
+)
+
+BENCHMARK_STEPS = 20
+
+
+def main() -> int:
+  # V6e cluster config
+  cluster_config = mxr.XpkClusterConfig(
+      cluster_name=CLUSTER,
+      project=PROJECT,
+      zone=ZONE,
+      device_type=DEVICE_TYPE,
+  )
+
+  # Handle command line arguments using args_helper
+  should_continue = helper.handle_cmd_args(
+      cluster_config, helper.DELETE, xpk_path=XPK_PATH
+  )
+
+  if not should_continue:
+    return 0
+
+  models = {
+      "mcjax": [
+          # model_configs.llama3_1_8b_8192,
+          # model_configs.llama3_1_70b_8192,
+          # model_configs.llama3_1_405b_8192_fsdp_dcn,
+          # model_configs.llama2_70b_4096_real_data_long_run,
+      ],
+      "pathways": [
+          model_configs.llama3_1_8b_8192,
+          # model_configs.llama3_1_70b_8192,
+          # model_configs.llama3_1_405b_8192_fsdp_dcn,
+          # model_configs.llama2_70b_4096_real_data_long_run,
+      ]
+  }
+  pathways_config = mxr.PathwaysConfig(
+      server_image=SERVER_IMAGE,
+      proxy_server_image=PROXY_IMAGE,
+      runner_image=RUNNER,
+
+      # User can add additional flags here.
+      server_flags="",
+      proxy_flags="",
+      worker_flags="",
+  )
+  num_slices_list = [
+      2
+  ]
+
+  xpk_workload_cmds = []
+  xpk_workload_names = []
+
+  for infra, model_list in models.items():
+    for model in model_list:
+      # Run workloads on the below clusters
+      for cluster_config in [
+          cluster_config,
+      ]:
+
+        # Make modifications to the model config here to add in any additional
+        # flags or changes to the model config.
+        model.tuning_params["use_vertex_tensorboard"] = True
+        model.tuning_params["vertex_tensorboard_project"] = PROJECT
+        model.tuning_params["vertex_tensorboard_location"] = REGION
+
+        # Run workloads in the following slice configurations
+        for num_slices in num_slices_list:
+          wl_config = mxr.WorkloadConfig(
+              model=model,
+              num_slices=num_slices,
+              device_type=cluster_config.device_type,
+              base_output_directory=BASE_OUTPUT_DIRECTORY
+              + f"{infra}_{num_slices}_slice_{DEVICE_TYPE}_{model.model_name}/",
+              max_restarts=0,
+              libtpu_type=None,
+              libtpu_nightly_version="",
+              base_docker_image=RUNNER if infra == "mcjax" else None,
+              pathways_config=pathways_config if infra == "pathways" else None,
+              xpk_path=XPK_PATH,
+              num_steps=BENCHMARK_STEPS,
+              priority="low",
+          )
+          command, name = mxr.generate_xpk_workload_cmd(
+              cluster_config=cluster_config, wl_config=wl_config
+          )
+
+          print(f"Name of the workload is: {name} \n")
+          xpk_workload_names.append(name)
+
+          print(f"XPK command to be used is: {command} \n")
+          xpk_workload_cmds.append(command)
+
+  for xpk_workload_name, xpk_workload_cmd in zip(
+      xpk_workload_names, xpk_workload_cmds
+  ):
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{timestamp}] Running workload: {xpk_workload_name} with command: {xpk_workload_cmd}")
+    return_code = mxr.run_command_with_updates(
+        xpk_workload_cmd, xpk_workload_name
+    )
+    if return_code != 0:
+      print(f"Unable to run xpk workload: {xpk_workload_name}")
+
+
+if __name__ == "__main__":
+  main()

--- a/benchmarks/recipes/pw_remote_python_recipe.py
+++ b/benchmarks/recipes/pw_remote_python_recipe.py
@@ -59,7 +59,7 @@ def main() -> int:
   base_output_directory = f"gs://{user}-{region}/{user}"
 
   list_of_models = [
-      model_configs.default_basic_1_pw,
+      model_configs.default_basic_1,
   ]
   pathways_config = mxr.PathwaysConfig(
       server_image=server_image,

--- a/benchmarks/xla_flags_library.py
+++ b/benchmarks/xla_flags_library.py
@@ -21,6 +21,11 @@
 # but provide a recommendation for potential grouping of xla flags and their
 # usage. Please refer to their usage for examples.
 
+REMOVE = "remove"
+ADD_SERVER = "add_server"
+ADD_PROXY = "add_proxy"
+ADD_WORKER = "add_worker"
+
 # xla tpu scoped vmem defines the amount of vmem used for the current hlo op.
 # The remaining vmem is used for prefetching latter op needs.
 # These limits are experimentally recommended values for compute bound models.
@@ -74,13 +79,6 @@ ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS = (
     " --2a886c8_chip_config_name=megachip_tccontrol"
 )
 
-ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS_PW = (
-    " --xla_tpu_use_tc_device_shape_on_sc=true"
-    " --xla_sc_enable_instruction_fusion=false"
-    " --xla_sc_disjoint_spmem=false"
-    " --xla_sc_disable_megacore_partitioning=true"
-    # " --2a886c8_chip_config_name=megachip_tccontrol"  # Flag has issues in PW.
-)
 
 # Enable SparseCore All Gather (1D), Reduce Scatter (1D) and All Reduce (ND)
 ENABLE_SPARSECORE_OFFLOADING_FOR_RS_AG_AR = (
@@ -123,12 +121,6 @@ ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE = (
     " --xla_tpu_enable_all_reduce_offload_tracing=true"
 ) + ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS
 
-ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE_PW = (
-    " --xla_tpu_enable_async_collective_fusion_fuse_all_reduce=false"
-    " --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true"
-    " --xla_tpu_enable_all_reduce_offload_tracing=true"
-) + ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS_PW
-
 # Better memory layout for all-reduce (AR).
 LAYOUT_FOR_ALL_REDUCE_SCATTER = (
     " --xla_tpu_use_minor_sharding_for_major_trivial_input=true"
@@ -150,6 +142,13 @@ REDUCE_SCATTER_FUSION = (
 DATA_PARALLEL_OVERLAP = (
     " --xla_tpu_enable_data_parallel_all_reduce_opt=true"
     " --xla_tpu_data_parallel_opt_different_sized_ops=true"
+)
+
+# Enable Enhanced Launch Barrier.
+# Gracefully handle dispatch failures on TPU workers. For Pathways is required
+# for error propagation and out-of-order execution detection.
+ENHANCED_LAUNCH_BARRIER = (
+    " --xla_tpu_use_enhanced_launch_barrier=true"
 )
 
 # Host offloading Flags. These are optimizations recommended when using host


### PR DESCRIPTION
# Description

This PR contains the following changes:

1. Adds the following 2 recipes:

   a. Benchmarking Pathways and McJAX code
   b. Long running test on Pathways.

   This is done to improve code/recipe sharing between developers during testing and make benchmarking simpler by 
   sharing a single, well-defined config. This will be used for testing and verification on v6e capacity.

2. By default allows all configs to run pathways (enable_single_controller, disable zarr3, enable_pathways_goodput etc.), with additional configs that can be added by the user with `pathways_tuning_params`.
3. Allow removing problematic XLA flags for pathways with `pathways_xla_flag_options` or subsequently adding xla flags to different pods.
4. Cleans up a lot of old pathways specific configs and adds some new ones as well.

# Tests

Run multiple rounds on multiple v6e clusters

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
