### PR TITLE
Add an option to disable tensorboard

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -465,6 +465,8 @@ report_heartbeat_metric_for_gcp_monitoring: False
 heartbeat_reporting_interval_in_seconds: 5
 report_performance_metric_for_gcp_monitoring: False
 
+enable_tensorboard: True
+
 # Vertex AI Tensorboard Configurations - https://github.com/google/maxtext/tree/main/getting_started/Use_Vertex_AI_Tensorboard.md
 # Set to True for GCE, False if running via XPK
 use_vertex_tensorboard: False

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -144,7 +144,8 @@ def write_metrics(writer, local_metrics_file, running_gcs_metrics, metrics, step
     steps_to_write = step
 
   if metrics_to_write:
-    write_metrics_to_tensorboard(writer, metrics_to_write, steps_to_write, config, is_training)
+    if config.enable_tensorboard:
+      write_metrics_to_tensorboard(writer, metrics_to_write, steps_to_write, config, is_training)
 
     if config.metrics_file:
       max_utils.write_metrics_locally(metrics_to_write, steps_to_write, config, local_metrics_file, is_training)


### PR DESCRIPTION
We have found that tensorboard does not support
our network based storage backend. Add an option to disable it.


# Tests
maxtext/train_gpu
  base.yml
  tokenizer_path=*
  per_device_batch_size=1
  max_target_length=8192
  base_output_directory=/network-storage/*
  enable_tensorboard=false
  enable_checkpointing=true
  checkpoint_period=10


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ x ] I have performed a self-review of my code.
- [ x ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ x ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ x ] I have made or will make corresponding changes to the doc if needed.
