### PR TITLE
pin wheel version in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -43,7 +43,7 @@ rm -rf /var/lib/apt/lists/*
 EOF
 
 # We need to pin specific versions of setuptools, see b/402501203 for more.
-python3 -m pip install setuptools==65.5.0
+python3 -m pip install setuptools==65.5.0 wheel==0.45.1
 
 # Set environment variables
 for ARGUMENT in "$@"; do


### PR DESCRIPTION
# Description

fix the error mentioned in thread: https://chat.google.com/room/AAAA5hZCgEg/rIRI6_MqxJs
The wheel package comes with the image is 0.46.1, which is yanked (https://pypi.org/project/wheel/#history), need to re-install an older version

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
