### PR TITLE
maxtext_xpk_runner bq upload fixes

### DIFF
--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -107,14 +107,21 @@ class WorkloadConfig:
   db_is_test: bool = True
 
   def __post_init__(self):
-    if self.device_type.startswith("v6e"):
+    """Initializes num_devices_per_slice and topology for recording the run into BigQuery"""
+    if self.device_type.startswith("v6e") or self.device_type.startswith("v5e") or self.device_type.startswith("v5litepod"):
       size = int(self.device_type.split("-")[-1])
       if size == 256:
         self.num_devices_per_slice = 256
         self.topology = "16x16"
+      elif size == 128:
+        self.num_devices_per_slice = 128
+        self.topology = "8x16"
       elif size == 64:
         self.num_devices_per_slice = 64
         self.topology = "8x8"
+      elif size == 32:
+        self.num_devices_per_slice = 32
+        self.topology = "4x8"
       elif size == 16:
         self.num_devices_per_slice = 16
         self.topology = "4x4"
@@ -125,9 +132,10 @@ class WorkloadConfig:
         self.num_devices_per_slice = 4
         self.topology = "2x2"
       else:
-        raise ValueError(f"Unsupported v6e size: {size}")
+        raise ValueError(f"Unsupported v5e or v6e size: {size}")
     else:
-      raise ValueError(f"topology and num_devices_per_slice must be inferred when device_type starts with v6e. device_type: {self.device_type}")
+      self.num_devices_per_slice = int(self.device_type.split("-")[1])/2
+      self.topology = ""
 
 
 @dataclasses.dataclass
@@ -603,7 +611,7 @@ def generate_xpk_workload_cmd(
     args_str = ""
     for k,v in args.items():
       args_str += f'--{k}={v} '
-    upload_metrics_to_bq_cmd = f"python3 benchmarks/upload_metrics_to_bq.py {args_str}"
+    upload_metrics_to_bq_cmd = f"&& python3 benchmarks/upload_metrics_to_bq.py {args_str}"
 
   print(f'User command: {user_command}')
   return (
@@ -615,7 +623,7 @@ def generate_xpk_workload_cmd(
           f' --zone={cluster_config.zone}'
           f' {device_type}'
           f' --num-slices={wl_config.num_slices}'
-          f' --command="{user_command} && {upload_metrics_to_bq_cmd}"'
+          f' --command="{user_command} {upload_metrics_to_bq_cmd}"'
           f' {docker_image_flag}'
           ' --enable-debug-logs'
           f' --workload={name}'


### PR DESCRIPTION
# Description

- remove the raise error during topology parsing when running with other device types
- fix `upload_metrics_to_bq_cmd` so that it works when bq uploading is disabled
- add missing v5e/v6e slice sizes

# Tests

```
bash docker_build_dependency_image.sh MODE=stable MANTARAY=true
python benchmarks/maxtext_xpk_runner.py 
```

Be sure to modify main of maxtext_xpk_runner.py such that it is targeting the correct xpk cluster. After the model finishes running, you should be able to see DB write success logs https://screenshot.googleplex.com/3EfzU6Dh9QbGShi

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
