### PR TITLE
[MaxText.kernels] Use dict literal (linter picked this up)

### DIFF
--- a/MaxText/kernels/ragged_attention.py
+++ b/MaxText/kernels/ragged_attention.py
@@ -277,11 +277,7 @@ def ragged_mqa(
           ],
           grid=(batch_size, seq_len // block_size),
       ),
-      compiler_params=dict(
-          mosaic=dict(
-              dimension_semantics=("parallel", "arbitrary"),
-          )
-      ),
+      compiler_params={"mosaic": {"dimension_semantics": ("parallel", "arbitrary")}},
       out_shape=[
           jax.ShapeDtypeStruct((batch_size, num_heads, head_dim), jnp.float32),
           jax.ShapeDtypeStruct((batch_size, num_heads, head_dim), jnp.float32),


### PR DESCRIPTION
# Description

FIXES (in part): #1107

For commentary see #1108

Merge this after #1458 #1482

# Tests

`python -m pytest` and `pytest` should both now work when pointed to this directory.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.