### PR TITLE
[MaxText/inference_mlperf/offline_mode.py] Add back `maxengine_config_filepath` flag

### DIFF
--- a/MaxText/inference_mlperf/offline_mode.py
+++ b/MaxText/inference_mlperf/offline_mode.py
@@ -172,6 +172,13 @@ flags.DEFINE_string(
     required=False,
 )
 
+flags.DEFINE_string(
+    "maxengine_config_filepath",
+    None,
+    "Base config filepath for initializing MaxEngine.",
+    required=False,
+)
+
 scenario_map = {
     "offline": lg.TestScenario.Offline,
     "server": lg.TestScenario.Server,
@@ -456,7 +463,7 @@ def main(argv):
     target_length = 2 * length
     log.info("Using batch size: %d and length: %d", batch, length)
     engine = create_engine_from_config_flags(
-        maxengine_config_filepath=None,
+        maxengine_config_filepath=FLAGS.maxengine_config_filepath,
         batch_size=batch,
         max_prefill_predict_length=length,
         max_target_length=target_length,


### PR DESCRIPTION
# Description

Accidentally removed this in my d9c3767


# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
