### PR TITLE
Add support for xpk storage for MaxText benchmark runner

### DIFF
--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -173,6 +173,14 @@ def add_xpk_runner_arguments(custom_parser: argparse.ArgumentParser):
       default=0,
       help='Number of restarts to attempt.',
   )
+  # To create storage follow https://github.com/AI-Hypercomputer/xpk?tab=readme-ov-file#storage.
+  custom_parser.add_argument(
+      '--xpk_storage',
+      default= None,
+      action="append",
+      help='Names of XPK storages the workload uses. Example, --xpk_storage=storage_test1 --xpk_storage=storage_test2',
+  )
+
 
 def add_on_device_runner_arguments(custom_parser: argparse.ArgumentParser):
   """Add arguments to the on-device runner parser.
@@ -283,6 +291,7 @@ def main() -> None:
       pathways_config=pw_config,
       # Internal only support, not for customers
       generate_metrics_and_upload_to_big_query=False,
+      xpk_storage=options.xpk_storage,
     )
 
     xpk_benchmark_runner(cluster_config, [workload_config])

--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -975,6 +975,176 @@ llama3_1_70b_8192 = _add_to_model_dictionary(
     ),
 )
 
+llama3_1_70b_8192_iter_synthetic = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama3_1_70b_8192_synthetic",
+    model_type="llama3.1-70b",
+    tuning_params={
+        "per_device_batch_size": 2,
+        "ici_fsdp_parallelism": -1,
+        "remat_policy": "custom",
+        "decoder_layer_input": "offload",
+        "query_proj": "offload",
+        "key_proj": "offload",
+        "value_proj": "offload",
+        "max_target_length": 8192,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_type": "synthetic",
+        "enable_checkpointing": False,
+        "sa_block_q": 2048,
+        "sa_block_kv": 2048,
+        "sa_block_kv_compute": 2048,
+        "sa_block_q_dkv": 2048,
+        "sa_block_kv_dkv": 2048,
+        "sa_block_kv_dkv_compute": 2048,
+        "sa_block_q_dq": 2048,
+        "sa_block_kv_dq": 2048,
+        "sa_use_fused_bwd_kernel": True,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+        + xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.HOST_OFFLOAD_FLAGS
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE 
+        +  " --xla_tpu_iova_dma_chunk_size_bytes=104857"
+    ),
+  )
+)
+ 
+llama3_1_70b_8192_iter_real_data_grain = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama3_1_70b_8192_rd_grain",
+    model_type="llama3.1-70b",
+    tuning_params={
+        "per_device_batch_size": 2,
+        "ici_fsdp_parallelism": -1,
+        "remat_policy": "custom",
+        "decoder_layer_input": "offload",
+        "query_proj": "offload",
+        "key_proj": "offload",
+        "value_proj": "offload",
+        "max_target_length": 8192,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_path": "/tmp/dataset",
+        "dataset_type": "grain",
+        "grain_train_files": "/tmp/dataset/array-record/c4/en/3.0.1/c4-train.array_record*",
+        "grain_worker_count": 24,
+        "enable_checkpointing": False,
+        "sa_block_q": 2048,
+        "sa_block_kv": 2048,
+        "sa_block_kv_compute": 2048,
+        "sa_block_q_dkv": 2048,
+        "sa_block_kv_dkv": 2048,
+        "sa_block_kv_dkv_compute": 2048,
+        "sa_block_q_dq": 2048,
+        "sa_block_kv_dq": 2048,
+        "sa_use_fused_bwd_kernel": True,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+        + xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.HOST_OFFLOAD_FLAGS
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE 
+        +  " --xla_tpu_iova_dma_chunk_size_bytes=104857"
+    ),
+  )
+)
+ 
+llama3_1_70b_8192_iter_synthetic_ckpt = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama3_1_70b_8192_synthetic_ckpt",
+    model_type="llama3.1-70b",
+    tuning_params={
+        "per_device_batch_size": 2,
+        "ici_fsdp_parallelism": -1,
+        "remat_policy": "custom",
+        "decoder_layer_input": "offload",
+        "query_proj": "offload",
+        "key_proj": "offload",
+        "value_proj": "offload",
+        "max_target_length": 8192,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_type": "synthetic",
+        "enable_checkpointing": True,
+        "async_checkpointing": True,
+        "checkpoint_period": 20,
+        "sa_block_q": 2048,
+        "sa_block_kv": 2048,
+        "sa_block_kv_compute": 2048,
+        "sa_block_q_dkv": 2048,
+        "sa_block_kv_dkv": 2048,
+        "sa_block_kv_dkv_compute": 2048,
+        "sa_block_q_dq": 2048,
+        "sa_block_kv_dq": 2048,
+        "sa_use_fused_bwd_kernel": True,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+        + xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.HOST_OFFLOAD_FLAGS
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE 
+        +  " --xla_tpu_iova_dma_chunk_size_bytes=104857"
+    ),
+  )
+)
+ 
+llama3_1_70b_8192_iter_real_data_and_checkpointing = _add_to_model_dictionary(
+  trillium_model_dict,
+  MaxTextModel(
+    model_name="llama3_1_70b_8192_rd_ckpt_grain",
+    model_type="llama3.1-70b",
+    tuning_params={
+        "per_device_batch_size": 2,
+        "ici_fsdp_parallelism": -1,
+        "remat_policy": "custom",
+        "decoder_layer_input": "offload",
+        "query_proj": "offload",
+        "key_proj": "offload",
+        "value_proj": "offload",
+        "max_target_length": 8192,
+        "attention": "flash",
+        "use_iota_embed": True,
+        "dataset_path": "/tmp/dataset",
+        "dataset_type": "grain",
+        "grain_train_files": "/tmp/dataset/array-record/c4/en/3.0.1/c4-train.array_record*",
+        "grain_worker_count": 24,
+        "enable_checkpointing": True,
+        "async_checkpointing": True,
+        "checkpoint_period": 20,
+        "sa_block_q": 2048,
+        "sa_block_kv": 2048,
+        "sa_block_kv_compute": 2048,
+        "sa_block_q_dkv": 2048,
+        "sa_block_kv_dkv": 2048,
+        "sa_block_kv_dkv_compute": 2048,
+        "sa_block_q_dq": 2048,
+        "sa_block_kv_dq": 2048,
+        "sa_use_fused_bwd_kernel": True,
+    },
+    xla_flags=(
+        xla_flags_library.DENSE_VMEM_LIMIT_FLAG
+        + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+        + xla_flags_library.DATA_PARALLEL_OVERLAP
+        + xla_flags_library.CF_FOR_ALL_GATHER
+        + xla_flags_library.HOST_OFFLOAD_FLAGS
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE 
+        +  " --xla_tpu_iova_dma_chunk_size_bytes=104857"
+    ),
+  )
+)
+
 
 llama3_1_70b_8192_lr_real_data = _add_to_model_dictionary(
     trillium_model_dict,

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -43,6 +43,7 @@ from benchmark_db_utils import DEFAULT_TUNING_PARAMS_FILE
 import xla_flags_library as xla_flags
 from disruption_management.disruption_handler import DisruptionConfig
 from disruption_management.disruption_manager import DisruptionManager
+from typing import Optional, List
 from xpk_configs import XpkClusterConfig
 
 from MaxText.globals import PKG_DIR
@@ -111,6 +112,7 @@ class WorkloadConfig:
   db_dataset: str = ""
   db_is_test: bool = True
   disruption_configs: DisruptionConfig = None
+  xpk_storage: Optional[List[str]] = None
 
   def __post_init__(self):
     """Initializes num_devices_per_slice and topology for recording the run into BigQuery"""
@@ -620,6 +622,9 @@ def generate_xpk_workload_cmd(
     upload_metrics_to_bq_cmd = f"&& python3 benchmarks/upload_metrics_to_bq.py {args_str}"
 
   print(f'User command: {user_command}')
+  all_xpk_storage = ""
+  if wl_config.xpk_storage:
+    all_xpk_storage = " ".join(f"--storage={storage_test}" for storage_test in wl_config.xpk_storage)
   return (
       (
           f'{workload_create_command}'
@@ -628,6 +633,7 @@ def generate_xpk_workload_cmd(
           f' --project={cluster_config.project}'
           f' --zone={cluster_config.zone}'
           f' {device_type}'
+          f' {all_xpk_storage}'
           f' --num-slices={wl_config.num_slices}'
           f' --command="{user_command} {upload_metrics_to_bq_cmd}"'
           f' {docker_image_flag}'


### PR DESCRIPTION
# Description

Support for xpk storage for MaxText benchmark runner. Add model configurations which will be used in creating recipes for tpu storage benchmarks for Cloud Next.
XPK Storage is referring to a FUSE adapter lets you mount and access Cloud Storage buckets as local file systems, so applications can read and write objects in your bucket using standard file system semantics(https://github.com/AI-Hypercomputer/xpk?tab=readme-ov-file#storage). We can provide multiple storage , for example, `--xpk_storage=storage_test1 --xpk_storage=storage_test2`



# Tests
Tested by running the workloads using maxtext benchmark runner. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.