### PR TITLE
gemma3 multimodal: image and text token fusion

### DIFF
--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -94,11 +94,10 @@ def main(argv: Sequence[str]) -> None:
   params = engine.load_params(rng_load_params)
 
   text = config.prompt
-  images = None
+  prefill_length = config.max_prefill_predict_length
   if config.use_multimodal:
-    # TODO(hengtaoguo): Support multiple images as input.
-    images = multimodal_utils.load_image_from_path(config.image_path)
-    images = multimodal_utils.pre_process_image(images, model_name=config.model_name)
+    text = multimodal_utils.reformat_prompt(text, config.model_name)
+    prefill_length -= multimodal_utils.get_image_offsets(config.model_name)
 
   metadata = engine.get_tokenizer()
   tokenizer_model = engine.build_tokenizer(metadata)
@@ -107,10 +106,18 @@ def main(argv: Sequence[str]) -> None:
     has_chat_template = getattr(tokenizer_model.tokenizer, "chat_template", False)  # pytype: disable=attribute-error
   except AttributeError as _:
     has_chat_template = False
-  tokens, true_length = tokenizer_model.encode(
-      text, is_bos=not has_chat_template, prefill_lengths=[config.max_prefill_predict_length]
-  )
-  assert true_length <= config.max_prefill_predict_length, "can't take too many tokens"
+  tokens, _ = tokenizer_model.encode(text, is_bos=not has_chat_template, prefill_lengths=[prefill_length])
+  images = None
+  if config.use_multimodal:
+    # TODO(hengtaoguo): Support multiple images as input.
+    images = multimodal_utils.load_image_from_path(config.image_path)
+    images = multimodal_utils.pre_process_image(images, model_name=config.model_name)
+    tokens = multimodal_utils.prepare_text_for_image_fusion(tokens, model_name=config.model_name)
+
+  true_length = tokens.shape[0]
+  assert (
+      true_length <= config.max_prefill_predict_length
+  ), f"Input token length {true_length} is longer than {config.max_prefill_predict_length=}"
   assert config.quantization != "fp8", "fp8 on NVIDIA GPUs is not supported in decode.py yet"
   assert config.quantization != "nanoo_fp8", "NANOO fp8 on AMD MI300/MI325 GPUs is not supported in decode.py yet"
 

--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -47,7 +47,12 @@ BATCH = common_types.BATCH
 LENGTH = common_types.LENGTH
 HEAD = common_types.HEAD
 D_KV = common_types.D_KV
+BEGIN_IMAGE_TOKEN = 255999
+END_IMAGE_TOKEN = 262144
+NEW_LINE_TOKEN = 108
 TOKEN_PLACEHOLDER = -2
+NUM_PLACEHOLDER_TOKENS_PER_IMAGE = 256
+NUM_TOKENS_PER_MEDIA = NUM_PLACEHOLDER_TOKENS_PER_IMAGE + 4
 
 nd_dense_init = initializers.nd_dense_init
 Quant = quantizations.AqtQuantization

--- a/MaxText/multimodal_utils.py
+++ b/MaxText/multimodal_utils.py
@@ -82,3 +82,258 @@ def pre_process_image(image, model_name):
     return pre_process_gemma3_image(image)
   else:
     raise ValueError(f"Model {model_name} does not support multimodal inference.")
+
+
+def reformat_prompt(prompt, model_name):
+  """Reformat prompt for different models."""
+  if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+    PROMPT = """\
+    <start_of_turn>user
+    {}<end_of_turn>
+    <start_of_turn>model
+    """
+    return PROMPT.format(prompt)
+  else:
+    return prompt
+
+
+def get_image_offsets(model_name):
+  """Get the increase in total token count after inserting image token placeholders"""
+  if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+    from MaxText.layers import gemma3
+
+    return gemma3.NUM_TOKENS_PER_MEDIA - 1  # -1 because <start_of_image> is already present in the input tokens.
+  else:
+    return 0
+
+
+def prepare_text_for_image_fusion(texts, model_name):
+  if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+    return add_extra_tokens_for_images_gemma3(texts)
+  else:
+    raise ValueError(f"Model {model_name} does not support multimodal inference.")
+
+
+def add_extra_tokens_for_images_gemma3(
+    tokens: np.ndarray | jnp.ndarray,
+    *,
+    max_num_images: int = 1,
+):  # -> Int['B L+(max_num_images * (num_tokens_per_image + 3))']:
+  r"""Add the extra image tokens to the text tokens.
+
+  If the model has images, we expand each `<start_of_image>` token by the image
+  placeholder tokens.
+
+  Example:
+
+  ```python
+  input = [..., x, <start_of_image>, y, ...]
+  output = [
+      ..., x, \n\n, <start_of_image>, SOFT_TOKEN_PLACEHOLDER,
+      SOFT_TOKEN_PLACEHOLDER, ..., SOFT_TOKEN_PLACEHOLDER,
+      SOFT_TOKEN_PLACEHOLDER, <end_of_image>, \n\n, y, ...
+  ]
+  ```
+
+  The `\n\n` tokens are added to match how the model was trained.
+
+  Args:
+    tokens: The text tokens.
+    max_num_images: The maximum number of images in the batch.
+    num_tokens_per_image: The number of soft tokens per image.
+
+  Returns:
+    The text tokens with the extra image tokens.
+  """
+
+  from MaxText.layers import gemma3
+
+  # New tokens which will be inserted for each image.
+  mm_tokens = [
+      gemma3.NEW_LINE_TOKEN,
+      gemma3.BEGIN_IMAGE_TOKEN,
+      *[gemma3.TOKEN_PLACEHOLDER] * gemma3.NUM_PLACEHOLDER_TOKENS_PER_IMAGE,
+      gemma3.END_IMAGE_TOKEN,
+      gemma3.NEW_LINE_TOKEN,
+  ]
+
+  return insert_sequence(
+      at=gemma3.BEGIN_IMAGE_TOKEN,
+      sequence=mm_tokens,
+      tokens=tokens,
+      max_num_images=max_num_images,
+  )
+
+
+def insert_sequence(
+    tokens: np.ndarray | jnp.ndarray,
+    *,
+    at: int,
+    sequence: np.ndarray | jnp.ndarray,
+    max_num_images: int,
+) -> np.ndarray | jnp.ndarray:
+  """Insert a sequence of tokens at a given position."""
+  tokens_dim = len(tokens.shape)
+  if tokens_dim == 1:
+    tokens = tokens[None, :]
+  _, length = tokens.shape
+
+  mm_tokens = jnp.array(sequence, dtype=jnp.int32)
+
+  # `-1` because `<start_of_image>` is already present in the input tokens.
+  offset_by = len(mm_tokens) - 1
+
+  # Maximum length, if all images are present.
+  length_with_mm = length + max_num_images * offset_by
+
+  mm_start = tokens == at
+
+  # Get the text tokens correctly placed at their final position.
+  # The `<start_of_image>` are removed and expanded to leave space for the MM
+  # tokens.
+  # tokens = [..., x, <start_of_image>, y, ...]
+  # new_text_tokens = [..., x, 0, 0, 0, ..., 0, 0, 0, y, ...]
+  new_text_tokens = _get_new_text_tokens(
+      mm_start=mm_start,
+      text_tokens=tokens,
+      offset_by=offset_by,
+      length_with_mm=length_with_mm,
+  )
+
+  # Get the mm tokens placeholders, correctly placed at their final position.
+  # new_mm_tokens = [
+  #     ..., 0, 0, \n\n, <start_of_image>, ..., <end_of_image>, \n\n, 0, 0, ...
+  # ]
+  new_mm_tokens = _get_new_mm_tokens(
+      mm_start=mm_start,
+      mm_tokens_to_insert=mm_tokens,
+      max_num_images=max_num_images,
+      offset_by=offset_by,
+      length_with_mm=length_with_mm,
+  )
+
+  # Merge the text and MM tokens.
+  new_tokens = new_text_tokens + new_mm_tokens
+  if tokens_dim < len(new_tokens.shape):
+    new_tokens = jnp.squeeze(new_tokens)
+  return new_tokens
+
+
+def _get_new_text_tokens(
+    *,
+    mm_start: np.ndarray | jnp.ndarray,
+    text_tokens: np.ndarray | jnp.ndarray,
+    offset_by: int,
+    length_with_mm: int,
+) -> np.ndarray | jnp.ndarray:
+  # Jax vmap does not support positional arguments, so need the
+  # _get_new_text_tokens_inner indirection.
+  return jax.vmap(_get_new_text_tokens_inner, in_axes=(0, 0, None, None))(mm_start, text_tokens, offset_by, length_with_mm)
+
+
+def _get_new_text_tokens_inner(
+    mm_start: np.ndarray | jnp.ndarray,
+    text_tokens: np.ndarray | jnp.ndarray,
+    offset_by: int,
+    length_with_mm: int,
+) -> np.ndarray | jnp.ndarray:
+  """`_get_new_text_tokens_positions` without batch dimension."""
+
+  # Empty buffer in which text and MM tokens will be inserted.
+  tokens_with_mm = jnp.zeros((length_with_mm,), dtype=jnp.int32)
+
+  # Shift the original tokens, so that the new soft tokens can be inserted.
+  new_text_tokens_pos = _get_new_text_tokens_positions(
+      offset_on=mm_start,
+      offset_by=offset_by,
+  )
+
+  tokens_with_mm = tokens_with_mm.at[new_text_tokens_pos].set(text_tokens)
+
+  # Remove the `<start_of_image>` tokens (will be added afterwards when
+  # merging with `_get_new_mm_tokens`).
+  first_mm_pos = tokens_with_mm[0]
+  new_start_mm_pos = new_text_tokens_pos * mm_start
+  tokens_with_mm = tokens_with_mm.at[new_start_mm_pos].set(0)
+  tokens_with_mm = tokens_with_mm.at[0].set(first_mm_pos)
+
+  return tokens_with_mm
+
+
+def _get_new_text_tokens_positions(
+    *,
+    offset_on: np.ndarray | jnp.ndarray,
+    offset_by: int,
+) -> np.ndarray | jnp.ndarray:
+  """Create the positions of the new tokens.
+
+  Input: `[x, x, x, offset_on, x, x, offset_on, x]`
+  Output: `[0, 1, 2, 3, 4+Offset, 5+Offset, 6+Offset, 7+Offset^2]`
+
+  Args:
+    offset_on: The token to offset on.
+    offset_by: The number of tokens to offset by.
+
+  Returns:
+    The new positions of the tokens.
+  """
+  offset = jnp.cumsum(offset_on, axis=-1) * offset_by
+  new_positions = jnp.arange(offset_on.shape[-1]) + offset
+  # Do not shift the `<start_of_image>` token, it will be overwritten by the MM
+  # tokens.
+  new_positions -= offset_by * offset_on
+  return new_positions
+
+
+def _get_new_mm_tokens(
+    *,
+    mm_start: np.ndarray | jnp.ndarray,
+    mm_tokens_to_insert: np.ndarray | jnp.ndarray,
+    max_num_images: int,
+    offset_by: int,
+    length_with_mm: int,
+) -> np.ndarray | jnp.ndarray:
+  # Jax vmap does not support positional argiments, so need the
+  # _get_new_mm_tokens_inner indirection.
+  return jax.vmap(_get_new_mm_tokens_inner, in_axes=(0, None, None, None, None))(
+      mm_start, mm_tokens_to_insert, max_num_images, offset_by, length_with_mm
+  )
+
+
+def _get_new_mm_tokens_inner(
+    mm_start: np.ndarray | jnp.ndarray,
+    mm_tokens_to_insert: np.ndarray | jnp.ndarray,
+    max_num_images: int,
+    offset_by: int,
+    length_with_mm: int,
+) -> np.ndarray | jnp.ndarray:
+  """`_get_new_mm_tokens` without batch dimension."""
+  # Empty buffer row, which will be merged with the final tokens.
+  row = jnp.zeros((length_with_mm,), dtype=jnp.int32)
+
+  ones = jnp.ones((len(mm_tokens_to_insert),), dtype=jnp.int32)
+
+  (offset,) = jnp.nonzero(mm_start, size=max_num_images)
+
+  # Because not all elements in the batch do have the same number of images
+  # we need to mask out the `offset == 0` values.
+  # This means that `<start_of_images>` can never be the first token, but this
+  # should never happen in practice as sequences should start by `<bos>`
+  mask = offset != 0
+  mask = jnp.einsum("...x,y->xy", mask, ones)
+
+  # After the mask is created, offset each individual images
+  offset += jnp.arange(len(offset)) * offset_by
+
+  new_positions = jnp.einsum("x,y->xy", offset, ones)
+  new_positions += jnp.arange(len(mm_tokens_to_insert))
+
+  new_positions = new_positions * mask
+
+  # Because not all elements in the batch do have the same number of images
+  # we need to mask out the `offset == 0` values.
+  # This means that `<start_of_images>` can never be the first token, but this
+  # should never happen in practice as sequences should start by `<bos>`
+  row = row.at[new_positions].set(mm_tokens_to_insert)
+  row = row.at[0].set(0)
+  return row

--- a/MaxText/tests/multimodal_utils_test.py
+++ b/MaxText/tests/multimodal_utils_test.py
@@ -1,0 +1,68 @@
+"""
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+""" Tests for the common MaxText utilities """
+import unittest
+import numpy as np
+
+from MaxText import multimodal_utils
+
+
+class TestTextImageFusionGemma3(unittest.TestCase):
+  """Test inserting place_holder tokens for image"""
+
+  def setUp(self):
+    super().setUp()
+    self.BEGIN_IMAGE_TOKEN = 255999
+    self.mm_tokens = [self.BEGIN_IMAGE_TOKEN, -2, -2]
+
+  def test_add_single_image(self):
+    tokens = np.asarray([1, 2, 3, self.BEGIN_IMAGE_TOKEN, 5, 6])
+    num_images = 1
+    new_tokens = multimodal_utils.insert_sequence(
+        at=self.BEGIN_IMAGE_TOKEN, sequence=self.mm_tokens, tokens=tokens, max_num_images=num_images
+    )
+    expected = np.asarray([1, 2, 3] + self.mm_tokens + [5, 6])
+    np.testing.assert_array_equal(new_tokens, expected)
+
+  def test_add_two_images(self):
+    tokens = np.asarray([1, self.BEGIN_IMAGE_TOKEN, 3, 4, self.BEGIN_IMAGE_TOKEN, 6])
+    num_images = 2
+    new_tokens = multimodal_utils.insert_sequence(
+        at=self.BEGIN_IMAGE_TOKEN, sequence=self.mm_tokens, tokens=tokens, max_num_images=num_images
+    )
+    expected = np.asarray([1] + self.mm_tokens + [3, 4] + self.mm_tokens + [6])
+    np.testing.assert_array_equal(new_tokens, expected)
+
+  def test_add_images_in_batch(self):
+    tokens = np.asarray(
+        [[1, 2, 3, self.BEGIN_IMAGE_TOKEN, 5, 6], [1, self.BEGIN_IMAGE_TOKEN, 3, 4, self.BEGIN_IMAGE_TOKEN, 6]]
+    )
+    num_images = 2
+    new_tokens = multimodal_utils.insert_sequence(
+        at=self.BEGIN_IMAGE_TOKEN, sequence=self.mm_tokens, tokens=tokens, max_num_images=num_images
+    )
+    expected = np.asarray(
+        [
+            [1, 2, 3] + self.mm_tokens + [5, 6] + [0] * (len(self.mm_tokens) - 1),
+            [1] + self.mm_tokens + [3, 4] + self.mm_tokens + [6],
+        ]
+    )
+    np.testing.assert_array_equal(new_tokens, expected)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description
In gemma3, <start_of_image> is used in prompt to mark the place of images (for exp, prompt="Describe this image <start_of_image>"). The <start_of_image> token is then replaced by some placeholder tokens, which is later used when merging text and image embeddings.
 
Reference functions published in gemma3: https://github.com/google-deepmind/gemma/blob/main/gemma/gm/vision/_token_utils.py#L45

# Tests
Added unit tests. Also breakpoint checked when passing an image and run decode.py

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
