### PR TITLE
Update XPK Docker config command to enable all repos

### DIFF
--- a/getting_started/Run_MaxText_via_xpk.md
+++ b/getting_started/Run_MaxText_via_xpk.md
@@ -48,7 +48,7 @@ gcloud auth login
 
 * Run this command to configure docker to use docker-credential-gcloud for GCR registries:
 ```
-gcloud auth configure-docker us-docker.pkg.dev
+gcloud auth configure-docker
 ```
 
 * Test the installation by running


### PR DESCRIPTION
# Description

Small documentation change to use `gcloud auth configure-docker` instead of `gcloud auth configure-docker us-docker.pkg.dev` when setting up Docker/XPK on a TPU VM. Ran into this XPK error when running with the old command:

```
denied: Unauthenticated request. Unauthenticated requests do not have permission "artifactregistry.repositories.uploadArtifacts" on resource "projects/tpu-prod-env-one-vm/locations/us/repositories/gcr.io" (or it may not exist)
[XPK] Task: `Upload Docker Image` terminated with code `1`
[XPK] Failed to upload docker image. You should be able to navigate to the URL gcr.io/tpu-prod-env-one-vm/bvandermoon-runner:agcs-2025-04-09-22-00-07 in tpu-prod-env-one-vm.
```

Note that the [XPK documentation](https://github.com/AI-Hypercomputer/xpk?tab=readme-ov-file#prerequisites) already recommends this command during setup.

# Tests

I was able to run XPK successfully through benchmark_runner.py after running this Docker config command.

```
python3 benchmarks/benchmark_runner.py xpk \
    --project=${PROJECT} \
    --zone=${ZONE} \
    --device_type=v6e-256 \
    --num_slices=1 \
    --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="mixtral_8x7b_dropped" \
    --base_docker_image=maxtext_base_image
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
