### PR TITLE
Fix the data sharding for TP.

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -338,6 +338,7 @@ logical_axis_rules: [
                     ]
 # Axes used for DCN must be earlier in this list than ICI, see (b/339009148) for details
 data_sharding: [['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'context', 'context_autoregressive', 'tensor', 'tensor_transpose', 'tensor_sequence', 'expert', 'autoregressive']]
+input_data_sharding_logical_axes: ['activation_embed_and_logits_batch', 'activation_norm_length']
 
 # sharding tolerance: float between 0.0 and 1.0 representing the allowed percentage of non-sharded parameters.
 sharding_tolerance: 0.02

--- a/MaxText/experimental/rl/grpo_trainer.py
+++ b/MaxText/experimental/rl/grpo_trainer.py
@@ -806,6 +806,7 @@ def train_loop(config, config_inference, state=None):
       gcp_workload_monitor.start_performance_reporting_thread(performance_metric_queue)
 
   metric_logger = MetricLogger(writer, config)
+  input_data_shardings = maxtext_utils.get_input_data_shardings(config, mesh)
   for step in np.arange(start_step, config.steps):
     if step == first_profiling_step or prof.should_activate_periodic_profile(step):
       optional_postfix = f"step_{step}" if config.profile_periodically_period > 0 else ""
@@ -814,6 +815,7 @@ def train_loop(config, config_inference, state=None):
     with jax.profiler.StepTraceAnnotation("train", step_num=step):
       record_goodput(recorder, config, recorder.record_data_loading_start_time if recorder else None)
       example_batch = load_next_batch(data_iterator, example_batch, config)
+      example_batch = jax.lax.with_sharding_constraint(example_batch, input_data_shardings)
       record_goodput(recorder, config, recorder.record_data_loading_end_time if recorder else None)
       check_example_batch(config, example_batch=example_batch)
       # pylint: disable=not-callable

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -53,12 +53,16 @@ NUM_IMAGES_PER_SEQUENCE = 1
 NUM_IMAGE_CHANNELS = 3
 
 
+def get_input_data_sharding(config, mesh):
+  """Get the input data sharding for the model"""
+  return nn.logical_to_mesh_sharding(P(*config.input_data_sharding_logical_axes), mesh, config.logical_axis_rules)
+
+
 def get_functional_train_with_signature(train_step, mesh, state_mesh_shardings, model, config):
   """Get the shardings (both state and data) for train_step"""
   functional_train = get_functional_train_step(train_step, model, config, state_mesh_shardings)
   functional_train.__name__ = "train_step"
-  data_pspec = P(*config.data_sharding)
-  data_sharding = jax.tree_util.tree_map(lambda p: jax.sharding.NamedSharding(mesh, p), data_pspec)
+  data_sharding = get_input_data_sharding(config, mesh)
   in_shardings = (state_mesh_shardings, data_sharding, None)  # State, batch, rng
   out_shardings = (state_mesh_shardings, None)  # State, metrics
   static_argnums = ()  # We partial out the static argnums of model and config
@@ -74,8 +78,7 @@ def get_functional_eval_with_signature(eval_step, mesh, state_mesh_shardings, mo
   """Get the shardings (both state and data) for eval_step"""
   functional_eval = get_functional_eval_step(eval_step, model, config)
   functional_eval.__name__ = "eval_step"
-  data_pspec = P(*config.data_sharding)
-  data_sharding = jax.tree_util.tree_map(lambda p: jax.sharding.NamedSharding(mesh, p), data_pspec)
+  data_sharding = get_input_data_sharding(config, mesh)
   in_shardings = (state_mesh_shardings, data_sharding, None)  # State, batch, rng
   out_shardings = None  # metrics
   static_argnums = ()  # We partial out the static argnums of model, config

--- a/MaxText/tests/integration_tests/train_tests.py
+++ b/MaxText/tests/integration_tests/train_tests.py
@@ -247,13 +247,33 @@ class TrainTests(unittest.TestCase):
         "enable_checkpointing=False",
         "enable_goodput_recording=False",
         "attention=cudnn_flash_te",
-        "ici_fsdp_parallelism=2",
+        "ici_fsdp_parallelism=-1",
         "ici_context_parallelism=2",
         "context_parallel_load_balance=True",
         "packing=False",
         rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
     ]
     train_main(context_parallel)
+
+  @pytest.mark.integration_test
+  @pytest.mark.gpu_only
+  def test_gpu_tensor_parallelism(self):
+    os.environ["NVTE_FUSED_ATTN"] = "1"  # Enable fused attention
+    tensor_parallel = [  # tests base config on GPU with context parallelism and flash attention"""
+        None,
+        os.path.join(PKG_DIR, "configs", "base.yml"),
+        rf"base_output_directory=gs://runner-maxtext-logs",
+        "run_name=runner_test",
+        r"dataset_path=gs://maxtext-dataset",
+        "steps=10",
+        "enable_checkpointing=False",
+        "attention=cudnn_flash_te",
+        "ici_fsdp_parallelism=-1",
+        "ici_tensor_parallelism=2",
+        "packing=False",
+        rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
+    ]
+    train_main(tensor_parallel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
Another attempt after rolled back PR#1533 because TPU hardware topology and dcn/ici concept is different from GPU and it breaks the TPU dataloading.

This PR takes another easier approach that it reshards input data from (B,) to (B, S) instead of attempting to load every data shards correctly at the very beginning. It avoids the complicated logic of manual sharding input data at the cost of 1 additional reshard for every batch of data.

# Tests

Run unit tests locally.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
