### PR TITLE
[Inference PagedAttention] Add configs for paged attention and allow attention=paged (0/N)

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -592,3 +592,12 @@ sa_use_fused_bwd_kernel: False
 sa_q_layout: "HEAD_DIM_MINOR"
 sa_k_layout: "HEAD_DIM_MINOR"
 sa_v_layout: "HEAD_DIM_MINOR"
+
+#######################
+### Paged Attention ###
+#######################
+# These settings take effect only when `attention=paged`.
+# They should be adjusted based on the available HBM and model config.
+pagedattn_num_pages: 64
+pagedattn_tokens_per_page: 32
+pagedattn_pages_per_compute_block: 8

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -70,7 +70,7 @@ def validate_kv_quant_axis(s: str, quantize_kvcache: bool) -> None:
 
 
 def validate_attention_kernel(s: str) -> None:
-  valid_attention_kernels = ("autoselected", "dot_product", "flash", "cudnn_flash_te")
+  valid_attention_kernels = ("autoselected", "dot_product", "flash", "cudnn_flash_te", "paged")
   if s not in valid_attention_kernels:  # currently supported attention
     raise ValueError("Invalid attention kernel was passed. Valid options ", valid_attention_kernels)
 


### PR DESCRIPTION
This change is based on a branch from Pate and Rupeng.

Impact of the change:
* This change is currently a noop. The new configurations are not yet utilized within the codebase.

Major changes:
* MaxText/configs/base.yml: Add configs to be used by paged attention
* MaxText/pyconfig.py: Update the validation to allow setting attention to 'paged'

Reason:
* This change prepares the codebase for paged attention, which will be used to improve inference performance. This PR is one of a series of changes that will gradually introduce paged attention functionality

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
