### PR TITLE
Adjust chunked_prefill

### DIFF
--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -64,6 +64,7 @@ class DecoderLayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
       page_state: Optional[page_manager.PageState] = None,
   ):
     cfg = self.config
@@ -485,7 +486,8 @@ class Decoder(nn.Module):
                   decoder_positions,
                   deterministic,
                   model_mode,
-                  page_state,
+                  previous_chunk=previous_chunk,
+                  page_state=page_state,
               )
         else:
           for lyr in range(cfg.num_decoder_layers):
@@ -502,7 +504,8 @@ class Decoder(nn.Module):
                 decoder_positions,
                 deterministic,
                 model_mode,
-                page_state,
+                previous_chunk=previous_chunk,
+                page_state=page_state,
             )
     y = self.get_norm_layer()(
         dtype=cfg.dtype,

--- a/MaxText/layers/simple_layer.py
+++ b/MaxText/layers/simple_layer.py
@@ -63,7 +63,9 @@ class SimpleMlpDecoderLayer(nn.Module):
         (self.config.mlp_dim, self.config.emb_dim),
     )
 
-  def __call__(self, inputs: jnp.ndarray, positions, segmentation, deterministic, model_mode, page_state=None):
+  def __call__(
+      self, inputs: jnp.ndarray, positions, segmentation, deterministic, model_mode, previous_chunk=None, page_state=None
+  ):
     intermediate = inputs @ self.ff_1.astype(inputs.dtype)
     output = intermediate @ self.ff_2.astype(inputs.dtype)
     if self.config.scan_layers:


### PR DESCRIPTION
# Description

Add chunked prefill unittest.
Adjust some call to use previous chunk.
Mask from decoder_segment_ids maybe needed, or the attention could wrong with batch or padding.
Some call with decoder_segment_ids=None, return None for some cases in chunked prefill kv cache.

Todo
* Although the kv cache without chunked return key is equal to the cache without quant, it still produce different results.

# Tests

unittest

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
