### PR TITLE
Support v6e-8 in XPK runner

### DIFF
--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -118,6 +118,9 @@ class WorkloadConfig:
       elif size == 16:
         self.num_devices_per_slice = 16
         self.topology = "4x4"
+      elif size == 8:
+        self.num_devices_per_slice = 8
+        self.topology = "2x4"
       elif size == 4:
         self.num_devices_per_slice = 4
         self.topology = "2x2"


### PR DESCRIPTION
# Description

Support v6e-8 in the `maxtext_xpk_runner`. Got the following error when using the benchmark runner with v6e-8:

```
Traceback (most recent call last):
  File "/home/bvandermoon/workspace/maxtext/benchmarks/benchmark_runner.py", line 313, in <module>
    main()
  File "/home/bvandermoon/workspace/maxtext/benchmarks/benchmark_runner.py", line 269, in main
    workload_config = WorkloadConfig(
  File "<string>", line 23, in __init__
  File "/home/bvandermoon/workspace/maxtext/benchmarks/maxtext_xpk_runner.py", line 128, in __post_init__
    raise ValueError(f"Unsupported v6e size: {size}")
ValueError: Unsupported v6e size: 8
```

The benchmark runner ran properly after this change. Note that the workload is failing with this change due to a recent MaxText regression. We are waiting on a different update for that.

# Tests

```
python3 benchmarks/benchmark_runner.py xpk \
    --project=$PROJECT \
    --zone=$ZONE \
    --device_type=v6e-8 \
    --num_slices=1  \
    --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="llama3_1_8b_8192_no_collective_matmul" \
    --base_docker_image=maxtext_base_image
```

The benchmark_runner succeeded in creating a run for this. Note that the workload itself failed due to a different runner error

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
