### PR TITLE
Add MTC Phase-2 save path script for XLML

### DIFF
--- a/end_to_end/test_mtc_phase_2_save_path.sh
+++ b/end_to_end/test_mtc_phase_2_save_path.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+RUN_NAME=${1}_$(date +%Y-%m-%d-%H)
+OUTPUT_PATH=${2}
+DATASET_PATH=${3}
+
+export TPU_PREMAPPED_BUFFER_SIZE=20000014336
+export TPU_PREMAPPED_BUFFER_TRANSFER_THRESHOLD_BYTES=20000014336
+
+# Train and save checkpoint
+python3 MaxText/train.py MaxText/configs/base.yml remat_policy=full base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH \
+steps=100 checkpoint_period=200 run_name=$RUN_NAME enable_emergency_checkpoint=true local_checkpoint_directory=/local local_checkpoint_period=20 use_replicator_service=True replicator_backup_interval_minutes=5 metrics_file='saved_metrics.txt'


### PR DESCRIPTION
# Description

Adding MTC Phase-2 save path script, this is precursor to enable airflow tests for Phase-2 multi-tier checkpointing tests.

FIXES: b/406254473

# Checklist

- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
