### PR TITLE
Update Llama3.1-8B v5e benchmark name to avoid duplicates

### DIFF
--- a/benchmarks/maxtext_v5e_model_configs.py
+++ b/benchmarks/maxtext_v5e_model_configs.py
@@ -223,10 +223,10 @@ llama2_70b_v5e_256 = _add_to_model_dictionary(
 )
 
 
-llama3_1_8b_8192 = _add_to_model_dictionary(
+llama3_1_8b_8192_v5e_256 = _add_to_model_dictionary(
     v5e_model_dict,
     MaxTextModel(
-        model_name="llama3_1-8b-8192",
+        model_name="llama3_1-8b-8192-v5e-256",
         model_type="llama3.1-8b",
         tuning_params={
             "per_device_batch_size": 2,


### PR DESCRIPTION
# Description

Added `_v5e_256` suffix to the Llama3.1-8B v5e benchmark. This follows the same format as the other v5e benchmarks. @SujeethJinesh let me know if this benchmark is intended for a different slice size.

I saw the following error when running a Llama3.1-405B benchmark on v6e:
```
Traceback (most recent call last):
  File "/home/bvandermoon/workspace/maxtext/benchmarks/benchmark_runner.py", line 311, in <module>
    main()
  File "/home/bvandermoon/workspace/maxtext/benchmarks/benchmark_runner.py", line 236, in main
    assert len(duplicates) == 0 , f'Found duplicate model config {duplicates}'
AssertionError: Found duplicate model config {'llama3_1_8b_8192'}
```
This change allowed the benchmark to run properly.

# Tests

I was able to successfully trigger the Llama3.1-405B benchmark with this change. Didn't run the LLama3.1-8B benchmark since I am not using v5e currently. @SujeethJinesh do you have references to this benchmark that need to be updated?

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
