### PR TITLE
feat: Add prefix caching support

### DIFF
--- a/MaxText/benchmark_chunked_prefill.py
+++ b/MaxText/benchmark_chunked_prefill.py
@@ -1,34 +1,127 @@
-"""
- Copyright 2025 Google LLC
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-      https://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- """
+# Copyright 2025 Google LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      https://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-"""Shared Benchmark config for v5e orchestrations."""
+"""Microbenchmark script for evaluating chunked prefill performance.
+
+This script benchmarks the `chunked_prefill.do_chunked_prefill` function
+from the JetStream engine, integrated with MaxText's `MaxEngine`.
+It measures the average time taken for chunked prefill over several iterations,
+both with and without prefix caching enabled.
+
+Key functionalities:
+1.  Initializes MaxEngine with chunked prefill enabled.
+2.  Loads model parameters and tokenizer.
+3.  Tokenizes a prompt and splits it into chunks based on `config.prefill_chunk_size`.
+4.  Benchmarks the standard chunked prefill operation (without caching).
+5.  Initializes and populates a `PrefixCache` instance.
+6.  Benchmarks chunked prefill with varying levels of prefix cache hits.
+7.  Benchmarks chunked prefill including the time taken to save the final result
+    to the prefix cache.
+
+Configuration options like `use_chunked_prefill`, `prefill_chunk_size`,
+`prefix_caching_hbm_byte`, `prefix_caching_dram_byte`, and
+`inference_microbenchmark_prefix_cache_entries_num` control the benchmark behavior.
+"""
+
 
 # pylint: disable=ungrouped-imports
+import datetime
+import os
+from typing import Any, Sequence
+
 import jax
+from absl import app
+from jetstream.core import prefix_cache
+from jetstream.engine import chunked_prefill
+from jetstream.engine import engine_api
 
 from MaxText import max_utils
 from MaxText import maxengine
-
-import os
 from MaxText import pyconfig
 
-from typing import Sequence
-from absl import app
-import datetime
-from jetstream.engine import token_utils
 
 _WARMUP_ITERS = 2
 _BENCHMARK_ITERS = 5
+
+
+def fill_prefix_cache(
+    prefix_cache_inst: prefix_cache.PrefixCache,
+    prefix: Any,
+    cache_num: int,
+    hit_tokens: jax.Array,
+    padded_length: int,
+) -> None:
+  """Fill prefix cache to a specified number of entries.
+
+  The cache will be filled with `cache_num` dummy entries, each using a
+  copy of the provided `prefix` but associated with a unique dummy token key.
+  Finally, an entry using `hit_tokens` as the key and the `prefix` as the
+  value is added.
+
+  Args:
+    prefix_cache_inst: The PrefixCache instance to fill.
+    prefix: The KVCache (value) to store in the cache entries.
+    cache_num: The number of dummy entries to add before the target entry.
+    hit_tokens: The token sequence (key) for the target cache entry.
+    padded_length: The sequence length (including padding) that corresponds
+      to the provided `prefix` KVCache.
+  """
+  true_length = len(hit_tokens)
+  key_to_hit = tuple(hit_tokens.tolist())
+
+  def copy_prefix():
+    return jax.tree.map(lambda x: x.copy(), prefix)
+
+  # --- Fill the cache with dummy entries ---
+  print(f"Filling cache with {cache_num} dummy entries...")
+  for i in range(cache_num):
+    # Create a unique dummy key, ensuring it's different from key_to_hit
+    # and has the same length for consistency (though not strictly required by Trie).
+    # Adding a large offset makes collisions highly unlikely.
+    dummy_key = tuple(int(token) + 1000 + i * true_length for token in key_to_hit)
+
+    # Create the final Value object for the dummy entry, associating
+    # the copied prefix with the *dummy* key.
+    dummy_value_with_key = prefix_cache.Value(
+        prefix=copy_prefix(),
+        true_length=true_length,
+        padded_length=padded_length,
+        tokens=dummy_key,  # Use the dummy key here
+    )
+
+    # Save the dummy entry to the cache
+    prefix_cache_inst.save(dummy_key, dummy_value_with_key)
+    # Block to make sure the cache is synced
+    load_result = prefix_cache_inst.load(dummy_key)
+    assert load_result is not None
+    jax.block_until_ready(load_result.prefix)
+    del load_result
+
+  print(f"Finished filling cache with {cache_num} dummy entries.")
+
+  # --- Add the actual target entry ---
+  print(f"Adding the target entry with key length {len(key_to_hit)}...")
+
+  value_to_hit = prefix_cache.Value(
+      prefix=copy_prefix(),
+      true_length=true_length,
+      padded_length=padded_length,
+      tokens=key_to_hit,
+  )
+  prefix_cache_inst.save(key_to_hit, value_to_hit)
+  load_result = prefix_cache_inst.load(key_to_hit)
+  assert load_result is not None
+  jax.block_until_ready(load_result.prefix)
+  del load_result
+  print("Finished adding the target entry.")
 
 
 def main(argv: Sequence[str]) -> None:
@@ -37,10 +130,16 @@ def main(argv: Sequence[str]) -> None:
   config = pyconfig.initialize(argv)
   max_utils.print_system_information()
 
+  prefix_caching_hbm_byte = config.prefix_caching_hbm_byte
+  prefix_caching_dram_byte = config.prefix_caching_dram_byte
+  inference_microbenchmark_prefix_cache_entries_num = config.inference_microbenchmark_prefix_cache_entries_num
+
   engine = maxengine.MaxEngine(config)
-  rng = jax.random.PRNGKey(1234)
-  rng, rng_load_params = jax.random.split(rng)
-  params = engine.load_params(rng_load_params)
+
+  if not engine.use_chunked_prefill:
+    raise ValueError("Engine must be configured with use_chunked_prefill=True")
+
+  params = engine.load_params()
 
   text = config.prompt
   metadata = engine.get_tokenizer()
@@ -50,64 +149,112 @@ def main(argv: Sequence[str]) -> None:
   tokens, _ = tokenizer_model.encode(text, is_bos=True, prefill_lengths=[max_prefill_length])
 
   chunk_size = config.prefill_chunk_size
-  # set this to array of acceptable chunk sizes
-  prefill_lengths = [1024, 2048, 4096, 8192]
 
-  # chunked first to separate time of chunked and tokenized.
-  common_prefix_tokens = []
-  padded_input_tokens = []
-  input_true_lengths = []
-  # use whole tokens with padding for long context to max_prefill_length
-  for start_pos in range(0, len(tokens), chunk_size):
-    input_token = tokens[start_pos : min(len(tokens), start_pos + chunk_size)]
-    padded_input_token, input_true_length = token_utils.pad_tokens(
-        input_token,
-        tokenizer_model.bos_id,
-        tokenizer_model.pad_id,
-        is_bos=False,
-        prefill_lengths=prefill_lengths,
-        max_prefill_length=max_prefill_length,
-        jax_padding=True,
+  chunked_tokens_list = chunked_prefill.gen_chunked_padded_tokens(
+      tokens=tokens,
+      chunk_size=chunk_size,
+      tokenizer=tokenizer_model,
+      jax_padding=True,
+  )
+
+  def run_chunked_prefill_utility():
+    prefill_result, _ = chunked_prefill.do_chunked_prefill(
+        prefill_engine=engine,
+        prefill_params=params,
+        chunked_tokens_list=chunked_tokens_list,
     )
-    common_prefix_tokens.append(tokens[0 : min(len(tokens), start_pos + chunk_size)])
-    padded_input_tokens.append(padded_input_token)
-    input_true_lengths.append(input_true_length)
+    return prefill_result
 
-  rng, _ = jax.random.split(rng)
+  print("Starting warmup...")
+  for i in range(_WARMUP_ITERS):
+    start = datetime.datetime.now()
+    prefill_result = run_chunked_prefill_utility()
+    jax.block_until_ready(prefill_result)
+    end = datetime.datetime.now()
+    print(f"  Warmup iteration {i+1} time: {end - start}")
 
-  def run_chunked_prefill():
-    prefill_result = None
-    existing_prefix = None
-    for common_prefix_token, padded_input_token, input_true_length in zip(
-        common_prefix_tokens, padded_input_tokens, input_true_lengths
-    ):
-      prefill_result, _ = engine.prefill(
-          params=params,
-          existing_prefix=existing_prefix,
-          padded_tokens=padded_input_token,
-          true_length=input_true_length,
-          rng=rng,
+  print("\nStarting benchmark...")
+  total_time = datetime.timedelta()
+  for i in range(_BENCHMARK_ITERS):
+    start = datetime.datetime.now()
+    prefill_result = run_chunked_prefill_utility()
+    jax.block_until_ready(prefill_result)
+    end = datetime.datetime.now()
+    iter_time = end - start
+    total_time += iter_time
+    print(f"  Benchmark iteration {i+1} time: {iter_time}")
+
+  average_time = total_time / _BENCHMARK_ITERS
+  print(f"\nAverage time taken for chunked prefill over {_BENCHMARK_ITERS} iterations: {average_time}")
+
+  # Run prefix caching benchmark
+  prefill_result = run_chunked_prefill_utility()
+  prefix_cache_inst = prefix_cache.PrefixCache(prefix_caching_hbm_byte, prefix_caching_dram_byte)
+  fill_prefix_cache(
+      prefix_cache_inst,
+      prefill_result["cache"],
+      inference_microbenchmark_prefix_cache_entries_num,
+      tokens,
+      max_prefill_length,
+  )
+
+  def run_chunked_prefill_with_prefix_caching(cache_hit_chunk: int, need_save: bool):
+    # Load to simulated the time consuming for reading the cache
+    # TODO: Separate test case load from DRAM
+    tokens_list = tokens.tolist()
+    existing_prefix = prefix_cache.load_existing_prefix(prefix_cache_inst, tuple(tokens_list), chunk_size)
+    assert existing_prefix is not None
+    # Simulate prefix cache hit with chunked sized
+    if cache_hit_chunk > 0:
+      existing_prefix = engine_api.ExistingPrefix(
+          cache=existing_prefix[0].cache, common_prefix_tokens=tokens[: cache_hit_chunk * chunk_size]
       )
-      existing_prefix = maxengine.ExistingPrefix(
-          cache=prefill_result["cache"],
-          common_prefix_tokens=common_prefix_token,
+    else:
+      existing_prefix = None
+
+    prefill_result, _ = chunked_prefill.do_chunked_prefill(
+        prefill_engine=engine,
+        prefill_params=params,
+        chunked_tokens_list=chunked_tokens_list[cache_hit_chunk:],
+        existing_prefix=existing_prefix,
+    )
+    # Simulate save to cache
+    if need_save:
+      # Assume directly call save will happen
+      prefix_cache_inst.save(
+          tuple(tokens_list),
+          prefix_cache.Value(
+              prefix=jax.tree_map(lambda x: x.copy(), prefill_result["cache"]),
+              true_length=len(tokens_list),
+              padded_length=len(tokens_list),
+              tokens=tuple(tokens_list),
+          ),
       )
 
     return prefill_result
 
-  for _ in range(_WARMUP_ITERS):
-    start = datetime.datetime.now()
-    prefill_result = run_chunked_prefill()
-    jax.block_until_ready(prefill_result)
-    end = datetime.datetime.now()
-    print("time taken for chunk prefill warmup: ", end - start)
+  for cache_hit_chunk in range(len(chunked_tokens_list)):
+    for need_save in [True, False]:
+      print(f"\nBenchmark prefix caching {cache_hit_chunk=}, {need_save=}")
+      for i in range(_WARMUP_ITERS):
+        start = datetime.datetime.now()
+        prefill_result = run_chunked_prefill_with_prefix_caching(cache_hit_chunk, need_save)
+        jax.block_until_ready(prefill_result)
+        end = datetime.datetime.now()
+        print(f"  Warmup iteration {i+1} time: {end - start}")
 
-  for _ in range(_BENCHMARK_ITERS):
-    start = datetime.datetime.now()
-    prefill_result = run_chunked_prefill()
-    jax.block_until_ready(prefill_result)
-    end = datetime.datetime.now()
-    print("time taken for chunk prefill ", end - start)
+      total_time = datetime.timedelta()
+      for i in range(_BENCHMARK_ITERS):
+        start = datetime.datetime.now()
+        prefill_result = run_chunked_prefill_with_prefix_caching(cache_hit_chunk, need_save)
+        jax.block_until_ready(prefill_result)
+        end = datetime.datetime.now()
+        iter_time = end - start
+        total_time += iter_time
+        print(f"  Benchmark iteration {i+1} time: {iter_time}")
+
+      average_time = total_time / _BENCHMARK_ITERS
+      print(f"\nAverage time taken for prefix caching chunked prefill: {average_time}")
 
 
 if __name__ == "__main__":

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -667,6 +667,11 @@ pagedattn_pages_per_compute_block: 8
 prefill_chunk_size: 256
 use_chunked_prefill: False
 
+# Prefix Caching parameters in jetstream
+enable_prefix_caching: False
+prefix_caching_hbm_byte: 10_000_000_000 # 10 GB
+prefix_caching_dram_byte: 100_000_000_000 # 100 GB
+
 # This is a temporary flag that will removed soon after the fix lands in TE
 enable_padding_causal_mask: True
 

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -438,6 +438,8 @@ class MaxEngine(engine_api.Engine):
     previous_chunk = None
     input_params = params
     if existing_prefix is not None:
+      if not self.use_chunked_prefill:
+        raise ValueError("Using chunked prefill is needed for existing_prefix.")
       input_params = params | {"cache": existing_prefix.cache}
       start_position = existing_prefix.common_prefix_tokens.shape[0]
       # TODO(yuyanpeng): rename previous_chunk

--- a/MaxText/maxengine_server.py
+++ b/MaxText/maxengine_server.py
@@ -34,6 +34,19 @@ from jetstream.core import server_lib, config_lib
 # )
 
 
+def _create_prefix_caching_config(config) -> config_lib.PrefixCachingConfig | None:
+  if not config.enable_prefix_caching:
+    return None
+
+  if not config.use_chunked_prefill:
+    raise ValueError("Prefix caching requires chunked prefill.")
+
+  return config_lib.PrefixCachingConfig(
+      max_hbm_byte=config.prefix_caching_hbm_byte,
+      max_dram_byte=config.prefix_caching_dram_byte,
+  )
+
+
 def main(config):
   pathwaysutils.initialize()
 
@@ -60,6 +73,7 @@ def main(config):
       enable_model_warmup=config.enable_model_warmup if config.enable_model_warmup else False,
       lora_input_adapters_path=config.lora_input_adapters_path,
       multi_sampling=config.multi_sampling if config.multi_sampling else False,
+      prefix_caching_config=_create_prefix_caching_config(config),
   )
   jetstream_server.wait_for_termination()
 


### PR DESCRIPTION
Depend on https://github.com/AI-Hypercomputer/JetStream/pull/243

Key changes include:

- **Prefix Caching Integration:**
    - Integrated `jetstream.core.prefix_cache` into the benchmark to simulate and measure prefix caching performance.
    - Added configuration options (`enable_prefix_caching`, `prefix_caching_hbm_byte`, `prefix_caching_dram_byte`) to `base.yml`.
    - Updated `maxengine_server.py` to utilize these configurations for setting up prefix caching via `config_lib.PrefixCachingConfig`.
- **KV Cache Refactoring:**
    - Modified `KVCache` in `inference/kvcache.py` to handle chunked prefill more robustly.
    - Introduced `kv_cache_chunked_prefill` which uses `jax.lax.dynamic_update_slice_in_dim` to update the cache, avoiding potential recompilations caused by varying sequence lengths across chunks compared to the previous concatenation approach.
    - Updated the main `KVCache.__call__` method to dispatch to the appropriate prefill logic based on `use_chunked_prefill`.
- **Testing:** Updated `maxengine_test.py` to align with the KVCache refactoring, ensuring tests correctly compare the relevant portions of the cache state.

# Tests

Run benchmark serving mixtral-8x7b using openrca to test accuracy.
Run benchmark_chunked_prefill to test the latency.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
