### PR TITLE
[MultiLora for inference] Unapply adapter and safe-checks

### DIFF
--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -244,6 +244,12 @@ class MaxEngine(engine_api.Engine):
 
     params, config = lora_utils.load_adapter(self.config, self.abstract_params, adapter_config_path, adapter_weights_path)
 
+    if config is None:
+      raise ValueError(f"Failed to read lora_config from {adapter_config_path}")
+
+    if params is None:
+      raise ValueError(f"Failed to read lora_config from {adapter_config_path}")
+
     config["adapter_path"] = adapter_weights_path
 
     self.print_stats("After load_single_adapter.")
@@ -256,6 +262,13 @@ class MaxEngine(engine_api.Engine):
     lora_rank = int(adapter_config["r"])
     lora_scale_factor = float(adapter_config["lora_alpha"]) / lora_rank
     lora_utils.apply_lora_on_base_params(base_params, adapter_params, lora_scale_factor)
+
+  def unapply_adapter(self, base_params, adapter_config, adapter_params):
+    """Unapply the adapter params from the merged params to get back the base params."""
+
+    lora_rank = int(adapter_config["r"])
+    lora_scale_factor = float(adapter_config["lora_alpha"]) / lora_rank
+    lora_utils.unapply_lora_from_base_params(base_params, adapter_params, lora_scale_factor)
 
   def quantize_params(self, state, rng: Optional[PRNGKeyType] = None):
     """Forward pass to quantize decode params."""


### PR DESCRIPTION
# Description
- Adding safechecks to raise errors.
- Added unapply_adapter, which performs action reverse of the apply adapter. Previously I was creating a deep copy of the base params to create the merged params and deleting the merged params after prefill. But this operation is more expensive and not scalable for inference of large models. Instead we should support unapply of lora params from base.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
