### PR TITLE
fix libtpu nightly installation for benchmark runer

### DIFF
--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -132,14 +132,14 @@ def add_xpk_runner_arguments(custom_parser: argparse.ArgumentParser):
   custom_parser.add_argument(
       '--libtpu_version',
       type=str,
-      default='20241009',
+      default='',
       help='version of libtpu-nightly to be benchmarked command.',
   )
   custom_parser.add_argument(
       '--libtpu_type',
       type=str,
       choices=[t.value for t in LibTpuType],
-      default='nightly',
+      default='maxtext-docker',
       help='type of libtpu to be benchmarked command.',
   )
   custom_parser.add_argument(
@@ -211,14 +211,14 @@ def add_on_device_runner_arguments(custom_parser: argparse.ArgumentParser):
   custom_parser.add_argument(
       '--libtpu_version',
       type=str,
-      default='20241009',
+      default='',
       help='version of libtpu-nightly to be benchmarked command.',
   )
   custom_parser.add_argument(
       '--libtpu_type',
       type=str,
       choices=[t.value for t in LibTpuType],
-      default='nightly',
+      default='maxtext-docker',
       help='type of libtpu to be benchmarked command.',
   )
   custom_parser.add_argument(

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -375,10 +375,17 @@ def build_user_command(
     jax_platforms = 'proxy'
   else:
     if wl_config.libtpu_type == LibTpuType.NIGHTLY:
-      install_libtpu_cmd += (
-          f' python3 -m pip install libtpu-nightly==0.1.dev{wl_config.libtpu_nightly_version} -f'
-          ' https://storage.googleapis.com/libtpu-releases/index.html &&'
-      )
+      if wl_config.libtpu_nightly_version:
+        install_libtpu_cmd += (
+            f' python3 -m pip install libtpu=={wl_config.libtpu_nightly_version} -f'
+            ' https://storage.googleapis.com/libtpu-wheels/index.html &&'
+        )
+      else:
+        # If no version is specified, install the latest stable libtpu.
+        install_libtpu_cmd += (
+            ' python3 -m pip install libtpu --pre -f'
+            ' https://storage.googleapis.com/libtpu-wheels/index.html &&'
+        )
     elif wl_config.libtpu_type == LibTpuType.CUSTOM:
       # In order to use a custom libtpu, put a libtpu.so file in your local
       # working directory.


### PR DESCRIPTION
# Description

Fix outdated libtpu nightly installation code in maxtext benchmark runner xpk.

Context: libtpu-nightly has been retired, and the nightly need to be installed via `pip install libtpu==<version> -f https://storage.googleapis.com/libtpu-wheels/index.html` where the version can be looked up on https://storage.googleapis.com/libtpu-wheels/index.html. 

Changes:
- Changed the libtpu night installation code
- Changed the default value of `--libtpu_version` to be empty str, and by default, it should install latest libtpu stable.
- Fixed default value for `--libtpu_type`, which was not defined in the enum.

# Tests

Cienet team helped test it with latest tpu-info, where libtpu nightly had a fix. Results shows that libtpu nightly was correctly installed with proper `--libtpu_type` and `--libtpu_version` flags.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
