### PR TITLE
support bidirectional attention mask for multimodal

### DIFF
--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -47,7 +47,7 @@ BATCH = common_types.BATCH
 LENGTH = common_types.LENGTH
 HEAD = common_types.HEAD
 D_KV = common_types.D_KV
-
+TOKEN_PLACEHOLDER = -2
 
 nd_dense_init = initializers.nd_dense_init
 Quant = quantizations.AqtQuantization
@@ -122,6 +122,7 @@ class Gemma3DecoderLayer(nn.Module):
       previous_chunk=None,
       page_state=None,
       slot=None,
+      bidirectional_mask=None,
   ):
     cfg = self.config
     mesh = self.mesh
@@ -166,6 +167,7 @@ class Gemma3DecoderLayer(nn.Module):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         model_mode=model_mode,
+        bidirectional_mask=bidirectional_mask,
     )
     if cfg.use_post_attn_norm:
       attention_lnx = RMSNorm(


### PR DESCRIPTION
# Description

Support Gemma3 style bidirectional attention for image tokens in dot_product attention
(image from: https://huggingface.co/blog/gemma3)
![image](https://github.com/user-attachments/assets/7c1ac896-a318-47c6-bf5b-6fae38318eb2)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
