### PR TITLE
Update SFT trainer test script to run on Airflow

### DIFF
--- a/MaxText/tests/integration_tests/sft_trainer_correctness_test.py
+++ b/MaxText/tests/integration_tests/sft_trainer_correctness_test.py
@@ -32,6 +32,9 @@ def test_maxtext_with_sft_in_trl():
       "--model-name=llama3.1-8b",
       "--tokenizer-path=assets/llama3.1-tokenizer",
       "--model-ckpt-path=gs://maxtext-model-checkpoints/llama3.1-8b/2025-01-23-19-04/scanned/0/items",
+      "--rtol=1e-05",
+      "--atol=0.06",
+      "--kl-div=7e-05",
   ]
 
   subprocess.run(command, check=True, cwd="..")

--- a/end_to_end/tpu/test_sft_trainer.sh
+++ b/end_to_end/tpu/test_sft_trainer.sh
@@ -1,24 +1,28 @@
 #!/bin/bash
 
+:'
 # This script is designed for internal use within Google.
 # External users can update pre-trained model checkpoint GCS path (gs://) to your accessible locations.
+# Usage:
+  HF_TOKEN=<huggingface access token> \
+  PRE_TRAINED_MODEL=llama2-7b PRE_TRAINED_MODEL_TOKENIZER=meta-llama/Llama-2-7b-hf \
+  PRE_TRAINED_MODEL_CKPT_PATH=gs://maxtext-model-checkpoints/llama2-7b/2025-01-23-19-26/scanned/0/items \
+  BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs STEPS=100 \
+  PROMPT="Suggest some famous landmarks in London." \
+  ROTL=1e-05 ATOL=0.09 KL_DIV=7e-05 \
+  bash end_to_end/tpu/test_sft_trainer.sh
+'
 
 set -xe
 
 RUN_NAME=sft-$(date +%Y-%m-%d-%H-%M-%S)
-STEPS=300000
 PER_DEVICE_BATCH_SIZE=1
 LOSS_THRESHOLD=100.0 # Set to large value so test is guaranteed to pass
-
-PRE_TRAINED_MODEL=llama2-7b
-PRE_TRAINED_MODEL_TOKENIZER=meta-llama/Llama-2-7b-hf
-PRE_TRAINED_MODEL_CKPT_PATH=$(gcloud storage ls gs://maxtext-model-checkpoints/llama2-7b | sort -r | head -1)
-BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs
 
 # SFT with HF pipeline
 python MaxText/sft_trainer.py MaxText/configs/sft.yml \
     run_name=${RUN_NAME}-hf base_output_directory=${BASE_OUTPUT_DIRECTORY} \
-    model_name=${PRE_TRAINED_MODEL} load_parameters_path=${PRE_TRAINED_MODEL_CKPT_PATH}/scanned/0/items \
+    model_name=${PRE_TRAINED_MODEL} load_parameters_path=${PRE_TRAINED_MODEL_CKPT_PATH} \
     dataset_type=hf hf_access_token=$HF_TOKEN tokenizer_path=${PRE_TRAINED_MODEL_TOKENIZER} \
     per_device_batch_size=${PER_DEVICE_BATCH_SIZE} \
     steps=${STEPS} max_target_length=1024 checkpoint_period=100 \
@@ -41,11 +45,20 @@ sorted_dirs=($(printf '%s\n' "${integer_dirs[@]}" | sort -n))
 largest_dir="${sorted_dirs[-1]}"
 FINE_TUNED_MODEL_CKPT_PATH=${CHECKPOINTS_PATH}/${largest_dir}/items
 
+# Apply chat template to prompt before decoding
+PROMPT="<user>${PROMPT}</user> <assistant>"
+
 # Decode
 python MaxText/decode.py MaxText/configs/sft.yml \
     run_name=${RUN_NAME}-hf-decode \
-    model_name=${PRE_TRAINED_MODEL} tokenizer_path=assets/tokenizer.llama2 \
+    model_name=${PRE_TRAINED_MODEL} tokenizer_path=${PRE_TRAINED_MODEL_TOKENIZER} \
     load_parameters_path=${FINE_TUNED_MODEL_CKPT_PATH} \
     per_device_batch_size=${PER_DEVICE_BATCH_SIZE} max_target_length=128 max_prefill_predict_length=64 \
-    attention=dot_product decode_sampling_strategy=greedy prompt="<user>Suggest some famous landmarks in London.</user> <assistant>" \
-    autoregressive_decode_assert="1. Tower of London"
+    attention=dot_product decode_sampling_strategy=greedy prompt="${PROMPT}"
+
+# Correctness test
+python MaxText/tests/sft_trainer_correctness.py \
+    --model-name=${PRE_TRAINED_MODEL} \
+    --tokenizer-path=${PRE_TRAINED_MODEL_TOKENIZER} \
+    --model-ckpt-path=${PRE_TRAINED_MODEL_CKPT_PATH} \
+    --rtol=${RTOL} --atol=${ATOL} --kl-div=${KL_DIV}


### PR DESCRIPTION
# Description
This PR updates the end-to-end test script for SFT Trainer that will run on Airflow DAG. The test script will do the following:
1. Run fine-tuning using SFT.
2. Run inference on a test prompt.
3. Run SFT trainer correctness test to match the logits.

*NOTE*: This PR depends on [HF Tokenizer Support PR](https://github.com/AI-Hypercomputer/maxtext/pull/1439). Merge this only when HF Tokenizer PR is merged, otherwise the airflow tests would fail.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
Ran airflow test on local server. Related airflow test PR: 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
