### PR TITLE
Transposed tensor parallelism

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -246,49 +246,54 @@ jax_cache_dir: "~/jax_cache"
 hardware: 'tpu' # Supported hardware types are 'tpu', 'gpu', 'gpu_multiprocess' and 'cpu'
 
 # Parallelism
-mesh_axes: ['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'tensor', 'tensor_sequence', 'expert', 'autoregressive']
+mesh_axes: ['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'tensor', 'tensor_transpose', 'tensor_sequence', 'expert', 'autoregressive']
 logical_axis_rules: [
                       ['activation_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_batch_no_exp', ['data', 'fsdp', 'fsdp_transpose']],
                       ['activation_embed_and_logits_batch', ['data', 'stage', 'fsdp', 'fsdp_transpose', 'expert']],
-                      ['activation_heads', ['tensor','sequence','tensor_sequence']],
-                      ['activation_kv_heads', ['tensor','sequence','tensor_sequence']],
+                      ['activation_heads', ['tensor', 'tensor_transpose', 'sequence','tensor_sequence']],
+                      ['activation_kv_heads', ['tensor', 'tensor_transpose', 'sequence','tensor_sequence']],
                       ['activation_length', ['sequence']],
                       ['activation_norm_length', ['tensor_sequence', 'sequence']],
-                      ['activation_embed', 'tensor'],
-                      ['activation_mlp', ['tensor', 'tensor_sequence']],
-                      ['activation_kv', ['tensor', 'tensor_sequence']],
+                      ['activation_embed', ['tensor', 'tensor_transpose']],
+                      ['activation_mlp', ['tensor', 'tensor_transpose', 'tensor_sequence']],
+                      ['activation_kv', ['tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['activation_prefill_kv_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_kv_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
-                      ['activation_kv_head_dim', ['tensor', 'tensor_sequence']],
-                      ['activation_vocab', ['tensor', 'sequence', 'tensor_sequence']],
-                      ['activation_vocab', 'tensor'],
+                      ['activation_kv_head_dim', ['tensor', 'tensor_transpose', 'tensor_sequence']],
+                      ['activation_vocab', ['tensor', 'tensor_transpose', 'sequence', 'tensor_sequence']],
+                      ['activation_vocab', ['tensor', 'tensor_transpose']],
                       ['activation_vocab', 'tensor_sequence'],
                       ['activation_vocab', 'sequence'],
                       ['activation_stage', 'stage'],
                       ['activation_exp', 'expert'],
                       ['mlp', ['fsdp_transpose', 'tensor', 'tensor_sequence', 'autoregressive']],
-                      ['vocab', ['tensor', 'tensor_sequence', 'autoregressive']],
+                      ['vocab', ['tensor', 'tensor_transpose', 'tensor_sequence', 'autoregressive']],
+                      ['heads', ['tensor', 'tensor_transpose', 'tensor_sequence', 'autoregressive']],
+                      ['q_heads', ['tensor', 'tensor_transpose', 'tensor_sequence', 'autoregressive']],
+                      ['kv_heads', ['tensor', 'tensor_transpose', 'tensor_sequence', 'autoregressive']],  
+                      ['embed', ['fsdp', 'fsdp_transpose', 'sequence', 'tensor_transpose', 'expert']],
+                      ['embed', ['fsdp', 'sequence', 'tensor_transpose', 'expert']],
                       ['embed', ['fsdp', 'fsdp_transpose', 'sequence', 'expert']],
                       ['embed', ['fsdp', 'sequence', 'expert']],
+                      ['embed_no_exp', ['fsdp', 'fsdp_transpose', 'sequence', 'tensor_transpose']],
+                      ['embed_no_exp', ['fsdp', 'sequence', 'tensor_transpose']],
                       ['embed_no_exp', ['fsdp', 'fsdp_transpose', 'sequence']],
                       ['embed_no_exp', ['fsdp', 'sequence']],
-                      ['norm', ['tensor', 'tensor_sequence']],
-                      ['q_heads', ['tensor', 'tensor_sequence', 'autoregressive']],
-                      ['heads', ['tensor', 'tensor_sequence', 'autoregressive']],
+                      ['norm', ['tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['layers', 'stage'],
                       ['kv', []],
-                      ['kv_heads', ['tensor', 'tensor_sequence', 'autoregressive']],
                       ['kv_head_dim', []],
                       ['cache_batch_prefill', []],
                       ['cache_batch', []],
+                      ['cache_heads', ['autoregressive', 'tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['cache_heads', ['autoregressive', 'tensor', 'tensor_sequence']],
                       ['cache_kv', []],
                       ['cache_sequence', []],
                       ['exp', 'expert'],
                     ]
 # Axes used for DCN must be earlier in this list than ICI, see (b/339009148) for details
-data_sharding: [['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'tensor', 'tensor_sequence', 'expert', 'autoregressive']]
+data_sharding: [['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'tensor', 'tensor_transpose', 'tensor_sequence', 'expert', 'autoregressive']]
 
 # sharding tolerance: float between 0.0 and 1.0 representing the allowed percentage of non-sharded parameters.
 sharding_tolerance: 0.02
@@ -302,6 +307,7 @@ dcn_fsdp_parallelism: 1
 dcn_fsdp_transpose_parallelism: 1
 dcn_sequence_parallelism: 1  # never recommended
 dcn_tensor_parallelism: 1 # never recommended
+dcn_tensor_transpose_parallelism: 1
 dcn_tensor_sequence_parallelism: 1 # never recommended
 dcn_pipeline_parallelism: 1
 dcn_expert_parallelism: 1
@@ -311,6 +317,7 @@ ici_fsdp_parallelism: -1 # recommended ICI axis to be auto-sharded
 ici_fsdp_transpose_parallelism: 1
 ici_sequence_parallelism: 1
 ici_tensor_parallelism: 1
+ici_tensor_transpose_parallelism: 1
 ici_tensor_sequence_parallelism: 1
 ici_autoregressive_parallelism: 1
 ici_pipeline_parallelism: 1

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -239,13 +239,13 @@ def assert_params_sufficiently_sharded(params, mesh, tolerance):
   """
   total_num_params = max_utils.calculate_num_params_from_pytree(params)
   product_num_devices_for_weight_sharding = 1
-  for axis in ["fsdp", "fsdp_transpose", "sequence", "tensor", "tensor_sequence", "stage", "expert"]:
+  for axis in ["fsdp", "fsdp_transpose", "sequence", "tensor", "tensor_transpose", "tensor_sequence", "stage", "expert"]:
     product_num_devices_for_weight_sharding *= mesh.shape[axis]
   total_num_params_per_chip = max_utils.calculate_total_params_per_chip(params)
   perfectly_sharded_params_per_chip = total_num_params / product_num_devices_for_weight_sharding
   assert total_num_params_per_chip >= perfectly_sharded_params_per_chip, (
       "Number of parameters per chip must not be less than in the ideal sharded "
-      "scenario across `fsdp`, `fsdp_transpose`,`sequence`, `tensor`, `tensor_sequence`, `expert` axes."
+      "scenario across `fsdp`, `fsdp_transpose`,`sequence`, `tensor`, `tensor_transpose`, `tensor_sequence`, `expert` axes."
   )
   unsharded_param_perc = total_num_params_per_chip / perfectly_sharded_params_per_chip - 1
   assert unsharded_param_perc < tolerance, (

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -515,6 +515,7 @@ def create_parallelisms_list(raw_keys):
       raw_keys["ici_fsdp_transpose_parallelism"],
       raw_keys["ici_sequence_parallelism"],
       raw_keys["ici_tensor_parallelism"],
+      raw_keys["ici_tensor_transpose_parallelism"],
       raw_keys["ici_tensor_sequence_parallelism"],
       raw_keys["ici_expert_parallelism"],
       raw_keys["ici_autoregressive_parallelism"],
@@ -526,6 +527,7 @@ def create_parallelisms_list(raw_keys):
       raw_keys["dcn_fsdp_transpose_parallelism"],
       raw_keys["dcn_sequence_parallelism"],
       raw_keys["dcn_tensor_parallelism"],
+      raw_keys["dcn_tensor_transpose_parallelism"],
       raw_keys["dcn_tensor_sequence_parallelism"],
       raw_keys["dcn_expert_parallelism"],
       raw_keys["dcn_autoregressive_parallelism"],
@@ -602,6 +604,7 @@ def set_and_validate_pipeline_config(raw_keys):
           raw_keys["ici_fsdp_transpose_parallelism"],
           raw_keys["ici_sequence_parallelism"],
           raw_keys["ici_tensor_parallelism"],
+          raw_keys["ici_tensor_transpose_parallelism"],
           raw_keys["ici_tensor_sequence_parallelism"],
           raw_keys["ici_expert_parallelism"],
           raw_keys["ici_autoregressive_parallelism"],
@@ -613,6 +616,7 @@ def set_and_validate_pipeline_config(raw_keys):
           raw_keys["dcn_fsdp_transpose_parallelism"],
           raw_keys["dcn_sequence_parallelism"],
           raw_keys["dcn_tensor_parallelism"],
+          raw_keys["dcn_tensor_transpose_parallelism"],
           raw_keys["dcn_tensor_sequence_parallelism"],
           raw_keys["dcn_expert_parallelism"],
           raw_keys["dcn_autoregressive_parallelism"],
@@ -624,12 +628,24 @@ def set_and_validate_pipeline_config(raw_keys):
           "fsdp_transpose",
           "sequence",
           "tensor",
+          "tensor_transpose",
           "tensor_sequence",
           "expert",
           "autoregressive",
       ]
       data_sharding = [
-          ["stage", "data", "fsdp", "fsdp_transpose", "sequence", "tensor", "tensor_sequence", "expert", "autoregressive"]
+          [
+              "stage",
+              "data",
+              "fsdp",
+              "fsdp_transpose",
+              "sequence",
+              "tensor",
+              "tensor_transpose",
+              "tensor_sequence",
+              "expert",
+              "autoregressive",
+          ]
       ]
 
       raw_keys["ici_parallelism"] = ici_parallelism
@@ -693,6 +709,8 @@ def validate_megablox_parallelism(raw_keys):
       * raw_keys["dcn_tensor_parallelism"]
       * raw_keys["ici_tensor_sequence_parallelism"]
       * raw_keys["dcn_tensor_sequence_parallelism"]
+      * raw_keys["ici_tensor_transpose_parallelism"]
+      * raw_keys["dcn_tensor_transpose_parallelism"]
   )
   if raw_keys["megablox"] and using_tensor_parallelism(raw_keys) and (raw_keys["emb_dim"] % tensor_parallelism):
     raise ValueError(

--- a/MaxText/tests/train_tests.py
+++ b/MaxText/tests/train_tests.py
@@ -59,6 +59,16 @@ class TrainTests(unittest.TestCase):
           "ici_tensor_parallelism=4",
           r"tokenizer_path=../assets/tokenizer.llama2",
       ],
+      "tp_transpose": [  # tests base config with ici_tensor_transpose_parallelism=4
+          None,
+          "configs/base.yml",
+          r"base_output_directory=gs://runner-maxtext-logs",
+          "run_name=runner_test",
+          r"dataset_path=gs://maxtext-dataset",
+          "steps=2",
+          "ici_tensor_transpose_parallelism=4",
+          r"tokenizer_path=../assets/tokenizer.llama2",
+      ],
       "int8": [  # tests base config with int8
           None,
           "configs/base.yml",


### PR DESCRIPTION
# Description
Adds a physical mesh dimension `tensor_transpose` which acts like the "transpose" of the current tensor parallel one. The transposition is for the FF layer only - instead of sharding the weights over the intermediate dimension (named mlp in maxtext), it shards over the model dimension (named embed in maxtext). This is more efficient when the intermediate dimension is smaller than the model dimension, for instance deepseek (intermediate=2k, model=7k). However EP is probably still preferred to using TP_transpose for deepseek sizes on most hardwares.

All of the activations and everything in attention is sharded the same comparing tensor and tensor_transpose - this probably optimal the use case of above (deep seek where intermediate < model), but if we wanted to support optimal 2D TP then the attention weights should also be transposed.

This change was somewhat painful to keep the attention sharded the same because of a new conflict of this axes and having the "embed" axis higher in the logical axis list. To make changes like this less painful in the future we may refactor the code to instead spell out every single tensor - e.g. a separate embed for the FF and another one for the attention



# Tests
Ran manually + added unit test for ici_fsdp_transpose=4 [trace](https://xprof.corp.google.com/trace_viewer/mattdavidow-7715041776055520987?hosts=t1v-n-5e50d777-w-0&host_index=0&trace_filter_config={}&view_start=-2491.864&view_end=19114.998)
* We see the larger FF communications since communicating the larger intemdiate dim (7k vs 2k)
*  Attention comms still the same


Identical FSDP and/or TP before and after this change
* After FSDP=4 [trace](https://xprof.corp.google.com/trace_viewer/mattdavidow-8862010460681537468?hosts=t1v-n-5e50d777-w-0&host_index=0&trace_filter_config={}&view_start=-898.629&view_end=6898.003)
* Before FSDP=4 [trace](https://xprof.corp.google.com/trace_viewer/mattdavidow-6700410146796011473?hosts=t1v-n-5e50d777-w-0&host_index=0&trace_filter_config={}&view_start=-895.326&view_end=6885.725)
* After FSDP=2 TP = 2 [trace](https://xprof.corp.google.com/trace_viewer/mattdavidow-12057818565425852671?hosts=t1v-n-5e50d777-w-0&host_index=0&trace_filter_config={}&view_start=-1158.804&view_end=8893.257)
* After FSDP=2 TP=2 [trace](https://xprof.corp.google.com/trace_viewer/mattdavidow-8658107239586086943?hosts=t1v-n-5e50d777-w-0&host_index=0&trace_filter_config={})
* After TP=4 [trace](https://xprof.corp.google.com/trace_viewer/mattdavidow-1897398112547252107?hosts=t1v-n-5e50d777-w-0&host_index=0&trace_filter_config={}&view_start=2751.510&view_end=2849.525)
* Before TP=4 [trace](https://xprof.corp.google.com/trace_viewer/mattdavidow-10095792202374032590?hosts=t1v-n-5e50d777-w-0&host_index=0&trace_filter_config={}&view_start=3351.443&view_end=3400.640)
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
