### PR TITLE
Update parallelism sharding from mesh

### DIFF
--- a/MaxText/layers/moe.py
+++ b/MaxText/layers/moe.py
@@ -172,6 +172,15 @@ class MoeBlock(nn.Module):
   wi_kernel_axes = ("exp", "embed_no_exp", "mlp")
   wo_kernel_axes = ("exp", "mlp", "embed_no_exp")
 
+  def get_expert_parallelism_size(self):
+    return self.mesh.shape["expert"]
+
+  def get_tensor_parallelism_size(self):
+    return self.mesh.shape["tensor"]
+
+  def get_context_autoregressive_parallelism_size(self):
+    return self.mesh.shape["context_autoregressive"]
+
   def generate_kernels(self, num_experts, emb_dim, mlp_dim):
 
     kernel_in_axis = np.arange(1)
@@ -463,22 +472,22 @@ class MoeBlock(nn.Module):
       batch_size, sequence_length, _ = x.shape
       x, sorted_selected_experts, weights, group_sizes = self.permute(x, logits, pre_bias_logits)
 
-      if self.get_expert_parallelism() > 1:
+      if self.get_expert_parallelism_size() > 1:
         axis_name = "expert"
         # get group sizes for all shards
-        local_expert_size = self.config.num_experts // self.get_expert_parallelism()
+        local_expert_size = self.config.num_experts // self.get_expert_parallelism_size()
         reshaped_group_sizes = jnp.sum(group_sizes.reshape(-1, local_expert_size), axis=1)
         all_shards_group_sizes = lax.all_gather(reshaped_group_sizes, axis_name=axis_name)
         # calculate offsets and sizes for ragged_all_to_all operation
         input_offsets, send_sizes, output_offsets, recv_sizes = get_all_to_all_params(
-            all_shards_group_sizes, local_expert_size, self.get_expert_parallelism()
+            all_shards_group_sizes, local_expert_size, self.get_expert_parallelism_size()
         )
         # TODO(ranran): For better performance, we could update output buffer to a smaller
-        # size to replace self.get_expert_parallelism() for efficiency,
+        # size to replace self.get_expert_parallelism_size() for efficiency,
         # Or we could apply capacity_factor for excessive experts.
         # Note: Reducing buffer increase the risk of token dropping under unbalanced distribution.
         buffer_size = int(
-            self.get_expert_parallelism()
+            self.get_expert_parallelism_size()
             * self.config.per_device_batch_size
             * self.config.max_target_length
             * self.config.num_experts_per_tok
@@ -504,18 +513,17 @@ class MoeBlock(nn.Module):
       intermediate_layer = jnp.multiply(layer_act, layer_w1)
       intermediate_output = gmm(intermediate_layer, wo, group_sizes)
       intermediate_output = checkpoint_name(intermediate_output, "mlpwo")
-      tensor_parallelism = self.config.ici_tensor_parallelism * self.config.dcn_tensor_parallelism
-      if tensor_parallelism > 1:
+      if self.get_tensor_parallelism_size() > 1:
         intermediate_output = jax.lax.psum_scatter(intermediate_output, "tensor", scatter_dimension=1, tiled=True)
 
-      if self.get_expert_parallelism() > 1:
+      if self.get_expert_parallelism_size() > 1:
         axis_name = "expert"
         # locally unpermute back to the original order
         local_output = jnp.take(intermediate_output, indices=jnp.argsort(local_sorted_indices), axis=0)
         original_inputs_first_dim = batch_size * sequence_length * self.config.num_experts_per_tok
         output_shape = jnp.zeros((original_inputs_first_dim, self.config.emb_dim), dtype=local_output.dtype)
         input_offsets, send_sizes, output_offsets, recv_sizes = get_all_to_all_params(
-            jnp.transpose(all_shards_group_sizes), local_expert_size, self.get_expert_parallelism()
+            jnp.transpose(all_shards_group_sizes), local_expert_size, self.get_expert_parallelism_size()
         )
         intermediate_output = jax.lax.ragged_all_to_all(
             local_output,
@@ -546,7 +554,7 @@ class MoeBlock(nn.Module):
     return update_weights
 
   def get_context_partition_and_sub_seq(self, seq_len):
-    cp = self.config.ici_context_autoregressive_parallelism
+    cp = self.get_context_autoregressive_parallelism_size()
     if seq_len % cp != 0:
       cp = 1
     sub_seq = seq_len // cp
@@ -719,11 +727,8 @@ class MoeBlock(nn.Module):
       einsum_op = jnp.einsum
     return einsum_op
 
-  def get_expert_parallelism(self):
-    return self.config.ici_expert_parallelism * self.config.dcn_expert_parallelism
-
   def maybe_all_gather_kernel_weight_in_expert_parallelism(self, kernel, kernel_axes):
-    if self.get_expert_parallelism() > 1:
+    if self.get_expert_parallelism_size() > 1:
       # This will trigger all-gather using weight_dtype
       # relax it unless really necessary in expert parallelism only
       # Otherwise compiler will handle communication automatically
@@ -777,7 +782,7 @@ class MoeBlock(nn.Module):
         # todo: try replace softmax_probs with padded weights and verify with decode acc tests
         softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
         dispatch_mask, combine_mask = self.generate_masks_subgroup(top_k_indices, softmax_probs)
-        if self.config.ici_context_autoregressive_parallelism > 0 and cp == 1:
+        if self.get_context_autoregressive_parallelism_size() > 0 and cp == 1:
           mask_axes = ("activation_length", "activation_batch", None, None, None)
           input_axis = ("activation_length", "activation_batch", None, "activation_embed")
           dispatch_axis = ("activation_exp", "activation_batch_no_exp", None, None, "activation_embed")


### PR DESCRIPTION
# Description

Update parallelism sharding from mesh to fix b/408278115.


# Tests

Local test  - expected results with `ici_expert_parallelism=-1 ici_fsdp_parallelism=2 ` & `ici_expert_parallelism=-1 ici_fsdp_parallelism=1` on v5p-8

```
python3 -m MaxText.train MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_DIRECTORY} dataset_path=${DATASET_PATH} run_name=v2_test_pre_training_ep4 per_device_batch_size=12 enable_checkpointing=false model_name=deepseek2-16b steps=3 max_target_length=4096 async_checkpointing=false tokenizer_type=huggingface tokenizer_path='deepseek-ai/DeepSeek-V2-Lite' attention=flash dtype=bfloat16 weight_dtype=bfloat16 megablox=True sparse_matmul=True enable_checkpointing=false ici_fsdp_parallelism=1 ici_expert_parallelism=-1 dataset_type=synthetic 
```

```
# ici_expert_parallelism=-1 ici_fsdp_parallelism=1
-> axis_name = "expert"
(Pdb) 
self.get_expert_parallelism_size()
4

# ici_expert_parallelism=-1 ici_fsdp_parallelism=2 
(Pdb) self.get_expert_parallelism_size()
2
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
