### PR TITLE
Fix FP8 Quantization Error With Pipeline Parallelism

### DIFF
--- a/MaxText/layers/pipeline.py
+++ b/MaxText/layers/pipeline.py
@@ -362,7 +362,7 @@ class Pipeline(nn.Module):
         func_to_vmap,
         in_axes=(0, 0, 0, None, None),
         spmd_axis_name="stage",
-        variable_axes={"params": 0},
+        variable_axes={"params": 0, "_overwrite_with_gradient": 0},
         split_rngs={"params": self.is_initializing()},
         metadata_params={
             nn.PARTITION_NAME: "layers",
@@ -417,7 +417,7 @@ class Pipeline(nn.Module):
 
       vmap_func = nn.map_variables(
           vmap_func,
-          mapped_collections=["params", "non_trainable", "summaries", "intermediates"],
+          mapped_collections=["params", "_overwrite_with_gradient", "non_trainable", "summaries", "intermediates"],
           mutable=True,
           trans_in_fn=prepare_vars_for_main_vmap,
       )
@@ -510,6 +510,7 @@ class Pipeline(nn.Module):
             in_axes=(0, segment_idx, position_idx, None, None),
             variable_axes={
                 "params": 0,
+                "_overwrite_with_gradient": 0,
                 "non_trainable": 0,
                 "hyper_params": 0,
             },
@@ -566,7 +567,10 @@ class Pipeline(nn.Module):
     # The scan cannot be used on init since it broadcasts the weights, which aren't yet initialized.
     if self.config.scan_pipeline_iterations:
       variable_carry = []
-      variable_broadcast = ["params"]  # All loop iterations need the weights for the full pipeline.
+      variable_broadcast = [
+          "params",
+          "_overwrite_with_gradient",
+      ]  # All loop iterations need the weights for the full pipeline.
       if self.is_mutable_collection("non_trainable"):
         variable_carry.append("non_trainable")
       else:

--- a/MaxText/tests/pipeline_parallelism_test.py
+++ b/MaxText/tests/pipeline_parallelism_test.py
@@ -279,6 +279,36 @@ class PipelineParallelismTest(unittest.TestCase):
         ]
     )
 
+  def test_full_train_fp8(self):
+    # Run a full train.py call with fp8 quantization, which adds extra
+    # variable collections that need to be handled
+    train_main(
+        [
+            None,
+            "configs/base.yml",
+            r"base_output_directory=gs://runner-maxtext-logs",
+            "run_name=runner_pipeline_parallelism_fp8_test",
+            r"dataset_path=gs://maxtext-dataset",
+            "base_emb_dim=28",
+            "base_num_query_heads=4",
+            "base_num_kv_heads=4",
+            "base_mlp_dim=32",
+            "base_num_decoder_layers=4",
+            "head_dim=128",
+            "per_device_batch_size=2",
+            "max_target_length=1024",
+            "vocab_size=32",
+            "dataset_type=synthetic",
+            "steps=3",
+            "enable_checkpointing=False",
+            "ici_pipeline_parallelism=4",
+            "tokenizer_path=../assets/tokenizer.llama2",
+            "quantization=fp8",
+            "scan_layers=False",
+            "attention=dot_product",
+        ]
+    )
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description

Pipeline Parallelism maps over the `params` variable collection in a few places, but it also needs to map over '_overwrite_with_gradient' collection that is added when using FP8 quantization 

FIXES: b/392895962


# Tests

Added a new pipeline parallelism test that uses FP8 quantization. Test requires these changes to pass. I also did a manual test on my TPU VM (which exercises the same code paths as GPU)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
