### PR TITLE
Add Step Monitor to Disruption Manager & Suspend/Resume Recipe (SIGTERM Path)

### DIFF
--- a/benchmarks/disruption_management/disruption_manager.py
+++ b/benchmarks/disruption_management/disruption_manager.py
@@ -113,10 +113,11 @@ class DisruptionManager:
   ) -> None:
     """Monitors workload progress, triggers disruptions, and recoveries."""
     target_pod_regex = f"{workload_name}{disruption_config.target_pod_regex}"
+    step_pod_regex = f"{workload_name}{disruption_config.step_pod_regex}"
 
     # Create Monitor based on trigger type
     monitor: Monitor = create_monitor(
-        workload_name, disruption_config, target_pod_regex
+        workload_name, disruption_config, step_pod_regex
     )
     disruption_handler: DisruptionHandler = create_disruption_handler(
         disruption_config

--- a/benchmarks/disruption_management/disruption_utils.py
+++ b/benchmarks/disruption_management/disruption_utils.py
@@ -1,0 +1,137 @@
+"""
+ Copyright 2025 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+"""Utility functions for disrupting workloads."""
+
+import subprocess
+import time
+
+POLLING_INTERVAL_SECONDS = 10
+
+
+def execute_command_as_subprocess(
+    command: str,
+) -> None:
+  """Executes the command in the pod."""
+  print(f"Executing command: {command}")
+  try:
+    process = subprocess.run(
+        command,
+        shell=True,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if process.stdout:
+      print(process.stdout)
+    if process.stderr:
+      print(f"stderr: {process.stderr}")
+    print(f"✅ Successfully executed command: {command}")
+  except subprocess.CalledProcessError as e:
+    print(f"❌ Error executing command: {command}")
+    print(f"Return code: {e.returncode}")
+    print(f"Error: {e}")
+
+
+def get_pod_name_from_regex(workload_name: str, pod_regex: str) -> str | None:
+  """Returns the name of the first pod matching the regex."""
+  print(
+      f"Workload '{workload_name}': Getting pod name matching"
+      f" '{pod_regex}'..."
+  )
+  pod_name_command = [
+      "kubectl",
+      "get",
+      "pods",
+      "-o=custom-columns=NAME:.metadata.name",
+      "--no-headers",
+      f"| grep -E '{pod_regex}'",
+  ]
+  pod_name_command_str = " ".join(pod_name_command)
+  try:
+    process = subprocess.run(
+        pod_name_command_str,
+        shell=True,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    pod_names = process.stdout.strip().splitlines()
+    if pod_names:
+      # Assuming there's only one step pod.
+      pod_name = pod_names[0]
+      print(f"Workload '{workload_name}': Found pod: {pod_name}")
+      return pod_name
+    else:
+      print(
+          f"Workload '{workload_name}': No pod found matching"
+          f" regex '{pod_regex}'."
+      )
+  except subprocess.CalledProcessError as e:
+    print(
+        f"Workload '{workload_name}': Error getting pod information:"
+        f" {e}"
+    )
+
+
+def get_pod_status(workload_name: str, pod_name: str) -> str | None:
+  """Returns the status of the pod."""
+  print(
+      f"Workload '{workload_name}': Getting status of pod '{pod_name}'..."
+  )
+  pod_status_command = [
+      "kubectl",
+      "get",
+      "pod",
+      pod_name,
+      "-o=jsonpath='{.status.phase}'",
+  ]
+  pod_status_command_str = " ".join(pod_status_command)
+  status_process = subprocess.run(
+      pod_status_command_str,
+      shell=True,
+      check=True,
+      capture_output=True,
+      text=True,
+  )
+  pod_status = status_process.stdout.strip()
+  print(
+      f"Workload '{workload_name}': Pod '{pod_name}' is in '{pod_status}'"
+      " state."
+  )
+  return pod_status
+
+
+def wait_for_pod_to_start(workload_name: str, pod_regex: str) -> str | None:
+  """Waits for the step pod to be in 'Running' state and returns its name."""
+  print(
+      f"Workload '{workload_name}': Waiting for pod matching"
+      f" '{pod_regex}' to be in 'Running' state..."
+  )
+  while True:
+    pod_name = get_pod_name_from_regex(workload_name, pod_regex)
+    if pod_name:
+      pod_status = get_pod_status(workload_name, pod_name)
+      if pod_status == "Running":
+        print(
+            f"Workload '{workload_name}': Step pod '{pod_name}'"
+            f" is now in 'Running' state."
+        )
+        return pod_name
+    time.sleep(POLLING_INTERVAL_SECONDS)
+
+  print(
+      f"Workload '{workload_name}': Timed out waiting for step pod"
+      f" matching '{pod_regex}' to reach 'Running' state."
+  )
+  return None

--- a/benchmarks/disruption_management/monitor.py
+++ b/benchmarks/disruption_management/monitor.py
@@ -13,8 +13,12 @@
 
 import abc
 import os
+import re
+import subprocess
 import sys
 import time
+
+from disruption_management.disruption_utils import wait_for_pod_to_start
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
@@ -22,7 +26,7 @@ sys.path.append(parent_dir)
 from disruption_management.disruption_handler import DisruptionConfig
 from disruption_management.disruption_handler import TriggerType
 
-POLLING_INTERVAL_SECONDS = 10
+STANDARD_STEP_LOG_REGEX = r".*completed step: (\d+), .*"
 
 
 class Monitor(abc.ABC):
@@ -54,18 +58,80 @@ class StepMonitor(Monitor):
       self,
       workload_name: str,
       disruption_config: DisruptionConfig,
-      target_pod_regex: str,
+      step_pod_regex: str,
   ):
     """Initializes StepMonitor."""
     super().__init__(workload_name, disruption_config)
-    self.target_pod_regex = target_pod_regex
-    if not target_pod_regex:
-      raise ValueError("Target pod regex is required for monitoring.")
+    self.step_pod_regex = step_pod_regex
+    if not step_pod_regex:
+      raise ValueError("Step pod regex is required for monitoring.")
 
-  # TODO(sujinesh): Implement step monitor.
   def monitor_and_detect_trigger(self):
-    """Monitors logs and detects step trigger."""
-    raise NotImplementedError("Step monitor not implemented yet.")
+    """Waits for target pod to start and returns when it detects the step trigger."""
+    pod_name = wait_for_pod_to_start(self.workload_name, self.step_pod_regex)
+    if not pod_name:
+      return False
+
+    kubectl_logs_command = [
+        "kubectl",
+        "logs",
+        "-f",  # Follow the logs for real-time updates
+        pod_name,
+    ]
+    kubectl_logs_command_str = " ".join(kubectl_logs_command)
+
+    process = None
+    try:
+      print(
+          f"Workload '{self.workload_name}', Pod '{pod_name}': Tailing logs for"
+          f" real-time step detection (reading in chunks)..."
+      )
+      process = subprocess.Popen(
+          kubectl_logs_command_str,
+          shell=True,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          text=True,
+      )
+
+      last_step = -1
+      with process.stdout as pipe:
+        for line in iter(pipe.readline, ""):
+          print(f"Workload '{self.workload_name}', Pod '{pod_name}': {line}")
+          line = line.strip()
+          print(
+              f"Workload '{self.workload_name}', Pod '{pod_name}': {line}"
+          )
+          match = re.search(STANDARD_STEP_LOG_REGEX, line)
+          if match:
+            step_number = int(match.group(1))
+            if step_number > last_step:
+              last_step = step_number  # Update last seen step
+            if step_number >= self.disruption_config.trigger_value:
+              print(
+                  f"Workload '{self.workload_name}', Pod '{pod_name}': STEP"
+                  f" trigger reached! Detected step: {step_number}, Trigger"
+                  f" Value: {self.disruption_config.trigger_value}."
+              )
+              return True
+
+    except subprocess.CalledProcessError as e:
+      print(
+          f"Error getting logs for pod '{pod_name}' of workload"
+          f" '{self.workload_name}': {e.stderr}"
+      )
+      return False
+    except Exception as e:
+      print(f"An error occurred during log tailing: {e}")
+    finally:
+      if process:
+        process.kill()
+
+    print(
+        f"Workload '{self.workload_name}', Pod '{pod_name}': No step trigger"
+        " detected."
+    )
+    return False
 
 
 class TimeMonitor(Monitor):
@@ -85,11 +151,11 @@ class TimeMonitor(Monitor):
     return True
 
 
-def create_monitor(workload_name, disruption_config, target_pod_regex):
+def create_monitor(workload_name, disruption_config, step_pod_regex):
   """Factory function to create the appropriate monitor."""
   if disruption_config.trigger_type == TriggerType.STEP:
     return StepMonitor(
-        workload_name, disruption_config, target_pod_regex=target_pod_regex
+        workload_name, disruption_config, step_pod_regex=step_pod_regex
     )
   elif disruption_config.trigger_type == TriggerType.TIME_SECONDS:
     return TimeMonitor(workload_name, disruption_config)

--- a/benchmarks/recipes/pw_suspend_resume.py
+++ b/benchmarks/recipes/pw_suspend_resume.py
@@ -1,0 +1,148 @@
+"""
+ Copyright 2025 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import os
+import sys
+
+import args_helper as helper
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+from disruption_management.disruption_handler import DisruptionConfig
+from disruption_management.disruption_handler import DisruptionMethod
+from disruption_management.disruption_handler import PATHWAYS_STANDARD_TARGET_POD_REGEX_SUFFIX
+from disruption_management.disruption_handler import PATHWAYS_WORKER_CONTAINER_NAME
+from disruption_management.disruption_handler import PATHWAYS_STANDARD_STEP_POD_REGEX_SUFFIX
+from disruption_management.disruption_handler import TriggerType
+from maxtext_trillium_model_configs import MaxTextModel
+import maxtext_v5e_model_configs as v5e_model_configs
+import maxtext_xpk_runner as mxr
+from xpk_configs import XpkClusterConfig
+
+PROXY_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_proxy_server:latest"
+SERVER_IMAGE = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/unsanitized_server:latest"
+RUNNER = "us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/maxtext_jax_stable:latest"
+
+# Cluster Params
+CLUSTER = "v6e-256-cluster"
+PROJECT = "tpu-prod-env-cluster"
+ZONE = "us-east5-b"
+COUNTRY = "us"
+DEVICE_TYPE = "v6e-256"
+
+# Other parameters (MUST BE SET BY USER)
+XPK_PATH = "../xpk"  # We're running this script from the maxtext directory
+USER = os.environ["USER"]
+BASE_OUTPUT_DIRECTORY = (
+    f"gs://{USER}-{PROJECT}-{COUNTRY}/disruption_management/"
+)
+MAX_RESTARTS = 0
+NUM_SLICES = 2
+BENCHMARK_STEPS = 101
+
+
+def construct_disruption_configs() -> list[DisruptionConfig]:
+  """Constructs the disruption configs for the benchmark."""
+  return [
+      DisruptionConfig(
+          name="sigill_5step",
+          trigger_type=TriggerType.STEP,
+          trigger_value=3,  # 3rd step trigger
+          disruption_method=DisruptionMethod.SIGTERM,
+          target_pod_regex=PATHWAYS_STANDARD_TARGET_POD_REGEX_SUFFIX,
+          step_pod_regex=PATHWAYS_STANDARD_STEP_POD_REGEX_SUFFIX,
+          worker_container_name=PATHWAYS_WORKER_CONTAINER_NAME,
+      ),
+  ]
+
+
+def construct_workload_config_with_disruptions(
+    cluster_config: XpkClusterConfig,
+    model: MaxTextModel,
+    pathways_config: mxr.PathwaysConfig,
+) -> list[mxr.WorkloadConfig]:
+  """Constructs the workload configs for the benchmark."""
+  return mxr.WorkloadConfig(
+      model=model,
+      num_slices=NUM_SLICES,
+      device_type=cluster_config.device_type,
+      base_output_directory=BASE_OUTPUT_DIRECTORY,
+      max_restarts=MAX_RESTARTS,
+      libtpu_type=None,
+      libtpu_nightly_version="",
+      base_docker_image=RUNNER,
+      pathways_config=pathways_config,
+      xpk_path=XPK_PATH,
+      num_steps=BENCHMARK_STEPS,
+      disruption_configs=construct_disruption_configs()
+  )
+
+
+def main() -> None:
+  """Main function to run the suspend/resume disruption test."""
+
+  # Cluster Configuration
+  cluster_config = XpkClusterConfig(
+      cluster_name=CLUSTER,
+      project=PROJECT,
+      zone=ZONE,
+      device_type=DEVICE_TYPE,
+  )
+
+  # Handle command line arguments using args_helper
+  should_continue = helper.handle_cmd_args(
+      cluster_config, helper.DELETE, xpk_path=XPK_PATH
+  )
+
+  if not should_continue:
+    return 0
+
+  # Model Configuration - Using a simple default model for testing
+  model = v5e_model_configs.llama3_1_8b_8192
+
+  pathways_config = mxr.PathwaysConfig(
+      server_image=SERVER_IMAGE,
+      proxy_server_image=PROXY_IMAGE,
+      runner_image=RUNNER,
+
+      # User can add additional flags here.
+      server_flags="--enable_metrics_collection=false",
+      proxy_flags="--enable_metrics_collection=false",
+      worker_flags="--enable_metrics_collection=false",
+  )
+
+  # Pathways Workload Configuration with Disruption
+  workload_configs = []
+  pathways_workload_config = construct_workload_config_with_disruptions(
+      cluster_config, model, pathways_config
+  )
+  workload_configs.append(pathways_workload_config)
+
+  # Run the benchmark and use the returned disruption manager.
+  disruption_manager = mxr.xpk_benchmark_runner(
+      cluster_config=cluster_config,
+      workload_configs=workload_configs,
+  )
+
+  # Wait for disruptions to complete
+  disruption_manager.start_disruptions_and_wait_for_completion()
+
+  print(
+      "Suspend/Resume disruptions completed. Please check logs for results."
+  )
+
+
+if __name__ == "__main__":
+  main()
+


### PR DESCRIPTION
# Description

Adds a Step Monitor to the Disruption Manager so the user can specify they want a trigger to occur at a specific step. I also added a SIGTERM Handler that will SIGTERM the primary process on the pod, which simulates a maintenance event. To exercise these paths I also adds a Suspend/Resume Recipe for pathways.

Note that this implementation does not simulate an unschedulable pod using maintenance handler labels as there are some possible problems with that. This SIGTERM path appears to be consistently able to reproduce Suspend/Resume logic.

This PR should be checked into main after https://github.com/AI-Hypercomputer/maxtext/pull/1383 is checked in.

# Tests

Tested on a v5e cluster. b/395936838 and b/401565554

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
