### PR TITLE
Add Pillow to JAX-stable-stack dependency files

### DIFF
--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -11,6 +11,7 @@ pytest
 pyink
 pre-commit
 pytype
+pillow>=11.1.0
 sentencepiece==0.1.97
 tensorflow-text>=2.13.0
 tensorflow-datasets

--- a/requirements_with_jax_stable_stack_0_5_2_pipreqs.txt
+++ b/requirements_with_jax_stable_stack_0_5_2_pipreqs.txt
@@ -35,6 +35,7 @@ psutil==7.0.0
 pytest==8.3.5
 PyYAML==6.0.2
 PyYAML==6.0.2
+pillow>=11.1.0
 Requests==2.32.3
 safetensors==0.5.3
 sentencepiece==0.1.97


### PR DESCRIPTION
# Description

Add `pillow>=11.1.0` to two JAX-stable-stack dependency files

Currently, we only have `pillow>=11.1.0` in [requirements.txt](https://github.com/AI-Hypercomputer/maxtext/blob/e0fe857280edf63e84be2ce63061bc5d39cc0c36/requirements.txt#L29).

FIXES: b/413463826

# Tests

Successfully build with base image tpu:jax0.5.2-rev1
```                                                                                                                                                                                              
BASE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.5.2-rev1                                                                                                                                  
bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=$BASE
```                                                                                                                          


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
