### PR TITLE
Initial support for pipelining a subset of layers

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -162,6 +162,12 @@ topk_routing_group: -1 # number of top groups to route inputs. For EP,
 num_layers_per_pipeline_stage: 1
 # The number of repeats will be set to num_decoder_layers / (num_pipeline_stages * num_layers_per_pipeline_stage)
 num_pipeline_repeats: -1
+pipeline_parallel_layers: -1 # Pipeline only this number of layers - for the remaining layers the "stage" mesh axes will act like data parallelism.
+# This option helps when the number of layers does not have friendly divisors since SPMD pipelining requires that the 
+# PP degree divides the number of layers.
+# By default (when set to -1) we pipeline all of the decoder layers.
+
+
 # num_pipeline_microbatches must be a multiple of the number of pipeline stages. By default it is set to the number of stages.
 # Note the microbatch_size is given by global_batch_size / num_pipeline_microbatches, where global_batch_size = per_device_batch_size * num_devices
 num_pipeline_microbatches: -1
@@ -185,7 +191,7 @@ pipeline_fsdp_ag_once: False # If set to true then all gather all of the weights
 # It may be useful to do the reverse when the layers_per_stage is very large.
 # The below settings only have effect when using pipeline parallelism.
 scan_pipeline_iterations: True
-# The layers per stage scanning option is set by scan_layers, we recommend setting scan_layers=False
+scan_layers_per_stage: False
 set_remat_policy_on_pipeline_iterations: True
 set_remat_policy_on_layers_per_stage: False
 

--- a/MaxText/layers/pipeline.py
+++ b/MaxText/layers/pipeline.py
@@ -358,7 +358,7 @@ class Pipeline(nn.Module):
     Gets the current weights used for one iteration. Outputs a pytree whose arrays have leading dimension of stages, e.g.
     {'mlp': 'wo': [stages, mlp, embed]}. Stage 0 will use the 0th index of this pytree, Stage 1 the 1st index, etc.
     For non-circular pipelines, this simply returns all weights - every weight is used in every iteraiton. However
-    for ciruclar pipelines each stage grabs only the weights correpsonding to the current repeat.
+    for circular pipelines each stage grabs only the weights corresponding to the current repeat.
     """
     if self.config.num_pipeline_repeats > 1:
       return self.get_current_repeat_from_stages(pipeline_weights, loop_iteration)

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -689,6 +689,23 @@ def add_config_to_summary_writer(config, summary_writer):
     for key, value in config.get_keys().items():
       max_utils.add_text_to_summary_writer(key, str(value), summary_writer)
 
+def logical_axis_rules_pp_act_as_dp(logical_rules):
+  """Add stage as a physical axes before data for each rule, so stage acts just like data instead of PP.
+  This is used when we want to pipeline only a subset of layers, and leave the rest like DP.
+  """
+  new_rules = []
+  for key, physical_axes in logical_rules:
+    if isinstance(physical_axes, str):
+      physical_axes = (physical_axes,)
+    else:
+      physical_axes = tuple(physical_axes)
+    new_physical_axes = tuple(axis for axis in physical_axes if axis != "stage")
+    if "data" in new_physical_axes:
+      data_idx = new_physical_axes.index("data")
+      new_physical_axes = new_physical_axes[0:data_idx] + ("stage",) + new_physical_axes[data_idx:]
+    new_rules.append((key, new_physical_axes))
+  return tuple(new_rules)
+
 
 def create_device_mesh(config, devices=None):
   """Creates a device mesh with each slice in its own data parallel group. If there is only one slice, uses two replicas"""

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -775,18 +775,25 @@ def set_and_validate_pipeline_config(raw_keys):
     raw_keys["logical_axis_rules"] = modify_activation_embed_and_logits_batch(raw_keys["logical_axis_rules"])
     raw_keys = pipeline_first_axis(raw_keys)
     num_stages = int(raw_keys["ici_pipeline_parallelism"] * raw_keys["dcn_pipeline_parallelism"])
+    if raw_keys["pipeline_parallel_layers"] == -1:
+      raw_keys["pipeline_parallel_layers"] = raw_keys["num_decoder_layers"]
+    else:
+      assert (raw_keys["pipeline_parallel_layers"] <= raw_keys["num_decoder_layers"]), f"You can only pipeline a subset of the decoder layers, but you requested to pipeline {raw_keys['pipeline_parallel_layers']} with pipeline_parallel_layers and there are only {raw_keys['num_decoder_layers']} decoder layers."
+    assert raw_keys["scan_layers"] or raw_keys["pipeline_parallel_layers"]==raw_keys["num_decoder_layers"], "Currently we only support scan_layers=True when pipelining a subset of layers."
+    assert raw_keys["pipeline_parallel_layers"] > 0, "You must set pipeline_parallel_layers to a positive integer less than or equal to the number of layers"
+
     if raw_keys["num_pipeline_repeats"] == -1:
       num_pipeline_repeats, remainder = divmod(
-          raw_keys["num_decoder_layers"], num_stages * raw_keys["num_layers_per_pipeline_stage"]
+          raw_keys["pipeline_parallel_layers"], num_stages * raw_keys["num_layers_per_pipeline_stage"]
       )
       assert (
           not remainder
-      ), f"The number of layers per stage ({raw_keys['num_layers_per_pipeline_stage']}) times the number of stages ({num_stages}) must divide the number of decoder layers ({raw_keys['num_decoder_layers']}) "
+      ), f"The number of layers per stage ({raw_keys['num_layers_per_pipeline_stage']}) times the number of stages ({num_stages}) must divide the number of pipeline_parallel_layers which defaults to decoder layers  ({raw_keys['pipeline_parallel_layers']}) "
       raw_keys["num_pipeline_repeats"] = num_pipeline_repeats
     assert (
         num_stages * raw_keys["num_pipeline_repeats"] * raw_keys["num_layers_per_pipeline_stage"]
-        == raw_keys["num_decoder_layers"]
-    ), f"The product of pipeline stages ({num_stages}), repeats ({raw_keys['num_pipeline_repeats']}), and layers per stage ({raw_keys['num_layers_per_pipeline_stage']}) must be equal to the number of layers ({raw_keys['num_decoder_layers']})"
+        == raw_keys["pipeline_parallel_layers"]
+    ), f"The product of pipeline stages ({num_stages}), repeats ({raw_keys['num_pipeline_repeats']}), and layers per stage ({raw_keys['num_layers_per_pipeline_stage']}) must be equal to pipeline_parallel_layers which defaults to decoder layers ({raw_keys['pipeline_parallel_layers']})"
     if raw_keys["num_pipeline_microbatches"] == -1:
       if raw_keys["pipeline_delay_activation_forwarding"]:
         raw_keys["num_pipeline_microbatches"] = 2 * num_stages

--- a/MaxText/tests/maxtext_utils_test.py
+++ b/MaxText/tests/maxtext_utils_test.py
@@ -215,6 +215,34 @@ class MaxUtilsInitTransformerState(unittest.TestCase):
     self.assertEqual(state.tx, tx)
     self.assertNotEqual(state.opt_state, {})
 
+class MaxUtilsPpAsDp(unittest.TestCase):
+  """Tests logical_axis_rules_pp_act_as_dp converts rules so stage is added before data."""
+
+  def test_stage_added_before_data(self):
+    input_rules = (("activation_batch", ("data","fsdp")),)
+    expected_transform = (("activation_batch", ("stage", "data","fsdp")),)
+    transformed_rules = maxtext_utils.logical_axis_rules_pp_act_as_dp(input_rules)
+    self.assertEqual(transformed_rules, expected_transform)
+
+  def test_stage_removed(self):
+    input_rules = (("layers", "stage"),)
+    expected_transform = (("layers", (),),)
+    transformed_rules = maxtext_utils.logical_axis_rules_pp_act_as_dp(input_rules)
+    self.assertEqual(transformed_rules, expected_transform)
+
+  def multiple_rules(self):
+    input_rules = (
+      ("activation_batch", ("data","fsdp")),
+      ("layers", "stage"),
+      ("experts", "expert"),
+    )
+    expected_transform = (
+      ("activation_batch", ("stage", "data","fsdp")),
+      ("layers", ()),
+      ("experts", "expert"),
+    )
+    transformed_rules = maxtext_utils.logical_axis_rules_pp_act_as_dp(input_rules)
+    self.assertEqual(transformed_rules, expected_transform)
 
 if __name__ == "__main__":
   unittest.main()

--- a/MaxText/tests/pipeline_parallelism_test.py
+++ b/MaxText/tests/pipeline_parallelism_test.py
@@ -248,7 +248,7 @@ class PipelineParallelismTest(unittest.TestCase):
             "num_layers_per_pipeline_stage=2",
             "num_pipeline_microbatches=8",
             rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
-            "scan_layers=False",  # We see better performance only scanning the pipeline iterations.
+            "scan_layers_per_stage=False",  # We see better performance only scanning the pipeline iterations.
         ]
     )
 
@@ -295,7 +295,39 @@ class PipelineParallelismTest(unittest.TestCase):
             "num_layers_per_pipeline_stage=8",
             "num_pipeline_microbatches=8",
             rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
-            "scan_layers=False",  # We see better performance only scanning the pipeline iterations.
+            "scan_layers_per_stage=False",  # We see better performance only scanning the pipeline iterations.
+        ]
+    )
+
+  @pytest.mark.tpu_only
+  def test_subset_layers(self):
+    # Run a full train.py call with 4 stages, 16 layers - 8 in pipeline, 8 ran outside of pipeline
+    train_main(
+        [
+            None,
+            os.path.join(PKG_DIR, "configs", "base.yml"),
+            rf"base_output_directory=gs://runner-maxtext-logs",
+            "run_name=runner_pipeline_parallelism_test",
+            r"dataset_path=gs://maxtext-dataset",
+            "base_emb_dim=28",
+            "base_num_query_heads=4",
+            "base_num_kv_heads=4",
+            "base_mlp_dim=32",
+            "base_num_decoder_layers=16",
+            "head_dim=128",
+            "per_device_batch_size=2",
+            "max_target_length=1024",
+            "vocab_size=32",
+            "dataset_type=synthetic",
+            "steps=3",
+            "enable_checkpointing=False",
+            "ici_pipeline_parallelism=4",
+            "num_layers_per_pipeline_stage=1",
+            "num_pipeline_repeats=2",
+            "pipeline_parallel_layers=8",
+            "num_pipeline_microbatches=8",
+            rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
+            "scan_layers_per_stage=False",  # We see better performance only scanning the pipeline iterations.
         ]
     )
 
@@ -324,7 +356,7 @@ class PipelineParallelismTest(unittest.TestCase):
             "ici_pipeline_parallelism=4",
             rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
             "quantization=fp8",
-            "scan_layers=False",
+            "scan_layers_per_stage=False",
             "attention=dot_product",
         ]
     )
@@ -354,7 +386,7 @@ class PipelineParallelismTest(unittest.TestCase):
             "ici_pipeline_parallelism=4",
             rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
             "quantization=nanoo_fp8",
-            "scan_layers=False",
+            "scan_layers_per_stage=False",
             "attention=dot_product",
         ]
     )


### PR DESCRIPTION
# Description

 Support an option to pipeline a subset of layers. This is useful for our currently SPMD pipelining implementation which requires that the pipelining degree must divide the number of layers. Some OSS models don't have a friendly number of layers, e.g. 58 for deepseek.

This additionally separates the scanning pipeline layers per stage into its own option.

Full support for PP of subset on DeepSeek and Llama4 will require more modifications because they have non-homogenous layers which is handled [here](https://github.com/AI-Hypercomputer/maxtext/blob/3409fb4f9264809723a83892240b452feb5837fb/MaxText/layers/models.py#L462) 

Supporting: b/404566880

# Tests

* Added tests in this PR
* [xprof](https://xprof.corp.google.com/trace_viewer/mattdavidow-12989516961696272071?hosts=t1v-n-70a81276-w-0&host_index=0&trace_filter_config={}&view_start=-789.326&view_end=6058.069) of PP=4, subset layers=8, total layers=16 on a v6e-16

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
