### PR TITLE
Add option to set mu_dtype differently than weight_dtype

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -115,7 +115,7 @@ decoder_block: "llama2" # which style of DecoderBlock to use.
 # Global parameter scale needs to be a power of 2. If you want finer grained control of the model sizes
 # then you should explicitly set base_embed_dim, base_num_query_heads, base_num_kv_heads,
 # base_mlp_dim, base_num_decoder_layers and/or head_dim.
-weight_dtype: float32
+weight_dtype: "float32"
 global_parameter_scale: 1
 base_emb_dim: 2048
 base_num_query_heads: 16
@@ -484,14 +484,18 @@ gradient_clipping_threshold: 1.0
 # batch by accumulating the gradient over a set of steps.
 gradient_accumulation_steps: 1
 
+opt_type: "adamw"  # one of "adamw", "adam_pax" or "sgd" 
+
 # AdamW optimizer parameters
 # We use AdamW following Llama2's training details, see https://arxiv.org/pdf/2307.09288.pdf section 2.2
-opt_type: "adamw"  # one of "adam_pax" or "adamw"
 adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradients.
 adam_b2: 0.95 # Exponential decay rate to track the second moment of past gradients.
 adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
 adam_eps_root: 0. # A small constant applied to denominator inside the square root.
 adam_weight_decay: 0.1 # AdamW Weight decay
+mu_dtype: "" # data type to store "mu" of AdamW tracking the first moment. Inherits from  weight_dtype if unset.
+# Setting nu_dtype is not yet supported by optax, instead nu_dtype is always inherited from weights.
+# See b/399961932 for more.
 
 # Stack trace parameters
 collect_stack_trace: False

--- a/MaxText/optimizers.py
+++ b/MaxText/optimizers.py
@@ -35,6 +35,7 @@ def get_optimizer(config, learning_rate_schedule):
         eps=config.adam_eps,
         eps_root=config.adam_eps_root,
         weight_decay=config.adam_weight_decay,
+        mu_dtype=config.mu_dtype,
     )
   elif config.opt_type == "adam_pax":
     return adam_pax(

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -488,6 +488,8 @@ class _HyperParameters:
 
     # Type conversions
     raw_keys["dtype"] = jax.numpy.dtype(raw_keys["dtype"])
+    raw_keys["weight_dtype"] = jax.numpy.dtype(raw_keys["weight_dtype"])
+    raw_keys["mu_dtype"] = set_mu_dtype(raw_keys)
     raw_keys["logical_axis_rules"] = _lists_to_tuples(raw_keys["logical_axis_rules"])
     raw_keys["data_sharding"] = _lists_to_tuples(raw_keys["data_sharding"])
 
@@ -565,6 +567,17 @@ def create_parallelisms_list(raw_keys):
   raw_keys["ici_parallelism"] = ici_parallelism
   raw_keys["dcn_parallelism"] = dcn_parallelism
   return raw_keys
+
+
+def set_mu_dtype(raw_keys):
+  # Default mu_dtype to weight_dtype if unset
+  if raw_keys["mu_dtype"]:
+    assert raw_keys["opt_type"] != "adam_pax", "opt_type adam_pax doesn't support explicitly setting mu_dtype"
+
+  if raw_keys["mu_dtype"] == "":
+    return raw_keys["weight_dtype"]
+  else:
+    return jax.numpy.dtype(raw_keys["mu_dtype"])
 
 
 def validate_and_set_hlo_dump_defaults(raw_keys):

--- a/MaxText/tests/state_dtypes_test.py
+++ b/MaxText/tests/state_dtypes_test.py
@@ -31,11 +31,11 @@ import jax.numpy as jnp
 Transformer = models.Transformer
 
 
-class WeightDtypes(unittest.TestCase):
-  """Test that all weights are expected dtype (default float32)"""
+class StateDtypes(unittest.TestCase):
+  """Tests that state has expected dtypes, e.g. weights default to float32"""
 
-  def get_weights(self, argv):
-    """Gets model weights"""
+  def get_state(self, argv):
+    """Gets model state including weights and optimizer state"""
 
     # Setup necessary inputs to build a model state
     config = pyconfig.initialize(argv)
@@ -48,17 +48,33 @@ class WeightDtypes(unittest.TestCase):
     _, example_rng = jax.random.split(jax.random.PRNGKey(0), 2)
 
     abstract_state, _, _ = max_utils.get_abstract_state(model, tx, config, example_rng, mesh)
-    return abstract_state.params
+    return abstract_state
 
-  def assert_weights_are_dtype(self, weights, expected_dtype):
+  def get_weights(self, argv):
+    return self.get_state(argv).params
+
+  def get_mu(self, argv):
+    return self.get_state(argv).opt_state[0].mu
+
+  def assert_pytree_is_dtype(self, weights, expected_dtype):
     jax.tree_util.tree_map_with_path(lambda x, y: self.assertEqual(y.dtype, expected_dtype), weights)
 
   def test_default_float32(self):
     argv = [None, "configs/base.yml", "enable_checkpointing=False"]
     weights = self.get_weights(argv)
-    self.assert_weights_are_dtype(weights, jnp.float32)
+    self.assert_pytree_is_dtype(weights, jnp.float32)
 
   def test_set_bf16(self):
     argv = [None, "configs/base.yml", "enable_checkpointing=False", "weight_dtype=bfloat16"]
     weights = self.get_weights(argv)
-    self.assert_weights_are_dtype(weights, jnp.bfloat16)
+    self.assert_pytree_is_dtype(weights, jnp.bfloat16)
+
+  def test_default_mu_float32(self):
+    argv = [None, "configs/base.yml", "enable_checkpointing=False"]
+    mu = self.get_mu(argv)
+    self.assert_pytree_is_dtype(mu, jnp.float32)
+
+  def test_set_mu_bf16(self):
+    argv = [None, "configs/base.yml", "enable_checkpointing=False", "mu_dtype=bfloat16"]
+    mu = self.get_mu(argv)
+    self.assert_pytree_is_dtype(mu, jnp.bfloat16)


### PR DESCRIPTION
# Description

This PR adds an option to set mu_dtype differently than weight_dtype.

DeepSeek uses bfloat16 for mu (first moment) and nu (second moment) and float32 for the parameters. Prior to this change we used only one setting weight_dtype for mu,nu and params. Now we are able to set mu to bfloat16 and params to float32. Unfortunately optax does not yet support setting nu differently than params, we may add this functionality to maxtext once its also in optax.
This should save 20% of memory from the optimizer state, instead of 12 bytes per param (float32 mu, float32 nu, float32 params), we can use 10 bytes per param (bf16 mu, float32 nu, float32 params)



If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/399961932

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Added unit tests for  mu dtype with and without setting new option mu_dtype

Also locally confirmed with memory traces on a v4-8 that memory usage goes down
(for a 1B model we save 2 bytes / param / 4 devices * 1B params = 0.5GB), and can confirm the mu tensors are bf16 from trace memory viewer pane.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
