### PR TITLE
Decouple printing logs to stdout from tensorboard

### DIFF
--- a/MaxText/metric_logger.py
+++ b/MaxText/metric_logger.py
@@ -60,6 +60,7 @@ class MetricLogger:
           raise ValueError(f"When writing metrics, {self.buffered_step=} was none")
         metrics_to_write = self.buffered_metrics
         steps_to_write = self.buffered_step
+        self.log_metrics(metrics_to_write, steps_to_write)
       self.buffered_metrics = metrics
       self.buffered_step = step
     else:
@@ -75,6 +76,16 @@ class MetricLogger:
 
       if self.config.gcs_metrics and jax.process_index() == 0:
         running_gcs_metrics = self.write_metrics_for_gcs(metrics_to_write, steps_to_write, running_gcs_metrics, is_training)
+
+  def log_metrics(self, metrics, step):
+    """Logs metrics via max_logging"""
+    max_logging.log(
+        f"completed step: {step}, seconds: {metrics['scalar']['perf/step_time_seconds']:.3f}, "
+        f"TFLOP/s/device: {metrics['scalar']['perf/per_device_tflops_per_sec']:.3f}, "
+        f"Tokens/s/device: {metrics['scalar']['perf/per_device_tokens_per_sec']:.3f}, "
+        f"total_weights: {metrics['scalar']['learning/total_weights']}, "
+        f"loss: {metrics['scalar']['learning/loss']:.3f}"
+    )
 
   def write_metrics_locally(self, metrics, step):
     """Writes metrics locally for testing"""
@@ -114,14 +125,6 @@ class MetricLogger:
 
       if is_training:
         full_log = step % self.config.log_period == 0
-
-        max_logging.log(
-            f"completed step: {step}, seconds: {metrics['scalar']['perf/step_time_seconds']:.3f}, "
-            f"TFLOP/s/device: {metrics['scalar']['perf/per_device_tflops_per_sec']:.3f}, "
-            f"Tokens/s/device: {metrics['scalar']['perf/per_device_tokens_per_sec']:.3f}, "
-            f"total_weights: {metrics['scalar']['learning/total_weights']}, "
-            f"loss: {metrics['scalar']['learning/loss']:.3f}"
-        )
 
         if full_log and jax.process_index() == 0:
           max_logging.log(f"To see full metrics 'tensorboard --logdir={self.config.tensorboard_dir}'")


### PR DESCRIPTION
Commit 7bc0f48 introduced a config to disable tensorboard. However, it unintentionally disable printing to stdout as well. This CL separates the logic that prints logs  from the logic the writes to tensorboard.

Test:
Check that enable_tensorboard=False and enable_tensorboard=True lead to the same logs on stdout.

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
