### PR TITLE
Enable mlperf to use mixtral-v1 tokenized dataset to avoid dropping in total_weights when splitting data across multiple host

### DIFF
--- a/MaxText/configs/models/mixtral-8x22b-mlperf.yml
+++ b/MaxText/configs/models/mixtral-8x22b-mlperf.yml
@@ -31,6 +31,6 @@ num_experts: 8
 num_experts_per_tok: 2
 rope_max_timescale: 1_000_000
 decoder_block: "mistral"
-dataset_path: "gs://mlperf-llm-public2"
+dataset_path: "gs://maxtext-dataset"
 dataset_name: "c4/en:3.0.4"
-eval_dataset_name: "c4/en:3.0.4"
+eval_dataset_name: "c4/en:3.0.6"


### PR DESCRIPTION
# Description

We observed drop in total_weights in multihost training. It comes from splitting untokenized data across host. Switch to tokenized dataset fixes it
b/394692604

# Tests

self tested

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
