### PR TITLE
Disable bq uploading for on-device runner as it's not supported yet

### DIFF
--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -306,7 +306,9 @@ def main() -> None:
       libtpu_type=libtpu_type,
       libtpu_nightly_version=options.libtpu_version,
       run_name=options.run_name,
-      pathways_config=pw_config
+      pathways_config=pw_config,
+      # Internal only support, not for customers
+      generate_metrics_and_upload_to_big_query=False,
     )
     on_device_benchmark_runner(workload_configs=[workload_config])
 

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -114,6 +114,10 @@ class WorkloadConfig:
 
   def __post_init__(self):
     """Initializes num_devices_per_slice and topology for recording the run into BigQuery"""
+    if not self.generate_metrics_and_upload_to_big_query:
+      return
+    if self.device_type is None:
+      raise ValueError(f"device_type is None and generate_metrics_and_upload_to_big_query is enabled. Device_type is required for uploading run results to BigQuery")
     if self.device_type.startswith("v6e") or self.device_type.startswith("v5e") or self.device_type.startswith("v5litepod"):
       size = int(self.device_type.split("-")[-1])
       if size == 256:


### PR DESCRIPTION
# Description

Turning off BigQuery uploading when using on-device runner as it's not supported yet to unblock nightly XLML tests http://b/407541014.

# Tests

Ran XLML test in local Composer env.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
