### PR TITLE
Fix MaxText pyconfig import in page_manager_test

### DIFF
--- a/MaxText/tests/inference/page_manager_test.py
+++ b/MaxText/tests/inference/page_manager_test.py
@@ -18,11 +18,10 @@ import os
 import sys
 import unittest
 
-import pyconfig
-
 import jax
 import jax.numpy as jnp
 
+from MaxText import pyconfig
 from MaxText.globals import PKG_DIR
 from MaxText.inference.page_manager import PageManager, PageState
 


### PR DESCRIPTION
# Description

Saw this error while running `python3 -m pytest` on a local TPU VM:

```
ImportError while importing test module '/home/bvandermoon/workspace/nnx_maxtext/maxtext/MaxText/tests/inference/page_manager_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
MaxText/tests/inference/page_manager_test.py:21: in <module>
    import pyconfig
E   ModuleNotFoundError: No module named 'pyconfig'
```

Updating this import let the tests start locally

# Tests

After this change, I was able to run the unit tests on a TPU VM with this:

```
python3 -m pytest
python3 -m pytest MaxText/tests/inference/page_manager_test.py # Tests passed
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
