### PR TITLE
Fix duplicate model_names for llama2-70b benchmarks

### DIFF
--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -428,7 +428,7 @@ llama2_70b_4096_sc = _add_to_model_dictionary(
 llama2_70b_4096_sc_real_data_tfds = _add_to_model_dictionary(
     trillium_model_dict,
     MaxTextModel(
-        model_name="llama2-70b-4096-sc",
+        model_name="llama2-70b-4096-sc-real-data-tfds",
         model_type="llama2-70b",
         tuning_params={
             "per_device_batch_size": 2,
@@ -473,7 +473,7 @@ llama2_70b_4096_sc_real_data_tfds = _add_to_model_dictionary(
 llama2_70b_4096_sc_real_data_grain = _add_to_model_dictionary(
     trillium_model_dict,
     MaxTextModel(
-        model_name="llama2-70b-4096",
+        model_name="llama2-70b-4096-sc-real-data-grain",
         model_type="llama2-70b",
         tuning_params={
             "per_device_batch_size": 2,
@@ -528,7 +528,7 @@ llama2_70b_4096_sc_real_data_grain = _add_to_model_dictionary(
 llama2_70b_4096_sc_real_data_grain_checkpoint = _add_to_model_dictionary(
     trillium_model_dict,
     MaxTextModel(
-        model_name="llama2-70b-4096",
+        model_name="llama2-70b-4096-sc-real-data-grain-checkpoint",
         model_type="llama2-70b",
         tuning_params={
             "per_device_batch_size": 2,


### PR DESCRIPTION
# Description

There are several benchmarks named `llama2_70b_4096`. I tried to run this benchmark but was getting a different config then expected. A different llama2 benchmark with the same name was getting pulled instead of mine. This PR changes the other benchmark names to reduce duplicates.

# Tests

* Ran the benchmarks with the updated names and the workloads kicked off properly (although they fail for other reasons)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
