### PR TITLE
Fix true_length in decode.py

### DIFF
--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -106,7 +106,7 @@ def main(argv: Sequence[str]) -> None:
     has_chat_template = getattr(tokenizer_model.tokenizer, "chat_template", False)  # pytype: disable=attribute-error
   except AttributeError as _:
     has_chat_template = False
-  tokens, _ = tokenizer_model.encode(text, is_bos=not has_chat_template, prefill_lengths=[prefill_length])
+  tokens, true_length = tokenizer_model.encode(text, is_bos=not has_chat_template, prefill_lengths=[prefill_length])
   images = None
   if config.use_multimodal:
     # TODO(hengtaoguo): Support multiple images as input.
@@ -114,7 +114,6 @@ def main(argv: Sequence[str]) -> None:
     images = multimodal_utils.pre_process_image(images, model_name=config.model_name)
     tokens = multimodal_utils.prepare_text_for_image_fusion(tokens, model_name=config.model_name)
 
-  true_length = tokens.shape[0]
   assert (
       true_length <= config.max_prefill_predict_length
   ), f"Input token length {true_length} is longer than {config.max_prefill_predict_length=}"


### PR DESCRIPTION
# Description
This PR fixes the `true_length` variable in `decode.py`, which is used in prefill operation. `tokenizer_model.encode()` returns padded tokens and true length of tokens (token length before padding): https://source.corp.google.com/piper///depot/google3/third_party/py/jetstream/engine/token_utils.py;l=566?q=HuggingFaceTokenizer%20%2B%20jetstream.

Input Prompt: `Compose a speech about the need for more affordable dental care.`

Decode results before this change,
```
MS Dearly, and the first time to the end of the most important to the world.

The following is a list of the most important things to do in the world.

1. Learn about the history of the world.

2. Learn about the history of the world.

3. Learn about the history of the world.

4. Learn about the history of the world.
```

Decode results after this change:
```
Introduction:
Good afternoon everyone,

Today, I want to talk about a pressing issue that affects millions of people around the world: the lack of affordable dental care. Dental health is crucial for our overall well-being, yet many individuals struggle to access the care they need due to financial constraints. As a society, it is our responsibility to ensure that everyone has access to quality dental care, regardless of their financial situation.

Body:

Firstly, let's look at the statistics. According to the World Health Organization, more than 30% of the world's population suffers from untreated dental caries, also known as tooth decay. This is a preventable condition that can lead to pain, infection, and even death. In addition, dental problems can have a significant impact on a person's quality of life, causing anxiety, depression, and social isolation.

Secondly, the cost of dental care is a significant barrier for many people. In the United States, for example, the average cost of a dental visit can range from $100 to $500, depending on the complexity of the procedure. This can be a significant burden for individuals who are living paycheck to paycheck or who have limited financial resources.

```
*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
tested by running `decode.py`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
