### PR TITLE
Fix SFT dataset transformation issue

### DIFF
--- a/MaxText/input_pipeline/_hf_data_processing.py
+++ b/MaxText/input_pipeline/_hf_data_processing.py
@@ -68,9 +68,9 @@ def preprocessing_pipeline(
 
     if len(data_column_names) > 1:
       dataset = dataset.map(
-          _input_pipeline_utils.combine_columns, fn_kwargs={"columns": data_column_names}, remove_columns=data_column_names
+          _input_pipeline_utils.combine_columns, fn_kwargs={"columns": data_column_names}, remove_columns=dataset.column_names
       )
-      data_column_names = dataset.column_names[:1]
+      data_column_names = list(next(iter(dataset)).keys())
     dataset = dataset.select_columns(data_column_names)
     dataset = dataset.map(
         _input_pipeline_utils.extract_messages_and_mask, fn_kwargs={"data_column_name": data_column_names[0]}

--- a/MaxText/input_pipeline/_hf_data_processing.py
+++ b/MaxText/input_pipeline/_hf_data_processing.py
@@ -68,7 +68,9 @@ def preprocessing_pipeline(
 
     if len(data_column_names) > 1:
       dataset = dataset.map(
-          _input_pipeline_utils.combine_columns, fn_kwargs={"columns": data_column_names}, remove_columns=dataset.column_names
+          _input_pipeline_utils.combine_columns,
+          fn_kwargs={"columns": data_column_names},
+          remove_columns=dataset.column_names
       )
       data_column_names = list(next(iter(dataset)).keys())
     dataset = dataset.select_columns(data_column_names)

--- a/MaxText/input_pipeline/_hf_data_processing.py
+++ b/MaxText/input_pipeline/_hf_data_processing.py
@@ -70,7 +70,7 @@ def preprocessing_pipeline(
       dataset = dataset.map(
           _input_pipeline_utils.combine_columns,
           fn_kwargs={"columns": data_column_names},
-          remove_columns=dataset.column_names
+          remove_columns=dataset.column_names,
       )
       data_column_names = list(next(iter(dataset)).keys())
     dataset = dataset.select_columns(data_column_names)


### PR DESCRIPTION
# Description

To enable the [trl-lib/ultrafeedback-gpt-3.5-turbo-helpfulness dataset](https://huggingface.co/datasets/trl-lib/ultrafeedback-gpt-3.5-turbo-helpfulness) for SFT when loaded as an IterativeDataset, "prompt" and "completion" columns must be combined into a single column "messages". However, the dataset.column_names can become None if the transformation changes the data schema. This fix:

1. Removes original columns by specifying ```remove_columns=dataset.column_names```, which only keeps the new "messages" column.
2. Since the dataset.column_names becomes None after map function, we get the column name from ```next(iter(dataset)).keys()```.

Fixes: https://b.corp.google.com/issues/408463732

# Tests

Locally tested on VM using command:
```
python MaxText/sft_trainer.py MaxText/configs/sft.yml run_name=ht_test profiler=xplane steps=5 base_output_directory=gs://hengtaoguo-maxtext-logs/1-correctness/mm dataset_type=hf use_sft=True hf_path=\'trl-lib/ultrafeedback-gpt-3.5-turbo-helpfulness\' train_data_columns=\[\'prompt\',\ \'completion\',\ \'label\'\] train_split=\'train\' tokenizer_path=\'google/gemma-3-4b-it\' enable_checkpointing=false sharding_tolerance=0.03 profiler=xplane remat_policy=full max_prefill_predict_length=4 max_target_length=12 quantization=int8
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
