### PR TITLE
use scores for all experts not only top-k experts for load balancing loss

### DIFF
--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -721,7 +721,8 @@ class MoeBlock(nn.Module):
     matmul_precision = lax.Precision(self.config.matmul_precision)
 
     if self.config.model_call_mode != "inference":
-      loss = self.load_balance_loss(top_k_indices, weights)
+      scores = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
+      loss = self.load_balance_loss(top_k_indices, scores)
     else:
       loss = None
     batch_size = inputs.shape[0]


### PR DESCRIPTION
```python
  def dense_matmul(self, inputs, gate_logits, w0_kernel, w1_kernel, wo_kernel):
    # gate_logits: batch, length, expert
    # follow router_logits non-sharded kernel
    gate_logits = nn.with_logical_constraint(gate_logits, ("activation_batch", "activation_length", None))
    # shape of top_k_weights & top_k_indices: (batch, sequence, num_experts_per_tok)
    top_k_weights, top_k_indices = jax.lax.top_k(gate_logits, self.num_experts_per_tok)

    if self.config.decoder_block == "deepseek":
      top_k_weights = self.deepseek_scale_weights(top_k_weights)
    else:
      top_k_weights = jax.nn.softmax(top_k_weights.astype(jnp.float32), axis=-1).astype(self.dtype)

    weights = self.reshape_and_update_weights(top_k_weights, top_k_indices)
    matmul_precision = lax.Precision(self.config.matmul_precision)

    if self.config.model_call_mode != "inference":
      loss = self.load_balance_loss(top_k_indices, weights)
```
Current implementation is to use `top_k_weights` for `load_balance_loss` but it needs to use none-top-k weights (probs) as following.

```python
scores = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
loss = self.load_balance_loss(top_k_indices, scores)
```

resolved: #1432 