### PR TITLE
Support Huggingface tokenizer

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -330,6 +330,7 @@ num_slices: -1
 # Tokenizer
 vocab_size: 32_000 # powers of 2 for sharding
 tokenizer_path: "assets/tokenizer.llama2"
+tokenizer_type: "sentencepiece"
 tokenize_train_data: True  # False if the dataset is pre-tokenized
 tokenize_eval_data: True  # False if the dataset is pre-tokenized
 add_bos: True

--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -38,9 +38,9 @@ def normalize_features(x, column_name):
   return {"inputs": x[column_name], "targets": x[column_name]}
 
 
-def get_tokenizer(tokenizer_path, add_bos, add_eos):
+def get_tokenizer(tokenizer_path, tokenizer_type, add_bos, add_eos, hf_access_token=""):
   # Load tokenizer
-  tokenizer_model = tokenizer.build_tokenizer(tokenizer_path, add_bos, add_eos)
+  tokenizer_model = tokenizer.build_tokenizer(tokenizer_path, tokenizer_type, add_bos, add_eos, hf_access_token)
   return tokenizer_model
 
 

--- a/MaxText/input_pipeline/_tfds_data_processing_c4_mlperf.py
+++ b/MaxText/input_pipeline/_tfds_data_processing_c4_mlperf.py
@@ -308,7 +308,9 @@ def make_c4_mlperf_train_iterator(
   )
   train_ds = rekey(train_ds, {"inputs": None, "targets": "text"})
 
-  sp_tokenizer = get_tokenizer(config.tokenizer_path, config.add_bos, config.add_eos)
+  sp_tokenizer = get_tokenizer(
+      config.tokenizer_path, config.tokenizer_type, config.add_bos, config.add_eos, config.hf_access_token
+  )
   train_ds = preprocess_train_dataset(
       train_ds,
       sp_tokenizer=sp_tokenizer,

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -397,7 +397,8 @@ class _HyperParameters:
 
     if raw_keys["log_config"]:
       for k in keys:
-        max_logging.log(f"Config param {k}: {raw_keys[k]}")
+        if k != "hf_access_token":
+          max_logging.log(f"Config param {k}: {raw_keys[k]}")
 
   @staticmethod
   def user_init(raw_keys):

--- a/MaxText/tokenizer.py
+++ b/MaxText/tokenizer.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import tensorflow as tf
 import tensorflow_text as tftxt
 import max_logging
+import transformers
 import tiktoken
 from tiktoken.load import load_tiktoken_bpe
 
@@ -200,13 +201,39 @@ class SentencePieceTokenizer:
     return self.sp_tokenizer.detokenize(t)
 
 
-def build_tokenizer(tokenizer_path, add_bos, add_eos):
+class HFTokenizer:
+  """
+  Tokenizing using huggingface tokenizer
+  """
+
+  def __init__(self, model_path: str, add_bos: bool, add_eos: bool, hf_access_token: str):
+    max_logging.log(f"Loading HF tokenizer: {model_path}")
+    self.tokenizer = transformers.AutoTokenizer.from_pretrained(
+        model_path,
+        add_bos_token=add_bos,
+        add_eos_token=add_eos,
+        token=hf_access_token,
+    )
+
+  def encode(self, s: str) -> List[int]:
+    return self.tokenizer.encode(s)
+
+  def decode(self, t: Sequence[int]) -> str:
+    return self.tokenizer.decode(t)
+
+
+def build_tokenizer(tokenizer_path, tokenizer_type, add_bos, add_eos, hf_access_token):
   """Loads the tokenizer at `tokenizer_path`"""
   max_logging.log(f"Tokenizer path: {tokenizer_path}")
-  if "tiktoken" in tokenizer_path:
+  if tokenizer_type == "tiktoken":
+    assert "tiktoken" in tokenizer_path, f"Invalid tokenizer type: {tokenizer_type} chosen for {tokenizer_path}"
     return TikTokenTokenizer(tokenizer_path, add_bos, add_eos)
-  else:
+  elif tokenizer_type == "huggingface":
+    return HFTokenizer(tokenizer_path, add_bos, add_eos, hf_access_token)
+  elif tokenizer_type == "sentencepiece":
     return SentencePieceTokenizer(tokenizer_path, add_bos, add_eos)
+  else:
+    raise ValueError(f"Invalid tokenizer_type:{tokenizer_type} chosen in config")
 
 
 def TokenizeOp(tokenizer, features: Features, data_keys: Iterable[str] = ("inputs", "targets")) -> Features:
@@ -220,7 +247,7 @@ def TokenizeOp(tokenizer, features: Features, data_keys: Iterable[str] = ("input
     return [modified_string]
 
   for k in data_keys:
-    if isinstance(tokenizer, TikTokenTokenizer):
+    if isinstance(tokenizer, (TikTokenTokenizer, HFTokenizer)):
       features[k] = tf.py_function(_process_string, [features[k]], Tout=[tf.int32])[0]
     elif isinstance(tokenizer, SentencePieceTokenizer):
       features[k] = tokenizer.encode(features[k])


### PR DESCRIPTION
# Description

Support Huggingface tokenizer and decouple it out of the input pipeline. 


If the change fixes a bug or a Github issue, please include a link, e.g.,:
b/394635939

# Tests

Tested using `python MaxText/train.py MaxText/configs/base.yml tokenizer_path='google/gemma-2-2b-it' tokenizer_type=huggingface run_name=${USER}-$RANDOM model_name=gemma2-2b base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset per_device_batch_size=1.0 enable_checkpointing=false steps=2` and added a test for comparing Gemma2-2b HF tokenizer with Sentencepiece. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
