### PR TITLE
Adds a toy llama2 model

### DIFF
--- a/MaxText/configs/models/llama2-toy.yml
+++ b/MaxText/configs/models/llama2-toy.yml
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# model config for llama2-44m
+
+base_emb_dim: 256
+base_num_query_heads: 64
+base_num_kv_heads: 8
+base_mlp_dim: 896
+base_num_decoder_layers: 8
+head_dim: 128
+mlp_activations: ["silu","linear"]
+vocab_size: 320
+logits_via_embedding: False
+normalization_layer_epsilon: 1.0e-5
+decoder_block: "llama2"
+logical_axis_rules: [['norm', 'fsdp']]

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -398,7 +398,7 @@ class MaxEngine(engine_api.Engine):
 
   @functools.partial(jax.jit, static_argnums=(0,), static_argnames=("request_id",))
   def _prefill_jit(
-      self, # pytype: disable=signature-mismatch
+      self,  # pytype: disable=signature-mismatch
       *,
       params: Params,
       existing_prefix: Optional[ExistingPrefix] = None,
@@ -510,7 +510,7 @@ class MaxEngine(engine_api.Engine):
 
   # Public non-JIT prefill method that updates page state
   def prefill(
-      self, # pytype: disable=signature-mismatch
+      self,  # pytype: disable=signature-mismatch
       *,
       params: Params,
       existing_prefix: Optional[ExistingPrefix] = None,

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -219,6 +219,7 @@ def validate_model_name(s: str) -> bool:
   # currently supported models
   valid_model_names = (
       "default",
+      "llama2-toy",
       "llama2-7b",
       "llama2-13b",
       "llama2-70b",


### PR DESCRIPTION
# Description

The smallest llama model we support is 7b, which is still too slow for local development. This PR creates a toy model with much smaller For functional testing and non accuracy validation only.

# Tests
export XLA_FLAGS="--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_command_buffer=FUSION --xla_disable_hlo_passes=rematerialization --xla_disable_hlo_passes=gpu-convert-async-collectives-to-sync" # flags from NVidia
export TF_FORCE_GPU_ALLOW_GROWTH=true
export BASE_OUTPUT_DIRECTORY=/scratch/temp
export ASYNC_CHECKPOINTING=false
export XLA_PYTHON_CLIENT_MEM_FRACTION=0.92
export PER_DEVICE_BATCH_SIZE=2

python3  MaxText/decode.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_DIRECTORY}  model_name='llama2-toy' max_prefill_predict_length=1024  max_target_length=2048  attention=dot_product scan_layers=false hardware=gpu async_checkpointing=${ASYNC_CHECKPOINTING} per_device_batch_size=${PER_DEVICE_BATCH_SIZE} run_name=$(date +%Y-%m-%d-%H-%M) ici_fsdp_parallelism=1 ici_autoregressive_parallelism=1 ici_tensor_parallelism=-1 skip_jax_distributed_system=True weight_dtype=float16 dtype=float16 kv_quant_dtype=fp8 quantize_kvcache=True

Finish less than 1 minute.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
