### PR TITLE
Fix deprecated jax.lib.xla_bridge.get_backend()

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -1063,7 +1063,7 @@ def print_system_information():
   Note that this will initialize the JAX backend."""
   max_logging.log(f"System Information: Jax Version: {jax.__version__}")
   max_logging.log(f"System Information: Jaxlib Version: {jax.lib.__version__}")
-  max_logging.log(f"System Information: Jax Backend: {jax.lib.xla_bridge.get_backend().platform_version}")
+  max_logging.log(f"System Information: Jax Backend: {jax.extend.backend.get_backend().platform_version}")
 
 
 def permute_to_match_maxtext_rope(arr):


### PR DESCRIPTION
# Description
This PR replaces the deprecated `jax.lib_xla_bridge_get_backend()` (deprecated in JAX v0.4.32, see [here](https://github.com/jax-ml/jax/blob/main/CHANGELOG.md#jax-0432-september-11-2024)) with `jax.extend.backend.get_backend()`.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/391688887

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
python3 -m pytest tests/train_tests.py


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
