### PR TITLE
Allow to dump at the specified step. This is useful for AutoPGLE

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -437,6 +437,7 @@ profile_periodically_period: -1 # If set to a positive integer, profile every pr
 
 # Dump HLO options
 dump_hlo: False
+dump_step: -1 # Dump modules at the given step if set to a positive integer.
 dump_hlo_local_dir: "/tmp/xla_dump/"
 dump_hlo_delete_local_after: True # Cleans local directory after its uploaded
 dump_hlo_gcs_dir: "" # Defaults to {base_output_directory}/{run_name}/xla_dump

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -840,7 +840,7 @@ def train_loop(config, state=None):
 
     metric_logger.write_metrics(running_gcs_metrics, metrics, step)
 
-    if config.dump_hlo and step == start_step:
+    if config.dump_hlo and step == (config.dump_step if config.dump_step >= 0 else start_step):
       jax.block_until_ready(state)  # Ensure compilation has finished.
       max_utils.upload_dump(
           config.dump_hlo_local_dir,


### PR DESCRIPTION
# Description

When AutoPGLE is used the modules are getting recompiled after several training steps. We need to be able to dump modules after recompilation.

# Test

Locally launched llama2_7b