### PR TITLE
Multimodal MaxText skeleton with Gemma3

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -677,3 +677,7 @@ enable_padding_causal_mask: True
 use_qk_norm: False
 # Every `X` layers will NOT use RoPE
 nope_layer_interval: -1
+
+# Multimodal flags
+use_multimodal: False
+image_size_for_vit: 896 # Default for Gemma3, and should be overwritten by model's config

--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -79,6 +79,33 @@ def get_query_pre_attn_scalar(config) -> float:
     raise ValueError(f"Unsupported model name: {config.model_name}")
 
 
+class Gemma3VisionEncoderLayer(nn.Module):
+  config: Config
+
+  @nn.compact
+  def __call__(self, inputs, train=False):
+    """ViT model that transforms image inputs to image embeddings.
+    Args:
+      inputs: jnp.array shaped [B, N, H, W, C], e.g. [4, 1, 896, 896, 3]
+    Returns:
+      jnp.array for image embeddings, shaped [B, N, P, D], e.g. [4, 1, 256, 2560]
+    """
+    cfg = self.config
+    print(f"Gemma3VisionEncoderLayer input: {inputs.shape}")
+    x = inputs.squeeze(axis=1)
+    x = nn.Conv(features=1152,
+        kernel_size=(14, 14),
+        strides=14,
+        padding="VALID",
+        name="embedding")(x)
+    n, h, w, c = x.shape
+    x = jnp.reshape(x, [n, h * w, c])
+    # TODO(hengtaoguo): finish the ViT with posemb, dropout and transformation layers.
+    # Currently it is only a placeholder with one Conv layer.
+    # Placeholder x shape (B, 4096, 1152).
+    return x
+
+
 # Gemma3 Decoder Layer
 class Gemma3DecoderLayer(nn.Module):
   """Transformer decoder layer that attends to the encoder."""

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -430,10 +430,12 @@ def init_initial_state(model, tx, config, is_training, key):
   Args: model, tx, config, is_training, key
   """
   input_shape = (config.micro_batch_size_to_train_on, config.max_target_length)
+  image_shape = (config.micro_batch_size_to_train_on, 1, config.image_size_for_vit, config.image_size_for_vit, 3)
   model_vars = model.init(
       {"params": key, "dropout": key, "aqt": key},
       np.ones(input_shape, dtype=jnp.int32),
       np.ones(input_shape, dtype=jnp.int32),
+      encoder_images=np.ones(image_shape, dtype=jnp.int32),
   )
   if is_training:
     return init_training_state(model.apply, model_vars, tx)

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -187,6 +187,9 @@ def validate_keys(keys):
     validate_sparse_matmul_parallelism(keys)
     validate_deepseek_moe(keys)
 
+  if keys["use_multimodal"]:
+    validate_multimodal_model_name(keys["model_name"])
+
 
 def validate_tokenizer(keys):
   assert keys[
@@ -277,6 +280,16 @@ def validate_model_name(s: str) -> bool:
   )
   if s not in valid_model_names:
     raise ValueError(f"Invalid model name was passed. Got {s}, Valid options {valid_model_names}")
+
+
+def validate_multimodal_model_name(s: str) -> bool:
+  valid_model_names = (
+      "gemma3-4b",
+      "gemma3-12b",
+      "gemma3-27b",
+  )
+  if s not in valid_model_names:
+    raise ValueError(f"Invalid multimodal model name was passed. Got {s}. Valid options which support multimodal inputs are: {valid_model_names}")
 
 
 def validate_no_keys_overwritten_twice(keys1: list[str], keys2: list[str]):

--- a/MaxText/tests/maxtext_utils_test.py
+++ b/MaxText/tests/maxtext_utils_test.py
@@ -152,7 +152,7 @@ class ModelWithMultipleCollections(nn.Module):
     self.dense = nn.Dense(4)
     self.kernel = self.variable("special_variables", "my_first_kernel", lambda: jnp.ones((4, 5)))
 
-  def __call__(self, x, y):
+  def __call__(self, x, y, encoder_images=None):
     x = self.dense(x)
     x = x @ self.kernel.value
     return x

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -378,6 +378,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
       data["inputs"],
       data["inputs_position"],
       decoder_segment_ids=data["inputs_segmentation"],
+      encoder_images=data["images"] if config.use_multimodal else None,
       enable_dropout=config.enable_dropout if is_train else False,
       rngs={"dropout": rng1, "params": aqt_rng},
       mutable="intermediates",


### PR DESCRIPTION
# Description

This PR provide a skeleton to include an additional VisionEncoder branch in the models.Transformer class, enabling multimodal MaxText. Starting from sft_trainer because we want to save a checkpoint for following checkpoint conversion.

0. The most critical changes are in `models.Transformer`. We add an extensible `VisionEncoder` building block (similar to the `Decoder` block) to specify the vision encoders for different models `self.vision_encoder=VisionEncoder(cfg),` starting with Gemma3. `gemma3.Gemma3VisionEncoderLayer` is the specific part where we implement vision encoder logics for Gemma3.
1. Add a new flag `use_multimodal` in base.yml to specify whether images will be used in sft training, associated with `validate_multimodal_model_name()` to verify whether the input `model_name` is supported by multimodal. If `use_multimodal=True`, trainer will include image inputs and use corresponding vision encoder in the Transformer.
2. Add an additional and optional input field `encoder_images` to the `models.Transformer`. The input shape is supposed to be [B, N, H, W, C] as jnp array (e.g. [48, 1, 896, 896, 3]).

Currently, `Gemma3VisionEncoderLayer` is a placeholder where the soft_embeddings after nn.Conv is shaped [B, 4096, 1152]. A following PR should implement the details.

In progress: [b/410616175](https://b.corp.google.com/issues/410616175)

# Tests

Tested command:
```
python3 -m MaxText.sft_trainer MaxText/configs/sft.yml model_name=gemma3-4b use_multimodal=True run_name=2025-04-14-20-41-48 profiler=xplane steps=5 base_output_directory=gs://hengtaoguo-maxtext-logs/1-correctness/mm dataset_type=hf use_sft=True hf_path=\'trl-lib/ultrafeedback-gpt-3.5-turbo-helpfulness\' train_data_columns=\[\'prompt\',\ \'completion\'\] train_split=\'train\' tokenizer_path=\'google/gemma-3-4b-it\' enable_checkpointing=true sharding_tolerance=0.03 profiler=xplane remat_policy=full max_prefill_predict_length=4 max_target_length=12 quantization=int8
```

We are able to see the params for the added Conv layer through state.params: 
![params](https://github.com/user-attachments/assets/c2cf2afe-8ffb-4d4e-b4e2-0394159a3149)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
