### PR TITLE
Parameter Offloading for Single/Multi-Devices

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -215,6 +215,7 @@ qkv_proj: 'remat'
 out_proj: 'remat'
 
 optimizer_memory_host_offload: False
+parameter_memory_host_offload: False
 scan_layers: True # We recommend setting this to false when using pipeline parallelism, instead scanning the PP iterations.
 param_scan_axis: 1
 

--- a/MaxText/layers/embeddings.py
+++ b/MaxText/layers/embeddings.py
@@ -20,8 +20,10 @@ from typing import Any, Optional
 from flax import linen as nn
 import jax
 from jax import lax
+from jax._src.sharding_impls import TransferToMemoryKind
 import jax.numpy as jnp
 from MaxText.layers import initializers
+from MaxText import max_logging
 
 Config = Any
 Array = jnp.ndarray
@@ -54,12 +56,32 @@ class Embed(nn.Module):
   embedding_init: Initializer = default_embed_init
 
   def setup(self):
-    self.embedding = self.param(
+    """
+    Sets up the embedding parameters for the model.
+
+    This method initializes the embedding parameters with logical partitioning.
+    The embedding is represented as a parameter with the specified shape and data type.
+
+    Parameters:
+    - embedding: The embedding parameter initialized using the specified method,
+                 partitioned logically along the 'vocab' and 'embed' dimensions.
+
+    Returns:
+    None
+    """
+
+    embedding = self.param(
         "embedding",
         with_logical_partitioning(self.embedding_init, ("vocab", "embed")),
         (self.num_embeddings, self.features),
         self.config.weight_dtype,
     )
+    # Move embeddings to device if parameter offloading is enabled
+    if self.config.parameter_memory_host_offload:
+      max_logging.log("embeddings.py: Moving embedding parameter to device")
+      self.embedding = jax.device_put(embedding, TransferToMemoryKind("device"))
+    else:
+      self.embedding = embedding
 
   def __call__(self, inputs: Array) -> Array:
     """Embeds the inputs along the last dimension.

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -22,11 +22,13 @@ import functools
 import jax
 import jax.numpy as jnp
 from jax.ad_checkpoint import checkpoint_name
+from jax._src.sharding_impls import TransferToMemoryKind
 
 from flax import linen as nn
 
 from MaxText import common_types
 from MaxText.common_types import DecoderBlockType
+from MaxText import max_logging
 from MaxText.inference import page_manager
 from MaxText.layers import attentions
 from MaxText.layers import embeddings
@@ -290,7 +292,25 @@ class Decoder(nn.Module):
     """Set remat policy"""
     RemattedBlockLayers = []
     for block_layer in block_layers:
-      layer = nn.remat(  # pylint: disable=invalid-name
+      if self.config.parameter_memory_host_offload:
+        # Define parameter movement with mesh-based sharding
+        def move_to_device(variables):
+          """Move parameters to device with proper sharding."""
+          def map_fn(path, value):
+            max_logging.log(f"models.py: Moving parameter {path} to device")
+            return jax.device_put(value, TransferToMemoryKind("device"))
+          return jax.tree_util.tree_map_with_path(map_fn, variables)
+
+        # Transform layer class before remat
+        block_layer = nn.map_variables(
+            block_layer,
+            ['params'],
+            move_to_device,
+            mutable=True
+        )
+
+      # Apply remat policy to layer
+      layer = nn.remat(
           block_layer,
           prevent_cse=not self.config.scan_layers,
           policy=policy,
@@ -590,6 +610,7 @@ class Decoder(nn.Module):
         name="decoder_norm",
         epsilon=cfg.normalization_layer_epsilon,
         kernel_axes=("norm",),
+        parameter_memory_host_offload=cfg.parameter_memory_host_offload,
     )(y)
     y = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(y, deterministic=deterministic)
 
@@ -611,6 +632,7 @@ class Decoder(nn.Module):
           kernel_axes=("embed", "vocab"),
           name="logits_dense",
           matmul_precision=self.config.matmul_precision,
+          parameter_memory_host_offload=cfg.parameter_memory_host_offload,
       )(
           y
       )  # We do not quantize the logits matmul.

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -613,8 +613,14 @@ def get_abstract_state(model, tx, config, rng, mesh, is_training=True):
   state_mesh_shardings = nn.logical_to_mesh_sharding(state_logical_annotations, mesh, config.logical_axis_rules)
   if is_training and config.optimizer_memory_host_offload:
     opt_state = jax.tree_util.tree_map(lambda x: x.with_memory_kind(kind="pinned_host"), state_mesh_shardings.opt_state)
-    params = jax.tree_util.tree_map(lambda x: x.with_memory_kind(kind="pinned_host"), state_mesh_shardings.params)
-    state_mesh_shardings = state_mesh_shardings.replace(opt_state=opt_state, params=params)
+    state_mesh_shardings = state_mesh_shardings.replace(opt_state=opt_state)
+  if is_training and config.parameter_memory_host_offload:
+    assert config.param_scan_axis == 0, "You must set the scan axis 0 to enable parameter offloading."
+    def move(path, x):
+      max_logging.log(f"max_utils.py: Moving {path} to host")
+      return x.with_memory_kind(kind="pinned_host")
+    params = jax.tree_util.tree_map_with_path(move, state_mesh_shardings.params)
+    state_mesh_shardings = state_mesh_shardings.replace(params=params)
 
   abstract_sharded_state = jax.jit(init_state_partial, in_shardings=None, out_shardings=state_mesh_shardings).eval_shape()
 

--- a/MaxText/tests/integration_tests/train_tests.py
+++ b/MaxText/tests/integration_tests/train_tests.py
@@ -275,6 +275,44 @@ class TrainTests(unittest.TestCase):
     ]
     train_main(tensor_parallel)
 
+  @pytest.mark.integration_test
+  @pytest.mark.gpu_only
+  def test_gpu_optimizer_offload(self):
+    os.environ["NVTE_FUSED_ATTN"] = "1"  # Enable fused attention
+    optimizer_offload = [  # tests base config on GPU with optimizer state offload"""
+        None,
+        os.path.join(PKG_DIR, "configs", "base.yml"),
+        rf"base_output_directory=gs://runner-maxtext-logs",
+        "run_name=runner_test",
+        r"dataset_path=gs://maxtext-dataset",
+        "steps=10",
+        "attention=dot_product",
+        "optimizer_memory_host_offload=True", # enable optimizer state offload
+        "dataset_type=synthetic",
+        "enable_checkpointing=False",
+        rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
+    ]
+    train_main(optimizer_offload)
+
+  @pytest.mark.integration_test
+  @pytest.mark.gpu_only
+  def test_gpu_parameter_offload(self):
+    os.environ["NVTE_FUSED_ATTN"] = "1"  # Enable fused attention
+    parameter_offload = [  # tests base config on GPU with parameter offload"""
+        None,
+        os.path.join(PKG_DIR, "configs", "base.yml"),
+        rf"base_output_directory=gs://runner-maxtext-logs",
+        "run_name=runner_test",
+        r"dataset_path=gs://maxtext-dataset",
+        "steps=10",
+        "param_scan_axis=0", # scan axis 0 is required for parameter offload
+        "attention=dot_product",
+        "parameter_memory_host_offload=True", # enable parameter offload
+        "dataset_type=synthetic",
+        "enable_checkpointing=False",
+        rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
+    ]
+    train_main(parameter_offload)
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Enable parameter offloading for all the parameters, supporting both single and multiple device configurations, with control via a dedicated flag (disabled by default when optimizer state offloading is enabled).

Parameter Offloading Process (When Explicitly Enabled):
1. Initialization: Parameters are initially placed on the host and passed the sharding with memory kind to the jitted function. So they are on the host by default inside the jitted function.
2. Pre-Computation: all parameters: decoder layer, linear, embedding and normalization parameters are moved to the device before any computations occur. This ensures parameters are on the device for both forward and backward pass in the training loop. 
3. Post-Backward Pass: Parameters are moved back to the device before the optimizer update. Otherwise, they are on the host again and can not run on the device efficiently.

Enablement Criteria: param_scan_axis = 0 (no transpose).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.