### PR TITLE
add trillium config for deepseek3

### DIFF
--- a/benchmarks/maxtext_trillium_model_configs.py
+++ b/benchmarks/maxtext_trillium_model_configs.py
@@ -1007,12 +1007,12 @@ llama3_1_70b_8192_iter_synthetic = _add_to_model_dictionary(
         + xla_flags_library.DATA_PARALLEL_OVERLAP
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.HOST_OFFLOAD_FLAGS
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE 
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
         +  " --xla_tpu_iova_dma_chunk_size_bytes=104857"
     ),
   )
 )
- 
+
 llama3_1_70b_8192_iter_real_data_grain = _add_to_model_dictionary(
   trillium_model_dict,
   MaxTextModel(
@@ -1050,12 +1050,12 @@ llama3_1_70b_8192_iter_real_data_grain = _add_to_model_dictionary(
         + xla_flags_library.DATA_PARALLEL_OVERLAP
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.HOST_OFFLOAD_FLAGS
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE 
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
         +  " --xla_tpu_iova_dma_chunk_size_bytes=104857"
     ),
   )
 )
- 
+
 llama3_1_70b_8192_iter_synthetic_ckpt = _add_to_model_dictionary(
   trillium_model_dict,
   MaxTextModel(
@@ -1092,12 +1092,12 @@ llama3_1_70b_8192_iter_synthetic_ckpt = _add_to_model_dictionary(
         + xla_flags_library.DATA_PARALLEL_OVERLAP
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.HOST_OFFLOAD_FLAGS
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE 
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
         +  " --xla_tpu_iova_dma_chunk_size_bytes=104857"
     ),
   )
 )
- 
+
 llama3_1_70b_8192_iter_real_data_and_checkpointing = _add_to_model_dictionary(
   trillium_model_dict,
   MaxTextModel(
@@ -1137,7 +1137,7 @@ llama3_1_70b_8192_iter_real_data_and_checkpointing = _add_to_model_dictionary(
         + xla_flags_library.DATA_PARALLEL_OVERLAP
         + xla_flags_library.CF_FOR_ALL_GATHER
         + xla_flags_library.HOST_OFFLOAD_FLAGS
-        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE 
+        + xla_flags_library.ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE
         +  " --xla_tpu_iova_dma_chunk_size_bytes=104857"
     ),
   )
@@ -1584,6 +1584,48 @@ mixtral_8x22b_dropped = _add_to_model_dictionary(
         ),
     ),
 )
+
+
+deepseek_v3_ep16 = _add_to_model_dictionary(
+    trillium_model_dict,
+    MaxTextModel(
+        model_name="deepseek_v3_ep16",
+        model_type="deepseek3-671b",
+        tuning_params={
+            "per_device_batch_size": 1,
+            "max_target_length": 8192,
+            "ici_fsdp_parallelism": 16,
+            "ici_expert_parallelism": 16,
+            "dcn_fsdp_parallelism": 2,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "profiler": "xplane",
+            "sa_block_q": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+            "megablox": False,
+            "sparse_matmul": False,
+            "capacity_factor": 1.0,
+            "tokenizer_path": "assets/tokenizer.mistral-v3",
+            "dtype": "bfloat16",
+            "opt_type": "sgd",
+            "weight_dtype": "bfloat16",
+            "attention": "flash",
+        },
+        xla_flags=(
+            xla_flags_library.MOE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+        ),
+    ),
+)
+
 
 gemma2_9b_8192 = _add_to_model_dictionary(
     trillium_model_dict,


### PR DESCRIPTION
# Description

- add deepseek3 trillium config for benchmarking
- the settings is based on: gpaste/4839162195476480 (from b/400276716#comment2)

# Tests

on XLML, using this as a template: https://github.com/GoogleCloudPlatform/ml-auto-solutions/blob/master/dags/multipod/maxtext_trillium_configs_perf.py
- I create a local dag for testing pretraining of deepseek (num_slice=2, jax nightly docker). Code: https://screenshot.googleplex.com/9LFdtaCxN6u59RX
- The pretraining is successful. Result:
https://screenshot.googleplex.com/AGofVG4t5pdUCyU

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
