### PR TITLE
Add Llama3.1-8B benchmark with disabled collective matmul

### DIFF
--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -874,6 +874,52 @@ llama3_1_8b_8192 = _add_to_model_dictionary(
 )
 
 
+llama3_1_8b_8192_no_collective_matmul = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama3_1-8b-8192-no-collective-matmul",
+    model_type="llama3.1-8b",
+    tuning_params={
+        "per_device_batch_size": 3,
+        "ici_fsdp_parallelism": -1,
+        "remat_policy": "custom",
+        "decoder_layer_input": "offload",
+        "out_proj": "offload",
+        "query_proj": "offload",
+        "key_proj": "offload",
+        "value_proj": "offload",
+        "max_target_length": 8192,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "enable_checkpointing": False,
+        "sa_block_q": 2048,
+        "sa_block_kv": 2048,
+        "sa_block_kv_compute": 2048,
+        "sa_block_q_dkv": 2048,
+        "sa_block_kv_dkv": 2048,
+        "sa_block_kv_dkv_compute": 2048,
+        "sa_block_q_dq": 2048,
+        "sa_block_kv_dq": 2048,
+        "sa_use_fused_bwd_kernel": True,
+        "profiler": "xplane",
+        "skip_first_n_steps_for_profiler": 10,
+        "profiler_steps": 5,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+        + xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+        + xla_flags_library.HOST_OFFLOAD_FLAGS
+        + xla_flags_library.DISABLE_COLLECTIVE_MATMUL
+    ),
+  )
+)
+
+
 llama3_1_70b_8192 = _add_to_model_dictionary(
   trillium_model_dict,
   MaxTextModel(

--- a/benchmarks/xla_flags_library.py
+++ b/benchmarks/xla_flags_library.py
@@ -202,3 +202,8 @@ DEBUG_LOGS = {
     "TPU_MIN_LOG_LEVEL": "0",
     "TPU_VMODULE": "tpu_configuration_ops_impl=3",  # Enable TPU logging
 }
+
+# Disables collective matmul operations.
+DISABLE_COLLECTIVE_MATMUL = (
+    " --xla_jf_spmd_threshold_for_windowed_einsum_mib=1000000"
+)


### PR DESCRIPTION
# Description

Add a new Trillium benchmark that runs Llama3.1 with collective matmuls disabled. I ran this on v6e-8 and saw an improvement from ~350 TFLOPs to ~410-420 TFLOPs after this change. 

This change is needed to support adding a reproducible recipe for v6e-8.

# Tests

Ran this benchmark on v6e-8 using the following command:

```
python3 benchmarks/benchmark_runner.py xpk \
    --project=$PROJECT \
    --zone=$ZONE \
    --device_type=v6e-8 \
    --num_slices=1  \
    --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="llama3_1_8b_8192_no_collective_matmul" \
    --libtpu_version=20241209 \
    --base_docker_image=maxtext_base_image
```

I got the perf described above. Also confirmed in the profile that the previous collective matmuls in the MLP are now gone:

![image](https://github.com/user-attachments/assets/049d5106-399d-4e5c-861e-7b483d3feae5)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
