### PR TITLE
Pin orbax to 0.11.7

### DIFF
--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -308,9 +308,7 @@ def setup_checkpoint_logger(config) -> ocp.logging.CloudLogger | None:
   max_logging.log("Setting up checkpoint logger...")
   if config.enable_checkpoint_cloud_logger:
     logger_name = f"goodput_{config.run_name}"
-    options = ocp.logging.CloudLoggerOptions(
-        job_name=config.run_name, logger_name=logger_name
-    )
+    options = ocp.logging.CloudLoggerOptions(job_name=config.run_name, logger_name=logger_name)
     orbax_cloud_logger = ocp.logging.CloudLogger(options=options)
     max_logging.log("Successfully set up checkpoint cloud logger.")
     return orbax_cloud_logger

--- a/constraints_gpu.txt
+++ b/constraints_gpu.txt
@@ -123,7 +123,7 @@ opentelemetry-api==1.27.0
 opt_einsum==3.4.0
 optax==0.2.3
 optree==0.13.0
-orbax-checkpoint==0.10.3
+orbax-checkpoint==0.11.7
 packaging==24.1
 pandas==2.2.3
 parameterized==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jax>=0.4.30
 jaxlib>=0.4.30
-orbax-checkpoint>=0.5.12
+orbax-checkpoint>=0.11.7
 absl-py
 array-record
 aqtp

--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -5,7 +5,7 @@ aqtp==0.8.2
 datasets
 grain-nightly>=0.0.10
 ml-goodput-measurement==0.0.5
-orbax-checkpoint>=0.10.3
+orbax-checkpoint>=0.11.7
 pylint
 pytest
 pyink


### PR DESCRIPTION
# Description

Orbax needs to be pinned to latest after breaking change https://github.com/AI-Hypercomputer/maxtext/commit/ff1c3e8326ec68da4aba0d3981c2012c3387e126

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Relying on unit tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
