### PR TITLE
Explicitly add pad_token_id attribute to HF tokenizer if not present

### DIFF
--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -1254,7 +1254,13 @@ class MaxEngine(engine_api.Engine):
     elif metadata.tokenizer_type == TokenizerType.sentencepiece:
       return token_utils.SentencePieceTokenizer(metadata)
     elif metadata.tokenizer_type == TokenizerType.huggingface:
-      return token_utils.HuggingFaceTokenizer(metadata)
+      tokenizer_model = token_utils.HuggingFaceTokenizer(metadata)
+      if tokenizer_model.tokenizer.pad_token_id is None:
+        if tokenizer_model.tokenizer.unk_token_id is not None:
+          tokenizer_model.tokenizer.pad_token_id = tokenizer_model.tokenizer.unk_token_id
+        else:
+          tokenizer_model.tokenizer.pad_token_id = -1
+      return tokenizer_model
     else:
       raise ValueError(f"Unsupported tokenizer type: {metadata.tokenizer_type}")
 

--- a/end_to_end/tpu/test_sft_trainer.sh
+++ b/end_to_end/tpu/test_sft_trainer.sh
@@ -51,7 +51,7 @@ PROMPT="<user>${PROMPT}</user> <assistant>"
 # Decode
 python3 -m MaxText.decode MaxText/configs/sft.yml \
     run_name=${RUN_NAME}-hf-decode \
-    model_name=${PRE_TRAINED_MODEL} tokenizer_path=${PRE_TRAINED_MODEL_TOKENIZER} \
+    model_name=${PRE_TRAINED_MODEL} tokenizer_path=${PRE_TRAINED_MODEL_TOKENIZER} tokenizer_type=huggingface \
     load_parameters_path=${FINE_TUNED_MODEL_CKPT_PATH} \
     per_device_batch_size=${PER_DEVICE_BATCH_SIZE} max_target_length=128 max_prefill_predict_length=64 \
     attention=dot_product decode_sampling_strategy=greedy prompt="${PROMPT}"


### PR DESCRIPTION
# Description
Recently, support for HF tokenizer was added to [Jetstream](https://github.com/AI-Hypercomputer/JetStream/pull/229) and [maxengine](https://github.com/AI-Hypercomputer/maxtext/pull/1439). `decode.py` would fail if a user will try to run inference using a HF tokenizer that doesn't have `pad_token_id` attribute. This issue was identified when we run decode on SFT fine-tuned model using `meta-llama/Llama-2-7b-hf`. SFT trainer works only for HF tokenizer and if we use the same HF tokenizer for decode, then it would fail.

This PR explicitly adds a `pad_token_id` to the tokenizer if it is not present to handle this case. This is similar to how HF data pipeline adds a pad token id to HF tokenizer: https://github.com/AI-Hypercomputer/maxtext/blob/main/MaxText/input_pipeline/_hf_data_processing.py#L99.


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
```
python3 -m MaxText.decode MaxText/configs/sft.yml run_name=sft-2025-04-07-10-02-04-hf-decode model_name=llama2-7b tokenizer_path=meta-llama/Llama-2-7b-hf load_parameters_path=gs://ml-auto-solutions/output/maxtext_sft_trainer/sft-2025-04-07-10-02-04-hf/checkpoints/2499/items per_device_batch_size=1 max_target_length=128 max_prefill_predict_length=64 attention=dot_product decode_sampling_strategy=greedy 'prompt=<user>Suggest some famous landmarks in London.</user> <assistant>' tokenizer_type=huggingface
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
