### PR TITLE
[benchmarks] Use correct exit code on function that is meant to return ; typo fix ; minor formatting improvements

### DIFF
--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -836,8 +836,8 @@ def main() -> int:
   #     batch=1,  # Parallel execution of workloads is not supported in XPK yet.
   #     dry_run=False,
   # )
- # print(f'Return_codes: {return_codes}')
-
+  # print(f'Return_codes: {return_codes}')
+  return os.EX_OK
 
 
 if __name__ == '__main__':

--- a/benchmarks/mmlu/mmlu_eval.py
+++ b/benchmarks/mmlu/mmlu_eval.py
@@ -14,28 +14,28 @@
 
 """This is a simple script for MMLU benchmark for a trained checkpoint.
 
-To get optimal performace the prompt template needs to be adjusted (e.g. CoT or 5-shot prompt) per model.
+To get optimal performance the prompt template needs to be adjusted (e.g. CoT or 5-shot prompt) per model.
 
 
 To run the MMLU benchmark:
 python3 -m MaxText.benchmarks.mmlu.mmlu_eval MaxText/configs/base.yml \
-tokenizer_path=assets/tokenizer_llama3.tiktoken \
-load_parameters_path=check_point_path model_name=llama3.1-8b \
-max_prefill_predict_length=1024 max_target_length=2048 ici_tensor_parallelism=4  per_device_batch_size=1
+  tokenizer_path=assets/tokenizer_llama3.tiktoken \
+  load_parameters_path=check_point_path model_name=llama3.1-8b \
+  max_prefill_predict_length=1024 max_target_length=2048 ici_tensor_parallelism=4  per_device_batch_size=1
 
 # Example of using the prompt_template flag for Chain-of-Thought (CoT) prompting:
 python3 -m MaxText.benchmarks.mmlu.mmlu_eval MaxText/configs/base.yml \
-tokenizer_path=assets/tokenizer_llama3.tiktoken \
-load_parameters_path=check_point_path model_name=llama3.1-8b \
-max_prefill_predict_length=1024 max_target_length=2048 ici_tensor_parallelism=4 per_device_batch_size=1 \
-prompt_template="The following are multiple choice questions (with answers) about {subject}.\n\n{question}\n{choices}\nAnswer: Let's think step by step."
+  tokenizer_path=assets/tokenizer_llama3.tiktoken \
+  load_parameters_path=check_point_path model_name=llama3.1-8b \
+  max_prefill_predict_length=1024 max_target_length=2048 ici_tensor_parallelism=4 per_device_batch_size=1 \
+  prompt_template="The following are multiple choice questions (with answers) about {subject}.\n\n{question}\n{choices}\nAnswer: Let's think step by step."
 
 # Example of using the prompt_template flag for 5-shot prompting (replace with actual examples):
 python3 -m MaxText.benchmarks.mmlu.mmlu_eval MaxText/configs/base.yml \
-tokenizer_path=assets/tokenizer_llama3.tiktoken \
-load_parameters_path=check_point_path model_name=llama3.1-8b \
-max_prefill_predict_length=1024 max_target_length=2048 ici_tensor_parallelism=4 per_device_batch_size=1 \
-prompt_template='Example 1:\nQuestion: What is the capital of France?\nChoices:\nA. London\nB. Paris\nC. Rome\nD. Berlin\nAnswer: B\n\nExample 2:\nQuestion: What is the highest mountain in the world?\nChoices:\nA. K2\nB. Kangchenjunga\nC. Mount Everest\nD. Lhotse\nAnswer: C\n\nExample 3:\nQuestion: What is the chemical symbol for water?\nChoices:\nA. H2O\nB. CO2\nC. O2\nD. NaCl\nAnswer: A\n\nExample 4:\nQuestion: Who painted the Mona Lisa?\nChoices:\nA. Michelangelo\nB. Leonardo da Vinci\nC. Raphael\nD. Donatello\nAnswer: B\n\nExample 5:\nQuestion: Which planet is known as the Red Planet?\nChoices:\nA. Venus\nB. Mars\nC. Jupiter\nD. Saturn\nAnswer: B\n\nThe following are multiple choice questions (with answers) about {subject}.\n\n{question}\n{choices}\nAnswer:'
+  tokenizer_path=assets/tokenizer_llama3.tiktoken \
+  load_parameters_path=check_point_path model_name=llama3.1-8b \
+  max_prefill_predict_length=1024 max_target_length=2048 ici_tensor_parallelism=4 per_device_batch_size=1 \
+  prompt_template='Example 1:\nQuestion: What is the capital of France?\nChoices:\nA. London\nB. Paris\nC. Rome\nD. Berlin\nAnswer: B\n\nExample 2:\nQuestion: What is the highest mountain in the world?\nChoices:\nA. K2\nB. Kangchenjunga\nC. Mount Everest\nD. Lhotse\nAnswer: C\n\nExample 3:\nQuestion: What is the chemical symbol for water?\nChoices:\nA. H2O\nB. CO2\nC. O2\nD. NaCl\nAnswer: A\n\nExample 4:\nQuestion: Who painted the Mona Lisa?\nChoices:\nA. Michelangelo\nB. Leonardo da Vinci\nC. Raphael\nD. Donatello\nAnswer: B\n\nExample 5:\nQuestion: Which planet is known as the Red Planet?\nChoices:\nA. Venus\nB. Mars\nC. Jupiter\nD. Saturn\nAnswer: B\n\nThe following are multiple choice questions (with answers) about {subject}.\n\n{question}\n{choices}\nAnswer:'
 """
 
 import collections


### PR DESCRIPTION
# Description

FIXES (in part): #1107

For commentary see #1108

Merge this after #1456 #1482

# Tests

`python -m pytest` and `pytest` should both now work when pointed to this directory.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.