### PR TITLE
Add multimodal_utils and support multimodal in decode.py

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -681,3 +681,4 @@ nope_layer_interval: -1
 # Multimodal flags
 use_multimodal: False
 image_size_for_vit: 896 # Default for Gemma3, and should be overwritten by model's config
+image_path: "" # Local image path used for decoding

--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -25,6 +25,7 @@ from jetstream.engine import engine_api
 from MaxText import max_utils
 from MaxText import maxengine
 from MaxText import pyconfig
+from MaxText import multimodal_utils
 
 # Number of text sequences to process in a single batch.
 _NUM_STREAMS = 1
@@ -91,6 +92,12 @@ def main(argv: Sequence[str]) -> None:
   params = engine.load_params(rng_load_params)
 
   text = config.prompt
+  images = None
+  if config.use_multimodal:
+    # TODO(hengtaoguo): Support multiple images as input.
+    images = multimodal_utils.load_image_from_path(config.image_path)
+    images = multimodal_utils.pre_process_image(images, model_name=config.model_name)
+
   metadata = engine.get_tokenizer()
   tokenizer_model = engine.build_tokenizer(metadata)
   try:
@@ -116,7 +123,7 @@ def main(argv: Sequence[str]) -> None:
   rng, rng_prefill = jax.random.split(rng)  # Split RNG before calling prefill
   for i in range(_NUM_STREAMS):
     prefill_result, first_token = engine.prefill(
-        params=params, padded_tokens=tokens, true_length=true_length, rng=rng_prefill, slot=i
+        params=params, padded_tokens=tokens, images=images, true_length=true_length, rng=rng_prefill, slot=i
     )
     prefill_result_list.append(prefill_result)
     first_token_list.append(first_token)

--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -90,14 +90,10 @@ class Gemma3VisionEncoderLayer(nn.Module):
     Returns:
       jnp.array for image embeddings, shaped [B, N, P, D], e.g. [4, 1, 256, 2560]
     """
-    cfg = self.config
-    print(f"Gemma3VisionEncoderLayer input: {inputs.shape}")
-    x = inputs.squeeze(axis=1)
-    x = nn.Conv(features=1152,
-        kernel_size=(14, 14),
-        strides=14,
-        padding="VALID",
-        name="embedding")(x)
+    b, n, h, w, c = inputs.shape
+    x = jnp.reshape(inputs, [b * n, h, w, c])
+    x = nn.Conv(features=1152, kernel_size=(14, 14), strides=14, padding="VALID", name="embedding")(x)
+    jax.debug.print("x after: {}", x.mean())
     n, h, w, c = x.shape
     x = jnp.reshape(x, [n, h * w, c])
     # TODO(hengtaoguo): finish the ViT with posemb, dropout and transformation layers.

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -578,6 +578,7 @@ class Decoder(nn.Module):
 
 class VisionEncoder(nn.Module):
   """Vision encoder to encode images into soft tokens."""
+
   config: Config
 
   def setup(self):
@@ -586,6 +587,7 @@ class VisionEncoder(nn.Module):
   def get_vision_encoder_layers(self):
     if self.config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
       from MaxText.layers import gemma3
+
       return [gemma3.Gemma3VisionEncoderLayer]
     else:
       raise ValueError(f"No VisionEncoder implemented for {self.config.model_name} yet")
@@ -628,7 +630,7 @@ class Transformer(nn.Module):
       decoder_input_tokens: jnp.ndarray,
       decoder_positions: jnp.ndarray,
       decoder_segment_ids=None,
-      encoder_images: Optional[jnp.ndarray]=None,
+      encoder_images: Optional[jnp.ndarray] = None,
       enable_dropout=True,
       model_mode=common_types.MODEL_MODE_TRAIN,
       previous_chunk=None,
@@ -650,7 +652,7 @@ class Transformer(nn.Module):
           f" which is always {common_types.DECODING_ACTIVE_SEQUENCE_INDICATOR}."
       )
 
-    if self.config.use_multimodal:
+    if self.config.use_multimodal and encoder_images is not None:
       image_embeddings = self.vision_encoder(input_images=encoder_images)
       # TODO(hengtaoguo, aireen): merge image_embeddings with decoder_input_tokens.
 

--- a/MaxText/multimodal_utils.py
+++ b/MaxText/multimodal_utils.py
@@ -1,0 +1,84 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Utils needed by multimodal pipelines for image processing."""
+
+import os
+import numpy as np
+import jax
+import jax.numpy as jnp
+from PIL import Image
+
+
+_GEMMA_DEFAULT_IMAGE_SIZE = 896
+_GEMMA_IMAGE_MEAN = (127.5,) * 3
+_GEMMA_IMAGE_STD = (127.5,) * 3
+_NUM_IMAGE_CHANNELS = 3
+
+
+def load_image_from_path(image_path):
+  """Loads an image from a given file path and returns a jnp.array."""
+  if not os.path.isfile(image_path):
+    raise FileNotFoundError(f"Image not found at path {image_path}. Please specify a valid image path")
+  try:
+    image = Image.open(image_path).convert("RGB")
+    image.load()  # Load image data to catch errors early
+    return jnp.asarray(np.array(image))
+  except (IOError, OSError) as e:
+    raise IOError(f"Error loading image from {image_path}")
+
+
+def _normalize_images(images, mean, std):
+  """Normalize the image to zero mean and unit variance.
+  Change the image mean and std based on parameters mean and std.
+  Args:
+    images: The images to normalize.
+    mean: tuple[float, float, float].
+    std: tuple[float, float, float].
+  Returns:
+    The normalized images.
+  """
+  images -= jnp.asarray(mean)
+  images /= jnp.asarray(std)
+  return images
+
+
+def pre_process_gemma3_image(image):
+  """Performs a bi-linear resize (with anti-aliasing) and normalizes the image."""
+  image_shape = (_GEMMA_DEFAULT_IMAGE_SIZE, _GEMMA_DEFAULT_IMAGE_SIZE, _NUM_IMAGE_CHANNELS)
+  image = jax.image.resize(
+      image,
+      shape=image_shape,
+      method="bilinear",
+      antialias=True,
+  )
+  image = _normalize_images(image, mean=_GEMMA_IMAGE_MEAN, std=_GEMMA_IMAGE_STD)
+  image = jnp.clip(image, -1, 1)
+  return image
+
+
+def pre_process_image(image, model_name):
+  """Pre-process image according to different model's requirements.
+  Args:
+    image: The jnp.array image [H, W, C] to pre-process.
+    model_name: The config.model_name that specifies the image preprocess ways.
+  Returns:
+    The pre-processed image in jnp.array [H, W, C].
+  """
+  if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+    return pre_process_gemma3_image(image)
+  else:
+    raise ValueError(f"Model {model_name} does not support multimodal inference.")

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -289,7 +289,9 @@ def validate_multimodal_model_name(s: str) -> bool:
       "gemma3-27b",
   )
   if s not in valid_model_names:
-    raise ValueError(f"Invalid multimodal model name was passed. Got {s}. Valid options which support multimodal inputs are: {valid_model_names}")
+    raise ValueError(
+        f"Invalid multimodal model name was passed. Got {s}. Valid options which support multimodal inputs are: {valid_model_names}"
+    )
 
 
 def validate_no_keys_overwritten_twice(keys1: list[str], keys2: list[str]):

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ pytest
 pyink
 pre-commit
 pytype
+pillow>=11.1.0
 sentencepiece==0.1.97
 tensorflow-text>=2.13.0
 tensorflow>=2.13.0


### PR DESCRIPTION
# Description

Add multimodal support for decode.py. Add image preprocessing functions for Gemma3, especially used for decode.py. 

1. Add local image read function and resize/normalize for preprocessing.
2. Allow the loaded image to be passed through the Conv layer in Gemma3 vision encoder. Add conditional logic that if no images are passed, the vision_encoder branch won't be used.
3. Update prefill, insert and generate logics in maxengine.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: [b/407783855](https://b.corp.google.com/issues/407783855)

# Tests

Locally tested for both use_multimodal=True/False.

`python -m MaxText.decode MaxText/configs/base.yml model_name=gemma3-4b tokenizer_path=assets/tokenizer.gemma3 load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/gemma3-4b/vit/unscanned/checkpoints/0/items per_device_batch_size=1 run_name=runner_2025-04-18-18-20-33 max_prefill_predict_length=8 max_target_length=16 dataset_type=synthetic steps=1 async_checkpointing=false scan_layers=false prompt=\'I\ love\ to\' use_multimodal=True image_path=\'/home/hengtaoguo/projects/dog.jpg\'`

Compared with HF Gemma3 implementation. Loaded images and feature maps after Conv are matching:
<img width="646" alt="image" src="https://github.com/user-attachments/assets/dc3ddcfb-105a-491b-8e91-6e4b02272136" />


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
