### PR TITLE
Functioning decode on multimodal Gemma3-4b

### DIFF
--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -46,12 +46,6 @@ BATCH = common_types.BATCH
 LENGTH = common_types.LENGTH
 HEAD = common_types.HEAD
 D_KV = common_types.D_KV
-BEGIN_IMAGE_TOKEN = 255999
-END_IMAGE_TOKEN = 262144
-NEW_LINE_TOKEN = 108
-TOKEN_PLACEHOLDER = -2
-NUM_PLACEHOLDER_TOKENS_PER_IMAGE = 256
-NUM_TOKENS_PER_MEDIA = NUM_PLACEHOLDER_TOKENS_PER_IMAGE + 4
 
 nd_dense_init = initializers.nd_dense_init
 Quant = quantizations.AqtQuantization

--- a/MaxText/tests/forward_pass_logit_checker.py
+++ b/MaxText/tests/forward_pass_logit_checker.py
@@ -109,6 +109,7 @@ def main(config, test_args):  # pylint: disable=W0621
       with torch.no_grad():
         full_train_logits = model(torch.tensor(ids.tolist())).logits.cpu().numpy().astype("float32")
     else:
+      # TODO(hengtaoguo): Add support for multimodal full prompt decoding check
       full_train_logits = model.apply(
           state.params,
           ids,

--- a/MaxText/tests/integration_tests/vision_encoder_test.py
+++ b/MaxText/tests/integration_tests/vision_encoder_test.py
@@ -57,6 +57,7 @@ class VisionEncoderEmbeddingTest(unittest.TestCase):
       ],
   }
 
+  @pytest.mark.skip(reason="until b/416335384 is fixed")
   @pytest.mark.tpu_only
   def test_image_embedding_gemma3_4b_tpu(self):
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"


### PR DESCRIPTION
# Description

Insert the vision embeddings into text embeddings and allow a fully functioning decode forward pass on multimodal Gemma3-4b model.

- The most critical change here is that `merge_mm_embeddings` inserts the image_embeddings into the text_embeddings based on the image placeholder token information in the bidirectional_mask:
```
y = multimodal_utils.merge_mm_embeddings(
      text_embeddings=y,
      vision_embeddings=image_embeddings,
      mask=bidirectional_mask,
)
```
- We have a separate script [golden_gemma3-4b-mm-export.py](https://paste.googleplex.com/4539691606736896) generates golden logits with fields (prompt, tokens, image_array, logits). This has been offline compared with MaxText logits with kl_div<0.01. We are not uploading this script and logits because of [b/416290849](https://b.corp.google.com/issues/416290849). Later we need to modify [MaxText/tests/forward_pass_logit_checker.py](https://github.com/AI-Hypercomputer/maxtext/pull/1689/files#diff-8fef4ecc1ce7f7a99732ef78655388e492d1588a4b508f85d744433bafefc5af) to make it accept full multimodal prompt for logits comparison (and add to end_to_end tests potentially).

# Tests

A full decode forward pass command line, using `prompt='Describe image <start_of_image>` and [image](https://github.com/AI-Hypercomputer/maxtext/blob/main/MaxText/test_assets/test_image.jpg):
```
python -m MaxText.decode MaxText/configs/base.yml model_name=gemma3-4b tokenizer_path=assets/tokenizer.gemma3 load_parameters_path=gs://maxtext-model-checkpoints/gemma3-4b/multimodal/2025-04-25-18-06-04/checkpoints/0/items per_device_batch_size=1 run_name=ht_test max_prefill_predict_length=272 max_target_length=300 steps=1 async_checkpointing=false scan_layers=false use_multimodal=true prompt=\'Describe\ image\ \<start_of_image\>\' image_path=\'/home/hengtaoguo/projects/maxtext/MaxText/test_assets/test_image.jpg\' attention=\'dot_product\'
```
This yields the outcome image description logs:
```
RAMstats: After load_params:
        Using (GB) 31.82 / 1417.33 (2.245066%) -->  Available:1377.1
normalizer.cc(51) LOG(INFO) precompiled_charsmap is empty. use identity normalization.
Input `<start_of_turn>user
Describe image <start_of_image><end_of_turn>
<start_of_turn>model
` -> `Here's a description of the image:

**Overall Impression:** The image is a bright, expansive cityscape view of Seattle, Washington, with`
```
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
