### PR TITLE
Fix benchmark_db_utils imports and invocation

### DIFF
--- a/benchmarks/benchmark_db_utils.py
+++ b/benchmarks/benchmark_db_utils.py
@@ -22,7 +22,6 @@ import uuid
 import dataclasses
 from tempfile import gettempdir
 
-from benchmarks.command_utils import run_command_with_updates
 from argparse import Namespace
 
 BQ_WRITER_PATH = "/benchmark-automation/benchmark_db_writer/src"

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -14,7 +14,7 @@
  limitations under the License.
  """
 
-"""  This file contains data classes and runner logic to execute the XPK runs triggered by benchmarks/benchmark_runner.py"
+"""  This file contains data classes and runner logic to execute the XPK runs triggered by benchmarks.benchmark_runner"
 
 """
 # Improvements:
@@ -623,7 +623,7 @@ def generate_xpk_workload_cmd(
     args_str = ""
     for k,v in args.items():
       args_str += f'--{k}={v} '
-    upload_metrics_to_bq_cmd = f"&& python3 benchmarks/upload_metrics_to_bq.py {args_str}"
+    upload_metrics_to_bq_cmd = f"&& python3 -m benchmarks.upload_metrics_to_bq {args_str}"
 
   print(f'User command: {user_command}')
   all_xpk_storage = ""

--- a/benchmarks/upload_metrics_to_bq.py
+++ b/benchmarks/upload_metrics_to_bq.py
@@ -18,12 +18,11 @@ from typing import Any, Dict, Sequence
 from statistics import median
 
 import omegaconf
-from command_utils import run_command_with_updates
-# from benchmark_db_utils import install_mantaray_locally
-from benchmark_db_utils import write_run
-from benchmark_db_utils import DEFAULT_LOCAL_DIR
-from benchmark_db_utils import recover_tuning_params
-from benchmark_db_utils import Metrics
+from benchmarks.command_utils import run_command_with_updates
+from benchmarks.benchmark_db_utils import write_run
+from benchmarks.benchmark_db_utils import DEFAULT_LOCAL_DIR
+from benchmarks.benchmark_db_utils import recover_tuning_params
+from benchmarks.benchmark_db_utils import Metrics
 from MaxText.inference_utils import str2bool
 import dataclasses
 import fnmatch


### PR DESCRIPTION
# Description

* `maxtext_xpk_runner` was still using the pre-refactor way of running `upload_metrics_to_bq`. This caused an expected `no module named ...` error.
* Fix the `upload_metrics_to_bq` import statements after the MaxText refactor. We started seeing import errors after fixing the way the module is called

@yiqian-xu first noticed this issue

# Tests

```
bash docker_build_dependency_image.sh MODE=stable MANTARAY=true
python3 -m benchmarks.maxtext_xpk_runner
```

Saw `no module`/import errors before this change. After this error the workload runs properly and writes to BQ. Note that the metrics written to BQ are incorrect, which is a separate known issue

![Screenshot 2025-04-24 at 3 44 44 PM](https://github.com/user-attachments/assets/bbe37721-586d-4d0c-8cdd-d8c407d3d72b)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
