### PR TITLE
support parquet dataset in grain and refactor

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -385,6 +385,7 @@ max_corpus_chars: 10_000_000
 train_data_columns: ['text'] # for DPO dataset containing "chosen" and "rejected"
 eval_data_columns: ['text'] # for DPO dataset containing "chosen" and "rejected"
 packing: True
+num_epoch: 1  # only grain and tfds pipeline supports num_epoch > 1
 
 # direct preference optimization (DPO)
 use_dpo: False
@@ -415,7 +416,9 @@ hf_access_token: ''
 # for Grain input pipeline (dataset_type=grain)
 grain_train_files: ''
 grain_eval_files: ''
+grain_file_type: 'arrayrecord' # arrayrecord or parquet 
 grain_worker_count: 1
+grain_worker_count_eval: 1
 # for using pathways
 colocated_python_data_input: False  # experimental feature, under testing
 

--- a/MaxText/input_pipeline/_tfds_data_processing.py
+++ b/MaxText/input_pipeline/_tfds_data_processing.py
@@ -192,6 +192,7 @@ def make_tfds_train_iterator(
         tokenize=config.tokenize_train_data,
         add_bos=config.add_bos,
         add_eos=config.add_eos,
+        num_epochs=config.num_epoch,
         use_dpo=config.use_dpo,
         hf_access_token=config.hf_access_token,
     )
@@ -217,6 +218,7 @@ def make_tfds_train_iterator(
         tokenize=config.tokenize_train_data,
         add_bos=config.add_bos,
         add_eos=config.add_eos,
+        num_epochs=config.num_epoch,
         use_dpo=config.use_dpo,
         hf_access_token=config.hf_access_token,
     )

--- a/MaxText/multihost_dataloading.py
+++ b/MaxText/multihost_dataloading.py
@@ -95,7 +95,7 @@ def get_next_batch_sharded(local_iterator: Iterator, global_mesh: Mesh) -> jax.A
 class MultiHostDataLoadIterator:
   """fold get_next_batch_sharded into a iterator class"""
 
-  def __init__(self, dataloader: Union[tf.data.Dataset, grain.DataLoader], global_mesh: Mesh):
+  def __init__(self, dataloader: Union[tf.data.Dataset, Iterable], global_mesh: Mesh):
     self.global_mesh = global_mesh
     self.dataloader = dataloader
     if isinstance(self.dataloader, tf.data.Dataset):
@@ -175,32 +175,26 @@ def _get_cpu_mesh(mesh: Mesh):
 class RemoteIterator:
   "iterator class for using colocated python, iterator is initiated remotely and stored in the state of colocated python"
 
-  def __init__(self, get_ds_fn, preprocessing_fn, config, global_mesh):
-    self.config = config
+  def __init__(self, get_ds_fn, preprocessing_fn, global_mesh, global_shape):
     self.cpu_devices = _colocated_cpu_devices(jax.local_devices())
     self.tpu_devices = jax.local_devices()
-    self.global_mesh = global_mesh
     self.cpu_mesh = _get_cpu_mesh(global_mesh)
-    self.tpu_sharding = jax.sharding.NamedSharding(self.global_mesh, PartitionSpec(global_mesh.axis_names))
+    self.tpu_sharding = jax.sharding.NamedSharding(global_mesh, PartitionSpec(global_mesh.axis_names))
     self.cpu_sharding = jax.sharding.NamedSharding(self.cpu_mesh, PartitionSpec(self.cpu_mesh.axis_names))
-    global_shape = (config.global_batch_size_to_load, config.max_target_length)
     self.dummy_array = jnp.zeros((len(self.cpu_devices)))
     self.dummy_array = jax.device_put(self.dummy_array, self.cpu_sharding)
 
     @colocated_python.colocated_python
     def init(dummy_array):
-      colocated_python.config = config
       colocated_python.global_shape = global_shape
-      if config.dataset_type == "tfds":
-        ds = get_ds_fn(dataloading_host_index=jax.process_index(), dataloading_host_count=jax.process_count())
-        dataloader = preprocessing_fn(dataset=ds)
+      ds = get_ds_fn(dataloading_host_index=jax.process_index(), dataloading_host_count=jax.process_count())
+      dataloader = preprocessing_fn(dataset=ds)
+      if isinstance(dataloader, tf.data.Dataset):
         colocated_python.iterator = dataloader.as_numpy_iterator()
-      elif config.dataset_type == "grain":
-        ds = get_ds_fn()
-        dataloader = preprocessing_fn(
-            dataset=ds, dataloading_host_index=jax.process_index(), dataloading_host_count=jax.process_count()
-        )
+      elif isinstance(dataloader, Iterable):
         colocated_python.iterator = iter(dataloader)
+      else:
+        raise ValueError("Type error: dataloader should be either tf.data.Dataset or grain.DataLoader.")
       return dummy_array
 
     out = jax.device_get(init(self.dummy_array))

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -211,6 +211,7 @@ def validate_data_input(keys):
       keys["hf_eval_split"] = "train"
     if keys["eval_interval"] > 0:
       assert keys["hf_eval_split"], "Please specify hf_eval_split or set eval_interval to <=0."
+    assert keys["num_epoch"] == 1, f"hf pipeline only supports num_epoch=1, but num_epoch={keys['num_epoch']} is given."
 
   elif keys["dataset_type"] == "grain":
     max_logging.log(

--- a/MaxText/tests/grain_data_processing_test.py
+++ b/MaxText/tests/grain_data_processing_test.py
@@ -31,7 +31,8 @@ from MaxText.input_pipeline import input_pipeline_interface
 from MaxText.globals import PKG_DIR
 
 
-class GrainDataProcessingTest(unittest.TestCase):
+
+class GrainArrayRecordProcessingTest(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
@@ -73,9 +74,91 @@ class GrainDataProcessingTest(unittest.TestCase):
     )
     self.train_iter = _grain_data_processing.make_grain_train_iterator(self.config, self.mesh, self.process_indices)
 
-  # def _get_train_iterator(self):
-  #   train_iter, _ = _grain_data_processing.make_grain_iterator(self.config, self.mesh, self.process_indices)
-  #   return train_iter
+  def test_train_ds(self):
+    expected_shape = [jax.device_count(), self.config.max_target_length]
+    # For training we pack multiple short examples in one example.
+    # *_position and *_segmentation indicate the boundaries.
+    batch = next(self.train_iter)
+    self.assertEqual(
+        {k: list(v.shape) for k, v in batch.items()},
+        {
+            "inputs": expected_shape,
+            "inputs_position": expected_shape,
+            "inputs_segmentation": expected_shape,
+            "targets": expected_shape,
+            "targets_position": expected_shape,
+            "targets_segmentation": expected_shape,
+        },
+    )
+
+  def test_batch_determinism(self):
+    batch1 = next(self.train_iter)
+    train_iter = _grain_data_processing.make_grain_train_iterator(self.config, self.mesh, self.process_indices)
+    batch2 = next(train_iter)
+    self.assertTrue((batch1["inputs"] == batch2["inputs"]).all())
+    self.assertTrue((batch1["targets"] == batch2["targets"]).all())
+    self.assertTrue((batch1["inputs_segmentation"] == batch2["inputs_segmentation"]).all())
+    self.assertTrue((batch1["targets_segmentation"] == batch2["targets_segmentation"]).all())
+    self.assertTrue((batch1["inputs_position"] == batch2["inputs_position"]).all())
+    self.assertTrue((batch1["targets_position"] == batch2["targets_position"]).all())
+
+  def test_for_loop_repeatable(self):
+    def get_first_batch(iterator):
+      batch = None
+      for batch in iterator:
+        break
+      return batch
+
+    train_batch1 = get_first_batch(self.train_iter)
+    train_batch2 = get_first_batch(self.train_iter)
+    self.assertTrue((train_batch1["inputs"] == train_batch2["inputs"]).all())
+    self.assertTrue((train_batch1["targets"] == train_batch2["targets"]).all())
+
+
+class GrainParquetProcessingTest(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    temp_dir = tempfile.gettempdir()
+    script_path = os.path.join(os.path.dirname(PKG_DIR), "setup_gcsfuse.sh")
+    if not os.path.isfile(script_path):
+      raise FileNotFoundError(script_path)
+    exit_code = subprocess.call(
+        ["bash", script_path,
+        "DATASET_GCS_BUCKET=maxtext-dataset", f"MOUNT_PATH={os.path.join(temp_dir, 'gcsfuse')}"]
+    )
+    if exit_code != 0:
+      raise ValueError(f"Running setup_gcsfuse.sh failed with exit code: {exit_code}")
+
+  def setUp(self):
+    super().setUp()
+    temp_dir = tempfile.gettempdir()
+    self.config = pyconfig.initialize(
+        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
+        per_device_batch_size=1,
+        run_name="test",
+        mesh_axes=["data"],
+        logical_axis_rules=[["batch", "data"]],
+        data_sharding=["data"],
+        base_output_directory="gs://max-experiments/",
+        dataset_type="grain",
+        grain_file_type="parquet",
+        grain_train_files=os.path.join(temp_dir, "gcsfuse", "hf", "c4", "c4-train-00000-of-01637.parquet"),
+        grain_worker_count=1,
+        tokenizer_path=os.path.join(os.path.dirname(PKG_DIR), "assets", "tokenizer"),
+        enable_checkpointing=False,
+    )
+    self.mesh_shape_1d = (len(jax.devices()),)
+    self.mesh = Mesh(mesh_utils.create_device_mesh(self.mesh_shape_1d), self.config.mesh_axes)
+    self.process_indices = input_pipeline_interface.get_process_loading_real_data(
+        self.config.data_sharding,
+        self.config.global_batch_size_to_load,
+        self.config.global_batch_size_to_train_on,
+        self.config.max_target_length,
+        self.mesh,
+    )
+    self.train_iter = _grain_data_processing.make_grain_train_iterator(self.config, self.mesh, self.process_indices)
 
   def test_train_ds(self):
     expected_shape = [jax.device_count(), self.config.max_target_length]
@@ -119,4 +202,13 @@ class GrainDataProcessingTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
+  temp_dir = tempfile.gettempdir()
+  script_path = os.path.join(os.path.dirname(PKG_DIR), "setup_gcsfuse.sh")
+  if not os.path.isfile(script_path): raise FileNotFoundError(script_path)
+  exit_code = subprocess.call(
+      ["bash", script_path,
+        "DATASET_GCS_BUCKET=maxtext-dataset", f"MOUNT_PATH={os.path.join(temp_dir, 'gcsfuse')}"]
+  )
+  if exit_code != 0:
+    raise ValueError(f"Running setup_gcsfuse.sh failed with exit code: {exit_code}")
   unittest.main()

--- a/MaxText/tokenizer.py
+++ b/MaxText/tokenizer.py
@@ -24,6 +24,7 @@ from MaxText import max_logging
 import transformers
 import tiktoken
 from tiktoken.load import load_tiktoken_bpe
+from sentencepiece import SentencePieceProcessor
 
 
 Features = Dict[str, tf.Tensor]
@@ -185,7 +186,7 @@ class TikTokenTokenizer:
 
 class SentencePieceTokenizer:
   """
-  Tokenizing and encoding/decoding text using the Sentencepiece tokenizer.
+  Tokenizing and encoding/decoding text using the Sentencepiece tokenizer loaded with tensorflow_text
   """
 
   def __init__(self, model_path: str, add_bos: bool, add_eos: bool):
@@ -201,6 +202,34 @@ class SentencePieceTokenizer:
 
   def decode(self, t: Sequence[int]) -> str:
     return self.sp_tokenizer.detokenize(t)
+
+
+class SentencePieceTokenizerGrain:
+  """
+  Tokenizing and encoding/decoding text using the Sentencepiece tokenizer loaded with sentencepiece
+  """
+
+  def __init__(self, model_path: str, add_bos: bool, add_eos: bool):
+    max_logging.log(f"Loading sentencepiece tokenizer: {model_path}")
+    self._tokenizer_model = SentencePieceProcessor()
+    self._tokenizer_model.Load(model_path)
+    self.pad_id = self._tokenizer_model.pad_id()
+    self.unk_id = self._tokenizer_model.unk_id()
+    self.bos_id = self._tokenizer_model.bos_id()
+    self.eos_id = self._tokenizer_model.eos_id()
+    self.add_bos = add_bos
+    self.add_eos = add_eos
+
+  def encode(self, s: str) -> List[int]:
+    token_ids = self._tokenizer_model.EncodeAsIds(s)
+    if self.add_bos:
+      token_ids = [self.bos_id] + token_ids
+    if self.add_eos:
+      token_ids += [self.eos_id]
+    return token_ids
+
+  def decode(self, t: Sequence[int]) -> str:
+    return self._tokenizer_model.DecodeIds(t)
 
 
 class HFTokenizer:
@@ -228,7 +257,7 @@ class HFTokenizer:
     return self.tokenizer.decode(t)
 
 
-def build_tokenizer(tokenizer_path, tokenizer_type, add_bos, add_eos, hf_access_token):
+def build_tokenizer(tokenizer_path, tokenizer_type, add_bos, add_eos, hf_access_token, dataset_type):
   """Loads the tokenizer at `tokenizer_path`"""
   max_logging.log(f"Tokenizer path: {tokenizer_path}")
   if tokenizer_type == "tiktoken":
@@ -237,7 +266,10 @@ def build_tokenizer(tokenizer_path, tokenizer_type, add_bos, add_eos, hf_access_
   elif tokenizer_type == "huggingface":
     return HFTokenizer(tokenizer_path, add_bos, add_eos, hf_access_token)
   elif tokenizer_type == "sentencepiece":
-    return SentencePieceTokenizer(tokenizer_path, add_bos, add_eos)
+    if dataset_type == "tfds":
+      return SentencePieceTokenizer(tokenizer_path, add_bos, add_eos)
+    else:
+      return SentencePieceTokenizerGrain(tokenizer_path, add_bos, add_eos)
   else:
     raise ValueError(f"Invalid tokenizer_type:{tokenizer_type} chosen in config")
 

--- a/getting_started/Data_Input_Pipeline.md
+++ b/getting_started/Data_Input_Pipeline.md
@@ -20,8 +20,8 @@ Currently MaxText has three data input pipelines:
 | Pipeline | Dataset formats | Features | Limitations |
 | -------- | --------------- | -------- | ----------- |
 | HuggingFace | datasets in HuggingFace Hub<br>local/Cloud Storage datasets in json, parquet, arrow, csv, txt | convenience<br>multiple formats | limit scalability using HuggingFace Hub<br>non-deterministic with preemption<br>(deterministic without preemption) |
-| Grain | ArrayRecord, available through Tensorflow Datasets | fully deterministic, regardless of preemption | only supports random access datasets |
-| TFDS | TFRecord, available through Tensorflow Datasets |  | only supports TFRecords<br>non-deterministic with preemption<br>(deterministic without preemption) |
+| Grain | ArrayRecord (available through Tensorflow Datasets), Parquet | fully deterministic, regardless of preemption; global shuffle with random access datasets; performant |  |
+| TFDS | TFRecord, available through Tensorflow Datasets | performant | only supports TFRecords<br>non-deterministic with preemption<br>(deterministic without preemption) |
 
 ### Performance
 * Perf data for all 3 input pipeline: https://github.com/google/maxtext/blob/main/getting_started/Data_Input_Perf.md
@@ -90,11 +90,11 @@ Grain ensures determinism in data input pipelines by saving the pipeline's state
 * **Debug training anomalies.** When troubleshooting training spikes or anomalies, the ability to replay the exact data sequence helps distinguish between bad data batches and underlying hardware or software issues.
 
 #### Global shuffle in Grain
-In HF or TFDS data pipeline, global shuffle is performed by a shuffle buffer with limited size. Grain performs global shuffle of the indices in the beginning of each epoch and then reads the elements according to the random order. We have found this to be generally fast enough, even when using hard drives and distributed file systems.
+In HF or TFDS data pipeline, shuffle is performed by file shuffling, interleave from files, and windowshuffle using a fixed size buffer. Similar shuffle strategy applies if using Grain with [Parquet](https://arrow.apache.org/docs/python/parquet.html) format. The global shuffle feature is only available when using Grain with [ArrayRecord](https://github.com/google/array_record) (random access) format, achieved by shuffling indices globally at the beginning of each epoch and then reads the elements according to the random order. We have found this to be generally fast enough, even when using hard drives and distributed file systems.
 
 #### Using Grain
-1. Dataset needs to be in a format that supports random access. The default format is [ArrayRecord](https://github.com/google/array_record). For converting a dataset into ArrayRecord, see [instructions](https://github.com/google/array_record/tree/main/beam). Additionally, other random accessible data sources can be supported via a custom data source class ([docs](https://github.com/google/grain/blob/main/docs/data_sources.md)).
-2. ArrayRecord dataset, when hosted on GCS bucket, can only be read through [Cloud Storage FUSE](https://cloud.google.com/storage/docs/gcs-fuse). The installation of Cloud Storage FUSE is included in [setup.sh](https://github.com/google/maxtext/blob/main/setup.sh). User then needs to mount the GCS bucket to a local path for each worker, using the script [setup_gcsfuse.sh](https://github.com/google/maxtext/blob/main/setup_gcsfuse.sh). The script configs some parameters for the mount.
+1. Grain currently supports two data formats: [ArrayRecord](https://github.com/google/array_record) (random access) and [Parquet](https://arrow.apache.org/docs/python/parquet.html) (partial random-access through row group). Only ArrayRecord format supports global shuffle mentioned above. For converting a dataset into ArrayRecord, see [instructions](https://github.com/google/array_record/tree/main/beam). Additionally, other random accessible data sources can be supported via a custom data source class ([docs](https://github.com/google/grain/blob/main/docs/data_sources.md)).
+2. When the dataset is hosted on GCS bucket, grain can read it through [Cloud Storage FUSE](https://cloud.google.com/storage/docs/gcs-fuse). The installation of Cloud Storage FUSE is included in [setup.sh](https://github.com/google/maxtext/blob/main/setup.sh). User then needs to mount the GCS bucket to a local path for each worker, using the script [setup_gcsfuse.sh](https://github.com/google/maxtext/blob/main/setup_gcsfuse.sh). The script configs some parameters for the mount.
 ```
 bash setup_gcsfuse.sh DATASET_GCS_BUCKET=$BUCKET_NAME MOUNT_PATH=$MOUNT_PATH [FILE_PATH=$MOUNT_PATH/my_dataset]
 # FILE_PATH is optional, when provided, the script runs "ls -R" for pre-filling the metadata cache
@@ -110,6 +110,7 @@ MOUNT_PATH=/tmp/gcsfuse && \
 python3 -m MaxText.train MaxText/configs/base.yml \
 run_name=<RUN_NAME> base_output_directory=gs://<MY_BUCKET>  \
 dataset_type=grain \
+grain_file_type=arrayrecord \
 grain_train_files=/tmp/gcsfuse/array-record/c4/en/3.0.1/c4-train.array_record* \
 grain_worker_count=2
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ google-cloud-storage
 google-cloud-monitoring
 google-api-core
 google-api-python-client
-grain-nightly
+grain[parquet]>=0.2.6
 flax>=0.8.0
 ml-collections
 ml-goodput-measurement==0.0.8

--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -3,7 +3,7 @@
 absl-py
 aqtp==0.8.2
 datasets
-grain-nightly>=0.0.10
+grain[parquet]>=0.2.6
 ml-goodput-measurement==0.0.8
 orbax-checkpoint>=0.10.3
 pylint


### PR DESCRIPTION
# Description

* Usage demo of using grain with parquet files
* migrate grain to the recommended lazy data API
* refactor grain to separate pretrain and dpo preprocessing pipelines

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
