### PR TITLE
Added conditional statement to upgrade libtpu version only if using old stable stack tpu images

### DIFF
--- a/maxtext_jax_stable_stack.Dockerfile
+++ b/maxtext_jax_stable_stack.Dockerfile
@@ -2,6 +2,7 @@ ARG JAX_STABLE_STACK_BASEIMAGE
 
 # JAX Stable Stack Base Image
 FROM $JAX_STABLE_STACK_BASEIMAGE
+ARG JAX_STABLE_STACK_BASEIMAGE
 
 ARG COMMIT_HASH
 
@@ -16,18 +17,18 @@ WORKDIR /deps
 COPY . .
 RUN ls .
 
-# b/399968784 - Temporary fix till we install JStS[tpu]>=0.5.1
+# For stable stack tpu training images 0.4.37 AND 0.4.35
 # Orbax checkpoint installs the latest version of JAX,
-# but the libtpu version in this base image is older.
+# but the libtpu version in the base image is older.
 # This version mismatch can cause compatibility issues
 # and break MaxText.
+# Upgrade libtpu version if using either of the old stable images
 
 ARG DEVICE
 ENV DEVICE=$DEVICE
 
-RUN if [ $DEVICE = "tpu" ]; then \
-        pip install --no-cache-dir jax[tpu]==0.5.1; \
-    fi
+RUN if [ "$DEVICE" = "tpu" ] && ([ "$JAX_STABLE_STACK_BASEIMAGE" = "us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1" ] || [ "$JAX_STABLE_STACK_BASEIMAGE" = "us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.35-rev1" ]); then \
+        pip install --no-cache-dir --upgrade jax[tpu]; fi
 
 # Install Maxtext requirements with Jax Stable Stack
 RUN pip install -r /deps/requirements_with_jax_stable_stack.txt


### PR DESCRIPTION
Due to the new stable stack image being released with JAX version 0.5.2, no longer need to pin the libtpu version in stable stack dockerfile if device is TPU. However, to ensure backwards compatability with older stable stack versions, changed the dockerfile to include a conditional that upgrades the libtpu version if using an old stable stack version(0.4.35 AND 0.4.37).

FIXES: b/403608588

# Tests

Tested the new stable stack image by building maxtext on the new JStS candidate image 0.5.2-rev1 and verifying that they pass DAG's.

Link to candidate image: https://pantheon.corp.google.com/artifacts/docker/tpu-prod-env-multipod/us/jax-stable-stack/candidate%2Fgpu?e=13802955&inv=1&invt=AbsCTg&mods=allow_workbench_image_override&project=tpu-prod-env-multipod

The conditional statement was tested by building docker images using 0.4.37 and 0.5.2 as base images. Then verified in logs that the right libtpu version is being installed.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
