### PR TITLE
Change the FP8 dot from fake quantization to direct quantization op

### DIFF
--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -204,7 +204,7 @@ class Fp8Quantization(Quantization):
 
   def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
     """Returns dot_general configured with aqt params."""
-    return nn.Fp8DotGeneralOp
+    return nn.Fp8DirectDotGeneralOp
 
   def einsum(self, dtype: DType = jnp.float32):
     return Fp8Einsum(dtype=dtype)


### PR DESCRIPTION
Currently the FP8 dot in maxtext is using `Fp8DotGeneralOp` which is a fake quantization pattern for FP8 dot product. This pattern is not trivial to capture in the XLA compiler and could silently fall back to high precision if the pattern was broken.
The preferred API for FP8 dot product is now changed to [`Fp8DirectDotGeneralOp`](https://github.com/google/flax/blob/e58aeea9286f891b2f210dc84363986e93fdb255/flax/linen/fp8_ops.py#L642) in flax, which ensures the FP8 GEMM is emitted during the XLA compilation. 


- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.