### PR TITLE
Inference Support in sparse_matmul

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -141,6 +141,10 @@ sparse_matmul: True
 capacity_factor: -1.0 # a factor to decide expert capacity for token dropping, and no dropping by default
 load_balance_loss_weight: 0.01 # weight for the load balance loss
 use_random_routing: False # whether to use random routing for debug/test purpose
+# Tunable tiling dimensions used for Megablox
+tile_batch_seq: 512
+tile_activation_dim: 1024
+tile_weight_dim: 1024
 
 # deepseek moe
 base_moe_mlp_dim: 7168 # intermediate dimension at MoE layer (use base_mlp_dim if not DeepSeek style)


### PR DESCRIPTION
# Description

This PR provides support for inference workloads with sparse_matmul. The main difference is that Inference does not use batch sharding (not possible for Prefill for instance) while the sparse_matmul logic was originally created assuming that the batch was sharded.
Changes also include a fix for local_permute which counts just the data to be processed and fixes a bug where the last assigned expert recieves the padding assignments.
Changes also support using AQT-quantized checkpoints.
There was also a small fix to support TP + EP sharding.

The rest of the description includes relevant details and context, examples:
- these changes are needed to explore sparse_matmul techniques such as ragged_dot and Megablox which previously OOM'd due to a bug.
- After the PR, the prefill and decode latencies drop from 6.48s/6.08s to 346ms/78ms respectively (see b/411762258#comment7).
- I am still finding that ragged_all_to_all performs rather slowly (compared to all-gather) so the investigation may continue separately.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/406081672

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
