### PR TITLE
Maintain fp32 for optimizer state when offloading is enabled

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -65,10 +65,6 @@ def cast_dtype_from_to(nest, src, dst):
   return jax.tree_util.tree_map(lambda t: t.astype(dst) if t.dtype == src else t, nest)
 
 
-def cast_to_bf16(params):
-  return cast_dtype_from_to(params, np.float32, jnp.bfloat16)
-
-
 def find_nans_and_infs(pytree):
   def finder(x):
     return jnp.any(jnp.isinf(x) | jnp.isnan(x))

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -514,11 +514,9 @@ def train_step(model, config, state_mesh_shardings, state, data, dropout_rng):
   else:
     if config.optimizer_memory_host_offload:
       cast_params = jax.device_put(state.params, max_utils.with_memory_kind(state_mesh_shardings.params, "device"))
-      cast_params = max_utils.cast_to_bf16(cast_params)
       state = state.replace(params=cast_params)
       if config.use_dpo:
         reference_params = jax.device_put(reference_params, max_utils.with_memory_kind(reference_params_sharding, "device"))
-        reference_params = max_utils.cast_to_bf16(reference_params)
         extra_dpo_args = [reference_params]
     grad_func = jax.value_and_grad(_loss_fn, argnums=4, has_aux=True)
     (loss, aux), raw_grads = grad_func(model, config, data, dropout_rng, state.params, *extra_dpo_args, is_train=True)


### PR DESCRIPTION
Address issues with optimizer state offloading and data type conversion.

We identified two issues concerning the conversion from fp32 to fp16 for the optimizer state when enabling optimizer state offloading:

The comparison between configurations without and with optimizer state offloading was unfair because the data sizes differed, with the former using fp32 and the latter using fp16.
The presence of two modules with jit_train_step due to separate versions for fp32 and fp16 created inconsistencies.

This commit removes the fp32 to fp16 conversion, ensuring that the optimizer state retains its original data type.

We observed no memory savings when switching from f16 to f32 previously. The root cause is that the GPU memory scheduler does not distinguish between CPU memory and GPU memory. [This XLA PR](https://github.com/openxla/xla/pull/21825) modifies the scheduler to exclude CPU memory and is merged so that we could reenable the CL (#1184) again.
