### PR TITLE
Fix import statements in convert_deepseek_unscanned_ckpt

### DIFF
--- a/MaxText/convert_deepseek_unscanned_ckpt.py
+++ b/MaxText/convert_deepseek_unscanned_ckpt.py
@@ -34,11 +34,11 @@ import torch
 import psutil
 from tqdm import tqdm
 
+from MaxText import convert_deepseek_ckpt as ds_ckpt
+from MaxText import llama_or_mistral_ckpt
 from MaxText import max_logging
 from MaxText.inference_utils import str2bool
 from safetensors import safe_open
-import llama_or_mistral_ckpt
-import convert_deepseek_ckpt as ds_ckpt
 
 
 def _convert_huggingface_to_jax_weights(base_model_path, model_params, mem_info) -> dict:


### PR DESCRIPTION
# Description

Fix import statements in convert_deepseek_unscanned_ckpt.py after recent refactoring.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
```
JAX_PLATFORMS=cpu python3 -m MaxText.convert_deepseek_unscanned_ckpt --base_model_path ${CHKPT_BUCKET} --maxtext_model_path ${MODEL_BUCKET}/unscanned --model_size=deepseek2-16b
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
