### PR TITLE
Adding missing deps for running with helm.

### DIFF
--- a/maxtext_jax_stable_stack.Dockerfile
+++ b/maxtext_jax_stable_stack.Dockerfile
@@ -32,6 +32,7 @@ RUN if [ "$DEVICE" = "tpu" ] && ([ "$JAX_STABLE_STACK_BASEIMAGE" = "us-docker.pk
         pip install --no-cache-dir --upgrade jax[tpu]; fi
 
 # Install Maxtext requirements with Jax Stable Stack
+RUN apt-get update && apt-get install --yes google-cloud-cli && apt-get install --yes dnsutils
 RUN pip install -r /deps/requirements_with_jax_stable_stack.txt
 
 # Run the script available in JAX Stable Stack base image to generate the manifest file


### PR DESCRIPTION
# Description

The JSTS image (gcr.io/tpu-prod-env-multipod/maxtext_gpu_stable_stack_nightly_jax and gcr.io/tpu-prod-env-multipod/maxtext_gpu_jax_stable_stack) missed 2 dependencies to run on GCP. This PR adds those deps to the JSTS workflow.

# Tests

Manually tested the generated image of 2025-03-25 and it's working.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
