### PR TITLE
Cancel previous runs for pull requests only.

### DIFF
--- a/.github/workflows/CPUTests.yml
+++ b/.github/workflows/CPUTests.yml
@@ -6,7 +6,8 @@ on:
     branches: [ "main" ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Dedup pull requests (canceling previous runs of the same workflow for same PR), but nothing else
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -27,7 +27,8 @@ on:
     - cron:  '0 */4 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Dedup pull requests (canceling previous runs of the same workflow for same PR), but nothing else
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
In pull/1651, we started cancling previous test runs, however the expression had a bug -- it deduped PRs but grouped everything that isn't a PR into one group. So for example a copybara merge would be grouped with another merge or a periodic scheduled test run.

In this PR we fix the expression so that only PR runs get dedupped. Other runs each get their own unique group (based on their unique github.run_id) and never deduped.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
