### PR TITLE
Improve SFT Dataset Feature Handling

### DIFF
--- a/MaxText/configs/models/gemma3-4b.yml
+++ b/MaxText/configs/models/gemma3-4b.yml
@@ -14,7 +14,7 @@
 
 # model config for gemma3-4b
 
-base_num_decoder_layers: 34
+base_num_decoder_layers: 2
 base_emb_dim: 2560
 base_num_query_heads: 8
 base_num_kv_heads: 4

--- a/MaxText/input_pipeline/_hf_data_processing.py
+++ b/MaxText/input_pipeline/_hf_data_processing.py
@@ -67,9 +67,7 @@ def preprocessing_pipeline(
     assert _input_pipeline_utils.is_conversational(example), "Dataset is not in conversational format."
 
     if len(data_column_names) > 1:
-      dataset = dataset.map(
-          _input_pipeline_utils.combine_columns, fn_kwargs={"columns": data_column_names}, remove_columns=data_column_names
-      )
+      dataset = _input_pipeline_utils.combine_columns(dataset)
       data_column_names = dataset.column_names[:1]
     dataset = dataset.select_columns(data_column_names)
     dataset = dataset.map(

--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -66,15 +66,16 @@ def add_segmentation_and_position(x, data_columns, padding_token=0):
 ########## Functions used by HF pipeline
 
 
-def combine_columns(example, columns):
+def combine_columns(example):
   """Combine columns such as 'prompt' and 'completion' for sft training"""
-  assert len(columns) > 1
-  combined = []
-  for i in range(len(example[columns[0]])):
-    for c in columns:
-      combined.append(example[c][i])
-  example["messages"] = combined
-  return example
+  assert len(example.column_names) > 1
+  def join_fields(example):
+    return {"messages": [example["prompt"][0], example["completion"][0]]}
+  features = example.features.copy()
+  features["messages"] = datasets.Sequence(datasets.Value("string"))
+  new_ds = example.map(join_fields, features=features)
+  new_ds = new_ds.select_columns(["messages"])
+  return new_ds
 
 
 def is_conversational(example):

--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -69,8 +69,10 @@ def add_segmentation_and_position(x, data_columns, padding_token=0):
 def combine_columns(example):
   """Combine columns such as 'prompt' and 'completion' for sft training"""
   assert len(example.column_names) > 1
+
   def join_fields(example):
     return {"messages": [example["prompt"][0], example["completion"][0]]}
+
   features = example.features.copy()
   features["messages"] = datasets.Sequence(datasets.Value("string"))
   new_ds = example.map(join_fields, features=features)

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -946,7 +946,7 @@ def train_loop(config, state=None):
 
 
 def main(argv: Sequence[str]) -> None:
-  pathwaysutils.initialize()
+  # pathwaysutils.initialize()
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   # TF allocates extraneous GPU memory when using TFDS data
   # this leads to CUDA OOMs. WAR for now is to hide GPUs from TF


### PR DESCRIPTION
# Description
To enable the [trl-lib/ultrafeedback-gpt-3.5-turbo-helpfulness dataset](https://huggingface.co/datasets/trl-lib/ultrafeedback-gpt-3.5-turbo-helpfulness) for SFT when loaded as an IterativeDataset, "prompt" and "completion" columns must be combined into a single column "messages". However, the previous method resulted in 'Unknown' features. This change improves the column combination step, making the dataset directly usable for SFT training.

# Tests

Locally tested on VM using command:
```
python MaxText/train.py MaxText/configs/base.yml run_name=ht_test profiler=xplane steps=5 base_output_directory=gs://hengtaoguo-maxtext-logs/1-correctness/mm dataset_type=hf use_sft=True hf_path=\'trl-lib/ultrafeedback-gpt-3.5-turbo-helpfulness\' train_data_columns=\[\'prompt\',\ \'completion\',\ \'label\'\] train_split=\'train\' tokenizer_path=\'google/gemma-3-4b-it\' enable_checkpointing=false sharding_tolerance=0.03 profiler=xplane remat_policy=full max_prefill_predict_length=4 max_target_length=12 quantization=int8
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
