### PR TITLE
Update mmlu path

### DIFF
--- a/benchmarks/mmlu/mmlu_eval.py
+++ b/benchmarks/mmlu/mmlu_eval.py
@@ -41,11 +41,19 @@ prompt_template='Example 1:\nQuestion: What is the capital of France?\nChoices:\
 import collections
 import re
 import sys
+import os
 
+current_dir = os.path.dirname(os.path.abspath(__file__))
+benchmark_parent_dir = os.path.dirname(current_dir)
+maxtext_parent_dir = os.path.dirname(benchmark_parent_dir)
+
+sys.path.append(maxtext_parent_dir)
+sys.path.append(maxtext_parent_dir + "/MaxText")
+
+import max_logging
 from absl import flags
 import datasets
 import jax
-import max_logging
 import max_utils
 import maxengine
 from mmlu_categories import categories


### PR DESCRIPTION
# Description

Enable to run MMLU without changing the local Python path. This will be helpful to run on other GKE cluster, like xpk.

# Tests

Tested it locally as well as triggered a xpk workload. 

Error before the change:

```
Traceback (most recent call last):
  File "/home/ranran/maxtext/benchmarks/mmlu/mmlu_eval.py", line 48, in <module>
    import max_logging
ModuleNotFoundError: No module named 'max_logging'
```

I think it's missing python path `maxtext/MaxText` to find the max_logging.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
