### PR TITLE
Fix setup.sh to not block on the service restart screen

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,14 @@ export DEBIAN_FRONTEND=noninteractive
 export NEEDRESTART_SUSPEND=1
 export NEEDRESTART_MODE=l
 
+# Enable automatic restart of services without the need for prompting 
+if command -v sudo &> /dev/null
+then
+   sudo sed -i "s/#\$nrconf{restart} = 'i';/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
+else
+   echo "Unable to find sudo. Skipping editing needrestart.conf" 
+fi
+
 apt-get update && apt-get install -y sudo
 (sudo bash || bash) <<'EOF'
 apt update && \


### PR DESCRIPTION
# Description

Fix the setup.sh script to not block on a service restart screen. 

Certain TPU images use a Linux version where when running setup.sh, users get a purple screen to restart services. This ends up often hanging the session and preventing set up from continuing. This changes enables the auto mode for service restart and stops this from happening. It uses sed to replace the interactive flag with the automatic flag in the /etc/needrestart/needrestart.conf file. 

This is fairly basic quick fix and more comprehensive solution would require larger changes to the set up workflow. 

# Tests

1. Launched a version of Linux where setup.sh triggers the purple screen that hangs set up.
2. Verified that with this change that screen doesn't appear and set up continues. 
3. Confirmed I could run the training loop.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
