### PR TITLE
Warn when invoked as a script

### DIFF
--- a/MaxText/inference_microbenchmark.py
+++ b/MaxText/inference_microbenchmark.py
@@ -407,7 +407,7 @@ def run_benchmarks(config):
 
   text = config.prompt
   metadata = engine.get_tokenizer()
-  vocab = token_utils.load_vocab(metadata.path, metadata.extra_ids)
+  tokenizer_model = engine.build_tokenizer(metadata)
   rng, rng_init_decode = jax.random.split(rng)
 
   generate_executable, params, decode_state_executable = engine.aot_compile(params, pass_rng_shape=True)
@@ -429,8 +429,8 @@ def run_benchmarks(config):
     rng_shape = jax.ShapeDtypeStruct([4], jax.numpy.dtype("uint32"))
 
     for prefill_length in prefill_lengths:
-      prefill_tokens[prefill_length], prefill_true_lengths[prefill_length] = token_utils.tokenize_and_pad(
-          text, vocab, is_bos=True, prefill_lengths=[prefill_length]
+      prefill_tokens[prefill_length], prefill_true_lengths[prefill_length] = tokenizer_model.encode(
+          text, is_bos=True, prefill_lengths=[prefill_length]
       )
 
       key_shape = jax.ShapeDtypeStruct([prefill_length], jax.numpy.dtype("int32"))

--- a/MaxText/tests/grpo_trainer_correctness_test.py
+++ b/MaxText/tests/grpo_trainer_correctness_test.py
@@ -82,17 +82,16 @@ def prepare_maxtext_inputs(input_str, tokenizer_model):
   return input_ids, input_segmentation, input_position, completion_segmentation
 
 
-
 class GrpoTrainerTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
     command = [
-      "gsutil",
-      "cp",
-      "-r",
-      "gs://maxtext-dataset/hf/llama3.1-tokenizer",
-      os.path.join(os.path.dirname(PKG_DIR), "assets", ""),
+        "gsutil",
+        "cp",
+        "-r",
+        "gs://maxtext-dataset/hf/llama3.1-tokenizer",
+        os.path.join(os.path.dirname(PKG_DIR), "assets", ""),
     ]
     exit_code = subprocess.call(command, cwd=os.path.dirname(PKG_DIR))
     if exit_code != 0:
@@ -100,13 +99,13 @@ class GrpoTrainerTest(unittest.TestCase):
     self.config = pyconfig.initialize(
         [None, "MaxText/experimental/rl/grpo_trainer_test.yml"],
         run_name="unit_test_grpo_trainer",
-        tokenizer_path=os.path.join(os.path.dirname(PKG_DIR), 'assets', 'llama3.1-tokenizer'),
+        tokenizer_path=os.path.join(os.path.dirname(PKG_DIR), "assets", "llama3.1-tokenizer"),
         enable_checkpointing=False,
     )
     self.config_inference = pyconfig.initialize(
         [None, "MaxText/experimental/rl/grpo_trainer_test.yml"],
         run_name="unit_test_grpo_trainer_inference",
-        tokenizer_path=os.path.join(os.path.dirname(PKG_DIR), 'assets', 'llama3.1-tokenizer'),
+        tokenizer_path=os.path.join(os.path.dirname(PKG_DIR), "assets", "llama3.1-tokenizer"),
         enable_checkpointing=False,
         ici_tensor_parallelism=4,
         per_device_batch_size=self.config.per_device_batch_size * self.config.num_generations,
@@ -115,11 +114,11 @@ class GrpoTrainerTest(unittest.TestCase):
     self.atol = 1e-08
     self.rng = jax.random.PRNGKey(self.config.init_weights_seed)
     self.tokenizer_model = transformers.AutoTokenizer.from_pretrained(
-      self.config.tokenizer_path,
-      add_bos_token=self.config.add_bos,
-      add_eos_token=self.config.add_eos,
-      legacy=False,
-      padding_side="left"
+        self.config.tokenizer_path,
+        add_bos_token=self.config.add_bos,
+        add_eos_token=self.config.add_eos,
+        legacy=False,
+        padding_side="left",
     )
     self.tokenizer_model.add_special_tokens({"pad_token": "<pad>"})
 
@@ -135,22 +134,23 @@ class GrpoTrainerTest(unittest.TestCase):
     )
     # Obtain per-token logits.
     maxtext_per_token_logps, _ = compute_log_probs(
-      maxtext_model,
-      state.params,
-      input_ids,
-      input_position,
-      input_segmentation,
-      completion_segmentation,
-      self.config,
-      is_train=False,
-      rngs=self.rng,
+        maxtext_model,
+        state.params,
+        input_ids,
+        input_position,
+        input_segmentation,
+        completion_segmentation,
+        self.config,
+        is_train=False,
+        rngs=self.rng,
     )
-    jax.debug.print("maxtext_per_token_logps={maxtext_per_token_logps}",maxtext_per_token_logps=maxtext_per_token_logps)
-    jax.debug.print("golden_per_token_logps={golden_per_token_logps}",golden_per_token_logps=golden_data["maxtext_per_token_logps_no_ckpt_loading"])
+    jax.debug.print("maxtext_per_token_logps={maxtext_per_token_logps}", maxtext_per_token_logps=maxtext_per_token_logps)
+    jax.debug.print(
+        "golden_per_token_logps={golden_per_token_logps}",
+        golden_per_token_logps=golden_data["maxtext_per_token_logps_no_ckpt_loading"],
+    )
     golden_maxtext_logits = np.array(golden_data["maxtext_per_token_logps_no_ckpt_loading"])
-    self.assertTrue(
-      jnp.all(np.array(golden_data["input_ids"]) == np.array(input_ids[0]))
-    )
+    self.assertTrue(jnp.all(np.array(golden_data["input_ids"]) == np.array(input_ids[0])))
     self.assertTrue(
         jax.numpy.allclose(
             maxtext_per_token_logps[0],

--- a/MaxText/tests/module_tests.py
+++ b/MaxText/tests/module_tests.py
@@ -1,0 +1,53 @@
+"""
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Tests for train.py with various configs"""
+
+import os
+import sys
+import subprocess
+import unittest
+import pytest
+from absl.testing import absltest
+
+from MaxText.globals import PKG_DIR
+
+class ModuleTests(unittest.TestCase):
+  """Tests train.py with various invokation methods"""
+
+  def test_get_informative_error(self):
+    # cwd is MaxText so step up a level
+    os.chdir("..")
+    
+    command = [
+        sys.executable,  # use the same interpreter instance
+        "MaxText/train.py",
+        "MaxText/configs/base.yml",
+        "run_name=maxtext-module-test",
+        "base_output_directory=gs://does-not-exist",
+        "dataset_type=synthetic"
+    ]
+
+    with self.assertRaises(subprocess.CalledProcessError) as context:
+        subprocess.run(command, check=True, text=True, capture_output=True)
+  
+    ex = context.exception
+    self.assertEqual(ex.returncode, 64)
+    self.assertIn("The MaxText API has changed", ex.stderr)
+
+if __name__ == "__main__":
+  absltest.main()
+  

--- a/MaxText/tests/module_tests.py
+++ b/MaxText/tests/module_tests.py
@@ -29,9 +29,6 @@ class ModuleTests(unittest.TestCase):
   """Tests train.py with various invokation methods"""
 
   def test_get_informative_error(self):
-    # cwd is MaxText so step up a level
-    os.chdir("..")
-
     command = [
         sys.executable,  # use the same interpreter instance
         "MaxText/train.py",

--- a/MaxText/tests/module_tests.py
+++ b/MaxText/tests/module_tests.py
@@ -31,7 +31,7 @@ class ModuleTests(unittest.TestCase):
   def test_get_informative_error(self):
     # cwd is MaxText so step up a level
     os.chdir("..")
-    
+
     command = [
         sys.executable,  # use the same interpreter instance
         "MaxText/train.py",
@@ -42,12 +42,12 @@ class ModuleTests(unittest.TestCase):
     ]
 
     with self.assertRaises(subprocess.CalledProcessError) as context:
-        subprocess.run(command, check=True, text=True, capture_output=True)
-  
+      subprocess.run(command, check=True, text=True, capture_output=True)
+
     ex = context.exception
     self.assertEqual(ex.returncode, 64)
     self.assertIn("The MaxText API has changed", ex.stderr)
 
 if __name__ == "__main__":
   absltest.main()
-  
+

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -28,7 +28,8 @@ if not __package__:
         "`python3 -m MaxText.train <args>`.",
         file=sys.stderr
     )
-    sys.exit(1)
+    # EX_USAGE
+    sys.exit(64)
 
 import datetime
 import os

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -21,15 +21,12 @@ limitations under the License.
 import sys
 
 if not __package__:
-    print(
-        "Error: The MaxText API has changed. MaxText entry-points are now "
-        "invoked as modules, with syntax of the form "
-        "`python3 -m MaxText.module <args>`, e.g., "
-        "`python3 -m MaxText.train <args>`.",
-        file=sys.stderr
-    )
-    # EX_USAGE
-    sys.exit(64)
+  print("Error: The MaxText API has changed. MaxText entry-points are now "
+    "invoked as modules, with syntax of the form "
+    "`python3 -m MaxText.module <args>`, e.g., "
+    "`python3 -m MaxText.train <args>`.",
+    file=sys.stderr)
+  sys.exit(1)
 
 import datetime
 import os

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -15,10 +15,20 @@ limitations under the License.
 """
 
 # pylint: disable=g-bad-todo, abstract-method, consider-using-with, ungrouped-imports
+
 """Training loop and Decoding of the model."""
 
-# Calling jax.device_count here prevents a "TPU platform already registered" error.
-# See github.com/google/maxtext/issues/20 for more
+import sys
+
+if not __package__:
+    print(
+        "Error: The MaxText API has changed. MaxText entry-points are now "
+        "invoked as modules, with syntax of the form "
+        "`python3 -m MaxText.module <args>`, e.g., "
+        "`python3 -m MaxText.train <args>`.",
+        file=sys.stderr
+    )
+    sys.exit(1)
 
 import datetime
 import os

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -663,7 +663,7 @@ def setup_train_loop(config):
   record_goodput(recorder, config, recorder.record_training_preparation_start_time if recorder else None)
   data_iterator, eval_data_iterator = create_data_iterator(config, mesh)
 
-  context_parallel_size = mesh.shape['context']
+  context_parallel_size = mesh.shape["context"]
   # Check if context parallelism is being used with sequence packing
   if context_parallel_size > 1 and config.packing and config.dataset_type != "synthetic":
     raise ValueError(


### PR DESCRIPTION
# Description

We recently changed the MaxText API such that invoking e.g. `MaxText/train.py` will no longer work (`MaxText.train` needs to be invoked as a module. This change adds a warning when the user tries to invoke in the old manner (vs. a cryptic import error message, without this change)

# Tests

- Tested get warning: `python3 MaxText/train.py MaxText/configs/base.yml   run_name=rjx-run-v5p-8-b   base_output_directory=gs://rjx-storage   dataset_type=synthetic`
- Tested works: `python3 -m MaxText.train MaxText/configs/base.yml   run_name=rjx-run-v5p-8-b   base_output_directory=gs://rjx-storage   dataset_type=synthetic`
- Tested works (imports from train.py): `python3 -m MaxText.sft_trainer MaxText/configs/base.yml   run_name=rjx-run-v5p-8-b   base_output_directory=gs://rjx-storage   dataset_type=synthetic`

I believe this covers all cases. I might try to capture these in unit tests but want to get this change in ASAP.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
