### PR TITLE
Fix miss previous_chunk args in decoder layers

### DIFF
--- a/MaxText/layers/deepseek.py
+++ b/MaxText/layers/deepseek.py
@@ -149,6 +149,7 @@ class DeepSeekDenseLayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
       page_state=None,
   ):
     cfg = self.config
@@ -197,6 +198,7 @@ class DeepSeekMoELayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
       page_state=None,
   ):
     cfg = self.config

--- a/MaxText/layers/gemma.py
+++ b/MaxText/layers/gemma.py
@@ -66,6 +66,7 @@ class GemmaDecoderLayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
       page_manager=None,
   ):
     cfg = self.config

--- a/MaxText/layers/gemma2.py
+++ b/MaxText/layers/gemma2.py
@@ -66,6 +66,7 @@ class Gemma2DecoderLayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
       page_state=None,
   ):
     cfg = self.config

--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -96,6 +96,7 @@ class Gemma3DecoderLayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
       page_state=None,
   ):
     cfg = self.config

--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -278,6 +278,7 @@ class Gpt3DecoderLayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
       page_state=None,
   ):
     cfg = self.config

--- a/MaxText/layers/simple_layer.py
+++ b/MaxText/layers/simple_layer.py
@@ -37,7 +37,9 @@ class SimpleDecoderLayer(nn.Module):
         (self.config.emb_dim, self.config.emb_dim),
     )
 
-  def __call__(self, inputs: jnp.ndarray, positions, segmentation, deterministic, model_mode, page_state=None):
+  def __call__(
+      self, inputs: jnp.ndarray, positions, segmentation, deterministic, model_mode, previous_chunk=None, page_state=None
+  ):
     if self.config.scan_layers:
       return inputs @ self.weight_mat.astype(inputs.dtype), None
     else:


### PR DESCRIPTION
# Description

Fix miss previous_chunk args in decoder layers

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
