### PR TITLE
Adding a parameter=lora_input_adapters_path, to start the server with the input adapters path.

### DIFF
--- a/MaxText/maxengine_server.py
+++ b/MaxText/maxengine_server.py
@@ -56,7 +56,7 @@ def main(config):
       enable_jax_profiler=config.enable_jax_profiler if config.enable_jax_profiler else False,
       jax_profiler_port=config.jax_profiler_port if config.jax_profiler_port else 9999,
       enable_model_warmup=config.enable_model_warmup if config.enable_model_warmup else False,
-      enable_llm_inference_pool=config.enable_llm_inference_pool if config.enable_llm_inference_pool else False,
+      lora_input_adapters_path=config.lora_input_adapters_path,
       multi_sampling=config.multi_sampling if config.multi_sampling else False,
   )
   jetstream_server.wait_for_termination()


### PR DESCRIPTION
# Description

Small change to fix the JetStream server workflow due to mismatch of the params. Previously we expected bool parameter to control the lora functionality in JetStream. But with recent developments, `lora_input_adapters_path` is the must requirement as a base directory for all the adapters. So we are using this instead.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
