### PR TITLE
Increase Llama3.1-70B and Llama2-70B benchmark batch sizes

### DIFF
--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -417,7 +417,7 @@ llama2_70b_4096_sc = _add_to_model_dictionary(
         model_name="llama2-70b-4096-sc",
         model_type="llama2-70b",
         tuning_params={
-            "per_device_batch_size": 2,
+            "per_device_batch_size": 3,
             "ici_fsdp_parallelism": 1,
             "ici_fsdp_transpose_parallelism": -1,
             "ici_tensor_parallelism": 1,
@@ -939,7 +939,7 @@ llama3_1_70b_8192 = _add_to_model_dictionary(
         model_name="llama3_1-70b-8192",
         model_type="llama3.1-70b",
         tuning_params={
-            "per_device_batch_size": 4,
+            "per_device_batch_size": 5,
             "ici_fsdp_parallelism": -1,
             "remat_policy": "custom",
             "decoder_layer_input": "offload",


### PR DESCRIPTION
# Description

Increase Llama3.1-70B and Llama2-70B batch sizes. Saw a good perf increase on LLama2-70B and a very slight perf increase on Llama3.1-70B with these changes.
* LLama2-70B: 402 -> 435 TFLOPs
* Llama3.1-70B: 458 -> 461 TFLOPs

# Tests

Ran the following tpu-recipes:

### [Llama2-70B](https://github.com/AI-Hypercomputer/tpu-recipes/tree/af2a7cd202de19e689504eec3e86c02bda527375/training/trillium/Llama2-70B-MaxText)
```
python3 benchmarks/benchmark_runner.py xpk \
    --project=$PROJECT \
    --zone=$ZONE \
    --device_type=v6e-256 \
    --num_slices=1  \
    --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="llama2_70b_4096_sc" \
    --base_docker_image=maxtext_base_image
```
### [Llama3.1-70B](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/training/trillium/Llama3.1-70B-MaxText)
```
python3 benchmarks/benchmark_runner.py xpk \
    --project=$PROJECT \
    --zone=$ZONE \
    --device_type=v6e-256 \
    --num_slices=1  \
    --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="llama3_1_70b_8192" \
    --base_docker_image=maxtext_base_image
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
