### PR TITLE
Updating elastic training to work with pathwaysutils 0.1.1

### DIFF
--- a/MaxText/elastic_train.py
+++ b/MaxText/elastic_train.py
@@ -118,7 +118,7 @@ def elastic_handler(
     with mesh:
       data_iterator, _ = create_data_iterator(config, mesh)
 
-      step, snapshot = elastic_manager.get_resharded_snapshot(mesh)
+      step, snapshot_jax_arrays, _ = elastic_manager.get_resharded_snapshot(mesh)
 
       # We do not want to restore from the previous checkpoint but instead
       # restore from the host offloaded snapshot.
@@ -143,7 +143,7 @@ def elastic_handler(
           checkpoint_manager=None,
       )
 
-      state = state.replace(**snapshot)
+      state = state.replace(**snapshot_jax_arrays)
       state = state.replace(step=state.step.at[None].set(step))
 
       (
@@ -259,7 +259,7 @@ def train_loop(config, elastic_manager, state=None):
 
   elastic_manager.maybe_snapshot(
       step,
-      snapshot={
+      snapshot_jax_arrays={
           "params": state.params,
           "opt_state": state.opt_state,
       },
@@ -314,7 +314,7 @@ def train_loop(config, elastic_manager, state=None):
 
       elastic_manager.maybe_snapshot(
           step=step,
-          snapshot={
+          snapshot_jax_arrays={
               "params": state.params,
               "opt_state": state.opt_state,
           },
@@ -323,7 +323,7 @@ def train_loop(config, elastic_manager, state=None):
 
       ret = elastic_manager.maybe_reshard_up(
           step=step,
-          snapshot={
+          snapshot_jax_arrays={
               "params": state.params,
               "opt_state": state.opt_state,
           },

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,5 +38,5 @@ transformers
 mlperf-logging@git+https://github.com/mlperf/logging.git
 google-jetstream@git+https://github.com/AI-Hypercomputer/JetStream.git
 jsonlines
-pathwaysutils@git+https://github.com/AI-Hypercomputer/pathways-utils.git
+pathwaysutils==0.1.1
 omegaconf

--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -18,7 +18,7 @@ transformers
 mlperf-logging@git+https://github.com/mlperf/logging.git
 google-jetstream@git+https://github.com/AI-Hypercomputer/JetStream.git
 jsonlines
-pathwaysutils@git+https://github.com/AI-Hypercomputer/pathways-utils.git
+pathwaysutils==0.1.1
 google-api-python-client
 omegaconf
 jaxtyping

--- a/requirements_with_jax_stable_stack_0_5_2_pipreqs.txt
+++ b/requirements_with_jax_stable_stack_0_5_2_pipreqs.txt
@@ -27,7 +27,7 @@ omegaconf==2.3.0
 optax==0.2.4
 orbax==0.1.9
 pandas==2.2.3
-pathwaysutils==0.1.0
+pathwaysutils==0.1.1
 # Removing due to conflicts during build
 # protobuf==3.20.3
 protobuf


### PR DESCRIPTION
# Description

The elastic manager introduced controller snapshots as opposed to Jax array snapshots. This changed some of the argument names in elastic function calls.

We are adding a pinned version for `pathwaysutils` so that a new release or change in `pathwaysutils` does not break MaxText immediately.

# Tests

I ran the test described [here](https://github.com/AI-Hypercomputer/pathways-utils/blob/main/pathwaysutils/elastic/README.md) locally.

I am waiting on a simulated elastic manager in `pathwaysutils` before creating more unit tests for elastic_train.py.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
