### PR TITLE
[benchmarks] Fix xpk path to be `$HOME/xpk` rather than `maxtext/xpk`

### DIFF
--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -151,7 +151,7 @@ def add_xpk_runner_arguments(custom_parser: argparse.ArgumentParser):
   custom_parser.add_argument(
       '--xpk_path',
       type=str,
-      default=os.path.join("~", "xpk"),
+      default=os.path.join(os.path.expanduser("~"), "xpk"),
       help='path to xpk dir.',
   )
   custom_parser.add_argument(

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -99,7 +99,7 @@ class WorkloadConfig:
   num_steps: int = 20
   max_restarts: int = 0
   priority: str = 'medium'
-  xpk_path: str = os.path.join("~", "xpk")
+  xpk_path: str = os.path.join(os.path.expanduser("~"), "xpk")
   pathways_config: PathwaysConfig = None
   run_name: str = None
   generate_metrics_and_upload_to_big_query: bool = True

--- a/benchmarks/recipes/pw_elastic_training_recipe.py
+++ b/benchmarks/recipes/pw_elastic_training_recipe.py
@@ -43,7 +43,7 @@ COUNTRY = "us"
 DEVICE_TYPE = "v6e-256"
 
 # Other parameters (MUST BE SET BY USER)
-XPK_PATH = "../xpk"  # We're running this script from the maxtext directory
+XPK_PATH = os.path.join(os.path.expanduser("~"), "xpk")
 USER = os.environ["USER"]
 BASE_OUTPUT_DIRECTORY = (
     f"gs://{USER}-{PROJECT}-{COUNTRY}/disruption_management/"

--- a/benchmarks/recipes/pw_long_running_recipe.py
+++ b/benchmarks/recipes/pw_long_running_recipe.py
@@ -39,7 +39,7 @@ COUNTRY = "us"
 DEVICE_TYPE = "v6e-256"
 
 # Other parameters (MUST BE SET BY USER)
-XPK_PATH = os.path.join("~", "xpk")  # We're running this script from the maxtext directory
+XPK_PATH = os.path.join(os.path.expanduser("~"), "xpk")
 USER = os.environ["USER"]
 BASE_OUTPUT_DIRECTORY = (
     f"gs://{USER}-{PROJECT}-{COUNTRY}/pw_mcjax_benchmarking/"

--- a/benchmarks/recipes/pw_mcjax_benchmark_recipe.py
+++ b/benchmarks/recipes/pw_mcjax_benchmark_recipe.py
@@ -42,7 +42,7 @@ COUNTRY = "us"
 DEVICE_TYPE = "v6e-256"
 
 # Other parameters (MUST BE SET BY USER)
-XPK_PATH = os.path.join("~", "xpk")  # We're running this script from the maxtext directory
+XPK_PATH = os.path.join(os.path.expanduser("~"), "xpk")
 USER = os.environ["USER"]
 BASE_OUTPUT_DIRECTORY = (
     f"gs://{USER}-{PROJECT}-{COUNTRY}/pw_mcjax_benchmarking/"

--- a/benchmarks/recipes/pw_mcjax_checkpoint_benchmark_recipe.py
+++ b/benchmarks/recipes/pw_mcjax_checkpoint_benchmark_recipe.py
@@ -46,7 +46,7 @@ COUNTRY = "us"
 DEVICE_TYPE = "v6e-256"
 
 # Other parameters (MUST BE SET BY USER)
-XPK_PATH = os.path.join("~", "xpk")  # We're running this script from the maxtext directory
+XPK_PATH = os.path.join(os.path.expanduser("~"), "xpk")
 USER = os.environ["USER"]
 BASE_OUTPUT_DIRECTORY = (
     f"gs://{USER}-{PROJECT}-{COUNTRY}/pw_mcjax_benchmarking/"

--- a/benchmarks/recipes/pw_remote_python_recipe.py
+++ b/benchmarks/recipes/pw_remote_python_recipe.py
@@ -34,7 +34,7 @@ def main() -> int:
       device_type="v6e-256",
   )
 
-  xpk_path = "xpk"
+  xpk_path = os.path.join(os.path.expanduser("~"), "xpk")
 
   # Handle command line arguments using args_helper
   should_continue = helper.handle_cmd_args(

--- a/benchmarks/recipes/pw_suspend_resume.py
+++ b/benchmarks/recipes/pw_suspend_resume.py
@@ -42,7 +42,7 @@ COUNTRY = "us"
 DEVICE_TYPE = "v6e-256"
 
 # Other parameters (MUST BE SET BY USER)
-XPK_PATH = "../xpk"  # We're running this script from the maxtext directory
+XPK_PATH = os.path.join(os.path.expanduser("~"), "xpk")
 USER = os.environ["USER"]
 BASE_OUTPUT_DIRECTORY = (
     f"gs://{USER}-{PROJECT}-{COUNTRY}/disruption_management/"


### PR DESCRIPTION
# Description

Fix xpk path to be `$HOME/xpk` rather than `maxtext/xpk`

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: #1561

> Nothing is wrong with `~` but you can't just use it like that. That's why we see `maxtext/~/xpk` rather than `/home/myname/xpk`
> 
> ```sh
> $ python3 -c 'import os; print(os.path.expanduser("~"))'
> /Users/myname
> $ python3 -c 'import os; print("~")' 
> ~
> ```
> Details of `os.path.expanduser`: https://docs.python.org/3/library/os.path.html#os.path.expanduser

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
