### PR TITLE
Prefix Caching with HBM and latency test

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -525,6 +525,8 @@ vertex_tensorboard_region: ""
 max_checkify: False
 
 # Inference
+inference_microbenchmark_prefix_cache_entries_num: 100
+inference_microbenchmark_prefix_cache_common_prefix_proportion: 0.5
 inference_microbenchmark_prefill_lengths: "64,128,256,512,1024"
 inference_microbenchmark_stages: "prefill,generate"
 inference_microbenchmark_loop_iters: 10

--- a/MaxText/inference_microbenchmark.py
+++ b/MaxText/inference_microbenchmark.py
@@ -27,6 +27,7 @@ from jetstream.engine import token_utils
 import max_utils
 import maxengine
 import maxtext_utils
+import prefix_cache
 import profiler
 import pyconfig
 
@@ -37,6 +38,103 @@ warnings.simplefilter("ignore", category=FutureWarning)
 _WARMUP_ITERS = 2
 _FLATTEN_MICROBENCHMARK_RESULTS = False
 # pylint: disable=too-many-positional-arguments
+
+
+def prefix_cache_benchmark(
+    prefix, prefill_length: int, true_length: int, common_prefix_proportion: float, prefix_cache_entries_num: int, iters: int
+):
+  """Handles running prefix cache benchmark, and printing results.
+
+  Create different key with half of prefill_length common prefix insert into cache.
+  The value is not relevant to the cache for now. Just copy the prefix for every cache entry.
+  1. Fill the prefix cache to full capacity.
+  2. Benchmark save prefix cache with evicting time average by prefix_cache_entries_num.
+  3. Benchmark fetch_longest_common_prefix_key average by iters.
+  4. Benchmark load prefix cache time average by iters.
+
+  Args:
+    prefix: prefix return from prefill function
+    prefill_length: prefill token length after padding
+    true_length: true prefill token length
+    common_prefix_proportion: [0., 1.] common prefix proportion to the prefill_length
+    prefix_cache_entries_num: number of prefix cache entries insert into PrefixCache
+    iters: repeat time to test fetch_longest_common_prefix_key and load from cache
+  """
+
+  print(f"Prefix Cache benchmark results for prefill length {prefill_length}:\n")
+
+  value = prefix_cache.Value(
+      prefix=prefix,
+      true_length=true_length,
+      padded_length=prefill_length,
+      tokens=tuple(i for i in range(prefill_length)),
+  )
+  prefix_size_bytes_gb = value.prefix_size_bytes / 1024 / 1024 / 1024
+  prefix_cache_inst = prefix_cache.PrefixCache(prefix_cache_entries_num * value.prefix_size_bytes)
+  common_len = int(prefill_length * common_prefix_proportion)
+  remain_len = prefill_length - common_len
+  common_prefix_key = tuple(i for i in range(common_len))
+
+  # Fill the prefix caching
+  new_value_list = []
+  for c_idx in range(prefix_cache_entries_num):
+    # Add 100 to make sure filled prefix caching will not share the common_prefix_key.
+    # The later save prefix part will evict all of them.
+    key = tuple(100 + i + c_idx * prefill_length for i in range(prefill_length))
+    new_value = value.clone()
+    prefix_cache_inst.save(key, new_value)
+    new_value_list.append(new_value)
+  jax.block_until_ready(new_value_list)
+  del new_value_list
+
+  # Save prefix
+  new_value = None
+  save_sec = 0
+  for c_idx in range(iters):
+    key = common_prefix_key + tuple(i + c_idx * remain_len for i in range(remain_len))
+    # values are not relevant for caching now, just clone the same tokens and values for test
+    new_value = value.clone()
+    jax.block_until_ready(new_value)
+    start = datetime.datetime.now()
+    prefix_cache_inst.save(key, new_value)
+    end = datetime.datetime.now()
+    save_sec += (end - start).total_seconds()
+  del new_value
+  save_avg_ms = save_sec * 1000 / iters
+
+  # Fetch longest prefix key
+  key_load = common_prefix_key + tuple(i + prefix_cache_entries_num * remain_len for i in range(remain_len))
+  matched_key = None
+  fetch_sec = 0
+  for _ in range(iters):
+    start = datetime.datetime.now()
+    matched_key = prefix_cache_inst.fetch_longest_common_prefix_key(key_load)
+    end = datetime.datetime.now()
+    fetch_sec += (end - start).total_seconds()
+  fetch_avg_ms = fetch_sec * 1000 / iters
+
+  assert matched_key is not None
+
+  # Load prefix
+  load_sec = 0
+  value_load = None
+  for _ in range(iters):
+    start = datetime.datetime.now()
+    value = prefix_cache_inst.load(matched_key)
+    jax.block_until_ready(value)
+    end = datetime.datetime.now()
+    load_sec += (end - start).total_seconds()
+  del value_load
+  load_avg_ms = load_sec * 1000 / iters
+
+  print(
+      f"PrefixCaching results:\n"
+      f"\tPer prefix size bytes: {prefix_size_bytes_gb:.3f} GB\n"
+      f"\tAverage save cache time: {save_avg_ms:.3f} ms\n"
+      f"\tAverage fetch longest prefix time: {fetch_avg_ms:.3f} ms\n"
+      f"\tAverage load cache time: {load_avg_ms:.3f} ms\n\n\n"
+  )
+  del prefix_cache_inst
 
 
 def prefill_benchmark_loop(engine_prefill, params, tokens, true_length, iters):
@@ -304,6 +402,22 @@ def run_benchmarks(config):
       benchmark_results["prefill-result-sizes"][prefill_length] = summarize_prefill_result(
           prefill_executable[prefill_length], params, prefill_tokens[prefill_length], prefill_true_lengths[prefill_length]
       )
+
+    if "prefix_cache" in stages_to_benchmark:
+      for prefill_length in prefill_lengths:
+        rng_cache = jax.random.PRNGKey(1234)
+        prefill_result, _ = prefill_executable[prefill_length](
+            params, prefill_tokens[prefill_length], prefill_true_lengths[prefill_length], rng_cache
+        )
+        prefix_cache_benchmark(
+            prefill_result,
+            prefill_length,
+            prefill_true_lengths[prefill_length],
+            config.inference_microbenchmark_prefix_cache_common_prefix_proportion,
+            config.inference_microbenchmark_prefix_cache_entries_num,
+            benchmark_loop_iters,
+        )
+        del prefill_result
 
     for prefill_length in prefill_lengths:
       benchmark_results["prefill"][prefill_length] = prefill_benchmark(

--- a/MaxText/prefix_cache.py
+++ b/MaxText/prefix_cache.py
@@ -1,0 +1,411 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of PrefixCache with LRU cache and Trie based key lookup.
+
+i) Initialize cache
+
+# HBM size with Trillium 8 core use about 17 / 31.25 GB per core after loading models.
+# To utilize HBM memory to 80%, about (30 * 0.8 - 16) * 8 = 64GB
+# Prefix return by prefill function of mixtral-8x22b model with max_prefill_length=1024,
+# int8 quantize_kvcache is 235_930_060 bytes, nearly 256 MB.
+# HBM cache can store about 64GB / 256 MB = 256 prompts.
+hbm_bytes = 64 * 1024 * 1024 * 1024  # 64 GB
+prefix_cache = PrefixCache(hbm_bytes)
+
+ii) Read from Cache:
+
+# From request
+prompt: str = "blah"
+full_key: Key = tokenizer.tokenize(prompt)
+
+# Inside prefill call
+orig_key_len = len(full_key)
+
+matched_key = prefix_cache.fetch_longest_common_prefix_key(key)
+if matched_key is not None and load_cache_is_efficient_enough(matched_key):
+  cache_results = prefix_cache.load(matched_key)
+else:
+  cache_results = None
+
+if cache_results:
+   # load cache successfully
+   matched_len = calculate_matched_len(full_key, matched_key)
+   cached_prefix = cache_results.prefix
+else:
+   cached_prefix = None
+
+iii) Run prefill un-cached prompt and write to cache
+
+full_kv_cache = prefill(prompt, cached_prefix, matched_len)
+
+# if the cache didn't contain prefix or if it was a partial match
+if cached_prefix is None or matched_len != orig_key_len:
+    prefix_cache.save(full_key, Value(
+        prefix=full_kv_cache,
+        true_length=true_length,
+        padded_length=padded_length,
+        tokens=full_key,
+    ))
+
+"""
+
+from collections import OrderedDict
+from typing import Tuple, Any, Optional
+import dataclasses
+import jax
+import jax.numpy as jnp
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+Token = int
+# Tuple of tokens from prompt
+Key = Tuple[Token, ...]
+Prefix = Any  # KVCache for one prompt
+
+
+@jax.jit
+def tree_copy(tree):
+  return jax.tree.map(lambda x: x.copy() if isinstance(x, jax.Array) else x, tree)
+
+
+class Value:
+  """Object stored contains the actual KVcache
+
+  Attributes:
+    prefix:
+      Readonly. Prefix Cache using in model. Should be dictionary of jnp.array.
+    true_length:
+      Readonly. True length of tokens calculate prefix. Should be <= than len(tokens).
+      true_length will be min(true_length, len(tokens))
+    padded_length:
+      Readonly. Length of tokens including padding calculate prefix.
+    tokens:
+      Readonly. Tokens calculate prefix. may include partial of padding.
+    prefix_size_bytes:
+      Readonly. bytes of prefix.
+  """
+
+  def __init__(
+      self,
+      *,
+      prefix: Prefix,
+      true_length: int,
+      padded_length: int,
+      tokens: tuple[Token, ...],
+      prefix_size_bytes: Optional[int] = None,
+  ):
+    """Attributes to store.
+    If true_length shorter than len(tokens), true_length will adjust to len(tokens).
+    If prefix_size_bytes is not provided, calculate automatically.
+    """
+    self._prefix = prefix
+    self._true_length = self._maybe_adjust_true_length(true_length, tokens)
+    self._padded_length = padded_length
+    self._tokens = tokens
+    if prefix_size_bytes is None:
+      self._prefix_size_bytes: int = self._calculate_prefix_bytes(prefix)
+    else:
+      self._prefix_size_bytes = prefix_size_bytes
+
+  @property
+  def prefix(self) -> Prefix:
+    return self._prefix
+
+  @property
+  def true_length(self) -> int:
+    return self._true_length
+
+  @property
+  def padded_length(self) -> int:
+    return self._padded_length
+
+  @property
+  def tokens(self) -> tuple[Token, ...]:
+    return self._tokens
+
+  @property
+  def prefix_size_bytes(self) -> int:
+    return self._prefix_size_bytes
+
+  def clone(self) -> "Value":
+    """Clone to prevent using the same jax array."""
+    copied_prefix = tree_copy(self._prefix)
+    return Value(
+        prefix=copied_prefix,
+        true_length=self._true_length,
+        padded_length=self._padded_length,
+        tokens=self._tokens,
+        prefix_size_bytes=self._prefix_size_bytes,
+    )
+
+  def __eq__(self, other: Any) -> bool:
+    if not isinstance(other, Value):
+      return False
+    return (
+        other.padded_length == self.padded_length
+        and other.tokens == self.tokens
+        and jax.tree.all(jax.tree.map(jnp.array_equal, other.prefix, self.prefix))
+        and other.prefix_size_bytes == self.prefix_size_bytes
+    )
+
+  def _calculate_prefix_bytes(self, prefix: Prefix) -> int:
+    def has_nbytes_int(obj) -> bool:
+      return hasattr(obj, "nbytes") and isinstance(obj.nbytes, int)
+
+    # calculate all bytes of jnp.array in the prefix
+    return jax.tree.reduce(
+        lambda acc, array: acc + (array.nbytes if has_nbytes_int(array) else 0),
+        prefix,
+        0,
+    )
+
+  def _maybe_adjust_true_length(self, true_length: int, tokens: tuple[Token, ...]) -> int:
+    if true_length > len(tokens):
+      logger.warning("true_length=%d should <= len(tokens)=%d.", true_length, len(tokens))
+
+    return min(true_length, len(tokens))
+
+
+class PrefixCacheTrie:
+  """Stores prefix tokens as a trie for fast lookup index of PrefixCache store in cache.
+
+  Insert longer Key replace shorter key to be the longest common prefix key.
+  The shorter key will never be returned even if longer key is erased, and should got evicted in the future.
+
+  Assume Key is equal length to tokens, which can be used to slice prompt and cache Value.
+  Should check the return key common prefix length by the caller.
+
+  If erase the Key not the leaf, nothing will happen.
+  If erased key match at a leaf, delete the node and ancestors would be the leaf after deleted.
+  """
+
+  @dataclasses.dataclass
+  class Node:
+    """Trie Node."""
+
+    parent: Optional["PrefixCacheTrie.Node"] = None
+    token: Optional[Token] = None
+    children: dict[Token, "PrefixCacheTrie.Node"] = dataclasses.field(default_factory=dict)
+
+    def is_leaf(self):
+      return len(self.children) == 0
+
+    def get_one_child_token(self) -> Optional[Token]:
+      if len(self.children) == 0:
+        return None
+      return next(iter(self.children.keys()))
+
+  def __init__(self):
+    self._saved_keys: list[Key] = []
+    self._root = PrefixCacheTrie.Node()
+
+  def insert(self, key: Key):
+    """Insert key into the trie."""
+    node = self._root
+    for token in key:
+      if token not in node.children:
+        node.children[token] = PrefixCacheTrie.Node(parent=node, token=token)
+      node = node.children[token]
+
+  def get_longest_common_prefix_key(self, key: Key) -> Optional[Key]:
+    """Get the key with longest common prefix.
+    If not found at least one token match, return None."""
+    result_tokens: list[Token] = []
+
+    node = self._root
+    for token in key:
+      if token not in node.children:
+        break
+      node = node.children[token]
+      result_tokens.append(token)
+
+    if len(result_tokens) == 0:
+      return None
+
+    while not node.is_leaf():
+      token = node.get_one_child_token()
+      if token is None:
+        break
+      result_tokens.append(token)
+      node = node.children[token]
+
+    return tuple(result_tokens)
+
+  def erase(self, key: Key) -> None:
+    """Erase key in trie if it is leaf."""
+    node = self._root
+    for token in key:
+      if token not in node.children:
+        return
+      node = node.children[token]
+
+    while node.is_leaf():
+      parent = node.parent
+      if parent is None or node.token not in parent.children:
+        return
+      del parent.children[node.token]
+      node = parent
+
+
+class HBMCache:
+  """Stores kv cache values in HBM.
+
+  Cache is remain the sharding status before save.
+  """
+
+  def __init__(self, max_size_bytes: int):
+    """
+    Args:
+      max_size_bytes: Maximum bytes of HBM to use for cache
+    """
+    self._remain_size_bytes = max_size_bytes
+    self._saved_values: dict[Key, Value] = {}
+
+  def has_enough_space(self, value: Value) -> bool:
+    """Calculate if value size can add to cache."""
+    return self._remain_size_bytes >= value.prefix_size_bytes
+
+  def add_to_cache(self, key: Key, value: Value) -> bool:
+    """
+    Value will be moved to the cache, which means cannot used the same value reference after add_to_cache.
+
+    The jax may modified the value even stored in another python reference.
+    If the value need to be used after add_to_cache, make sure copy them before add_to_cache.
+    Return False if cache is full.
+    """
+    if not self.has_enough_space(value):
+      return False
+
+    self._saved_values[key] = value
+    self._remain_size_bytes -= value.prefix_size_bytes
+    return True
+
+  def retrieve_from_cache(self, key: Key) -> Optional[Value]:
+    """Return value from cache or None if not found.
+    Be aware the cache is not return a copy. If additional modified needed, clone the Value first.
+    """
+    if key in self._saved_values:
+      return self._saved_values[key]
+    return None
+
+  def evict_cache(self, key: Key) -> Optional[Value]:
+    """Evict and return value, or None if key is not in cache."""
+    if key not in self._saved_values:
+      return None
+    value = self._saved_values.pop(key)
+    self._remain_size_bytes += value.prefix_size_bytes
+    return value
+
+
+class LRUStrategy:
+  """Least recently used cache strategy manage key."""
+
+  def __init__(self):
+    self._order: OrderedDict[Key, None] = OrderedDict()
+
+  def evict(self) -> Optional[Key]:
+    """Return and pop the least recently used key."""
+    if len(self._order) == 0:
+      return None
+    return self._order.popitem(last=False)[0]
+
+  def use(self, key: Key) -> None:
+    """Updated the usage history."""
+    if key not in self._order:
+      self._order[key] = None
+    else:
+      self._order.move_to_end(key, last=True)
+
+
+class PrefixCache:
+  """Store Prefix KV cache.
+
+  If cache is full, evict least-recently used entries (LRU).
+  """
+
+  def __init__(self, hbm_bytes: int):
+    """
+    Args:
+      hbm_bytes: Total amount of HBM to use for cache.
+    """
+    self._hbm_bytes = hbm_bytes
+    self._lock = threading.Lock()
+    # init in clear()
+    self._hbm_cache: HBMCache
+    self._trie: PrefixCacheTrie
+    self._cache_strategy: LRUStrategy
+    self.clear()
+
+  def fetch_longest_common_prefix_key(self, key: Key) -> Optional[Key]:
+    """Returns key with longest common prefix matched or None if not found."""
+    logger.debug("fetch_longest_common_prefix_key, key=%r", key)
+    with self._lock:
+      matched_key = self._trie.get_longest_common_prefix_key(key)
+      logger.debug("matched_key=%r", matched_key)
+      return matched_key
+
+  def save(self, key: Key, value: Value) -> bool:
+    """Save key/value to the cache."""
+    logger.debug("save key=%r", key)
+    with self._lock:
+      while not self._hbm_cache.has_enough_space(value):
+        if self._hbm_bytes < value.prefix_size_bytes:
+          logger.debug("hbm_bytes=%r < value.prefix_size_bytes=%r", self._hbm_bytes, value.prefix_size_bytes)
+          break
+        if self._evict_cache() is None:
+          logger.debug("cannot evict cache")
+          break
+      if not self._hbm_cache.add_to_cache(key, value):
+        logger.debug("cannot add to cache even after evict")
+        return False
+      self._trie.insert(key)
+      self._cache_strategy.use(key)
+      return True
+
+  def load(self, key: Key) -> Optional[Value]:
+    """Returns Value stored with key or None if not found."""
+    logger.debug("load key=%r", key)
+    with self._lock:
+      value = self._hbm_cache.retrieve_from_cache(key)
+      if value is None:
+        logger.warning(
+            "The key should fetched by fetch_longest_common_prefix_key, load key=%r should be valid but not.", key
+        )
+        return None
+      self._cache_strategy.use(key)
+      return value
+
+  def clear(self):
+    """Clear entire cache."""
+    logger.debug("clear cache")
+    self._hbm_cache = HBMCache(max_size_bytes=self._hbm_bytes)
+    self._trie = PrefixCacheTrie()
+    self._cache_strategy = LRUStrategy()
+
+  def _evict_cache(self) -> Optional[Value]:
+    """Evict cache based on strategy."""
+    logger.debug("_evict_cache")
+    key = self._cache_strategy.evict()
+    if key is None:
+      logger.debug("no key to evict")
+      return None
+    logger.debug("evict key=%r", key)
+    value = self._hbm_cache.evict_cache(key)
+    if value is None:
+      logger.warning("key=%r should exist in HBM cache.", key)
+    self._trie.erase(key)
+    return value

--- a/MaxText/tests/prefix_cache_test.py
+++ b/MaxText/tests/prefix_cache_test.py
@@ -1,0 +1,478 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prefix Cache Test"""
+
+import prefix_cache
+
+import pytest
+import unittest
+import jax
+import jax.numpy as jnp
+
+
+def create_default_value(prefix=None, true_length=1, padded_length=1, tokens=None) -> prefix_cache.Value:
+  if prefix is None:
+    prefix = {"decoder": jnp.array([1, 2, 3, 4, 5, 0, 0, 0, 0, 0])}
+  if tokens is None:
+    tokens = (1, 2, 3, 4, 5, 0, 0, 0, 0, 0)
+  return prefix_cache.Value(
+      prefix=prefix,
+      true_length=true_length,
+      padded_length=padded_length,
+      tokens=tokens,
+  )
+
+
+class ValueTest(unittest.TestCase):
+  """Test for Value."""
+
+  def test_get_the_set_value(self):
+    true_length = 5
+    tokens = (1, 2, 3, 4, 5, 0, 0, 0, 0, 0)
+    padded_length = 10
+    prefix = {
+        "decoder": {
+            "layer_0": {
+                "cached_prefill_key": jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=jnp.int8),
+                "cached_prefill_value": jnp.array([11, 12, 13, 14, 15, 16, 17, 18, 19, 20], dtype=jnp.float32),
+            },
+            "layer_1": {
+                "cached_prefill_key": jnp.array([11, 22, 33, 44, 55, 66, 77, 88, 99, 1010], dtype=jnp.float16),
+                "cached_prefill_value": jnp.array(
+                    [1111, 1212, 1313, 1414, 1515, 1616, 1717, 1818, 1919, 2020],
+                    dtype=jnp.int32,
+                ),
+            },
+        }
+    }
+    # array len * byte size(int8, + float32 + float16 + int32) in the prefix
+    prefix_size_byte = 10 * (1 + 4 + 2 + 4)
+    value = prefix_cache.Value(
+        prefix=prefix,
+        true_length=true_length,
+        padded_length=padded_length,
+        tokens=tokens,
+    )
+    assert value.true_length == true_length
+    assert value.padded_length == padded_length
+    assert value.tokens == tokens
+    assert jax.tree_util.tree_all(jax.tree.map(jnp.array_equal, value.prefix, prefix))
+    assert value.prefix_size_bytes == prefix_size_byte
+
+  def test_set_none_prefix_without_error(self):
+    value = prefix_cache.Value(
+        prefix=None,
+        true_length=1,
+        padded_length=2,
+        tokens=(1,),
+    )
+    assert value.prefix is None
+    assert value.prefix_size_bytes == 0
+
+  def test_set_prefix_tree_with_non_jax_array_member_ignore_the_bytes(self):
+    prefix = {
+        "non_jax_array": "member",
+        "jax_array": jnp.array([1, 2, 3], dtype=jnp.int8),
+    }
+    prefix_size_bytes = 3
+    value = create_default_value(prefix=prefix)
+    assert value.prefix == prefix
+    assert value.prefix_size_bytes == prefix_size_bytes
+
+  def test_adjust_true_length_shorter_equal_than_tokens(self):
+    value = create_default_value(true_length=100, tokens=jnp.array([1, 2, 3]))
+    assert value.true_length == 3
+
+  def test_equal(self):
+    prefix1 = {
+        "decoder": jnp.array([1, 2, 3], dtype=jnp.int8),
+    }
+    prefix2 = {
+        "decoder": jnp.array([1, 2, 3, 4, 5], dtype=jnp.int8),
+    }
+    value1_1 = create_default_value(prefix=prefix1)
+    value1_2 = create_default_value(prefix=prefix1)
+    assert value1_1 != 42
+    assert value1_1 == value1_2
+    assert value1_1.true_length == value1_2.true_length
+    assert value1_1.padded_length == value1_2.padded_length
+    assert value1_1.tokens == value1_2.tokens
+    assert jax.tree_util.tree_all(jax.tree.map(jnp.array_equal, value1_1.prefix, value1_2.prefix))
+    assert value1_1.prefix_size_bytes == value1_2.prefix_size_bytes
+    value1_2 = create_default_value(prefix=prefix2)
+    assert value1_1 != value1_2
+
+  def test_clone_for_copy_jax_array(self):
+    """jax array in value prefix should be different or may destroy the array in cache."""
+    prefix = {
+        "decoder": jnp.array([1, 2, 3], dtype=jnp.int8),
+    }
+    value1_1 = create_default_value(prefix=prefix)
+    value1_2 = value1_1
+    assert value1_1.prefix is value1_2.prefix
+    assert value1_1.prefix["decoder"] is value1_2.prefix["decoder"]
+    value2 = value1_1.clone()
+    assert value2.prefix is not value1_1.prefix
+    assert value2.prefix["decoder"] is not value1_1.prefix["decoder"]
+    assert value2 == value1_1
+
+
+class PrefixCacheTrieTest(unittest.TestCase):
+  """Test for PrefixCacheTrie."""
+
+  def test_get_longest_common_prefix_key(self):
+    trie = prefix_cache.PrefixCacheTrie()
+    key = (1, 2, 3, 4)
+    trie.insert(key)
+    assert trie.get_longest_common_prefix_key((1, 2, 3, 4)) == key
+    assert trie.get_longest_common_prefix_key((1, 2, 3)) == key
+    assert trie.get_longest_common_prefix_key((1, 2, 3, 4, 5)) == key
+    assert trie.get_longest_common_prefix_key((1, 2, 6, 7)) == key
+    assert trie.get_longest_common_prefix_key((2, 3, 4, 5)) is None
+
+  def test_insert_longer_key_replace_shorter_key(self):
+    trie = prefix_cache.PrefixCacheTrie()
+    trie.insert((1, 2, 3))
+    trie.insert((1, 2, 3, 4))
+    assert trie.get_longest_common_prefix_key((1, 2, 3)) == (1, 2, 3, 4)
+
+  def test_insert_key_with_different_suffix_will_store_another_one(self):
+    trie = prefix_cache.PrefixCacheTrie()
+    trie.insert((1, 2, 3, 4))
+    trie.insert((1, 2, 3, 5))
+    assert trie.get_longest_common_prefix_key((1, 2, 3, 4)) == (1, 2, 3, 4)
+    assert trie.get_longest_common_prefix_key((1, 2, 3, 5)) == (1, 2, 3, 5)
+
+  def test_insert_shorter_key_will_not_replace_longer_key(self):
+    trie = prefix_cache.PrefixCacheTrie()
+    trie.insert((1, 2, 3, 4))
+    trie.insert((1, 2, 3))
+    assert trie.get_longest_common_prefix_key((1, 2, 3, 4)) == (1, 2, 3, 4)
+
+  def test_insert_multiple_key_and_get_longest_common_prefix(self):
+    trie = prefix_cache.PrefixCacheTrie()
+    trie.insert((1, 2, 3))
+    trie.insert((1, 2, 4))
+    trie.insert((11, 2, 3))
+    trie.insert((11, 2))
+    trie.insert((11, 3, 4))
+    result1 = trie.get_longest_common_prefix_key((1, 2, 3, 4, 5))
+    assert result1 is not None
+    assert result1[:3] == (1, 2, 3)
+    result2 = trie.get_longest_common_prefix_key((1, 2, 4, 5, 6))
+    assert result2 is not None
+    assert result2[:3] == (1, 2, 4)
+    result3 = trie.get_longest_common_prefix_key((11, 2, 3, 4))
+    assert result3 is not None
+    assert result3[:3] == (11, 2, 3)
+    result4 = trie.get_longest_common_prefix_key((11, 3, 6))
+    assert result4 is not None and result4[:2] == (11, 3)
+
+  def test_erase_matched_key(self):
+    trie = prefix_cache.PrefixCacheTrie()
+    trie.insert((1, 2, 3))
+    trie.erase((1, 2, 3))
+    assert trie.get_longest_common_prefix_key((1, 2, 3)) is None
+
+  def test_erase_shorter_or_longer_key_will_not_effect(self):
+    trie = prefix_cache.PrefixCacheTrie()
+    trie.insert((1, 2, 3))
+    trie.erase((1, 2, 3, 4))
+    trie.erase((1, 2))
+    assert trie.get_longest_common_prefix_key((1, 2, 3)) == (1, 2, 3)
+
+  def test_erase_key_will_change_to_another_longest_common_prefix_key(self):
+    trie = prefix_cache.PrefixCacheTrie()
+    trie.insert((1, 2, 3))
+    trie.insert((1, 2, 4))
+    first_matched_key = trie.get_longest_common_prefix_key((1, 2))
+    assert first_matched_key is not None
+    trie.erase(first_matched_key)
+    second_matched_key = trie.get_longest_common_prefix_key((1, 2))
+    assert second_matched_key is not None
+    assert second_matched_key[:2] == (1, 2)
+    trie.erase(second_matched_key)
+    assert trie.get_longest_common_prefix_key((1, 2)) is None
+
+  def test_insert_after_erase_to_empty(self):
+    trie = prefix_cache.PrefixCacheTrie()
+    trie.insert((1, 2, 3))
+    trie.erase((1, 2, 3))
+    trie.insert((4, 5, 6))
+    assert trie.get_longest_common_prefix_key((4, 5, 6)) == (4, 5, 6)
+
+
+class HBMCacheTest(unittest.TestCase):
+
+  def test_is_enough_space_remain(self):
+    value = create_default_value()
+    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes)
+    assert hbm_cache.has_enough_space(value) is True
+    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes - 1)
+    assert hbm_cache.has_enough_space(value) is False
+
+  def test_add_to_cache_and_fetch_with_key_exactly_matched(self):
+    key = (1, 2, 3)
+    value = create_default_value()
+    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes)
+    assert hbm_cache.add_to_cache(key, value) is True
+    assert hbm_cache.retrieve_from_cache(key) == value
+
+  def test_add_to_cache_fail_if_not_enough_space(self):
+    value = create_default_value()
+    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes * 2 - 1)
+    assert hbm_cache.add_to_cache((1,), value) is True
+    # The second one will exceed 1 bytes
+    assert hbm_cache.add_to_cache((2,), value) is False
+    assert hbm_cache.retrieve_from_cache((2,)) is None
+
+  def test_cannot_retrieve_not_exactly_matched_key(self):
+    key = (1, 2, 3)
+    value = create_default_value()
+    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes)
+    assert hbm_cache.add_to_cache(key, value) is True
+    assert hbm_cache.retrieve_from_cache((1, 2, 4)) is None
+    assert hbm_cache.retrieve_from_cache((1, 2)) is None
+
+  def test_add_and_retrieve_multiple_keys(self):
+    hbm_cache = prefix_cache.HBMCache(max_size_bytes=1_000_000)
+    value1 = create_default_value(tokens=[1])
+    hbm_cache.add_to_cache((1,), value1)
+    value2 = create_default_value(tokens=[2])
+    hbm_cache.add_to_cache((2,), value2)
+    assert hbm_cache.retrieve_from_cache((1,)) == value1
+    assert hbm_cache.retrieve_from_cache((2,)) == value2
+
+  def test_evict_cache_return_evicted_value(self):
+    value = create_default_value()
+    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes)
+    hbm_cache.add_to_cache((1,), value)
+    evict_value = hbm_cache.evict_cache((1,))
+    assert evict_value == value
+
+  def test_evict_cache_will_release_the_memory_usage_and_cannot_retrieve_and_evict_after_evict(self):
+    value = create_default_value()
+    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes)
+    hbm_cache.add_to_cache((1,), value)
+    # memory is not enough
+    assert hbm_cache.add_to_cache((2,), create_default_value()) is False
+    hbm_cache.evict_cache((1,))
+    assert hbm_cache.retrieve_from_cache((1,)) is None
+    assert hbm_cache.evict_cache((1,)) is None
+    # should add another after evict
+    value2 = create_default_value()
+    assert hbm_cache.add_to_cache((2,), value2) is True
+    assert hbm_cache.retrieve_from_cache((2,)) == value2
+
+  def test_evict_multiple_caches(self):
+    key1 = (1,)
+    value1 = create_default_value(tokens=key1)
+    key2 = (
+        1,
+        2,
+    )
+    value2 = create_default_value(tokens=key2)
+    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value1.prefix_size_bytes * 2)
+    hbm_cache.add_to_cache(key1, value1)
+    hbm_cache.add_to_cache(key2, value2)
+    evict_value = hbm_cache.evict_cache(key2)
+    assert evict_value == value2
+    assert hbm_cache.retrieve_from_cache(key2) is None
+    assert hbm_cache.retrieve_from_cache(key1) is not None
+    evict_value = hbm_cache.evict_cache(key1)
+    assert hbm_cache.retrieve_from_cache(key1) is None
+
+
+class LRUStrategyTest(unittest.TestCase):
+
+  def test_evict_none_if_no_use(self):
+    strategy = prefix_cache.LRUStrategy()
+    assert strategy.evict() is None
+
+  def test_evict_FIFO(self):
+    strategy = prefix_cache.LRUStrategy()
+    strategy.use((1,))
+    strategy.use((2,))
+    strategy.use((3,))
+    assert strategy.evict() == (1,)
+    assert strategy.evict() == (2,)
+    assert strategy.evict() == (3,)
+    assert strategy.evict() is None
+
+  def test_use_in_the_middle_update_to_the_last(self):
+    strategy = prefix_cache.LRUStrategy()
+    strategy.use((1,))
+    strategy.use((2,))
+    strategy.use((1,))
+    assert strategy.evict() == (2,)
+    assert strategy.evict() == (1,)
+    assert strategy.evict() is None
+
+
+class PrefixCacheTest(unittest.TestCase):
+
+  def test_cache_miss_save_hit_load(self):
+    hbm_bytes = 64 * 1024 * 1024 * 1024  # 64 GB
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=hbm_bytes)
+    tokens = (1, 2, 3)
+    no_matched_key = prefix_cache_inst.fetch_longest_common_prefix_key(tokens)
+    # first seen prefix will not match any key
+    assert no_matched_key is None
+    # Use dummy cache which should be returned from prefill: cache, _ = prefill(tokens)
+    kv_cache = {
+        "decoder": {
+            "layer_0": {
+                "cached_prefill_key": jnp.array([1, 2, 3, 0, 0, 0, 0, 0], dtype=jnp.bfloat16),
+                "cached_prefill_value": jnp.array([1, 2, 3, 0, 0, 0, 0, 0], dtype=jnp.bfloat16),
+            },
+            "layer_1": {
+                "cached_prefill_key": jnp.array([1, 2, 3, 0, 0, 0, 0, 0], dtype=jnp.bfloat16),
+                "cached_prefill_value": jnp.array([1, 2, 3, 0, 0, 0, 0, 0], dtype=jnp.bfloat16),
+            },
+        }
+    }
+    # Should copy kv_cache before saved if the kv_cache is used after saved.
+    kv_cache_copy = jax.tree_util.tree_map(lambda x: x.copy(), kv_cache)
+    saved_value = prefix_cache.Value(prefix=kv_cache_copy, true_length=len(tokens), padded_length=len(tokens), tokens=tokens)
+    prefix_cache_inst.save(tuple(tokens), saved_value)
+
+    tokens_with_common_prefix = tokens + (4, 5, 6)
+    matched_key = prefix_cache_inst.fetch_longest_common_prefix_key(tokens_with_common_prefix)
+    assert matched_key is not None
+    assert matched_key == tokens
+    loaded_value = prefix_cache_inst.load(matched_key)
+    assert loaded_value == saved_value
+
+  def test_clear_cache(self):
+    tokens = (1, 2, 3)
+    value = create_default_value(tokens=tokens)
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=value.prefix_size_bytes)
+    assert prefix_cache_inst.save(tokens, value) is True
+    assert prefix_cache_inst.load(tokens) == value
+    prefix_cache_inst.clear()
+    assert prefix_cache_inst.load(tokens) is None
+
+  def test_evict_cache_with_LRU_strategy(self):
+    tokens1 = (1,)
+    value1 = create_default_value(tokens=tokens1)
+    tokens2 = (2,)
+    value2 = create_default_value(tokens=tokens2)
+    tokens3 = (3,)
+    value3 = create_default_value(tokens=tokens3)
+    # cache with 2 values size, and will evict with LRU
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=(value1.prefix_size_bytes) * 2)
+    assert prefix_cache_inst.save(tokens1, value1) is True
+    assert prefix_cache_inst.save(tokens2, value2) is True
+    assert prefix_cache_inst.load(tokens1) == value1
+    assert prefix_cache_inst.save(tokens3, value3) is True
+    assert prefix_cache_inst.load(tokens2) is None
+
+  def test_fetch_longest_common_prefix_key_does_not_affect_LRU(self):
+    tokens1 = (1,)
+    value1 = create_default_value(tokens=tokens1)
+    tokens2 = (2,)
+    value2 = create_default_value(tokens=tokens2)
+    tokens3 = (3,)
+    value3 = create_default_value(tokens=tokens3)
+    # cache with 2 values size, and will evict with LRU
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=(value1.prefix_size_bytes) * 2)
+    assert prefix_cache_inst.save(tokens1, value1) is True
+    assert prefix_cache_inst.save(tokens2, value2) is True
+    assert prefix_cache_inst.fetch_longest_common_prefix_key(tokens1) == tokens1
+    assert prefix_cache_inst.save(tokens3, value3) is True
+    assert prefix_cache_inst.fetch_longest_common_prefix_key(tokens1) is None
+    assert prefix_cache_inst.load(tokens1) is None
+
+  def test_evict_cache_until_feasible_to_new_cache(self):
+    # value2 is double size of value1
+    value1 = create_default_value(prefix=[jnp.array([1, 2, 3]) for _ in range(1)])
+    value2 = create_default_value(prefix=[jnp.array([1, 2, 3]) for _ in range(2)])
+
+    # Only feasible for two value1 or one value2
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=(value1.prefix_size_bytes) * 2)
+    assert prefix_cache_inst.save(key=(1,), value=value1) is True
+    assert prefix_cache_inst.save(key=(2,), value=value1) is True
+    assert prefix_cache_inst.load(key=(1,)) == value1
+    assert prefix_cache_inst.load(key=(2,)) == value1
+    assert prefix_cache_inst.save(key=(3,), value=value2) is True
+    assert prefix_cache_inst.load(key=(1,)) is None
+    assert prefix_cache_inst.load(key=(2,)) is None
+    assert prefix_cache_inst.load(key=(3,)) == value2
+
+  def test_will_not_evict_if_whole_cache_is_not_feasible(self):
+    # value2 is triple size of value1
+    value1 = create_default_value(prefix=[jnp.array([1, 2, 3]) for _ in range(1)])
+    value2 = create_default_value(prefix=[jnp.array([1, 2, 3]) for _ in range(3)])
+
+    # Only feasible for two value1 and never value2
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=(value1.prefix_size_bytes) * 2)
+    assert prefix_cache_inst.save(key=(1,), value=value1) is True
+    assert prefix_cache_inst.save(key=(2,), value=value1) is True
+    assert prefix_cache_inst.load(key=(1,)) == value1
+    assert prefix_cache_inst.load(key=(2,)) == value1
+    assert prefix_cache_inst.save(key=(3,), value=value2) is False
+    assert prefix_cache_inst.load(key=(1,)) == value1
+    assert prefix_cache_inst.load(key=(2,)) == value1
+    assert prefix_cache_inst.load(key=(3,)) is None
+
+  @pytest.mark.tpu_only
+  def test_hbm_memory_usage(self):
+    """Test HBM memory change.
+    Create the class instance will not pre allocate memory.
+    Save the cache will move without copy.
+    Load the cache will copy from cache.
+    Clear the cache will clear the saved cache.
+    """
+    device = jax.local_devices()[0]
+    memory_stats = device.memory_stats()
+    assert memory_stats is not None
+
+    def get_byte_in_use():
+      jax.clear_caches()
+      return memory_stats["bytes_in_use"]
+
+    pre_bytes_in_use = get_byte_in_use()
+    hbm_bytes = 1024
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=hbm_bytes)
+    # prefix_cache will not pre allocate the memory
+    assert pre_bytes_in_use == get_byte_in_use()
+    prefix = {"cached_prefill_key": jnp.array([1, 2, 3, 4], dtype=jnp.bfloat16, device=device)}
+    prefix_create_bytes_in_use = get_byte_in_use()
+    # memory would be allocated with chunked minimum size
+    prefix_bytes = prefix_create_bytes_in_use - pre_bytes_in_use
+    assert prefix_create_bytes_in_use == pre_bytes_in_use + prefix_bytes
+    key = (1, 2, 3)
+    prefix_cache_inst.save(key, create_default_value(prefix=prefix))
+    # cache save will not copy
+    assert prefix_create_bytes_in_use == get_byte_in_use()
+    del prefix
+    # prefix move into the cache
+    assert prefix_create_bytes_in_use == get_byte_in_use()
+    loaded_value = prefix_cache_inst.load(key)
+    assert loaded_value is not None
+    loaded_bytes_in_use = get_byte_in_use()
+    # load cache will not copy from cache
+    assert loaded_bytes_in_use == prefix_create_bytes_in_use
+    del loaded_value
+    del_loaded_bytes_in_use = get_byte_in_use()
+    assert del_loaded_bytes_in_use == loaded_bytes_in_use
+    prefix_cache_inst.clear()
+    clear_bytes_in_use = get_byte_in_use()
+    assert clear_bytes_in_use == del_loaded_bytes_in_use - prefix_bytes
+    assert prefix_cache_inst.load(key) is None
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

Implements Prefix Caching in HBM and latency test in inference_microbenchmark.
 
Stores prefix tokens as a trie for fast lookup index of PrefixCache store in cache.

Insert longer Key replace shorter key to be the longest common prefix key.
The shorter key will never be returned even if longer key is erased, and should got evicted in the future.

Assume Key is equal length to tokens, which can be used to slice prompt and cache Value.
Should check the return key common prefix length by the caller.

If erase the Key not the leaf, nothing will happen.
If erased key match at a leaf, delete the node and ancestors would be the leaf after deleted.

Value will be moved to the cache, which means cannot used the same value reference after add_to_cache.

The jax may modified the value even stored in another python reference.
If the value need to be used after add_to_cache, make sure copy them before add_to_cache.

Return value copied from cache to avoid modified value in the cache, always copied the value before return.

Add PrefixCaching benchmark test in inference_microbenchmark.

Using half of the prefill_length as the common prefix and save 100 prefix in the cache.

Loading the cache (including jax.array.copy) appears to be independent of the prefill_length (tested with 128 and 1024), even though the saved cache sizes are different.

Using jax.profiler shows that the copy operation consumes a similar amount of time on TPU. This might be because the sizes aren't large or different enough to see a significant impact.

Part of results below
```
Prefix Cache benchmark results for prefill length 128:

PrefixCaching results:
	Per prefix size bytes: 0.124 GB
	Average save cache time: 12.142 ms
	Average fetch longest prefix time: 0.029 ms
	Average load cache time: 5.589 ms


Prefix Cache benchmark results for prefill length 1024:

PrefixCaching results:
	Per prefix size bytes: 0.220 GB
	Average save cache time: 12.987 ms
	Average fetch longest prefix time: 0.218 ms
	Average load cache time: 5.143 ms
```

FIXES: b/389788256
TESTED: unittest

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
