### PR TITLE
Add bf16 benchmark for GPT3-175B

### DIFF
--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -284,6 +284,34 @@ gpt_3_175b = _add_to_model_dictionary(
     ),
 )
 
+gpt_3_175b_bf16 = _add_to_model_dictionary(
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="gpt-3-175b-bf16",
+        model_type="gpt3-175b",
+        tuning_params={
+            "per_device_batch_size": 3,
+            "ici_fsdp_parallelism": -1,
+            "remat_policy": "full",
+            "attention": "flash",
+            "gcs_metrics": True,
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 1024,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+        },
+        xla_flags=(
+            xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+            + xla_flags_library.DISABLE_BUNDLE_AWARE_COST_MODEL
+        ),
+    ),
+)
+
 
 llama2_7b_4096 = _add_to_model_dictionary(
     trillium_model_dict,


### PR DESCRIPTION
# Description

Add a new Trillium benchmark that runs GPT3-175B with BF16. I ran this on v6e-256 and got 392 TFLOPs.

This change is needed to support adding a reproducible Trillium recipe.

# Tests

Ran this on one slice of v6e-256 using the following command:

```
python3 benchmarks/benchmark_runner.py xpk \
    --project=${PROJECT} \
    --zone=${ZONE} \
    --device_type=v6e-256 \
    --num_slices=1  \
    --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="gpt_3_175b_bf16" \
    --base_docker_image=maxtext_base_image
```

I got the perf described above.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
