### PR TITLE
Add hierarchical PrefixCache with host DRAM

### DIFF
--- a/MaxText/prefix_cache.py
+++ b/MaxText/prefix_cache.py
@@ -16,13 +16,12 @@
 
 i) Initialize cache
 
-# HBM size with Trillium 8 core use about 17 / 31.25 GB per core after loading models.
-# To utilize HBM memory to 80%, about (30 * 0.8 - 16) * 8 = 64GB
 # Prefix return by prefill function of mixtral-8x22b model with max_prefill_length=1024,
 # int8 quantize_kvcache is 235_930_060 bytes, nearly 256 MB.
-# HBM cache can store about 64GB / 256 MB = 256 prompts.
-hbm_bytes = 64 * 1024 * 1024 * 1024  # 64 GB
-prefix_cache = PrefixCache(hbm_bytes)
+# It need about 256 * 256 MB = 64GB to caching 256 prompts prefill.
+hbm_bytes = 64_000_000_000  # 64 GB
+dram_bytes = 640_000_000_000  # 640 GB
+prefix_cache = PrefixCache(hbm_bytes=hbm_bytes, dram_bytes=dram_bytes)
 
 ii) Read from Cache:
 
@@ -62,7 +61,8 @@ if cached_prefix is None or matched_len != orig_key_len:
 """
 
 from collections import OrderedDict
-from typing import Tuple, Any, Optional
+from typing import Any, Optional, Tuple
+import abc
 import dataclasses
 import jax
 import jax.numpy as jnp
@@ -77,17 +77,12 @@ Key = Tuple[Token, ...]
 Prefix = Any  # KVCache for one prompt
 
 
-@jax.jit
-def tree_copy(tree):
-  return jax.tree.map(lambda x: x.copy() if isinstance(x, jax.Array) else x, tree)
-
-
 class Value:
   """Object stored contains the actual KVcache
 
   Attributes:
     prefix:
-      Readonly. Prefix Cache using in model. Should be dictionary of jnp.array.
+      Readonly. Prefix Cache using in model. Should be pytree of all jax.Array.
     true_length:
       Readonly. True length of tokens calculate prefix. Should be <= than len(tokens).
       true_length will be min(true_length, len(tokens))
@@ -97,6 +92,10 @@ class Value:
       Readonly. Tokens calculate prefix. may include partial of padding.
     prefix_size_bytes:
       Readonly. bytes of prefix.
+    device:
+      Readonly. Devices of prefix. The same structure of pytree to prefix.
+      The device may be different from actually prefix is in.
+      It used for retrieved back to original device.
   """
 
   def __init__(
@@ -107,19 +106,32 @@ class Value:
       padded_length: int,
       tokens: tuple[Token, ...],
       prefix_size_bytes: Optional[int] = None,
+      device=None,
   ):
-    """Attributes to store.
+    """Init Value with attributes.
+
     If true_length shorter than len(tokens), true_length will adjust to len(tokens).
     If prefix_size_bytes is not provided, calculate automatically.
+    prefix should be pytree of all jax.Array. It may raise exception if there is anything not a jax.Array,
+    If either prefix_size_bytes and device is None, get from prefix.
     """
     self._prefix = prefix
     self._true_length = self._maybe_adjust_true_length(true_length, tokens)
     self._padded_length = padded_length
     self._tokens = tokens
     if prefix_size_bytes is None:
-      self._prefix_size_bytes: int = self._calculate_prefix_bytes(prefix)
+      self._prefix_size_bytes: int = jax.tree.reduce(
+          lambda acc, array: acc + array.nbytes,
+          prefix,
+          0,
+      )
     else:
       self._prefix_size_bytes = prefix_size_bytes
+
+    if device is None:
+      self._device = jax.tree.map(lambda x: x.device, prefix)
+    else:
+      self._device = device
 
   @property
   def prefix(self) -> Prefix:
@@ -141,16 +153,9 @@ class Value:
   def prefix_size_bytes(self) -> int:
     return self._prefix_size_bytes
 
-  def clone(self) -> "Value":
-    """Clone to prevent using the same jax array."""
-    copied_prefix = tree_copy(self._prefix)
-    return Value(
-        prefix=copied_prefix,
-        true_length=self._true_length,
-        padded_length=self._padded_length,
-        tokens=self._tokens,
-        prefix_size_bytes=self._prefix_size_bytes,
-    )
+  @property
+  def device(self) -> int:
+    return self._device
 
   def __eq__(self, other: Any) -> bool:
     if not isinstance(other, Value):
@@ -162,22 +167,37 @@ class Value:
         and other.prefix_size_bytes == self.prefix_size_bytes
     )
 
-  def _calculate_prefix_bytes(self, prefix: Prefix) -> int:
-    def has_nbytes_int(obj) -> bool:
-      return hasattr(obj, "nbytes") and isinstance(obj.nbytes, int)
-
-    # calculate all bytes of jnp.array in the prefix
-    return jax.tree.reduce(
-        lambda acc, array: acc + (array.nbytes if has_nbytes_int(array) else 0),
-        prefix,
-        0,
-    )
-
   def _maybe_adjust_true_length(self, true_length: int, tokens: tuple[Token, ...]) -> int:
     if true_length > len(tokens):
       logger.warning("true_length=%d should <= len(tokens)=%d.", true_length, len(tokens))
 
     return min(true_length, len(tokens))
+
+
+def device_put_value(value: Value, device: Any = None) -> Value:
+  """Create a new value with prefix put to device.
+
+  If the device is the same as value.prefix, we expect no copy here in jax.device_put.
+
+  Args:
+    value: Value to put.
+    device:
+      The same as the jax.device_put device to put the value.prefix.
+      if None, put to the value.device.
+  Returns:
+    Values with prefix put to device.
+  """
+  put_device = device
+  if put_device is None:
+    put_device = value.device
+  return Value(
+      prefix=jax.device_put(value.prefix, put_device),
+      true_length=value.true_length,
+      padded_length=value.padded_length,
+      tokens=value.tokens,
+      prefix_size_bytes=value.prefix_size_bytes,
+      device=value.device,
+  )
 
 
 class PrefixCacheTrie:
@@ -261,54 +281,228 @@ class PrefixCacheTrie:
       node = parent
 
 
-class HBMCache:
-  """Stores kv cache values in HBM.
+class ValueStorageInterface(abc.ABC):
+  """Interface for Value storage."""
 
-  Cache is remain the sharding status before save.
-  """
+  @abc.abstractmethod
+  def get_max_size_bytes(self) -> int:
+    """Get the max size bytes in storage."""
+
+  @abc.abstractmethod
+  def has_enough_space(self, needed_bytes: int) -> bool:
+    """Calculate if needed_bytes size can add to storage."""
+
+  @abc.abstractmethod
+  def add(self, key: Key, value: Value) -> bool:
+    """Add value and return True. If storage is full, return False."""
+
+  @abc.abstractmethod
+  def retrieve(self, key: Key, device: Any = None) -> Optional[Value]:
+    """Return value from storage or None if not found.
+
+    Args:
+      key: key to retrieve value.
+      device:
+        The same as device in jax.device_put. Retrieve the value to device.
+        If device is None, retrieve the value to it's original device while saved.
+    Returns:
+      Value retrieved from storage or None if not found.
+    """
+
+  @abc.abstractmethod
+  def evict(self, key: Key) -> Optional[Value]:
+    """Evict and return value, or None if key is not in storage."""
+
+  @abc.abstractmethod
+  def contains(self, key: Key) -> bool:
+    """If there is key in storage."""
+
+
+class BasicStorage:
+  """Basic implement calculating size and save value into dict without modify."""
 
   def __init__(self, max_size_bytes: int):
     """
     Args:
-      max_size_bytes: Maximum bytes of HBM to use for cache
+      max_size_bytes: Maximum bytes use
     """
+    self._max_size_bytes = max_size_bytes
     self._remain_size_bytes = max_size_bytes
     self._saved_values: dict[Key, Value] = {}
 
-  def has_enough_space(self, value: Value) -> bool:
-    """Calculate if value size can add to cache."""
-    return self._remain_size_bytes >= value.prefix_size_bytes
+  def get_max_size_bytes(self) -> int:
+    return self._max_size_bytes
 
-  def add_to_cache(self, key: Key, value: Value) -> bool:
-    """
-    Value will be moved to the cache, which means cannot used the same value reference after add_to_cache.
+  def has_enough_space(self, needed_bytes: int) -> bool:
+    """Calculate if needed_bytes size can add to storage."""
+    return self._remain_size_bytes >= needed_bytes
 
-    The jax may modified the value even stored in another python reference.
-    If the value need to be used after add_to_cache, make sure copy them before add_to_cache.
-    Return False if cache is full.
+  def add(self, key: Key, value: Value) -> bool:
+    """Add value and return True. If storage is full, return False.
+
+    The value will not copied. Be aware not to modify the value after add to storage.
+    Storage is expected to have enough space.
     """
-    if not self.has_enough_space(value):
+    if not self.has_enough_space(value.prefix_size_bytes):
+      logger.warning(
+          "should check enough space before add to storage, but remain=%d not enough for value=%d",
+          self._remain_size_bytes,
+          value.prefix_size_bytes,
+      )
       return False
 
     self._saved_values[key] = value
     self._remain_size_bytes -= value.prefix_size_bytes
     return True
 
-  def retrieve_from_cache(self, key: Key) -> Optional[Value]:
-    """Return value from cache or None if not found.
-    Be aware the cache is not return a copy. If additional modified needed, clone the Value first.
-    """
-    if key in self._saved_values:
-      return self._saved_values[key]
-    return None
+  def retrieve(self, key: Key) -> Optional[Value]:
+    """Return value from storage or None if not found.
 
-  def evict_cache(self, key: Key) -> Optional[Value]:
-    """Evict and return value, or None if key is not in cache."""
+    Be aware the storage is not return a copy. Clone the Value first if additional modification needed.
+    """
     if key not in self._saved_values:
+      logger.warning("key=%r should exist in storage before retrieve, but not found", key)
+      return None
+    return self._saved_values[key]
+
+  def evict(self, key: Key) -> Optional[Value]:
+    """Evict and return value, or None if key is not in storage.
+    Key is expected to be found.
+    """
+    if key not in self._saved_values:
+      logger.warning("key=%r should exist in storage before evict, but not found", key)
       return None
     value = self._saved_values.pop(key)
     self._remain_size_bytes += value.prefix_size_bytes
     return value
+
+  def contains(self, key: Key) -> bool:
+    """If there is key in storage."""
+    return key in self._saved_values
+
+
+class HBMStorage(ValueStorageInterface):
+  """Stores kv storage values in HBM.
+
+  Store the Value into the specific HBM device, which is the same type as device in jax.device_put.
+  The Value would be jax.device_put to the HBM device after add, and retrieve back to the original device.
+  """
+
+  def __init__(self, max_size_bytes: int, device: Any = None):
+    """Init the HBMStorage with max size limit and device to store the Value.
+
+    Args:
+      max_size_bytes: Maximum bytes of HBM to use for storage
+      device:
+        the same type as jax.device_put. It is used to store the cache Value.
+        If None, do not move the Value.
+    """
+    self._storage = BasicStorage(max_size_bytes)
+    self._device = device
+
+  def get_max_size_bytes(self) -> int:
+    return self._storage.get_max_size_bytes()
+
+  def has_enough_space(self, needed_bytes: int) -> bool:
+    """Calculate if needed_bytes size can add to storage."""
+    return self._storage.has_enough_space(needed_bytes)
+
+  def add(self, key: Key, value: Value) -> bool:
+    """Add key/value pair into the cache.
+
+    Depend on jax.device_put,
+    the Value will not be copied if the device storing the cache is the same as the origin device of Value.
+    Storage is expected to have enough space.
+
+    Args:
+      key: key of cache index.
+      value: Value to store.
+    Returns:
+      True if successful. False if failed due to not enough space.
+    """
+    hbm_value = device_put_value(value, self._device)
+    return self._storage.add(key, hbm_value)
+
+  def retrieve(self, key: Key, device: Any = None) -> Optional[Value]:
+    """Retrieve value back to the original device or None if not found.
+
+    Be aware the storage may not return a copy if the original devices is the same as depend on jax.device_put.
+    Key is expected to be found.
+    """
+    hbm_value = self._storage.retrieve(key)
+    if hbm_value is None:
+      return None
+
+    return device_put_value(hbm_value, device)
+
+  def evict(self, key: Key) -> Optional[Value]:
+    """Evict and return value, or None if key is not in storage.
+    Key is expected to be found.
+    """
+    return self._storage.evict(key)
+
+  def contains(self, key: Key) -> bool:
+    """If there is key in storage."""
+    return self._storage.contains(key)
+
+
+class DRAMStorage(ValueStorageInterface):
+  """Stores KV Cache values in host DRAM."""
+
+  def __init__(self, max_size_bytes: int):
+    """
+    Args:
+      max_size_bytes: Maximum bytes of host DRAM to use for storage
+    """
+    self._storage = BasicStorage(max_size_bytes)
+
+  def get_max_size_bytes(self) -> int:
+    return self._storage.get_max_size_bytes()
+
+  def has_enough_space(self, needed_bytes: int) -> bool:
+    """Calculate if needed_bytes size can add to storage."""
+    return self._storage.has_enough_space(needed_bytes)
+
+  def add(self, key: Key, value: Value) -> bool:
+    """Add value into host DRAM.
+
+    Return false if storage does not have enough space.
+    Do not use this function to check if has enough space.
+    This function will first move to host DRAM before check the space.
+    The storage will copy to the host DRAM if originally on device,
+    or with the same reference to the value if originally on host.
+    Do not use the value after this function if originally on host since the value will not copy.
+    """
+    host_value = Value(
+        prefix=jax.device_get(value.prefix),
+        true_length=value.true_length,
+        padded_length=value.padded_length,
+        tokens=value.tokens,
+        prefix_size_bytes=value.prefix_size_bytes,
+        device=value.device,
+    )
+
+    return self._storage.add(key, host_value)
+
+  def retrieve(self, key: Key, device: Any = None) -> Optional[Value]:
+    """Return value from storage to the original device or None if not found.
+
+    If the original device save in the storage is cpu, the storage will not copied.
+    Do not modify the storage prefix retrieved.
+    """
+    host_value = self._storage.retrieve(key)
+    if host_value is None:
+      return None
+
+    return device_put_value(host_value, device)
+
+  def evict(self, key: Key) -> Optional[Value]:
+    """Evict and return value, or None if key is not in storage."""
+    return self._storage.evict(key)
+
+  def contains(self, key: Key) -> bool:
+    """If there is key in storage."""
+    return self._storage.contains(key)
 
 
 class LRUStrategy:
@@ -331,23 +525,158 @@ class LRUStrategy:
       self._order.move_to_end(key, last=True)
 
 
+@dataclasses.dataclass
+class StorageWithStrategy:
+  """Storage with corresponding strategy"""
+
+  storage: ValueStorageInterface
+  strategy: LRUStrategy
+
+
+class HierarchicalCache:
+  """Hierarchical Cache contains two layers of ValueStorageInterface.
+
+  The first layer contains subset fo key / value pairs of the second layer.
+  The second storage max size bytes should >= first storage max size bytes.
+  Use LRU for each layer.
+  Add the Value will save to all layers.
+  Retrieve the Value will retrieve to HBM and then saved to all layers.
+  The added value size should less than the first layer max size.
+  If the first layer max size cannot contains the added Value, add will failed.
+  """
+
+  def __init__(self, layers: Tuple[ValueStorageInterface, ValueStorageInterface]):
+    assert (
+        layers[0].get_max_size_bytes() <= layers[1].get_max_size_bytes()
+    ), "Bottom layer of storage need to be larger than top."
+
+    self._layers = [StorageWithStrategy(storage, LRUStrategy()) for storage in layers]
+
+  def add(self, key: Key, value: Value) -> tuple[bool, dict[Key, Value]]:
+    """Add to all layers and return (ok, dict[fully evicted from hierarchical cache key value pair]).
+
+    Beware in some error case, there may be not ok but have some evicted key value.
+    """
+    needed_bytes = value.prefix_size_bytes
+    if self._layers[0].storage.get_max_size_bytes() < needed_bytes:
+      logging.warning(
+          "Trying to add value larger than top layer max size. need_bytes=%d, max_size_bytes=%d",
+          needed_bytes,
+          self._layers[0].storage.get_max_size_bytes(),
+      )
+      return False, {}
+
+    # Only return last layers evicted key value pair which is fully evicted from hierarchical cache.
+    all_ok = True
+    last_layer_evicted_key_values: dict[Key, Value] = {}
+    for layer in self._layers:
+      if layer.storage.contains(key):
+        last_layer_evicted_key_values = {}
+        continue
+
+      ok, last_layer_evicted_key_values = self._evict_to_enough_space(layer, needed_bytes)
+      all_ok = all_ok and ok
+
+    if not all_ok:
+      logging.error("Cannot evict enough space after checking max_size is enough for bytes=%d.", needed_bytes)
+      return False, last_layer_evicted_key_values
+
+    for layer in self._layers:
+      if not layer.storage.contains(key):
+        if not layer.storage.add(key, value):
+          logging.error("Cannot add to storage. key=%r, needed_bytes=%d", key, needed_bytes)
+          return False, last_layer_evicted_key_values
+
+      layer.strategy.use(key)
+
+    return True, last_layer_evicted_key_values
+
+  def retrieve(self, key: Key, device: Any = None) -> Optional[Value]:
+    """Retrieve from all layers and add to all layers.
+
+    Args:
+      key: key to retrieve.
+      device:
+        The same type as the device in jax.device_put. Return the Value put on the device.
+        If None, the Value will be put on the Value.device.
+    Returns:
+      Value retrieved from all layers or None if not found.
+      The Value.device is not changed to device retrieved.
+    """
+    value: Optional[Value] = None
+    for layer in self._layers:
+      if layer.storage.contains(key):
+        value = layer.storage.retrieve(key, device)
+        break
+
+    if value is None:
+      logging.warning("Should check key exist before retrieve, but fail for key=%r", key)
+      return None
+
+    for layer in self._layers:
+      if not layer.storage.contains(key):
+        if not self._evict_to_enough_space(layer, value.prefix_size_bytes):
+          logging.error("Cannot evict enough space for retrieved Value to other layers.")
+          continue
+
+        if not layer.storage.add(key, value):
+          logging.error("Cannot add retrieved Value to other layers.")
+          continue
+
+      layer.strategy.use(key)
+
+    return value
+
+  def _evict_to_enough_space(self, layer: StorageWithStrategy, needed_bytes: int) -> tuple[bool, dict[Key, Value]]:
+    """Evict layer to enough bytes for add and return (ok, dict[evicted key, evicted value])."""
+    evicted_key_values: dict[Key, Value] = {}
+    while not layer.storage.has_enough_space(needed_bytes):
+      evicted_key = layer.strategy.evict()
+      if evicted_key is None:
+        logging.error("Cannot evict enough space for bytes=%d.", needed_bytes)
+        return False, evicted_key_values
+
+      evicted_value = layer.storage.evict(evicted_key)
+      if evicted_value is None:
+        logging.error("Key should in storage before evict but not. key=%r", evicted_key)
+        continue
+
+      evicted_key_values[evicted_key] = evicted_value
+
+    return True, evicted_key_values
+
+
 class PrefixCache:
   """Store Prefix KV cache.
 
+  Use hierarchical cache of two layers the first in the HBM and the second in the host DRAM.
+  Assuming HBM is available, or the cache would degrade to two layers on DRAM.
   If cache is full, evict least-recently used entries (LRU).
+  LRU strategy is apply to all layers.
+  The cache in HBM will be subset of the cache in host DRAM.
+  For example:
+    For HBM can contain 2 values, and DRAM can contain 5 values,
+    [1, 2, 3, 4, 5] LRU history, the [1, 2] will in HBM, and [1, 2, 3, 4, 5] will in DRAM.
+  Always return cache after load into HBM.
+  The value need to be <= to the max size in HBM.
+  DRAM max size need to be >= than HBM max size.
   """
 
-  def __init__(self, hbm_bytes: int):
+  def __init__(self, hbm_bytes: int, dram_bytes: int):
     """
+    dram_bytes >= hbm_bytes
     Args:
       hbm_bytes: Total amount of HBM to use for cache.
+      dram_bytes: Total amount of DRAM to use for cache.
     """
-    self._hbm_bytes = hbm_bytes
+    # TODO(yuyanpeng): way to disable DRAM cache
+    assert dram_bytes >= hbm_bytes, "DRAM max size need to be >= than HBM max size."
     self._lock = threading.Lock()
+    self._hbm_bytes = hbm_bytes
+    self._dram_bytes = dram_bytes
     # init in clear()
-    self._hbm_cache: HBMCache
     self._trie: PrefixCacheTrie
-    self._cache_strategy: LRUStrategy
+    self._cache: HierarchicalCache
     self.clear()
 
   def fetch_longest_common_prefix_key(self, key: Key) -> Optional[Key]:
@@ -362,50 +691,45 @@ class PrefixCache:
     """Save key/value to the cache."""
     logger.debug("save key=%r", key)
     with self._lock:
-      while not self._hbm_cache.has_enough_space(value):
-        if self._hbm_bytes < value.prefix_size_bytes:
-          logger.debug("hbm_bytes=%r < value.prefix_size_bytes=%r", self._hbm_bytes, value.prefix_size_bytes)
-          break
-        if self._evict_cache() is None:
-          logger.debug("cannot evict cache")
-          break
-      if not self._hbm_cache.add_to_cache(key, value):
-        logger.debug("cannot add to cache even after evict")
+      ok, evicted = self._cache.add(key, value)
+      for evicted_key in evicted.keys():
+        self._trie.erase(evicted_key)
+      if not ok:
+        logger.warning("Cannot add to cache")
         return False
       self._trie.insert(key)
-      self._cache_strategy.use(key)
       return True
 
-  def load(self, key: Key) -> Optional[Value]:
-    """Returns Value stored with key or None if not found."""
+  def load(self, key: Key, device: Any = None) -> Optional[Value]:
+    """Returns Value stored with key or None if not found.
+
+    Args:
+      key: key to load.
+      device:
+        The same type as device in the jax.device_put. Load the Value on the device.
+        If None, load the Value on the original device Value.device.
+    Return:
+      Value stored with key or None if not found.
+      The Value.device is not changed to device loaded on.
+    """
     logger.debug("load key=%r", key)
     with self._lock:
-      value = self._hbm_cache.retrieve_from_cache(key)
+      value = self._cache.retrieve(key, device)
       if value is None:
         logger.warning(
             "The key should fetched by fetch_longest_common_prefix_key, load key=%r should be valid but not.", key
         )
         return None
-      self._cache_strategy.use(key)
       return value
 
   def clear(self):
     """Clear entire cache."""
     logger.debug("clear cache")
-    self._hbm_cache = HBMCache(max_size_bytes=self._hbm_bytes)
-    self._trie = PrefixCacheTrie()
-    self._cache_strategy = LRUStrategy()
-
-  def _evict_cache(self) -> Optional[Value]:
-    """Evict cache based on strategy."""
-    logger.debug("_evict_cache")
-    key = self._cache_strategy.evict()
-    if key is None:
-      logger.debug("no key to evict")
-      return None
-    logger.debug("evict key=%r", key)
-    value = self._hbm_cache.evict_cache(key)
-    if value is None:
-      logger.warning("key=%r should exist in HBM cache.", key)
-    self._trie.erase(key)
-    return value
+    with self._lock:
+      self._trie = PrefixCacheTrie()
+      self._cache = HierarchicalCache(
+          layers=(
+              HBMStorage(self._hbm_bytes),
+              DRAMStorage(self._dram_bytes),
+          )
+      )

--- a/MaxText/tests/prefix_cache_test.py
+++ b/MaxText/tests/prefix_cache_test.py
@@ -21,6 +21,9 @@ import unittest
 import jax
 import jax.numpy as jnp
 
+from jax.experimental import mesh_utils
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
 
 def create_default_value(prefix=None, true_length=1, padded_length=1, tokens=None) -> prefix_cache.Value:
   if prefix is None:
@@ -33,6 +36,16 @@ def create_default_value(prefix=None, true_length=1, padded_length=1, tokens=Non
       padded_length=padded_length,
       tokens=tokens,
   )
+
+
+def get_byte_in_use(device_idx: int = 0) -> int:
+  jax.clear_caches()
+  device = jax.local_devices()[device_idx]
+  memory_stats = device.memory_stats()
+  if memory_stats is None:
+    pytest.skip("Cannot get device memory stats. Does the test run with TPU?")
+
+  return memory_stats["bytes_in_use"]
 
 
 class ValueTest(unittest.TestCase):
@@ -81,15 +94,9 @@ class ValueTest(unittest.TestCase):
     assert value.prefix is None
     assert value.prefix_size_bytes == 0
 
-  def test_set_prefix_tree_with_non_jax_array_member_ignore_the_bytes(self):
-    prefix = {
-        "non_jax_array": "member",
-        "jax_array": jnp.array([1, 2, 3], dtype=jnp.int8),
-    }
-    prefix_size_bytes = 3
-    value = create_default_value(prefix=prefix)
-    assert value.prefix == prefix
-    assert value.prefix_size_bytes == prefix_size_bytes
+  def test_throw_exception_if_prefix_containing_non_array(self):
+    with self.assertRaises(Exception):
+      create_default_value(prefix={"a": "abc"})
 
   def test_adjust_true_length_shorter_equal_than_tokens(self):
     value = create_default_value(true_length=100, tokens=jnp.array([1, 2, 3]))
@@ -114,19 +121,54 @@ class ValueTest(unittest.TestCase):
     value1_2 = create_default_value(prefix=prefix2)
     assert value1_1 != value1_2
 
-  def test_clone_for_copy_jax_array(self):
-    """jax array in value prefix should be different or may destroy the array in cache."""
+  @pytest.mark.tpu_only
+  def test_device_saved_as_prefix_tree(self):
+    local_devices = jax.local_devices()
+    num_devices = jax.local_device_count()
+    mesh_shape1 = (num_devices,)
+    device_mesh1 = mesh_utils.create_device_mesh(mesh_shape1, devices=local_devices)
+    mesh1 = Mesh(device_mesh1, axis_names=("x",))
+    partition_spec1_1 = PartitionSpec("x", None)
+    partition_spec1_2 = PartitionSpec(None, "x")
+    sharding1_1 = NamedSharding(mesh1, partition_spec1_1)
+    sharding1_2 = NamedSharding(mesh1, partition_spec1_2)
+
     prefix = {
-        "decoder": jnp.array([1, 2, 3], dtype=jnp.int8),
+        "a": jnp.ones((512, 512), device=local_devices[0]),
+        "b": jnp.ones((mesh_shape1[0], 512, 512), device=sharding1_1),
+        "c": jnp.ones((512, mesh_shape1[0], 512), device=sharding1_2),
     }
-    value1_1 = create_default_value(prefix=prefix)
-    value1_2 = value1_1
-    assert value1_1.prefix is value1_2.prefix
-    assert value1_1.prefix["decoder"] is value1_2.prefix["decoder"]
-    value2 = value1_1.clone()
-    assert value2.prefix is not value1_1.prefix
-    assert value2.prefix["decoder"] is not value1_1.prefix["decoder"]
-    assert value2 == value1_1
+    expected_device = {
+        "a": local_devices[0],
+        "b": sharding1_1,
+        "c": sharding1_2,
+    }
+    value = create_default_value(prefix=prefix)
+    assert value.device == expected_device
+
+  @pytest.mark.tpu_only
+  def test_device_saved_as_prefix_tree_with_sharding_multiple_dimension(self):
+    local_devices = jax.local_devices()
+    num_devices = jax.local_device_count()
+    # assume number of devices will be multiple of 2
+    if num_devices % 2 != 0:
+      pytest.skip("Need multiple of 2 devices on testing environment.")
+    mesh_shape2 = (num_devices // 2, 2)
+    device_mesh2 = mesh_utils.create_device_mesh(mesh_shape2, devices=local_devices)
+    mesh2 = Mesh(device_mesh2, axis_names=("x", "y"))
+    partition_spec2 = PartitionSpec("x", "y", None)
+    sharding2 = NamedSharding(mesh2, partition_spec2)
+
+    prefix = {
+        "a": jnp.ones((512, 512), device=local_devices[0]),
+        "d": jnp.ones((mesh_shape2[0], mesh_shape2[1], 512), device=sharding2),
+    }
+    expected_device = {
+        "a": local_devices[0],
+        "d": sharding2,
+    }
+    value = create_default_value(prefix=prefix)
+    assert value.device == expected_device
 
 
 class PrefixCacheTrieTest(unittest.TestCase):
@@ -214,69 +256,69 @@ class PrefixCacheTrieTest(unittest.TestCase):
     assert trie.get_longest_common_prefix_key((4, 5, 6)) == (4, 5, 6)
 
 
-class HBMCacheTest(unittest.TestCase):
+class BasicStorageTest(unittest.TestCase):
 
   def test_is_enough_space_remain(self):
     value = create_default_value()
-    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes)
-    assert hbm_cache.has_enough_space(value) is True
-    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes - 1)
-    assert hbm_cache.has_enough_space(value) is False
+    storage = prefix_cache.BasicStorage(max_size_bytes=value.prefix_size_bytes)
+    assert storage.has_enough_space(value.prefix_size_bytes) is True
+    storage = prefix_cache.BasicStorage(max_size_bytes=value.prefix_size_bytes - 1)
+    assert storage.has_enough_space(value.prefix_size_bytes) is False
 
-  def test_add_to_cache_and_fetch_with_key_exactly_matched(self):
+  def test_add_and_fetch_with_key_exactly_matched(self):
     key = (1, 2, 3)
     value = create_default_value()
-    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes)
-    assert hbm_cache.add_to_cache(key, value) is True
-    assert hbm_cache.retrieve_from_cache(key) == value
+    storage = prefix_cache.BasicStorage(max_size_bytes=value.prefix_size_bytes)
+    assert storage.add(key, value) is True
+    assert storage.retrieve(key) == value
 
-  def test_add_to_cache_fail_if_not_enough_space(self):
+  def test_add_fail_if_not_enough_space(self):
     value = create_default_value()
-    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes * 2 - 1)
-    assert hbm_cache.add_to_cache((1,), value) is True
+    storage = prefix_cache.BasicStorage(max_size_bytes=value.prefix_size_bytes * 2 - 1)
+    assert storage.add((1,), value) is True
     # The second one will exceed 1 bytes
-    assert hbm_cache.add_to_cache((2,), value) is False
-    assert hbm_cache.retrieve_from_cache((2,)) is None
+    assert storage.add((2,), value) is False
+    assert storage.retrieve((2,)) is None
 
   def test_cannot_retrieve_not_exactly_matched_key(self):
     key = (1, 2, 3)
     value = create_default_value()
-    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes)
-    assert hbm_cache.add_to_cache(key, value) is True
-    assert hbm_cache.retrieve_from_cache((1, 2, 4)) is None
-    assert hbm_cache.retrieve_from_cache((1, 2)) is None
+    storage = prefix_cache.BasicStorage(max_size_bytes=value.prefix_size_bytes)
+    assert storage.add(key, value) is True
+    assert storage.retrieve((1, 2, 4)) is None
+    assert storage.retrieve((1, 2)) is None
 
   def test_add_and_retrieve_multiple_keys(self):
-    hbm_cache = prefix_cache.HBMCache(max_size_bytes=1_000_000)
-    value1 = create_default_value(tokens=[1])
-    hbm_cache.add_to_cache((1,), value1)
-    value2 = create_default_value(tokens=[2])
-    hbm_cache.add_to_cache((2,), value2)
-    assert hbm_cache.retrieve_from_cache((1,)) == value1
-    assert hbm_cache.retrieve_from_cache((2,)) == value2
+    storage = prefix_cache.BasicStorage(max_size_bytes=1_000_000)
+    value1 = create_default_value(tokens=(1,))
+    storage.add((1,), value1)
+    value2 = create_default_value(tokens=(2,))
+    storage.add((2,), value2)
+    assert storage.retrieve((1,)) == value1
+    assert storage.retrieve((2,)) == value2
 
-  def test_evict_cache_return_evicted_value(self):
+  def test_evict_return_evicted_value(self):
     value = create_default_value()
-    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes)
-    hbm_cache.add_to_cache((1,), value)
-    evict_value = hbm_cache.evict_cache((1,))
+    storage = prefix_cache.BasicStorage(max_size_bytes=value.prefix_size_bytes)
+    storage.add((1,), value)
+    evict_value = storage.evict((1,))
     assert evict_value == value
 
-  def test_evict_cache_will_release_the_memory_usage_and_cannot_retrieve_and_evict_after_evict(self):
+  def test_evict_will_release_the_memory_usage_and_cannot_retrieve_and_evict_after_evict(self):
     value = create_default_value()
-    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value.prefix_size_bytes)
-    hbm_cache.add_to_cache((1,), value)
+    storage = prefix_cache.BasicStorage(max_size_bytes=value.prefix_size_bytes)
+    storage.add((1,), value)
     # memory is not enough
-    assert hbm_cache.add_to_cache((2,), create_default_value()) is False
-    hbm_cache.evict_cache((1,))
-    assert hbm_cache.retrieve_from_cache((1,)) is None
-    assert hbm_cache.evict_cache((1,)) is None
+    assert storage.add((2,), create_default_value()) is False
+    storage.evict((1,))
+    assert storage.retrieve((1,)) is None
+    assert storage.evict((1,)) is None
     # should add another after evict
     value2 = create_default_value()
-    assert hbm_cache.add_to_cache((2,), value2) is True
-    assert hbm_cache.retrieve_from_cache((2,)) == value2
+    assert storage.add((2,), value2) is True
+    assert storage.retrieve((2,)) == value2
 
-  def test_evict_multiple_caches(self):
+  def test_evict_multiple_values(self):
     key1 = (1,)
     value1 = create_default_value(tokens=key1)
     key2 = (
@@ -284,15 +326,199 @@ class HBMCacheTest(unittest.TestCase):
         2,
     )
     value2 = create_default_value(tokens=key2)
-    hbm_cache = prefix_cache.HBMCache(max_size_bytes=value1.prefix_size_bytes * 2)
-    hbm_cache.add_to_cache(key1, value1)
-    hbm_cache.add_to_cache(key2, value2)
-    evict_value = hbm_cache.evict_cache(key2)
+    storage = prefix_cache.BasicStorage(max_size_bytes=value1.prefix_size_bytes * 2)
+    storage.add(key1, value1)
+    storage.add(key2, value2)
+    evict_value = storage.evict(key2)
     assert evict_value == value2
-    assert hbm_cache.retrieve_from_cache(key2) is None
-    assert hbm_cache.retrieve_from_cache(key1) is not None
-    evict_value = hbm_cache.evict_cache(key1)
-    assert hbm_cache.retrieve_from_cache(key1) is None
+    assert storage.retrieve(key2) is None
+    assert storage.retrieve(key1) is not None
+    evict_value = storage.evict(key1)
+    assert storage.retrieve(key1) is None
+
+  def test_get_max_size_bytes(self):
+    storage = prefix_cache.BasicStorage(max_size_bytes=100)
+    assert storage.get_max_size_bytes() == 100
+
+  def test_contains_key(self):
+    value = create_default_value()
+    storage = prefix_cache.BasicStorage(max_size_bytes=value.prefix_size_bytes)
+    key = (1,)
+    assert storage.contains(key) is False
+    storage.add(key, value)
+    assert storage.contains(key) is True
+    storage.evict(key)
+    assert storage.contains(key) is False
+
+
+class HBMStorageTest(unittest.TestCase):
+  """Test roughly for HBMStorage while HBMStorage is a wrapper of BasicStorage."""
+
+  def test_basic_usage(self):
+    """Test basic usage of HBMStorage checking all functions work."""
+    key = (1,)
+    value = create_default_value()
+    storage = prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes)
+    assert storage.get_max_size_bytes() == value.prefix_size_bytes
+    assert storage.contains(key) is False
+    assert storage.has_enough_space(value.prefix_size_bytes) is True
+    assert storage.add(key, value) is True
+    assert storage.contains(key) is True
+    assert storage.retrieve(key) == value
+    # Only have one value size, and cannot afford the second.
+    assert storage.has_enough_space(value.prefix_size_bytes) is False
+    assert storage.evict(key) == value
+    assert storage.contains(key) is False
+    assert storage.retrieve(key) is None
+    assert storage.evict(key) is None
+    # After evict, it should have enough space
+    assert storage.has_enough_space(value.prefix_size_bytes) is True
+    assert storage.add(key, value) is True
+
+  @pytest.mark.tpu_only
+  def test_move_value_to_and_from_different_device(self):
+    local_devices = jax.local_devices()
+    if len(local_devices) < 2:
+      pytest.skip("Need to test with multiple devices")
+
+    key = (1,)
+
+    device_0_bytes_before = get_byte_in_use(0)
+    value = create_default_value(prefix={"a": jnp.ones((4, 4), device=local_devices[0])})
+    device_0_bytes_create_value = get_byte_in_use(0)
+    prefix_actually_used_byte = device_0_bytes_create_value - device_0_bytes_before
+    # Storage on device 1
+    storage = prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes, device=local_devices[1])
+    device_1_bytes_before = get_byte_in_use(1)
+    assert storage.add(key, value) is True
+    # The value will not removed from device 0 until async saved complete.
+    # Block the retrieved value to make sure the save complete.
+    retrieved_back_value = storage.retrieve(key)
+    assert retrieved_back_value is not None
+    jax.block_until_ready(retrieved_back_value.prefix)
+    del retrieved_back_value
+    del value
+    device_1_byte_after_add = get_byte_in_use(1)
+    # The prefix value is saved in device 1, and delete in device 0
+    assert device_1_byte_after_add - device_1_bytes_before == prefix_actually_used_byte
+    assert device_0_bytes_before == get_byte_in_use(0)
+    # Retrieve back to the original device
+    retrieved_back_value = storage.retrieve(key)
+    assert retrieved_back_value is not None
+    assert device_0_bytes_create_value == get_byte_in_use(0)
+
+  @pytest.mark.tpu_only
+  def test_retrieve_to_specific_device(self):
+    local_devices = jax.local_devices()
+    if len(local_devices) < 2:
+      pytest.skip("Need to test with multiple devices")
+
+    key = (1,)
+
+    device_0_bytes_before = get_byte_in_use(0)
+    value = create_default_value(prefix={"a": jnp.ones((4, 4), device=local_devices[0])})
+    device_0_bytes_create_value = get_byte_in_use(0)
+    prefix_actually_used_byte = device_0_bytes_create_value - device_0_bytes_before
+    # Storage without move device
+    storage = prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes)
+    assert storage.add(key, value) is True
+
+    device_1_byte_before = get_byte_in_use(1)
+    # Retrieve to device 1 from storage device 0
+    retrieved_back_value = storage.retrieve(key, device=local_devices[1])
+    assert retrieved_back_value is not None
+    device_1_byte_after = get_byte_in_use(1)
+    assert retrieved_back_value.prefix["a"].device == local_devices[1]
+    assert device_1_byte_after - device_1_byte_before == prefix_actually_used_byte
+
+
+class DRAMStorageTest(unittest.TestCase):
+  """Test basic usage of DRAMStorage only since DRAMStorage is wrapper of BasicStorage with device_get and device_put."""
+
+  def test_basic_usage(self):
+    """Test basic usage of DRAMStorage checking all functions work."""
+    key = (1,)
+    value = create_default_value()
+    storage = prefix_cache.DRAMStorage(max_size_bytes=value.prefix_size_bytes)
+    assert storage.get_max_size_bytes() == value.prefix_size_bytes
+    assert storage.has_enough_space(value.prefix_size_bytes) is True
+    assert storage.contains(key) is False
+    assert storage.add(key, value) is True
+    assert storage.contains(key) is True
+    assert storage.retrieve(key) == value
+    # Only have one value size, and cannot afford the second.
+    assert storage.has_enough_space(value.prefix_size_bytes) is False
+    assert storage.evict(key) == value
+    assert storage.contains(key) is False
+    assert storage.retrieve(key) is None
+    assert storage.evict(key) is None
+    # After evict, it should have enough space
+    assert storage.has_enough_space(value.prefix_size_bytes) is True
+    assert storage.add(key, value) is True
+
+  @pytest.mark.tpu_only
+  def test_move_value_between_device_and_host(self):
+    origin_hbm_byte = get_byte_in_use()
+    key = (1,)
+    value = create_default_value()
+    storage = prefix_cache.DRAMStorage(max_size_bytes=value.prefix_size_bytes)
+    value_on_device_hbm_byte = get_byte_in_use()
+    assert storage.add(key, value) is True
+    # add to cache will not copy another in HBM
+    assert value_on_device_hbm_byte == get_byte_in_use()
+    del value
+    value_on_host_hbm_byte = get_byte_in_use()
+    # after del the value on device, hbm memory should release
+    assert value_on_host_hbm_byte == origin_hbm_byte
+    device_value = storage.retrieve(key)
+    # copy the value back to device
+    assert value_on_device_hbm_byte == get_byte_in_use()
+    del device_value
+
+  @pytest.mark.tpu_only
+  def test_value_retrieve_back_to_the_same_device_sharding(self):
+    local_devices = jax.local_devices()
+    num_devices = jax.local_device_count()
+    mesh_shape = (num_devices,)
+    device_mesh = mesh_utils.create_device_mesh(mesh_shape, devices=local_devices)
+    mesh = Mesh(device_mesh, axis_names=("x",))
+    partition_spec = PartitionSpec("x", None)
+    sharding = NamedSharding(mesh, partition_spec)
+
+    key = (1,)
+    prefix = {
+        "cache": jnp.ones((mesh_shape[0], 512, 512), device=sharding),
+    }
+    value = create_default_value(prefix=prefix)
+    storage = prefix_cache.DRAMStorage(max_size_bytes=value.prefix_size_bytes)
+    assert storage.add(key, value)
+    del value
+    retrieved_value = storage.retrieve(key)
+    assert retrieved_value is not None
+    assert retrieved_value.prefix["cache"].device == sharding
+
+  @pytest.mark.tpu_only
+  def test_retrieve_to_specific_device(self):
+    local_devices = jax.local_devices()
+    if len(local_devices) < 2:
+      pytest.skip("Need to test with multiple devices")
+
+    key = (1,)
+    device_0_bytes_before = get_byte_in_use(0)
+    value = create_default_value(prefix={"a": jnp.ones((4, 4), device=local_devices[0])})
+    device_0_bytes_create_value = get_byte_in_use(0)
+    prefix_actually_used_byte = device_0_bytes_create_value - device_0_bytes_before
+    # Storage without move device
+    storage = prefix_cache.DRAMStorage(max_size_bytes=value.prefix_size_bytes)
+    assert storage.add(key, value) is True
+
+    device_1_byte_before = get_byte_in_use(1)
+    # Retrieve to device 1 from storage device 0
+    retrieved_back_value = storage.retrieve(key, device=local_devices[1])
+    assert retrieved_back_value is not None
+    device_1_byte_after = get_byte_in_use(1)
+    assert retrieved_back_value.prefix["a"].device == local_devices[1]
+    assert device_1_byte_after - device_1_byte_before == prefix_actually_used_byte
 
 
 class LRUStrategyTest(unittest.TestCase):
@@ -321,11 +547,158 @@ class LRUStrategyTest(unittest.TestCase):
     assert strategy.evict() is None
 
 
+class HierarchicalCacheTest(unittest.TestCase):
+
+  def test_add_to_all_layers(self):
+    value = create_default_value()
+    layers = (
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes),
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes),
+    )
+    cache = prefix_cache.HierarchicalCache(layers)
+    key = (1,)
+    assert cache.add(key, value)[0] is True
+    assert layers[0].contains(key)
+    assert layers[1].contains(key)
+
+  def test_cannot_add_if_first_layer_max_size_is_not_enough(self):
+    value = create_default_value()
+    layers = (
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes - 1),
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes),
+    )
+    cache = prefix_cache.HierarchicalCache(layers)
+    key = (1,)
+    assert cache.add(key, value)[0] is False
+    assert not layers[0].contains(key)
+    assert not layers[1].contains(key)
+
+  def test_add_evict_to_enough_space_by_lru(self):
+    value = create_default_value()
+    layers = (
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes),
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes * 2),
+    )
+    cache = prefix_cache.HierarchicalCache(layers)
+    assert cache.add((1,), value)[0] is True
+    assert cache.add((2,), value)[0] is True
+    ok, evicted = cache.add((3,), value)
+    assert ok is True
+    assert len(evicted) == 1
+    assert (1,) in evicted
+    assert not layers[0].contains((1,))
+    assert not layers[0].contains((2,))
+    assert layers[0].contains((3,))
+    assert not layers[1].contains((1,))
+    assert layers[1].contains((2,))
+    assert layers[1].contains((3,))
+
+  def test_retrieve_will_from_all_layer_and_add_to_all_layer(self):
+    value = create_default_value()
+    layers = (
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes),
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes * 2),
+    )
+    cache = prefix_cache.HierarchicalCache(layers)
+    assert cache.add((1,), value)[0] is True
+    assert cache.add((2,), value)[0] is True
+    assert not layers[0].contains((1,))
+    assert layers[1].contains((1,))
+    assert cache.retrieve((1,)) == value
+    assert layers[0].contains((1,))
+    assert not layers[0].contains((2,))
+
+  def test_retrieve_not_exist_in_any_layers_return_none(self):
+    value = create_default_value()
+    layers = (
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes),
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes * 2),
+    )
+    cache = prefix_cache.HierarchicalCache(layers)
+    assert cache.add((1,), value)[0] is True
+    assert cache.add((2,), value)[0] is True
+    assert cache.add((3,), value)[0] is True
+    # Key (1,) is evicted since LRU
+    assert cache.retrieve((1,)) is None
+
+  def test_add_will_happen_to_all_layers_even_if_some_layers_already_contains_the_key(self):
+    value = create_default_value()
+    layers = (
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes),
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes * 2),
+    )
+    cache = prefix_cache.HierarchicalCache(layers)
+    assert cache.add((1,), value)[0] is True
+    assert cache.add((2,), value)[0] is True
+    # layers[0] do not have (1,) now since LRU
+    assert not layers[0].contains((1,))
+    assert layers[1].contains((1,))
+    ok, evicted = cache.add((1,), value)
+    assert ok is True
+    # (1,) is not evicted from the second layer
+    assert not evicted
+    assert layers[0].contains((1,))
+    assert not layers[0].contains((2,))
+    assert layers[1].contains((1,))
+    assert layers[1].contains((2,))
+
+  def test_lru_affect_all_layers_when_add_and_retrieve(self):
+    value = create_default_value()
+    layers = (
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes * 2),
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes * 5),
+    )
+    cache = prefix_cache.HierarchicalCache(layers)
+    # There is a LRU queue length of 5. The first 2 will also at the first layer
+    assert cache.add((1,), value)[0] is True
+    assert cache.add((2,), value)[0] is True
+    assert cache.retrieve((1,)) is not None
+    assert cache.add((3,), value)[0] is True
+    assert cache.add((4,), value)[0] is True
+    assert cache.add((5,), value)[0] is True
+    assert cache.retrieve((4,)) is not None
+    ok, evicted = cache.add((6,), value)
+    assert ok is True
+    assert len(evicted) == 1
+    assert (2,) in evicted
+    assert cache.retrieve((3,)) is not None
+    # Now [3, 6, 4, 5, 1] in LRU
+    assert layers[0].contains((3,))
+    assert layers[0].contains((6,))
+    assert layers[1].contains((3,))
+    assert layers[1].contains((6,))
+    assert layers[1].contains((4,))
+    assert layers[1].contains((5,))
+    assert layers[1].contains((1,))
+    # 2 is evicted
+    assert not layers[1].contains((2,))
+
+  @pytest.mark.tpu_only
+  def test_retrieve_to_specific_device(self):
+    local_devices = jax.local_devices()
+    if len(local_devices) < 2:
+      pytest.skip("Need to test with multiple devices")
+
+    key = (1,)
+    value = create_default_value(prefix=jnp.ones((512, 512), device=local_devices[0]))
+    layers = (
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes * 2),
+        prefix_cache.HBMStorage(max_size_bytes=value.prefix_size_bytes * 5),
+    )
+    cache = prefix_cache.HierarchicalCache(layers)
+    assert cache.add(key, value)[0]
+    retrieved_value = cache.retrieve(key, device=local_devices[1])
+    assert retrieved_value is not None
+    assert retrieved_value.prefix.device == local_devices[1]
+    # The device in the Value remain the original before saved
+    assert retrieved_value.device == local_devices[0]
+
+
 class PrefixCacheTest(unittest.TestCase):
 
   def test_cache_miss_save_hit_load(self):
-    hbm_bytes = 64 * 1024 * 1024 * 1024  # 64 GB
-    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=hbm_bytes)
+    max_bytes = 64 * 1024 * 1024 * 1024  # 64 GB
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=max_bytes, dram_bytes=max_bytes)
     tokens = (1, 2, 3)
     no_matched_key = prefix_cache_inst.fetch_longest_common_prefix_key(tokens)
     # first seen prefix will not match any key
@@ -358,7 +731,8 @@ class PrefixCacheTest(unittest.TestCase):
   def test_clear_cache(self):
     tokens = (1, 2, 3)
     value = create_default_value(tokens=tokens)
-    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=value.prefix_size_bytes)
+    max_bytes = value.prefix_size_bytes
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=max_bytes, dram_bytes=max_bytes)
     assert prefix_cache_inst.save(tokens, value) is True
     assert prefix_cache_inst.load(tokens) == value
     prefix_cache_inst.clear()
@@ -372,7 +746,8 @@ class PrefixCacheTest(unittest.TestCase):
     tokens3 = (3,)
     value3 = create_default_value(tokens=tokens3)
     # cache with 2 values size, and will evict with LRU
-    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=(value1.prefix_size_bytes) * 2)
+    max_bytes = value1.prefix_size_bytes * 2
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=max_bytes, dram_bytes=max_bytes)
     assert prefix_cache_inst.save(tokens1, value1) is True
     assert prefix_cache_inst.save(tokens2, value2) is True
     assert prefix_cache_inst.load(tokens1) == value1
@@ -387,7 +762,8 @@ class PrefixCacheTest(unittest.TestCase):
     tokens3 = (3,)
     value3 = create_default_value(tokens=tokens3)
     # cache with 2 values size, and will evict with LRU
-    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=(value1.prefix_size_bytes) * 2)
+    max_bytes = value1.prefix_size_bytes * 2
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=max_bytes, dram_bytes=max_bytes)
     assert prefix_cache_inst.save(tokens1, value1) is True
     assert prefix_cache_inst.save(tokens2, value2) is True
     assert prefix_cache_inst.fetch_longest_common_prefix_key(tokens1) == tokens1
@@ -401,7 +777,8 @@ class PrefixCacheTest(unittest.TestCase):
     value2 = create_default_value(prefix=[jnp.array([1, 2, 3]) for _ in range(2)])
 
     # Only feasible for two value1 or one value2
-    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=(value1.prefix_size_bytes) * 2)
+    max_bytes = value1.prefix_size_bytes * 2
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=max_bytes, dram_bytes=max_bytes)
     assert prefix_cache_inst.save(key=(1,), value=value1) is True
     assert prefix_cache_inst.save(key=(2,), value=value1) is True
     assert prefix_cache_inst.load(key=(1,)) == value1
@@ -417,7 +794,8 @@ class PrefixCacheTest(unittest.TestCase):
     value2 = create_default_value(prefix=[jnp.array([1, 2, 3]) for _ in range(3)])
 
     # Only feasible for two value1 and never value2
-    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=(value1.prefix_size_bytes) * 2)
+    max_bytes = value1.prefix_size_bytes * 2
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=max_bytes, dram_bytes=max_bytes)
     assert prefix_cache_inst.save(key=(1,), value=value1) is True
     assert prefix_cache_inst.save(key=(2,), value=value1) is True
     assert prefix_cache_inst.load(key=(1,)) == value1
@@ -427,28 +805,45 @@ class PrefixCacheTest(unittest.TestCase):
     assert prefix_cache_inst.load(key=(2,)) == value1
     assert prefix_cache_inst.load(key=(3,)) is None
 
+  def test_cannot_fetch_longest_common_prefix_key_while_fully_evicted_from_dram(self):
+    value = create_default_value()
+    max_bytes = value.prefix_size_bytes
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=max_bytes, dram_bytes=max_bytes * 2)
+    assert (
+        prefix_cache_inst.save(
+            (1, 2),
+            value,
+        )
+        is True
+    )
+    assert (
+        prefix_cache_inst.save(
+            (1, 3),
+            value,
+        )
+        is True
+    )
+    # (1,2,) is only in DRAM now
+    assert prefix_cache_inst.fetch_longest_common_prefix_key((1, 2, 3)) == (1, 2)
+    assert (
+        prefix_cache_inst.save(
+            (2, 3),
+            value,
+        )
+        is True
+    )
+    # (1,2,) is fully evicted now
+    assert prefix_cache_inst.fetch_longest_common_prefix_key((1, 2, 3)) == (1, 3)
+
   @pytest.mark.tpu_only
   def test_hbm_memory_usage(self):
-    """Test HBM memory change.
-    Create the class instance will not pre allocate memory.
-    Save the cache will move without copy.
-    Load the cache will copy from cache.
-    Clear the cache will clear the saved cache.
-    """
-    device = jax.local_devices()[0]
-    memory_stats = device.memory_stats()
-    assert memory_stats is not None
-
-    def get_byte_in_use():
-      jax.clear_caches()
-      return memory_stats["bytes_in_use"]
-
+    """Test HBM memory change."""
     pre_bytes_in_use = get_byte_in_use()
     hbm_bytes = 1024
-    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=hbm_bytes)
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=hbm_bytes, dram_bytes=hbm_bytes)
     # prefix_cache will not pre allocate the memory
     assert pre_bytes_in_use == get_byte_in_use()
-    prefix = {"cached_prefill_key": jnp.array([1, 2, 3, 4], dtype=jnp.bfloat16, device=device)}
+    prefix = {"cached_prefill_key": jnp.array([1, 2, 3, 4], dtype=jnp.bfloat16)}
     prefix_create_bytes_in_use = get_byte_in_use()
     # memory would be allocated with chunked minimum size
     prefix_bytes = prefix_create_bytes_in_use - pre_bytes_in_use
@@ -469,9 +864,54 @@ class PrefixCacheTest(unittest.TestCase):
     del_loaded_bytes_in_use = get_byte_in_use()
     assert del_loaded_bytes_in_use == loaded_bytes_in_use
     prefix_cache_inst.clear()
+    # clear the cache will clear the saved cache.
     clear_bytes_in_use = get_byte_in_use()
     assert clear_bytes_in_use == del_loaded_bytes_in_use - prefix_bytes
     assert prefix_cache_inst.load(key) is None
+
+  @pytest.mark.tpu_only
+  def test_cache_move_between_device_and_host_with_hierarchical_cache(self):
+    value1 = create_default_value()
+    prefix_size_bytes = value1.prefix_size_bytes
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=prefix_size_bytes, dram_bytes=prefix_size_bytes * 2)
+    assert prefix_cache_inst.save((1,), value1)
+    del value1
+    first_save_bytes_in_use = get_byte_in_use()
+    value2 = create_default_value()
+    assert prefix_size_bytes == value2.prefix_size_bytes
+    assert prefix_cache_inst.save((2,), value2)
+    del value2
+    # the first saved cache (1,) is evicted since the size of HBM is one value.
+    assert first_save_bytes_in_use == get_byte_in_use()
+
+    # loaded value will move to HBM and (2,) in the HBM layer is evicted. The loaded value is the value in the HBM layer
+    loaded_value = prefix_cache_inst.load((1,))
+    assert loaded_value is not None
+    assert first_save_bytes_in_use == get_byte_in_use()
+    del loaded_value
+    assert first_save_bytes_in_use == get_byte_in_use()
+
+    # switch the cache again
+    loaded_value = prefix_cache_inst.load((2,))
+    assert loaded_value is not None
+    assert first_save_bytes_in_use == get_byte_in_use()
+    del loaded_value
+    assert first_save_bytes_in_use == get_byte_in_use()
+
+  @pytest.mark.tpu_only
+  def test_load_to_specific_device(self):
+    local_devices = jax.local_devices()
+    if len(local_devices) < 2:
+      pytest.skip("Need to test with multiple devices")
+
+    key = (1,)
+    value = create_default_value(prefix=jnp.ones((512, 512), device=local_devices[0]))
+    prefix_cache_inst = prefix_cache.PrefixCache(hbm_bytes=value.prefix_size_bytes, dram_bytes=value.prefix_size_bytes * 2)
+    assert prefix_cache_inst.save(key, value)
+    loaded_value = prefix_cache_inst.load(key, device=local_devices[1])
+    assert loaded_value is not None
+    assert loaded_value.prefix.device == local_devices[1]
+    assert loaded_value.device == local_devices[0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Support hierarchical cache including host DRAM in PrefixCache.
It is useful when the transfer latency is lower than the recompute common prefix KV cache.

Possible future improvements:
- Benchmark and add config to decide if loading from DRAM is beneficial depend on common prefix length.
- Add a config to disable DRAM cache if HBM is larger enough to get the beneficial without use DRAM.

FIXES: b/397854783

# Tests

Unittest

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
