### PR TITLE
Add has_bos to Jetstream decode request

### DIFF
--- a/MaxText/generate_distillation_data.py
+++ b/MaxText/generate_distillation_data.py
@@ -80,6 +80,7 @@ async def send_request(config, request, stub, tokenizer, progress_bar):  # pylin
       token_content=jetstream_pb2.DecodeRequest.TokenContent(token_ids=prompt_token_ids),
       max_tokens=request.max_output_tokens,
       num_samples=config.num_generations,  # number of responses to generate for each request
+      has_bos=True,
   )
 
   response = stub.Decode(decode_request)


### PR DESCRIPTION
# Description
This PR sets `has_bos=True` in JetStream decode request because `generate_distillation_data.py` applies chat template to the prompt before sending it to JetStream for decoding. Initially, JetStream was hardcoding `bos` token to all the prompts before running inference. This was corrupting our results for distillation. [PR](https://github.com/AI-Hypercomputer/JetStream/pull/266) in JetStream fixes this issue and added a new argument to DecodeRequest proto.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
Tested by running `generate_distillation_data.py`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
