### PR TITLE
Add flops calculation for DeepSeek

### DIFF
--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -124,51 +124,121 @@ def calculate_gemma2_tflops_training_per_device(config, total_ffn_flops, qkv_flo
   return attention_tflops, learnable_weight_tflops
 
 
+def calculate_mla_tflops_per_device(config):
+  """Calculate Multi-Head Latent Attention TFLOP"""
+  batch_len = config.per_device_batch_size * config.max_target_length
+  qk_head_dim_sum = config.qk_nope_head_dim + config.qk_rope_head_dim
+  # calculate mla query projection
+  if config.q_lora_rank == 0:
+    q_flops = 2 * batch_len * config.emb_dim * config.num_query_heads * qk_head_dim_sum
+  else:
+    # calculate query down and up flops
+    q_flops = (
+        2 * batch_len * (config.emb_dim * config.q_lora_rank + config.q_lora_rank * config.num_query_heads * qk_head_dim_sum)
+    )
+  # calculate mla kv projection with down and up flops
+  kv_flops = (
+      2
+      * batch_len
+      * (
+          config.emb_dim * (config.kv_lora_rank + config.qk_rope_head_dim)
+          + config.kv_lora_rank * config.num_query_heads * (config.qk_nope_head_dim + config.v_head_dim)
+      )
+  )
+  qkv_flops = q_flops + kv_flops
+
+  attention_flops = 2 * batch_len * config.max_target_length * config.num_query_heads * (qk_head_dim_sum + config.v_head_dim)
+  projection_flops = 2 * batch_len * config.emb_dim * config.num_query_heads * config.v_head_dim
+  return qkv_flops, attention_flops, projection_flops
+
+
+def calculate_ffn_mamtul_tflops_per_device(config, mlp_dim):
+  """Helper function to calculate matmul TFLOP in ffn based on MLP dimension.
+
+  Applies to:
+    - Dense FFN layers (mlp_dim = config.mlp_dim).
+    - MoE FFN layers (mlp_dim = config.moe_mlp_dim),
+      need to scale by shared_experts or num_experts_per_tok.
+  """
+  ffn1_flops = (
+      2 * config.per_device_batch_size * config.max_target_length * mlp_dim * config.emb_dim * len(config.mlp_activations)
+  )
+  ffn2_flops = 2 * config.per_device_batch_size * config.max_target_length * mlp_dim * config.emb_dim
+  return ffn1_flops + ffn2_flops
+
+
+def calculate_deepseek_ffn_tflops_per_device(config):
+  """Helper function to calculate DeepSeek-style ffn TFLOP"""
+  gate_flops = 2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.num_experts
+  # Due to the mixed decoder layers, the flops is multiplied by num of layers for both dense and moe
+  dense_ffn_flops = calculate_ffn_mamtul_tflops_per_device(config, config.mlp_dim) * config.first_num_dense_layers
+  shared_experts_flops = calculate_ffn_mamtul_tflops_per_device(config, config.moe_mlp_dim) * config.shared_experts
+  routed_experts_flops = calculate_ffn_mamtul_tflops_per_device(config, config.moe_mlp_dim) * config.num_experts_per_tok
+  moe_layers = config.num_decoder_layers - config.first_num_dense_layers
+  moe_ffn_flops = (gate_flops + shared_experts_flops + routed_experts_flops) * moe_layers
+  total_ffn_flops = dense_ffn_flops + moe_ffn_flops
+  return total_ffn_flops
+
+
 def calculate_tflops_training_per_device(config, log=True):
   """Calculate training TFLOP"""
-  ffn1_flops = (
-      2
-      * config.per_device_batch_size
-      * config.max_target_length
-      * config.mlp_dim
-      * config.emb_dim
-      * len(config.mlp_activations)
-  )
-  ffn2_flops = 2 * config.per_device_batch_size * config.max_target_length * config.mlp_dim * config.emb_dim
-  total_ffn_flops = ffn1_flops + ffn2_flops
-
+  # MLP flops
   if config.num_experts > 1:
-    # MoE: brute force implementation
-    gate_flops = 2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.num_experts
-    total_ffn_flops = gate_flops + config.num_experts_per_tok * total_ffn_flops
+    # calculation based on dropless implementation
+    if config.decoder_block == "deepseek":
+      total_ffn_flops = calculate_deepseek_ffn_tflops_per_device(config)
+    else:
+      gate_flops = 2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.num_experts
+      total_ffn_flops = (
+          gate_flops + calculate_ffn_mamtul_tflops_per_device(config, config.mlp_dim) * config.num_experts_per_tok
+      )
+  else:
+    total_ffn_flops = calculate_ffn_mamtul_tflops_per_device(config, config.mlp_dim)
 
-  qkv_flops = (
-      2
-      * config.per_device_batch_size
-      * config.max_target_length
-      * config.emb_dim
-      * (config.num_query_heads + 2 * config.num_kv_heads)
-      * config.head_dim
-  )
-  attention_flops = 4 * config.per_device_batch_size * config.max_target_length**2 * config.num_query_heads * config.head_dim
-  projection_flops = (
-      2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.num_query_heads * config.head_dim
-  )
+  # Attention flops
+  if config.attention_type == "mla":
+    qkv_flops, attention_flops, projection_flops = calculate_mla_tflops_per_device(config)
+  else:
+    qkv_flops = (
+        2
+        * config.per_device_batch_size
+        * config.max_target_length
+        * config.emb_dim
+        * (config.num_query_heads + 2 * config.num_kv_heads)
+        * config.head_dim
+    )
+    attention_flops = (
+        4 * config.per_device_batch_size * config.max_target_length**2 * config.num_query_heads * config.head_dim
+    )
+    projection_flops = (
+        2
+        * config.per_device_batch_size
+        * config.max_target_length
+        * config.emb_dim
+        * config.num_query_heads
+        * config.head_dim
+    )
+
+  # Embedding flops
   embedding_flops = 2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.vocab_size
 
-  # multiply by 3 for both feed forward and back propagation flops
-  learnable_weight_tflops = (
-      ((total_ffn_flops + qkv_flops + projection_flops) * config.num_decoder_layers + embedding_flops) * 3 / 10**12
-  )
-
-  # megatron tflops calculation does not account for causality in attention
-  attention_tflops = attention_flops * config.num_decoder_layers * 3 / 10**12
-
-  # override for gemma2 decoder tflop calculation
+  # Combine flops with number of decoder layers
   if config.decoder_block == "gemma2":
     attention_tflops, learnable_weight_tflops = calculate_gemma2_tflops_training_per_device(
         config, total_ffn_flops, qkv_flops, projection_flops, embedding_flops
     )
+  elif config.decoder_block == "deepseek":
+    learnable_weight_tflops = (
+        (total_ffn_flops + (qkv_flops + projection_flops) * config.num_decoder_layers + embedding_flops) * 3 / 10**12
+    )
+    attention_tflops = attention_flops * config.num_decoder_layers * 3 / 10**12
+  else:
+    # multiply by 3 for both feed forward and back propagation flops
+    learnable_weight_tflops = (
+        ((total_ffn_flops + qkv_flops + projection_flops) * config.num_decoder_layers + embedding_flops) * 3 / 10**12
+    )
+    # megatron tflops calculation does not account for causality in attention
+    attention_tflops = attention_flops * config.num_decoder_layers * 3 / 10**12
 
   learnable_weight_tflops = learnable_weight_tflops * config.gradient_accumulation_steps
   attention_tflops = attention_tflops * config.gradient_accumulation_steps


### PR DESCRIPTION
# Description

Update flops calculation to include MLA and DeepSeek structure
* Add a few helper functions
* Tested locally with 6BP rule

# Tests

Using test like below

```
  @pytest.mark.tpu_only
  def test_flops(self):

    import maxtext_utils
    total_tflops, learnable_weight_tflops, attention_tflops = maxtext_utils.calculate_tflops_training_per_device(self.cfg)
    print("after change....")
    print(f"total_tflops: {total_tflops}")
    print(f"learnable_weight_tflops: {learnable_weight_tflops}")
    print(f"attention_tflops: {attention_tflops}")
    total_tflops2, learnable_weight_tflops2, attention_tflops2 = maxtext_utils.calculate_tflops_training_original(self.cfg)
    print("before change....")
    print(f"total_tflops2: {total_tflops2}")
    print(f"learnable_weight_tflops2: {learnable_weight_tflops2}")
    print(f"attention_tflops2: {attention_tflops2}")
```

`per_device_batch_size=4 max_target_length=256`

| Model | Before | After |
| ------------- | ------------- | ------------- |
| llama2-7b | total_tflops: 41.00620025856, learnable_weight_tflops: 40.593883398144, attention_tflops: 0.412316860416 | total_tflops2: 41.00620025856, learnable_weight_tflops2: 40.593883398144, attention_tflops2: 0.412316860416 |
| gemma2-2b | total_tflops2: 15.515032485888, learnable_weight_tflops2: 15.399068368896, attention_tflops2: 0.115964116992 | total_tflops: 15.515032485888, learnable_weight_tflops: 15.399068368896, attention_tflops: 0.115964116992 | 
| mixtral 8x7b | total_tflops: 78.739635437568, learnable_weight_tflops: 78.327318577152, attention_tflops: 0.412316860416 | total_tflops2: 78.739635437568, learnable_weight_tflops2: 78.327318577152, attention_tflops2: 0.412316860416 | 
| deepseek2-16b | NA | total_tflops: 15.278272413696, learnable_weight_tflops: 15.060839694336, attention_tflops: 0.21743271936 | 
| deepseek3-671b | NA | total_tflops: 228.951418994688, learnable_weight_tflops: 225.021523918848, attention_tflops: 3.92989507584 | 

Comparing to 6BP rule:

```
1) llama2-7b, reported total 41 tflops, 6BP = 6 * 4 * 256 * 7 /10^3 = 43
2) DeepSeek v2-16b: reported total 15 tflops, 6BP = 6 * 4 * 256 * 2.4/10^3 = 14.7
3) DeepSeek v3-671b: reported total 229 tflops, 6BP = 6 * 4* 256 * 37/10^3 = 227
```


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
