### PR TITLE
Get partition spec only when needed

### DIFF
--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -396,9 +396,12 @@ class Decoder(nn.Module):
     RemattedBlockLayer = self.set_remat_policy(self.decoder_layer, policy)
 
     if cfg.using_pipeline_parallelism:
-      partition_spec = self.pipeline_module.get_weight_sharding(
-          y, decoder_segment_ids, decoder_positions, deterministic, model_mode
-      )
+      if cfg.pipeline_fsdp_ag_once:
+        partition_spec = self.pipeline_module.get_weight_sharding(
+            y, decoder_segment_ids, decoder_positions, deterministic, model_mode
+        )
+      else:
+        partition_spec = None  # This partition spec is only used for the fsdp_ag_once feature.
       y = self.pipeline_module(
           y, decoder_segment_ids, decoder_positions, deterministic, model_mode, partition_spec=partition_spec
       )

--- a/MaxText/tests/pipeline_parallelism_test.py
+++ b/MaxText/tests/pipeline_parallelism_test.py
@@ -304,7 +304,6 @@ class PipelineParallelismTest(unittest.TestCase):
         ]
     )
 
-  @pytest.mark.skip(reason="Test is flaky / failing")
   def test_full_train_fp8(self):
     # Run a full train.py call with fp8 quantization, which adds extra
     # variable collections that need to be handled


### PR DESCRIPTION
# Description

Fixes the PP tests - only pass partition spec to pipelining when needed. We will need to look into why fp8 + this feature pipeline_fsdp_ag_once are not working together - b/394961837

# Tests

Existing tests pass

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
