### PR TITLE
Remove torch dependency to avoid conflict

### DIFF
--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -16,7 +16,6 @@ tensorflow-text>=2.13.0
 tensorflow-datasets
 tensorboardx>=2.6.2.2
 tiktoken
-torch
 transformers
 mlperf-logging@git+https://github.com/mlperf/logging.git
 google-jetstream@git+https://github.com/AI-Hypercomputer/JetStream.git


### PR DESCRIPTION
# Description

```
Loaded runtime CuDNN library: 9.1.0 but source was compiled with: 9.8.0.  CuDNN library needs to have matching major version and equal or higher minor version. If using a binary install, upgrade your CuDNN library.  If building from sources, make sure the library loaded at runtime is compatible with the version specified during compile configuration.
```

JAX nightly now was a requirement for cudnn 9.8 https://github.com/jax-ml/jax/commit/e342f2dd602ea33cc395dbcd71e38191ebf593d3 

Upon further investigation, it turns out that this issue is because the Torch library is installing NVIDIA packages (which it should not, as the base JSTS already has those packages) and that these are of a lower version than what is required by JAX. Due to this, we are seeing the error mentioned above.


If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/406802558


# Tests

Verified with local build

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
