### PR TITLE
Add more Code Owners, require 2 approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Changes in this file should match with requiredReviewers in file .github/workflows/AddLabel.yml
-* @gobbleturk @khatwanimohit @bvandermoon @vipannalla @RissyRan @richjames0 @rni418 @gagika
+* @gobbleturk @khatwanimohit @bvandermoon @vipannalla @RissyRan @richjames0 @rni418 @gagika @shralex @yangyuwei @SurbhiJainUSC @hengtaoguo @A9isha

--- a/.github/workflows/AddLabel.yml
+++ b/.github/workflows/AddLabel.yml
@@ -61,6 +61,11 @@ jobs:
               richjames0: "",
               rni418: "",
               gagika: "",
+              shralex: "",
+              yangyuwei: "",
+              SurbhiJainUSC: "",
+              hengtaoguo: "",
+              A9isha: "",
             }
             const reviews = await github.rest.pulls.listReviews({
               owner,
@@ -79,15 +84,14 @@ jobs:
               console.log("Not adding pull ready because the PR is not approved yet.")
               process.exit()
             }
-            let is_approved=false
+            let num_approved = 0
             for (const review of reviews.data) {
-              if (review.state === "APPROVED" && (review.user.login in requiredReviewers || pullRequester in requiredReviewers)) {
-                is_approved=true
-                break;
+              if (review.state === "APPROVED" && review.user.login in requiredReviewers) {
+                num_approved = num_approved + 1
               }
             }
-            if (!is_approved) {
-              console.log("Not adding pull ready because the PR is not approved yet by a code owner.")
+            if (num_approved < 2) {
+              console.log("Not adding pull ready because the PR is not approved yet by 2 code owners.")
               process.exit()
             }
 


### PR DESCRIPTION
This PR adds more MaxText contributors to code owners, and requires 2 code owners for approval.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned. This label is used
for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
