### PR TITLE
Parse empty strings passed in CLI as None as opposed to 'none' string

### DIFF
--- a/MaxText/configs/v5e/128b.sh
+++ b/MaxText/configs/v5e/128b.sh
@@ -49,5 +49,5 @@ python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     use_iota_embed=true reuse_example_batch=1\
     dataset_type=synthetic attention='flash' gcs_metrics=true\
-    fused_qkv=True fused_mlp=True\
+    fused_qkv=True fused_mlp=True
     

--- a/MaxText/configs/v5p/128b.sh
+++ b/MaxText/configs/v5p/128b.sh
@@ -47,4 +47,4 @@ python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\
-    dataset_type=synthetic gcs_metrics=true attention='flash' quantization=""\
+    dataset_type=synthetic gcs_metrics=true attention='flash' quantization=""

--- a/MaxText/configs/v5p/32b.sh
+++ b/MaxText/configs/v5p/32b.sh
@@ -47,4 +47,4 @@ python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\
-    dataset_type=synthetic gcs_metrics=true attention='flash' quantization=""\
+    dataset_type=synthetic gcs_metrics=true attention='flash' quantization=""

--- a/MaxText/configs/v5p/64b.sh
+++ b/MaxText/configs/v5p/64b.sh
@@ -47,4 +47,4 @@ python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\
-    dataset_type=synthetic gcs_metrics=true attention='flash' quantization=""\
+    dataset_type=synthetic gcs_metrics=true attention='flash' quantization=""

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -333,7 +333,9 @@ class _HyperParameters:
             " at the CLI or ENV"
         )
 
-      if isinstance(new_proposal, type(raw_data_from_yaml[k])):
+      if new_proposal is None:
+        raw_keys[k] = None  # This allows users to set empty strings via CLI, otherwise parsed as "None" - b/405981568
+      elif isinstance(new_proposal, type(raw_data_from_yaml[k])):
         raw_keys[k] = new_proposal  # take the raw data, no type conversion
       else:
         try:

--- a/MaxText/tests/pyconfig_test.py
+++ b/MaxText/tests/pyconfig_test.py
@@ -26,6 +26,24 @@ class PyconfigTest(unittest.TestCase):
 
     self.assertEqual(raw_keys, {"megablox": None, "foo": ["x", "y"]})
 
+  def test_empty_string_parse_as_empty_string(self):
+    config = pyconfig.initialize(
+        ["train.py", "configs/base.yml"],
+        skip_jax_distributed_system=True,  # We should check for this automatically instead - b/407047411
+        quantization="",
+    )
+
+    self.assertTrue(config.quantization is None or config.quantization == "")
+
+  def test_empty_string_parse_as_empty_string(self):
+    config = pyconfig.initialize(
+        ["train.py", "configs/base.yml"],
+        skip_jax_distributed_system=True,  # We should check for this automatically instead - b/407047411
+        quantization=None,
+    )
+
+    self.assertTrue(config.quantization is None or config.quantization == "")
+
   def test_logical_axis_override(self):
     raw_keys = {
         "megablox": None,


### PR DESCRIPTION
# Description

Passing in the empty string "" via CLI gets parsed as a 4 character 'None' string, which breaks some of our logic.

Also unrelated this removes a training backslash \ at the end of the final line of many of our config.sh files (these backslashes were found investigating the first 'None' issue passed for quantization). This trailing backslash indicates there is another the line despite being the last line, I'm surprised this doesn't crash some of our scripts like XPK which has to do a lot of string wrapping. It makes copy/paste onto CLI not work because the CLI expects me to continue with more arguments. 



FIXES: b/405981568


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Ran on my devbox before and after this PR

```
EXECUTABLE=train_compile.py
DATASET_PATH=gs://max-datasets-rogue
OUTPUT_PATH=gs://maxtext-experiments-multipod

export M_COMPILE_TOPOLOGY=v5p-128 
export M_COMPILE_TOPOLOGY_NUM_SLICES=1

python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
    steps=15 per_device_batch_size=3 enable_checkpointing=false\
    remat_policy=minimal global_parameter_scale=64\
    ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\
    max_target_length=2048 base_output_directory=$OUTPUT_PATH\
    dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\
    dataset_type=synthetic gcs_metrics=true attention='flash' quantization=""
```

Before getting error `ValueError: Invalid value configured for quantization None.`, after the AOT compilation succeeds.

Also more importantly added unit tests
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
