### PR TITLE
Add microbenchmark support for multisampling_prefill.

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -556,6 +556,7 @@ inference_microbenchmark_prefill_lengths: "64,128,256,512,1024"
 inference_microbenchmark_stages: "prefill,generate"
 inference_microbenchmark_loop_iters: 10
 inference_microbenchmark_log_file_path: ""
+inference_microbenchmark_num_samples: [1, 2, 3, 4, 5]
 inference_metadata_file: "" # path to a json file
 inference_server: "MaxtextInterleavedServer"  # inference server to start
 inference_benchmark_test: False

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -495,7 +495,6 @@ class Decoder(nn.Module):
               from layers import gemma3
               # Gemma3 uses both global and sliding window attention depending on the layer index.
               layer_kwargs = {"attention_type": gemma3.get_attention_type(layer_id=lyr)}
-
             layer = RemattedBlockLayer(config=cfg, mesh=mesh, name=f"layers_{lyr}", quant=self.quant, **layer_kwargs)
             y = layer(
                 y,

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -341,99 +341,6 @@ class MaxEngine(engine_api.Engine):
         previous_chunk=previous_chunk,
     )
 
-  @functools.partial(jax.jit, static_argnums=(0,), static_argnames=("num_samples",))
-  def prefill_multisampling(
-      self,
-      *,
-      params: Params,
-      existing_prefix: Optional[jax.Array] = None,
-      padded_tokens: jax.Array,
-      true_length: int,
-      sampler: Optional[Callable[[Any], Any]] = None,  # pylint: disable=unused-argument
-      rng: Optional[PRNGKeyType] = None,
-      num_samples: int = 1,
-  ) -> Tuple[Prefix, engine_api.ResultTokens]:
-    """Computes a kv-cache for a new generate request.
-
-    With multi-sampling, the engine will generate multiple first tokens in the
-    prefilling stage. The number of tokens is specified by num_samples.
-    """
-    if existing_prefix:
-      raise ValueError("We don't know what to do with existing_prefix")
-
-    if rng is None:
-      rng = jax.random.PRNGKey(0)
-
-    input_tokens = jnp.expand_dims(padded_tokens, 0)  # [BATCH, SEQUENCE]
-    positions = jnp.expand_dims(jnp.arange(0, input_tokens.shape[1]), 0)
-
-    zero_to_n = jnp.arange(0, padded_tokens.shape[0])
-    ones_to_keep = zero_to_n < true_length
-    one_d_output = ones_to_keep * common_types.DECODING_ACTIVE_SEQUENCE_INDICATOR
-    sequence_indicator = jnp.expand_dims(one_d_output, 0)
-
-    rng, new_rng = jax.random.split(rng)
-    with self._mesh, nn_partitioning.axis_rules(self.config.logical_axis_rules):
-      flat_logits, new_vars = self.model.apply(
-          params,
-          input_tokens,
-          positions,
-          decoder_segment_ids=sequence_indicator,
-          enable_dropout=False,
-          model_mode=common_types.MODEL_MODE_PREFILL,
-          rngs={"params": new_rng},
-          mutable=["cache"],
-      )
-
-    next_pos = jnp.full((1, 1), true_length, dtype=jnp.int32)
-    selected_logits = jax.lax.dynamic_slice(
-        flat_logits,
-        (0, true_length - 1, 0),
-        (flat_logits.shape[0], 1, flat_logits.shape[2]),
-    )
-    selected_logits = jax.lax.with_sharding_constraint(selected_logits, self.replicated_sharding)
-
-    # sampling first tokens
-    first_generated_tokens = []
-    for _ in range(num_samples):
-      rng, new_rng = jax.random.split(rng)
-      first_generated_token = inference_utils.sampling(
-          selected_logits,
-          new_rng,
-          self.config.decode_sampling_strategy,
-          topk=self.config.decode_sampling_top_k,
-          nucleus_topp=self.config.decode_sampling_nucleus_p,
-          temperature=self.config.decode_sampling_temperature,
-      )
-      first_generated_tokens.append(first_generated_token)
-    first_generated_tokens = jnp.concatenate(first_generated_tokens, axis=0)
-
-    all_valid = jnp.ones((num_samples, 1), dtype=jnp.int8)
-    generated_tokens = jnp.zeros((num_samples, 1), dtype=jnp.int32)
-    result = engine_api.ResultTokens(
-        data=jnp.concatenate((first_generated_tokens, all_valid, generated_tokens), axis=1),
-        # Tokens are shape [batch, speculations], so when we concatenate
-        # tokens, validity and length along their index 1 dimension then they
-        # occupy 0:speculations.
-        tokens_idx=(0, 1),
-        # Validity occupies the same amount of space, but next in line.
-        valid_idx=(1, 2),
-        # And lengths is rank 1.
-        length_idx=(2, 3),
-        samples_per_slot=num_samples,
-    )
-
-    cache = new_vars["cache"]
-    cache = self._maybe_stack_prefill_result_cache(cache)
-
-    return {
-        "logits": selected_logits,
-        "cache": cache,
-        "next_pos": next_pos,
-        "generated_tokens": generated_tokens,
-        "tokens": first_generated_tokens,
-    }, result
-
   @functools.partial(jax.jit, static_argnums=(0,), static_argnames=("request_id",))
   def prefill(
       self,
@@ -574,6 +481,115 @@ class MaxEngine(engine_api.Engine):
         "next_pos": next_pos,
         "generated_tokens": generated_tokens,
         "tokens": first_generated_token,
+    }, result
+
+  def prefill_multisampling_aot(  # pylint: disable=too-many-positional-arguments
+      self,
+      params: Params,
+      padded_tokens: jax.Array,
+      true_length: int,
+      rng: Optional[PRNGKeyType] = None,
+      num_samples: int = 1,
+      sampler: Optional[Callable[[Any], Any]] = None,
+  ) -> Tuple[Prefix, engine_api.ResultTokens]:
+    """Wrapper for multi-sampling prefill for ahead-of-time compilation."""
+    return self.prefill_multisampling(
+        params=params,
+        padded_tokens=padded_tokens,
+        true_length=true_length,
+        sampler=sampler,
+        rng=rng,
+        num_samples=num_samples,
+    )
+
+  @functools.partial(jax.jit, static_argnums=(0,), static_argnames=("num_samples",))
+  def prefill_multisampling(
+      self,
+      *,
+      params: Params,
+      padded_tokens: jax.Array,
+      true_length: int,
+      sampler: Optional[Callable[[Any], Any]] = None,  # pylint: disable=unused-argument
+      rng: Optional[PRNGKeyType] = None,
+      num_samples: int = 1,
+  ) -> Tuple[Prefix, engine_api.ResultTokens]:
+    """Computes a kv-cache for a new generate request.
+
+    With multi-sampling, the engine will generate multiple first tokens in the
+    prefilling stage. The number of tokens is specified by num_samples.
+    """
+
+    if rng is None:
+      rng = jax.random.PRNGKey(0)
+
+    input_tokens = jnp.expand_dims(padded_tokens, 0)  # [BATCH, SEQUENCE]
+    positions = jnp.expand_dims(jnp.arange(0, input_tokens.shape[1]), 0)
+
+    zero_to_n = jnp.arange(0, padded_tokens.shape[0])
+    ones_to_keep = zero_to_n < true_length
+    one_d_output = ones_to_keep * common_types.DECODING_ACTIVE_SEQUENCE_INDICATOR
+    sequence_indicator = jnp.expand_dims(one_d_output, 0)
+
+    rng, new_rng = jax.random.split(rng)
+    with self._mesh, nn_partitioning.axis_rules(self.config.logical_axis_rules):
+      flat_logits, new_vars = self.model.apply(
+          params,
+          input_tokens,
+          positions,
+          decoder_segment_ids=sequence_indicator,
+          enable_dropout=False,
+          model_mode=common_types.MODEL_MODE_PREFILL,
+          rngs={"params": new_rng},
+          mutable=["cache"],
+      )
+
+    next_pos = jnp.full((1, 1), true_length, dtype=jnp.int32)
+    selected_logits = jax.lax.dynamic_slice(
+        flat_logits,
+        (0, true_length - 1, 0),
+        (flat_logits.shape[0], 1, flat_logits.shape[2]),
+    )
+    selected_logits = jax.lax.with_sharding_constraint(selected_logits, self.replicated_sharding)
+
+    # sampling first tokens
+    first_generated_tokens = []
+    for _ in range(num_samples):
+      rng, new_rng = jax.random.split(rng)
+      first_generated_token = inference_utils.sampling(
+          selected_logits,
+          new_rng,
+          self.config.decode_sampling_strategy,
+          topk=self.config.decode_sampling_top_k,
+          nucleus_topp=self.config.decode_sampling_nucleus_p,
+          temperature=self.config.decode_sampling_temperature,
+      )
+      first_generated_tokens.append(first_generated_token)
+    first_generated_tokens = jnp.concatenate(first_generated_tokens, axis=0)
+
+    all_valid = jnp.ones((num_samples, 1), dtype=jnp.int8)
+    generated_tokens = jnp.zeros((num_samples, 1), dtype=jnp.int32)
+    result = engine_api.ResultTokens(
+        data=jnp.concatenate((first_generated_tokens, all_valid, generated_tokens), axis=1),
+        # Tokens are shape [batch, speculations], so when we concatenate
+        # tokens, validity and length along their index 1 dimension then they
+        # occupy 0:speculations.
+        tokens_idx=(0, 1),
+        # Validity occupies the same amount of space, but next in line.
+        valid_idx=(1, 2),
+        # And lengths is rank 1.
+        length_idx=(2, 3),
+        samples_per_slot=num_samples,
+    )
+
+    cache = new_vars["cache"]
+    cache = self._maybe_stack_prefill_result_cache(cache)
+
+    return {
+        "logits": selected_logits,
+        "cache": cache,
+        "next_pos": next_pos,
+        "generated_tokens": generated_tokens,
+        "tokens": first_generated_tokens,
     }, result
 
   @functools.partial(jax.jit, static_argnums=(0,), static_argnames=("num_prompts",))


### PR DESCRIPTION
# Description

Includes multisampling_prefill for microbenchmarking. To enable this microbenchmark, add `prefill-multisampling` to `inference_microbenchmark_stages` in the base.yml. The number of samples to benchmark is specified by `inference_microbenchmark_num_samples` in `base.yml`. The overall microbenchmark duration will be longer due to aot compilation for the multisampling_prefill with different `num_samples`

# Tests
Microbenchmark numbers:
```
Prefill benchmark results for length 64:

Per prefill step per device: 
        Total TFLOPs: 0.22 
                Learnable weight TFLOPs: 0.22  (99.88)% of Total
                Causal attention TFLOPs: 0.00  (0.12)% of Total
        Prefill step average time: 9.004 ms
        Prefill total TFLOPs/device: 0.216
        Prefill TFLOPs/sec/device: 23.983




Multi-sampling prefill benchmark results for length 64:


Num samples: 1
        Prefill step average time: 8.984 ms





Num samples: 2
        Prefill step average time: 8.693 ms





Num samples: 3
        Prefill step average time: 8.697 ms





Num samples: 4
        Prefill step average time: 8.904 ms





Num samples: 5
        Prefill step average time: 8.675 ms




Prefill and insert benchmark results for length 64:

        Prefill + Insert step average time: 9.135 ms




Prefill benchmark results for length 128:

Per prefill step per device: 
        Total TFLOPs: 0.43 
                Learnable weight TFLOPs: 0.43  (99.75)% of Total
                Causal attention TFLOPs: 0.00  (0.25)% of Total
        Prefill step average time: 9.357 ms
        Prefill total TFLOPs/device: 0.432
        Prefill TFLOPs/sec/device: 46.212




Multi-sampling prefill benchmark results for length 128:


Num samples: 1
        Prefill step average time: 9.272 ms





Num samples: 2
        Prefill step average time: 9.349 ms





Num samples: 3
        Prefill step average time: 9.380 ms





Num samples: 4
        Prefill step average time: 9.299 ms





Num samples: 5
        Prefill step average time: 9.279 ms




Prefill and insert benchmark results for length 128:

        Prefill + Insert step average time: 9.891 ms




Prefill benchmark results for length 256:

Per prefill step per device: 
        Total TFLOPs: 0.87 
                Learnable weight TFLOPs: 0.86  (99.50)% of Total
                Causal attention TFLOPs: 0.00  (0.50)% of Total
        Prefill step average time: 15.014 ms
        Prefill total TFLOPs/device: 0.867
        Prefill TFLOPs/sec/device: 57.744




Multi-sampling prefill benchmark results for length 256:


Num samples: 1
        Prefill step average time: 15.025 ms





Num samples: 2
        Prefill step average time: 15.018 ms





Num samples: 3
        Prefill step average time: 15.010 ms





Num samples: 4
        Prefill step average time: 15.029 ms





Num samples: 5
        Prefill step average time: 15.015 ms




Prefill and insert benchmark results for length 256:

        Prefill + Insert step average time: 16.696 ms




Prefill benchmark results for length 512:

Per prefill step per device: 
        Total TFLOPs: 1.74 
                Learnable weight TFLOPs: 1.73  (99.01)% of Total
                Causal attention TFLOPs: 0.02  (0.99)% of Total
        Prefill step average time: 27.097 ms
        Prefill total TFLOPs/device: 1.743
        Prefill TFLOPs/sec/device: 64.310




Multi-sampling prefill benchmark results for length 512:


Num samples: 1
        Prefill step average time: 27.050 ms





Num samples: 2
        Prefill step average time: 27.082 ms





Num samples: 3
        Prefill step average time: 27.098 ms





Num samples: 4
        Prefill step average time: 27.079 ms





Num samples: 5
        Prefill step average time: 27.100 ms




Prefill and insert benchmark results for length 512:

        Prefill + Insert step average time: 30.693 ms




Prefill benchmark results for length 1024:

Per prefill step per device: 
        Total TFLOPs: 3.52 
                Learnable weight TFLOPs: 3.45  (98.05)% of Total
                Causal attention TFLOPs: 0.07  (1.95)% of Total
        Prefill step average time: 54.951 ms
        Prefill total TFLOPs/device: 3.519
        Prefill TFLOPs/sec/device: 64.047




Multi-sampling prefill benchmark results for length 1024:


Num samples: 1
        Prefill step average time: 55.753 ms





Num samples: 2
        Prefill step average time: 55.742 ms





Num samples: 3
        Prefill step average time: 55.733 ms





Num samples: 4
        Prefill step average time: 55.737 ms





Num samples: 5
        Prefill step average time: 55.757 ms




Prefill and insert benchmark results for length 1024:

        Prefill + Insert step average time: 63.158 ms




AutoRegressive results:
        AR step average time: 361.095 ms
        AR step average time per seq: 5.642 ms
        AR global batch size: 64
        AR throughput: 177.238 tokens/second
        AR memory bandwidth per device: 28.661 GB/s




For usage in analyze_sharegpt.py :
PREFILL_BUCKET_SIZE_TO_MS = {64: 9.004, 128: 9.357, 256: 15.014, 512: 27.097, 1024: 54.951}
MULTISAMPLING_PREFILL_BUCKET_SIZE_TO_MS = {64: {1: 8.984, 2: 8.693, 3: 8.697, 4: 8.904, 5: 8.675}, 128: {1: 9.272, 2: 9.349, 3: 9.38, 4: 9.299, 5: 9.279}, 256: {1: 15.025, 2: 15.018, 3: 15.01, 4: 15.029, 5: 15.015}, 512: {1: 27.05, 2: 27.082, 3: 27.098, 4: 27.079, 5: 27.1}, 1024: {1: 55.753, 2: 55.742, 3: 55.733, 4: 55.737, 5: 55.757}}
INSERT_BUCKET_SIZE_TO_MS = {64: 0.131, 128: 0.534, 256: 1.682, 512: 3.597, 1024: 8.206}
SYSTEM_TIME_PER_DECODE_TOKEN_MS = 5.642115625
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
