### PR TITLE
Updates the jax compilation cache setting.

### DIFF
--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -948,7 +948,6 @@ def train_loop(config, state=None):
 def main(argv: Sequence[str]) -> None:
   pathwaysutils.initialize()
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
-  jax.config.update("jax_enable_compilation_cache", os.environ.get("JAX_ENABLE_COMPILATION_CACHE", True))
   # TF allocates extraneous GPU memory when using TFDS data
   # this leads to CUDA OOMs. WAR for now is to hide GPUs from TF
   tf.config.set_visible_devices([], "GPU")


### PR DESCRIPTION
# Description

In PR#1386, the JAX_ENABLE_COMPILATION_CACHE always defaults to True even if not set in the environment variable. However, pathway utils set this to False but this setting overwrites it. This PR only removes it.

# Tests

Manually run and see the JAX_ENABLE_COMPILATION_CACHE takes effect when it's set explicitly.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
