### PR TITLE
Updated get_tokenizer and build_tokenizer in maxengine to support Hug…

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -364,7 +364,8 @@ tokenizer_path: "assets/tokenizer.llama2"
 # tfds pipeline supports tokenizer_type: sentencepiece, huggingface, tiktoken
 # grain pipeline supports tokenizer_type: sentencepiece, huggingface
 # hf pipeline only supports huggingface type, and will ignore tokenizer_type flag
-tokenizer_type: "sentencepiece"
+tokenizer_type: "sentencepiece" # Currently supporting: "tiktoken", "sentencepiece", "huggingface"
+use_chat_template: False
 tokenize_train_data: True  # False if the dataset is pre-tokenized
 tokenize_eval_data: True  # False if the dataset is pre-tokenized
 add_bos: True

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -32,7 +32,8 @@ from jax.experimental import layout as jax_layout
 import common_types
 from jetstream.core import config_lib
 from jetstream.engine import engine_api
-from jetstream.engine import tokenizer_pb2
+from jetstream.engine.tokenizer_pb2 import TokenizerParameters
+from jetstream.engine.tokenizer_pb2 import TokenizerType
 from jetstream.engine import tokenizer_api
 from jetstream.engine import token_utils
 from utils import lora_utils
@@ -40,7 +41,6 @@ from utils import lora_utils
 import max_utils
 import inference_utils
 import pyconfig
-
 import warnings
 
 warnings.simplefilter("ignore", category=FutureWarning)
@@ -1165,16 +1165,30 @@ class MaxEngine(engine_api.Engine):
         "tokens": self.replicated_sharding,
     }
 
-  def get_tokenizer(self) -> tokenizer_pb2.TokenizerParameters:
+  def get_tokenizer(self) -> TokenizerParameters:
     """Return a protobuf of tokenizer info, callable from Py or C++."""
-    return tokenizer_pb2.TokenizerParameters(path=self.config.tokenizer_path, extra_ids=0)
+    try:
+      tokenizer_type_val = TokenizerType.DESCRIPTOR.values_by_name[self.config.tokenizer_type].number
+      return TokenizerParameters(
+          path=self.config.tokenizer_path,
+          tokenizer_type=tokenizer_type_val,
+          access_token=self.config.hf_access_token,
+          use_chat_template=self.config.use_chat_template,
+          extra_ids=0,
+      )
+    except KeyError as _:
+      raise KeyError(f"Unsupported tokenizer type: {self.config.tokenizer_type}") from None
 
-  def build_tokenizer(self, metadata: tokenizer_pb2.TokenizerParameters) -> tokenizer_api.Tokenizer:
+  def build_tokenizer(self, metadata: TokenizerParameters) -> tokenizer_api.Tokenizer:
     """Return a tokenizer"""
-    if "tiktoken" in metadata.path:
+    if metadata.tokenizer_type == TokenizerType.tiktoken:
       return token_utils.TikToken(metadata)
-    else:
+    elif metadata.tokenizer_type == TokenizerType.sentencepiece:
       return token_utils.SentencePieceTokenizer(metadata)
+    elif metadata.tokenizer_type == TokenizerType.huggingface:
+      return token_utils.HuggingFaceTokenizer(metadata)
+    else:
+      raise ValueError(f"Unsupported tokenizer type: {metadata.tokenizer_type}")
 
   def init_decode_state(
       self,

--- a/constraints_gpu.txt
+++ b/constraints_gpu.txt
@@ -56,7 +56,6 @@ google-cloud-logging==3.11.3
 google-cloud-resource-manager==1.12.5
 google-cloud-storage==2.18.2
 google-crc32c==1.6.0
-google-jetstream==0.2.2
 google-pasta==0.2.0
 google-resumable-media==2.7.2
 googleapis-common-protos==1.65.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ tensorboard-plugin-profile
 tiktoken
 transformers
 mlperf-logging@git+https://github.com/mlperf/logging.git
-google-jetstream
+google-jetstream@git+https://github.com/AI-Hypercomputer/JetStream.git
 jsonlines
 pathwaysutils@git+https://github.com/google/pathways-utils.git
 omegaconf

--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -19,7 +19,7 @@ tiktoken
 torch
 transformers
 mlperf-logging@git+https://github.com/mlperf/logging.git
-google-jetstream
+google-jetstream@git+https://github.com/AI-Hypercomputer/JetStream.git
 jsonlines
 pathwaysutils@git+https://github.com/google/pathways-utils.git
 google-cloud-monitoring


### PR DESCRIPTION
…gingFace tokenizer types.

# Description

This PR updates Maxtext to be able to use tokenizers from HuggingFace. To do this, it also passes adds a few more tokenizer metadata entries into base.yml and updates get/build_tokenizer to use the updated TokenizerParameters proto.

This change is needed to provide e2e testing of DeepSeek-v3 and to more generally allow using models that use HuggingFace tokenizers.

This is one of 2 PRs needed to fix b/403276371 (the second one is a JetStream PR).

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
I ran the following decode.py command and confirmed the output looked sensible:
python MaxText/decode.py MaxText/configs/base.yml  run_name=test_dsv2_16b_decode max_prefill_predict_length=100 per_device_batch_size=1 model_name=deepseek2-16b async_checkpointing=false ici_tensor_parallelism=4 max_target_length=2048 ici_fsdp_parallelism=1 ici_autoregressive_parallelism=2 prompt="An attention function can be described as mapping a query and a set of key-value pairs to an output, where the query, keys, values, and outputs are all vectors. The output is " megablox=False sparse_matmul=False scan_layers=False attention=dot_product tokenizer_type=huggingface tokenizer_path=deepseek-ai/DeepSeek-V2-Lite load_parameters_path=gs://agagik-us/deepseek/maxtext_checkpoints/ds_16b_unscanned_new_3/unscanned_chkpt/checkpoints/0/items scan_layers=False

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
