### PR TITLE
SWE formats code instead of AI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,8 @@ If the change fixes a bug or a Github issue, please include a link, e.g.,:
 FIXES: b/123456
 FIXES: #123456
 
-*Notice 1* Once all tests pass, the "pull ready" label will automatically be assigned. This label is used
-for administrative purposes. Please do not add it manually.
+*Notice 1* Once all tests pass, the "pull ready" label will automatically be assigned.
+This label is used for administrative purposes. Please do not add it manually.
 
 *Notice 2* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.
 


### PR DESCRIPTION
# Description

Fix formatting of Notice 1
From
![image](https://github.com/user-attachments/assets/fbd1932e-34ac-4ed2-8ef3-9941a23c6ea1)

To
[something nicer]

*Notice 1* Once all tests pass, the "pull ready" label will automatically be assigned. This label is used
for administrative purposes. Please do not add it manually.

*Notice 2* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Formatting is hard
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
