### PR TITLE
[MaxText.inference] Use `python3 -m pip` over `pip` ; simplify `assert` with `in` (linter-found); fix tuple transposer types and use generator over comprehension [linter found]

### DIFF
--- a/MaxText/inference/jetstream_pathways/Dockerfile
+++ b/MaxText/inference/jetstream_pathways/Dockerfile
@@ -42,9 +42,9 @@ bash setup.sh
 
 RUN cd /JetStream && \
 git checkout ${JETSTREAM_VERSION} && \
-pip install -e .
+python3 -m pip install -e .
 
-RUN pip install setuptools fastapi uvicorn
+RUN python3 -m pip install setuptools fastapi uvicorn
 
 RUN apt -y update && apt-get -y install python3-dev && apt-get -y install build-essential
 

--- a/MaxText/inference/kvcache.py
+++ b/MaxText/inference/kvcache.py
@@ -49,8 +49,8 @@ def reverse_transpose(transposed_array, transpose_axis_order):
   return jax.numpy.moveaxis(transposed_array, (0, 1, 2, 3), transpose_axis_order)
 
 
-def transpose_tuple(items: tuple[Any, Any, Any, Any], axis_order: AxisIdxes) -> tuple[Any, Any, Any, Any]:
-  return tuple([items[i] for i in axis_order])
+def transpose_tuple(items: tuple[Any, ...], axis_order: AxisIdxes) -> tuple[Any, ...]:
+  return tuple((items[i] for i in axis_order))
 
 
 class KVQuant:
@@ -550,7 +550,6 @@ class KVCache(nn.Module):
           ar_cache_update_idx,
           ar_cache_scale_update_axis,
       )
-    return
 
   def get_cached_values(self, cache_vars, target_dtype, cache_axis_order) -> jax.Array | KVTensor:
     cache_var, cache_scale_var = cache_vars

--- a/MaxText/inference/paged_attention_kernel_v2.py
+++ b/MaxText/inference/paged_attention_kernel_v2.py
@@ -253,7 +253,7 @@ def ragged_paged_attention_kernel(
     return pltpu.bitcast(b, jnp.float32).astype(jnp.bfloat16)
 
   def fold_on_2nd_minor(vec):
-    assert vec.dtype == jnp.bfloat16 or vec.dtype == jnp.float32
+    assert vec.dtype in (jnp.bfloat16, jnp.float32)
     assert len(vec.shape) >= 2
     last_dim = vec.shape[-1]
     packing = get_dtype_packing(vec.dtype)


### PR DESCRIPTION
# Description

FIXES (in part): #1107

For commentary see #1108

Merge this after #1482

# Tests

`python -m pytest` and `pytest` should both now work when pointed to this directory.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.