### PR TITLE
Support zarr checkpoints for inference with Pathways.

### DIFF
--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -467,7 +467,7 @@ def setup_decode_state(model, config, rng, mesh, checkpoint_manager):
     unboxed_abstract_state, state_mesh_annotations, _ = get_abstract_state(model, None, config, rng, mesh, False)
     with nn_partitioning.axis_rules(config.logical_axis_rules):
       params = checkpointing.load_params_from_path(
-          config.load_parameters_path, unboxed_abstract_state.params, config.checkpoint_storage_concurrent_gb
+          config.load_parameters_path, unboxed_abstract_state.params, config.checkpoint_storage_concurrent_gb, config.checkpoint_storage_use_ocdbt, config.checkpoint_storage_use_zarr3
       )
     state = init_decode_state(None, params)
 
@@ -531,6 +531,8 @@ def setup_initial_state(
         unboxed_abstract_state,
         config.enable_single_replica_ckpt_restoring,
         config.dataset_type,
+        use_ocdbt=config.checkpoint_storage_use_ocdbt,
+        use_zarr3=config.checkpoint_storage_use_zarr3,
     )
 
     if restored:

--- a/MaxText/standalone_checkpointer.py
+++ b/MaxText/standalone_checkpointer.py
@@ -64,6 +64,8 @@ def checkpoint_loop(config, state=None):
         config.load_full_state_path,
         config.checkpoint_storage_concurrent_gb,
         unboxed_abstract_state,
+        use_ocdbt=config.checkpoint_storage_use_ocdbt,
+        use_zarr3=config.checkpoint_storage_use_zarr3,
     )
     if state:
       state = state["items"]

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -701,6 +701,8 @@ def setup_train_loop(config):
           enable_single_replica_ckpt_restoring=False,
           dataset_type=config.dataset_type,
           step=0,
+          use_ocdbt=config.checkpoint_storage_use_ocdbt,
+          use_zarr3=config.checkpoint_storage_use_zarr3,
       )
     except FileNotFoundError:
       step0_restored = None

--- a/MaxText/utils/lora_utils.py
+++ b/MaxText/utils/lora_utils.py
@@ -132,7 +132,7 @@ def load_adapter(config, base_abstract_state_params, adapter_config_path, adapte
 
     with nn_partitioning.axis_rules(config.logical_axis_rules):
       lora_params = checkpointing.load_params_from_path(
-          adapter_weights_path, lora_state.params, config.checkpoint_storage_concurrent_gb
+          adapter_weights_path, lora_state.params, config.checkpoint_storage_concurrent_gb, config.checkpoint_storage_use_ocdbt, config.checkpoint_storage_use_zarr3
       )
 
   return lora_params, lora_config
@@ -185,6 +185,8 @@ def setup_initial_lora_state(model, data_iterator, tx, config, rng, mesh, checkp
           lora_state,
           config.enable_single_replica_ckpt_restoring,
           config.dataset_type,
+          use_ocdbt=config.checkpoint_storage_use_ocdbt,
+          use_zarr3=config.checkpoint_storage_use_zarr3,
       )
 
       if restored_lora:


### PR DESCRIPTION
# Description
Adding support for zarr checkpoints, compatible with Pathways. This helps with disaggregated serving using persistence APIs in Pathways.

Zarr checkpoints are generated when `use_ocdbt=False` and `use_zarr3=False` . There are config variables in Maxtext corresponding to both these flags `checkpoint_storage_use_ocdbt` and `checkpoint_storage_use_zarr3` which default to True. Through this PR, I am plumbing config overrides all the way to checkpointing functions.

Bug b/409627162

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
