### PR TITLE
Fix if condition that saves checkpoint for the last step

### DIFF
--- a/MaxText/sft_trainer.py
+++ b/MaxText/sft_trainer.py
@@ -294,7 +294,7 @@ def train_loop(config, state=None):
       max_utils.print_mem_stats("After params initialized")
 
   if checkpoint_manager is not None:
-    if int(state.step) - 1 % config.checkpoint_period != 0:
+    if (int(state.step) - 1) % config.checkpoint_period != 0:
       try:
         if save_checkpoint(
             checkpoint_manager, int(state.step) - 1, state, config.dataset_type, data_iterator, config, force=True

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -911,7 +911,7 @@ def train_loop(config, state=None):
       max_utils.print_mem_stats("After params initialized")
 
   if checkpoint_manager is not None:
-    if int(state.step) - 1 % config.checkpoint_period != 0:
+    if (int(state.step) - 1) % config.checkpoint_period != 0:
       try:
         state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]
         if save_checkpoint(


### PR DESCRIPTION
# Description
This PR fixes an if condition that was added in [PR](https://github.com/AI-Hypercomputer/maxtext/pull/1443) to save the checkpoint for the last executed step. 

`int(state.step)-1` should be in parenthesis because `%` has higher precedence than `-`. Currently, 
`int(state.step) - 1 % config.checkpoint_period != 0` is executing `(int(state.step) - (1 % config.checkpoint_period)) != 0` which is same as `(int(state.step) - 1) != 0`. This will always return `True`.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
Ran training on a v4-8.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
