### PR TITLE
Add Mistral-7B benchmark

### DIFF
--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -1041,6 +1041,52 @@ llama3_1_70b_129024 = _add_to_model_dictionary(
 )
 
 
+mistral_7b = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="mistral-7b",
+    model_type="mistral-7b",
+    tuning_params={
+        "per_device_batch_size": 6,
+        "ici_fsdp_parallelism": -1,
+        "remat_policy": "custom",
+        "decoder_layer_input": "offload",
+        "out_proj": "offload",
+        "query_proj": "offload",
+        "key_proj": "offload",
+        "value_proj": "offload",
+        "max_target_length": 8192,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_path": "gs://max-datasets-rogue",
+        "dataset_type": "synthetic",
+        "enable_checkpointing": False,
+        "sa_block_q": 2048,
+        "sa_block_kv": 2048,
+        "sa_block_kv_compute": 2048,
+        "sa_block_q_dkv": 2048,
+        "sa_block_kv_dkv": 2048,
+        "sa_block_kv_dkv_compute": 2048,
+        "sa_block_q_dq": 2048,
+        "sa_block_kv_dq": 2048,
+        "sa_use_fused_bwd_kernel": True,
+        "profiler": "xplane",
+        "skip_first_n_steps_for_profiler": 10,
+        "profiler_steps": 5,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+        + xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
+        + xla_flags_library.HOST_OFFLOAD_FLAGS
+        + xla_flags_library.DISABLE_COLLECTIVE_MATMUL
+    ),
+  )
+)
+
+
 mixtral_8x7b_dropless = _add_to_model_dictionary(
   trillium_model_dict,
   MaxTextModel(


### PR DESCRIPTION
# Description

Add a new Trillium benchmark that runs Mistral-7B. I ran this on v6e-8 and got around ~450 TFLOPs.

This change is needed to support adding a reproducible recipe for v6e-8.

# Tests

Ran this on v6e-8 using the following command:

```
python3 benchmarks/benchmark_runner.py xpk \
    --project=$PROJECT\
    --zone=$ZONE \
    --device_type=v6e-8 \
    --num_slices=1  \
    --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="mistral_7b" \
    --base_docker_image=maxtext_base_image
```
I got the perf described above.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
