### PR TITLE
Fix TPU unit tests related to JAX 0.6.0

### DIFF
--- a/MaxText/experimental/rl/grpo_trainer.py
+++ b/MaxText/experimental/rl/grpo_trainer.py
@@ -543,7 +543,7 @@ def train_step(model, config, state_mesh_shardings, state, data, dropout_rng):
         + grad_and_loss["moe_lb_loss"] / config.gradient_accumulation_steps
     )
     raw_grads = jax.tree_util.tree_map(lambda arr: arr / grad_and_loss["total_weights"], grad_and_loss["grad"])
-    aux = jax.tree_map(lambda x: jnp.sum(x, axis=0), aux)
+    aux = jax.tree.map(lambda x: jnp.sum(x, axis=0), aux)
   else:
     if config.optimizer_memory_host_offload:
       cast_params = jax.device_put(state.params, max_utils.with_memory_kind(state_mesh_shardings.params, "device"))

--- a/MaxText/kernels/ragged_attention.py
+++ b/MaxText/kernels/ragged_attention.py
@@ -52,7 +52,7 @@ def get_mha_cost_estimate(shape_dtype):
   return pl.CostEstimate(
       flops=flops,
       transcendentals=batch_size * num_heads * seq_len,
-      bytes_accessed=sum(np.prod(s.shape) * s.dtype.itemsize for s in shape_dtype),
+      bytes_accessed=int(sum(np.prod(s.shape) * s.dtype.itemsize for s in shape_dtype)),
   )
 
 

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -461,7 +461,7 @@ def train_step(model, config, state_mesh_shardings, state, data, dropout_rng):
         + grad_and_loss["moe_lb_loss"] / config.gradient_accumulation_steps
     )
     raw_grads = jax.tree_util.tree_map(lambda arr: arr / grad_and_loss["total_weights"], grad_and_loss["grad"])
-    aux = jax.tree_map(lambda x: jnp.sum(x, axis=0), aux)  # pytype: disable=module-attr
+    aux = jax.tree.map(lambda x: jnp.sum(x, axis=0), aux)  # pytype: disable=module-attr
   else:
     if config.optimizer_memory_host_offload:
       cast_params = jax.device_put(state.params, max_utils.with_memory_kind(state_mesh_shardings.params, "device"))


### PR DESCRIPTION
# Description

With JAX updated to 0.6.0, some of our unit tests are broken ([failed tpu_unit_tests](https://github.com/AI-Hypercomputer/maxtext/actions/runs/14541032330/job/40799138266)). This PR fixes:

1. Change from jax.tree_map to jax.tree.map. This fixes gradient_accumulation_test.py: `FAILED MaxText/tests/gradient_accumulation_test.py::GradientAccumulationTest::test_grad_accumulate_same_loss - AttributeError: jax.tree_map was removed in JAX v0.6.0: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version).`
3. Cast bytes_accessed to int. This fixes kernels_test.py: `FAILED MaxText/tests/kernels_test.py::RaggedAttentionTest::test_ragged_gqa - ValueError: All fields in CostEstimate must be ints. bytes_accessed is not an int: <class 'numpy.int64'>(16842768)`. 

# Tests

Local unit tests are passing. Check this PR's unit tests.
```
pytest MaxText/tests/gradient_accumulation_test.py
pytest MaxText/tests/kernels_test.py
```


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
