### PR TITLE
Jax implementation of creating unified_lora_params and computing xAB for a batch of decode requests.

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -1530,7 +1530,7 @@ class Attention(nn.Module):
       key = self.kv_projection(inputs_kv, proj_name="key")
       value = self.kv_projection(inputs_kv, proj_name="value")
 
-    if lora_params:   # Non-empty LoRA Parameters
+    if lora_params:  # Non-empty LoRA Parameters
       # TODO: Hardcoded the scale_factor. Pass it via call_stack
       # scale_factor = lora_alpha / lora_rank
       scale_factor = 4
@@ -1543,8 +1543,8 @@ class Attention(nn.Module):
       # lora_b_q: [b, r, h, d]
 
       if "lora_a.kernel" in lora_params[self.name]["query"]:
-        lora_a_q = lora_params[self.name]["query"]["lora_a.kernel"]       # [batch, hidden_size, rank]
-        lora_b_q = lora_params[self.name]["query"]["lora_b.kernel"]       # [batch, rank, num_heads, head_dim]
+        lora_a_q = lora_params[self.name]["query"]["lora_a.kernel"]  # [batch, hidden_size, rank]
+        lora_b_q = lora_params[self.name]["query"]["lora_b.kernel"]  # [batch, rank, num_heads, head_dim]
         query = query + jnp.einsum("bsH,bHr,brhd->bshd", inputs_q, lora_a_q, lora_b_q) * scale_factor
 
       if "lora_a.kernel" in lora_params[self.name]["key"]:

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -1494,6 +1494,7 @@ class Attention(nn.Module):
       deterministic: bool = False,
       previous_chunk: Any = None,
       page_state: Optional[page_manager.PageState] = None,
+      lora_params: Optional[dict] = None,
   ):
     """Applies Attention on the input data.
 
@@ -1513,6 +1514,7 @@ class Attention(nn.Module):
       inputs_kv: key/values of shape `[batch, kv_length, kv_features]`.
       model_mode: corresponding to train, prefill and decode.
       deterministic: Disables dropout if set to True.
+      lora_params: A dictionry of unified LoRA params.
 
     Returns:
       output of shape `[batch, length, q_features]`.
@@ -1527,6 +1529,33 @@ class Attention(nn.Module):
       query = self.query_projection(inputs_q)
       key = self.kv_projection(inputs_kv, proj_name="key")
       value = self.kv_projection(inputs_kv, proj_name="value")
+
+    if lora_params:   # Non-empty LoRA Parameters
+      # TODO: Hardcoded the scale_factor. Pass it via call_stack
+      # scale_factor = lora_alpha / lora_rank
+      scale_factor = 4
+
+      # Unified batched matmul for query update:
+      # b: batch, s: sequence length, H: hidden_size (h * d), h: num_heads, d: head_dim, r: lora_rank
+      # query: [b, s, h, d]
+      # input_q: [b, s, H]
+      # lora_a_q: [b, H, r]
+      # lora_b_q: [b, r, h, d]
+
+      if "lora_a.kernel" in lora_params[self.name]["query"]:
+        lora_a_q = lora_params[self.name]["query"]["lora_a.kernel"]       # [batch, hidden_size, rank]
+        lora_b_q = lora_params[self.name]["query"]["lora_b.kernel"]       # [batch, rank, num_heads, head_dim]
+        query = query + jnp.einsum("bsH,bHr,brhd->bshd", inputs_q, lora_a_q, lora_b_q) * scale_factor
+
+      if "lora_a.kernel" in lora_params[self.name]["key"]:
+        lora_a_k = lora_params[self.name]["key"]["lora_a.kernel"]
+        lora_b_k = lora_params[self.name]["key"]["lora_b.kernel"]
+        key = key + jnp.einsum("bsH,bHr,brhd->bshd", inputs_kv, lora_a_k, lora_b_k) * scale_factor
+
+      if "lora_a.kernel" in lora_params[self.name]["query"]:
+        lora_a_v = lora_params[self.name]["value"]["lora_a.kernel"]
+        lora_b_v = lora_params[self.name]["value"]["lora_b.kernel"]
+        value = value + jnp.einsum("bsH,bHr,brhd->bshd", inputs_kv, lora_a_v, lora_b_v) * scale_factor
 
     # apply ROPE
     query = self.apply_rotary_embedding(query, inputs_positions, name="query_rotary")

--- a/MaxText/layers/llama2.py
+++ b/MaxText/layers/llama2.py
@@ -75,6 +75,7 @@ class LlamaDecoderLayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      lora_params,
       page_state: Optional[page_manager.PageState] = None,
   ):
     cfg = self.config
@@ -119,6 +120,10 @@ class LlamaDecoderLayer(nn.Module):
         ragged_block_size=cfg.ragged_block_size,
     )
 
+    lora_params_layers = {}
+    if lora_params:
+      lora_params_layers = lora_params[self.name]   # Fetch the self-attention params of each `layers_{idx}`
+
     attention_lnx = attention_layer(
         lnx,
         lnx,
@@ -126,6 +131,7 @@ class LlamaDecoderLayer(nn.Module):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         model_mode=model_mode,
+        lora_params=lora_params_layers,
         page_state=page_state,
     )
 

--- a/MaxText/layers/llama2.py
+++ b/MaxText/layers/llama2.py
@@ -122,7 +122,7 @@ class LlamaDecoderLayer(nn.Module):
 
     lora_params_layers = {}
     if lora_params:
-      lora_params_layers = lora_params[self.name]   # Fetch the self-attention params of each `layers_{idx}`
+      lora_params_layers = lora_params[self.name]  # Fetch the self-attention params of each `layers_{idx}`
 
     attention_lnx = attention_layer(
         lnx,

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -385,6 +385,7 @@ class Decoder(nn.Module):
       deterministic=False,
       model_mode=common_types.MODEL_MODE_TRAIN,
       previous_chunk=None,
+      lora_params=None,
       page_state: Optional[page_manager.PageState] = None,
   ):
     cfg = self.config
@@ -474,12 +475,18 @@ class Decoder(nn.Module):
         else:
           for lyr in range(cfg.num_decoder_layers):
             RemattedBlockLayer = RemattedBlockLayers[0]
+
+            lora_params_decoder = {}
+            if lora_params:
+              lora_params_decoder = lora_params["params"]["decoder"]
+
             y = RemattedBlockLayer(config=cfg, mesh=mesh, name=f"layers_{lyr}", quant=self.quant)(
                 y,
                 decoder_segment_ids,
                 decoder_positions,
                 deterministic,
                 model_mode,
+                lora_params_decoder,
                 page_state,
             )
     y = self.get_norm_layer()(
@@ -589,6 +596,7 @@ class Transformer(nn.Module):
       enable_dropout=True,
       model_mode=common_types.MODEL_MODE_TRAIN,
       previous_chunk=None,
+      lora_params=None,
       true_length: Optional[int] = None,
       slot: Optional[int] = None,
   ):
@@ -613,6 +621,7 @@ class Transformer(nn.Module):
         deterministic=not enable_dropout,
         model_mode=model_mode,
         previous_chunk=previous_chunk,
+        lora_params=lora_params,
         page_state=self._create_page_state(model_mode=model_mode, true_length=true_length, slot=slot),
     )
     return logits

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -700,6 +700,7 @@ class MaxEngine(engine_api.Engine):
       self,
       params: Params,
       decode_state: DecodeState,
+      lora_params: Params = None,
       sampler: Optional[Callable[[Any], Any]] = None,  # pylint: disable=unused-argument
       rng: Optional[PRNGKeyType] = None,
   ) -> Tuple[DecodeState, engine_api.ResultTokens]:
@@ -717,6 +718,7 @@ class MaxEngine(engine_api.Engine):
           decode_state["next_pos"],
           enable_dropout=False,
           model_mode=common_types.MODEL_MODE_AUTOREGRESSIVE,
+          lora_params=lora_params,
           rngs={"params": new_rng},
           mutable=["cache"],
       )


### PR DESCRIPTION
# Description

Jax implementation of creating unified_lora_params and computing xAB for a batch of decode requests.

- Created a cache enough to hold the LoRA adapter params for each slot. Here the tensors has an extra dimension(0) which is size = #slots. From JetStream we can insert the LoRA adapter params (A and B) into the cache.
- As each slot could have different parameters, multiple different adapters can be used in the same decoding batch.
- This cache is further utilized in the Attention module to calculate xAB for query, key and value for all the currently processing decoding requests. 
- 
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.