### PR TITLE
Update XPK path to not include full package directory

### DIFF
--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -13,7 +13,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  """
-from benchmarks.globals import PKG_DIR
 
 """ Script to run a benchmark/benchmarks on existing xpk or QR nodes (to be implemented)
                           ***** IMPORTANT *****
@@ -152,7 +151,7 @@ def add_xpk_runner_arguments(custom_parser: argparse.ArgumentParser):
   custom_parser.add_argument(
       '--xpk_path',
       type=str,
-      default=os.path.join(os.path.dirname(PKG_DIR), os.path.join("~", "xpk")),
+      default=os.path.join("~", "xpk"),
       help='path to xpk dir.',
   )
   custom_parser.add_argument(

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -99,7 +99,7 @@ class WorkloadConfig:
   num_steps: int = 20
   max_restarts: int = 0
   priority: str = 'medium'
-  xpk_path: str = os.path.join(os.path.dirname(PKG_DIR), os.path.join("~", "xpk"))
+  xpk_path: str = os.path.join("~", "xpk")
   pathways_config: PathwaysConfig = None
   run_name: str = None
   generate_metrics_and_upload_to_big_query: bool = True

--- a/benchmarks/recipes/pw_long_running_recipe.py
+++ b/benchmarks/recipes/pw_long_running_recipe.py
@@ -18,7 +18,6 @@ import datetime
 import sys
 import os
 import args_helper as helper
-from benchmarks.globals import PKG_DIR
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
@@ -40,7 +39,7 @@ COUNTRY = "us"
 DEVICE_TYPE = "v6e-256"
 
 # Other parameters (MUST BE SET BY USER)
-XPK_PATH = os.path.join(os.path.dirname(PKG_DIR), os.path.join("~", "xpk"))  # We're running this script from the maxtext directory
+XPK_PATH = os.path.join("~", "xpk")  # We're running this script from the maxtext directory
 USER = os.environ["USER"]
 BASE_OUTPUT_DIRECTORY = (
     f"gs://{USER}-{PROJECT}-{COUNTRY}/pw_mcjax_benchmarking/"

--- a/benchmarks/recipes/pw_mcjax_benchmark_recipe.py
+++ b/benchmarks/recipes/pw_mcjax_benchmark_recipe.py
@@ -13,7 +13,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  """
-from benchmarks.globals import PKG_DIR
 
 """Used to perf benchmarks between Pathways and McJax."""
 
@@ -43,7 +42,7 @@ COUNTRY = "us"
 DEVICE_TYPE = "v6e-256"
 
 # Other parameters (MUST BE SET BY USER)
-XPK_PATH = os.path.join(os.path.dirname(PKG_DIR), os.path.join("~", "xpk"))  # We're running this script from the maxtext directory
+XPK_PATH = os.path.join("~", "xpk")  # We're running this script from the maxtext directory
 USER = os.environ["USER"]
 BASE_OUTPUT_DIRECTORY = (
     f"gs://{USER}-{PROJECT}-{COUNTRY}/pw_mcjax_benchmarking/"

--- a/benchmarks/recipes/pw_mcjax_checkpoint_benchmark_recipe.py
+++ b/benchmarks/recipes/pw_mcjax_checkpoint_benchmark_recipe.py
@@ -13,7 +13,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  """
-from benchmarks.globals import PKG_DIR
 
 """Recipe to test checkpointing and restore for Pathways and McJax.
  The recipe will run synchronously and will run the benchmark steps for each
@@ -47,7 +46,7 @@ COUNTRY = "us"
 DEVICE_TYPE = "v6e-256"
 
 # Other parameters (MUST BE SET BY USER)
-XPK_PATH = os.path.join(os.path.dirname(PKG_DIR), os.path.join("~", "xpk"))  # We're running this script from the maxtext directory
+XPK_PATH = os.path.join("~", "xpk")  # We're running this script from the maxtext directory
 USER = os.environ["USER"]
 BASE_OUTPUT_DIRECTORY = (
     f"gs://{USER}-{PROJECT}-{COUNTRY}/pw_mcjax_benchmarking/"


### PR DESCRIPTION
# Description

Use `~/xpk/xpk.py` as the default `xpk_path` instead of a path with the full package directory like `/home/bvandermoon/workspace/maxtext/~/xpk/xpk.py`. This change is needed to make the benchmark_runner work after a [recent refactor](https://github.com/AI-Hypercomputer/maxtext/pull/1482).

I was getting an error when running the benchmark runner without this change:

```
Waiting for `bvand-mixtral-8x7b-1-041000-m6p`, for 0 seconds
python3: can't open file '/home/bvandermoon/workspace/maxtext/~/xpk/xpk.py': [Errno 2] No such file or directory
Task: `bvand-mixtral-8x7b-1-041000-m6p` terminated with code `2`
No monitoring threads found for workload 'bvand-mixtral-8x7b-1-041000-m6p'.
Unable to run xpk workload: {xpk_workload_name}
```

@shauryagup there are a few pathways files that look like they have this same issue. You may want to check if these files are still working for you and try this change if they are not:
* [pw_long_running_recipe.py](https://github.com/AI-Hypercomputer/maxtext/blob/da3acbd25eccce2f9e27e191bf53b6944ca7fe20/benchmarks/recipes/pw_long_running_recipe.py#L43)
* [pw_mcjax_checkpoint_benchmark_recipe.py](https://github.com/AI-Hypercomputer/maxtext/blob/da3acbd25eccce2f9e27e191bf53b6944ca7fe20/benchmarks/recipes/pw_mcjax_checkpoint_benchmark_recipe.py#L50)
* [pw_mcjax_benchmark_recipe.py](https://github.com/AI-Hypercomputer/maxtext/blob/da3acbd25eccce2f9e27e191bf53b6944ca7fe20/benchmarks/recipes/pw_mcjax_benchmark_recipe.py#L46)

# Tests

The benchmark runner schedules the workload after this change and I get a link to logs in the XPK output. 
### Seeing a different issue now where the actual workload does not run properly. I will keep debugging that.

```
python3 benchmarks/benchmark_runner.py xpk \
    --project=${PROJECT} \
    --zone=${ZONE} \
    --device_type=v6e-256 \
    --num_slices=1 \
    --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="mixtral_8x7b_dropped" \
    --base_docker_image=maxtext_base_image
```


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
