### PR TITLE
Fix true_length issue just for multimodal

### DIFF
--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -113,6 +113,7 @@ def main(argv: Sequence[str]) -> None:
     images = multimodal_utils.load_image_from_path(config.image_path)
     images = multimodal_utils.pre_process_image(images, model_name=config.model_name)
     tokens = multimodal_utils.prepare_text_for_image_fusion(tokens, model_name=config.model_name)
+    true_length += multimodal_utils.get_image_offsets(config.model_name)
 
   assert (
       true_length <= config.max_prefill_predict_length


### PR DESCRIPTION
# Description

When `use_multimodal=True`, true_length is the sum of text tokens and image tokens length (~256). This PR fixes the `true_length` for multimodal scenario following [PR#1704](https://github.com/AI-Hypercomputer/maxtext/pull/1704). For example, prompt "<start_of_turn>user\nDescribe image <start_of_image><end_of_turn>\n<start_of_turn>model\n" is of length 13 when converted to text tokens, but its multimodal true_length should be 13 + 256 + 4 - 1 = 272 ([add extra tokens](https://github.com/AI-Hypercomputer/maxtext/blob/b52b2e551bd67e7e4e4ca3d092b52476f363075e/MaxText/multimodal_utils.py#L125)).

# Tests

Command line for multimodal decode:
```
python -m MaxText.decode MaxText/configs/base.yml model_name=gemma3-4b tokenizer_path=assets/tokenizer.gemma3 load_parameters_path=gs://maxtext-model-checkpoints/gemma3-4b/multimodal/2025-04-25-18-06-04/checkpoints/0/items per_device_batch_size=1 run_name=ht_test max_prefill_predict_length=272 max_target_length=300 steps=1 async_checkpointing=false scan_layers=false use_multimodal=true prompt=\'Describe\ image\ \<start_of_image\>\' image_path=\'/home/hengtaoguo/projects/maxtext/MaxText/test_assets/test_image.jpg\' attention=\'dot_product\'
```

Results:
```
RAMstats: After load_params:
        Using (GB) 31.95 / 1417.33 (2.254239%) -->  Available:1377.04
normalizer.cc(51) LOG(INFO) precompiled_charsmap is empty. use identity normalization.
Input `<start_of_turn>user
Describe image <start_of_image><end_of_turn>
<start_of_turn>model
` -> `Here's a description of the image:

**Overall Impression:** The image is a bright, expansive cityscape view of Seattle, Washington, with`
```
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
