### PR TITLE
Offloaded train_compile tests to CPU Runners

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -60,6 +60,19 @@ jobs:
       device_name: a100-40gb-4
       build_mode: stable_stack
       base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/gpu:latest
+  
+  cpu_unit_tests:
+    needs: tpu_image
+    uses: ./.github/workflows/run_tests_internal.yml
+    with:
+      device_type: cpu
+      device_name: X64
+      cloud_runner: linux-x86-n2-16
+      image_type: tpu
+      pytest_marker: 'cpu_only'
+      xla_python_client_mem_fraction: 0.75
+      tf_force_gpu_allow_growth: false
+      container_resource_option: "--privileged"
 
   tpu_unit_tests:
     needs: tpu_image
@@ -68,8 +81,7 @@ jobs:
       device_type: tpu
       device_name: v4-8
       # cloud_runner: linux-x86-ct4p-240-4tpu
-      pytest_marker: 'not gpu_only and not integration_test'
-      test_directory: 'tests'
+      pytest_marker: 'not cpu_only and not gpu_only and not integration_test'
       xla_python_client_mem_fraction: 0.75
       tf_force_gpu_allow_growth: false
       container_resource_option: "--privileged"
@@ -81,8 +93,7 @@ jobs:
       device_type: tpu
       device_name: v4-8
       # cloud_runner: linux-x86-ct4p-240-4tpu
-      pytest_marker: 'not gpu_only and integration_test'
-      test_directory: 'tests/integration_tests'
+      pytest_marker: 'not cpu_only and not gpu_only and integration_test'
       xla_python_client_mem_fraction: 0.75
       tf_force_gpu_allow_growth: false
       container_resource_option: "--privileged"
@@ -94,8 +105,7 @@ jobs:
       device_type: gpu
       device_name: a100-40gb-4
       # cloud_runner: linux-x86-a2-48-a100-4gpu
-      pytest_marker: 'not tpu_only and not integration_test'
-      test_directory: 'tests'
+      pytest_marker: 'not cpu_only and not tpu_only and not integration_test'
       xla_python_client_mem_fraction: 0.65
       tf_force_gpu_allow_growth: true
       container_resource_option: "--shm-size 2g --runtime=nvidia --gpus all --privileged"
@@ -107,15 +117,14 @@ jobs:
       device_type: gpu
       device_name: a100-40gb-4
       # cloud_runner: linux-x86-a2-48-a100-4gpu
-      pytest_marker: 'not tpu_only and integration_test'
-      test_directory: 'tests/integration_tests'
+      pytest_marker: 'not cpu_only and not tpu_only and integration_test'
       xla_python_client_mem_fraction: 0.65
       tf_force_gpu_allow_growth: true
       container_resource_option: "--shm-size 2g --runtime=nvidia --gpus all --privileged"
 
   clean_up:
     if: ${{ always() }}  # always execute, regardless of previous jobs or steps.
-    needs: [gpu_unit_tests, gpu_integration_tests, tpu_unit_tests, tpu_integration_tests]
+    needs: [cpu_unit_tests, gpu_unit_tests, gpu_integration_tests, tpu_unit_tests, tpu_integration_tests]
     name: "Clean up"
     runs-on: ["self-hosted"]
     permissions:
@@ -137,7 +146,7 @@ jobs:
 
   notify:
     name: Notify failed build # creates an issue or modifies last open existing issue for failed build
-    needs: [gpu_unit_tests, gpu_integration_tests, tpu_unit_tests, tpu_integration_tests]
+    needs: [cpu_unit_tests, gpu_unit_tests, gpu_integration_tests, tpu_unit_tests, tpu_integration_tests]
     runs-on: ubuntu-latest
     steps:
     - name: Check whether one of the jobs failed

--- a/.github/workflows/run_tests_internal.yml
+++ b/.github/workflows/run_tests_internal.yml
@@ -25,10 +25,10 @@ on:
       device_name:
         required: true
         type: string
-      pytest_marker:
-        required: true
+      image_type:
+        required: false
         type: string
-      test_directory:
+      pytest_marker:
         required: true
         type: string
       xla_python_client_mem_fraction:
@@ -48,15 +48,16 @@ jobs:
   run:
     runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
     container:
-      image: gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:${{ inputs.device_type }}
+      image: gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:${{ inputs.image_type != '' && inputs.image_type || inputs.device_type }}
       env:
         XLA_PYTHON_CLIENT_MEM_FRACTION: ${{ inputs.xla_python_client_mem_fraction }}
         TF_FORCE_GPU_ALLOW_GROWTH: ${{ inputs.tf_force_gpu_allow_growth }}
+        TPU_SKIP_MDS_QUERY: ${{ inputs.image_type == 'tpu' && inputs.device_type != 'tpu' && '1' || '' }}
       options: ${{ inputs.container_resource_option }}
     steps:
       - uses: actions/checkout@v4
       - name: Run Tests
         run: |
           python3 -m pip install -e . --no-dependencies &&
-          python3 -m pytest --pyargs MaxText.tests -m '${{ inputs.pytest_marker }}' --durations=0
+          python3 -m pytest -v --pyargs MaxText.tests -m '${{ inputs.pytest_marker }}' --durations=0
 

--- a/MaxText/tests/train_compile_test.py
+++ b/MaxText/tests/train_compile_test.py
@@ -29,7 +29,7 @@ from MaxText.globals import PKG_DIR
 class TrainCompile(unittest.TestCase):
   """Tests for the Ahead of Time Compilation functionality, train_compile.py"""
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_save_compiled_v4(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_v4.pickle")
@@ -46,7 +46,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_save_compiled_v5e(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_v5e.pickle")
@@ -65,6 +65,7 @@ class TrainCompile(unittest.TestCase):
 
   # TODO (b/366200617) : This tests fails in AOT, but config works fine on real hardware
   @pytest.mark.skip(reason="Issue w/ kernels_test. Error: The TPU is already in use by process...")
+  @pytest.mark.cpu_only
   def test_minimal_offloaded_v5e(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_v5e_offload.pickle")
@@ -87,7 +88,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_save_compiled_v5p_two_slices(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_v5p_two_slices.pickle")
@@ -106,7 +107,7 @@ class TrainCompile(unittest.TestCase):
 
   # TODO (b/374764692) : Enable when v6e AOT test when stable Jax supports v6e AOT.
   @pytest.mark.skip(reason="Enable when downstream v6e AOT support reaches stable Jax.")
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_save_compiled_v6e(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_v6e.pickle")
@@ -123,7 +124,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_sequence_parallelism(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled.pickle")
@@ -142,7 +143,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_remat_save_dot_except_mlpwi(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_remat_save_dot_except_mlpwi.pickle")
@@ -165,7 +166,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_remat_save_dot_except_mlp(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_remat_save_dot_except_mlp.pickle")
@@ -188,7 +189,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_remat_save_qkv_proj(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_remat_save_qkv_proj.pickle")
@@ -211,7 +212,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_remat_full(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_remat_full.pickle")
@@ -234,7 +235,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_custom_64x4_mesh(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_custom_64x4_mesh.pickle")
@@ -257,7 +258,7 @@ class TrainCompile(unittest.TestCase):
 
   # TODO (b/376470419) : Enable when AOT test work with host offloading.
   @pytest.mark.skip(reason="Enable when AOT test work with host offloading.")
-  @pytest.mark.tpu_only
+  @pytest.mark.gpu_only
   def test_llama3_1_70b_opt_offload(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_llama3_1_70b_opt_offload.pickle")
@@ -276,7 +277,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_custom_32x8_mesh(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_custom_32x8_mesh.pickle")
@@ -301,7 +302,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_dropping_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_dropping_bf16.pickle")
@@ -324,7 +325,7 @@ class TrainCompile(unittest.TestCase):
     )
 
   @pytest.mark.skip(reason="b/400476456 Tests are currently flaking / failing due to JAX 0.5.1 upgrade")
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_dropping_int8(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_dropping_int8.pickle")
@@ -348,7 +349,7 @@ class TrainCompile(unittest.TestCase):
     )
 
   # TODO(b/388572320): Add int8 quantization test once this bug is fixed.
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_megablox_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_megablox_bf16.pickle")
@@ -370,7 +371,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_ragged_dot_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_ragged_dot_bf16.pickle")
@@ -392,7 +393,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_dense_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_dense_bf16.pickle")
@@ -415,7 +416,7 @@ class TrainCompile(unittest.TestCase):
     )
 
   @pytest.mark.skip(reason="b/400476456 Tests are currently flaking / failing due to JAX 0.5.1 upgrade")
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_dense_int8(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_dense_int8.pickle")
@@ -438,7 +439,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_pp_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_pp_bf16.pickle")
@@ -462,7 +463,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_deepseek_scanned_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_deepseek_scanned_bf16.pickle")
@@ -487,7 +488,7 @@ class TrainCompile(unittest.TestCase):
     )
 
   @pytest.mark.skip(reason="Fix sharding issue of all layers of DeepSeek")
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_deepseek_unscanned_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_deepseek_unscanned_bf16.pickle")
@@ -511,7 +512,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_deepseek_with_device_limit(self):
     compiled_trainstep_file = "/tmp/test_moe_deepseek_with_device_limit.pickle"
     train_compile_main(
@@ -535,7 +536,7 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_deepseek_without_device_limit(self):
     compiled_trainstep_file = "/tmp/test_moe_deepseek_without_device_limit.pickle"
     train_compile_main(
@@ -560,7 +561,7 @@ class TrainCompile(unittest.TestCase):
     )
 
   @pytest.mark.skip(reason="b/415132665: Enable it once scan is supported in training for shorter compiler time")
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
   def test_moe_llama4_17b_16e(self):
     compiled_trainstep_file = "/tmp/test_moe_llama4_17b_16e.pickle"
     train_compile_main(

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,6 +13,7 @@ addopts =
 markers =
     tpu_only: marks tests to be run on TPUs only
     gpu_only: marks tests to be run on GPUs only
+    cpu_only: marks tests to be run on CPUs only
     integration_test: tests exercising larger portions of the system,
                       including interactions with other systems like GCS,
                       e.g., end_to_end tests


### PR DESCRIPTION
# Description

To reduce the total time for unit tests, the train_compile tests can be offloaded to CPUs. There are CPU Github Runners that can be used for this. 

During this pr there was a bug found in attentions.py related to cross-AOT compilation. When performing cross-AOT, compilation is done based on the target hardware, where the base hardware is irrelevant. Attentions.py had a few instances of using jax.devices() in conditional logic. Since this provides information related to base hardware and not target hardware, cross_AOT fails to enter the proper conditional statements. To solve this used the mesh attribute to get the target hardware information. 

Graph of RunTests DAG before this PR: 
<img width="1295" alt="Screenshot 2025-05-10 at 5 34 25 PM" src="https://github.com/user-attachments/assets/d735f1de-7825-421e-92d7-a67148c6ae7c" />

Graph of RunTests DAG after this PR: 

<img width="1319" alt="Screenshot 2025-05-10 at 5 33 20 PM" src="https://github.com/user-attachments/assets/83c6905e-bd57-4072-92a1-60672fdd68c0" />

Cuts down total time by ~45% from ~23min to ~13min.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/412682781
Attentions.py Bug: b/415388899

# Tests

Ran the train compile tests locally on cloudtop and verified that cross_AOT using CPU as base hardware works. 
Link to logs timing the tests: https://paste.googleplex.com/4727983644082176 
Link to commands ran: https://paste.googleplex.com/6411891204947968

Note: The total time taken to run and pass all train_compile tests on CPUs ~15 min

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
