### PR TITLE
Fix TP + TransformerEngine issue.

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -314,7 +314,11 @@ logical_axis_rules: [
                       ['paged_kv_head_dim_size', []],
                     ]
 # Axes used for DCN must be earlier in this list than ICI, see (b/339009148) for details
-data_sharding: [['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'context', 'tensor', 'tensor_transpose', 'tensor_sequence', 'expert', 'autoregressive']]
+# All the axis except TP for data sharding
+data_sharding: [['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'context', 'tensor_sequence', 'expert', 'autoregressive']]
+
+# All the axis for data sharding, used only for subset hosts data loading
+all_shardings: [['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'context', 'tensor', 'tensor_transpose', 'tensor_sequence', 'expert', 'autoregressive']]
 
 # sharding tolerance: float between 0.0 and 1.0 representing the allowed percentage of non-sharded parameters.
 sharding_tolerance: 0.02

--- a/MaxText/input_pipeline/input_pipeline_interface.py
+++ b/MaxText/input_pipeline/input_pipeline_interface.py
@@ -150,8 +150,9 @@ def create_data_iterator(config, mesh):
   if config.dataset_type == "synthetic":
     return SyntheticDataIterator(config, mesh), None
 
+  data_load_sharding = config.data_sharding if config.expansion_factor_real_data == -1 else config.all_shardings
   process_indices_train = get_process_loading_real_data(
-      config.data_sharding,
+      data_load_sharding,
       config.global_batch_size_to_load,
       config.global_batch_size_to_train_on,
       config.max_target_length,
@@ -159,7 +160,7 @@ def create_data_iterator(config, mesh):
   )
   if config.eval_interval > 0:
     process_indices_eval = get_process_loading_real_data(
-        config.data_sharding,
+        data_load_sharding,
         config.global_batch_size_to_load_eval,
         config.global_batch_size_to_eval_on,
         config.max_target_length,


### PR DESCRIPTION
The data sharding applies to the data pipeline while TP applies to model parallelism. TP + TransformerEngine suffers from this and causes training hang due to much longer NCCL communication. It's verified by running llama 8B on 16 nodes and works fine.

FIXES: b/384441280

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
