### PR TITLE
Fix the last checkpoint not being skipped

### DIFF
--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -939,14 +939,14 @@ def train_loop(config, state=None):
         state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]
         if save_checkpoint(
             checkpoint_manager,
-            int(state_to_save) - 1,
+            int(state.step) - 1,
             state_to_save,
             config.dataset_type,
             data_iterator,
             config,
             force=True,
         ):
-          checkpointing.print_save_message(int(state_to_save) - 1, config.async_checkpointing)
+          checkpointing.print_save_message(int(state.step) - 1, config.async_checkpointing)
       except Exception:  # pylint: disable=broad-except
         max_logging.log(f"Checkpoint is already saved for step {int(state.step)-1}.")
 


### PR DESCRIPTION
# Description

Fixes `int() argument must be a string, a bytes-like object or a real number, not 'TrainState'`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
