### PR TITLE
Update per-device batch size to 190, use inference.yml for inference by default, and use relative paths benchmarking scripts 

### DIFF
--- a/MaxText/inference_mlperf/llama_offline_run.sh
+++ b/MaxText/inference_mlperf/llama_offline_run.sh
@@ -83,6 +83,9 @@ then
   HF_CKPT="meta-llama/Llama-2-70b-chat-hf"
 fi
 
+if [[ -z ${MAXENGINE_CONFIG_FILEPATH} ]] ; then
+    MAXENGINE_CONFIG_FILEPATH="./MaxText/configs/base.yml"
+fi
 
 
 if [ -z "$MAXENGINE_ARGS" ];
@@ -122,6 +125,9 @@ fi
 export JAX_COMPILATION_CACHE_DIR="/tmp/jax_cache2"
 export LIBTPU_INIT_ARGS
 
+# Ensure working directory is at repository root.
+cd $(dirname $0)/../../
+
 run_loadgen() {
   OUTPUT_LOG_ID=llama70b-${run_name}-${DATASET_TYPE}-${LOADGEN_RUN_TYPE}-${LOADGEN_RUN_TYPE}_${LOADGEN_RUN_TIMESTAMP}
   OUTPUT_LOG_DIR=${DATA_DISK_DIR}/logs/${OUTPUT_LOG_ID}
@@ -136,7 +142,8 @@ run_loadgen() {
   echo "PREFILL_LENS_AND_PER_DEVICE_BATCH_SIZES: ${PREFILL_LENS_AND_PER_DEVICE_BATCH_SIZES}"
   echo "MAXENGINE_ARGS: ${MAXENGINE_ARGS}"
   echo
-  ${CMD} python3 -m offline_mode \
+  ${CMD} python3 -m MaxText.inference_mlperf.offline_mode \
+    --maxengine_config_filepath=${MAXENGINE_CONFIG_FILEPATH} \
     --mlperf_test_mode=${TEST_MODE} \
     --input_mode tokenized \
     --output_mode tokenized \
@@ -179,12 +186,12 @@ run_loadgen_accuracy () {
   # Eval Run
   if [ -e ${OUTPUT_ACCURACY_JSON_PATH} ]; then
     if [ "${FAST_EVAL:-false}" = "true" ] || "$fast_eval"; then
-      EVAL_SCRIPT="evaluate-accuracy-fast.py"
+      EVAL_SCRIPT="evaluate-accuracy-fast"
     else
-      EVAL_SCRIPT="evaluate-accuracy.py"
+      EVAL_SCRIPT="evaluate-accuracy"
     fi
     echo
-    ${CMD} python3 ${EVAL_SCRIPT} \
+    ${CMD} python3 -m MaxText.inference_mlperf.${EVAL_SCRIPT} \
       --checkpoint-path ${HF_CKPT} \
       --mlperf-accuracy-file ${OUTPUT_ACCURACY_JSON_PATH} \
       --dataset-file ${DATASET_PATH} 2>&1 | tee ${OUTPUT_LOG_DIR}/evaluate_offline_accuracy_log.log

--- a/MaxText/inference_mlperf/offline_mode.py
+++ b/MaxText/inference_mlperf/offline_mode.py
@@ -44,7 +44,7 @@ parent_dir = os.path.dirname(current_dir)
 sys.path.insert(0, parent_dir)
 
 from MaxText.maxengine import create_engine_from_config_flags
-import offline_inference
+from MaxText.inference_mlperf import offline_inference
 
 _MLPERF_ID = "llama2-70b"
 log = logging.getLogger(__name__)
@@ -180,6 +180,13 @@ flags.DEFINE_string(
     "Rename some of the dataset columns to whats expected by code. For example, "
     "mixtral dataset uses ref_token_length instead of ref_token_len. Format is a string dict "
     'eg. {"tok_input_len": "tok_input_length"}',
+    required=False,
+)
+
+flags.DEFINE_string(
+    "maxengine_config_filepath",
+    None,
+    "Base config filepath for initializing MaxEngine.",
     required=False,
 )
 
@@ -465,6 +472,7 @@ def main(argv):
     target_length = 2 * length
     log.info(f"Using batch size: {batch} and length: {length}")
     engine = create_engine_from_config_flags(
+        maxengine_config_filepath=FLAGS.maxengine_config_filepath,
         batch_size=batch,
         max_prefill_predict_length=length,
         max_target_length=target_length,

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -1395,7 +1395,7 @@ def set_engine_vars_from_base_engine(
   )
 
 
-def create_engine_from_config_flags(batch_size, max_prefill_predict_length, max_target_length, args_str):
+def create_engine_from_config_flags(maxengine_config_filepath, batch_size, max_prefill_predict_length, max_target_length, args_str):
   """Create new MaxEngine instance with given batch_size, prefill and target lengths, and any config
   params provided through `args_str`.
   """
@@ -1418,7 +1418,9 @@ def create_engine_from_config_flags(batch_size, max_prefill_predict_length, max_
     k, v = cmd_arg.split("=")
     args[k.strip()] = v.strip()
   assert "load_parameters_path" in args, "load_parameters_path must be defined"
-  updated_args = [os.path.join(PKG_DIR, "maxengine_server.py"), os.path.join(PKG_DIR, "configs", "base.yml")]
+  if maxengine_config_filepath is None:
+    maxengine_config_filepath = os.path.join(PKG_DIR, "configs", "base.yml")
+  updated_args = [os.path.join(PKG_DIR, "maxengine_server.py"), maxengine_config_filepath]
   for k, v in args.items():
     option = f"{k}={v}"
     updated_args.append(option)


### PR DESCRIPTION
Changes in this PR:
 - Change per device batch size to 190
 - Execute microbenchmark by module
 - Fix working directory module pathing for mlperf

# Description

Current H100 tests can support per-device batch size of 190, so we update the default to be 190 for current highest performance pre https://github.com/jax-ml/jax/issues/27817.

# Tests

Ran the tests and was able to confirm best performance using container from 2025-03-25.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
