### PR TITLE
Add default to rope_type in llama_or_mistral_ckpt

### DIFF
--- a/MaxText/llama_or_mistral_ckpt.py
+++ b/MaxText/llama_or_mistral_ckpt.py
@@ -329,7 +329,7 @@ def initialize_self_attention_lora_kernels(
     reshape_b: bool = False,
     shape_b: bool = None,
 ):
-  """Helper function to intialize LoRA kernels for given target module.
+  """Helper function to initialize LoRA kernels for given target module.
 
   Args:
     self_attention_lora (dict): Intermediate dictionary to store LoRA kernels.
@@ -826,7 +826,7 @@ def _convert_pytorch_to_jax_weights(base_model_path: str, model_size: str, model
   base_num_kv_heads = model_params["num_kv_heads"]
   vocab_size = model_params["vocab"]
   num_experts = model_params["num_experts"] if "num_experts" in model_params else None
-  rope_type = model_params.get("rope_type")
+  rope_type = model_params.get("rope_type", "")
   scale_query = model_params.get("scale_query", True)
 
   chkpt_vars = {}


### PR DESCRIPTION
# Description

Otherwise conversion fails for any model other than llama3.1 with the following error:

```
Loading the base model from /tmp/7b
Loading checkpoint 1 of 1 ...
Processing decoder norm scale
Processing logits dense
Processing token embeddings
Processing self attention
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/karangoel_google_com/code/maxtext/MaxText/llama_or_mistral_ckpt.py", line 1434, in <module>
    convert_to_jax_weights(args.base_model_path, args.model_size, args.huggingface_checkpoint),
  File "/home/karangoel_google_com/code/maxtext/MaxText/llama_or_mistral_ckpt.py", line 1314, in convert_to_jax_weights
    return _convert_pytorch_to_jax_weights(base_model_path, model_size, model_params, mem_info)
  File "/home/karangoel_google_com/code/maxtext/MaxText/llama_or_mistral_ckpt.py", line 969, in _convert_pytorch_to_jax_weights
    if model_size[:8] not in llama3_variants and not rope_type.startswith("llama3.1"):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

# Tests

Tested locally.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.