### PR TITLE
Properly parsing boolean args with argparse

### DIFF
--- a/MaxText/convert_deepseek_ckpt.py
+++ b/MaxText/convert_deepseek_ckpt.py
@@ -35,6 +35,7 @@ import psutil
 from tqdm import tqdm
 
 import max_logging
+from inference_utils import str2bool
 from safetensors import safe_open
 import llama_or_mistral_ckpt
 
@@ -499,8 +500,8 @@ def main() -> None:
   parser.add_argument("--maxtext_model_path", type=str, required=True)
   parser.add_argument("--model_size", type=str, required=True)
   parser.add_argument("--simulated_cpu_devices_count", type=int, required=False, default=16)
-  parser.add_argument("--use-ocdbt", type=bool, required=False, default=True)
-  parser.add_argument("--use-zarr3", type=bool, required=False, default=True)
+  parser.add_argument("--use-ocdbt", type=str2bool, required=False, default=True)
+  parser.add_argument("--use-zarr3", type=str2bool, required=False, default=True)
   args = parser.parse_args()
 
   if args.model_size not in MODEL_PARAMS_DICT:

--- a/MaxText/convert_deepseek_unscanned_ckpt.py
+++ b/MaxText/convert_deepseek_unscanned_ckpt.py
@@ -35,6 +35,7 @@ import psutil
 from tqdm import tqdm
 
 import max_logging
+from inference_utils import str2bool
 from safetensors import safe_open
 import llama_or_mistral_ckpt
 import convert_deepseek_ckpt as ds_ckpt
@@ -325,8 +326,8 @@ def main() -> None:
   parser.add_argument("--maxtext_model_path", type=str, required=True)
   parser.add_argument("--model_size", type=str, required=True)
   parser.add_argument("--simulated_cpu_devices_count", type=int, required=False, default=16)
-  parser.add_argument("--use-ocdbt", type=bool, required=False, default=True)
-  parser.add_argument("--use-zarr3", type=bool, required=False, default=True)
+  parser.add_argument("--use-ocdbt", type=str2bool, required=False, default=True)
+  parser.add_argument("--use-zarr3", type=str2bool, required=False, default=True)
   args = parser.parse_args()
 
   if args.model_size not in ds_ckpt.MODEL_PARAMS_DICT:

--- a/MaxText/inference_utils.py
+++ b/MaxText/inference_utils.py
@@ -27,6 +27,31 @@ NEG_INF = -1.0e7  # Masking purpose
 """
 
 
+def str2bool(v: str) -> bool:
+  """Convert a string of truth to True or False.
+
+  Args:
+    - v (str):
+      - True values are 'y', 'yes', 't', 'true', and '1';
+      - False values are 'n', 'no', 'f', 'false', and '0'.
+
+  Returns:
+    bool: True or False
+
+  Raises:
+    ValueError if v is anything else.
+  """
+  v = v.lower()
+  true_values = ["y", "yes", "t", "true", "1"]
+  false_values = ["n", "no", "f", "false", "0"]
+  if v in true_values:
+    return True
+  elif v in false_values:
+    return False
+  else:
+    raise ValueError(f"Invalid value '{v}'!")
+
+
 def sampling(logits, rng, algorithm, topk=0, nucleus_topp=0, temperature=1.0):
   """
   logits: unnormalized logits to sample, shaped [YOUR_LEADING_DIMS, Vocab], before logit

--- a/MaxText/llama_or_mistral_ckpt.py
+++ b/MaxText/llama_or_mistral_ckpt.py
@@ -38,6 +38,7 @@ import re
 import logging
 import json
 from dataclasses import dataclass
+from inference_utils import str2bool
 
 os.environ["JAX_PLATFORMS"] = "cpu"
 
@@ -1053,9 +1054,9 @@ if __name__ == "__main__":
   parser.add_argument("--maxtext-model-path", type=str, required=True)
   parser.add_argument("--model-size", type=str, required=True)
   parser.add_argument("--lora-input-adapters-path", type=str, required=False)
-  parser.add_argument("--huggingface-checkpoint", type=bool, required=False, default=False)
-  parser.add_argument("--use-ocdbt", type=bool, required=False, default=True)
-  parser.add_argument("--use-zarr3", type=bool, required=False, default=True)
+  parser.add_argument("--huggingface-checkpoint", type=str2bool, required=False, default=False)
+  parser.add_argument("--use-ocdbt", type=str2bool, required=False, default=True)
+  parser.add_argument("--use-zarr3", type=str2bool, required=False, default=True)
   args = parser.parse_args()
 
   if args.model_size not in MODEL_PARAMS_DICT:

--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -25,6 +25,7 @@ import argparse
 import os
 import time
 
+from inference_utils import str2bool
 from maxtext_trillium_model_configs import trillium_model_dict
 from maxtext_v5e_model_configs import v5e_model_dict
 from maxtext_xpk_runner import PathwaysConfig
@@ -68,7 +69,7 @@ def add_pathways_arguments(parser: argparse.ArgumentParser):
   )
   parser.add_argument(
       '--use_pathways',
-      type=bool,
+      type=str2bool,
       default=False,
       help='whether to use pathways or not.',
   )

--- a/benchmarks/upload_metrics_to_bq.py
+++ b/benchmarks/upload_metrics_to_bq.py
@@ -24,6 +24,7 @@ from benchmark_db_utils import write_run
 from benchmark_db_utils import DEFAULT_LOCAL_DIR
 from benchmark_db_utils import recover_tuning_params
 from benchmark_db_utils import Metrics
+from inference_utils import str2bool
 import dataclasses
 import fnmatch
 import getpass
@@ -165,7 +166,7 @@ def add_parser_arguments(parser: argparse.ArgumentParser):
   )
   parser.add_argument(
       '--is_test',
-      type=bool,
+      type=str2bool,
       required=False,
       default=True,
       help='Whether to use the testing project or production project',

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -45,6 +45,7 @@ import subprocess
 from datetime import datetime
 import os
 import shutil
+from inference_utils import str2bool
 
 
 
@@ -284,7 +285,7 @@ def main(raw_args=None) -> None:
   parser.add_argument('--CQR_EXTRA_ARGS', type=str, default=None,
                       help='Additional arguments to be passed verbatim to the CQR request, e.g. \
                       --CQR_EXTRA_ARGS="--reserved --service-account=my-service-account-email-address')
-  parser.add_argument('--ENABLE_AUTOCHECKPOINT', type=bool, default=False,
+  parser.add_argument('--ENABLE_AUTOCHECKPOINT', type=str2bool, default=False,
                       help='Whether to enable the Autocheckpoint feature')
   args = parser.parse_args(raw_args)
 


### PR DESCRIPTION
…ol. This should correctly parse boolean args now.

# Description

argparse was previously incorrectly using type=bool. This would result in True for any string passed. Now defining str2bool expression to properly parse args passed in command-line (similar to [JetStream](https://github.com/AI-Hypercomputer/JetStream/blob/main/benchmarks/benchmark_serving.py#L87)).
This also allows preserving the arg names and defaults.

# Tests
Ran with different combinations of flags and also tested the defaults locally.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
