### PR TITLE
Support emergency checkpointing on GPUs

### DIFF
--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -110,6 +110,16 @@ def create_orbax_emergency_checkpoint_manager(
   flags.FLAGS.experimental_orbax_use_distributed_process_id = True
   max_logging.log("Creating emergency checkpoint manager...")
 
+  # Only create directories if running on GPUs as the previous
+  # directory structure might be assumed by TPUs
+  if global_mesh.devices.flatten()[0].platform == 'gpu':
+    # pylint: disable=protected-access
+    local_checkpoint_dir = f"{local_checkpoint_dir}/{jax._src.distributed.global_state.process_id}"
+    local_p = epath.Path(local_checkpoint_dir)
+    persistent_p = epath.Path(persistent_checkpoint_dir)
+    local_p.mkdir(exist_ok=True, parents=True)
+    persistent_p.mkdir(exist_ok=True, parents=True)
+
   options = emergency_checkpoint_manager.CheckpointManagerOptions(
       local=LocalCheckpointOptions(save_interval_steps=local_save_interval_steps),
       persistent=PersistentCheckpointOptions(save_interval_steps=persistent_save_interval_steps),

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -159,7 +159,13 @@ def maybe_initialize_jax_distributed_system(raw_keys):
     if not raw_keys["enable_emergency_checkpoint"]:
       jax.distributed.initialize(initialization_timeout=raw_keys["jax_distributed_initialization_timeout"])
     else:
-      initialize_jax_for_tpu_with_emergency_checkpointing(raw_keys)
+      if raw_keys["hardware"] == "gpu_multiprocess":
+        max_logging.log("Initializing jax distribtued to support local checkpointing with GPUs...")
+        jax.distributed.initialize(initialization_timeout=raw_keys["jax_distributed_initialization_timeout"])
+        ocp.multihost.initialize_runtime_to_distributed_ids()
+        ocp.multihost.initialize_distributed_to_device_ids()
+      else:
+        initialize_jax_for_tpu_with_emergency_checkpointing(raw_keys)
     max_logging.log("Jax distributed system initialized!")
 
 


### PR DESCRIPTION
This PR makes two changes to allow emergency checkpointing when running on GPUs:

1. **Create separate emergency ckpt directories for each process**

Running Maxtext with local/emergency checkpointing and 1 process per GPU leads to a duplicate directory runtime error currently. This is because the local_checkpoint_dir is only unique per node, and when running with one process per GPU, all processes on a node attempt to write to the same local checkpoint. 

2. **Enable emergency checkpointing when running on GPU hardware**

Currently, when emergency checkpointing is enabled Maxtext assumes that the hardware is tpu.

