### PR TITLE
Remove spurious logging

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -667,9 +667,6 @@ class AttentionOp(nn.Module):
     axis_names_splash_kernel = nn.logical_to_mesh_axes(self.flash_axis_names_splash_kernel)
     axis_names_q = nn.logical_to_mesh_axes(self.flash_axis_names_q)
     axis_names_kv = nn.logical_to_mesh_axes(self.flash_axis_names_kv)
-    max_logging.log(f"axis_names_q: {axis_names_q}")
-    max_logging.log(f"axis_names_kv: {axis_names_kv}")
-    max_logging.log(f"axis_names_splash_kernel: {axis_names_splash_kernel}")
 
     global_block_q = self.config.sa_block_q
     global_block_kv = self.config.sa_block_kv


### PR DESCRIPTION
# Description

Remove spurious logging of `axis_names_q`, `axis_names_kv`, `axis_names_splash_kernel` from `attentions.py`.

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
