### PR TITLE
Show test run times in CI, not only completion %

### DIFF
--- a/.github/workflows/run_tests_internal.yml
+++ b/.github/workflows/run_tests_internal.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Run Tests
         run: |
           python3 -m pip install -e .
-          python3 -m pytest --pyargs MaxText.tests -m "${{ inputs.pytest_marker }}"
+          python3 -m pytest --pyargs MaxText.tests -m "${{ inputs.pytest_marker }}" --durations=0


### PR DESCRIPTION
Currently, we don't see the run time of tests in CI, and it is difficult to detect regressions. This PR aims to change that.

It shows up after the tests, like this:

============================== slowest durations ===============================
74.99s call MaxText/tests/train_tests.py::TrainTests::test_gpu_int8
64.32s call MaxText/tests/train_tests.py::TrainTests::test_gpu_context_parallelism
59.01s call MaxText/tests/train_tests.py::TrainTests::test_gpu_fp8
54.18s call MaxText/tests/train_int8_smoke_test.py::Train::test_tiny_config
52.85s call MaxText/tests/train_tests.py::TrainTests::test_gpu_nanoo_fp8
44.40s call MaxText/tests/train_tests.py::TrainTests::test_gpu_base
38.51s call MaxText/tests/train_tests.py::TrainTests::test_gpu_hf_input_pipeline
37.77s call MaxText/tests/pipeline_parallelism_test.py::PipelineParallelismTest::test_full_train_fp8
35.82s call MaxText/tests/train_tests.py::TrainTests::test_gpu_dropout
34.49s call MaxText/tests/pipeline_parallelism_test.py::PipelineParallelismTest::test_full_train_nanoo_fp8
32.14s call MaxText/tests/train_tests.py::TrainTests::test_gpu_pdb_lt_1
27.84s call MaxText/tests/train_tests.py::TrainTests::test_gpu_synthetic
26.75s call MaxText/tests/train_smoke_test.py::Train::test_tiny_config

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
