### PR TITLE
Fix imports for inference_utils

### DIFF
--- a/MaxText/llama_or_mistral_ckpt.py
+++ b/MaxText/llama_or_mistral_ckpt.py
@@ -38,7 +38,7 @@ import re
 import logging
 import json
 from dataclasses import dataclass
-from inference_utils import str2bool
+from safetensors import safe_open
 
 os.environ["JAX_PLATFORMS"] = "cpu"
 
@@ -50,11 +50,11 @@ import torch
 import psutil
 from tqdm import tqdm
 
+from MaxText import checkpointing
 from MaxText import max_logging
 from MaxText import max_utils
+from MaxText.inference_utils import str2bool
 from MaxText.train import save_checkpoint
-from MaxText import checkpointing
-from safetensors import safe_open
 from MaxText.utils import gcs_utils
 
 MODEL_PARAMS_DICT = {

--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -26,7 +26,7 @@ import argparse
 import os
 import time
 
-from inference_utils import str2bool
+from MaxText.inference_utils import str2bool
 from maxtext_trillium_model_configs import trillium_model_dict
 from maxtext_v5e_model_configs import v5e_model_dict
 from maxtext_xpk_runner import PathwaysConfig


### PR DESCRIPTION
# Description
This PR fixes the import for `inference_utils` module. Two of the modules in MaxText were incorrectly importing `inference_utils`.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
```
python3 -m MaxText.llama_or_mistral_ckpt --base-model-path /tmp/meta-ckpt --model-size llama2-7b --maxtext-model-path gs://maxtext-llama/test/2025-04-09-04-15/decode-ckpt-maxtext
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
