### PR TITLE
fixes to conversion script and llama3.1-405b checkpointing

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -54,6 +54,9 @@ force_unroll: False # during generate_param_only_checkpoint should we unroll the
 checkpoint_storage_target_data_file_size_bytes: 2147483648
 checkpoint_storage_use_ocdbt: True
 checkpoint_storage_use_zarr3: True
+# larger models requires higher concurrent GB for I/O
+# default concurrent gb for PytreeCheckpointHandler is 96GB
+checkpoint_storage_concurrent_gb: 96
 ############################### END CHECKPOINTING ##################################
 
 

--- a/MaxText/llama_or_mistral_ckpt.py
+++ b/MaxText/llama_or_mistral_ckpt.py
@@ -111,6 +111,13 @@ MODEL_PARAMS_DICT = {
         "dims_per_head": 128,
         "vocab": 128256,
     },
+    "llama3.3-70b": {
+        "num_layers": 80,
+        "num_heads": 64,
+        "num_kv_heads": 8,
+        "dims_per_head": 128,
+        "vocab": 128256,
+    },
     "mistral-7b": {
         "num_layers": 32,
         "num_heads": 32,
@@ -141,6 +148,8 @@ MODEL_PARAMS_DICT = {
         "num_experts": 8,
     },
 }
+
+llama3_variants = {"llama3.1", "llama3.3"}
 
 SIMULATED_CPU_DEVICES_COUNT = 16
 
@@ -527,21 +536,28 @@ def _convert_pytorch_to_jax_weights(base_model_path, model_size, model_params, m
       "value": {"kernel": None},
       "out": {"kernel": None},
   }
+
+  # llama3.1-405b kv weight is replicated within every two files.
+  wkv_step = 1 if model_size != "llama3.1-405b" else 2
+
   for layer_idx in tqdm(range(base_num_decoder_layers), desc="layers", leave=False):
     wq = np.concatenate(
         [var[f"layers.{layer_idx}.attention.wq.weight"].type(torch.float16).numpy() for var in chkpt_vars], axis=0
     ).transpose()
     wk = np.concatenate(
-        [var[f"layers.{layer_idx}.attention.wk.weight"].type(torch.float16).numpy() for var in chkpt_vars], axis=0
+        [var[f"layers.{layer_idx}.attention.wk.weight"].type(torch.float16).numpy() for var in chkpt_vars[::wkv_step]],
+        axis=0,
     ).transpose()
     wv = np.concatenate(
-        [var[f"layers.{layer_idx}.attention.wv.weight"].type(torch.float16).numpy() for var in chkpt_vars], axis=0
+        [var[f"layers.{layer_idx}.attention.wv.weight"].type(torch.float16).numpy() for var in chkpt_vars[::wkv_step]],
+        axis=0,
     ).transpose()
 
     wq = np.reshape(wq, [base_num_query_heads * head_dim, base_num_query_heads, head_dim])
     wk = np.reshape(wk, [base_num_query_heads * head_dim, base_num_kv_heads, head_dim])
     wv = np.reshape(wv, [base_num_query_heads * head_dim, base_num_kv_heads, head_dim])
-    if model_size[:8] != "llama3.1":
+
+    if model_size[:8] not in llama3_variants:
       wq = permute_to_match_maxtext_rope(wq)
       wk = permute_to_match_maxtext_rope(wk)
 
@@ -707,6 +723,7 @@ def _convert_pytorch_to_jax_weights(base_model_path, model_size, model_params, m
   del chkpt_vars
   gc.collect()
   logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
+  return jax_weights
 
 
 def convert_to_jax_weights(base_model_path, model_size, huggingface_ckpt):

--- a/MaxText/load_and_quantize_checkpoint.py
+++ b/MaxText/load_and_quantize_checkpoint.py
@@ -30,8 +30,7 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
-  pyconfig.initialize(argv)
-  config = pyconfig.config
+  config = pyconfig.initialize(argv)
   validate_config(config)
   max_utils.print_system_information()
 

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -759,7 +759,9 @@ def setup_decode_state(model, config, rng, mesh, checkpoint_manager):
     max_logging.log(f"Loading decode params from {config.load_parameters_path}")
     unboxed_abstract_state, state_mesh_annotations, _ = get_abstract_state(model, None, config, rng, mesh, False)
     with nn_partitioning.axis_rules(config.logical_axis_rules):
-      params = checkpointing.load_params_from_path(config.load_parameters_path, unboxed_abstract_state.params)
+      params = checkpointing.load_params_from_path(
+          config.load_parameters_path, unboxed_abstract_state.params, config.checkpoint_storage_concurrent_gb
+      )
     state = init_decode_state(None, params)
 
   state = unbox_logicallypartioned(state)
@@ -818,6 +820,7 @@ def setup_initial_state(
         data_iterator,
         config.load_parameters_path,
         config.load_full_state_path,
+        config.checkpoint_storage_concurrent_gb,
         unboxed_abstract_state,
         config.enable_single_replica_ckpt_restoring,
         config.dataset_type,

--- a/MaxText/standalone_checkpointer.py
+++ b/MaxText/standalone_checkpointer.py
@@ -58,7 +58,12 @@ def checkpoint_loop(config, state=None):
   checkpoint_load_start = datetime.datetime.now()
   with nn_partitioning.axis_rules(config.logical_axis_rules):
     state, _ = checkpointing.load_state_if_possible(
-        checkpoint_manager, None, config.load_parameters_path, config.load_full_state_path, unboxed_abstract_state
+        checkpoint_manager,
+        None,
+        config.load_parameters_path,
+        config.load_full_state_path,
+        config.checkpoint_storage_concurrent_gb,
+        unboxed_abstract_state,
     )
     if state:
       state = state["items"]

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -737,6 +737,7 @@ def setup_train_loop(config):
           data_iterator,
           load_parameters_from_path="",
           load_full_state_from_path="",
+          checkpoint_storage_concurrent_gb=config.checkpoint_storage_concurrent_gb,
           abstract_unboxed_pre_state=abstract_state,
           enable_single_replica_ckpt_restoring=False,
           dataset_type=config.dataset_type,

--- a/end_to_end/tpu/llama3.1/405b/3_test_llama3.1_405b.sh
+++ b/end_to_end/tpu/llama3.1/405b/3_test_llama3.1_405b.sh
@@ -32,4 +32,4 @@ JAX_PLATFORMS=cpu python3 MaxText/load_and_quantize_checkpoint.py \
     attention=dot_product \
     quantization=${QUANTIZE_TYPE} \
     save_quantized_params_path=${SAVE_QUANT_PARAMS_PATH} \
-    async_checkpointing=false \
+    async_checkpointing=false


### PR DESCRIPTION
# Description

This PR has the following changes:

**Fixes bug where pytorch checkpoints conversion to training checkpoint will shard. The jax_weights in the pytorch checkpoint are currently not returned. The scanning checkpoint completes but when unscanning, we encounter this error:**

```
Traceback (most recent call last):
  File "/maxtext/MaxText/generate_param_only_checkpoint.py", line 150, in <module>
    app.run(main)
  File "/usr/local/lib/python3.10/dist-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "/usr/local/lib/python3.10/dist-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "/maxtext/MaxText/generate_param_only_checkpoint.py", line 146, in main
    generate_decode_checkpoint(config)
  File "/maxtext/MaxText/generate_param_only_checkpoint.py", line 134, in generate_decode_checkpoint
    _possibly_unroll_params(config, training_state, training_state_annotations, mesh)
  File "/maxtext/MaxText/generate_param_only_checkpoint.py", line 68, in _possibly_unroll_params
    new_layer = jax.jit(slice_ith, out_shardings=new_per_layer_state_sharding)(training_state_layers)
TypeError: Argument 'input_layers['mlp']['wi_0']['kernel']' of shape bfloat16[4096,32,14336] of type <class 'jax._src.api.ShapeDtypeStruct'> is not a valid JAX type.
``` 

After returning the jax_weights, we do not encounter this error anymore when unscanning. 

**Additionally fixes Llama3.1-405b checkpoint conversion for decode checkpoint / unscanning.**
Since the model is very large, the default bytes supported for restoring and saving is not enough, leading to errors such as

```
packages/orbax/checkpoint/_src/serialization/serialization.py", line 130, in wait_for_bytes
    raise ValueError('Requested more bytes than we reserved space for: '
ValueError: Requested more bytes than we reserved space for: 439697276928 > 96000000000
```

We bump up the bytes for larger models such as the llama3.1-405b. 

**Fixes llama3.1-405b kv weight replication within every two files.**

FIXES: b/397970646


# Tests

Tested with an e2e job that downloads checkpoint from Meta, converts to scanned checkpoint, and unscans. Further includes logic for quantization too. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
