### PR TITLE
Fix typo for module import

### DIFF
--- a/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
+++ b/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
@@ -28,7 +28,7 @@ gcsfuse --implicit-dirs maxtext-external "$PARAM_DIR"
 # alternatively: gcloud storage cp -r "gs://maxtext-external/$MODEL_NAME" /tmp
 
 # Convert it to MaxText(orbax) format - scanned ckpt
-JAX_PLATFORMS=cpu python3 -m MaxText.llama_or_mistral_ckpt.py --base-model-path="$PARAM_DIR/$MODEL_NAME" --model-size=mixtral-8x7b --maxtext-model-path=${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt/
+JAX_PLATFORMS=cpu python3 -m MaxText.llama_or_mistral_ckpt --base-model-path="$PARAM_DIR/$MODEL_NAME" --model-size=mixtral-8x7b --maxtext-model-path=${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt/
 echo "Wrote MaxText compatible scanned checkpoint to ${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt"
 
 # unmount the gcsfuse directory


### PR DESCRIPTION
# Description

change command to generate scanned checkpoint: update `MaxText.llama_or_mistral_ckpt.py` to `MaxText.llama_or_mistral_ckpt`

fix module import issue in test: https://screenshot.googleplex.com/3T9qRVFXbbCxivD

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
