### PR TITLE
[PP] Fix custom remat policy with PP on newer jax versions

### DIFF
--- a/MaxText/layers/pipeline.py
+++ b/MaxText/layers/pipeline.py
@@ -496,10 +496,10 @@ class Pipeline(nn.Module):
   def get_pipeline_remat_policy(self):
     # We ensure that the decoder layer inputs are saved, although we leave it to a custom
     # policy if they should be saved to device or offloaded.
-    if self.remat_policy != "custom":
-      save_input_policy = jax.checkpoint_policies.save_only_these_names("iteration_input", "decoder_layer_input")
-    else:
-      save_input_policy = jax.checkpoint_policies.save_only_these_names("iteration_input")
+    if self.config.remat_policy == "custom":
+      return self.remat_policy
+
+    save_input_policy = jax.checkpoint_policies.save_only_these_names("iteration_input", "decoder_layer_input")
     if self.remat_policy is not None:
       remat_policy = jax.checkpoint_policies.save_from_both_policies(self.remat_policy, save_input_policy)
     else:


### PR DESCRIPTION
# Description

This fixes custom remat policies for with pipelining. Since this [commit](https://source.corp.google.com/h/github/google/jax/+/7dd401cb2aedcee723bd24888ffbdfc1a6458367:jax/_src/ad_checkpoint.py;dlc=772339ec60f42b6c89350c66c1adb46cbf029ef9) of jax, `save_from_both_policies` requires simple booleans, precluding its use with maxtext's custom policy. So instead we will set the remat policy to just be the custom one the user sets, instead of `save_from_both_policies(custom, inputs)`.



If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/390212885

# Tests

Ran custom + multiple layers_per_stage
* query to device [trace](https://xprof.corp.google.com/memory_viewer/mattdavidow-6759798287817654173)
* query is rematted [trace](https://xprof.corp.google.com/memory_viewer/mattdavidow-2498137011450472646)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
