### PR TITLE
Add pure FSDP config for llama405b

### DIFF
--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -828,6 +828,37 @@ llama3_1_405b_8192_fsdp_dcn = _add_to_model_dictionary(
   )
 )
 
+llama3_1_405b_8192_pure_fsdp_ici = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama3-1-405b-8192-pure-fsdp-ici",
+    model_type="llama3.1-405b",
+    tuning_params={
+        "per_device_batch_size": 1,
+        "ici_fsdp_parallelism": 256,
+        "dcn_fsdp_parallelism": 2,
+        "remat_policy": "custom",
+        "decoder_layer_input": "offload",
+        "max_target_length": 8192,
+        "attention": "flash",
+        "gcs_metrics": True,
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "reuse_example_batch": 1,
+        "enable_checkpointing": False,
+        "profiler": "xplane",
+        "sa_block_q": 1024,
+        "sa_block_q_dkv": 2048,
+        "sa_block_q_dq": 2048,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.HOST_OFFLOAD_FLAGS
+    ),
+  )
+)
 
 llama3_1_8b_8192 = _add_to_model_dictionary(
   trillium_model_dict,


### PR DESCRIPTION
# Description

Add a pure ICI_FSDP=256  DCN_FSDP=2 config for Llama3.1 405B. This has a performance of ~400 TFLOPs improving over the ICI_TP=4 config of ~365 TFLOPs. This also differs from the existing config by only offloading the layer inputs. I found offloading everything degrades perf by ~5 FLOPs

Currently the collective matmul with TP=4 does okay, but collective matmuls may improve in the future- some more info in b/399228538.

# Tests
* Ran with maxtext_xpk_runner
* [logs](https://cloudlogging.app.goo.gl/BqnAfPEcM3egDxG78)
* [trace](https://xprof.corp.google.com/trace_viewer/mattdavidow-9149198018298669358?hosts=gke-tpu-c739aac2-stmp&host_index=0&trace_filter_config={})
Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
