### PR TITLE
Pin setuptools

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -42,6 +42,9 @@ apt update -y && apt -y install gcsfuse
 rm -rf /var/lib/apt/lists/*
 EOF
 
+# We need to pin specific versions of setuptools, see b/402501203 for more.
+pip3 install setuptools==65.5.0
+
 # Set environment variables
 for ARGUMENT in "$@"; do
     IFS='=' read -r KEY VALUE <<< "$ARGUMENT"


### PR DESCRIPTION
# Description

Pin setuptools - we have seen the default version on v6e 0.7.5 gets an error `TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'`

FIXES: b/402501203


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Manually setup.sh on a v6e (ssh), and also a `docker_build_dependency` + `docker_upload_runner`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
