### PR TITLE
Fix SFT data pipeline for prompt-completion dataset

### DIFF
--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -66,36 +66,34 @@ def add_segmentation_and_position(x, data_columns, padding_token=0):
 ########## Functions used by HF pipeline
 
 
-def combine_columns(example, columns):
+def combine_columns(example, columns, data_column):
   """Combine columns such as 'prompt' and 'completion' for sft training"""
   assert len(columns) > 1
   combined = []
   for i in range(len(example[columns[0]])):
     for c in columns:
       combined.append(example[c][i])
-  example["messages"] = combined
+  example[data_column] = combined
   return example
 
 
-def is_conversational(example):
+def is_conversational(features, data_columns):
   """Check if data is in a conversational format.
   Examples:
 
-  example = {'prompt': [{'content': 'question', 'role': 'user'}], 'completion': [{'content': 'answer', 'role': 'assistant'}]}
-  is_conversational(example) return True.
+  features = {'prompt': [{'content': Value(dtype='string', id=None), 'role': Value(dtype='string', id=None)}], 'completion': [{'content': Value(dtype='string', id=None), 'role': Value(dtype='string', id=None)}]}
+  data_columns = ["prompt", "completion"]
+  is_conversational(features, data_columns) return True.
 
-  example = {"prompt": "I love to"})
-  is_conversational(example) returns False.
+  features = {'prompt': [Value(dtype='string', id=None)], 'completion': [Value(dtype='string', id=None)]}
+  data_columns = ["prompt", "completion"]
+  is_conversational(features, data_columns) returns False.
   """
-  supported_columns = ["prompt", "completion", "messages"]
-  data_columns = [column for column in example.keys() if column in supported_columns]
-
-  if data_columns:
-    for column in data_columns:
-      messages = example[column]
-      if isinstance(messages, list):
-        if isinstance(messages[0], dict) and "role" in messages[0] and "content" in messages[0]:
-          return True
+  for column in data_columns:
+    messages = features[column]
+    if isinstance(messages, list):
+      if isinstance(messages[0], dict) and "role" in messages[0] and "content" in messages[0]:
+        return True
 
   return False
 


### PR DESCRIPTION
# Description
Changes in this PR include:
1. Assert on column names used to run SFT, ensuring only supported columns are present.
2. Simplify the implementation of `is_conversational()` method.
4.  Explicitly specify the schema returned by `combine_column()` method when `prompt` and `completion` columns are combined into `messages` for the [example dataset](https://huggingface.co/datasets/trl-lib/ultrafeedback-gpt-3.5-turbo-helpfulness).

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: [b/408463732](b/408463732)


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
Ran sft_trainer.py for the following configurations:
```

hf_path: 'trl-lib/ultrafeedback-gpt-3.5-turbo-helpfulness'
train_split: 'train'
hf_eval_split: 'test'
train_data_columns: ['prompt', 'completion']
eval_data_columns: ['prompt', 'completion']
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
