### PR TITLE
Fix MoE GPU e2e test script 

### DIFF
--- a/end_to_end/gpu/mixtral/test_8x7b.sh
+++ b/end_to_end/gpu/mixtral/test_8x7b.sh
@@ -32,7 +32,7 @@ python3 -m MaxText.train MaxText/configs/base.yml model_name=mixtral-8x7b hardwa
     enable_checkpointing=false ici_expert_parallelism=-1 ici_fsdp_parallelism=1 \
     max_target_length=1024 megablox=False per_device_batch_size=1 \
     reuse_example_batch=1 steps=5 tokenizer_path=assets/tokenizer.mistral-v1 \
-    weight_dtype=bfloat16 sparse_matmul=False
+    weight_dtype=bfloat16 sparse_matmul=False packing=False
 echo "Finished pre-training"
 
 # Run fine-tuning - dropping implementation
@@ -44,7 +44,7 @@ python3 -m MaxText.train MaxText/configs/base.yml model_name=mixtral-8x7b hardwa
     ici_expert_parallelism=-1 ici_fsdp_parallelism=1 \
     max_target_length=1024 megablox=False per_device_batch_size=1 \
     reuse_example_batch=1 steps=5 tokenizer_path=assets/tokenizer.mistral-v1 \
-    weight_dtype=bfloat16 sparse_matmul=False
+    weight_dtype=bfloat16 sparse_matmul=False packing=False
 echo "Finished fine-tuning"
 
 # # TODO(b/391864113): Add this once the bug is fixed


### PR DESCRIPTION
# Description

This PR fixes the MoE GPU e2e test script by setting the newly introduced config `packing=false` to work with `attention=cudnn_flash_te`

# Tests
Verified by running locally. 
http://shortn/_mwhcbLOOjM

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
