### PR TITLE
Update SparseCore Offloading flags

### DIFF
--- a/benchmarks/xla_flags_library.py
+++ b/benchmarks/xla_flags_library.py
@@ -74,9 +74,8 @@ CF_FOR_ALL_REDUCE_AND_ALL_GATHER = (
 ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS = (
     " --xla_tpu_use_tc_device_shape_on_sc=true"
     " --xla_sc_enable_instruction_fusion=false"
-    " --xla_sc_disjoint_spmem=false"
     " --xla_sc_disable_megacore_partitioning=true"
-    " --2a886c8_chip_config_name=megachip_tccontrol"
+    " --2a886c8_chip_config_name=megachip_tccontrol"  # Should be set by default but leaving here just in case.
 )
 
 


### PR DESCRIPTION
xla_sc_disjoint_spmem is no longer needed to be set

# Description

Update SC flags with latest recommendation.

# Tests

NA

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
