### PR TITLE
Fix bugs in Pathways Path for Maxtext Benchmark Runner

### DIFF
--- a/benchmarks/Getting_Started_Benchmarking.md
+++ b/benchmarks/Getting_Started_Benchmarking.md
@@ -23,7 +23,7 @@ export RUNNER=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/maxtext_jax_sta
 export PROXY_IMAGE=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/proxy_server:latest
 export SERVER_IMAGE=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/server:latest
 
-python3 benchmarks/benchmark_runner.py xpk --project $PROJECT --zone $ZONE --cluster_name $CLUSTER --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5 --pathways_server_image="${SERVER_IMAGE}" --pathways_proxy_image="${PROXY_IMAGE}" --pathways_runner_image="${RUNNER}"
+python3 benchmarks/benchmark_runner.py xpk --project $PROJECT --zone $ZONE --cluster_name $CLUSTER --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5 --pathways_server_image="${SERVER_IMAGE}" --pathways_proxy_server_image="${PROXY_IMAGE}" --pathways_runner_image="${RUNNER}"
 ```
 
 ```shell

--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -117,7 +117,7 @@ def add_xpk_runner_arguments(custom_parser: argparse.ArgumentParser):
       help='version of pathways server image to be benchmarked command.',
   )
   custom_parser.add_argument(
-      '--pathways_proxy_image',
+      '--pathways_proxy_server_image',
       type=str,
       default='us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/proxy_server:latest',
       help='version of pathways proxy image to be benchmarked command.',
@@ -251,7 +251,7 @@ def main() -> None:
     if options.use_pathways:
       pw_config = PathwaysConfig(
         server_image=options.pathways_server_image,
-        proxy_image=options.pathways_proxy_image,
+        proxy_server_image=options.pathways_proxy_server_image,
         runner_image=options.pathways_runner_image,
         remote_python_sidecar_image=options.remote_python_sidecar_image,
       )

--- a/benchmarks/recipes/pw_remote_python_recipe.py
+++ b/benchmarks/recipes/pw_remote_python_recipe.py
@@ -63,7 +63,7 @@ def main() -> int:
   ]
   pathways_config = mxr.PathwaysConfig(
       server_image=server_image,
-      proxy_image=proxy_image,
+      proxy_server_image=proxy_image,
       runner_image=runner,
       remote_python_sidecar_image=remote_python_image,
   )

--- a/benchmarks/xla_flags_library.py
+++ b/benchmarks/xla_flags_library.py
@@ -74,6 +74,14 @@ ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS = (
     " --2a886c8_chip_config_name=megachip_tccontrol"
 )
 
+ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS_PW = (
+    " --xla_tpu_use_tc_device_shape_on_sc=true"
+    " --xla_sc_enable_instruction_fusion=false"
+    " --xla_sc_disjoint_spmem=false"
+    " --xla_sc_disable_megacore_partitioning=true"
+    # " --2a886c8_chip_config_name=megachip_tccontrol"  # Flag has issues in PW.
+)
+
 # Enable SparseCore All Gather (1D), Reduce Scatter (1D) and All Reduce (ND)
 ENABLE_SPARSECORE_OFFLOADING_FOR_RS_AG_AR = (
     " --xla_tpu_enable_async_collective_fusion_fuse_all_gather=false"
@@ -114,6 +122,12 @@ ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE = (
     " --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true"
     " --xla_tpu_enable_all_reduce_offload_tracing=true"
 ) + ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS
+
+ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE_PW = (
+    " --xla_tpu_enable_async_collective_fusion_fuse_all_reduce=false"
+    " --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true"
+    " --xla_tpu_enable_all_reduce_offload_tracing=true"
+) + ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS_PW
 
 # Better memory layout for all-reduce (AR).
 LAYOUT_FOR_ALL_REDUCE_SCATTER = (


### PR DESCRIPTION
# Description

This PR fixes a few bugs and adds additional Pathways support.

1. Fixes a regressions in https://github.com/AI-Hypercomputer/maxtext/pull/1094 that requires the use of remote python to run a pathways workload.
2. If use_vertex_tensorboard is not defined, pyconfig.py would throw an exception because it cannot parse a None value when it requires an argument with "=" in it. This is fixed in this PR.
3. Adds support for passing Server, Proxy, and Worker arguments to the pods directly (builds off of https://github.com/AI-Hypercomputer/xpk/pull/364)
4. Adds support for passing XLA flags into the proxy server for all configs by default.
5. Replace use of `--use-pathways` with `create-pathways` instead.

# Tests

Ran on v6e clusters.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.