### PR TITLE
Build Image manual control

### DIFF
--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -21,6 +21,23 @@ on:
   schedule:
     # Run the job daily at 12AM UTC
     - cron:  '0 0 * * *'
+  workflow_dispatch:
+    # Trigger Manual run
+    branches:
+      - main
+    inputs:
+      target_device:
+        description: 'Specify target device (tpu or gpu)'
+        required: false
+        type: choice
+        options:
+          - tpu
+          - gpu
+      run_all_jobs:
+        description: 'Run all TPU and GPU build jobs (overrides target_device)'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   tpu:


### PR DESCRIPTION
# Description

Currently the build image is only triggered as per the cron schedule. This add the ability to manual trigger it and this access it to repo writers and admins.

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
