### PR TITLE
[gitignore] Add '.idea' dir in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 
 # Wheel build
 *.whl
+
+# Intellij IDEA setting folder
+.idea


### PR DESCRIPTION
# Description

Change:
Add '.idea' dir in .gitignore

Reason:
For developers using pycharm, it creates a hidden dir .idea which should be ignored.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.



