### PR TITLE
Add test scripts for llama2-7b int8/bf16 models

### DIFF
--- a/MaxText/tests/inference/test_llama2_7b_bf16.sh
+++ b/MaxText/tests/inference/test_llama2_7b_bf16.sh
@@ -1,0 +1,17 @@
+python MaxText/decode.py MaxText/configs/base.yml \
+    tokenizer_path=assets/tokenizer.llama2 \
+    model_name=llama2-7b \
+    load_parameters_path=gs://runner-maxtext-logs/direct_generate_param_only_checkpoint_2024-06-11-04-13/checkpoints/0/items/ \
+    checkpoint_is_quantized=false \
+    weight_dtype=bfloat16 \
+    max_prefill_predict_length=16 \
+    max_target_length=32 \
+    ici_fsdp_parallelism=1 \
+    ici_autoregressive_parallelism=1 \
+    ici_tensor_parallelism=-1 \
+    scan_layers=false \
+    per_device_batch_size=1 \
+    attention=paged \
+    pagedattn_num_pages=64 \
+    pagedattn_tokens_per_page=8 \
+    pagedattn_pages_per_compute_block=4

--- a/MaxText/tests/inference/test_llama2_7b_int8.sh
+++ b/MaxText/tests/inference/test_llama2_7b_int8.sh
@@ -1,0 +1,18 @@
+python MaxText/decode.py MaxText/configs/base.yml \
+    tokenizer_path=assets/tokenizer.llama2 \
+    model_name=llama2-7b \
+    load_parameters_path=gs://msingh-bkt/checkpoints/quant_llama2-7b-chat/20241120034012/int8_ \
+    checkpoint_is_quantized=true \
+    quantization=int8 \
+    weight_dtype=bfloat16 \
+    max_prefill_predict_length=16 \
+    max_target_length=32 \
+    ici_fsdp_parallelism=1 \
+    ici_autoregressive_parallelism=1 \
+    ici_tensor_parallelism=-1 \
+    scan_layers=false \
+    per_device_batch_size=1 \
+    attention=paged \
+    pagedattn_num_pages=64 \
+    pagedattn_tokens_per_page=8 \
+    pagedattn_pages_per_compute_block=4


### PR DESCRIPTION
Tested:
```
$ ./MaxText/tests/inference/test_llama2_7b_int8.sh
$ ./MaxText/tests/inference/test_llama2_7b_bf16.sh
```

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

*Notice 1* Once all tests pass, the "pull ready" label will automatically be assigned. This label is used
for administrative purposes. Please do not add it manually.

*Notice 2* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
