### PR TITLE
chunked prefill

### DIFF
--- a/MaxText/benchmark_chunked_prefill.py
+++ b/MaxText/benchmark_chunked_prefill.py
@@ -1,0 +1,111 @@
+"""
+ Copyright 2025 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+"""Shared Benchmark config for v5e orchestrations."""
+
+# pylint: disable=ungrouped-imports
+import jax
+
+import max_utils
+import maxengine
+
+import os
+import pyconfig
+
+from typing import Sequence
+from absl import app
+import jax.numpy as jnp
+import datetime
+from jetstream.engine import token_utils
+
+_WARMUP_ITERS = 2
+_BENCHMARK_ITERS = 5
+
+
+def main(argv: Sequence[str]) -> None:
+  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
+  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
+  config = pyconfig.initialize(argv)
+  max_utils.print_system_information()
+
+  engine = maxengine.MaxEngine(config)
+  rng = jax.random.PRNGKey(1234)
+  rng, rng_load_params = jax.random.split(rng)
+  params = engine.load_params(rng_load_params)
+
+  text = config.prompt
+  metadata = engine.get_tokenizer()
+  tokenizer_model = engine.build_tokenizer(metadata)
+  # set it to max complete prompt length that has to be bechmarked with chunked prefill
+  max_prefill_length = 7000
+  tokens, true_length = tokenizer_model.encode(text, is_bos=True, prefill_lengths=[max_prefill_length])
+
+  chunk_size = 2048
+  # set this to array of acceptable chunk sizes
+  prefill_lengths = [1024, 2048, 4096, 7000]
+  # prefill_lengths = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144]
+
+  padded_tokens, true_lengths, positions = token_utils.chunk_and_pad_tokens(
+      tokens, tokenizer_model.bos_id, tokenizer_model.pad_id, False, prefill_lengths, max_prefill_length, chunk_size, True
+  )
+  rng, _ = jax.random.split(rng)
+
+  def run_chunked_prefill():
+    prefill_result = None
+    next_pos = 0
+    for chunk_num, _ in enumerate(padded_tokens):
+      if prefill_result is None:
+        prefill_result, _ = engine.prefill(
+            params=params,
+            padded_tokens=padded_tokens[chunk_num],
+            true_length=true_lengths[chunk_num],
+            positions=positions[chunk_num],
+            complete_prompt_true_length=true_length,
+            complete_padded_prompt=tokens,
+            previous_chunk=prefill_result,
+            rng=rng,
+        )
+      else:
+        prefill_result, _ = engine.prefill(
+            params=params | {"cache": prefill_result["cache"]},
+            padded_tokens=padded_tokens[chunk_num],
+            true_length=true_lengths[chunk_num],
+            positions=positions[chunk_num],
+            complete_prompt_true_length=true_length,
+            complete_padded_prompt=tokens,
+            previous_chunk=prefill_result,
+            rng=rng,
+        )
+      true_length_array = jnp.expand_dims(jnp.arange(0, chunk_num * chunk_size + true_lengths[chunk_num]), 0)
+      prefill_result["true_length_array"] = true_length_array
+      prefill_result["next_pos"] = jnp.full((1, 1), next_pos + true_lengths[chunk_num], dtype=jnp.int32)
+      next_pos = next_pos + true_lengths[chunk_num]
+    return prefill_result
+
+  for _ in range(_WARMUP_ITERS):
+    start = datetime.datetime.now()
+    prefill_result = run_chunked_prefill()
+    jax.block_until_ready(prefill_result)
+    end = datetime.datetime.now()
+    print("time taken for chunk prefill warmup: ", end - start)
+
+  for _ in range(_BENCHMARK_ITERS):
+    start = datetime.datetime.now()
+    prefill_result = run_chunked_prefill()
+    jax.block_until_ready(prefill_result)
+    end = datetime.datetime.now()
+    print("time taken for chunk prefill ", end - start)
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -607,3 +607,7 @@ sa_v_layout: "HEAD_DIM_MINOR"
 pagedattn_num_pages: 64
 pagedattn_tokens_per_page: 32
 pagedattn_pages_per_compute_block: 8
+
+# Chunked Prefill Parameters
+prefill_chunk_size: 256
+use_chunked_prefill: False

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -155,6 +155,8 @@ class AttentionOp(nn.Module):
   prefill_cache_axis_order: AxisIdxes = (1, 2, 0, 3)
   ar_cache_axis_order: AxisIdxes = (1, 2, 0, 3)
   compute_axis_order: AxisIdxes = (0, 1, 2, 3)
+  key_axis_order: AxisIdxes = (2, 0, 1, 3)
+
   reshape_q: bool = False
   dropout_rate: float = 0.0
   dtype: DType = jnp.float32
@@ -175,10 +177,43 @@ class AttentionOp(nn.Module):
     assert key.shape[-3] == value.shape[-3], "k, v lengths must match."
     assert query.shape[-1] == key.shape[-1], "q, k depths must match."
 
+  # Attention mask is generated in the same way
+  # as mentioned in SARATHI - https://arxiv.org/abs/2308.16369
+  def generate_attention_mask_for_chunk(self, query, key, previous_chunk: Any = None) -> Array | None:
+    _, q_seq_len, _, _ = query.shape
+    _, kv_seq_len, _, _ = key.shape
+    mask_shape = (q_seq_len, q_seq_len)
+    row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+    col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+    # causal mask represents causality within query sequence
+    causal_mask = (col_ids <= row_ids).astype(jnp.int32)
+
+    next_pos = 0
+    if previous_chunk != None:
+      # shape[1] of ['true_length_array'] gives the length of previously processed chunk
+      next_pos = previous_chunk["true_length_array"].shape[1]
+      overall_mask = jnp.zeros((q_seq_len, kv_seq_len), jnp.int32)
+      # mask wrt to previous chunk is all ones as the current seq depends on all tokens from before
+      previous_mask = jnp.ones((q_seq_len, next_pos), jnp.int32)
+
+      # update current mask at next position
+      output_mask = jax.lax.dynamic_update_slice(overall_mask, causal_mask, (0, next_pos))
+      # update previous mask at the start of output mask
+      output_mask = jax.lax.dynamic_update_slice(output_mask, previous_mask, (0, 0))
+    else:
+      # if no previous chunk is processed, entire mask is just the causal mask within query seq
+      output_mask = jnp.zeros((q_seq_len, kv_seq_len), jnp.int32)
+      output_mask = jax.lax.dynamic_update_slice(output_mask, causal_mask, (0, next_pos))
+
+    output_mask = output_mask[None, None, None, :, :]
+    return jnp.where(output_mask, 0.0, DEFAULT_MASK_VALUE) if output_mask is not None else None
+
   # Following Pallas MHA Flash Attention Reference.
   # https://github.com/jax-ml/jax/blob/main/jax/experimental/pallas/ops/tpu/flash_attention.py
   # This mask models (1) separate sequences (decoder_segment_ids) and (2) causality
-  def generate_attention_mask(self, query, key, decoder_segment_ids: Array | None, model_mode: str) -> Array | None:
+  def generate_attention_mask(
+      self, query, key, decoder_segment_ids: Array | None, model_mode: str, previous_chunk: Any = None
+  ) -> Array | None:
     mask = None
     if model_mode == common_types.MODEL_MODE_AUTOREGRESSIVE:
       mask = decoder_segment_ids[:, None, None, None, :] == common_types.DECODING_ACTIVE_SEQUENCE_INDICATOR
@@ -198,7 +233,9 @@ class AttentionOp(nn.Module):
 
     output_mask = None
 
-    if (mask is not None) and (causal_mask is not None):
+    if self.config.use_chunked_prefill and model_mode == common_types.MODEL_MODE_PREFILL:
+      return self.generate_attention_mask_for_chunk(query, key, previous_chunk)
+    elif (mask is not None) and (causal_mask is not None):
       output_mask = jnp.logical_and(mask, causal_mask)
     elif mask is not None:
       output_mask = mask
@@ -224,6 +261,7 @@ class AttentionOp(nn.Module):
       lengths: Array | None,
       model_mode: str,
       use_ragged_attention: bool = False,
+      previous_chunk: Any = None,
   ):
     self.check_attention_inputs(query, key, value)
     length = query.shape[-3]
@@ -242,7 +280,7 @@ class AttentionOp(nn.Module):
         or (self.attention_kernel == "autoselected" and model_mode == common_types.MODEL_MODE_AUTOREGRESSIVE)
         or (self.attention_kernel == "autoselected" and length < 128)
     ):
-      return self.apply_attention_dot(query, key, value, decoder_segment_ids, model_mode)
+      return self.apply_attention_dot(query, key, value, decoder_segment_ids, model_mode, previous_chunk)
     elif self.attention_kernel == "flash" or self.attention_kernel == "autoselected":
       if jax.devices()[0].platform == "tpu":
         if isinstance(key, KVTensor):
@@ -517,6 +555,7 @@ class AttentionOp(nn.Module):
       value: Array | KVTensor,
       decoder_segment_ids: Array | None,
       model_mode: str = common_types.MODEL_MODE_TRAIN,
+      previous_chunk: Any = None,
   ):
     """Apply Attention."""
     validate_compute_axis_order(self.compute_axis_order)
@@ -537,7 +576,7 @@ class AttentionOp(nn.Module):
     # Casting softmaxt computation for float32 for model stability.
     if self.float32_logits:
       attn_weights = attn_weights.astype(jnp.float32)
-    attn_mask = self.generate_attention_mask(query, key, decoder_segment_ids, model_mode)
+    attn_mask = self.generate_attention_mask(query, key, decoder_segment_ids, model_mode, previous_chunk)
     if attn_mask is not None:
       attn_weights = apply_mask_to_logits(attn_weights, attn_mask)
     return self.compute_local_attention(attn_weights, value, q_seq_len, model_mode)
@@ -791,11 +830,82 @@ class AttentionOp(nn.Module):
     value_vars = (cached_value_var, cached_value_scale_var)
     return key_vars, value_vars, cached_segment_id_var, cache_index_var, cached_lengths_var
 
+  def chunked_prefill_kv_cache(self, key: Array, value: Array, decoder_segment_ids: Array, previous_chunk: Any = None):
+    """
+    function returns appropriate prefill_cache if there is previous_chunk already processed
+    if no pervious chunk is processed,
+    function returns a cache that has non zero first chunk part of key and value
+
+    else
+    function updates current key and value at the desired location and returns entire key and value
+
+    """
+    batch, _, heads, kv_head_size = key.shape
+    assert key.dtype == value.dtype, "Key and Value Dtypes should match."
+
+    cached_prefill_key_vars, cached_prefill_value_vars, cached_prefill_segment_id_var = self._get_prefill_cache_vars(
+        batch, heads, kv_head_size, common_types.MODEL_MODE_PREFILL
+    )
+    # TODO: Find a way to not enable the ar cache for prefill mode.
+    _ = self._get_ar_cache_vars(batch, heads, kv_head_size, common_types.MODEL_MODE_PREFILL)  # initialize it now
+
+    key_shaped_for_cache = jnp.transpose(key, self.prefill_cache_axis_order)
+    value_shaped_for_cache = jnp.transpose(value, self.prefill_cache_axis_order)
+
+    next_pos = 0
+    if previous_chunk != None:
+      """
+      if there is previous chunk information present,
+        1. Fetch the cached key, value
+        2. Update current key value at the desired position.
+        3. take transpose before returning as that is how the attention op expects the key and value
+      """
+      next_pos = previous_chunk["true_length_array"].shape[1]
+      cached_key = self.get_cached_values(cached_prefill_key_vars, key.dtype, self.prefill_cache_axis_order)
+      cached_value = self.get_cached_values(cached_prefill_value_vars, value.dtype, self.prefill_cache_axis_order)
+      cached_key_value = jnp.transpose(cached_key, self.prefill_cache_axis_order)
+      cached_value_value = jnp.transpose(cached_value, self.prefill_cache_axis_order)
+
+      cached_prefill_key_vars[0].value = jax.lax.dynamic_update_slice(
+          cached_key_value, key_shaped_for_cache, (next_pos, 0, 0, 0)
+      )
+
+      cached_prefill_value_vars[0].value = jax.lax.dynamic_update_slice(
+          cached_value_value, value_shaped_for_cache, (next_pos, 0, 0, 0)
+      )
+      cached_prefill_segment_id_var.value = decoder_segment_ids
+      return (
+          jnp.transpose(cached_prefill_key_vars[0].value, self.key_axis_order),
+          jnp.transpose(cached_prefill_value_vars[0].value, self.key_axis_order),
+          cached_prefill_segment_id_var.value,
+      )
+    else:
+      """
+      if there is previous chunk information present,
+        1. Fetch the cached key, value
+        2. Update current key value at the desired position. (beginning - (0,0,0,0))
+        3. take transpose before returning as that is how the attention op expects the key and value
+
+      """
+      cached_prefill_key_vars[0].value = jax.lax.dynamic_update_slice(
+          cached_prefill_key_vars[0].value, key_shaped_for_cache, (next_pos, 0, 0, 0)
+      )
+      cached_prefill_value_vars[0].value = jax.lax.dynamic_update_slice(
+          cached_prefill_value_vars[0].value, value_shaped_for_cache, (next_pos, 0, 0, 0)
+      )
+      cached_prefill_segment_id_var.value = decoder_segment_ids
+      return (
+          jnp.transpose(cached_prefill_key_vars[0].value, self.key_axis_order),
+          jnp.transpose(cached_prefill_value_vars[0].value, self.key_axis_order),
+          cached_prefill_segment_id_var.value,
+      )
+
   def kv_cache_prefill(
       self,
       key: Array,
       value: Array,
       decoder_segment_ids: Array,
+      previous_chunk: Any = None,
   ):
     """In prefill mode, we zero out the existing cache, run the computation and
     prepare the cache as necessary.
@@ -809,6 +919,9 @@ class AttentionOp(nn.Module):
       key, value, decoder_segment_id.
 
     """
+    if self.config.use_chunked_prefill:
+      return self.chunked_prefill_kv_cache(key, value, decoder_segment_ids, previous_chunk)
+
     batch, _, heads, kv_head_size = key.shape
     assert key.dtype == value.dtype, "Key and Value Dtypes should match."
 
@@ -835,7 +948,6 @@ class AttentionOp(nn.Module):
 
     if decoder_segment_ids is not None:
       cached_prefill_segment_id_var.value = decoder_segment_ids
-
     return key, value, decoder_segment_ids
 
   def update_ar_key_value(
@@ -1015,7 +1127,13 @@ class AttentionOp(nn.Module):
     return cached_prefill, cached_ar
 
   def kv_cache(
-      self, key: Array, value: Array, decoder_segment_ids: Array, model_mode: str, use_ragged_attention: bool = False
+      self,
+      key: Array,
+      value: Array,
+      decoder_segment_ids: Array,
+      model_mode: str,
+      use_ragged_attention: bool = False,
+      previous_chunk: Any = None,
   ) -> tuple:
     """KV cache takes the current state and updates the state accordingly.
 
@@ -1040,7 +1158,7 @@ class AttentionOp(nn.Module):
     if model_mode == common_types.MODEL_MODE_TRAIN:
       return (key, value, decoder_segment_ids), None
     elif model_mode == common_types.MODEL_MODE_PREFILL:
-      return self.kv_cache_prefill(key, value, decoder_segment_ids), None
+      return self.kv_cache_prefill(key, value, decoder_segment_ids, previous_chunk), None
     elif model_mode == common_types.MODEL_MODE_AUTOREGRESSIVE:
       return self.kv_cache_autoregressive(key, value, use_ragged_attention)
     else:
@@ -1070,7 +1188,7 @@ class AttentionOp(nn.Module):
     return attn_out
 
   @nn.compact
-  def __call__(self, query, key, value, decoder_segment_ids, model_mode):
+  def __call__(self, query, key, value, decoder_segment_ids, model_mode, previous_chunk=None):
     prefill_kv_cache, ar_kv_cache = self.kv_cache(
         key, value, decoder_segment_ids, model_mode, use_ragged_attention=self.use_ragged_attention
     )
@@ -1083,6 +1201,7 @@ class AttentionOp(nn.Module):
         lengths=None,
         model_mode=model_mode,
         use_ragged_attention=self.use_ragged_attention,
+        previous_chunk=previous_chunk,
     )
 
     # Return the "prefill" cache if it actually the combined prefill+ar kv cache
@@ -1348,6 +1467,7 @@ class Attention(nn.Module):
       *,
       model_mode: str = common_types.MODEL_MODE_TRAIN,
       deterministic: bool = False,
+      previous_chunk: Any = None,
   ):
     """Applies Attention on the input data.
 
@@ -1400,7 +1520,7 @@ class Attention(nn.Module):
 
     assert not self.config.quantize_kvcache or self.kv_quant
 
-    out = self.attention_op(query, key, value, decoder_segment_ids, model_mode)
+    out = self.attention_op(query, key, value, decoder_segment_ids, model_mode, previous_chunk)
 
     out = nn.with_logical_constraint(out, self.out_axis_names)
 
@@ -1570,6 +1690,7 @@ class MLA(Attention):
       *,
       model_mode: str = common_types.MODEL_MODE_TRAIN,
       deterministic: bool = False,
+      previous_chunk: Any = None,
   ) -> Array:
     """Forward pass for MLA, reusing `AttentionOp` for the actual attention.
 

--- a/MaxText/layers/mistral.py
+++ b/MaxText/layers/mistral.py
@@ -66,6 +66,7 @@ class MistralDecoderLayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
   ):
     cfg = self.config
     mesh = self.mesh
@@ -110,6 +111,7 @@ class MistralDecoderLayer(nn.Module):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         model_mode=model_mode,
+        previous_chunk=previous_chunk,
     )
 
     attention_lnx = nn.with_logical_constraint(

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -379,6 +379,7 @@ class Decoder(nn.Module):
       decoder_segment_ids=None,
       deterministic=False,
       model_mode=common_types.MODEL_MODE_TRAIN,
+      previous_chunk=None,
   ):
     cfg = self.config
     mesh = self.mesh
@@ -545,6 +546,7 @@ class Transformer(nn.Module):
       decoder_segment_ids=None,
       enable_dropout=True,
       model_mode=common_types.MODEL_MODE_TRAIN,
+      previous_chunk=None,
   ):
     """Applies Transformer decoder-branch on encoded-input and target."""
 
@@ -560,5 +562,6 @@ class Transformer(nn.Module):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=not enable_dropout,
         model_mode=model_mode,
+        previous_chunk=previous_chunk,
     )
     return logits


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.
The current CL is WIP and supports Chunked Prefill for unquantized KV Cache. 

attentions.py file has mainly 2 changes-
i) Fetching previous cache is there are processed chunks
ii) Generating attention masks for a particular chunk based on article - https://medium.com/byte-sized-ai/llm-inference-optimizations-2-chunked-prefill-764407b3a67a

Minor chnages - 
wiring previous chunk information to decoder, model, attentions layers. 

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
