### PR TITLE
Fix and refactor benchmark_chunked_prefill prefix caching

### DIFF
--- a/MaxText/benchmark_chunked_prefill.py
+++ b/MaxText/benchmark_chunked_prefill.py
@@ -32,15 +32,15 @@ Configuration options like `use_chunked_prefill`, `prefill_chunk_size`,
 """
 
 
-import os
-from typing import Any, Sequence
 import datetime
+import functools
+import os
+from typing import Any, Callable, Sequence
 
 import jax
 
 from jetstream.core import prefix_cache
 from jetstream.engine import chunked_prefill
-from jetstream.engine import engine_api
 
 from absl import app
 
@@ -50,6 +50,79 @@ from MaxText import pyconfig
 
 _WARMUP_ITERS = 2
 _BENCHMARK_ITERS = 5
+
+
+@jax.jit
+def _copy(cache):
+  def _array_copy(x):
+    return x.copy()
+
+  return jax.tree.map(_array_copy, cache)
+
+
+def _run_benchmark_loop(func_to_benchmark: Callable[[], Any], iters: int, label: str) -> datetime.timedelta:
+  """Runs warmup and benchmark iterations for a given function.
+
+  Args:
+    func_to_benchmark: The function to benchmark.
+    iters: The number of benchmark iterations to run.
+    label: A string label for printing output.
+
+  Returns:
+    The average time taken per iteration.
+  """
+  print(f"\nStarting warmup for {label}...")
+  for i in range(_WARMUP_ITERS):
+    start = datetime.datetime.now()
+    result = func_to_benchmark()
+    jax.block_until_ready(result)
+    end = datetime.datetime.now()
+    print(f"  Warmup iteration {i+1} time: {end - start}")
+
+  print(f"\nStarting benchmark for {label}...")
+  total_time = datetime.timedelta()
+  for i in range(iters):
+    start = datetime.datetime.now()
+    result = func_to_benchmark()
+    jax.block_until_ready(result)
+    end = datetime.datetime.now()
+    iter_time = end - start
+    total_time += iter_time
+    print(f"  Benchmark iteration {i+1} time: {iter_time}")
+
+  average_time = total_time / iters
+  print(f"\nAverage time taken for {label} over {iters} iterations: {average_time}")
+  return average_time
+
+
+def benchmark_chunked_prefill(
+    engine: maxengine.MaxEngine,
+    params: Any,
+    chunked_tokens_list: list[chunked_prefill.ChunkedTokens],
+):
+  """Benchmarks chunked prefill without prefix caching.
+
+  Args:
+    engine: The MaxEngine instance.
+    params: The model parameters.
+    chunked_tokens_list: A list of ChunkedTokens objects representing the
+      input sequence split into chunks.
+
+  Returns:
+    The average time taken for chunked prefill.
+  """
+
+  def run_chunked_prefill_utility():
+    prefill_result, _ = chunked_prefill.do_chunked_prefill(
+        prefill_engine=engine,
+        prefill_params=params,
+        chunked_tokens_list=chunked_tokens_list,
+    )
+    return prefill_result
+
+  # Benchmark standard chunked prefill (no caching)
+  average_time = _run_benchmark_loop(run_chunked_prefill_utility, _BENCHMARK_ITERS, "standard chunked prefill")
+  return average_time
 
 
 def fill_prefix_cache(
@@ -78,7 +151,7 @@ def fill_prefix_cache(
   key_to_hit = tuple(hit_tokens.tolist())
 
   def copy_prefix():
-    return jax.tree.map(lambda x: x.copy(), prefix)
+    return _copy(prefix)
 
   # --- Fill the cache with dummy entries ---
   print("Filling cache with", cache_num, "dummy entries...")
@@ -99,11 +172,6 @@ def fill_prefix_cache(
 
     # Save the dummy entry to the cache
     prefix_cache_inst.save(dummy_key, dummy_value_with_key)
-    # Block to make sure the cache is synced
-    load_result = prefix_cache_inst.load(dummy_key)
-    assert load_result is not None
-    jax.block_until_ready(load_result.prefix)
-    del load_result
 
   print("Finished filling cache with", cache_num, "dummy entries.")
 
@@ -117,77 +185,43 @@ def fill_prefix_cache(
       tokens=key_to_hit,
   )
   prefix_cache_inst.save(key_to_hit, value_to_hit)
-  load_result = prefix_cache_inst.load(key_to_hit)
-  assert load_result is not None
-  jax.block_until_ready(load_result.prefix)
-  del load_result
+  jax.effects_barrier()
   print("Finished adding the target entry.")
 
 
-def main(argv: Sequence[str]) -> None:
-  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
-  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
-  config = pyconfig.initialize(argv)
-  max_utils.print_system_information()
+def create_prefix_cache(
+    engine: maxengine.MaxEngine,
+    params: Any,
+    tokens: jax.Array,
+    chunked_tokens_list: list[chunked_prefill.ChunkedTokens],
+    prefix_caching_hbm_byte: int,
+    prefix_caching_dram_byte: int,
+    max_prefill_length: int,
+) -> prefix_cache.PrefixCache:
+  """Creates and populates a prefix cache.
 
-  prefix_caching_hbm_byte = config.prefix_caching_hbm_byte
-  prefix_caching_dram_byte = config.prefix_caching_dram_byte
+  Args:
+    engine: The MaxEngine instance.
+    params: The model parameters.
+    tokens: The input token sequence.
+    chunked_tokens_list: A list of ChunkedTokens objects representing the
+      input sequence split into chunks.
+    prefix_caching_hbm_byte: The size of the HBM layer in the prefix cache.
+    prefix_caching_dram_byte: The size of the DRAM layer in the prefix cache.
+    max_prefill_length: The maximum length of the prefill sequence.
 
-  engine = maxengine.MaxEngine(config)
+  Returns:
+    A populated PrefixCache instance.
+  """
+  print("\n--- Creating and Populating Prefix Cache ---")
 
-  if not engine.use_chunked_prefill:
-    raise ValueError("Engine must be configured with use_chunked_prefill=True")
-
-  params = engine.load_params()
-
-  text = config.prompt
-  metadata = engine.get_tokenizer()
-  tokenizer_model = engine.build_tokenizer(metadata)
-  # set it to max complete prompt length that has to be benchmarked with chunked prefill
-  max_prefill_length = config.max_prefill_predict_length
-  tokens, _ = tokenizer_model.encode(text, is_bos=True, prefill_lengths=[max_prefill_length])
-
-  chunk_size = config.prefill_chunk_size
-
-  chunked_tokens_list = chunked_prefill.gen_chunked_padded_tokens(
-      tokens=tokens,
-      chunk_size=chunk_size,
-      tokenizer=tokenizer_model,
-      jax_padding=True,
+  # Run chunked prefill to get the initial prefix
+  prefill_result, _ = chunked_prefill.do_chunked_prefill(
+      prefill_engine=engine,
+      prefill_params=params,
+      chunked_tokens_list=chunked_tokens_list,
   )
 
-  def run_chunked_prefill_utility():
-    prefill_result, _ = chunked_prefill.do_chunked_prefill(
-        prefill_engine=engine,
-        prefill_params=params,
-        chunked_tokens_list=chunked_tokens_list,
-    )
-    return prefill_result
-
-  print("Starting warmup...")
-  for i in range(_WARMUP_ITERS):
-    start = datetime.datetime.now()
-    prefill_result = run_chunked_prefill_utility()
-    jax.block_until_ready(prefill_result)
-    end = datetime.datetime.now()
-    print("  Warmup iteration", i + 1, "time:", end - start)
-
-  print("\nStarting benchmark...")
-  total_time = datetime.timedelta()
-  for i in range(_BENCHMARK_ITERS):
-    start = datetime.datetime.now()
-    prefill_result = run_chunked_prefill_utility()
-    jax.block_until_ready(prefill_result)
-    end = datetime.datetime.now()
-    iter_time = end - start
-    total_time += iter_time
-    print("  Benchmark iteration", i + 1, "time:", iter_time)
-
-  average_time = total_time / _BENCHMARK_ITERS
-  print("\nAverage time taken for chunked prefill over", _BENCHMARK_ITERS, "iterations:", average_time)
-
-  # Run prefix caching benchmark
-  prefill_result = run_chunked_prefill_utility()
   prefix_cache_inst = prefix_cache.PrefixCache(prefix_caching_hbm_byte, prefix_caching_dram_byte)
   # Fill cache to the max dram size
   prefill_result_cache_byte_size = jax.tree.reduce(
@@ -203,34 +237,60 @@ def main(argv: Sequence[str]) -> None:
       tokens,
       max_prefill_length,
   )
+  return prefix_cache_inst
+
+
+def benchmark_prefix_cache_loop(
+    engine: maxengine.MaxEngine,
+    params: Any,
+    tokens: jax.Array,
+    chunked_tokens_list: list[chunked_prefill.ChunkedTokens],
+    prefix_cache_inst: prefix_cache.PrefixCache,
+    chunk_size: int,
+    run_time: list[int],
+):
+  """Benchmarks chunked prefill with prefix caching.
+
+  This function benchmarks the performance of chunked prefill with varying
+  cache hit rates, including the impact of saving new prefixes to the cache.
+
+  Args:
+    engine: The MaxEngine instance.
+    params: The model parameters.
+    tokens: The input token sequence.
+    chunked_tokens_list: A list of ChunkedTokens objects representing the
+      input sequence split into chunks.
+    prefix_cache_inst: The PrefixCache instance to use.
+    chunk_size: The chunk size used for prefilling.
+    run_time: Length 1 int list (e.g. [1]) for pointer to counter. Use to prevent existing key collisions.
+  """
+
+  print("\n--- Starting Prefix Cache Benchmark ---")
 
   def run_chunked_prefill_with_prefix_caching(cache_hit_chunk: int, need_save: bool):
-    # Load to simulated the time consuming for reading the cache
-    # TODO: Separate test case load from DRAM
     tokens_list = tokens.tolist()
-    existing_prefix = prefix_cache.load_existing_prefix(prefix_cache_inst, tuple(tokens_list), chunk_size)
-    assert existing_prefix is not None
-    # Simulate prefix cache hit with chunked sized
-    if cache_hit_chunk > 0:
-      existing_prefix = engine_api.ExistingPrefix(
-          cache=existing_prefix[0].cache, common_prefix_tokens=tokens[: cache_hit_chunk * chunk_size]
-      )
-    else:
-      existing_prefix = None
 
+    # Load from cache (simulates reading)
+    existing_prefix, _ = prefix_cache.load_existing_prefix_and_get_remain_tokens(prefix_cache_inst, tokens, chunk_size)
+    assert existing_prefix is not None, "Should hit in benchmark"
+
+    # Perform chunked prefill on remaining tokens
     prefill_result, _ = chunked_prefill.do_chunked_prefill(
         prefill_engine=engine,
         prefill_params=params,
-        chunked_tokens_list=chunked_tokens_list[cache_hit_chunk:],
-        existing_prefix=existing_prefix,
+        chunked_tokens_list=chunked_tokens_list[cache_hit_chunk:],  # Pass only the remaining chunks
+        existing_prefix=existing_prefix if cache_hit_chunk > 0 else None,  # Pass existing prefix if hit
     )
+
     # Simulate save to cache
     if need_save:
-      # Assume directly call save will happen
+
+      # Assume save will happen
+      run_time[0] += 1
       prefix_cache_inst.save(
-          tuple(tokens_list),
+          tuple(tokens_list + [run_time[0]]),  # Prevent key existed.
           prefix_cache.Value(
-              prefix=jax.tree.map(lambda x: x.copy(), prefill_result["cache"]),
+              prefix=_copy(prefill_result["cache"]),
               true_length=len(tokens_list),
               padded_length=len(tokens_list),
               tokens=tuple(tokens_list),
@@ -241,26 +301,129 @@ def main(argv: Sequence[str]) -> None:
 
   for cache_hit_chunk in range(len(chunked_tokens_list)):
     for need_save in [True, False]:
-      print("\nBenchmark prefix caching cache_hit_chunk=", cache_hit_chunk, " need_save=", need_save, sep="")
-      for i in range(_WARMUP_ITERS):
-        start = datetime.datetime.now()
-        prefill_result = run_chunked_prefill_with_prefix_caching(cache_hit_chunk, need_save)
-        jax.block_until_ready(prefill_result)
-        end = datetime.datetime.now()
-        print("  Warmup iteration", i + 1, "time:", end - start)
+      label = f"prefix caching (hit_chunks={cache_hit_chunk}, save={need_save})"
+      benchmark_func = functools.partial(
+          run_chunked_prefill_with_prefix_caching,
+          cache_hit_chunk=cache_hit_chunk,
+          need_save=need_save,
+      )
+      _run_benchmark_loop(benchmark_func, _BENCHMARK_ITERS, label)
 
-      total_time = datetime.timedelta()
-      for i in range(_BENCHMARK_ITERS):
-        start = datetime.datetime.now()
-        prefill_result = run_chunked_prefill_with_prefix_caching(cache_hit_chunk, need_save)
-        jax.block_until_ready(prefill_result)
-        end = datetime.datetime.now()
-        iter_time = end - start
-        total_time += iter_time
-        print("  Benchmark iteration", i + 1, "time:", iter_time)
 
-      average_time = total_time / _BENCHMARK_ITERS
-      print("\nAverage time taken for prefix caching chunked prefill:", average_time)
+def benchmark_prefix_cache(
+    engine: maxengine.MaxEngine,
+    params: Any,
+    tokens: jax.Array,
+    chunked_tokens_list: list[chunked_prefill.ChunkedTokens],
+    prefix_caching_hbm_byte: int,
+    prefix_caching_dram_byte: int,
+    chunk_size: int,
+    max_prefill_length: int,
+):
+  """Benchmarks chunked prefill with prefix caching.
+
+  This function first creates and populates a prefix cache, then benchmarks
+  the performance of chunked prefill with varying cache hit rates, including
+  the impact of saving new prefixes to the cache.
+
+  Args:
+    engine: The MaxEngine instance.
+    params: The model parameters.
+    tokens: The input token sequence.
+    chunked_tokens_list: A list of ChunkedTokens objects representing the
+      input sequence split into chunks.
+    prefix_caching_hbm_byte: The size of the HBM layer in the prefix cache.
+    prefix_caching_dram_byte: The size of the DRAM layer in the prefix cache.
+    chunk_size: The chunk size used for prefilling.
+    max_prefill_length: The maximum length of the prefill sequence.
+  """
+  print("\n--- Starting Prefix Cache Benchmark ---")
+
+  prefix_cache_inst = create_prefix_cache(
+      engine,
+      params,
+      tokens,
+      chunked_tokens_list,
+      prefix_caching_hbm_byte,
+      prefix_caching_dram_byte,
+      max_prefill_length,
+  )
+
+  run_time = [0]
+  benchmark_prefix_cache_loop(engine, params, tokens, chunked_tokens_list, prefix_cache_inst, chunk_size, run_time)
+
+
+def prepare_setting(argv: Sequence[str]):
+  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
+  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
+  config = pyconfig.initialize(argv)
+  max_utils.print_system_information()
+
+  prefix_caching_hbm_byte = config.prefix_caching_hbm_byte
+  prefix_caching_dram_byte = config.prefix_caching_dram_byte
+  max_prefill_length = config.max_prefill_predict_length
+  text = config.prompt
+  chunk_size = config.prefill_chunk_size
+
+  engine = maxengine.MaxEngine(config)
+
+  if not engine.use_chunked_prefill:
+    raise ValueError("Engine must be configured with use_chunked_prefill=True")
+
+  params = engine.load_params()
+
+  metadata = engine.get_tokenizer()
+  tokenizer_model = engine.build_tokenizer(metadata)
+  # set it to max complete prompt length that has to be benchmarked with chunked prefill
+  tokens, _ = tokenizer_model.encode(text, is_bos=True, prefill_lengths=[max_prefill_length])
+
+  chunked_tokens_list = chunked_prefill.gen_chunked_padded_tokens(
+      tokens=tokens,
+      chunk_size=chunk_size,
+      tokenizer=tokenizer_model,
+      jax_padding=True,
+  )
+
+  return (
+      engine,
+      params,
+      tokens,
+      chunked_tokens_list,
+      prefix_caching_hbm_byte,
+      prefix_caching_dram_byte,
+      chunk_size,
+      max_prefill_length,
+  )
+
+
+def main(argv: Sequence[str]) -> None:
+  (
+      engine,
+      params,
+      tokens,
+      chunked_tokens_list,
+      prefix_caching_hbm_byte,
+      prefix_caching_dram_byte,
+      chunk_size,
+      max_prefill_length,
+  ) = prepare_setting(argv)
+
+  benchmark_chunked_prefill(
+      engine,
+      params,
+      chunked_tokens_list,
+  )
+
+  benchmark_prefix_cache(
+      engine,
+      params,
+      tokens,
+      chunked_tokens_list,
+      prefix_caching_hbm_byte,
+      prefix_caching_dram_byte,
+      chunk_size,
+      max_prefill_length,
+  )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix prefix_caching not save every time.
Use jit copy to prevent block until the prefill results ready.

# Tests

Run benchmark_chunked_prefill and not fail.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
