### PR TITLE
Supporting LoRA in MaxText for inference only, to support multi-LoRA adapters inferencing via JetStream.

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -31,6 +31,10 @@ normalization_layer_epsilon: 1.e-05
 # Loads a just parameters from a specific directory
 # e.g. gs://my-base-output-directory/my-previous-run-name/checkpoints/items/NUMBER or NUMBER/items
 load_parameters_path: ""
+
+# LoRA adapter support configs
+lora_input_adapters_path: ""    # Input GCS path for a parent directory which has all the LoRA adapters (lora_id as subdir)
+
 # Loads a full checkpoint including optimizer state and step count from a specific directory
 # e.g. gs://my-base-output-directory/my-previous-run-name/checkpoints/items/NUMBER or NUMBER/items
 load_full_state_path: ""
@@ -547,6 +551,7 @@ inference_metadata_file: "" # path to a json file
 inference_server: "MaxtextInterleavedServer"  # inference server to start
 inference_benchmark_test: False
 enable_model_warmup: False
+enable_llm_inference_pool: False          # Bool to launch inference server for llm_inference_gateway with their specified APIs
 multi_sampling: False
 
 # Stack prefill cache across the layer to reduce the

--- a/MaxText/llama_or_mistral_ckpt.py
+++ b/MaxText/llama_or_mistral_ckpt.py
@@ -36,6 +36,7 @@ import os
 import gc
 import re
 import logging
+import json
 from dataclasses import dataclass
 
 os.environ["JAX_PLATFORMS"] = "cpu"
@@ -49,10 +50,11 @@ import psutil
 from tqdm import tqdm
 
 import max_logging
+import max_utils
 from train import save_checkpoint
 import checkpointing
 from safetensors import safe_open
-import max_utils
+from utils import gcs_utils
 
 MODEL_PARAMS_DICT = {
     "llama2-70b": {
@@ -175,6 +177,15 @@ def _hf_mapping(layer_idx: int = -1, expert_idx: int = -1) -> dict:
       f"layers.{layer_idx}.feed_forward.w1.weight": f"model.layers.{layer_idx}.mlp.gate_proj.weight",
       f"layers.{layer_idx}.feed_forward.w2.weight": f"model.layers.{layer_idx}.mlp.down_proj.weight",
       f"layers.{layer_idx}.feed_forward.w3.weight": f"model.layers.{layer_idx}.mlp.up_proj.weight",
+      # LoRA Adapter
+      f"layers.{layer_idx}.attention.wq.lora_A.weights": f"base_model.model.model.layers.{layer_idx}.self_attn.q_proj.lora_A.weight",
+      f"layers.{layer_idx}.attention.wq.lora_B.weights": f"base_model.model.model.layers.{layer_idx}.self_attn.q_proj.lora_B.weight",
+      f"layers.{layer_idx}.attention.wk.lora_A.weights": f"base_model.model.model.layers.{layer_idx}.self_attn.k_proj.lora_A.weight",
+      f"layers.{layer_idx}.attention.wk.lora_B.weights": f"base_model.model.model.layers.{layer_idx}.self_attn.k_proj.lora_B.weight",
+      f"layers.{layer_idx}.attention.wv.lora_A.weights": f"base_model.model.model.layers.{layer_idx}.self_attn.v_proj.lora_A.weight",
+      f"layers.{layer_idx}.attention.wv.lora_B.weights": f"base_model.model.model.layers.{layer_idx}.self_attn.v_proj.lora_B.weight",
+      f"layers.{layer_idx}.attention.wo.lora_A.weights": f"base_model.model.model.layers.{layer_idx}.self_attn.o_proj.lora_A.weight",
+      f"layers.{layer_idx}.attention.wo.lora_B.weights": f"base_model.model.model.layers.{layer_idx}.self_attn.o_proj.lora_B.weight",
   }
 
 
@@ -190,6 +201,7 @@ def _hf_to_maxtext_mapping(layer_idx: int = -1, expert_idx: int = -1) -> dict:
       f"model.layers.{layer_idx}.self_attn.k_proj.weight": f"layers.{layer_idx}.attention.wk.weight",
       f"model.layers.{layer_idx}.self_attn.v_proj.weight": f"layers.{layer_idx}.attention.wv.weight",
       f"model.layers.{layer_idx}.self_attn.o_proj.weight": f"layers.{layer_idx}.attention.wo.weight",
+      f"model.layers.{layer_idx}.self_attn.rotary_emb.inv_freq": f"layers.{layer_idx}.attention.rotary_emb.inv_freq",
       # MOE model
       f"model.layers.{layer_idx}.block_sparse_moe.gate.weight": f"layers.{layer_idx}.feed_forward.gate.weight",
       f"model.layers.{layer_idx}.block_sparse_moe.experts.{expert_idx}.w1.weight": f"layers.{layer_idx}.feed_forward.experts.{expert_idx}.w1.weight",
@@ -230,6 +242,202 @@ def permute_to_match_maxtext_rope(arr):
   return np.concatenate((evens, odds), axis=arr.ndim - 1)
 
 
+# pylint: disable=too-many-positional-arguments
+def initialize_self_attention_lora_kernels(
+    self_attention_lora,
+    lora_chkpt_vars,
+    key_prefix,
+    stack_shape,
+    module_name,
+    layer_idx,
+    reshape_a=False,
+    shape_a=None,
+    reshape_b=False,
+    shape_b=None,
+):
+  """Helper function to intialize LoRA kernels for given target module."""
+
+  lora_A = lora_chkpt_vars[f"{key_prefix}.lora_A.weights"].type(torch.float16).numpy().transpose()
+  lora_B = lora_chkpt_vars[f"{key_prefix}.lora_B.weights"].type(torch.float16).numpy().transpose()
+
+  if reshape_a:
+    lora_A = np.reshape(lora_A, shape_a)
+  if reshape_b:
+    lora_B = np.reshape(lora_B, shape_b)
+
+  if self_attention_lora[module_name]["lora_a.kernel"] is None:
+    self_attention_lora[module_name]["lora_a.kernel"] = np.zeros(stack_shape + lora_A.shape, dtype=np.float16)
+    self_attention_lora[module_name]["lora_b.kernel"] = np.zeros(stack_shape + lora_B.shape, dtype=np.float16)
+
+  self_attention_lora[module_name]["lora_a.kernel"][layer_idx, ...] = lora_A  # pylint: disable=E1137
+  self_attention_lora[module_name]["lora_b.kernel"][layer_idx, ...] = lora_B  # pylint: disable=E1137
+
+
+def convert_lora_weights_to_jax_weights(lora_config, model_size):
+  """
+  Function to convert the loRA checkpoints at lora_model_path into Orbax checkpoints
+  for MaxText.
+
+  Attributes:
+  lora_config: Configuration of the LoRA adapter along with lora_model_path
+  model_size: llama2-7b to 70b, mistral-7b, or mixtral-8-7b, mixtral-8x22b
+  """
+  model_params = MODEL_PARAMS_DICT[model_size]
+  base_num_decoder_layers = model_params["num_layers"]
+  base_num_query_heads = model_params["num_heads"]
+  head_dim = model_params["dims_per_head"]
+  mem_info = psutil.Process()
+  logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
+
+  max_logging.log(f"Loading the lora  model from {lora_config['lora_model_path']}")
+  # Load LoRA model weights
+  lora_chkpt_vars = torch.load(lora_config["lora_model_path"])
+  lora_chkpt_vars = _HFNamespaceMapper(lora_chkpt_vars)
+
+  jax_weights_lora = {
+      "decoder": {
+          "layers": {
+              "mlp": {
+                  "wi_0": {
+                      "lora_a.kernel": None,
+                      "lora_b.kernel": None,
+                  },
+                  "wi_1": {
+                      "lora_a.kernel": None,
+                      "lora_b.kernel": None,
+                  },
+                  "wo": {
+                      "lora_a.kernel": None,
+                      "lora_b.kernel": None,
+                  },
+              },
+              "pre_self_attention_layer_norm": {"scale": None},
+              "post_self_attention_layer_norm": {"scale": None},
+              "self_attention": {},
+          },
+          "decoder_norm": {"scale": None},
+          "logits_dense": {"kernel": None},
+      },
+      "token_embedder": {"embedding": None},
+  }
+
+  # self attention ###############################################
+  self_attention_lora = {
+      "query": {
+          "lora_a.kernel": None,
+          "lora_b.kernel": None,
+      },
+      "key": {
+          "lora_a.kernel": None,
+          "lora_b.kernel": None,
+      },
+      "value": {
+          "lora_a.kernel": None,
+          "lora_b.kernel": None,
+      },
+      "out": {
+          "lora_a.kernel": None,
+          "lora_b.kernel": None,
+      },
+  }
+
+  lora_target_modules = lora_config["target_modules"]
+  lora_rank = int(lora_config["r"])
+  stack_shape = (base_num_decoder_layers,)
+
+  for layer_idx in range(base_num_decoder_layers):
+    for target_module in lora_target_modules:
+      if "q_proj" in target_module:
+        initialize_self_attention_lora_kernels(
+            self_attention_lora=self_attention_lora,
+            lora_chkpt_vars=lora_chkpt_vars,
+            key_prefix=f"layers.{layer_idx}.attention.wq",
+            stack_shape=stack_shape,
+            reshape_b=True,
+            shape_b=[lora_rank, base_num_query_heads, head_dim],
+            layer_idx=layer_idx,
+            module_name="query",
+        )
+
+      if "k_proj" in target_module:
+        initialize_self_attention_lora_kernels(
+            self_attention_lora=self_attention_lora,
+            lora_chkpt_vars=lora_chkpt_vars,
+            key_prefix=f"layers.{layer_idx}.attention.wk",
+            stack_shape=stack_shape,
+            reshape_b=True,
+            shape_b=[lora_rank, base_num_query_heads, head_dim],
+            layer_idx=layer_idx,
+            module_name="key",
+        )
+
+      if "v_proj" in target_module:
+        initialize_self_attention_lora_kernels(
+            self_attention_lora=self_attention_lora,
+            lora_chkpt_vars=lora_chkpt_vars,
+            key_prefix=f"layers.{layer_idx}.attention.wv",
+            stack_shape=stack_shape,
+            reshape_b=True,
+            shape_b=[lora_rank, base_num_query_heads, head_dim],
+            layer_idx=layer_idx,
+            module_name="value",
+        )
+
+      if "o_proj" in target_module:
+        lora_A_o = lora_chkpt_vars[f"layers.{layer_idx}.attention.wo.lora_A.weights"].type(torch.float16).numpy()
+        lora_B_o = lora_chkpt_vars[f"layers.{layer_idx}.attention.wo.lora_B.weights"].type(torch.float16).numpy()
+
+        # This is for "out" matrix. So we don't transpose it above as well as here
+        # we have to reshape the lora_A_o instead of lora_B_o.
+        lora_A_o = np.reshape(lora_A_o, [lora_rank, base_num_query_heads, head_dim])
+
+        if self_attention_lora["out"]["lora_a.kernel"] is None:
+          self_attention_lora["out"]["lora_a.kernel"] = np.zeros(stack_shape + lora_A_o.shape, dtype=np.float16)
+          self_attention_lora["out"]["lora_b.kernel"] = np.zeros(stack_shape + lora_B_o.shape, dtype=np.float16)
+
+        self_attention_lora["out"]["lora_a.kernel"][layer_idx, ...] = lora_A_o  # pylint: disable=E1137
+        self_attention_lora["out"]["lora_b.kernel"][layer_idx, ...] = lora_B_o  # pylint: disable=E1137# pylint: disable=E1137
+
+  if self_attention_lora["query"]["lora_a.kernel"] is not None:
+    self_attention_lora["query"]["lora_a.kernel"] = np.transpose(
+        self_attention_lora["query"]["lora_a.kernel"], axes=(1, 0, 2)
+    )
+    self_attention_lora["query"]["lora_b.kernel"] = np.transpose(
+        self_attention_lora["query"]["lora_b.kernel"], axes=(1, 0, 2, 3)
+    )
+
+  if self_attention_lora["key"]["lora_a.kernel"] is not None:
+    self_attention_lora["key"]["lora_a.kernel"] = np.transpose(self_attention_lora["key"]["lora_a.kernel"], axes=(1, 0, 2))
+    self_attention_lora["key"]["lora_b.kernel"] = np.transpose(
+        self_attention_lora["key"]["lora_b.kernel"], axes=(1, 0, 2, 3)
+    )
+
+  if self_attention_lora["value"]["lora_a.kernel"] is not None:
+    self_attention_lora["value"]["lora_a.kernel"] = np.transpose(
+        self_attention_lora["value"]["lora_a.kernel"], axes=(1, 0, 2)
+    )
+    self_attention_lora["value"]["lora_b.kernel"] = np.transpose(
+        self_attention_lora["value"]["lora_b.kernel"], axes=(1, 0, 2, 3)
+    )
+
+  if self_attention_lora["out"]["lora_a.kernel"] is not None:
+    self_attention_lora["out"]["lora_a.kernel"] = np.transpose(
+        self_attention_lora["out"]["lora_a.kernel"], axes=(2, 0, 3, 1)
+    )
+    self_attention_lora["out"]["lora_b.kernel"] = np.transpose(self_attention_lora["out"]["lora_b.kernel"], axes=(1, 0, 2))
+
+  # Not sure if I need to scale the lora query weights by dividing it by np.sqrt(head_dim). Validate it later.
+
+  jax_weights_lora["decoder"]["layers"]["self_attention"] = self_attention_lora
+
+  del lora_chkpt_vars
+  gc.collect()
+
+  logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
+
+  return jax_weights_lora
+
+
 def _convert_huggingface_to_jax_weights(base_model_path, model_size, model_params, mem_info):
   """Convert Huggingface Checkpoint to Jax."""
   base_num_decoder_layers = model_params["num_layers"]
@@ -239,6 +447,7 @@ def _convert_huggingface_to_jax_weights(base_model_path, model_size, model_param
   vocab_size = model_params["vocab"]
   num_experts = model_params["num_experts"] if "num_experts" in model_params else None
 
+  max_logging.log(f"Loading the base model from {base_model_path}")
   ckpt_paths = sorted(pathlib.Path(base_model_path).glob("[!.]*.safetensors"))
   chkpt_vars = {}
   for i, ckpt_path in enumerate(ckpt_paths):
@@ -811,11 +1020,35 @@ def save_jax_weights_to_checkpoint(maxtext_model_path, jax_weights):
     checkpoint_manager.wait_until_finished()
 
 
+def list_folders_pathlib(directory):
+  """Lists folders in a directory using pathlib module.
+
+  Args:
+    directory: The path to the directory
+
+  Returns:
+    A list of strings, where each string is the name of a folder.
+    Returns an empty list if the directory doesn't exist or is not a directory.
+  """
+  dir_path = pathlib.Path(directory)
+
+  if not dir_path.is_dir():
+    return []
+
+  folders = []
+  for item in dir_path.iterdir():
+    if item.is_dir():
+      folders.append(item.name)  # Append only the name
+
+  return folders
+
+
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   parser.add_argument("--base-model-path", type=str, required=True)
   parser.add_argument("--maxtext-model-path", type=str, required=True)
   parser.add_argument("--model-size", type=str, required=True)
+  parser.add_argument("--lora-input-adapters-path", type=str, required=False)
   parser.add_argument("--huggingface-checkpoint", type=bool, required=False, default=False)
   args = parser.parse_args()
 
@@ -823,6 +1056,47 @@ if __name__ == "__main__":
     raise NotImplementedError
 
   os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={SIMULATED_CPU_DEVICES_COUNT}"
+
+  base_weights_path = args.maxtext_model_path
+
+  if args.lora_input_adapters_path:
+    base_weights_path += "/base"
+
   save_jax_weights_to_checkpoint(
-      args.maxtext_model_path, convert_to_jax_weights(args.base_model_path, args.model_size, args.huggingface_checkpoint)
+      base_weights_path, convert_to_jax_weights(args.base_model_path, args.model_size, args.huggingface_checkpoint)
   )
+  max_logging.log(f"Successfully saved base_weights to {base_weights_path}.")
+
+  if args.lora_input_adapters_path:
+    max_logging.log(f"LoRA Adapters Path = {args.lora_input_adapters_path}")
+    if args.lora_input_adapters_path.startswith("gs://"):
+      max_logging.log("GCS Source path for the LoRA adapters is not supported as of now.")
+      raise NotImplementedError
+
+    lora_ids = list_folders_pathlib(args.lora_input_adapters_path)
+
+    for lora_id in lora_ids:
+      lora_path = f"{args.lora_input_adapters_path}/{lora_id}"
+      lora_config_path = f"{lora_path}/adapter_config.json"
+
+      if not os.path.exists(lora_config_path):
+        max_logging.log(f"Ignoring {lora_id} adapter because its directory doesn't have adapter_config.json.")
+        continue
+
+      with open(lora_config_path, "r", encoding="utf8") as file:
+        lora_config_dict = json.load(file)
+
+        if lora_config_dict is not None:
+          lora_model_path = f"{lora_path}/adapter_model.bin"
+          lora_config_dict["lora_model_path"] = lora_model_path
+
+          jax_lora_weights = convert_lora_weights_to_jax_weights(lora_config_dict, args.model_size)
+
+          del lora_config_dict["lora_model_path"]
+
+          lora_output_gcs_path = f"{args.maxtext_model_path}/loras/{lora_id}"
+
+          save_jax_weights_to_checkpoint(lora_output_gcs_path, jax_lora_weights)
+          gcs_utils.write_dict_to_gcs_json(lora_config_dict, f"{lora_output_gcs_path}/adapter_config.json")
+
+          max_logging.log(f"Successfully saved lora_weights to {lora_output_gcs_path}.")

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 """ Common Max Utils needed by multiple modules"""
-import shutil
 import numpy as np
 import jax
 import jax.numpy as jnp
@@ -26,6 +25,7 @@ import functools
 import time
 import optax
 import os
+import psutil
 import socket
 import subprocess
 from etils import epath
@@ -41,14 +41,12 @@ import orbax.checkpoint.experimental.emergency.checkpoint_manager as emergency_c
 import orbax.checkpoint.experimental.emergency.replicator_checkpoint_manager as emergency_replicator_checkpoint_manager
 
 
-import yaml
 import flax
 from flax.training import train_state
 from flax import linen as nn
 from flax.linen import partitioning as nn_partitioning
 
 from tensorboardX import writer
-from google.cloud import storage
 
 HYBRID_RING_64X4 = "hybrid_ring_64x4"
 HYBRID_RING_32X8 = "hybrid_ring_32x8"
@@ -130,74 +128,6 @@ def add_text_to_summary_writer(key, value, summary_writer):
   """Writes given key-value pair to tensorboard as text/summary"""
   if jax.process_index() == 0:
     summary_writer.add_text(key, value)
-
-
-def write_config_raw_keys_for_gcs(raw_keys):
-  """Writes config raw keys to GCS"""
-  if not raw_keys["save_config_to_gcs"] or jax.process_index() != 0:
-    return
-  max_logging.log("Writing config to GCS...")
-
-  raw_keys_dict = dict(raw_keys)
-  filename = "config.yml"
-  with open(filename, "w", encoding="utf8") as config_for_gcs:
-    yaml.dump(raw_keys_dict, config_for_gcs)
-  config_for_gcs.close()
-
-  gcs_filename = os.path.join(raw_keys["base_output_directory"], raw_keys["run_name"], filename)
-  max_logging.log(f"Moving file {filename} to GCS...")
-  upload_blob(gcs_filename, filename)
-  max_logging.log(f"File {filename} moved successfully!")
-
-
-def parse_gcs_bucket_and_prefix(destination_gcs_name):
-  path_parts = destination_gcs_name.replace("gs://", "").split("/")
-  bucket = path_parts.pop(0)
-  key = "/".join(path_parts)
-  return bucket, key
-
-
-def add_trailing_slash(path):
-  if not path.endswith("/"):
-    return path + "/"
-  return path
-
-
-def upload_blob(destination_gcs_name, source_file_name):
-  """Uploads a file to a GCS location"""
-  bucket_name, prefix_name = parse_gcs_bucket_and_prefix(destination_gcs_name)
-  storage_client = storage.Client()
-  bucket = storage_client.get_bucket(bucket_name)
-  blob = bucket.blob(prefix_name)
-  blob.upload_from_filename(source_file_name)
-
-
-def upload_dump(local_dir, target_dir, module_name=None, delete_local_after=True, all_host_upload=False):
-  """Uploads a directory to a GCS location, with an optional filter"""
-  if not all_host_upload and jax.process_index() != 0:
-    return
-  storage_client = storage.Client()
-  bucket_name, prefix_name = parse_gcs_bucket_and_prefix(target_dir)
-  bucket = storage_client.get_bucket(bucket_name)
-  if all_host_upload:
-    hostname = socket.gethostname()  # Alternatively can use jax.process_id()
-    prefix_name = os.path.join(prefix_name, hostname)
-    target_dir = os.path.join(target_dir, hostname)
-  max_logging.log(f"Uploading HLO Dump to {target_dir}...")
-  for root, _, files in os.walk(local_dir):
-    for file in files:
-      if module_name and module_name not in file:
-        continue
-      else:
-        max_logging.log(f"Uploading {file}")
-      local_path = os.path.join(root, file)
-      relative_path = os.path.relpath(local_path, local_dir)
-      blob_name = os.path.join(prefix_name, relative_path)
-      blob = bucket.blob(blob_name)
-      blob.upload_from_filename(local_path)
-  max_logging.log(f"HLO Dump Uploaded to {target_dir}!")
-  if delete_local_after:
-    shutil.rmtree(local_dir)
 
 
 def maybe_initialize_jax_distributed_system(raw_keys):
@@ -1106,6 +1036,21 @@ def print_mem_stats(label: str):
       max_logging.log(f"\tUsing (GB) {used} / {limit} ({used/limit:%}) on {d}")
   except (RuntimeError, KeyError, TypeError) as ex:
     max_logging.log(f"\tMemstats unavailable, error: {ex}")
+
+
+def print_cpu_ram_stats(label: str):
+  """Print stats of CPU RAM usage/availability."""
+  max_logging.log(f"\nRAMstats: {label}:")
+  try:
+    ram = psutil.virtual_memory()
+
+    total = round(ram.total / 2**30, 2)
+    available = round(ram.available / 2**30, 2)
+    used = round(ram.used / 2**30, 2)
+
+    max_logging.log(f"\tUsing (GB) {used} / {total} ({used/total:%}) -->  Available:{available}")
+  except (RuntimeError, KeyError, TypeError) as ex:
+    max_logging.log(f"\tRAM stats unavailable, error: {ex}")
 
 
 def print_system_information():

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -35,6 +35,7 @@ from jetstream.engine import engine_api
 from jetstream.engine import tokenizer_pb2
 from jetstream.engine import tokenizer_api
 from jetstream.engine import token_utils
+from utils import lora_utils
 
 import max_utils
 import inference_utils
@@ -102,6 +103,10 @@ class MaxEngine(engine_api.Engine):
     self.decode_state_shapes = None
     self.decode_state_layouts = None
     self.param_layouts = None
+
+  def print_stats(self, label: str):
+    max_utils.print_mem_stats(label)
+    max_utils.print_cpu_ram_stats(label)
 
   def generate_aot(
       self, params: Params, decode_state: DecodeState, rng: Optional[PRNGKeyType] = None
@@ -224,8 +229,33 @@ class MaxEngine(engine_api.Engine):
       params = self.quantize_params(state, rng3)
     else:
       params = state.params
-    max_utils.print_mem_stats("After load_params")
+
+    self.print_stats("After load_params")
+
     return params
+
+  def load_single_adapter(self, adapter_path):
+    """
+    Load Single adapter from adapter_path.
+    Expect adapter_config.json and LoRA adapter weights at this path within subdirectory `/0/items`.
+    """
+    adapter_config_path = f"{adapter_path}/adapter_config.json"
+    adapter_weights_path = f"{adapter_path}/0/items"
+
+    params, config = lora_utils.load_adapter(self.config, self.abstract_params, adapter_config_path, adapter_weights_path)
+
+    config["adapter_path"] = adapter_weights_path
+
+    self.print_stats("After load_single_adapter.")
+
+    return params, config
+
+  def apply_adapter(self, base_params, adapter_config, adapter_params):
+    """Apply the adapter params on the base params."""
+
+    lora_rank = int(adapter_config["r"])
+    lora_scale_factor = float(adapter_config["lora_alpha"]) / lora_rank
+    lora_utils.apply_lora_on_base_params(base_params, adapter_params, lora_scale_factor)
 
   def quantize_params(self, state, rng: Optional[PRNGKeyType] = None):
     """Forward pass to quantize decode params."""

--- a/MaxText/maxengine_server.py
+++ b/MaxText/maxengine_server.py
@@ -56,6 +56,7 @@ def main(config):
       enable_jax_profiler=config.enable_jax_profiler if config.enable_jax_profiler else False,
       jax_profiler_port=config.jax_profiler_port if config.jax_profiler_port else 9999,
       enable_model_warmup=config.enable_model_warmup if config.enable_model_warmup else False,
+      enable_llm_inference_pool=config.enable_llm_inference_pool if config.enable_llm_inference_pool else False,
       multi_sampling=config.multi_sampling if config.multi_sampling else False,
   )
   jetstream_server.wait_for_termination()

--- a/MaxText/metric_logger.py
+++ b/MaxText/metric_logger.py
@@ -23,7 +23,7 @@ import os
 import numpy as np
 
 import max_logging
-import max_utils
+from utils import gcs_utils
 
 
 def _prepare_metrics_for_json(metrics, step, run_name):
@@ -98,7 +98,7 @@ class MetricLogger:
 
       gcs_filename = os.path.join(self.config.metrics_dir, metrics_filename)
       max_logging.log(f"Moving file {metrics_filename} to GCS...")
-      max_utils.upload_blob(gcs_filename, metrics_filename)
+      gcs_utils.upload_blob(gcs_filename, metrics_filename)
       max_logging.log(f"File {metrics_filename} moved successfully!")
       running_metrics = []  # reset running_metrics to empty list
     return running_metrics

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -25,6 +25,7 @@ from typing import Any, Union
 import jax
 from jax.experimental.compilation_cache import compilation_cache
 from layers.attentions import AttentionType
+from utils import gcs_utils
 import accelerator_to_spec_map
 import max_logging
 import max_utils
@@ -480,7 +481,7 @@ class _HyperParameters:
       max_logging.log("Override add_bos and add_eos to False when dataset_type=c4_mlperf")
 
     # Write raw_keys to GCS before type conversions
-    max_utils.write_config_raw_keys_for_gcs(raw_keys)
+    gcs_utils.write_config_raw_keys_for_gcs(raw_keys)
 
     # Type conversions
     raw_keys["dtype"] = jax.numpy.dtype(raw_keys["dtype"])
@@ -575,7 +576,7 @@ def validate_and_set_hlo_dump_defaults(raw_keys):
   if not raw_keys["dump_hlo_gcs_dir"]:
     raw_keys["dump_hlo_gcs_dir"] = os.path.join(raw_keys["base_output_directory"], raw_keys["run_name"], "xla_dump")
   else:
-    raw_keys["dump_hlo_gcs_dir"] = max_utils.add_trailing_slash(raw_keys["dump_hlo_gcs_dir"])
+    raw_keys["dump_hlo_gcs_dir"] = gcs_utils.add_trailing_slash(raw_keys["dump_hlo_gcs_dir"])
   if not os.environ.get("XLA_FLAGS"):
     os.environ["XLA_FLAGS"] = raw_keys["dump_hlo_xla_flags"]
   return raw_keys

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -49,6 +49,7 @@ import pathwaysutils  # pylint: disable=unused-import
 import tensorflow as tf
 
 from metric_logger import MetricLogger
+from utils import gcs_utils
 
 from vertex_tensorboard import VertexTensorboardManager
 # Placeholder: internal
@@ -842,7 +843,7 @@ def train_loop(config, state=None):
 
     if config.dump_hlo and step == (config.dump_step if config.dump_step >= 0 else start_step):
       jax.block_until_ready(state)  # Ensure compilation has finished.
-      max_utils.upload_dump(
+      gcs_utils.upload_dump(
           config.dump_hlo_local_dir,
           config.dump_hlo_gcs_dir,
           module_name=config.dump_hlo_module_name,

--- a/MaxText/train_compile.py
+++ b/MaxText/train_compile.py
@@ -36,6 +36,7 @@ from layers import models
 from layers import quantizations
 from typing import Sequence
 from absl import app
+from utils import gcs_utils
 import os
 import pickle
 import accelerator_to_spec_map
@@ -184,7 +185,7 @@ def main(argv: Sequence[str]) -> None:
 
   # Dump HLO if requested
   if config.dump_hlo:
-    max_utils.upload_dump(
+    gcs_utils.upload_dump(
         config.dump_hlo_local_dir,
         config.dump_hlo_gcs_dir,
         module_name=config.dump_hlo_module_name,

--- a/MaxText/utils/gcs_utils.py
+++ b/MaxText/utils/gcs_utils.py
@@ -1,0 +1,193 @@
+"""
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+""" Common GCS Utils needed by multiple modules"""
+import shutil
+import jax
+import json
+import os
+import socket
+import yaml
+from pathlib import Path
+
+import max_logging
+from google.cloud import storage
+
+
+def write_config_raw_keys_for_gcs(raw_keys):
+  """Writes config raw keys to GCS"""
+  if not raw_keys["save_config_to_gcs"] or jax.process_index() != 0:
+    return
+  max_logging.log("Writing config to GCS...")
+
+  raw_keys_dict = dict(raw_keys)
+  filename = "config.yml"
+  with open(filename, "w", encoding="utf8") as config_for_gcs:
+    yaml.dump(raw_keys_dict, config_for_gcs)
+  config_for_gcs.close()
+
+  gcs_filename = os.path.join(raw_keys["base_output_directory"], raw_keys["run_name"], filename)
+  max_logging.log(f"Moving file {filename} to GCS...")
+  upload_blob(gcs_filename, filename)
+  max_logging.log(f"File {filename} moved successfully!")
+
+
+def parse_gcs_bucket_and_prefix(destination_gcs_name):
+  path_parts = destination_gcs_name.replace("gs://", "").split("/")
+  bucket = path_parts.pop(0)
+  key = "/".join(path_parts)
+  return bucket, key
+
+
+def add_trailing_slash(path):
+  if not path.endswith("/"):
+    return path + "/"
+  return path
+
+
+def upload_blob(destination_gcs_name, source_file_name):
+  """Uploads a file to a GCS location"""
+  bucket_name, prefix_name = parse_gcs_bucket_and_prefix(destination_gcs_name)
+  storage_client = storage.Client()
+  bucket = storage_client.get_bucket(bucket_name)
+  blob = bucket.blob(prefix_name)
+  blob.upload_from_filename(source_file_name)
+
+
+def upload_dump(local_dir, target_dir, module_name=None, delete_local_after=True, all_host_upload=False):
+  """Uploads a directory to a GCS location, with an optional filter"""
+  if not all_host_upload and jax.process_index() != 0:
+    return
+  storage_client = storage.Client()
+  bucket_name, prefix_name = parse_gcs_bucket_and_prefix(target_dir)
+  bucket = storage_client.get_bucket(bucket_name)
+  if all_host_upload:
+    hostname = socket.gethostname()  # Alternatively can use jax.process_id()
+    prefix_name = os.path.join(prefix_name, hostname)
+    target_dir = os.path.join(target_dir, hostname)
+  max_logging.log(f"Uploading HLO Dump to {target_dir}...")
+  for root, _, files in os.walk(local_dir):
+    for file in files:
+      if module_name and module_name not in file:
+        continue
+      else:
+        max_logging.log(f"Uploading {file}")
+      local_path = os.path.join(root, file)
+      relative_path = os.path.relpath(local_path, local_dir)
+      blob_name = os.path.join(prefix_name, relative_path)
+      blob = bucket.blob(blob_name)
+      blob.upload_from_filename(local_path)
+  max_logging.log(f"HLO Dump Uploaded to {target_dir}!")
+  if delete_local_after:
+    shutil.rmtree(local_dir)
+
+
+def gcs_path_exists(file_path):
+  """Checks if a GCS file_path exits."""
+  try:
+    storage_client = storage.Client()
+    bucket_name, file_name = parse_gcs_bucket_and_prefix(file_path)
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(file_name)
+
+    return blob.exists()
+  except Exception as e:
+    print(f"Error while accessing {file_path} from GCE: {str(e)}")
+    return False
+
+
+def gcs_list_directories(directory_path):
+  """
+  Lists "directories" (prefixes one level down) within a GCS "directory".
+
+  Args:
+      directory_path: The prefix representing the parent "directory".
+
+  Returns:
+      A list of "directory" names (prefixes).
+  """
+  storage_client = storage.Client()
+  bucket_name, directory_prefix = parse_gcs_bucket_and_prefix(directory_path)
+  bucket = storage_client.bucket(bucket_name)
+
+  # Ensures the prefix has a trailing slash to simulate a directory
+  if not directory_prefix.endswith("/"):
+    directory_prefix += "/"
+
+  # Use list_blobs with a delimiter to get "directories"
+  delimiter = "/"
+  blobs = bucket.list_blobs(prefix=directory_prefix, delimiter=delimiter)
+
+  directories = []
+  # Iterate through the blobs and extract the "directories"
+  for page in blobs.pages:
+    for prefix in page.prefixes:
+      path_obj = Path(prefix)
+
+      directory = path_obj.name
+
+      directories.append(directory)
+
+  return directories
+
+
+def read_json_from_gcs(file_path):
+  """
+  Read a json file from gcs bucket.
+
+  Args:
+    file_path: The gcs path of the json file.
+
+  Returns:
+    A dictionary with content from json file.
+  """
+  try:
+    storage_client = storage.Client()
+    bucket_name, file_prefix = parse_gcs_bucket_and_prefix(file_path)
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(file_prefix)
+
+    json_string = blob.download_as_string()
+
+    data = json.loads(json_string)
+
+    return data
+  except Exception as e:
+    print(f"Error reading JSON file from GCS: {str(e)}")
+    return None
+
+
+def write_dict_to_gcs_json(data_dict, file_path):
+  """
+  Writes a Python dictionary to a JSON file in GCS.
+
+  Args:
+    data_dict: The Python dictionary to write
+    file_path: GCS path (Bucket + blob) to create the json file
+  """
+  try:
+    storage_client = storage.Client()
+    bucket_name, file_prefix = parse_gcs_bucket_and_prefix(file_path)
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(file_prefix)
+
+    # Convert the dictionary to a JSON string
+    json_string = json.dumps(data_dict, indent=4)
+
+    # Upload the JSON string to GCS
+    blob.upload_from_string(json_string, content_type="application/json")
+  except Exception as e:
+    print(f"Failed to write json file at {file_path} with error: {str(e)}")

--- a/MaxText/utils/lora_utils.py
+++ b/MaxText/utils/lora_utils.py
@@ -1,0 +1,304 @@
+"""
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+""" Common LoRA utils needed to support LoRA adapters."""
+
+import checkpointing
+import os
+import json
+import jax
+import jax.numpy as jnp
+from flax.training import train_state
+from flax.linen import partitioning as nn_partitioning
+
+import max_utils
+import max_logging
+from utils import gcs_utils
+
+
+def apply_lora_on_base_params(base_params, lora_params, lora_scale_factor=1.0):
+  """
+  Apply the LoRA weights on the base weights of the model using formula:
+                W_new = W + BA, where
+                    W_new is the new weights with LoRA applied
+                    W is the base model weights
+                    B is lora_b adapter weights
+                    A is lora_a adapter weights
+
+  Here both the base_params and lora_params are PyTrees of same structure depending
+  on the base model. The leaf nodes of lora_params are only not-None if it is the target
+  module for lora in its config.
+  """
+
+  def lora_update_or_base(base_weight, lora_a, lora_b):
+    if lora_a is not None and lora_b is not None:
+      return base_weight + jnp.einsum("br,rnd->bnd", lora_b, lora_a) * lora_scale_factor
+    else:
+      return base_weight  # Keep the base weight if no Lora update
+
+  def apply_lora_recursively(base_params, lora_params, module_name):
+    for name, param in lora_params.items():
+      if isinstance(param, dict):
+        apply_lora_recursively(base_params[name], param, f"{module_name}.{name}")
+      elif param is not None:
+        if name not in ["lora_a.kernel", "lora_b.kernel"]:
+          raise ValueError(f"Unexpected non-lora specific weights ({module_name}.{name}) found in the lora_params")
+
+        lora_b = lora_params["lora_a.kernel"]
+        lora_a = lora_params["lora_b.kernel"]
+
+        base = base_params["kernel"]
+
+        base_params["kernel"] = lora_update_or_base(base, lora_a, lora_b)
+        break
+
+  apply_lora_recursively(base_params, lora_params, "")
+
+
+def load_adapter(config, base_abstract_state_params, adapter_config_path, adapter_weights_path):
+  """
+  Load the LoRA weights into a PyTree and return it.
+  """
+  # Load LoRA weights
+  lora_params = None
+  lora_config = None
+  if adapter_config_path:
+    if adapter_config_path.startswith("gs://"):
+      lora_config = gcs_utils.read_json_from_gcs(adapter_config_path)
+    else:
+      with open(adapter_config_path, "r") as f:
+        lora_config = json.load(f)
+
+    if lora_config is None:
+      max_logging.log(f"Failed to read lora_config from {adapter_config_path}.")
+      return None, None
+
+    if not gcs_utils.gcs_path_exists(f"{adapter_weights_path}/commit_success.txt"):
+      max_logging.log(f"Failed to read lora_weights from {adapter_weights_path}.")
+      return None, None
+
+    lora_state, _ = get_lora_abstract_state(base_abstract_state_params, lora_config)
+
+    with nn_partitioning.axis_rules(config.logical_axis_rules):
+      lora_params = checkpointing.load_params_from_path(
+          adapter_weights_path, lora_state.params, config.checkpoint_storage_concurrent_gb
+      )
+
+  return lora_params, lora_config
+
+
+def setup_initial_lora_state(model, data_iterator, tx, config, rng, mesh, checkpoint_manager, lora_adapter_path):
+  """We initialize the model and optimizer state, and optionally load from a
+  checkpoint as necessary.
+
+  Args:
+    model: the flax model to initialize
+    tx: the optax.GradientTransformation
+    config: config object
+    rng: jax.prng key
+    mesh: jax.devices() mesh
+    checkpoint_manager: an Orbax checkpointing.CheckpointManager object
+    lora_adapter_path: Path of the LoRA adapter which is expected to have
+        `adapter_config.json` and adapter weights
+
+  Returns:
+    state: the initialized train state
+    state_mesh_annotations: the mesh annotations for the train state
+  """
+
+  lora_state = None
+  lora_state_annotations = None
+  lora_config = None
+
+  if lora_adapter_path:
+    max_logging.log(f"Setting initial state of LoRA with lora_adapter_path = {lora_adapter_path}")
+    unboxed_abstract_state, state_mesh_annotations, state_mesh_shardings = max_utils.get_abstract_state(
+        model, tx, config, rng, mesh, True
+    )
+
+    lora_config_path = lora_adapter_path + "adapter_config.json"
+
+    lora_config = gcs_utils.read_json_from_gcs(lora_config_path)
+
+    lora_state, lora_state_annotations = get_lora_abstract_state(unboxed_abstract_state.params, lora_config)
+
+    lora_weights_path = f"{lora_adapter_path}/0/items"
+
+    with nn_partitioning.axis_rules(config.logical_axis_rules):
+      restored_lora, raw_lora_params = checkpointing.load_state_if_possible(
+          checkpoint_manager,
+          data_iterator,
+          lora_weights_path,
+          config.load_full_state_path,
+          config.checkpoint_storage_concurrent_gb,
+          lora_state,
+          config.enable_single_replica_ckpt_restoring,
+          config.dataset_type,
+      )
+
+      if restored_lora:
+        raise NotImplementedError("This codepath is not implemented for LoRA adapters yet.")
+      else:
+        lora_state = lora_state.replace(params=raw_lora_params)
+        lora_state = max_utils.unbox_logicallypartioned(lora_state)
+
+  return lora_config, lora_state, lora_state_annotations
+
+
+def get_lora_abstract_state(base_abstract_params, lora_config):
+  """
+  Generates an abstract state representing only the LoRA parameters,
+  inferring sharding information from the base parameters.
+
+  Args:
+    base_abstract_params: A PyTree containing jax.ShapeDtypeStruct objects
+                            representing the abstract state of the base model
+                            parameters. This includes sharding information.
+    lora_config: A config of the Lora adapter that includes details about the
+                 Lora like rank, or target_modules on which lora is implemented.
+
+  Returns:
+    A TrainState object representing the abstract state of the LoRA parameters, including
+    inferred sharding information.
+  """
+  other_lora_format_to_jax_format = {
+      "q_proj": "self_attention.query",
+      "k_proj": "self_attention.key",
+      "v_proj": "self_attention.value",
+      "o_proj": "self_attention.out",
+  }
+
+  lora_target_modules = lora_config["target_modules"]
+  lora_target_modules = [other_lora_format_to_jax_format.get(s, s) for s in lora_target_modules]
+
+  lora_rank = int(lora_config["r"])
+
+  lora_abstract_params = {}
+
+  def get_lora_param_shape(base_array_shape, lora_rank, lora_module):
+    base_array_dimensions = len(base_array_shape)
+
+    if base_array_dimensions > 4:
+      raise ValueError(
+          f"Encountered unexpected shape={base_array_shape} of array in base params. Array dimensions > 4 not supported."
+      )
+
+    if lora_module in ["self_attention.query", "self_attention.key", "self_attention.value"]:
+      lora_a_shape = base_array_shape[:-2] + (lora_rank,)
+      lora_b_shape = (lora_rank,) + base_array_shape[1:]
+    elif lora_module in ["self_attention.out"]:
+      lora_a_shape = base_array_shape[:-1] + (lora_rank,)
+      if base_array_dimensions == 4:
+        lora_b_shape = (lora_rank, base_array_shape[1], base_array_shape[-1])
+      else:
+        lora_b_shape = (lora_rank, base_array_shape[-1])
+    else:
+      raise ValueError(f"Unsupported lora_module={lora_module}")
+
+    return lora_a_shape, lora_b_shape
+
+  def get_lora_param_sharding(base_param_sharding, lora_module):
+    if base_param_sharding is None:  # Base parameter is replicated
+      return None, None  # Replicate LoRA parameters as well
+
+    base_sharding_pspec_size = len(base_param_sharding.spec)
+
+    if base_sharding_pspec_size > 4:
+      raise ValueError(f"Encountered unexpected size of PartitionSpec in sharding. Size > 4 is not supported")
+
+    base_mesh = base_param_sharding.mesh
+    base_memory_kind = base_param_sharding.memory_kind
+    base_pspec = base_param_sharding.spec
+
+    if lora_module in ["self_attention.query", "self_attention.key", "self_attention.value"]:
+      lora_a_pspec_tuple = base_pspec[:-2] + ((),)
+      lora_a_pspec = jax.sharding.PartitionSpec(*lora_a_pspec_tuple)
+
+      lora_b_pspec_tuple = ((),) + base_pspec[1:]
+      lora_b_pspec = jax.sharding.PartitionSpec(*lora_b_pspec_tuple)
+
+    elif lora_module in ["self_attention.out"]:
+      lora_a_pspec_tuple = base_pspec[:-1] + ((),)
+      lora_a_pspec = jax.sharding.PartitionSpec(*lora_a_pspec_tuple)
+      if base_sharding_pspec_size == 4:
+        lora_b_pspec = jax.sharding.PartitionSpec((), base_pspec[1], base_pspec[-1])
+      else:
+        lora_b_pspec = jax.sharding.PartitionSpec((), base_pspec[-1])
+    else:
+      raise ValueError(f"Unsupported lora_module={lora_module}")
+
+    lora_a_sharding = jax.sharding.NamedSharding(mesh=base_mesh, spec=lora_a_pspec, memory_kind=base_memory_kind)
+    lora_b_sharding = jax.sharding.NamedSharding(mesh=base_mesh, spec=lora_b_pspec, memory_kind=base_memory_kind)
+
+    return lora_a_sharding, lora_b_sharding
+
+  def module_is_target_module(module, target_modules):
+    """Checks if any of the target_modules is part of the current module which represents an array.
+
+    Args:
+      module: A string where nested dictionary keys are concatenated to make a path of the internal most kernel/scale arrays.
+      target_modules: A list of strings which represents the target_modules on which lora is applied.
+
+    Return:
+      The matched target_module, if that is found in the current module path, None otherwise.
+    """
+    for target_module in target_modules:
+      if target_module in module:
+        return target_module
+    return None
+
+  def add_lora_params(lora_params, module_name, base_params, lora_rank, lora_target_modules):
+    for name, param in base_params.items():
+      if isinstance(param, dict):
+        lora_params[name] = {}
+        add_lora_params(lora_params[name], f"{module_name}.{name}", param, lora_rank, lora_target_modules)
+      else:
+        if name not in ["kernel", "scale", "embedding"]:
+          raise ValueError(f"Unexpected key={name} exists in the abstract params of base model.")
+
+        if not isinstance(param, jax.ShapeDtypeStruct):
+          raise ValueError(f"Unexpected type found in the abstract params of the base model.")
+
+        lora_a_key = f"lora_a.kernel"
+        lora_b_key = f"lora_b.kernel"
+
+        target_module = module_is_target_module(module_name, lora_target_modules)
+
+        if target_module is not None:
+          lora_a_shape, lora_b_shape = get_lora_param_shape(param.shape, lora_rank, target_module)
+          base_dtype = param.dtype
+          lora_a_sharding, lora_b_sharding = get_lora_param_sharding(param.sharding, target_module)
+
+          lora_params[lora_a_key] = jax.ShapeDtypeStruct(shape=lora_a_shape, dtype=base_dtype, sharding=lora_a_sharding)
+
+          lora_params[lora_b_key] = jax.ShapeDtypeStruct(shape=lora_b_shape, dtype=base_dtype, sharding=lora_b_sharding)
+        else:
+          lora_params[name] = None
+
+  def get_lora_annotations(lora_abstract_params):
+    return jax.tree_util.tree_map(lambda x: x.sharding.spec, lora_abstract_params)
+
+  add_lora_params(lora_abstract_params, "", base_abstract_params, lora_rank, lora_target_modules)
+
+  unboxed_abstract_lora_state = train_state.TrainState(
+      step=0, apply_fn=None, params=lora_abstract_params, tx=None, opt_state={}  # type: ignore
+  )
+
+  lora_state_mesh_annotations = train_state.TrainState(
+      step=0, apply_fn=None, params=get_lora_annotations(lora_abstract_params), tx=None, opt_state={}  # type: ignore
+  )
+
+  return unboxed_abstract_lora_state, lora_state_mesh_annotations


### PR DESCRIPTION
# Description
Supporting LoRA in MaxText for inference only, to support multi-LoRA adapters inferencing via JetStream.

# Approach and changes details
- Added some LoRA specific config variables inside base.yml.
- Implemented naive way of merging LoRA weights to Base weights, which can be used only for inference purposes.
- Implemented methods to create the abstract_state of the LoRA params using the base_mode_abstract_state and the lora_adapter_config.
- The abstract_state of the LoRA params is used to Read the HuggingFace format of the LoRA checkpoints. It is further used to convert, validate & write the LoRA params in Jax format, which is used during the inference. 
- Implemented couple of util functions in max_utils which can be reused.
- The whole workflow of LoRA conversion of weights is guarded by the config flag `lora_adapters_path`.
- For reviewers, max_utils.py and maxengine.py doesn't have any significant change in existing methods. Only new methods were added which can be triggered in LoRA workflows. So ideally, non-LoRA workflows should not have any functionality impact.

# What next:
- In coming future there could be more core changes in MaxText to support multiple LoRA adapters in same batch of decoding.

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
