### PR TITLE
Fix the dataloading sharding, which causes Tensor Parallelism issue on GPU.

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -63,11 +63,12 @@ checkpoint_storage_use_zarr3: True
 checkpoint_storage_concurrent_gb: 96
 ############################### END CHECKPOINTING ##################################
 
-
+############################### BEGIN TESTING ##################################
 reuse_example_batch: 0 # for testing TPU performance, this options repeated uses the same batch.
-
-
 metrics_file: "" # for testing, local file that stores scalar metrics. If empty, no metrics are written.
+disalbe_key_validation: False # for testing, if true, skip the key validation.
+############################### END TESTING ##################################
+
 # If true save metrics such as loss and TFLOPS to GCS in {base_output_directory}/{run_name}/metrics/
 gcs_metrics: False
 
@@ -330,7 +331,7 @@ logical_axis_rules: [
                     ]
 # Axes used for DCN must be earlier in this list than ICI, see (b/339009148) for details
 data_sharding: [['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'context', 'context_autoregressive', 'tensor', 'tensor_transpose', 'tensor_sequence', 'expert', 'autoregressive']]
-
+input_data_sharding_logical_axes: ['activation_embed_and_logits_batch', 'activation_norm_length']
 # sharding tolerance: float between 0.0 and 1.0 representing the allowed percentage of non-sharded parameters.
 sharding_tolerance: 0.02
 

--- a/MaxText/input_pipeline/_grain_data_processing.py
+++ b/MaxText/input_pipeline/_grain_data_processing.py
@@ -196,7 +196,7 @@ def make_grain_train_iterator(
           tokenize=config.tokenize_train_data,
           grain_worker_count=config.grain_worker_count,
       )
-    return multihost_dataloading.MultiHostDataLoadIterator(train_dataloader, global_mesh)
+    return multihost_dataloading.MultiHostDataLoadIterator(train_dataloader, global_mesh, config)
   else:
     get_ds_fn = functools.partial(
         get_datasets,
@@ -262,7 +262,7 @@ def make_grain_eval_iterator(
           tokenize=config.tokenize_eval_data,
           grain_worker_count=config.grain_worker_count_eval,
       )
-    return multihost_dataloading.MultiHostDataLoadIterator(eval_dataloader, global_mesh)
+    return multihost_dataloading.MultiHostDataLoadIterator(eval_dataloader, global_mesh, config)
   else:
     get_ds_fn = functools.partial(
         get_datasets,

--- a/MaxText/input_pipeline/_hf_data_processing.py
+++ b/MaxText/input_pipeline/_hf_data_processing.py
@@ -185,10 +185,7 @@ def preprocessing_pipeline(
       read_options=grain.ReadOptions(num_threads=num_threads, prefetch_buffer_size=128),
   )
 
-  multihost_gen = multihost_dataloading.MultiHostDataLoadIterator(dataloader, global_mesh)
-
-  # Return multi-host jax.Array prep iterator
-  return multihost_gen
+  return dataloader
 
 
 def make_hf_train_iterator(
@@ -205,7 +202,7 @@ def make_hf_train_iterator(
       streaming=True,
       token=config.hf_access_token,
   )
-  train_iter = preprocessing_pipeline(
+  train_data_loader = preprocessing_pipeline(
       dataloading_host_index=process_indices_train.index(jax.process_index()),
       dataloading_host_count=len(process_indices_train),
       global_mesh=global_mesh,
@@ -226,6 +223,7 @@ def make_hf_train_iterator(
       use_sft=config.use_sft,
       sft_train_on_completion_only=config.sft_train_on_completion_only,
   )
+  train_iter = multihost_dataloading.MultiHostDataLoadIterator(train_data_loader, global_mesh, config)
   return train_iter
 
 
@@ -247,7 +245,7 @@ def make_hf_eval_iterator(
     eval_generate_padding_example = True
   else:
     eval_generate_padding_example = False
-  eval_iter = preprocessing_pipeline(
+  eval_data_loader = preprocessing_pipeline(
       dataloading_host_index=process_indices_eval.index(jax.process_index()),
       dataloading_host_count=len(process_indices_eval),
       global_mesh=global_mesh,
@@ -268,4 +266,5 @@ def make_hf_eval_iterator(
       use_sft=config.use_sft,
       sft_train_on_completion_only=config.sft_train_on_completion_only,
   )
+  eval_iter = multihost_dataloading.MultiHostDataLoadIterator(eval_data_loader, global_mesh, config)
   return eval_iter

--- a/MaxText/input_pipeline/_tfds_data_processing.py
+++ b/MaxText/input_pipeline/_tfds_data_processing.py
@@ -197,7 +197,7 @@ def make_tfds_train_iterator(
         use_dpo=config.use_dpo,
         hf_access_token=config.hf_access_token,
     )
-    return multihost_dataloading.MultiHostDataLoadIterator(train_dataloader, global_mesh)
+    return multihost_dataloading.MultiHostDataLoadIterator(train_dataloader, global_mesh, config)
   else:
     get_ds_fn = functools.partial(
         get_datasets,
@@ -261,7 +261,7 @@ def make_tfds_eval_iterator(
         use_dpo=config.use_dpo,
         hf_access_token=config.hf_access_token,
     )
-    return multihost_dataloading.MultiHostDataLoadIterator(eval_dataloader, global_mesh)
+    return multihost_dataloading.MultiHostDataLoadIterator(eval_dataloader, global_mesh, config)
   else:
     get_ds_fn = functools.partial(
         get_datasets,

--- a/MaxText/input_pipeline/_tfds_data_processing_c4_mlperf.py
+++ b/MaxText/input_pipeline/_tfds_data_processing_c4_mlperf.py
@@ -330,7 +330,7 @@ def make_c4_mlperf_train_iterator(
       shuffle_buffer_size=128,
       data_shuffle_seed=config.data_shuffle_seed,
   )
-  train_multihost_gen = multihost_dataloading.MultiHostDataLoadIterator(train_ds, global_mesh)
+  train_multihost_gen = multihost_dataloading.MultiHostDataLoadIterator(train_ds, global_mesh, config)
   return train_multihost_gen
 
 
@@ -360,7 +360,7 @@ def make_c4_mlperf_eval_iterator(
       max_target_length=config.max_target_length,
   )
 
-  eval_multihost_gen = multihost_dataloading.MultiHostDataLoadIterator(eval_ds, global_mesh)
+  eval_multihost_gen = multihost_dataloading.MultiHostDataLoadIterator(eval_ds, global_mesh, config)
 
   # Return multi-host jax.Array prep iterator
   return eval_multihost_gen

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -373,21 +373,27 @@ def get_coordinator_ip_address():
   return coordinator_ip_address
 
 
+def get_unspecified_mesh_axes_value(parallelism_vals, target_product, parallelism_type):
+  """Evaluates unspecified DCN/ICI parallelism values"""
+  assert (
+      parallelism_vals.count(-1) == 1
+  ), f"Found unspecified values (-1) for more than one {parallelism_type}\
+    parallelism axis. At most one axis can be unspecified."
+
+  determined_val = target_product / np.prod(parallelism_vals) * -1
+
+  assert (
+      determined_val >= 1 and determined_val.is_integer
+  ), f"Unspecified value unable to be determined with the given\
+    {parallelism_type} parallelism values"
+
+  return int(determined_val)
+
+
 def fill_unspecified_mesh_axes(parallelism_vals, target_product, parallelism_type):
   """Evaluates unspecified DCN/ICI parallelism values"""
   if -1 in parallelism_vals:
-    assert (
-        parallelism_vals.count(-1) == 1
-    ), f"Found unspecified values (-1) for more than one {parallelism_type}\
-      parallelism axis. At most one axis can be unspecified."
-
-    determined_val = target_product / np.prod(parallelism_vals) * -1
-
-    assert (
-        determined_val >= 1 and determined_val.is_integer
-    ), f"Unspecified value unable to be determined with the given\
-      {parallelism_type} parallelism values"
-
+    determined_val = get_unspecified_mesh_axes_value(parallelism_vals, target_product, parallelism_type)
     parallelism_vals[parallelism_vals.index(-1)] = int(determined_val)
 
   target_type = "slices" if parallelism_type == "DCN" else "devices per slice"
@@ -780,6 +786,35 @@ def reorder_causal_load_balanced(batch, cp_size):
   }
 
 
+def shard_reorder_causal_load_balanced(batch, cp_size):
+  """Shard the output of the reordered sequence."""
+  reordered = reorder_causal_load_balanced(batch, cp_size)
+  for _, v in batch.items():
+    if isinstance(v, jax.Array):
+      reordered = jax.lax.with_sharding_constraint(reordered, v.sharding)
+      break
+  return reordered
+
+
 def get_reorder_callable(cp_size):
   """Creates a callable that can be used with map() to reorder batches."""
-  return functools.partial(reorder_causal_load_balanced, cp_size=cp_size)
+  return functools.partial(shard_reorder_causal_load_balanced, cp_size=cp_size)
+
+
+def compute_axis_product(axis_spec, mesh_dict):
+  """Computes the product of the axis specified in axis_spec."""
+  if isinstance(axis_spec, str):
+    axis_spec = (axis_spec,)
+  elif axis_spec is None:
+    return 1
+  product = 1
+  for dim_name in axis_spec:
+    if dim_name in mesh_dict:
+      product *= mesh_dict[dim_name]
+  return product
+
+
+def construct_parallelism_name(mesh_axis: str, prefix: str) -> str:
+  if mesh_axis == "stage":
+    return f"{prefix}_pipeline_parallelism"
+  return f"{prefix}_{mesh_axis}_parallelism"

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -23,6 +23,7 @@ import os
 from MaxText import max_utils
 from jax.sharding import PartitionSpec as P
 from jax.experimental.serialize_executable import deserialize_and_load
+from flax import linen as nn
 
 import pickle
 import functools
@@ -32,6 +33,7 @@ from flax import linen as nn
 from flax.linen import partitioning as nn_partitioning
 
 from MaxText import max_logging
+import ml_collections
 import numpy as np
 import jax.numpy as jnp
 from MaxText import checkpointing
@@ -50,12 +52,16 @@ NUM_IMAGES_PER_SEQUENCE = 1
 NUM_IMAGE_CHANNELS = 3
 
 
+def get_input_data_sharding(mesh, input_data_sharding_logical_axes, logical_axis_rules):
+  data_pspec = P(*input_data_sharding_logical_axes)
+  return nn.logical_to_mesh_sharding(data_pspec, mesh, logical_axis_rules)
+
+
 def get_functional_train_with_signature(train_step, mesh, state_mesh_shardings, model, config):
   """Get the shardings (both state and data) for train_step"""
   functional_train = get_functional_train_step(train_step, model, config, state_mesh_shardings)
   functional_train.__name__ = "train_step"
-  data_pspec = P(*config.data_sharding)
-  data_sharding = jax.tree_util.tree_map(lambda p: jax.sharding.NamedSharding(mesh, p), data_pspec)
+  data_sharding = get_input_data_sharding(mesh, config.input_data_sharding_logical_axes, config.logical_axis_rules)
   in_shardings = (state_mesh_shardings, data_sharding, None)  # State, batch, rng
   out_shardings = (state_mesh_shardings, None)  # State, metrics
   static_argnums = ()  # We partial out the static argnums of model and config
@@ -71,8 +77,7 @@ def get_functional_eval_with_signature(eval_step, mesh, state_mesh_shardings, mo
   """Get the shardings (both state and data) for eval_step"""
   functional_eval = get_functional_eval_step(eval_step, model, config)
   functional_eval.__name__ = "eval_step"
-  data_pspec = P(*config.data_sharding)
-  data_sharding = jax.tree_util.tree_map(lambda p: jax.sharding.NamedSharding(mesh, p), data_pspec)
+  data_sharding = get_input_data_sharding(mesh, config.input_data_sharding_logical_axes, config.logical_axis_rules)
   in_shardings = (state_mesh_shardings, data_sharding, None)  # State, batch, rng
   out_shardings = None  # metrics
   static_argnums = ()  # We partial out the static argnums of model, config
@@ -690,14 +695,36 @@ def add_config_to_summary_writer(config, summary_writer):
       max_utils.add_text_to_summary_writer(key, str(value), summary_writer)
 
 
-def create_device_mesh(config, devices=None):
-  """Creates a device mesh with each slice in its own data parallel group. If there is only one slice, uses two replicas"""
+def get_ici_parallelism(config, devices=None):
+  """Get the ICI parallelism for the model."""
   if devices is None:
     devices = jax.devices()
   num_devices = len(devices)
   num_slices = 1 if config.inference_benchmark_test else config.num_slices
   num_devices_per_slice = num_devices // num_slices
 
+  return max_utils.fill_unspecified_mesh_axes(config.ici_parallelism.copy(), num_devices_per_slice, "ICI")
+
+
+def get_dcn_parallelism(config):
+  """Get the DCN parallelism for the model."""
+  num_slices = 1 if config.inference_benchmark_test else config.num_slices
+  return max_utils.fill_unspecified_mesh_axes(config.dcn_parallelism.copy(), num_slices, "DCN")
+
+
+def get_slices_and_devices(config, devices=None):
+  if devices is None:
+    devices = jax.devices()
+  num_devices = len(devices)
+  num_slices = 1 if config.inference_benchmark_test else config.num_slices
+  num_devices_per_slice = num_devices // num_slices
+  return num_slices, num_devices_per_slice
+
+
+def create_device_mesh(config, devices=None):
+  """Creates a device mesh with each slice in its own data parallel group. If there is only one slice, uses two replicas"""
+  num_slices, num_devices_per_slice = get_slices_and_devices(config, devices)
+  num_devices = num_devices_per_slice * num_slices
   multi_slice_env = num_slices > 1
 
   # Find possible unspecified parallelisms

--- a/MaxText/multihost_dataloading.py
+++ b/MaxText/multihost_dataloading.py
@@ -27,6 +27,8 @@ import tensorflow as tf  # pylint: disable=g-import-not-at-top
 import time
 import numpy as np
 
+from flax import linen as nn
+
 import jax
 import jax.tree_util as jtu
 from jax.sharding import PartitionSpec
@@ -34,39 +36,125 @@ from jax.sharding import NamedSharding
 from jax.sharding import Mesh
 from jax.experimental import colocated_python
 import jax.numpy as jnp
-import grain.python as grain
 
 from MaxText import max_logging
+from MaxText import max_utils
+import ml_collections
 
 
-def _build_global_shape_and_sharding(
-    local_shape: tuple[int, ...], global_mesh: Mesh
-) -> tuple[tuple[int, ...], NamedSharding]:
-  sharding = NamedSharding(global_mesh, PartitionSpec(global_mesh.axis_names))
+def _get_mesh_axes_prod(config, default_num: int, prefix: str, mesh_axes: list[str]) -> int:
+  """Get the mesh axes parallelism product from the config.
+  E.g. for mesh_axes = ["data", "fsdp"], and *_data_parallelism = 2 and *_fsdp_parallelism = 3 it will return 6
+  """
+  mesh_prod = 1
+  for mesh_axis in mesh_axes:
+    parallelism_name = max_utils.construct_parallelism_name(mesh_axis, prefix)
+    try:
+      scale_val = getattr(config, parallelism_name)
+    except AttributeError:
+      raise ValueError(f"Config does not have {parallelism_name}, " f"but it is needed for logical axes {mesh_axes}")
+    if scale_val == -1:
+      scale_val = default_num
+    assert scale_val > 0, f"Scale value for {parallelism_name} must be positive, got {scale_val}"
+    mesh_prod *= scale_val
+  return mesh_prod
 
-  global_shape = (jax.process_count() * local_shape[0],) + local_shape[1:]
 
-  return global_shape, sharding
+def _get_input_data_parallelisms(
+    config: ml_collections.ConfigDict, prefix: str, default_mesh_parallelism: int
+) -> tuple[int, ...]:
+  """Get the global input data scale from the config.
+  prefix: either "dcn" or "ici"
+  default_mesh_parallelism: fills the -1 in the parallelism config
+  Returns a tuple of integers representing the parallelism for each logical axis.
+
+  E.g. for input_data_sharding_logical_axes = ["batch", "length"]
+  logical_axes_rules = [["batch", ["data"]], ["length", ["sequence"]]]
+  ici_data_parallelism = 2
+  ici_sequence_parallelism = 3, it will return (2, 3)
+  """
+  input_data_prod = []
+  for i, logical_axis in enumerate(config.input_data_sharding_logical_axes):
+    # Find matching rule from the list
+    mesh_axes = []
+    for rule in config.logical_axis_rules:
+      if rule[0] == logical_axis:
+        mesh_axes = [rule[1]] if isinstance(rule[1], str) else rule[1]
+        break
+
+    assert len(mesh_axes) > 0, f"No matching rule found for logical axis {logical_axis}"
+    mesh_prod = _get_mesh_axes_prod(config, default_mesh_parallelism, prefix, mesh_axes)
+
+    input_data_prod.append(mesh_prod)
+  if len(input_data_prod) == 1:
+    input_data_prod.append(1)
+  return tuple(input_data_prod)
 
 
-def _form_global_array(path, array: np.ndarray, global_mesh: Mesh) -> jax.Array:
-  """Put local sharded array into local devices"""
-  global_shape, sharding = _build_global_shape_and_sharding(np.shape(array), global_mesh)
+def _build_global_shape(local_shape: tuple[int, ...], input_data_dcn_parallelisms: tuple[int, ...]) -> tuple[int, ...]:
+  """Builds the global shape from the local shape."""
+  assert len(local_shape) == len(input_data_dcn_parallelisms), (
+      f"Shape mismatch: local_shape has {len(local_shape)} dims, "
+      f"but input_data_dcn_parallelisms has {len(input_data_dcn_parallelisms)} axes"
+  )
+  global_shape = []
+  for local_dim, global_scale in zip(local_shape, input_data_dcn_parallelisms):
+    global_shape.append(local_dim * global_scale)
+  return tuple(global_shape)
 
-  try:
-    local_device_arrays = np.split(array, len(global_mesh.local_devices), axis=0)
-  except ValueError as array_split_error:
+
+def _form_global_array(
+    path,
+    array: np.ndarray,
+    global_mesh: Mesh,
+    input_data_shardings: NamedSharding,
+    input_data_dcn_parallelisms: tuple[int, ...],
+    input_data_ici_parallelisms: tuple[int, ...],
+) -> jax.Array:
+  """Put local sharded array into devices sharding, and return global array."""
+  global_shape = _build_global_shape(array.shape, input_data_dcn_parallelisms)
+
+  if len(global_shape) != array.ndim:
     raise ValueError(
-        f"Unable to put to devices shape {array.shape} with "
-        f"local device count {len(global_mesh.local_devices)} "
-        f"at {jtu.keystr(path)}"
-    ) from array_split_error
+        f"Sharding factor {global_shape} must match array rank {array.ndim} " f"for array of shape {array.shape}"
+    )
 
-  local_device_buffers = jax.device_put(local_device_arrays, global_mesh.local_devices)
-  return jax.make_array_from_single_device_arrays(global_shape, sharding, local_device_buffers)
+  # Split the array into subarrays based on the 2D (B, S) ici data sharding
+  def recursive_split(arr, factors, axis=0):
+    if axis >= len(factors):
+      return [arr]
+    if factors[axis] == 1:
+      return recursive_split(arr, factors, axis + 1)
+    split_chunks = np.array_split(arr, factors[axis], axis=axis)
+    return [s for chunk in split_chunks for s in recursive_split(chunk, factors, axis + 1)]
+
+  # Shard the array into subarrays
+  local_shards = recursive_split(array, input_data_ici_parallelisms)
+
+  num_shards = np.prod(input_data_ici_parallelisms)
+  num_devices = len(global_mesh.local_devices)
+
+  if num_devices % num_shards != 0:
+    raise ValueError(f"Cannot evenly replicate {num_shards} shards across {num_devices} devices. " f"at {jtu.keystr(path)}")
+
+  replication_factor = num_devices // num_shards
+  local_device_buffers = []
+
+  for i, shard in enumerate(local_shards):
+    shard_devices = global_mesh.local_devices[i * replication_factor : (i + 1) * replication_factor]
+    for device in shard_devices:
+      local_device_buffers.append(jax.device_put(shard, device))
+
+  return jax.make_array_from_single_device_arrays(global_shape, input_data_shardings, local_device_buffers)
 
 
-def get_next_batch_sharded(local_iterator: Iterator, global_mesh: Mesh) -> jax.Array:
+def get_next_batch_sharded(
+    local_iterator: Iterator,
+    global_mesh: Mesh,
+    input_data_shardings: NamedSharding,
+    input_data_dcn_parallelisms: tuple[int, ...],
+    input_data_ici_parallelisms: tuple[int, ...],
+) -> jax.Array:
   """Splits the host loaded data equally over all devices."""
 
   SLEEP_TIME = 10
@@ -86,8 +174,16 @@ def get_next_batch_sharded(local_iterator: Iterator, global_mesh: Mesh) -> jax.A
   # Try one last time, if this fails we will see the full stack trace.
   if not loaded_data_success:
     local_data = next(local_iterator)
-
-  input_gdas = jtu.tree_map_with_path(partial(_form_global_array, global_mesh=global_mesh), local_data)
+  input_gdas = jtu.tree_map_with_path(
+      partial(
+          _form_global_array,
+          global_mesh=global_mesh,
+          input_data_shardings=input_data_shardings,
+          input_data_dcn_parallelisms=input_data_dcn_parallelisms,
+          input_data_ici_parallelisms=input_data_ici_parallelisms,
+      ),
+      local_data,
+  )
 
   return input_gdas
 
@@ -95,9 +191,30 @@ def get_next_batch_sharded(local_iterator: Iterator, global_mesh: Mesh) -> jax.A
 class MultiHostDataLoadIterator:
   """fold get_next_batch_sharded into a iterator class"""
 
-  def __init__(self, dataloader: Union[tf.data.Dataset, Iterable], global_mesh: Mesh):
+  def __init__(self, dataloader: Union[tf.data.Dataset, Iterable], global_mesh: Mesh, config: ml_collections.ConfigDict):
     self.global_mesh = global_mesh
     self.dataloader = dataloader
+
+    num_devices = jax.device_count()
+    num_slices = 1 if config.inference_benchmark_test else config.num_slices
+    num_devices_per_slice = int(num_devices // num_slices)
+
+    default_dcn_parallelism = max_utils.get_unspecified_mesh_axes_value(config.dcn_parallelism, num_slices, "DCN")
+    default_ici_parallelism = max_utils.get_unspecified_mesh_axes_value(config.ici_parallelism, num_devices_per_slice, "ICI")
+
+    self.input_data_dcn_parallelisms = _get_input_data_parallelisms(
+        config, prefix="dcn", default_mesh_parallelism=default_dcn_parallelism
+    )
+    self.input_data_ici_parallelisms = _get_input_data_parallelisms(
+        config, prefix="ici", default_mesh_parallelism=default_ici_parallelism
+    )
+
+    max_logging.log(
+        f"Input data dcn parallelisms are {self.input_data_dcn_parallelisms} ici parallelisms are {self.input_data_ici_parallelisms}"
+    )
+    data_pspec = PartitionSpec(*config.input_data_sharding_logical_axes)
+    self.input_data_shardings = nn.logical_to_mesh_sharding(data_pspec, global_mesh, config.logical_axis_rules)
+
     if isinstance(self.dataloader, tf.data.Dataset):
       self.local_iterator = self.dataloader.as_numpy_iterator()
     elif isinstance(self.dataloader, Iterable):
@@ -118,7 +235,13 @@ class MultiHostDataLoadIterator:
     return self
 
   def __next__(self):
-    return get_next_batch_sharded(self.local_iterator, self.global_mesh)
+    return get_next_batch_sharded(
+        self.local_iterator,
+        self.global_mesh,
+        self.input_data_shardings,
+        self.input_data_dcn_parallelisms,
+        self.input_data_ici_parallelisms,
+    )
 
 
 @colocated_python.colocated_python

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -551,7 +551,8 @@ class _HyperParameters:
 
     if raw_keys["remat_policy"] == "custom":
       raw_keys = validate_and_assign_remat_tensors(raw_keys)
-    validate_keys(raw_keys)
+    if not raw_keys["disalbe_key_validation"]:
+      validate_keys(raw_keys)
     validate_tokenizer(raw_keys)
     validate_data_input(raw_keys)
 

--- a/MaxText/tests/multihost_dataloading_test.py
+++ b/MaxText/tests/multihost_dataloading_test.py
@@ -36,38 +36,170 @@ class MultihostDataloadingTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    batch_size = 4
-    config = pyconfig.initialize(
+    batch_size = 8
+    self.config = pyconfig.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1,
         run_name="test",
         mesh_axes=["data"],
         logical_axis_rules=[["batch", "data"]],
         data_sharding=["data"],
+        input_data_sharding_logical_axes=["batch"],
+        ici_data_parallelism=-1,
+        ici_fsdp_parallelism=1,
         base_output_directory="gs://max-experiments/",
         dataset_path="gs://maxtext-dataset/",
         enable_checkpointing=False,
     )
-    global_data_shape = PartitionSpec(batch_size, config.max_target_length)
+    global_data_shape = PartitionSpec(batch_size, self.config.max_target_length)
     data_sharding = ("data",)
     mesh_shape_1d = (len(jax.devices()),)
-    self.mesh = Mesh(mesh_utils.create_device_mesh(mesh_shape_1d), config.mesh_axes)
+    self.mesh = Mesh(mesh_utils.create_device_mesh(mesh_shape_1d), self.config.mesh_axes)
     data_axes = PartitionSpec(
         "data",
     )
     # creating 2 batches of data
-    global_data = np.arange(np.prod(global_data_shape) * 2).reshape((batch_size * 2, config.max_target_length))
+    global_data = np.arange(np.prod(global_data_shape) * 2).reshape((batch_size * 2, self.config.max_target_length))
 
     dataset = tf.data.Dataset.from_tensor_slices(global_data)
     dataset = dataset.repeat()
-    dataset = dataset.batch(batch_size)
-    self.multihost_gen = multihost_dataloading.MultiHostDataLoadIterator(dataset, self.mesh)
+    self.dataset = dataset.batch(batch_size)
 
   @pytest.mark.tpu_only
   def test_batch_sharded_data_pipeline(self):
+    self.multihost_gen = multihost_dataloading.MultiHostDataLoadIterator(self.dataset, self.mesh, self.config)
     first_batch = next(self.multihost_gen)
     sec_batch = next(self.multihost_gen)
     self.assertTrue(not np.array_equal(first_batch, sec_batch, equal_nan=True))
+
+  def test_get_dcn_mesh_axes_prod(self):
+    config = pyconfig.initialize(
+        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
+        run_name="test",
+        mesh_axes=["data", "fsdp", "expert"],
+        logical_axis_rules=[["batch", ["data", "fsdp", "expert"]]],
+        data_sharding=["data"],
+        input_data_sharding_logical_axes=["batch"],
+        base_output_directory="gs://max-experiments/",
+        dataset_path="gs://maxtext-dataset/",
+        enable_checkpointing=False,
+        dcn_data_parallelism=2,
+        dcn_fsdp_parallelism=3,
+        dcn_expert_parallelism=5,
+        disalbe_key_validation=True,  # We don't have that many slices
+    )
+    default_num = 2
+    prefix = "dcn"
+    prod = multihost_dataloading._get_mesh_axes_prod(config, default_num, prefix, config.mesh_axes)
+    assert prod == 30, f"{prod=} != 30"
+    input_data_scale = multihost_dataloading._get_input_data_parallelisms(config, prefix, default_num)
+    assert input_data_scale == (30, 1), f"{input_data_scale=} != (30,1)"
+
+  def test_get_dcn_partial_mesh_axes_prod(self):
+    config = pyconfig.initialize(
+        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
+        run_name="test",
+        mesh_axes=["data", "fsdp", "expert"],
+        logical_axis_rules=[["batch", ["data", "fsdp", "expert"]]],
+        data_sharding=["data"],
+        input_data_sharding_logical_axes=["batch"],
+        base_output_directory="gs://max-experiments/",
+        dataset_path="gs://maxtext-dataset/",
+        enable_checkpointing=False,
+        dcn_data_parallelism=2,
+        dcn_fsdp_parallelism=3,
+        dcn_tensor_parallelism=5,
+        disalbe_key_validation=True,  # We don't have that many slices
+    )
+    default_num = 2
+    prefix = "dcn"
+    prod = multihost_dataloading._get_mesh_axes_prod(config, default_num, prefix, config.mesh_axes)
+    assert prod == 6, f"{prod=} != 6"
+    input_data_scale = multihost_dataloading._get_input_data_parallelisms(config, prefix, default_num)
+    assert input_data_scale == (6, 1), f"{input_data_scale=} != (6,1)"
+
+  def test_get_2d_dcn_mesh_axes_prod(self):
+    config = pyconfig.initialize(
+        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
+        run_name="test",
+        mesh_axes=["data", "fsdp", "expert", "context", "sequence"],
+        logical_axis_rules=[["logical_batch", ["data", "fsdp", "expert"]], ["logical_sequence", ["context", "sequence"]]],
+        data_sharding=["data"],
+        input_data_sharding_logical_axes=["logical_batch", "logical_sequence"],
+        base_output_directory="gs://max-experiments/",
+        dataset_path="gs://maxtext-dataset/",
+        enable_checkpointing=False,
+        dcn_data_parallelism=2,
+        dcn_fsdp_parallelism=3,
+        dcn_expert_parallelism=5,
+        dcn_context_parallelism=6,
+        dcn_sequence_parallelism=7,
+        disalbe_key_validation=True,  # We don't have that many slices
+    )
+    default_num = 2
+    prefix = "dcn"
+    input_data_scale = multihost_dataloading._get_input_data_parallelisms(config, prefix, default_num)
+    assert input_data_scale == (30, 42), f"{input_data_scale=} != (30,42)"
+
+  def test_get_default_ici_mesh_axes_prod(self):
+    config = pyconfig.initialize(
+        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
+        run_name="test",
+        mesh_axes=["data", "fsdp", "expert"],
+        logical_axis_rules=[["batch", ["data", "fsdp", "expert"]]],
+        data_sharding=["data"],
+        input_data_sharding_logical_axes=["batch"],
+        base_output_directory="gs://max-experiments/",
+        dataset_path="gs://maxtext-dataset/",
+        enable_checkpointing=False,
+        ici_data_parallelism=-1,
+        ici_fsdp_parallelism=3,
+        ici_expert_parallelism=5,
+    )
+    default_num = 2
+    prefix = "ici"
+    prod = multihost_dataloading._get_mesh_axes_prod(config, default_num, prefix, config.mesh_axes)
+    assert prod == 30
+    input_data_scale = multihost_dataloading._get_input_data_parallelisms(config, prefix, default_num)
+    assert input_data_scale == (30, 1), f"{input_data_scale=} != (30,1)"
+
+  def test_get_2d_dcn_ici_scale(self):
+    config = pyconfig.initialize(
+        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
+        run_name="test",
+        mesh_axes=["data", "fsdp", "expert", "context", "sequence"],
+        logical_axis_rules=[["logical_batch", ["data", "fsdp", "expert"]], ["logical_sequence", ["context", "sequence"]]],
+        data_sharding=["data"],
+        input_data_sharding_logical_axes=["logical_batch", "logical_sequence"],
+        base_output_directory="gs://max-experiments/",
+        dataset_path="gs://maxtext-dataset/",
+        enable_checkpointing=False,
+        dcn_data_parallelism=-1,
+        dcn_fsdp_parallelism=3,
+        dcn_expert_parallelism=5,
+        dcn_context_parallelism=6,
+        dcn_sequence_parallelism=7,
+        ici_data_parallelism=2,
+        ici_fsdp_parallelism=3,
+        ici_expert_parallelism=5,
+        ici_context_parallelism=6,
+        ici_sequence_parallelism=-1,
+        disalbe_key_validation=True,  # We don't have that many slices
+    )
+    input_data_dcn_parallelisms = multihost_dataloading._get_input_data_parallelisms(
+        config, "dcn", default_mesh_parallelism=2
+    )
+    input_data_ici_parallelisms = multihost_dataloading._get_input_data_parallelisms(
+        config, "ici", default_mesh_parallelism=7
+    )
+    assert input_data_dcn_parallelisms == (30, 42), f"{input_data_dcn_parallelisms=} != (30,42)"
+    assert input_data_ici_parallelisms == (30, 42), f"{input_data_ici_parallelisms=} != (30,42)"
+
+  def test_build_global_shape(self):
+    local_shape = (3, 2)
+    input_data_scale = (30, 42)
+    global_shape = multihost_dataloading._build_global_shape(local_shape, input_data_scale)
+    assert global_shape == (90, 84), f"{global_shape=} != (90, 84)"
 
 
 if __name__ == "__main__":

--- a/MaxText/tests/sft_data_processing_test.py
+++ b/MaxText/tests/sft_data_processing_test.py
@@ -21,6 +21,7 @@ import os.path
 import numpy as np
 import jax
 from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
 from jax.experimental import mesh_utils
 from datasets import Dataset
 import transformers
@@ -29,6 +30,9 @@ from MaxText import pyconfig
 from MaxText.globals import PKG_DIR
 from MaxText.input_pipeline import _hf_data_processing
 from MaxText.input_pipeline import input_pipeline_interface
+from MaxText import multihost_dataloading
+from MaxText import maxtext_utils
+
 
 PROMPT_DATA = [
     [
@@ -110,6 +114,9 @@ class SFTDataProcessingTest(unittest.TestCase):
         mesh_axes=["data"],
         logical_axis_rules=[["batch", "data"]],
         data_sharding=["data"],
+        input_data_sharding_logical_axes=["batch"],
+        ici_data_parallelism=-1,
+        ici_fsdp_parallelism=1,
         base_output_directory="gs://max-experiments/",
         tokenizer_path=os.path.join(os.path.dirname(PKG_DIR), "assets", "llama2-tokenizer"),
         train_split="train",
@@ -119,8 +126,11 @@ class SFTDataProcessingTest(unittest.TestCase):
     )
     self.mesh_shape_1d = (len(jax.devices()),)
     self.mesh = Mesh(mesh_utils.create_device_mesh(self.mesh_shape_1d), self.config.mesh_axes)
+    data_sharding = maxtext_utils.get_input_data_sharding(
+        self.mesh, self.config.input_data_sharding_logical_axes, self.config.logical_axis_rules
+    )
     self.process_indices = input_pipeline_interface.get_process_loading_real_data(
-        self.config.data_sharding,
+        data_sharding,
         self.config.global_batch_size_to_load,
         self.config.global_batch_size_to_train_on,
         self.config.max_target_length,
@@ -135,7 +145,7 @@ class SFTDataProcessingTest(unittest.TestCase):
     )
 
   def get_train_iterator(self, train_ds, data_columns):
-    self.train_iter = _hf_data_processing.preprocessing_pipeline(
+    train_data_loader = _hf_data_processing.preprocessing_pipeline(
         dataloading_host_index=self.process_indices.index(jax.process_index()),
         dataloading_host_count=len(self.process_indices),
         global_mesh=self.mesh,
@@ -157,6 +167,7 @@ class SFTDataProcessingTest(unittest.TestCase):
         sft_train_on_completion_only=self.config.sft_train_on_completion_only,
         grain_worker_count=0,
     )
+    self.train_iter = multihost_dataloading.MultiHostDataLoadIterator(train_data_loader, self.mesh, self.config)
 
   def test_sft_format_with_messages(self):
     train_ds = Dataset.from_dict({"messages": MESSAGES_DATA * 4})

--- a/MaxText/tests/tfds_data_processing_test.py
+++ b/MaxText/tests/tfds_data_processing_test.py
@@ -19,6 +19,7 @@ import os
 import sys
 import jax
 from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
 from jax.experimental import mesh_utils
 
 import unittest
@@ -29,6 +30,7 @@ from MaxText import pyconfig
 from MaxText.globals import PKG_DIR
 from MaxText.input_pipeline import _tfds_data_processing
 from MaxText.input_pipeline import input_pipeline_interface
+from MaxText import maxtext_utils
 
 
 class TfdsDataProcessingTest(unittest.TestCase):
@@ -42,6 +44,9 @@ class TfdsDataProcessingTest(unittest.TestCase):
         mesh_axes=["data"],
         logical_axis_rules=[["batch", "data"]],
         data_sharding=["data"],
+        input_data_sharding_logical_axes=["batch"],
+        ici_data_parallelism=-1,
+        ici_fsdp_parallelism=1,
         base_output_directory="gs://max-experiments/",
         dataset_path="gs://maxtext-dataset/",
         tokenizer_path=os.path.join(os.path.dirname(PKG_DIR), "assets", "tokenizer"),
@@ -52,8 +57,11 @@ class TfdsDataProcessingTest(unittest.TestCase):
     self.config = config
     self.mesh_shape_1d = (len(jax.devices()),)
     self.mesh = Mesh(mesh_utils.create_device_mesh(self.mesh_shape_1d), self.config.mesh_axes)
+    data_sharding = maxtext_utils.get_input_data_sharding(
+        self.mesh, self.config.input_data_sharding_logical_axes, self.config.logical_axis_rules
+    )
     self.process_indices = input_pipeline_interface.get_process_loading_real_data(
-        self.config.data_sharding,
+        data_sharding,
         self.config.global_batch_size_to_load,
         self.config.global_batch_size_to_train_on,
         self.config.max_target_length,

--- a/MaxText/tests/train_tests.py
+++ b/MaxText/tests/train_tests.py
@@ -219,13 +219,32 @@ class TrainTests(unittest.TestCase):
         "steps=10",
         "enable_checkpointing=False",
         "attention=cudnn_flash_te",
-        "ici_fsdp_parallelism=2",
+        "ici_fsdp_parallelism=-1",
         "ici_context_parallelism=2",
         "context_parallel_load_balance=True",
         "packing=False",
         rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
     ]
     train_main(context_parallel)
+
+  @pytest.mark.gpu_only
+  def test_gpu_tensor_parallelism(self):
+    os.environ["NVTE_FUSED_ATTN"] = "1"  # Enable fused attention
+    tensor_parallel = [  # tests base config on GPU with context parallelism and flash attention"""
+        None,
+        os.path.join(PKG_DIR, "configs", "base.yml"),
+        rf"base_output_directory=gs://runner-maxtext-logs",
+        "run_name=runner_test",
+        r"dataset_path=gs://maxtext-dataset",
+        "steps=10",
+        "enable_checkpointing=False",
+        "attention=cudnn_flash_te",
+        "ici_fsdp_parallelism=-1",
+        "ici_tensor_parallelism=2",
+        "packing=False",
+        rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
+    ]
+    train_main(tensor_parallel)
 
 
 if __name__ == "__main__":

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -674,10 +674,11 @@ def setup_train_loop(config):
     )
 
   # Apply reordering wrapper to data iterators if context parallelism is enabled
-  if context_parallel_size > 1 and config.context_parallel_load_balance:
-    data_iterator = map(max_utils.get_reorder_callable(context_parallel_size), data_iterator)
-    if eval_data_iterator:
-      eval_data_iterator = map(max_utils.get_reorder_callable(context_parallel_size), eval_data_iterator)
+  with mesh:
+    if context_parallel_size > 1 and config.context_parallel_load_balance:
+      data_iterator = map(max_utils.get_reorder_callable(context_parallel_size), data_iterator)
+      if eval_data_iterator:
+        eval_data_iterator = map(max_utils.get_reorder_callable(context_parallel_size), eval_data_iterator)
 
   state, _, state_mesh_shardings, data_iterator = maxtext_utils.setup_training_state(
       model, data_iterator, tx, config, init_rng, mesh, checkpoint_manager


### PR DESCRIPTION
# Description

When we enable Tensor Parallelism on GPU normally the workload hang or corrupted with TransformerEngine errors. The root cause is the data sharding is incorrect and the decoder_segment_id will be sharded by (fsdp, tensor) on (Batch, Sequence). This PR fixed the data sharding of both synthetic data loader and the actual data loader. 

Fixes: b/384441280

# Tests

Manually tested the workload with 1 host + TP with synthetic dataloader. Relying on the presubmit test for the actual dataloader.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
