### PR TITLE
Fix DeepSeek MoE Weighting

### DIFF
--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -388,7 +388,7 @@ class MoeBlock(nn.Module):
     inputs_2d = jnp.reshape(inputs, (inputs_shape[0] * inputs_shape[1], inputs_shape[2]))
     weights, selected_experts = jax.lax.top_k(gate_logits, self.num_experts_per_tok)
     if self.config.decoder_block == "deepseek":
-      wegihts = self.deepseek_scale_weights(weights)
+      weights = self.deepseek_scale_weights(weights)
     else:
       weights = jax.nn.softmax(weights.astype(jnp.float32), axis=-1).astype(self.dtype)
     flatten_selected_experts = jnp.ravel(selected_experts)


### PR DESCRIPTION
# Description

Fix typo which causes DeepSeek expert weighting to be ignored when `config.decoder_block == "deepseek"`.

# Tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
