### PR TITLE
Update OS version for CPU test

### DIFF
--- a/.github/workflows/CPUTests.yml
+++ b/.github/workflows/CPUTests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         python-version: ['3.10']
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
# Description

Due to deprecation of 20.04 [version](https://github.com/actions/runner-images/issues/11101), the lint CPU test is stuck. So update OS version for CPU test to 22.04 version.

One example: [link](https://screenshot.googleplex.com/C8qkUm4HvJQZQmS)

[Done] TODO: will need to update checklist from CPU-20.04 version to 22.04 version once approved


# Tests

Test in github runner for this PR

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
