### PR TITLE
scale_factor configurable for cudnn attention. 

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -632,6 +632,9 @@ class AttentionOp(nn.Module):
       mask_type = "padding_causal"  # only padding_causal mask type can take a created mask
       attn_mask = self.generate_attention_mask(query, key, decoder_segment_ids, model_mode)
 
+    # for cudnn version only, weight already folding scaling.
+    scale_factor = 1
+
     dpa_layer = DotProductAttention(
         head_dim=head_dim,
         num_attention_heads=self.num_query_heads,
@@ -643,7 +646,7 @@ class AttentionOp(nn.Module):
         dtype=self.dtype,
         float32_logits=self.float32_logits,
         qkv_layout="BSHD_BSHD_BSHD",  # 'BS3HD', 'BSHD_BS2HD' or 'BSHD_BSHD_BSHD'
-        scale_factor=1.0 / math.sqrt(head_dim),
+        scale_factor=scale_factor,
         transpose_batch_sequence=False,
         window_size=sliding_window_size,
     )

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -273,7 +273,7 @@ class AttentionOp(nn.Module):
   use_ragged_attention: bool = False
   ragged_block_size: int = 256
 
-  scale_factor: float = 1
+  scale_factor: float = 1  # scaling factor for query in attention. currently used in cudnn only.
 
   def check_attention_inputs(self, query: Array, key: Array | KVTensor, value: Array | KVTensor) -> None:
     """Check attention inputs."""
@@ -637,9 +637,9 @@ class AttentionOp(nn.Module):
 
     # scaling factor for fused query weight or not
     if self.scale_factor is None:
-        scale_factor = 1.0 / sqrt(query.shape[-1])
+      scale_factor = 1.0 / jnp.sqrt(query.shape[-1])
     else:
-        scale_factor = self.scale_factor
+      scale_factor = self.scale_factor
 
     dpa_layer = DotProductAttention(
         head_dim=head_dim,

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -612,7 +612,6 @@ class AttentionOp(nn.Module):
       query: Array,
       key: Array,
       value: Array,
-      scale_factor: float | None,
       decoder_segment_ids: Array | None,
       model_mode: str = common_types.MODEL_MODE_TRAIN,
   ) -> Array:


### PR DESCRIPTION
# Description
GPU correctness tests are failing due to an issue with fused query weights. The fix is to set their scale_factor to 1.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/404877511

# Tests

1. verified with llama3.1 405b checkpoint with correct eval loss.
2. will add MaxText/tests/forward_pass_logit_checker.py for llama2-70b on GPU on later PR.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
