### PR TITLE
Fix number of steps in checkpointing airflow test

### DIFF
--- a/end_to_end/test_checkpointing.sh
+++ b/end_to_end/test_checkpointing.sh
@@ -35,14 +35,16 @@ then
     CMD_DATA=" grain_worker_count=0 dataset_type=grain grain_train_files=/tmp/gcsfuse/array-record/c4/en/3.0.1/c4-train.array_record*"
 fi
 
-#Train
+# This command runs training for some steps and saves a checkpoint.
 CMD1="python3 -m MaxText.train MaxText/configs/base.yml run_name=$RUN_NAME steps=5 max_target_length=128 per_device_batch_size=1\
     metrics_file=saved_metrics.txt checkpoint_period=3 base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH\
     async_checkpointing=$ASYNC_CHECKPOINTING collect_stack_trace=$COLLECT_STACK_TRACE attention=$ATTENTION"
 CMD1+=$model_params
 CMD1+=$CMD_DATA
 
-CMD2="python3 -m MaxText.train MaxText/configs/base.yml run_name=$RUN_NAME steps=5 max_target_length=128 per_device_batch_size=1\
+# This command restores the checkpoint from the previous run and continue training from the restored checkpoint.
+# This ensures actual new training steps are executed after restoring checkpoint from the above training run.
+CMD2="python3 -m MaxText.train MaxText/configs/base.yml run_name=$RUN_NAME steps=10 max_target_length=128 per_device_batch_size=1\
     metrics_file=restored_metrics.txt base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH\
     async_checkpointing=$ASYNC_CHECKPOINTING collect_stack_trace=$COLLECT_STACK_TRACE attention=$ATTENTION"
 CMD2+=$model_params
@@ -54,9 +56,7 @@ echo "Command is:"
 echo $CMD1
 
 $CMD1
-# Wait for first train to finish
-# process_id=$!
-# wait $process_id
+
 echo
 echo "First training run done"
 echo "Start the second training run"


### PR DESCRIPTION
# Description
This PR increases the number of steps for the training command that runs after checkpoint restoration in our checkpointing test. This test is designed to: 
1) train for some initial steps, 
2) save a checkpoint, 
3) restore that checkpoint, and 
4) continue training for further steps.

Previously, if the first command (train and save checkpoint) and the second command (restore checkpoint and train) aimed for the same total number of steps, the second command would effectively perform no training, as the restored checkpoint would already be at the target step count. This change ensures that additional, distinct training steps are executed after restoring of checkpoint.

Related Airflow test directory PR: https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/694

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: [b/413423342](https://buganizer.corp.google.com/issues/413423342)

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
Tested with local airflow server.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
