### PR TITLE
Fix failure notification action

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -101,7 +101,6 @@ jobs:
       tf_force_gpu_allow_growth: true
       container_resource_option: "--shm-size 2g --runtime=nvidia --gpus all --privileged"
 
-
   clean_up:
     if: ${{ always() }}  # always execute, regardless of previous jobs or steps.
     needs: [gpu_unit_tests, gpu_integration_tests, tpu_unit_tests, tpu_integration_tests]
@@ -115,9 +114,13 @@ jobs:
       run: gcloud container images delete gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:gpu --force-delete-tags --quiet
     - name: Delete TPU image
       run: gcloud container images delete gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:tpu --force-delete-tags --quiet
-    - name: Notify failed build  # creates an issue or modifies last open existing issue for failed build
-      uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
-      if: failure() && github.event.pull_request == null
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
 
+   notify:
+     name: Notify failed build # creates an issue or modifies last open existing issue for failed build
+     needs: [gpu_unit_tests, gpu_integration_tests, tpu_unit_tests, tpu_integration_tests, clean_up]
+     if: failure() && github.event.pull_request == null
+     runs-on: ["self-hosted"]
+     steps:
+       - uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
+         with:
+           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The current implementation did not correctly placed the notification action -- it was placed as a step inside a clean-up job, 
and as a result what was evaluated is only whether the clean up step succeeded or failed. Here we separate notification into its own job with explicit dependencies.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
