### PR TITLE
Llama 4 chunked attention

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -215,8 +215,9 @@ param_scan_axis: 1
 # The attention parameter dictates the specific algorithm/methodology used to compute the attention scores
 # The attention_type parameter determines the variants of attention, e.g. global or local_sliding
 attention: 'autoselected' # Supported attention: autoselected, dot_product, flash, cudnn_flash_te
-attention_type: 'global' # Supported attention_type: global, local_sliding, mla
+attention_type: 'global' # Supported attention_type: global, local_sliding, chunk, mla
 sliding_window_size: 0
+chunk_attn_window_size: 0
 attn_logits_soft_cap: 0.0
 final_logits_soft_cap: 0.0
 use_post_attn_norm: False

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -82,6 +82,29 @@ def validate_attention_type(s: str) -> None:
     raise ValueError("Invalid attention type was passed. Valid options ", valid_attention_types)
 
 
+def validate_attention_window_params(
+    attention_type: str,
+    chunk_attn_window_size: int,
+    sliding_window_size: int,
+) -> None:
+  """
+  Validates window size parameters for attention types 'chunk' and 'local'.
+  """
+  if attention_type == AttentionType.CHUNK.value:
+    # Validate chunk_attn_window_size for 'chunk' attention
+    if not isinstance(chunk_attn_window_size, int) or chunk_attn_window_size <= 0:
+      raise ValueError(
+          f"When attention_type is 'chunk', chunk_attn_window_size must be an integer greater than 0. "
+          f"Got: {chunk_attn_window_size}"
+      )
+  elif attention_type == AttentionType.LOCAL_SLIDING.value:
+    if not isinstance(sliding_window_size, int) or sliding_window_size <= 0:
+      raise ValueError(
+          f"When attention_type is 'local', sliding_window_size must be an integer greater than 0. "
+          f"Got: {sliding_window_size}"
+      )
+
+
 def validate_profiler_type(s: str) -> None:
   valid_profiler_types = ("", "nsys", "xplane")
   if s not in valid_profiler_types:  # currently supported attention
@@ -125,6 +148,9 @@ def validate_rope_type(rope_type: str) -> None:
 def validate_keys(keys):
   validate_attention_kernel(keys["attention"])
   validate_attention_type(keys["attention_type"])
+  validate_attention_window_params(
+      keys["attention_type"], keys.get("chunk_attn_window_size"), keys.get("sliding_window_size")
+  )
   validate_profiler_type(keys["profiler"])
   validate_periodic_profiler(keys["profiler"], keys["profile_periodically_period"], keys["profiler_steps"])
   validate_compute_axis_order(keys["compute_axis_order"])

--- a/MaxText/tests/attention_test.py
+++ b/MaxText/tests/attention_test.py
@@ -19,6 +19,7 @@ import random
 import sys
 import unittest
 import os.path
+import numpy as np
 from absl.testing import parameterized
 
 from MaxText import common_types
@@ -35,7 +36,97 @@ from MaxText.layers import attentions
 
 Mesh = jax.sharding.Mesh
 Attention = attentions.Attention
+ChunkedCausalMask = attentions.ChunkedCausalMask
 MLA = attentions.MLA
+
+
+class ChunkedCausalMaskTest(unittest.TestCase):
+  """Test for the ChunkedCausalMask."""
+
+  def test_basic_chunking(self):
+    """Tests the mask with a simple chunk size."""
+    seq_len = 8
+    chunk_size = 4
+    mask = ChunkedCausalMask(shape=(seq_len, seq_len), chunk_size=chunk_size)
+
+    # Manually compute the expected mask
+    # Causal within chunks (0-3, 4-7)
+    expected_mask = np.zeros((seq_len, seq_len), dtype=np.bool_)
+    for r in range(seq_len):
+      for c in range(seq_len):
+        q_chunk = r // chunk_size
+        kv_chunk = c // chunk_size
+        if q_chunk == kv_chunk and r >= c:
+          expected_mask[r, c] = True
+
+    # Get the actual mask by slicing
+    actual_mask = mask[:, :]
+
+    np.testing.assert_array_equal(actual_mask, expected_mask)
+    # Make sure _generate_chunk_attention_mask also produces the same mask
+    actual_mask = attentions._generate_chunk_attention_mask(mask_shape=mask.shape, chunk_size=chunk_size)
+    np.testing.assert_array_equal(actual_mask, expected_mask)
+
+  def test_full_length_chunk(self):
+    """Tests when chunk size equals sequence length (should be causal)."""
+    seq_len = 6
+    chunk_size = 6  # Same as seq_len
+    mask = ChunkedCausalMask(shape=(seq_len, seq_len), chunk_size=chunk_size)
+
+    # Expected mask is a standard lower triangular causal mask
+    expected_mask = np.tril(np.ones((seq_len, seq_len), dtype=np.bool_))
+
+    actual_mask = mask[:, :]
+    np.testing.assert_array_equal(actual_mask, expected_mask)
+    # Make sure _generate_chunk_attention_mask also produces the same mask
+    actual_mask = attentions._generate_chunk_attention_mask(mask_shape=mask.shape, chunk_size=chunk_size)
+    np.testing.assert_array_equal(actual_mask, expected_mask)
+
+  def test_single_token_chunk(self):
+    """Tests when chunk size is 1 (only attend to self)."""
+    seq_len = 5
+    chunk_size = 1
+    mask = ChunkedCausalMask(shape=(seq_len, seq_len), chunk_size=chunk_size)
+
+    # Expected mask is just the identity matrix
+    expected_mask = np.eye(seq_len, dtype=np.bool_)
+
+    actual_mask = mask[:, :]
+    np.testing.assert_array_equal(actual_mask, expected_mask)
+    # Make sure _generate_chunk_attention_mask also produces the same mask
+    actual_mask = attentions._generate_chunk_attention_mask(mask_shape=mask.shape, chunk_size=chunk_size)
+    np.testing.assert_array_equal(actual_mask, expected_mask)
+
+  def test_non_square_shape(self):
+    """Tests with different query and key sequence lengths."""
+    q_len = 6
+    kv_len = 8
+    chunk_size = 3
+    mask = ChunkedCausalMask(shape=(q_len, kv_len), chunk_size=chunk_size)
+
+    # Manually compute expected mask
+    expected_mask = np.zeros((q_len, kv_len), dtype=np.bool_)
+    for r in range(q_len):
+      for c in range(kv_len):
+        q_chunk = r // chunk_size
+        kv_chunk = c // chunk_size
+        if q_chunk == kv_chunk and r >= c:
+          expected_mask[r, c] = True
+
+    actual_mask = mask[:, :]
+    np.testing.assert_array_equal(actual_mask, expected_mask)
+    # Make sure _generate_chunk_attention_mask also produces the same mask
+    actual_mask = attentions._generate_chunk_attention_mask(mask_shape=mask.shape, chunk_size=chunk_size)
+    np.testing.assert_array_equal(actual_mask, expected_mask)
+
+  def test_value_error_on_zero_chunk_size(self):
+    """Tests that a ValueError is raised for chunk_size <= 0."""
+    with self.assertRaises(ValueError):
+      ChunkedCausalMask(shape=(4, 4), chunk_size=0)
+    with self.assertRaises(ValueError):
+      ChunkedCausalMask(shape=(4, 4), chunk_size=-2)
+    with self.assertRaises(ValueError):
+      attentions._generate_chunk_attention_mask(mask_shape=(4, 4), chunk_size=0)
 
 
 class AttentionTest(unittest.TestCase):


### PR DESCRIPTION
# Description

Llama 4 has [Chunked Attention](https://github.com/huggingface/transformers/blob/08e3217bafddc5d11ce0e7369bcfaaabe5501ba5/src/transformers/models/llama4/modeling_llama4.py#L828) which we need to support in MaxText.

create_chunked_attention_mask tokens (0, K), (K, 2K), (2K, 3K) attend to each other when doing local chunked attention.

# Tests
Added Tests for chunked attention

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.