### PR TITLE
Fix benchmark imports after recent refactor

### DIFF
--- a/benchmarks/Getting_Started_Benchmarking.md
+++ b/benchmarks/Getting_Started_Benchmarking.md
@@ -14,7 +14,7 @@ Two approaches are here:
 CLUSTER=my-cluster
 ZONE=my-zone
 PROJECT=my-project
-python3 benchmarks/benchmark_runner.py xpk --project $PROJECT --zone $ZONE --cluster_name $CLUSTER --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5
+python3 -m benchmarks.benchmark_runner xpk --project $PROJECT --zone $ZONE --cluster_name $CLUSTER --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5
 ```
 
 ```shell
@@ -23,13 +23,13 @@ export RUNNER=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/maxtext_jax_sta
 export PROXY_IMAGE=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/proxy_server:latest
 export SERVER_IMAGE=us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/server:latest
 
-python3 benchmarks/benchmark_runner.py xpk --project $PROJECT --zone $ZONE --cluster_name $CLUSTER --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5 --pathways_server_image="${SERVER_IMAGE}" --pathways_proxy_server_image="${PROXY_IMAGE}" --pathways_runner_image="${RUNNER}"
+python3 -m benchmarks.benchmark_runner xpk --project $PROJECT --zone $ZONE --cluster_name $CLUSTER --device_type v6e-256 --base_output_directory gs://maxtext-experiments-tpem/ --num_steps=5 --pathways_server_image="${SERVER_IMAGE}" --pathways_proxy_server_image="${PROXY_IMAGE}" --pathways_runner_image="${RUNNER}"
 ```
 
 ```shell
 # On-device
 # Run model benchmark on current device (must run same command on all workers).
-python3 benchmarks/benchmark_runner.py on-device --base_output_directory gs://maxtext-experiments-tpem/ --run_name="test-run" --num_steps=5
+python3 -m benchmarks.benchmark_runner on-device --base_output_directory gs://maxtext-experiments-tpem/ --run_name="test-run" --num_steps=5
 ```
 
 - **maxtext_xpk_runner.py**: A pythonic way to run xpk workloads! With the magic of for looping and python code, run several xpk workloads across a sweep of parameters including libtpu version, gke clusters, and maxtext parameters with one python script.

--- a/benchmarks/benchmark_db_utils.py
+++ b/benchmarks/benchmark_db_utils.py
@@ -22,7 +22,7 @@ import uuid
 import dataclasses
 from tempfile import gettempdir
 
-from command_utils import run_command_with_updates
+from benchmarks.command_utils import run_command_with_updates
 from argparse import Namespace
 
 BQ_WRITER_PATH = "/benchmark-automation/benchmark_db_writer/src"

--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -27,14 +27,14 @@ import os
 import time
 
 from MaxText.inference_utils import str2bool
-from maxtext_trillium_model_configs import trillium_model_dict
-from maxtext_v5e_model_configs import v5e_model_dict
-from maxtext_xpk_runner import PathwaysConfig
-from maxtext_xpk_runner import WorkloadConfig
-from maxtext_xpk_runner import xpk_benchmark_runner
-from maxtext_xpk_runner import on_device_benchmark_runner
-from xpk_configs import XpkClusterConfig
-from maxtext_xpk_runner import LibTpuType
+from benchmarks.maxtext_trillium_model_configs import trillium_model_dict
+from benchmarks.maxtext_v5e_model_configs import v5e_model_dict
+from benchmarks.maxtext_xpk_runner import PathwaysConfig
+from benchmarks.maxtext_xpk_runner import WorkloadConfig
+from benchmarks.maxtext_xpk_runner import xpk_benchmark_runner
+from benchmarks.maxtext_xpk_runner import on_device_benchmark_runner
+from benchmarks.xpk_configs import XpkClusterConfig
+from benchmarks.maxtext_xpk_runner import LibTpuType
 
 def add_pathways_arguments(parser: argparse.ArgumentParser):
   """Add pathways arguments to arg parsers that need it.

--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -19,7 +19,7 @@ import dataclasses
 import os.path
 import typing
 from tempfile import gettempdir
-import xla_flags_library
+from benchmarks import xla_flags_library
 
 from benchmarks.globals import PKG_DIR
 

--- a/benchmarks/maxtext_v5e_model_configs.py
+++ b/benchmarks/maxtext_v5e_model_configs.py
@@ -14,8 +14,8 @@
 """Shared Benchmark config for v5e orchestrations."""
 
 import os.path
-import xla_flags_library
-from maxtext_trillium_model_configs import MaxTextModel, _add_to_model_dictionary
+from benchmarks import xla_flags_library
+from benchmarks.maxtext_trillium_model_configs import MaxTextModel, _add_to_model_dictionary
 from benchmarks.globals import PKG_DIR
 
 

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -36,15 +36,15 @@ import tempfile
 import threading
 import time
 
-import maxtext_trillium_model_configs as model_configs
-from command_utils import run_command_with_updates
-from benchmark_db_utils import DEFAULT_TUNING_PARAMS_FILE
+import benchmarks.maxtext_trillium_model_configs as model_configs
+from benchmarks.command_utils import run_command_with_updates
+from benchmarks.benchmark_db_utils import DEFAULT_TUNING_PARAMS_FILE
 
-import xla_flags_library as xla_flags
-from disruption_management.disruption_handler import DisruptionConfig
-from disruption_management.disruption_manager import DisruptionManager
+import benchmarks.xla_flags_library as xla_flags
+from benchmarks.disruption_management.disruption_handler import DisruptionConfig
+from benchmarks.disruption_management.disruption_manager import DisruptionManager
 from typing import Optional, List
-from xpk_configs import XpkClusterConfig
+from benchmarks.xpk_configs import XpkClusterConfig
 
 from MaxText.globals import PKG_DIR
 


### PR DESCRIPTION
# Description

Updating imports in the benchmarks directory after a [recent refactor](https://github.com/AI-Hypercomputer/maxtext/pull/1482/commits/70a609f390b57b60b8ab4da6a613e87cd0e8068a). Was previously seeing errors related to not finding the imports

# Tests

I can kick off the benchmark runner with this command now:

```
python3 -m benchmarks.benchmark_runner xpk  \
    --project=${PROJECT} \
    --zone=${ZONE} \
    --device_type=v6e-256 \
    --num_slices=1 \
     --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="mixtral_8x7b_dropped" \
    --base_docker_image=maxtext_base_image
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
