### PR TITLE
Fix regex in pytest.ini for running train and decode tests

### DIFF
--- a/MaxText/pytest.ini
+++ b/MaxText/pytest.ini
@@ -2,7 +2,7 @@
 [pytest]
 testpaths =
     tests
-python_files = *_test.py
+python_files = *_test.py *_tests.py
 addopts =
     -rf --import-mode=importlib --strict-markers
     --ignore=tests/profiler_test.py

--- a/MaxText/tests/decode_tests.py
+++ b/MaxText/tests/decode_tests.py
@@ -77,6 +77,7 @@ class DecodeTests(unittest.TestCase):
   def test_gpu_base(self):
     decode_main(DecodeTests.CONFIGS["base"] + ["attention=dot_product"])
 
+  @pytest.mark.skip(reason="until b/400476456 is fixed")
   @pytest.mark.tpu_only
   def test_tpu_int8(self):
     decode_main(DecodeTests.CONFIGS["int8"])

--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -16,6 +16,7 @@ tensorflow-text>=2.13.0
 tensorflow-datasets
 tensorboardx>=2.6.2.2
 tiktoken
+torch
 transformers
 mlperf-logging@git+https://github.com/mlperf/logging.git
 google-jetstream


### PR DESCRIPTION
# Description

We were not running training/decode tests in pytest due to the mismatched regex in pytest.ini

If the change fixes a bug or a Github issue, please include a link, e.g.,:

# Tests

Unit tests



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
