### PR TITLE
Fix stable stack missing google-cloud-monitoring dependency

### DIFF
--- a/maxtext_jax_stable_stack.Dockerfile
+++ b/maxtext_jax_stable_stack.Dockerfile
@@ -34,6 +34,9 @@ RUN if [ "$DEVICE" = "tpu" ] && ([ "$JAX_STABLE_STACK_BASEIMAGE" = "us-docker.pk
 # Install Maxtext requirements with Jax Stable Stack
 RUN apt-get update && apt-get install --yes && apt-get install --yes dnsutils
 
+# TODO(bvandermoon, parambole): Remove this when it's added to JAX AI Image
+RUN pip install google-cloud-monitoring
+
 # Install requirements file generated with pipreqs for JSS 0.5.2. 
 # Othewise use general requirements_with_jax_stable_stack.txt
 RUN if [ "$DEVICE" = "tpu" ] && [ "$JAX_STABLE_STACK_BASEIMAGE" = "us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.5.2-rev1" ]; then \


### PR DESCRIPTION
# Description

Fixed missing dependency for JSS stable stack. This was hidden in tests because we are using a hardcoded pip freeze list for JSS 0.5.2 instead of `requirements_with_jax_stable_stack.txt`. I am thinking about removing that short-term solution file and noticed the issue then. But I believe JSS 0.4.35 and JSS 0.4.37 are likely impacted by this missing dependency.

I saw this workload error when running JSS 0.5.2 without using `requirements_with_jax_stable_stack_0_5_2_pipreqs.txt` locally:

![Screenshot 2025-05-02 at 4 35 34 PM](https://github.com/user-attachments/assets/bbf384b2-3945-4962-a321-1bcb614d708f)

# Tests

```
python3 -m benchmarks.benchmark_runner xpk \
    --project=$PROJECT \
    --zone=$ZONE \
    --device_type=v6e-8 \
    --num_slices=1  \
    --cluster_name=${CLUSTER_NAME} \
    --base_output_directory=${OUTPUT_DIR} \
    --model_name="llama3_1_8b_8192_no_collective_matmul" \
    --base_docker_image=maxtext_base_image
```

This workload runs successfully now after building JSS 0.5.2 without using the `pip freeze` requirements file locally.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
