### PR TITLE
Support CPU based quantization for large models

### DIFF
--- a/MaxText/configs/models/llama3.3-70b.yml
+++ b/MaxText/configs/models/llama3.3-70b.yml
@@ -1,0 +1,29 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# model config for llama3.3-70b
+
+base_emb_dim: 8192
+base_num_query_heads: 64
+base_num_kv_heads: 8
+base_num_decoder_layers: 80
+base_mlp_dim: 28672
+head_dim: 128
+mlp_activations: ["silu","linear"]
+vocab_size: 128256
+enable_dropout: False
+logits_via_embedding: False
+normalization_layer_epsilon: 1.0e-5
+rope_max_timescale: 500_000
+decoder_block: "llama2" # Uses the same decoder block as llama2

--- a/MaxText/configs/v5e/inference/llama3_405b_v5e-64.yml
+++ b/MaxText/configs/v5e/inference/llama3_405b_v5e-64.yml
@@ -5,7 +5,7 @@ base_config: "inference_jetstream.yml"
 # per_device_batch_size=1
 # weight bf16, kv cache bf16
 
-model_name: "llama3-405b"
+model_name: "llama3.1-405b"
 sharding_strategy: "experimental"
 attention: 'dot_product'
 allow_split_physical_axes: True

--- a/MaxText/llama_ckpt_conversion_inference_only.py
+++ b/MaxText/llama_ckpt_conversion_inference_only.py
@@ -52,11 +52,17 @@ def permute_to_match_maxtext_rope(arr):
   return jax.numpy.concatenate((evens, odds), axis=arr.ndim - 1)
 
 
+# Model params can be found in the config.json on HuggingFace of these models
+# num_layers -> num_hidden_layers
+# num_heads -> num_attention_heads
+# num_kv_heads -> num_key_value_heads
+# dims_per_head -> hidden_size / num_attention_heads
+# vocab -> vocab_size
 MODEL_PARAMS_DICT = {
-    "llama2-70b": {
-        "num_layers": 80,
-        "num_heads": 64,
-        "num_kv_heads": 8,
+    "llama2-7b": {
+        "num_layers": 32,
+        "num_heads": 32,
+        "num_kv_heads": 32,
         "dims_per_head": 128,
         "vocab": 32000,
     },
@@ -67,10 +73,10 @@ MODEL_PARAMS_DICT = {
         "dims_per_head": 128,
         "vocab": 32000,
     },
-    "llama2-7b": {
-        "num_layers": 32,
-        "num_heads": 32,
-        "num_kv_heads": 32,
+    "llama2-70b": {
+        "num_layers": 80,
+        "num_heads": 64,
+        "num_kv_heads": 8,
         "dims_per_head": 128,
         "vocab": 32000,
     },
@@ -88,9 +94,30 @@ MODEL_PARAMS_DICT = {
         "dims_per_head": 128,
         "vocab": 128256,
     },
-    "llama3-405b": {
+    "llama3.1-8b": {
+        "num_layers": 32,
+        "num_heads": 32,
+        "num_kv_heads": 8,
+        "dims_per_head": 128,
+        "vocab": 128256,
+    },
+    "llama3.1-70b": {
+        "num_layers": 80,
+        "num_heads": 64,
+        "num_kv_heads": 8,
+        "dims_per_head": 128,
+        "vocab": 128256,
+    },
+    "llama3.1-405b": {
         "num_layers": 126,
         "num_heads": 128,
+        "num_kv_heads": 8,
+        "dims_per_head": 128,
+        "vocab": 128256,
+    },
+    "llama3.3-70b": {
+        "num_layers": 80,
+        "num_heads": 64,
         "num_kv_heads": 8,
         "dims_per_head": 128,
         "vocab": 128256,
@@ -170,8 +197,8 @@ def convert(base_model_path, maxtext_model_path, model_size):
         },
     }
 
-  # llama3-405b kv weight is replicated within every two files.
-  wkv_step = 1 if model_size != "llama3-405b" else 2
+  # llama3.1-405b kv weight is replicated within every two files.
+  wkv_step = 1 if model_size != "llama3.1-405b" else 2
 
   for layer_idx in range(base_num_decoder_layers):
     print("layer idx: ", layer_idx)

--- a/MaxText/load_and_quantize_checkpoint.py
+++ b/MaxText/load_and_quantize_checkpoint.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI utility for loading and quantizing a checkpoint."""
+
+import jax
+
+import max_utils
+import maxengine
+
+import os
+import pyconfig
+
+from typing import Sequence
+from absl import app
+
+
+def main(argv: Sequence[str]) -> None:
+  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
+  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
+
+  pyconfig.initialize(argv)
+  config = pyconfig.config
+  validate_config(config)
+  max_utils.print_system_information()
+
+  engine = maxengine.MaxEngine(config)
+  rng = jax.random.PRNGKey(1234)
+  rng, rng_load_params = jax.random.split(rng)
+
+  # load_params will load a checkpoint and quantize if the following parameters are set:
+  # quantization=$valid_quantization_type \
+  # save_quantized_params_path=$gsbucket_path \
+  # checkpoint_is_quantized=false (default)
+  engine.load_params(rng_load_params)
+
+
+def validate_config(config):
+  assert config.load_full_state_path == "", "Operation on full states not supported! Convert to parameter checkpoint first."
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -200,6 +200,7 @@ def validate_model_name(s: str) -> bool:
       "llama3.1-8b",
       "llama3.1-70b",
       "llama3.1-405b",
+      "llama3.3-70b",
       "mistral-7b",
       "mixtral-8x7b",
       "mixtral-8x22b",

--- a/end_to_end/tpu/llama3.1/405b/3_test_llama3.1_405b.sh
+++ b/end_to_end/tpu/llama3.1/405b/3_test_llama3.1_405b.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This file tests the quantization of the Llama3.1-405b checkpoint, and assumes an unscanned checkpoint already exists.
+
+set -ex
+
+# We install torch CPU because the checkpoint conversion script does not need a TPU/GPU
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# This is defined in 2_test_llama3.1_405b.sh
+export MODEL_VARIATION='llama3.1-405b'
+export UNSCANNED_CHECKPOINT=gs://maxtext-llama/llama3.1_405b_bf16/unscanned/0/items
+
+# Non-Googlers please remember to point `SAVE_QUANT_PARAMS_PATH` to the GCS bucket where you want to save your quantized checkpoint
+export SAVE_QUANT_PARAMS_PATH=gs://maxtext-llama/llama3.1_405b_int8
+
+export QUANTIZE_TYPE="int8"
+
+JAX_PLATFORMS=cpu python3 MaxText/load_and_quantize_checkpoint.py \
+    MaxText/configs/base.yml \
+    tokenizer_path=assets/tokenizer_llama3.tiktoken \
+    load_parameters_path=${UNSCANNED_CHECKPOINT} \
+    max_prefill_predict_length=1024 \
+    max_target_length=2048 \
+    model_name=${MODEL_VARIATION} \
+    ici_fsdp_parallelism=1 \
+    ici_autoregressive_parallelism=1 \
+    ici_tensor_parallelism=-1 \
+    scan_layers=false \
+    weight_dtype=bfloat16 \
+    per_device_batch_size=1 \
+    attention=dot_product \
+    quantization=${QUANTIZE_TYPE} \
+    save_quantized_params_path=${SAVE_QUANT_PARAMS_PATH} \
+    async_checkpointing=false \


### PR DESCRIPTION
# Description

This PR adds CPU-based quantization support for large models such as Llama3.1-405b, and capability to quantize only using CPU. Additionally add an integration test for Llama3.1-405b. 

Prior, quantizations of models would have to be done on TPUs/GPUs, since the script for quantization includes decoding, requiring an accelerator. For smaller models, CPU based quantization was possible on TPUs by exporting `JAX_PLATFORMS=cpu` and using the CPU compute of TPUs to facilitate quantization, but for the Llama3-405b model, this is infeasible since the HBM of even large TPUs does not have enough memory for quantization of the 405b model, which require ~(810+410=1220GB)

This PR adds the file `load_and_quantize_checkpoint.py` to facilitate the logic. 

# Tests

Integration test `3_test_llama3.1_405b.sh` created as the quantization path of Llama3.1-405b post unscanning a checkpoint. 

Tested as part of GKE job in [checkpoint conversion](https://github.com/GoogleCloudPlatform/ai-on-gke/commit/8e8f1ac47b9d0493b7841512951878422381f7e2):

```
python3 MaxText/load_and_quantize_checkpoint.py \
MaxText/configs/base.yml \
tokenizer_path=${TOKENIZER} \
load_parameters_path=${LOAD_PARAMS_PATH} \
max_prefill_predict_length=1024 \
max_target_length=2048 \
model_name=${MODEL_SIZE} \
ici_fsdp_parallelism=1 \
ici_autoregressive_parallelism=1 \
ici_tensor_parallelism=-1 \
scan_layers=false \
weight_dtype=bfloat16 \
per_device_batch_size=1 \
attention=dot_product \
quantization=${QUANTIZE_TYPE} \
save_quantized_params_path=${SAVE_QUANT_PARAMS_PATH} \
async_checkpointing=false 

Quantized params checkpoint saved at: ${SAVE_QUANT_PARAMS_PATH}
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
