### PR TITLE
Fix the dtype when calling Moe megablox gmm kernel.

### DIFF
--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -445,7 +445,7 @@ class MoeBlock(nn.Module):
             lhs=inputs,
             rhs=kernel,
             group_sizes=group_sizes,
-            preferred_element_type=jnp.bfloat16,
+            preferred_element_type=self.config.dtype,
             tiling=(min(tile_size[0], m), min(tile_size[1], k), min(tile_size[2], n)),
             lhs_quantize_dtype=lhs_quantize_dtype,
             rhs_quantize_dtype=rhs_quantize_dtype,
@@ -457,7 +457,7 @@ class MoeBlock(nn.Module):
             lhs=inputs,
             rhs=kernel,
             group_sizes=group_sizes,
-            preferred_element_type=jnp.bfloat16,
+            preferred_element_type=self.config.dtype,
         )
       if hs_shape[0] % pad_length:
         output = output[: hs_shape[0]]


### PR DESCRIPTION
# Description

When calling the MoE megablox gmm kernle, the preferred_element_type is hardcoded to bfloat16. Replace with config controlled dtype instead of hardcoding.

# Tests

No functional change, reply on presubmit test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
