### PR TITLE
Authenticate to Google Cloud within each job in RunTests.yml

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -34,8 +34,6 @@ jobs:
       run: which gsutil >/dev/null 2>&1 || { echo >&2 "gsutil is required but not installed. Aborting"; exit 24;}
     - name: Cleanup old docker images
       run: docker system prune --all --force
-    - name: Authenticate gcloud
-      run: gcloud auth configure-docker us-docker.pkg.dev --quiet
 
   tpu_image:
     needs: prelim
@@ -112,6 +110,8 @@ jobs:
       contents: read
       issues: write  # for failed-build-issue
     steps:
+    - name: Authenticate gcloud
+      run: gcloud auth configure-docker us-docker.pkg.dev --quiet
     - name: Delete GPU image
       run: gcloud container images delete gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:gpu --force-delete-tags --quiet
     - name: Delete TPU image

--- a/.github/workflows/build_upload_internal.yml
+++ b/.github/workflows/build_upload_internal.yml
@@ -37,6 +37,8 @@ jobs:
     name: Build and upload image (${{ inputs.device_name }})
     runs-on: ["self-hosted", "${{ inputs.device_type }}", "${{ inputs.device_name }}"]
     steps:
+      - name: Authenticate gcloud
+        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
       - uses: actions/checkout@v4
       - name: Build an image
         run: |

--- a/.github/workflows/run_tests_internal.yml
+++ b/.github/workflows/run_tests_internal.yml
@@ -44,17 +44,22 @@ on:
 jobs:
   run:
     runs-on: ["self-hosted", "${{ inputs.device_type }}", "${{ inputs.device_name }}"]
-    container:
-      image: gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:${{ inputs.device_type }}
-      volumes:
-        - /home/runner/actions-runner/_work/maxtext/maxtext:/deps
-      env:
-        XLA_PYTHON_CLIENT_MEM_FRACTION: ${{ inputs.xla_python_client_mem_fraction }}
-        TF_FORCE_GPU_ALLOW_GROWTH: ${{ inputs.tf_force_gpu_allow_growth }}
-      options: ${{ inputs.container_resource_option }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Run Tests
+      - name: Authenticate gcloud
+        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
+      - name: Pull Docker image
         run: |
-          python3 -m pip install -e .
-          python3 -m pytest --pyargs MaxText.tests -m "${{ inputs.pytest_marker }}" --durations=0
+          docker pull gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:${{ inputs.device_type }}
+      - uses: actions/checkout@v4
+      - name: Run tests inside container
+        run: |
+          docker run --rm \
+            -v /home/runner/actions-runner/_work/maxtext/maxtext:/deps \
+            -e XLA_PYTHON_CLIENT_MEM_FRACTION=${{ inputs.xla_python_client_mem_fraction }} \
+            -e TF_FORCE_GPU_ALLOW_GROWTH=${{ inputs.tf_force_gpu_allow_growth }} \
+            ${{ inputs.container_resource_option }} \
+            gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:${{ inputs.device_type }} \
+            bash -c "
+              python3 -m pip install -e . &&
+              python3 -m pytest --pyargs MaxText.tests -m '${{ inputs.pytest_marker }}' --durations=0
+            "


### PR DESCRIPTION
Currently, auth happens in the prelim step, but other jobs might be picked up by different runners, that did not do auth. So, doing it in the prelim step is not sufficient. This PR moves auth to each step.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
