### PR TITLE
Rename Llama3.1-70B config to avoid duplicates

### DIFF
--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -1032,7 +1032,7 @@ llama3_1_70b_8192_lr_real_data = _add_to_model_dictionary(
 llama3_1_70b_8192_iter_real_data_and_checkpointing_tfds = _add_to_model_dictionary(
     trillium_model_dict,
     MaxTextModel(
-        model_name="llama3_1-70b-8192",
+        model_name="llama3_1-70b-8192-iter-real-data-and-checkpointing-tfds",
         model_type="llama3.1-70b",
         tuning_params={
             "per_device_batch_size": 2,


### PR DESCRIPTION
# Description

Update Llama3.1-70B real data benchmark name to avoid duplicates. My workload was failing when trying to run the `llama3_1-70b-8192` benchmark. Looks like it was actually running this `llama3_1_70b_8192_iter_real_data_and_checkpointing_tfds` benchmark under the hood. 

After this change, I am able to run the Llama3.1-70B benchmark that @raymondzouu added properly.

# Tests

Successfully ran the [Llama3.1-70B tpu-recipe](https://github.com/AI-Hypercomputer/tpu-recipes/tree/af2a7cd202de19e689504eec3e86c02bda527375/training/trillium/Llama3.1-70B-MaxText) (with a different commit). Before this change, the workload failed.

```
python3 benchmarks/benchmark_runner.py xpk \
    --project=$PROJECT \
    --zone=$ZONE \
    --device_type=v6e-256 \
    --num_slices=1  \
    --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="llama3_1_70b_8192" \
    --base_docker_image=maxtext_base_image
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
