### PR TITLE
New Goodput Flags for flexibility

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -568,6 +568,8 @@ goodput_upload_interval_seconds: 30
 enable_pathways_goodput: False
 monitor_step_time_deviation: True
 step_deviation_interval_seconds: 30
+enable_gcp_goodput_metrics: True
+enable_gcp_step_deviation_metrics: True
 
 # GCP workload monitoring
 report_heartbeat_metric_for_gcp_monitoring: False

--- a/MaxText/elastic_train.py
+++ b/MaxText/elastic_train.py
@@ -485,6 +485,17 @@ def main(argv: Sequence[str]) -> None:
 
   if config.monitor_goodput and jax.process_index() == 0:
     logger_name = f"goodput_{config.run_name}"
+    # Workload monitoring and Goodput monitoring both uses /workload/performance
+    # GCM metric to publish step_time and step_deviation metrics. For now, we
+    # will disable publishing step deviation metrics to GCM if workload
+    # monitoring is enabled. Will reconcile this in the future.
+    if config.report_performance_metric_for_gcp_monitoring:
+      config.enable_gcp_step_deviation_metrics = False
+
+    gcp_options = monitoring.GCPOptions(
+        enable_gcp_goodput_metrics=config.enable_gcp_goodput_metrics,
+        enable_gcp_step_deviation_metrics=config.enable_gcp_step_deviation_metrics,
+    )
     goodput_monitor = monitoring.GoodputMonitor(
         job_name=config.run_name,
         logger_name=logger_name,
@@ -495,12 +506,13 @@ def main(argv: Sequence[str]) -> None:
         include_badput_breakdown=True,
         include_step_deviation=config.monitor_step_time_deviation,
         step_deviation_interval_seconds=config.step_deviation_interval_seconds,
+        gcp_options=gcp_options,
     )
     goodput_monitor.start_goodput_uploader()
-    max_logging.log("Started Goodput upload to Tensorboard in the background!")
+    max_logging.log("Started Goodput upload to Tensorboard & GCM in the background!")
     if config.monitor_step_time_deviation:
       goodput_monitor.start_step_deviation_uploader()
-      max_logging.log("Started step time deviation upload to Tensorboard in the background!")
+      max_logging.log("Started step time deviation upload to Tensorboard & GCM in the background!")
   debug_config = debug_configuration.DebugConfig(
       stack_trace_config=stack_trace_configuration.StackTraceConfig(
           collect_stack_trace=config.collect_stack_trace,

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -998,6 +998,17 @@ def main(argv: Sequence[str]) -> None:
 
   if config.monitor_goodput and jax.process_index() == 0:
     logger_name = f"goodput_{config.run_name}"
+    # Workload monitoring and Goodput monitoring both uses /workload/performance
+    # GCM metric to publish step_time and step_deviation metrics. For now, we
+    # will disable publishing step deviation metrics to GCM if workload
+    # monitoring is enabled. Will reconcile this in the future.
+    if config.report_performance_metric_for_gcp_monitoring:
+      config.enable_gcp_step_deviation_metrics = False
+
+    gcp_options = monitoring.GCPOptions(
+        enable_gcp_goodput_metrics=config.enable_gcp_goodput_metrics,
+        enable_gcp_step_deviation_metrics=config.enable_gcp_step_deviation_metrics,
+    )
     goodput_monitor = monitoring.GoodputMonitor(
         job_name=config.run_name,
         logger_name=logger_name,
@@ -1008,12 +1019,13 @@ def main(argv: Sequence[str]) -> None:
         include_badput_breakdown=True,
         include_step_deviation=config.monitor_step_time_deviation,
         step_deviation_interval_seconds=config.step_deviation_interval_seconds,
+        gcp_options=gcp_options,
     )
     goodput_monitor.start_goodput_uploader()
-    max_logging.log("Started Goodput upload to Tensorboard in the background!")
+    max_logging.log("Started Goodput upload to Tensorboard & GCM in the background!")
     if config.monitor_step_time_deviation:
       goodput_monitor.start_step_deviation_uploader()
-      max_logging.log("Started step time deviation upload to Tensorboard in the background!")
+      max_logging.log("Started step time deviation upload to Tensorboard & GCM in the background!")
   debug_config = debug_configuration.DebugConfig(
       stack_trace_config=stack_trace_configuration.StackTraceConfig(
           collect_stack_trace=config.collect_stack_trace,

--- a/getting_started/Monitor_Goodput.md
+++ b/getting_started/Monitor_Goodput.md
@@ -151,52 +151,30 @@ goodput_monitor = monitoring.GoodputMonitor(
 If you do not wish to send metrics to Google Cloud Monitoring then please set
 the flag `enable_gcp_goodput_metrics` to `False` for disabling goodput metrics
 and `enable_gcp_step_deviation_metrics` to `False` for disabling step deviation
-metrics while creating the GCPOptions object.
+metrics.
 
-Setting `monitoring_enabled` to `False` will disable both tensorboard and GCM
+```Python
+python3 -m MaxText.train MaxText/configs/base.yml base_output_directory=$OUTPUT_PATH dataset_path=$DATA_PATH run_name=goodput-test-run steps=200 goodput_upload_interval_seconds=30 enable_gcp_goodput_metrics=False enable_gcp_step_deviation_metrics=False
+```
+
+Setting `monitor_goodput` to `False` will disable both tensorboard and GCM
 monitoring.
 
-```python
-
-gcp_options = goodput_utils.GCPOptions(
-      project_id=None, # If None, the library will automatically identify from GCE internal metadata
-      location=None, # If None, the library will automatically identify from GCE internal metadata
-      replica_id='0', # Default is '0'
-      acc_type=None, # If None, the library will automatically identify from GCE internal metadata
-      enable_gcp_goodput_metrics=False,
-      enable_gcp_step_deviation_metrics=False,
-    )
-
-
-goodput_monitor = monitoring.GoodputMonitor(
-      job_name=config.run_name,
-      logger_name=logger_name,
-      tensorboard_dir=config.tensorboard_dir,
-      upload_interval=config.goodput_upload_interval_seconds,
-      monitoring_enabled=True,
-      include_badput_breakdown=True,
-      include_step_deviation=True,
-      configured_ideal_step_time=None,
-      gcp_options=gcp_options,
-    )
-```
-#### Monitoring Dashboards
-
-Goodput, Badput and Step Time Deviation metrics can be visualized using GCM dashboards:
-
-1. Navigate to your projects Google Cloud Monitoring `Dashboards` page.
-2. Create a Custom Dashboard if you do not have one already, and select the [metrics](https://cloud.google.com/monitoring/api/metrics_gcp) you want to monitor.
-   - compute.googleapis.com/workload/goodput_time (Goodput)
-   - compute.googleapis.com/workload/badput_time (Badput Breakdown)
-   - compute.googleapis.com/workload/performance (Step Time Deviation)
-
-
-#### Monitoring Raw Metrics
+#### Monitoring Raw Metrics and Dashboards
 
 Goodput, Badput and Step Time Deviation metrics can be monitored using GCM Metrics Explorer:
 
-1. Navigate to your projects Google Cloud Monitoring `Metrics Explorer` page.
-2. Select the [metrics](https://cloud.google.com/monitoring/api/metrics_gcp) you want to monitor:
-   - compute.googleapis.com/workload/goodput_time (Goodput)
-   - compute.googleapis.com/workload/badput_time (Badput Breakdown)
-   - compute.googleapis.com/workload/performance (Step Time Deviation)
+1.  Verify that the workload is executing with monitoring enabled. This ensures automatic data ingestion into Google Cloud Monitoring.
+2.  Navigate to [Metrics Explorer](https://console.cloud.google.com/monitoring/metrics-explorer). Initiate metric selection by clicking `Select a metric` then search for and select the `Workload` resource. Subsequently, choose the `Workload` metric category.
+
+    a.  [**Productive Time:**](https://cloud.google.com/monitoring/api/metrics_gcp#:~:text=workload/goodput_time)
+    Represents the cumulative duration the workload spent on productive tasks,
+    measured by `compute.googleapis.com/workload/goodput_time`.  
+    b.  [**Non-Productive Time:**](https://cloud.google.com/monitoring/api/metrics_gcp#:~:text=workload/badput_time)
+    Represents the cumulative duration the workload spent on non-productive tasks,
+    measured by `compute.googleapis.com/workload/badput_time`.  
+    c.  [**Performance:**](https://cloud.google.com/monitoring/api/metrics_gcp#:~:text=workload/performance)
+    Represents the workload's performance metric, specifically step deviation
+    in this context, measured by `compute.googleapis.com/workload/performance`.  
+3.  Navigate to [Dashboards](https://console.cloud.google.com/monitoring/dashboards).
+4.  Create a custom dashboard if there isn't one and add useful widgets with the above mentioned metrics.


### PR DESCRIPTION
# Description

- New flags `enable_gcp_goodput_metrics` and `enable_gcp_step_deviation_metrics` that publishes goodput and step time deviation data to GCM for flexibility
- Workaround for b/409244592 
- Updated relevant docs

# Tests

Logs: https://cloudlogging.app.goo.gl/uE6aEzjmPTkGxqJw6
E2E on TPU: https://screenshot.googleplex.com/BZrMNqyKApboqLM
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
