### PR TITLE
Refactor page attention logic

### DIFF
--- a/MaxText/inference/page_manager.py
+++ b/MaxText/inference/page_manager.py
@@ -22,6 +22,8 @@ of variable-length sequences by dividing the attention context into fixed-size p
 similar to virtual memory systems.
 """
 
+# TODO Need to update unit tests for this file under Maxtext/tests/page_manager.py.
+
 from typing import Optional, Tuple
 
 import common_types
@@ -33,6 +35,7 @@ from flax import struct
 Array = common_types.Array
 DType = common_types.DType
 AxisNames = common_types.AxisNames
+Config = common_types.Config
 
 
 @struct.dataclass
@@ -56,7 +59,22 @@ class PageState:
   current_page_position: Array
 
 
-class PageManager(nn.Module):
+def initialize_page_state(
+    num_pages: int,
+    num_slots: int,
+    max_pages_per_slot: int,
+) -> PageState:
+  return PageState(
+      page_status=jnp.zeros((num_pages,), dtype=jnp.int32),
+      page_map=jnp.zeros((num_slots, max_pages_per_slot), dtype=jnp.int32),
+      sequence_lengths=jnp.zeros((num_slots,), dtype=jnp.int32),
+      num_pages_used=jnp.zeros((num_slots,), dtype=jnp.int32),
+      current_page=jnp.zeros((num_slots,), dtype=jnp.int32),
+      current_page_position=jnp.zeros((num_slots,), dtype=jnp.int32),
+  )
+
+
+class PageManager:
   """Manages paged attention mechanism for efficient sequence processing.
 
   The PageManager implements a virtual memory-like system for attention, where the
@@ -79,83 +97,25 @@ class PageManager(nn.Module):
   max_prefill_predict_length: int
   max_pages_per_slot: int
 
-  def init_or_get_vars(self):
-    """Initializes or retrieves the state variables for the paging system.
-
-    Returns:
-      Tuple of nn.Variable objects representing:
-        - page_status: Status of each page (free/used)
-        - page_map: Mapping between slots and their assigned pages
-        - sequence_lengths: Length of sequence in each slot
-        - num_pages_used: Number of pages used by each slot
-        - current_page: Current active page for each slot
-        - current_page_position: Position within current pages
-    """
-    page_status_var = self.variable(
-        "cache", "page_status", nn.with_logical_partitioning(jnp.zeros, ("num_pages",)), (self.num_pages,), jnp.int32
-    )
-    page_map_var = self.variable(
-        "cache",
-        "page_map",
-        nn.with_logical_partitioning(jnp.zeros, ("slots", "max_pages_per_slot")),
-        (self.slots, self.max_pages_per_slot),
-        jnp.int32,
-    )
-    sequence_lengths_var = self.variable(
-        "cache", "sequence_lengths", nn.with_logical_partitioning(jnp.zeros, ("slots",)), (self.slots,), jnp.int32
-    )
-    num_pages_used_var = self.variable(
-        "cache", "num_pages_used", nn.with_logical_partitioning(jnp.zeros, ("slots",)), (self.slots,), jnp.int32
-    )
-    current_page_var = self.variable(
-        "cache", "current_page", nn.with_logical_partitioning(jnp.zeros, ("slots",)), (self.slots,), jnp.int32
-    )
-    current_page_position_var = self.variable(
-        "cache", "current_page_position", nn.with_logical_partitioning(jnp.zeros, ("slots",)), (self.slots,), jnp.int32
-    )
-
-    return (
-        page_status_var,
-        page_map_var,
-        sequence_lengths_var,
-        num_pages_used_var,
-        current_page_var,
-        current_page_position_var,
-    )
+  def __init__(self, num_pages: int, tokens_per_page: int, max_target_length: int, max_prefill_length: int, batch_size: int):
+    self.num_pages = num_pages
+    self.tokens_per_page = tokens_per_page
+    self.max_target_length = max_target_length
+    self.max_pages_per_slot = max_target_length // tokens_per_page
+    self.slots = int(batch_size * jax.device_count())
+    self.max_prefill_predict_length = max_prefill_length
 
   def release_slot_pages(
       self,
       slot: int,
-      page_status_var: nn.Variable,
-      page_map_var: nn.Variable,
-      sequence_lengths_var: nn.Variable,
-      num_pages_used_var: nn.Variable,
-      current_page_var: nn.Variable,
-      current_page_position_var: nn.Variable,
-  ) -> Tuple:
-    """Releases all pages assigned to a specific slot.
-
-    This method frees up all pages currently assigned to the given slot,
-    resetting their status and updating the page mapping accordingly.
-
-    Args:
-      slot: Integer identifying the slot to be released
-      page_status_var: Variable tracking page usage status
-      page_map_var: Variable mapping slots to pages
-      sequence_lengths_var: Variable tracking sequence lengths
-      num_pages_used_var: Variable tracking page usage counts
-      current_page_var: Variable tracking current active pages
-      current_page_position_var: Variable tracking positions in current pages
-
-    Returns:
-      Tuple of updated variables after releasing the slot's pages
-    """
-    page_status = page_status_var.value
-    page_map = page_map_var.value
-    sequence_lengths = sequence_lengths_var.value
-    num_pages_used = num_pages_used_var.value
-    current_page = current_page_var.value
-    current_page_position = current_page_position_var.value
+      page_state: PageState,
+  ) -> PageState:
+    page_status = page_state.page_status
+    page_map = page_state.page_map
+    sequence_lengths = page_state.sequence_lengths
+    current_page = page_state.current_page
+    current_page_position = page_state.current_page_position
+    num_pages_used = page_state.num_pages_used
 
     def _release_page(i, state):
       page_map, page_status = state
@@ -171,74 +131,28 @@ class PageManager(nn.Module):
     current_page = current_page.at[slot].set(0)
     current_page_position = current_page_position.at[slot].set(0)
 
-    page_status_var.value = page_status
-    page_map_var.value = page_map
-    sequence_lengths_var.value = sequence_lengths
-    num_pages_used_var.value = num_pages_used
-    current_page_var.value = current_page
-    current_page_position_var.value = current_page_position
-
-    return (
-        page_status_var,
-        page_map_var,
-        sequence_lengths_var,
-        num_pages_used_var,
-        current_page_var,
-        current_page_position_var,
+    return PageState(
+        page_status=page_status,
+        page_map=page_map,
+        sequence_lengths=sequence_lengths,
+        num_pages_used=num_pages_used,
+        current_page=current_page,
+        current_page_position=current_page_position,
     )
 
   def reserve_prefix_slot_pages(
       self,
       slot: int,
       true_length: int,
-      page_status_var: nn.Variable,
-      page_map_var: nn.Variable,
-      sequence_lengths_var: nn.Variable,
-      num_pages_used_var: nn.Variable,
-      current_page_var: nn.Variable,
-      current_page_position_var: nn.Variable,
-  ) -> Tuple:
-    """Reserves pages for a prefix sequence in the specified slot.
-
-    This method allocates the necessary pages for a prefix sequence of given length,
-    first releasing any existing pages assigned to the slot.
-
-    Args:
-      slot: Integer identifying the target slot
-      true_length: Actual length of the prefix sequence
-      page_status_var: Variable tracking page usage status
-      page_map_var: Variable mapping slots to pages
-      sequence_lengths_var: Variable tracking sequence lengths
-      num_pages_used_var: Variable tracking page usage counts
-      current_page_var: Variable tracking current active pages
-      current_page_position_var: Variable tracking positions in current pages
-
-    Returns:
-      Tuple of updated variables after reserving pages for the prefix
-    """
-    (
-        page_status_var,
-        page_map_var,
-        sequence_lengths_var,
-        num_pages_used_var,
-        current_page_var,
-        current_page_position_var,
-    ) = self.release_slot_pages(
-        slot,
-        page_status_var,
-        page_map_var,
-        sequence_lengths_var,
-        num_pages_used_var,
-        current_page_var,
-        current_page_position_var,
-    )
-
-    page_status = page_status_var.value
-    page_map = page_map_var.value
-    sequence_lengths = sequence_lengths_var.value
-    num_pages_used = num_pages_used_var.value
-    current_page = current_page_var.value
-    current_page_position = current_page_position_var.value
+      page_state: PageState,
+  ) -> PageState:
+    page_state = self.release_slot_pages(slot, page_state)
+    page_status = page_state.page_status
+    page_map = page_state.page_map
+    sequence_lengths = page_state.sequence_lengths
+    num_pages_used = page_state.num_pages_used
+    current_page = page_state.current_page
+    current_page_position = page_state.current_page_position
 
     prefill_slot_num_pages = jnp.ceil(true_length / self.tokens_per_page).astype(jnp.int32)
     prefill_slot_page_slice_idx = jnp.where(true_length == 0, 0, (true_length - 1) % self.tokens_per_page)
@@ -258,54 +172,25 @@ class PageManager(nn.Module):
     num_pages_used = num_pages_used.at[slot].set(prefill_slot_num_pages)
     current_page_position = current_page_position.at[slot].set(prefill_slot_page_slice_idx)
 
-    page_status_var.value = page_status
-    page_map_var.value = page_map
-    sequence_lengths_var.value = sequence_lengths
-    num_pages_used_var.value = num_pages_used
-    current_page_var.value = current_page
-    current_page_position_var.value = current_page_position
-
-    return (
-        page_status_var,
-        page_map_var,
-        sequence_lengths_var,
-        num_pages_used_var,
-        current_page_var,
-        current_page_position_var,
+    return PageState(
+        page_status=page_status,
+        page_map=page_map,
+        sequence_lengths=sequence_lengths,
+        num_pages_used=num_pages_used,
+        current_page=current_page,
+        current_page_position=current_page_position,
     )
 
   def reserve_decode_step_pages(
       self,
-      page_status_var: nn.Variable,
-      page_map_var: nn.Variable,
-      sequence_lengths_var: nn.Variable,
-      num_pages_used_var: nn.Variable,
-      current_page_var: nn.Variable,
-      current_page_position_var: nn.Variable,
-  ) -> Tuple:
-    """Reserves additional pages needed for a decoding step.
-
-    This method allocates new pages as needed when sequences grow during
-    autoregressive decoding, ensuring each active slot has sufficient pages
-    for its sequence.
-
-    Args:
-      page_status_var: Variable tracking page usage status
-      page_map_var: Variable mapping slots to pages
-      sequence_lengths_var: Variable tracking sequence lengths
-      num_pages_used_var: Variable tracking page usage counts
-      current_page_var: Variable tracking current active pages
-      current_page_position_var: Variable tracking positions in current pages
-
-    Returns:
-      Tuple of updated variables after reserving pages for the decode step
-    """
-    page_status = page_status_var.value
-    page_map = page_map_var.value
-    sequence_lengths = sequence_lengths_var.value
-    num_pages_used = num_pages_used_var.value
-    current_page = current_page_var.value
-    current_page_position = current_page_position_var.value
+      page_state: PageState,
+  ) -> PageState:
+    page_status = page_state.page_status
+    page_map = page_state.page_map
+    sequence_lengths = page_state.sequence_lengths
+    num_pages_used = page_state.num_pages_used
+    current_page = page_state.current_page
+    current_page_position = page_state.current_page_position
 
     sequence_lengths_step = jnp.logical_and(jnp.ones(sequence_lengths.shape, dtype=jnp.int32), sequence_lengths).astype(
         jnp.int32
@@ -334,91 +219,14 @@ class PageManager(nn.Module):
         0, jnp.count_nonzero(seq_new_page), _reserve_page, (page_map, page_status, current_page, updating_slots)
     )
 
-    page_status_var.value = page_status
-    page_map_var.value = page_map
-    sequence_lengths_var.value = sequence_lengths
-    num_pages_used_var.value = num_pages_used
-    current_page_var.value = current_page
-    current_page_position_var.value = current_page_position
-
-    return (
-        page_status_var,
-        page_map_var,
-        sequence_lengths_var,
-        num_pages_used_var,
-        current_page_var,
-        current_page_position_var,
-    )
-
-  @nn.compact
-  def __call__(
-      self, model_mode: Optional[str] = None, slot: Optional[int] = None, true_length: Optional[int] = None
-  ) -> PageState:
-
-    (
-        page_status_var,
-        page_map_var,
-        sequence_lengths_var,
-        num_pages_used_var,
-        current_page_var,
-        current_page_position_var,
-    ) = self.init_or_get_vars()
-
-    if model_mode == common_types.MODEL_MODE_PREFILL and self.is_mutable_collection("params"):
-      return PageState(
-          page_status_var.value,
-          page_map_var.value,
-          sequence_lengths_var.value,
-          num_pages_used_var.value,
-          current_page_var.value,
-          current_page_position_var.value,
-      )
-    elif model_mode == common_types.MODEL_MODE_PREFILL and slot is None and true_length is None:
-      return PageState(
-          page_status_var.value,
-          page_map_var.value,
-          sequence_lengths_var.value,
-          num_pages_used_var.value,
-          current_page_var.value,
-          current_page_position_var.value,
-      )
-    elif model_mode == common_types.MODEL_MODE_PREFILL:
-      self.reserve_prefix_slot_pages(
-          slot,
-          true_length,
-          page_status_var,
-          page_map_var,
-          sequence_lengths_var,
-          num_pages_used_var,
-          current_page_var,
-          current_page_position_var,
-      )
-    elif model_mode == common_types.MODEL_MODE_INSERT:
-      self.reserve_prefix_slot_pages(
-          slot,
-          true_length,
-          page_status_var,
-          page_map_var,
-          sequence_lengths_var,
-          num_pages_used_var,
-          current_page_var,
-          current_page_position_var,
-      )
-    elif model_mode == common_types.MODEL_MODE_AUTOREGRESSIVE:
-      self.reserve_decode_step_pages(
-          page_status_var,
-          page_map_var,
-          sequence_lengths_var,
-          num_pages_used_var,
-          current_page_var,
-          current_page_position_var,
-      )
-
     return PageState(
-        page_status_var.value,
-        page_map_var.value,
-        sequence_lengths_var.value,
-        num_pages_used_var.value,
-        current_page_var.value,
-        current_page_position_var.value,
+        page_status=page_status,
+        page_map=page_map,
+        sequence_lengths=sequence_lengths,
+        num_pages_used=num_pages_used,
+        current_page=current_page,
+        current_page_position=current_page_position,
     )
+
+  def get_initial_page_state(self) -> PageState:
+    return initialize_page_state(num_pages=self.num_pages, num_slots=self.slots, max_pages_per_slot=self.max_pages_per_slot)

--- a/MaxText/inference/paged_attention.py
+++ b/MaxText/inference/paged_attention.py
@@ -20,6 +20,8 @@ WARNING: THIS FILE IS A WORK IN PROGRESS.
 import functools
 from typing import Optional
 
+import jax
+
 import common_types
 import jax.numpy as jnp
 from flax import linen as nn
@@ -247,6 +249,7 @@ class PagedAttentionOp(nn.Module):
       decoder_segment_ids: Array,
       model_mode: str,
       previous_chunk=None,
+      slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
   ):
     """Apply paged attention mechanism.
@@ -256,59 +259,47 @@ class PagedAttentionOp(nn.Module):
               are None for autoregressive mode (handled by paged_attention kernel)
     """
     key_pages_var, value_pages_var = self.init_or_get_kv_pages(model_mode)
-    self.update(key_pages_var, value_pages_var, key, value, model_mode, page_state)
 
+    # update kv pages and call page attention kernel
     if model_mode == common_types.MODEL_MODE_PREFILL:
+      self.update_prefill_step_pages(key_pages_var, value_pages_var, key, value, slot, page_state)
       if _use_kernel_v2:
         return self.paged_attention_v2_prefill(query, key_pages_var, value_pages_var, page_state), None, None
       return self.paged_dot_product_attention_with_max_and_sum(query, key, value)
     elif model_mode == common_types.MODEL_MODE_AUTOREGRESSIVE:
+      self.update_decode_step_pages(key_pages_var, value_pages_var, key, value, page_state)
       if _use_kernel_v2:
         return self.paged_attention_v2_decode(query, key_pages_var, value_pages_var, page_state), None, None
       return self.paged_attention_v1_decode(query, key_pages_var, value_pages_var, page_state), None, None
 
-  def update(
-      self,
-      key_pages_var: nn.Variable,
-      value_pages_var: nn.Variable,
-      key: Array,
-      value: Array,
-      model_mode: str,
-      page_state: Optional[page_manager.PageState] = None,
-  ) -> None:
-    """Update KV Pages."""
-    if model_mode == common_types.MODEL_MODE_PREFILL:
-      self.update_prefill_step_pages(key_pages_var, value_pages_var, key, value)
-    elif model_mode == common_types.MODEL_MODE_AUTOREGRESSIVE:
-      self.update_decode_step_pages(key_pages_var, value_pages_var, key, value, page_state)
-
   def update_prefill_step_pages(
       self,
-      key_pages_var: nn.Variable,
+      key_pages_var: nn.Variable,  # [num_kv_heads, num_pages, tokens_per_page, head_dim]
       value_pages_var: nn.Variable,
       key: Array,
       value: Array,
+      slot: int,
+      page_state: page_manager.PageState,
   ) -> None:
     """Update pages for prefill step."""
 
     assert (
         key.shape == value.shape
     ), f"prefill_step key/value should have the same shape, but getting {key.shape=} and {value.shape=} instead"
-    b, t, n_kv, d = key.shape
-    assert t % self.tokens_per_page == 0, f"seq_length {t} and  tokens_per_page {self.tokens_per_page}"
+    batch_size, seq_len, n_kv_head, head_dim = key.shape
+    assert seq_len % self.tokens_per_page == 0, f"seq_length {seq_len} and  tokens_per_page {self.tokens_per_page}"
     assert (
         key_pages_var.value.shape == value_pages_var.value.shape
     ), f"prefill_step key/value_pages_var should have the same shape, but getting {key_pages_var.shape=} and {value_pages_var.shape=} instead"
 
     v_n_kv, v_n_p, v_p, v_d = key_pages_var.value.shape
-    assert v_n_kv == n_kv, f"{v_n_kv=} {n_kv=}"
+    assert v_n_kv == n_kv_head, f"{v_n_kv=} {n_kv_head=}"
     assert v_p == self.tokens_per_page, f"{v_p=} {self.tokens_per_page=}"
-    assert v_d == d, f"{v_d=} {d=}"
-    assert v_n_p == self.max_pages_per_prefill, f"{v_n_p=} {self.max_pages_per_prefill=}"
+    assert v_d == head_dim, f"{v_d=} {head_dim=}"
 
     # Handle both init (b>1) and runtime (b=1) cases
-    if b == 1:
-      key = jnp.squeeze(key)
+    if batch_size == 1:
+      key = jnp.squeeze(key)  # [batch_size, seq_len, n_kv_head, head_dim] to [seq_len, n_kv_head, head_dim]
       value = jnp.squeeze(value)
     else:
       key = key[0]
@@ -317,8 +308,8 @@ class PagedAttentionOp(nn.Module):
     key = jnp.transpose(key, axes=(1, 0, 2))
     value = jnp.transpose(value, axes=(1, 0, 2))
 
-    key = jnp.reshape(key, shape=(n_kv, t // self.tokens_per_page, self.tokens_per_page, d))
-    value = jnp.reshape(value, shape=(n_kv, t // self.tokens_per_page, self.tokens_per_page, d))
+    key = jnp.reshape(key, shape=(n_kv_head, seq_len // self.tokens_per_page, self.tokens_per_page, head_dim))
+    value = jnp.reshape(value, shape=(n_kv_head, seq_len // self.tokens_per_page, self.tokens_per_page, head_dim))
 
     key_pages_var.value = nn.with_logical_constraint(key, self.kv_pages_axis_names)
     value_pages_var.value = nn.with_logical_constraint(value, self.kv_pages_axis_names)
@@ -331,15 +322,16 @@ class PagedAttentionOp(nn.Module):
     kv_heads, num_pages, tokens_per_page, head_dim = key_pages.shape
 
     new_key = key.reshape(batch_size, kv_heads, head_dim)[:, :, :]
-    new_key = jnp.transpose(new_key, (1, 0, 2))  # [n_kv, b, d]
+    new_key = jnp.transpose(new_key, (1, 0, 2))  # [n_kv_heads, batch_size, head_dim]
     new_value = value.reshape(batch_size, kv_heads, head_dim)[:, :, :]
-    new_value = jnp.transpose(new_value, (1, 0, 2))  # n_kv, b, d
+    new_value = jnp.transpose(new_value, (1, 0, 2))  # [n_kv_heads, batch_size, head_dim]
 
-    broadcast_pages = jnp.tile(page_state.current_page, (kv_heads, 1))  # [n_kv, b]
-    broadcast_pos = jnp.tile(page_state.current_page_position, (kv_heads, 1))  # [n_kv, b]
-    kv_indices = jnp.arange(kv_heads)[:, None]  # [n_kv, 1]
-    kv_indices = jnp.tile(kv_indices, (1, batch_size))  # [n_kv, b]
+    broadcast_pages = jnp.tile(page_state.current_page, (kv_heads, 1))  # [n_kv_heads, batch_size]
+    broadcast_pos = jnp.tile(page_state.current_page_position, (kv_heads, 1))  # [n_kv_heads, batch_size]
+    kv_indices = jnp.arange(kv_heads)[:, None]  # [n_kv_heads, 1]
+    kv_indices = jnp.tile(kv_indices, (1, batch_size))  # [n_kv_heads, batch_size]
 
+    # [num_kv_heads, num_pages, tokens_per_page, head_dim]
     key_pages_updated = key_pages.at[kv_indices, broadcast_pages, broadcast_pos].set(new_key)
     value_pages_updated = value_pages.at[kv_indices, broadcast_pages, broadcast_pos].set(new_value)
 

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -788,6 +788,7 @@ class AttentionOp(nn.Module):
       decoder_segment_ids,
       model_mode,
       previous_chunk=None,
+      slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
   ):
 
@@ -1113,6 +1114,7 @@ class Attention(nn.Module):
       model_mode: str = common_types.MODEL_MODE_TRAIN,
       deterministic: bool = False,
       previous_chunk: Any = None,
+      slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
   ):
     """Applies Attention on the input data.
@@ -1196,7 +1198,7 @@ class Attention(nn.Module):
 
     if self.config.attention == "paged" and model_mode != common_types.MODEL_MODE_TRAIN:
       unnormalized_out, _, exp_sum = self.paged_attention_op(
-          query, key, value, decoder_segment_ids, model_mode, previous_chunk, page_state=page_state
+          query, key, value, decoder_segment_ids, model_mode, previous_chunk, slot=slot, page_state=page_state
       )
       out = unnormalized_out / (exp_sum + 1e-9) if exp_sum is not None else unnormalized_out
     else:
@@ -1372,6 +1374,7 @@ class MLA(Attention):
       model_mode: str = common_types.MODEL_MODE_TRAIN,
       deterministic: bool = False,
       previous_chunk: Any = None,
+      slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
   ) -> Array:
     """Forward pass for MLA, reusing `AttentionOp` for the actual attention.

--- a/MaxText/layers/deepseek.py
+++ b/MaxText/layers/deepseek.py
@@ -150,6 +150,7 @@ class DeepSeekDenseLayer(nn.Module):
       model_mode,
       previous_chunk=None,
       page_state=None,
+      slot=None,
   ):
     cfg = self.config
     inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
@@ -199,6 +200,7 @@ class DeepSeekMoELayer(nn.Module):
       model_mode,
       previous_chunk=None,
       page_state=None,
+      slot=None,
   ):
     cfg = self.config
     inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))

--- a/MaxText/layers/gemma.py
+++ b/MaxText/layers/gemma.py
@@ -69,6 +69,7 @@ class GemmaDecoderLayer(nn.Module):
       previous_chunk=None,
       page_manager=None,
       page_state=None,
+      slot=None,
   ):
     cfg = self.config
     mesh = self.mesh

--- a/MaxText/layers/gemma2.py
+++ b/MaxText/layers/gemma2.py
@@ -68,6 +68,7 @@ class Gemma2DecoderLayer(nn.Module):
       model_mode,
       previous_chunk=None,
       page_state=None,
+      slot=None,
   ):
     cfg = self.config
     mesh = self.mesh

--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -98,6 +98,7 @@ class Gemma3DecoderLayer(nn.Module):
       model_mode,
       previous_chunk=None,
       page_state=None,
+      slot=None,
   ):
     cfg = self.config
     mesh = self.mesh

--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -280,6 +280,7 @@ class Gpt3DecoderLayer(nn.Module):
       model_mode,
       previous_chunk=None,
       page_state=None,
+      slot=None,
   ):
     cfg = self.config
     mesh = self.mesh

--- a/MaxText/layers/llama2.py
+++ b/MaxText/layers/llama2.py
@@ -75,6 +75,7 @@ class LlamaDecoderLayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
       previous_chunk=None,
   ):
@@ -127,6 +128,7 @@ class LlamaDecoderLayer(nn.Module):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         model_mode=model_mode,
+        slot=slot,
         page_state=page_state,
         previous_chunk=previous_chunk,
     )

--- a/MaxText/layers/mistral.py
+++ b/MaxText/layers/mistral.py
@@ -68,6 +68,7 @@ class MistralDecoderLayer(nn.Module):
       model_mode,
       previous_chunk=None,
       page_state=None,
+      slot=None,
   ):
     cfg = self.config
     mesh = self.mesh

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -65,6 +65,7 @@ class DecoderLayer(nn.Module):
       deterministic,
       model_mode,
       previous_chunk=None,
+      slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
   ):
     cfg = self.config
@@ -164,7 +165,14 @@ class SequentialBlockDecoderLayers(nn.Module):
 
   @nn.compact
   def __call__(
-      self, inputs: jnp.ndarray, decoder_segment_ids, decoder_positions, deterministic, model_mode, page_state=None
+      self,
+      inputs: jnp.ndarray,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic: bool,
+      model_mode,
+      slot: Optional[int] = None,
+      page_state: Optional[page_manager.PageState] = None,
   ) -> jnp.ndarray:
     for lyr in range(self.num_decoder_layers):
       inputs = self.decoder_layer(config=self.config, mesh=self.mesh, name=f"layers_{lyr}", quant=self.quant)(
@@ -173,6 +181,7 @@ class SequentialBlockDecoderLayers(nn.Module):
           decoder_positions,
           deterministic,
           model_mode,
+          slot=slot,
           page_state=page_state,
       )
     return inputs
@@ -400,6 +409,7 @@ class Decoder(nn.Module):
       deterministic=False,
       model_mode=common_types.MODEL_MODE_TRAIN,
       previous_chunk=None,
+      slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
   ):
     cfg = self.config
@@ -488,6 +498,7 @@ class Decoder(nn.Module):
                   model_mode,
                   previous_chunk=previous_chunk,
                   page_state=page_state,
+                  slot=slot,
               )
         else:
           for lyr in range(cfg.num_decoder_layers):
@@ -506,6 +517,7 @@ class Decoder(nn.Module):
                 model_mode,
                 previous_chunk=previous_chunk,
                 page_state=page_state,
+                slot=slot,
             )
     y = self.get_norm_layer()(
         dtype=cfg.dtype,
@@ -576,51 +588,17 @@ class Transformer(nn.Module):
 
     self.decoder = Decoder(config=cfg, shared_embedding=self.shared_embedding, mesh=mesh, quant=self.quant)
 
-    if cfg.attention == "paged":
-      self.page_manager = self._create_page_manager(cfg)
-
-  def _create_page_manager(self, config) -> Optional[page_manager.PageManager]:
-    """Creates page manager for managing pages in the paged attention mechanism"""
-    assert config.max_target_length % config.pagedattn_tokens_per_page == 0
-    assert config.max_prefill_predict_length % config.pagedattn_tokens_per_page == 0
-    return page_manager.PageManager(
-        num_pages=self.config.pagedattn_num_pages,
-        tokens_per_page=self.config.pagedattn_tokens_per_page,
-        slots=int(self.config.per_device_batch_size * jax.device_count()),
-        max_target_length=self.config.max_target_length,
-        max_prefill_predict_length=self.config.max_prefill_predict_length,
-        max_pages_per_slot=self.config.max_target_length // self.config.pagedattn_tokens_per_page,
-    )
-
-  def _create_page_state(
-      self, model_mode: str, true_length: Optional[int] = None, slot: Optional[int] = None
-  ) -> Optional[page_manager.PageState]:
-    """Creates page state for tracking page status in the paged attention mechanism."""
-    if self.config.attention != "paged" or model_mode == common_types.MODEL_MODE_TRAIN:
-      return None
-    page_state = None
-    if model_mode == common_types.MODEL_MODE_PREFILL:
-      page_state = self.page_manager(
-          model_mode=model_mode,
-          slot=slot,
-          true_length=true_length,
-      )
-    elif model_mode == common_types.MODEL_MODE_AUTOREGRESSIVE:
-      page_state = self.page_manager(model_mode)
-    else:
-      raise ValueError(f"Unsupported model_mode {model_mode} by paged attention")
-    return page_state
-
   def __call__(
       self,
-      decoder_input_tokens,
-      decoder_positions,
+      decoder_input_tokens: jnp.ndarray,
+      decoder_positions: jnp.ndarray,
       decoder_segment_ids=None,
       enable_dropout=True,
       model_mode=common_types.MODEL_MODE_TRAIN,
       previous_chunk=None,
       true_length: Optional[int] = None,
       slot: Optional[int] = None,
+      page_state: Optional[page_manager.PageState] = None,
   ):
     """Applies Transformer decoder-branch on encoded-input and target.
 
@@ -643,6 +621,7 @@ class Transformer(nn.Module):
         deterministic=not enable_dropout,
         model_mode=model_mode,
         previous_chunk=previous_chunk,
-        page_state=self._create_page_state(model_mode=model_mode, true_length=true_length, slot=slot),
+        slot=slot,
+        page_state=page_state,
     )
     return logits

--- a/MaxText/layers/simple_layer.py
+++ b/MaxText/layers/simple_layer.py
@@ -66,7 +66,15 @@ class SimpleMlpDecoderLayer(nn.Module):
     )
 
   def __call__(
-      self, inputs: jnp.ndarray, positions, segmentation, deterministic, model_mode, previous_chunk=None, page_state=None
+      self,
+      inputs: jnp.ndarray,
+      positions,
+      segmentation,
+      deterministic,
+      model_mode,
+      previous_chunk=None,
+      page_state=None,
+      slot=0,
   ):
     intermediate = inputs @ self.ff_1.astype(inputs.dtype)
     output = intermediate @ self.ff_2.astype(inputs.dtype)

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -19,6 +19,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax.experimental import mesh_utils
+from inference.page_manager import PageState
 import checkpointing
 import common_types
 import functools
@@ -31,7 +32,7 @@ import subprocess
 from etils import epath
 from collections.abc import Sequence
 import collections
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 import max_logging
 
@@ -913,7 +914,7 @@ def get_abstract_state(model, tx, config, rng, mesh, is_training=True):
   )
 
 
-def get_prefill_kv_cache_annotations(model, config, rng, mesh):
+def get_prefill_kv_cache_annotations(model, config, rng, mesh, page_state: Optional[PageState] = None):
   """Get a shaped abstraction of the state (including optimizer)"""
 
   def init_kv_cache(model, config):
@@ -927,6 +928,8 @@ def get_prefill_kv_cache_annotations(model, config, rng, mesh):
         jnp.ones(input_shape),
         jnp.ones(input_shape),
         model_mode=common_types.MODEL_MODE_PREFILL,
+        slot=0,
+        page_state=page_state,
     )
     return model_vars["cache"]
 
@@ -939,7 +942,7 @@ def get_prefill_kv_cache_annotations(model, config, rng, mesh):
   return state_mesh_annotations
 
 
-def get_kv_cache_annotations(model, config, rng, mesh):
+def get_kv_cache_annotations(model, config, rng, mesh, page_state: Optional[PageState] = None):
   """Get a shaped abstraction of the state (including optimizer)"""
 
   def init_kv_cache(model, config):
@@ -953,6 +956,8 @@ def get_kv_cache_annotations(model, config, rng, mesh):
         jnp.ones(input_shape),
         jnp.ones(input_shape),
         model_mode=common_types.MODEL_MODE_AUTOREGRESSIVE,
+        slot=0,
+        page_state=page_state,
     )
     return model_vars["cache"]
 

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -22,6 +22,7 @@ import flax
 from flax import linen as nn
 from flax.linen import partitioning as nn_partitioning
 
+from inference.page_manager import PageManager, PageState
 from layers import models, quantizations
 
 import jax
@@ -103,6 +104,26 @@ class MaxEngine(engine_api.Engine):
     self.decode_state_shapes = None
     self.decode_state_layouts = None
     self.param_layouts = None
+
+    if self.config.attention == "paged":
+      # Initialize page manager and page state
+      self.page_manager = PageManager(
+          num_pages=self.config.pagedattn_num_pages,
+          tokens_per_page=self.config.pagedattn_tokens_per_page,
+          max_target_length=self.config.max_target_length,
+          batch_size=self.config.per_device_batch_size,
+          max_prefill_length=self.config.max_prefill_predict_length,
+      )
+    else:
+      # Add a dummy object for page manager and page state to avoid tracing issue
+      self.page_manager = PageManager(
+          num_pages=1,
+          tokens_per_page=1,
+          max_target_length=2,
+          batch_size=1,
+          max_prefill_length=1,
+      )
+    self.page_state = self.page_manager.get_initial_page_state()
 
   def print_stats(self, label: str):
     max_utils.print_mem_stats(label)
@@ -215,7 +236,9 @@ class MaxEngine(engine_api.Engine):
         state.params,
     )
 
-    self.prefill_kv_cache_annotations = max_utils.get_prefill_kv_cache_annotations(self.model, self.config, rng2, self._mesh)
+    self.prefill_kv_cache_annotations = max_utils.get_prefill_kv_cache_annotations(
+        self.model, self.config, rng2, self._mesh, self.page_state
+    )
     self.prefill_kv_cache_shardings = jax.tree_util.tree_map(
         lambda x: jax.sharding.NamedSharding(self._mesh, x),
         self.prefill_kv_cache_annotations,
@@ -229,7 +252,9 @@ class MaxEngine(engine_api.Engine):
       )
       self.prefill_kv_cache_shardings = self.prefill_kv_cache_shardings["decoder"]["layers_0"]
 
-    self.kv_cache_annotations = max_utils.get_kv_cache_annotations(self.model, self.config, rng2, self._mesh)
+    self.kv_cache_annotations = max_utils.get_kv_cache_annotations(
+        self.model, self.config, rng2, self._mesh, self.page_state
+    )
     self.kv_cache_shardings = jax.tree_util.tree_map(
         lambda x: jax.sharding.NamedSharding(self._mesh, x),
         self.kv_cache_annotations,
@@ -365,7 +390,7 @@ class MaxEngine(engine_api.Engine):
     )
 
   @functools.partial(jax.jit, static_argnums=(0,), static_argnames=("request_id",))
-  def prefill(
+  def _prefill_jit(
       self,
       *,
       params: Params,
@@ -380,6 +405,7 @@ class MaxEngine(engine_api.Engine):
       previous_chunk: Optional[Any] = None,
       request_id: Optional[uuid.UUID] = None,  # pylint: disable=unused-argument
       slot: Optional[int] = None,
+      page_state: Optional[PageState] = None,
   ) -> Tuple[Prefix, engine_api.ResultTokens]:
     """Computes a kv-cache for a new generate request.
 
@@ -463,6 +489,7 @@ class MaxEngine(engine_api.Engine):
           previous_chunk=previous_chunk,
           true_length=true_length,
           slot=slot,
+          page_state=page_state,
       )
     generated_tokens = jnp.zeros((1, 1), dtype=jnp.int32)
     selected_logits = jax.lax.dynamic_slice(
@@ -505,6 +532,49 @@ class MaxEngine(engine_api.Engine):
         "generated_tokens": generated_tokens,
         "tokens": first_generated_token,
     }, result
+
+  # Public non-JIT prefill method that updates page state
+  def prefill(
+      self,
+      *,
+      params: Params,
+      existing_prefix: Optional[jax.Array] = None,
+      padded_tokens: jax.Array,
+      true_length: int,
+      sampler: Optional[Callable[[Any], Any]] = None,  # pylint: disable=unused-argument
+      rng: Optional[PRNGKeyType] = None,
+      complete_prompt_true_length: Optional[int] = None,
+      complete_padded_prompt: Optional[jax.Array] = None,
+      positions: Optional[jax.Array] = None,
+      previous_chunk: Optional[Any] = None,
+      request_id: Optional[uuid.UUID] = None,  # pylint: disable=unused-argument
+      slot: Optional[int] = None,
+  ) -> Tuple[Prefix, engine_api.ResultTokens]:
+    """Public API for prefill that updates page state outside JIT."""
+    # Update page state before JIT call
+    if self.config.attention == "paged":
+      self.page_state = self.page_manager.reserve_prefix_slot_pages(
+          slot=slot,
+          true_length=true_length,
+          page_state=self.page_state,
+      )
+
+    # Call JIT-compiled version with current state
+    return self._prefill_jit(
+        params=params,
+        existing_prefix=existing_prefix,
+        padded_tokens=padded_tokens,
+        sampler=sampler,
+        true_length=true_length,
+        page_state=self.page_state,  # Pass current page state
+        slot=slot,
+        rng=rng,
+        request_id=request_id,
+        complete_prompt_true_length=complete_prompt_true_length,
+        complete_padded_prompt=complete_padded_prompt,
+        positions=positions,
+        previous_chunk=previous_chunk,
+    )
 
   def prefill_multisampling_aot(  # pylint: disable=too-many-positional-arguments
       self,
@@ -735,13 +805,40 @@ class MaxEngine(engine_api.Engine):
     prefix, _ = self.prefill(params=params, padded_tokens=padded_tokens, true_length=true_length, rng=rng)
     return self.insert(prefix, decode_state, slot)
 
-  @functools.partial(jax.jit, static_argnums=(0,), donate_argnums=(2,))
+  # Public non-JIT generate method that updates page state
   def generate(
       self,
       params: Params,
       decode_state: DecodeState,
       sampler: Optional[Callable[[Any], Any]] = None,  # pylint: disable=unused-argument
       rng: Optional[PRNGKeyType] = None,
+  ) -> Tuple[DecodeState, engine_api.ResultTokens]:
+    """Public API for generate that updates page state outside JIT."""
+    # Update page state before JIT call
+
+    if self.config.attention == "paged":
+      self.page_state = self.page_manager.reserve_decode_step_pages(self.page_state)
+
+    # Call JIT-compiled version with current state
+    new_state, result = self._generate_jit(
+        params=params,
+        decode_state=decode_state,
+        sampler=sampler,
+        page_state=self.page_state,
+        rng=rng,
+    )
+
+    return new_state, result
+
+  @functools.partial(jax.jit, static_argnums=(0,), donate_argnums=(2,))
+  def _generate_jit(
+      self,
+      params: Params,
+      decode_state: DecodeState,
+      *,
+      sampler: Optional[Callable[[Any], Any]] = None,  # pylint: disable=unused-argument
+      rng: Optional[PRNGKeyType] = None,
+      page_state: Optional[PageState] = None,
   ) -> Tuple[DecodeState, engine_api.ResultTokens]:
     """Run one generate step"""
     if rng is None:
@@ -759,6 +856,7 @@ class MaxEngine(engine_api.Engine):
           model_mode=common_types.MODEL_MODE_AUTOREGRESSIVE,
           rngs={"params": new_rng},
           mutable=["cache"],
+          page_state=page_state,
       )
     out_logits = jax.lax.with_sharding_constraint(out_logits, self.replicated_sharding)
     new_cache = jax.lax.with_sharding_constraint(new_vars["cache"], self.kv_cache_shardings)
@@ -968,11 +1066,9 @@ class MaxEngine(engine_api.Engine):
       else:
         raise ValueError(f"We don't have a strategy for inserting {path_key}")
 
-    if self.config.attention == "paged":
+    if self.config.attention == "paged" and self.page_state is not None:
 
       def _copy_paged(path, prefix_cache, decode_state_cache):
-        if path[-2].key == "page_manager":
-          return prefix_cache
         path_key = path[-1].key
         if path_key in ["key_pages", "value_pages"]:
 
@@ -986,9 +1082,9 @@ class MaxEngine(engine_api.Engine):
 
           decode_state_cache, _, _ = jax.lax.fori_loop(
               0,
-              prefix["cache"]["page_manager"]["num_pages_used"].value[slot],
+              self.page_state.num_pages_used[slot],
               _update_pages,
-              (decode_state_cache, prefix_cache, prefix["cache"]["page_manager"]["page_map"].value[slot]),
+              (decode_state_cache, prefix_cache, self.page_state.page_map[slot]),
           )
           return decode_state_cache
         else:
@@ -1006,6 +1102,7 @@ class MaxEngine(engine_api.Engine):
           decode_state["cache"],
           self.kv_cache_annotations_named,
       )
+
     inserted_logits = jax.lax.dynamic_update_index_in_dim(decode_state["logits"], unboxed_prefix["logits"], slot, 0)
     inserted_next_pos = jax.lax.dynamic_update_index_in_dim(decode_state["next_pos"], unboxed_prefix["next_pos"], slot, 0)
     inserted_generated_tokens = jax.lax.dynamic_update_index_in_dim(
@@ -1183,12 +1280,14 @@ class MaxEngine(engine_api.Engine):
       **kwargs,  # pylint: disable=unused-argument
   ) -> DecodeState:
     """Initialises any state which a generation step transforms."""
-
     if rng is None:
       rng = jax.random.PRNGKey(0)
+    page_state = None
+    if self.config.attention == "paged":
+      page_state = self.page_manager.get_initial_page_state()
 
     # pylint: disable=unused-argument
-    def init(abstract_params):
+    def init(abstract_params, page_state):
       x = jnp.ones(
           (int(self.config.per_device_batch_size * jax.device_count()), 1),
           dtype=jnp.int32,
@@ -1201,6 +1300,8 @@ class MaxEngine(engine_api.Engine):
           model_mode=common_types.MODEL_MODE_AUTOREGRESSIVE,
           rngs={"params": rng},
           mutable=["cache"],
+          page_state=page_state,
+          slot=0,
       )
 
       next_pos = jnp.zeros(
@@ -1230,7 +1331,7 @@ class MaxEngine(engine_api.Engine):
       }
 
     with nn_partitioning.axis_rules(self.config.logical_axis_rules):
-      abstract_outputs = jax.eval_shape(init, self.abstract_params)
+      abstract_outputs = jax.eval_shape(init, self.abstract_params, page_state)
     logical_annotations = nn.get_partition_spec(abstract_outputs)
 
     with self._mesh, nn_partitioning.axis_rules(self.config.logical_axis_rules):

--- a/MaxText/tests/inference/paged_attention_test.py
+++ b/MaxText/tests/inference/paged_attention_test.py
@@ -90,9 +90,11 @@ class PagedAttentionTest(unittest.TestCase):
         current_page_position=jnp.zeros(1, dtype=jnp.int32),
     )
 
-    variables = attention_op.init(self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = attention_op.init(
+        self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
     output_tuple, mutated_variables = attention_op.apply(
-        variables, query, key, value, None, common_types.MODEL_MODE_PREFILL, page_state, mutable=["cache"]
+        variables, query, key, value, None, common_types.MODEL_MODE_PREFILL, slot=0, page_state=page_state, mutable=["cache"]
     )
 
     output, _, _ = output_tuple  # Unpack the tuple
@@ -129,7 +131,8 @@ class PagedAttentionTest(unittest.TestCase):
         None,
         common_types.MODEL_MODE_PREFILL,
         None,
-        page_state,
+        slot=0,
+        page_state=page_state,
     )
 
     # Use apply() to update the variable's value
@@ -142,6 +145,7 @@ class PagedAttentionTest(unittest.TestCase):
         # Provide a None or a suitable Array for decoder_segment_ids
         model_mode=common_types.MODEL_MODE_PREFILL,  # Provide the model mode
         previous_chunk=None,
+        slot=0,
         page_state=page_state,  # Provide the page_state
         mutable=["cache"],
     )
@@ -200,6 +204,7 @@ class PagedAttentionTest(unittest.TestCase):
         decoder_segment_ids=None,
         model_mode=common_types.MODEL_MODE_AUTOREGRESSIVE,
         previous_chunk=None,
+        slot=0,
         page_state=page_state,
     )
 
@@ -211,6 +216,7 @@ class PagedAttentionTest(unittest.TestCase):
         decoder_segment_ids=None,
         model_mode=common_types.MODEL_MODE_AUTOREGRESSIVE,
         previous_chunk=None,
+        slot=0,
         page_state=page_state,
         mutable=["cache"],
     )
@@ -260,9 +266,20 @@ class PagedAttentionTest(unittest.TestCase):
         current_page_position=jnp.zeros(1, dtype=jnp.int32),
     )
 
-    variables = self.attention_op.init(self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = self.attention_op.init(
+        self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
     output_tuple, _ = self.attention_op.apply(
-        variables, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        variables,
+        query,
+        key,
+        value,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
     paged_output, max_vals, sum_vals = output_tuple
 
@@ -289,10 +306,19 @@ class PagedAttentionTest(unittest.TestCase):
     )
 
     variables = self.attention_op.init(
-        self.rng, query, key, value, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, page_state
+        self.rng, query, key, value, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, slot=0, page_state=page_state
     )
     output_tuple, _ = self.attention_op.apply(
-        variables, query, key, value, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, page_state, mutable=["cache"]
+        variables,
+        query,
+        key,
+        value,
+        None,
+        common_types.MODEL_MODE_AUTOREGRESSIVE,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
 
     # In autoregressive mode, normalization is handled internally
@@ -323,7 +349,15 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Initialize attention op
     variables = self.attention_op.init(
-        self.rng, prefill_tokens, prefill_tokens, prefill_tokens, None, common_types.MODEL_MODE_PREFILL, None, page_state
+        self.rng,
+        prefill_tokens,
+        prefill_tokens,
+        prefill_tokens,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
     )
 
     output_tuple, _ = self.attention_op.apply(
@@ -334,7 +368,8 @@ class PagedAttentionTest(unittest.TestCase):
         None,
         common_types.MODEL_MODE_PREFILL,
         None,
-        page_state,
+        slot=0,
+        page_state=page_state,
         mutable=["cache"],
     )
 
@@ -371,7 +406,15 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Initialize attention ops
     variables = self.attention_op.init(
-        self.rng, prefill_tokens, prefill_tokens, prefill_tokens, None, common_types.MODEL_MODE_PREFILL, None, page_state
+        self.rng,
+        prefill_tokens,
+        prefill_tokens,
+        prefill_tokens,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
     )
 
     output_tuple, mutated_vars = self.attention_op.apply(
@@ -382,7 +425,8 @@ class PagedAttentionTest(unittest.TestCase):
         None,
         common_types.MODEL_MODE_PREFILL,
         None,
-        page_state,
+        slot=0,
+        page_state=page_state,
         mutable=["cache"],
     )
 
@@ -401,7 +445,8 @@ class PagedAttentionTest(unittest.TestCase):
         None,
         common_types.MODEL_MODE_AUTOREGRESSIVE,
         None,
-        page_state,
+        slot=0,
+        page_state=page_state,
         mutable=["cache"],
     )
 
@@ -439,11 +484,20 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Initialize and apply attention
     variables = self.attention_op.init(
-        self.rng, query, key, value, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, page_state
+        self.rng, query, key, value, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, slot=0, page_state=page_state
     )
 
     output_tuple, _ = self.attention_op.apply(
-        variables, query, key, value, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, page_state, mutable=["cache"]
+        variables,
+        query,
+        key,
+        value,
+        None,
+        common_types.MODEL_MODE_AUTOREGRESSIVE,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
 
     # AR mode returns (output, None, None)
@@ -471,10 +525,21 @@ class PagedAttentionTest(unittest.TestCase):
         current_page_position=jnp.zeros(batch_size, dtype=jnp.int32),
     )
 
-    variables = self.attention_op.init(self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = self.attention_op.init(
+        self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
 
     output_tuple, _ = self.attention_op.apply(
-        variables, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        variables,
+        query,
+        key,
+        value,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
 
     paged_output, max_vals, sum_vals = output_tuple
@@ -506,9 +571,20 @@ class PagedAttentionTest(unittest.TestCase):
     )
 
     # Run prefill
-    variables = self.attention_op.init(self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = self.attention_op.init(
+        self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
     output_tuple, mutated_vars = self.attention_op.apply(
-        variables, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        variables,
+        query,
+        key,
+        value,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
 
     prefill_output, _, _ = output_tuple
@@ -528,7 +604,8 @@ class PagedAttentionTest(unittest.TestCase):
         None,
         common_types.MODEL_MODE_AUTOREGRESSIVE,
         None,
-        page_state,
+        slot=0,
+        page_state=page_state,
         mutable=["cache"],
     )
 
@@ -566,7 +643,15 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Initialize attention op
     variables = self.attention_op.init(
-        self.rng, key, key, value, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, page_state  # Use as query too
+        self.rng,
+        key,
+        key,
+        value,
+        None,
+        common_types.MODEL_MODE_AUTOREGRESSIVE,
+        None,
+        slot=0,
+        page_state=page_state,  # Use as query too
     )
 
     # Perform multiple sequential updates
@@ -589,7 +674,8 @@ class PagedAttentionTest(unittest.TestCase):
           None,
           common_types.MODEL_MODE_AUTOREGRESSIVE,
           None,
-          page_state,
+          slot=0,
+          page_state=page_state,
           mutable=["cache"],
       )
 
@@ -665,10 +751,12 @@ class PagedAttentionTest(unittest.TestCase):
         current_page_position=jnp.zeros(batch_size, dtype=jnp.int32),
     )
 
-    variables = attention_op.init(self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = attention_op.init(
+        self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
 
     output_tuple, _ = attention_op.apply(
-        variables, query, key, value, None, common_types.MODEL_MODE_PREFILL, page_state, mutable=["cache"]
+        variables, query, key, value, None, common_types.MODEL_MODE_PREFILL, slot=0, page_state=page_state, mutable=["cache"]
     )
 
     output, max_vals, sum_vals = output_tuple
@@ -739,12 +827,21 @@ class PagedAttentionTest(unittest.TestCase):
     )
 
     variables = self.attention_op.init(
-        self.rng, key1, key1, value1, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, page_state
+        self.rng, key1, key1, value1, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, slot=0, page_state=page_state
     )
 
     # Store first sequence
     _, mutated_vars = self.attention_op.apply(
-        variables, key1, key1, value1, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, page_state, mutable=["cache"]
+        variables,
+        key1,
+        key1,
+        value1,
+        None,
+        common_types.MODEL_MODE_AUTOREGRESSIVE,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
 
     # Create new sequence with different values
@@ -763,7 +860,16 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Store second sequence in same location
     output_tuple, final_vars = self.attention_op.apply(
-        mutated_vars, key2, key2, value2, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, page_state, mutable=["cache"]
+        mutated_vars,
+        key2,
+        key2,
+        value2,
+        None,
+        common_types.MODEL_MODE_AUTOREGRESSIVE,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
 
     output, _, _ = output_tuple
@@ -806,10 +912,21 @@ class PagedAttentionTest(unittest.TestCase):
         current_page_position=jnp.zeros(batch_size, dtype=jnp.int32),
     )
 
-    variables = self.attention_op.init(self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = self.attention_op.init(
+        self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
 
     output_tuple, _ = self.attention_op.apply(
-        variables, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        variables,
+        query,
+        key,
+        value,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
 
     output, max_vals, sum_vals = output_tuple
@@ -848,10 +965,21 @@ class PagedAttentionTest(unittest.TestCase):
         current_page_position=jnp.zeros(batch_size, dtype=jnp.int32),
     )
 
-    variables = self.attention_op.init(self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = self.attention_op.init(
+        self.rng, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
 
     output_tuple, _ = self.attention_op.apply(
-        variables, query, key, value, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        variables,
+        query,
+        key,
+        value,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
 
     output, max_vals, sum_vals = output_tuple
@@ -897,11 +1025,20 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Initialize and run attention
     variables = self.attention_op.init(
-        self.rng, queries, queries, queries, None, common_types.MODEL_MODE_PREFILL, None, page_state
+        self.rng, queries, queries, queries, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
     )
 
     output_tuple, _ = self.attention_op.apply(
-        variables, queries, queries, queries, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        variables,
+        queries,
+        queries,
+        queries,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
 
     # Verify outputs are different for each slot
@@ -939,7 +1076,15 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Do prefill for all slots
     variables = self.attention_op.init(
-        self.rng, prefill_inputs, prefill_inputs, prefill_inputs, None, common_types.MODEL_MODE_PREFILL, None, page_state
+        self.rng,
+        prefill_inputs,
+        prefill_inputs,
+        prefill_inputs,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
     )
 
     _, mutated_vars = self.attention_op.apply(
@@ -950,7 +1095,8 @@ class PagedAttentionTest(unittest.TestCase):
         None,
         common_types.MODEL_MODE_PREFILL,
         None,
-        page_state,
+        slot=0,
+        page_state=page_state,
         mutable=["cache"],
     )
 
@@ -981,7 +1127,8 @@ class PagedAttentionTest(unittest.TestCase):
         None,
         common_types.MODEL_MODE_AUTOREGRESSIVE,
         None,
-        ar_page_state,
+        slot=0,
+        page_state=ar_page_state,
         mutable=["cache"],
     )
 
@@ -1025,7 +1172,15 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Do prefill
     variables = self.attention_op.init(
-        self.rng, prefill_inputs, prefill_inputs, prefill_inputs, None, common_types.MODEL_MODE_PREFILL, None, page_state
+        self.rng,
+        prefill_inputs,
+        prefill_inputs,
+        prefill_inputs,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
     )
 
     _, current_vars = self.attention_op.apply(
@@ -1036,7 +1191,8 @@ class PagedAttentionTest(unittest.TestCase):
         None,
         common_types.MODEL_MODE_PREFILL,
         None,
-        page_state,
+        slot=0,
+        page_state=page_state,
         mutable=["cache"],
     )
 
@@ -1107,7 +1263,8 @@ class PagedAttentionTest(unittest.TestCase):
           None,
           common_types.MODEL_MODE_AUTOREGRESSIVE,
           None,
-          current_page_state,
+          slot=0,
+          page_state=current_page_state,
           mutable=["cache"],
       )
 
@@ -1154,7 +1311,15 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Initialize attention op
     variables = self.attention_op.init(
-        self.rng, prefill_input, prefill_input, prefill_input, None, common_types.MODEL_MODE_PREFILL, None, page_state
+        self.rng,
+        prefill_input,
+        prefill_input,
+        prefill_input,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
     )
 
     output_tuple, variables = self.attention_op.apply(
@@ -1165,7 +1330,8 @@ class PagedAttentionTest(unittest.TestCase):
         None,
         common_types.MODEL_MODE_PREFILL,
         None,
-        page_state,
+        slot=0,
+        page_state=page_state,
         mutable=["cache"],
     )
 
@@ -1191,7 +1357,8 @@ class PagedAttentionTest(unittest.TestCase):
           None,
           common_types.MODEL_MODE_AUTOREGRESSIVE,
           None,
-          page_state,
+          slot=0,
+          page_state=page_state,
           mutable=["cache"],
       )
 
@@ -1226,9 +1393,20 @@ class PagedAttentionTest(unittest.TestCase):
     )
 
     # Store first sequence
-    variables = self.attention_op.init(self.rng, key1, key1, value1, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = self.attention_op.init(
+        self.rng, key1, key1, value1, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
     output_tuple1, vars1 = self.attention_op.apply(
-        variables, key1, key1, value1, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        variables,
+        key1,
+        key1,
+        value1,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
     first_output = output_tuple1[0]
 
@@ -1252,7 +1430,16 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Store second sequence in same slot
     output_tuple2, vars2 = self.attention_op.apply(
-        vars1, key2, key2, value2, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        vars1,
+        key2,
+        key2,
+        value2,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
     second_output = output_tuple2[0]
 
@@ -1296,7 +1483,9 @@ class PagedAttentionTest(unittest.TestCase):
     x1 = jax.random.normal(self.rng, (batch_size, seq_len, num_heads, head_dim))
 
     # Initialize and store first sequence
-    variables = self.attention_op.init(self.rng, x1, x1, x1, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = self.attention_op.init(
+        self.rng, x1, x1, x1, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
 
     # Get initial KV cache state
     initial_cache = variables["cache"]
@@ -1348,14 +1537,16 @@ class PagedAttentionTest(unittest.TestCase):
     x1 = jax.random.normal(self.rng, (batch_size, seq_len, num_heads, head_dim))
 
     # Initialize
-    variables = self.attention_op.init(self.rng, x1, x1, x1, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = self.attention_op.init(
+        self.rng, x1, x1, x1, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
 
     # Store sequence of outputs for examination
     outputs = []
 
     # Do prefill
     output_tuple, vars = self.attention_op.apply(
-        variables, x1, x1, x1, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        variables, x1, x1, x1, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state, mutable=["cache"]
     )
     outputs.append(output_tuple[0])
     variables = vars
@@ -1377,7 +1568,8 @@ class PagedAttentionTest(unittest.TestCase):
           None,
           common_types.MODEL_MODE_AUTOREGRESSIVE,
           None,
-          page_state,
+          slot=0,
+          page_state=page_state,
           mutable=["cache"],
       )
       outputs.append(output_tuple[0])
@@ -1417,14 +1609,25 @@ class PagedAttentionTest(unittest.TestCase):
         current_page_position=jnp.zeros(batch_size, dtype=jnp.int32),
     )
 
-    variables = self.attention_op.init(self.rng, x, x, x, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, page_state)
+    variables = self.attention_op.init(
+        self.rng, x, x, x, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, slot=0, page_state=page_state
+    )
 
     # Store initial KV cache state
     initial_k_pages = variables["cache"]["key_pages"].value.copy()
 
     # Do generation
     output_tuple, variables = self.attention_op.apply(
-        variables, x, x, x, None, common_types.MODEL_MODE_AUTOREGRESSIVE, None, page_state, mutable=["cache"]
+        variables,
+        x,
+        x,
+        x,
+        None,
+        common_types.MODEL_MODE_AUTOREGRESSIVE,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
 
     # Verify initial content preserved in unused pages
@@ -1458,9 +1661,20 @@ class PagedAttentionTest(unittest.TestCase):
     )
 
     # Store first sequence
-    variables = self.attention_op.init(self.rng, key1, key1, value1, None, common_types.MODEL_MODE_PREFILL, None, page_state)
+    variables = self.attention_op.init(
+        self.rng, key1, key1, value1, None, common_types.MODEL_MODE_PREFILL, None, slot=0, page_state=page_state
+    )
     output_tuple1, vars1 = self.attention_op.apply(
-        variables, key1, key1, value1, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        variables,
+        key1,
+        key1,
+        value1,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
     first_output = output_tuple1[0]
 
@@ -1474,7 +1688,16 @@ class PagedAttentionTest(unittest.TestCase):
 
     # Store second sequence in same slot
     output_tuple2, vars2 = self.attention_op.apply(
-        vars1, key2, key2, value2, None, common_types.MODEL_MODE_PREFILL, None, page_state, mutable=["cache"]
+        vars1,
+        key2,
+        key2,
+        value2,
+        None,
+        common_types.MODEL_MODE_PREFILL,
+        None,
+        slot=0,
+        page_state=page_state,
+        mutable=["cache"],
     )
     second_output = output_tuple2[0]
 


### PR DESCRIPTION
# Description

The changes is based on Pate and Wangyuan's work for refactoring page manager and integrating with JetStream.
It does below things:
1. Keep a global page_state and page_manager for each maxengine instance
2. Page_state will be the adapter to each prefill/insert/generate for sharing page information

tested with command: 
```
python MaxText/decode.py   MaxText/configs/base.yml   tokenizer_path=assets/tokenizer.llama2   load_parameters_path=gs://rupliu-llama2-7b-f32/unscanned/checkpoints/0/items/   max_prefill_predict_length=16   max_target_length=32   model_name=llama2-7b   ici_fsdp_parallelism=1   ici_autoregressive_parallelism=1   ici_tensor_parallelism=-1   scan_layers=false   weight_dtype=float32   per_device_batch_size=1   checkpoint_is_quantized=false  attention=paged  pagedattn_num_pages=64   pagedattn_tokens_per_page=8   pagedattn_pages_per_compute_block=4
```


The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
