### PR TITLE
Fix the assertion in multihost dataloader.

### DIFF
--- a/MaxText/multihost_dataloading.py
+++ b/MaxText/multihost_dataloading.py
@@ -199,8 +199,16 @@ class MultiHostDataLoadIterator:
     num_slices = 1 if config.inference_benchmark_test else config.num_slices
     num_devices_per_slice = int(num_devices // num_slices)
 
-    default_dcn_parallelism = max_utils.get_unspecified_mesh_axes_value(config.dcn_parallelism, num_slices, "DCN")
-    default_ici_parallelism = max_utils.get_unspecified_mesh_axes_value(config.ici_parallelism, num_devices_per_slice, "ICI")
+    default_dcn_parallelism = (
+        max_utils.get_unspecified_mesh_axes_value(config.dcn_parallelism, num_slices, "DCN")
+        if config.dcn_parallelism.count(-1) == 1
+        else 0
+    )
+    default_ici_parallelism = (
+        max_utils.get_unspecified_mesh_axes_value(config.ici_parallelism, num_devices_per_slice, "ICI")
+        if config.ici_parallelism.count(-1) == 1
+        else 0
+    )
 
     self.input_data_dcn_parallelisms = _get_input_data_parallelisms(
         config, prefix="dcn", default_mesh_parallelism=default_dcn_parallelism

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -27,7 +27,7 @@ import jax
 import omegaconf
 from jax.experimental.compilation_cache import compilation_cache
 
-from maxtext import accelerator_to_spec_map, max_logging, max_utils
+from MaxText import accelerator_to_spec_map, max_logging, max_utils
 from MaxText.layers.attentions import AttentionType
 from MaxText.common_types import DecoderBlockType
 from MaxText.utils import gcs_utils


### PR DESCRIPTION
# Description

In mulithost dataloader, it tried to get the unspecified parallelism value by calling a util function. However, there is an assertion in the util function checks if there is one unspecified parallelism value. We should put an guard before calling into this util function.



# Tests

pytest MaxText/tests/multihost_dataloading_test.py::MultihostDataloadingTest::test_batch_sharded_data_pipeline_without_unspecified_value

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
