### PR TITLE
Add Disruption Manager & Elastic Training Recipe (SIGILL path)

### DIFF
--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -31,7 +31,7 @@ from maxtext_xpk_runner import PathwaysConfig
 from maxtext_xpk_runner import WorkloadConfig
 from maxtext_xpk_runner import xpk_benchmark_runner
 from maxtext_xpk_runner import on_device_benchmark_runner
-from maxtext_xpk_runner import XpkClusterConfig
+from xpk_configs import XpkClusterConfig
 from maxtext_xpk_runner import LibTpuType
 
 def add_pathways_arguments(parser: argparse.ArgumentParser):

--- a/benchmarks/disruption_management/__init__.py
+++ b/benchmarks/disruption_management/__init__.py
@@ -1,0 +1,13 @@
+"""
+ Copyright 2025 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+ 

--- a/benchmarks/disruption_management/disruption_handler.py
+++ b/benchmarks/disruption_management/disruption_handler.py
@@ -1,0 +1,178 @@
+"""
+ Copyright 2025 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import abc
+import dataclasses
+import enum
+import os
+import subprocess
+import sys
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+from xpk_configs import XpkClusterConfig
+
+
+MCJAX_STANDARD_TARGET_POD_REGEX_SUFFIX = ".*slice-job-0-0.*"
+MCJAX_STANDARD_STEP_POD_REGEX_SUFFIX = ".*slice-job-0-0.*"
+PATHWAYS_STANDARD_TARGET_POD_REGEX_SUFFIX = ".*worker-0-0.*"
+PATHWAYS_STANDARD_STEP_POD_REGEX_SUFFIX = ".*main-0-0.*"
+
+STANDARD_STEP_LOG_REGEX = "completed step: (\\d+)"
+
+PATHWAYS_WORKER_CONTAINER_NAME = "pathways-worker"
+MCJAX_WORKER_CONTAINER_NAME = "jax-tpu"
+
+
+class TriggerType(enum.Enum):
+  TIME_SECONDS = "time_seconds"
+  STEP = "step"
+
+
+class DisruptionMethod(enum.Enum):
+  SIGILL = "sigill"  # simulate unplanned failure
+  SIGTERM = "sigterm"  # planned failure via node metadata update
+
+
+class RecoverMethod(enum.Enum):
+  SIGTERM_METADATA_REMOVE = "sigterm_metadata_remove"  # Remove node metadata
+
+
+@dataclasses.dataclass
+class DisruptionConfig:
+  """Configuration for workload disruptions and recovery."""
+  name: str  # Name of the disruption config
+  trigger_type: TriggerType  # Trigger for disruption (Time_Seconds or Step)
+  trigger_value: int  # Value for disruption trigger (seconds or steps)
+  disruption_method: DisruptionMethod  # Disruption method (SIGTERM, SIGILL)
+  worker_container_name: str  # Name of the container to disrupt
+
+  # TODO(sujinesh): Currently unimplemented.
+  # Some disruption types may require a recovery mechanism.
+  # For example, Simulating a maintenance event requires adding metadata to the
+  # node. To recover from this, a recovery method to remove the node metadata.
+  recover_trigger_type: TriggerType = None  # Trigger for recovery
+  recover_trigger_value: int = None  # Value for recovery trigger
+  recover_method: RecoverMethod = (
+      None  # Recovery method (SIGTERM_METADATA_REMOVE)
+  )
+
+  # Target pod regex needed for triggering disruption.
+  target_pod_regex: str = MCJAX_STANDARD_TARGET_POD_REGEX_SUFFIX
+
+
+class DisruptionHandler(abc.ABC):
+  """Abstract interface for disruption handlers."""
+
+  @abc.abstractmethod
+  def trigger_disruption(
+      self, workload_name: str, cluster_config: XpkClusterConfig,
+      disruption_config, target_pod_regex: str
+  ) -> None:
+    """Triggers the workload disruption."""
+    raise NotImplementedError("Subclasses must implement this method.")
+
+  def trigger_recovery(
+      self, workload_name: str, cluster_config: XpkClusterConfig,
+      disruption_config, target_pod_regex: str
+  ) -> None:
+    """Triggers workload recovery. Subclasses may implement this method."""
+    pass
+
+
+class SIGILLHandler(DisruptionHandler):
+  """Handles SIGILL disruption by sending a SIGILL signal to the pod."""
+
+  def trigger_disruption(
+      self, workload_name: str, cluster_config: XpkClusterConfig,
+      disruption_config, target_pod_regex: str
+  ) -> None:
+    """Triggers SIGILL disruption by executing kill -s SIGILL 1 in the pod."""
+    print(
+        f"🔥🔥🔥 Beginning SIGILL for workload: {workload_name} with pod regex:"
+        f" {target_pod_regex} 🔥🔥🔥"
+    )
+    pod_name_command = [
+        "kubectl",
+        "get",
+        "pods",
+        "-o=name",
+        "--no-headers",
+        f"| grep -E '{target_pod_regex}'",
+    ]
+    pod_name_command_str = " ".join(pod_name_command)
+    container_name = disruption_config.worker_container_name
+
+    try:
+      pod_name_process = subprocess.run(
+          pod_name_command_str,
+          shell=True,
+          check=True,
+          capture_output=True,
+          text=True,
+      )
+      pod_name = pod_name_process.stdout.strip()
+      if not pod_name:
+        print(
+            f"Warning: No pod found matching regex: '{target_pod_regex}' for"
+            f" workload '{workload_name}'"
+        )
+        return
+
+      print(f"🔍 Found pod: {pod_name}")
+      kill_command = [
+          "kubectl",
+          "exec",
+          "-it",
+          pod_name,
+          "-c",
+          container_name,
+          "--",
+          "/bin/bash",
+          "-c",
+          "\"kill -s SIGILL 1\"",
+      ]
+      kill_command_str = " ".join(kill_command)
+      print(f"🔥🔥🔥 Executing command in pod: {kill_command_str} 🔥🔥🔥")
+      subprocess.run(
+          kill_command_str,
+          shell=True,
+          check=True,
+          capture_output=True,
+          text=True,
+      )
+      print(
+          f"✅ Successfully sent SIGILL to pod: {pod_name} in container:"
+          f" {container_name}"
+      )
+
+    except subprocess.CalledProcessError as e:
+      print(
+          "❌ Error sending SIGILL to pod(s) matching regex"
+          f" '{target_pod_regex}' for workload '{workload_name}'"
+      )
+      print(f"Return code: {e.returncode}")
+      print(f"error: {e}")
+
+
+def create_disruption_handler(disruption_config):
+  """Factory function to create the appropriate disruption handler."""
+  if disruption_config.disruption_method == DisruptionMethod.SIGTERM:
+    raise NotImplementedError("SIGTERM Disruption Handler not implemented yet.")
+  elif disruption_config.disruption_method == DisruptionMethod.SIGILL:
+    return SIGILLHandler()
+  else:
+    raise ValueError(
+        f"Unsupported disruption method: {disruption_config.disruption_method}"
+    )

--- a/benchmarks/disruption_management/disruption_manager.py
+++ b/benchmarks/disruption_management/disruption_manager.py
@@ -1,0 +1,139 @@
+"""
+ Copyright 2025 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+from collections import defaultdict
+import os
+import sys
+import threading
+from typing import List
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+from disruption_management.disruption_handler import create_disruption_handler
+from disruption_management.disruption_handler import DisruptionConfig
+from disruption_management.disruption_handler import DisruptionHandler
+from disruption_management.monitor import create_monitor
+from disruption_management.monitor import Monitor
+from xpk_configs import XpkClusterConfig
+
+
+class DisruptionManager:
+  """Manages workload disruptions and recoveries."""
+
+  def __init__(self) -> None:
+    """Initializes the DisruptionManager."""
+    self.threads_to_monitor: defaultdict[str, List[threading.Thread]] = (
+        defaultdict(list)
+    )
+
+  def add_workload(
+      self,
+      workload_name: str,
+      cluster_config: XpkClusterConfig,
+      disruption_configs: List[DisruptionConfig],
+  ) -> None:
+    """Adds a workload and starts monitoring for disruptions & recovery.
+
+    Args:
+      workload_name: The name of the workload.
+      cluster_config: The cluster configuration for the workload.
+      disruption_configs: A list of DisruptionConfig for the workload.
+    """
+    if not disruption_configs:
+      print(f"No disruption configured for workload: {workload_name}")
+      return
+
+    # Add each thread to the list of threads to monitor.
+    # Note that we do not start the threads here.
+    for disruption_config in disruption_configs:
+      thread = threading.Thread(
+          target=self._monitor_and_disrupt_workload,
+          args=(workload_name, cluster_config, disruption_config),
+          daemon=True,
+      )
+      self.threads_to_monitor[workload_name].append(thread)
+    print(
+        f"Added {len(disruption_configs)} disruption configs for workload:"
+        f" {workload_name}"
+    )
+
+  def remove_workload(self, workload_name: str) -> None:
+    """Removes a workload from the disruption manager.
+
+    This will stop new disruptions from being triggered for this workload.
+    Running monitoring threads for this workload might continue until their
+    current cycle completes.
+
+    Note: this does not stop the workload itself or the threads, just the
+    monitoring.
+
+    Args:
+      workload_name: The name of the workload to remove.
+    """
+    if workload_name in self.threads_to_monitor:
+      self.threads_to_monitor[workload_name].clear()
+      print(f"Stopped monitoring threads for workload '{workload_name}'.")
+    else:
+      print(f"No monitoring threads found for workload '{workload_name}'.")
+
+  def start_disruptions_and_wait_for_completion(self) -> None:
+    """Starts disruption monitoring and waits for all disruptions to complete.
+
+    This is a blocking call.
+    """
+    print("Starting disruption monitoring! 🔥🩺")
+    for workload_name, threads in self.threads_to_monitor.items():
+      for thread in threads:
+        thread.start()
+        print(f"🔥🩺 Started monitoring thread for workload: {workload_name}")
+
+    # Wait for all threads to complete.
+    for _, threads in self.threads_to_monitor.items():
+      for thread in threads:
+        thread.join()
+
+    print("All disruptions completed.")
+
+  def _monitor_and_disrupt_workload(
+      self,
+      workload_name: str,
+      cluster_config: XpkClusterConfig,
+      disruption_config: DisruptionConfig,
+  ) -> None:
+    """Monitors workload progress, triggers disruptions, and recoveries."""
+    target_pod_regex = f"{workload_name}{disruption_config.target_pod_regex}"
+
+    # Create Monitor based on trigger type
+    monitor: Monitor = create_monitor(
+        workload_name, disruption_config, target_pod_regex
+    )
+    disruption_handler: DisruptionHandler = create_disruption_handler(
+        disruption_config
+    )
+
+    if monitor.monitor_and_detect_trigger():
+      print(
+          f"🔥🔥🔥 Trigger detected for workload: {workload_name}, triggering"
+          f" {disruption_config.disruption_method} 🔥🔥🔥"
+      )
+      disruption_handler.trigger_disruption(
+          workload_name, cluster_config, disruption_config, target_pod_regex
+      )
+    else:
+      print(f"Monitoring for workload: {workload_name} exited without trigger.")
+
+  # TODO(sujinesh): Implement recovery.
+  def _monitor_recovery(self) -> None:
+    """Monitors for recovery trigger and initiates recovery."""
+    raise NotImplementedError("Recovery not implemented yet.")

--- a/benchmarks/disruption_management/monitor.py
+++ b/benchmarks/disruption_management/monitor.py
@@ -1,0 +1,99 @@
+"""
+ Copyright 2025 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import abc
+import os
+import sys
+import time
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+from disruption_management.disruption_handler import DisruptionConfig
+from disruption_management.disruption_handler import TriggerType
+
+POLLING_INTERVAL_SECONDS = 10
+
+
+class Monitor(abc.ABC):
+  """Abstract base class for workload monitors."""
+
+  def __init__(
+      self,
+      workload_name: str,
+      disruption_config: DisruptionConfig,
+  ):
+    """Initializes a Monitor."""
+    self.workload_name = workload_name
+    self.disruption_config = disruption_config
+
+  @abc.abstractmethod
+  def monitor_and_detect_trigger(self):
+    """Monitors workload and detects trigger condition.
+
+    Returns:
+      bool: True if trigger condition is met, False otherwise.
+    """
+    raise NotImplementedError("Subclasses must implement this method.")
+
+
+class StepMonitor(Monitor):
+  """Monitors workload progress based on steps in logs."""
+
+  def __init__(
+      self,
+      workload_name: str,
+      disruption_config: DisruptionConfig,
+      target_pod_regex: str,
+  ):
+    """Initializes StepMonitor."""
+    super().__init__(workload_name, disruption_config)
+    self.target_pod_regex = target_pod_regex
+    if not target_pod_regex:
+      raise ValueError("Target pod regex is required for monitoring.")
+
+  # TODO(sujinesh): Implement step monitor.
+  def monitor_and_detect_trigger(self):
+    """Monitors logs and detects step trigger."""
+    raise NotImplementedError("Step monitor not implemented yet.")
+
+
+class TimeMonitor(Monitor):
+  """Monitors time and triggers after a set duration."""
+
+  def monitor_and_detect_trigger(self):
+    """Monitors time and detects time-based trigger by sleeping."""
+    print(
+        f"😴 Using TimeMonitor for workload: {self.workload_name}, sleeping for"
+        f" {self.disruption_config.trigger_value} seconds 😴."
+    )
+    time.sleep(self.disruption_config.trigger_value)
+    print(
+        "😳 Time trigger reached after"
+        f" {self.disruption_config.trigger_value} seconds 😳"
+    )
+    return True
+
+
+def create_monitor(workload_name, disruption_config, target_pod_regex):
+  """Factory function to create the appropriate monitor."""
+  if disruption_config.trigger_type == TriggerType.STEP:
+    return StepMonitor(
+        workload_name, disruption_config, target_pod_regex=target_pod_regex
+    )
+  elif disruption_config.trigger_type == TriggerType.TIME_SECONDS:
+    return TimeMonitor(workload_name, disruption_config)
+  else:
+    raise ValueError(
+        f"Unsupported trigger type: {disruption_config.trigger_type}"
+    )

--- a/benchmarks/recipes/args_helper.py
+++ b/benchmarks/recipes/args_helper.py
@@ -21,19 +21,19 @@ import sys
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
-import maxtext_xpk_runner as mxr
+from xpk_configs import XpkClusterConfig
 
 # Constants for defining supported actions
 DELETE = "delete"
 
 
 def _handle_delete(
-    cluster_config: mxr.XpkClusterConfig, user: str, **kwargs
+    cluster_config: XpkClusterConfig, user: str, **kwargs
 ) -> int:
   """Handles the deletion of workloads.
 
   Args:
-      cluster_config: mxr.XpkClusterConfig object
+      cluster_config: XpkClusterConfig object
       user: User string
       **kwargs: Optional keyword arguments, such as xpk_path
   """
@@ -52,12 +52,12 @@ def _handle_delete(
 
 
 def handle_delete_specific_workload(
-    cluster_config: mxr.XpkClusterConfig, workload_name: str, **kwargs
+    cluster_config: XpkClusterConfig, workload_name: str, **kwargs
 ) -> int:
   """Handles the deletion of workloads with a specific name.
 
   Args:
-      cluster_config: mxr.XpkClusterConfig object
+      cluster_config: XpkClusterConfig object
       workload_name: workload name
       **kwargs: Optional keyword arguments, such as xpk_path
   """
@@ -75,7 +75,7 @@ def handle_delete_specific_workload(
 
 
 def handle_cmd_args(
-    cluster_config: mxr.XpkClusterConfig, *actions: str, **kwargs
+    cluster_config: XpkClusterConfig, *actions: str, **kwargs
 ) -> bool:
   """Parses command-line arguments and executes the specified actions.
 

--- a/benchmarks/recipes/pw_elastic_training_recipe.py
+++ b/benchmarks/recipes/pw_elastic_training_recipe.py
@@ -1,0 +1,175 @@
+"""
+ Copyright 2025 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import os
+import sys
+
+import args_helper as helper
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+from disruption_management.disruption_handler import DisruptionConfig
+from disruption_management.disruption_handler import DisruptionMethod
+from disruption_management.disruption_handler import MCJAX_STANDARD_TARGET_POD_REGEX_SUFFIX
+from disruption_management.disruption_handler import MCJAX_WORKER_CONTAINER_NAME
+from disruption_management.disruption_handler import PATHWAYS_STANDARD_TARGET_POD_REGEX_SUFFIX
+from disruption_management.disruption_handler import PATHWAYS_WORKER_CONTAINER_NAME
+from disruption_management.disruption_handler import TriggerType
+from maxtext_trillium_model_configs import MaxTextModel
+import maxtext_v5e_model_configs as v5e_model_configs
+import maxtext_xpk_runner as mxr
+from xpk_configs import XpkClusterConfig
+
+PROXY_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_proxy_server:latest"
+SERVER_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_server:latest"
+RUNNER = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/maxtext_jax_stable:latest"
+
+# Cluster Params
+CLUSTER = "v6e-256-cluster"
+PROJECT = "tpu-prod-env-cluster"
+ZONE = "us-east5-b"
+COUNTRY = "us"
+DEVICE_TYPE = "v6e-256"
+
+# Other parameters (MUST BE SET BY USER)
+XPK_PATH = "../xpk"  # We're running this script from the maxtext directory
+USER = os.environ["USER"]
+BASE_OUTPUT_DIRECTORY = (
+    f"gs://{USER}-{PROJECT}-{COUNTRY}/disruption_management/"
+)
+MAX_RESTARTS = 10
+NUM_SLICES = 2
+BENCHMARK_STEPS = 101
+COMPARE_WITH_MCJAX = True
+
+
+# Do 2 total disruptions, once after 2 minutes and once after 6 minutes.
+def construct_disruption_configs(
+    pathways_config: mxr.PathwaysConfig,
+) -> list[DisruptionConfig]:
+  """Constructs the disruption configs for the benchmark."""
+
+  if pathways_config:
+    target_pod_regex = PATHWAYS_STANDARD_TARGET_POD_REGEX_SUFFIX
+    worker_container_name = PATHWAYS_WORKER_CONTAINER_NAME
+  else:
+    target_pod_regex = MCJAX_STANDARD_TARGET_POD_REGEX_SUFFIX
+    worker_container_name = MCJAX_WORKER_CONTAINER_NAME
+
+  # Do 2 total disruptions, once after 2 minutes and once after 6 minutes.
+  return [
+      DisruptionConfig(
+          name="sigill_2min",
+          trigger_type=TriggerType.TIME_SECONDS,
+          trigger_value=2 * 60,  # 2 minutes
+          disruption_method=DisruptionMethod.SIGILL,
+          target_pod_regex=target_pod_regex,
+          worker_container_name=worker_container_name,
+      ),
+      DisruptionConfig(
+          name="sigill_6min",
+          trigger_type=TriggerType.TIME_SECONDS,
+          trigger_value=6 * 60,  # 6 minutes
+          disruption_method=DisruptionMethod.SIGILL,
+          target_pod_regex=target_pod_regex,
+          worker_container_name=worker_container_name,
+      )
+  ]
+
+
+def construct_workload_config_with_disruptions(
+    cluster_config: XpkClusterConfig,
+    model: MaxTextModel,
+    pathways_config: mxr.PathwaysConfig = None,
+) -> list[mxr.WorkloadConfig]:
+  """Constructs the workload configs for the benchmark."""
+  return mxr.WorkloadConfig(
+      model=model,
+      num_slices=NUM_SLICES,
+      device_type=cluster_config.device_type,
+      base_output_directory=BASE_OUTPUT_DIRECTORY,
+      max_restarts=MAX_RESTARTS,
+      libtpu_type=None,
+      libtpu_nightly_version="",
+      base_docker_image=RUNNER,
+      pathways_config=pathways_config,
+      xpk_path=XPK_PATH,
+      num_steps=BENCHMARK_STEPS,
+      disruption_configs=construct_disruption_configs(pathways_config)
+  )
+
+
+def main() -> None:
+  """Main function to run the elastic training disruption test."""
+
+  # Cluster Configuration
+  cluster_config = XpkClusterConfig(
+      cluster_name=CLUSTER,
+      project=PROJECT,
+      zone=ZONE,
+      device_type=DEVICE_TYPE,
+  )
+
+  # Handle command line arguments using args_helper
+  should_continue = helper.handle_cmd_args(
+      cluster_config, helper.DELETE, xpk_path=XPK_PATH
+  )
+
+  if not should_continue:
+    return 0
+
+  # Model Configuration - Using a simple default model for testing
+  model = v5e_model_configs.llama3_1_8b_8192
+
+  pathways_config = mxr.PathwaysConfig(
+      server_image=SERVER_IMAGE,
+      proxy_server_image=PROXY_IMAGE,
+      runner_image=RUNNER,
+
+      # User can add additional flags here.
+      server_flags="--enable_metrics_collection=false",
+      proxy_flags="--enable_metrics_collection=false",
+      worker_flags="--enable_metrics_collection=false",
+  )
+
+  # Pathways Workload Configuration with Disruption
+  workload_configs = []
+  pathways_workload_config = construct_workload_config_with_disruptions(
+      cluster_config, model, pathways_config
+  )
+  workload_configs.append(pathways_workload_config)
+
+  if COMPARE_WITH_MCJAX:
+    # Add a workload config for MCJAX
+    mcjax_workload_config = construct_workload_config_with_disruptions(
+        cluster_config, model, None
+    )
+    workload_configs.append(mcjax_workload_config)
+
+  # Run the benchmark and use the returned disruption manager.
+  disruption_manager = mxr.xpk_benchmark_runner(
+      cluster_config=cluster_config,
+      workload_configs=workload_configs,
+  )
+
+  # Wait for disruptions to complete
+  disruption_manager.start_disruptions_and_wait_for_completion()
+
+  print(
+      "Elastic Training disruptions completed. Please check logs for results."
+  )
+
+
+if __name__ == "__main__":
+  main()

--- a/benchmarks/recipes/pw_long_running_recipe.py
+++ b/benchmarks/recipes/pw_long_running_recipe.py
@@ -24,6 +24,7 @@ sys.path.append(parent_dir)
 
 import maxtext_trillium_model_configs as model_configs
 import maxtext_xpk_runner as mxr
+from xpk_configs import XpkClusterConfig
 
 PROXY_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_proxy_server:latest"
 SERVER_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_server:latest"
@@ -50,7 +51,7 @@ BENCHMARK_STEPS=10_000_000
 
 def main() -> int:
   # V6e cluster config
-  cluster_config = mxr.XpkClusterConfig(
+  cluster_config = XpkClusterConfig(
       cluster_name=CLUSTER,
       project=PROJECT,
       zone=ZONE,

--- a/benchmarks/recipes/pw_mcjax_benchmark_recipe.py
+++ b/benchmarks/recipes/pw_mcjax_benchmark_recipe.py
@@ -25,6 +25,8 @@ sys.path.append(parent_dir)
 
 import maxtext_trillium_model_configs as model_configs
 import maxtext_xpk_runner as mxr
+from xpk_configs import XpkClusterConfig
+
 
 PROXY_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_proxy_server:latest"
 SERVER_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_server:latest"
@@ -50,7 +52,7 @@ BENCHMARK_STEPS = 20
 
 def main() -> int:
   # V6e cluster config
-  cluster_config = mxr.XpkClusterConfig(
+  cluster_config = XpkClusterConfig(
       cluster_name=CLUSTER,
       project=PROJECT,
       zone=ZONE,

--- a/benchmarks/recipes/pw_mcjax_checkpoint_benchmark_recipe.py
+++ b/benchmarks/recipes/pw_mcjax_checkpoint_benchmark_recipe.py
@@ -32,6 +32,7 @@ sys.path.append(parent_dir)
 
 import maxtext_trillium_model_configs as model_configs
 import maxtext_xpk_runner as mxr
+from xpk_configs import XpkClusterConfig
 
 PROXY_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_proxy_server:latest"
 SERVER_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_server:latest"
@@ -206,7 +207,7 @@ def _run_workloads_async(xpk_workloads, cluster_config, run_type="Initial"):
 
 def main() -> int:
   # V6e cluster config
-  cluster_config = mxr.XpkClusterConfig(
+  cluster_config = XpkClusterConfig(
       cluster_name=CLUSTER,
       project=PROJECT,
       zone=ZONE,

--- a/benchmarks/recipes/pw_remote_python_recipe.py
+++ b/benchmarks/recipes/pw_remote_python_recipe.py
@@ -22,11 +22,12 @@ sys.path.append(parent_dir)
 
 import maxtext_trillium_model_configs as model_configs
 import maxtext_xpk_runner as mxr
+from xpk_configs import XpkClusterConfig
 
 
 def main() -> int:
   # V6e cluster config
-  cluster_config = mxr.XpkClusterConfig(
+  cluster_config = XpkClusterConfig(
       cluster_name="v6e-256-cluster",
       project="tpu-project",
       zone="us-east5-b",

--- a/benchmarks/xpk_configs.py
+++ b/benchmarks/xpk_configs.py
@@ -1,0 +1,28 @@
+"""
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import dataclasses
+
+
+# This is needed to prevent circular imports.
+@dataclasses.dataclass
+class XpkClusterConfig:
+  """Holds details related to a XPK cluster to run workloads on."""
+
+  cluster_name: str
+  project: str
+  zone: str
+  device_type: str


### PR DESCRIPTION
# Description

This PR creates the disruption manager detailed in go/disruption-manager-for-model-benchmarking. It only creates the SIGILL path and Time step path with future iterations eventually adding the SIGTERM and Step based paths. It also includes a sample recipe for pw elastic training, with an option to also run a McJAX recipe alongside it for comparison.

# Tests

Tested on a v5e cluster. Some bugs with McJAX prevent making sure it's working fully, but the disruption manager code itself works end to end.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
