### PR TITLE
Save the last ckpt when running out of data

### DIFF
--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -820,7 +820,23 @@ def train_loop(config, state=None):
 
     with jax.profiler.StepTraceAnnotation("train", step_num=step):
       record_goodput(recorder, config, recorder.record_data_loading_start_time if recorder else None)
-      example_batch = load_next_batch(data_iterator, example_batch, config)
+      try:
+        example_batch = load_next_batch(data_iterator, example_batch, config)
+      except Exception as e:  # pylint: disable=broad-except
+        max_logging.log(f"load_next_batch failed, you may have run out of data. Error message: {e}")
+        if checkpoint_manager is not None:
+          state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]
+          if save_checkpoint(
+              checkpoint_manager,
+              int(state_to_save.step),
+              state_to_save,
+              config.dataset_type,
+              data_iterator,
+              config,
+              force=True,
+          ):
+            checkpointing.print_save_message(state_to_save.step, config.async_checkpointing)
+        break
       record_goodput(recorder, config, recorder.record_data_loading_end_time if recorder else None)
       check_example_batch(config, example_batch=example_batch)
       # pylint: disable=not-callable


### PR DESCRIPTION
# Description

We found this feature useful when working on SFT which uses a smaller dataset, and we want to save the last ckpt before running out of data. The same change has been added to the sft_trainer. This PR adds it to train.py

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
