### PR TITLE
Use GKE cloud runners for TPU and GPU tests

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -60,7 +60,7 @@ jobs:
       device_name: a100-40gb-4
       build_mode: stable_stack
       base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/gpu:latest
-  
+
   cpu_unit_tests:
     needs: tpu_image
     uses: ./.github/workflows/run_tests_internal.yml
@@ -80,7 +80,7 @@ jobs:
     with:
       device_type: tpu
       device_name: v4-8
-      # cloud_runner: linux-x86-ct4p-240-4tpu
+      cloud_runner: linux-x86-ct4p-240-4tpu
       pytest_marker: 'not cpu_only and not gpu_only and not integration_test'
       xla_python_client_mem_fraction: 0.75
       tf_force_gpu_allow_growth: false
@@ -92,7 +92,7 @@ jobs:
     with:
       device_type: tpu
       device_name: v4-8
-      # cloud_runner: linux-x86-ct4p-240-4tpu
+      cloud_runner: linux-x86-ct4p-240-4tpu
       pytest_marker: 'not cpu_only and not gpu_only and integration_test'
       xla_python_client_mem_fraction: 0.75
       tf_force_gpu_allow_growth: false
@@ -104,7 +104,7 @@ jobs:
     with:
       device_type: gpu
       device_name: a100-40gb-4
-      # cloud_runner: linux-x86-a2-48-a100-4gpu
+      cloud_runner: linux-x86-a2-48-a100-4gpu
       pytest_marker: 'not cpu_only and not tpu_only and not integration_test'
       xla_python_client_mem_fraction: 0.65
       tf_force_gpu_allow_growth: true
@@ -116,7 +116,7 @@ jobs:
     with:
       device_type: gpu
       device_name: a100-40gb-4
-      # cloud_runner: linux-x86-a2-48-a100-4gpu
+      cloud_runner: linux-x86-a2-48-a100-4gpu
       pytest_marker: 'not cpu_only and not tpu_only and integration_test'
       xla_python_client_mem_fraction: 0.65
       tf_force_gpu_allow_growth: true

--- a/MaxText/tests/grain_data_processing_test.py
+++ b/MaxText/tests/grain_data_processing_test.py
@@ -36,15 +36,7 @@ class GrainArrayRecordProcessingTest(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
     super().setUpClass()
-    temp_dir = tempfile.gettempdir()
-    script_path = os.path.join(os.path.dirname(PKG_DIR), "setup_gcsfuse.sh")
-    if not os.path.isfile(script_path):
-      raise FileNotFoundError(script_path)
-    exit_code = subprocess.call(
-        ["bash", script_path, "DATASET_GCS_BUCKET=maxtext-dataset", f"MOUNT_PATH={os.path.join(temp_dir, 'gcsfuse')}"]
-    )
-    if exit_code != os.EX_OK:
-      raise ValueError(f"Running setup_gcsfuse.sh failed with exit code: {exit_code}")
+    mount_gcsfuse()
 
   def setUp(self):
     super().setUp()
@@ -119,15 +111,7 @@ class GrainParquetProcessingTest(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
     super().setUpClass()
-    temp_dir = tempfile.gettempdir()
-    script_path = os.path.join(os.path.dirname(PKG_DIR), "setup_gcsfuse.sh")
-    if not os.path.isfile(script_path):
-      raise FileNotFoundError(script_path)
-    exit_code = subprocess.call(
-        ["bash", script_path, "DATASET_GCS_BUCKET=maxtext-dataset", f"MOUNT_PATH={os.path.join(temp_dir, 'gcsfuse')}"]
-    )
-    if exit_code != 0:
-      raise ValueError(f"Running setup_gcsfuse.sh failed with exit code: {exit_code}")
+    mount_gcsfuse()
 
   def setUp(self):
     super().setUp()
@@ -199,18 +183,27 @@ class GrainParquetProcessingTest(unittest.TestCase):
     self.assertTrue((train_batch1["targets"] == train_batch2["targets"]).all())  # pytype: disable=unsupported-operands
 
 
-def main():
+def mount_gcsfuse():
+  """
+  Mounts a GCS bucket (gs://maxtext-dataset) to a local directory (/tmp/gcsfuse)
+  using gcsfuse if not already mounted.
+  """
   temp_dir = tempfile.gettempdir()
-  script_path = os.path.join(os.path.dirname(PKG_DIR), "setup_gcsfuse.sh")
-  if not os.path.isfile(script_path):
-    raise FileNotFoundError(script_path)
-  exit_code = subprocess.call(
+  mount_path = os.path.join(temp_dir, "gcsfuse")
+
+  # Only mount if the directory is empty or not present
+  if not os.path.isdir(mount_path) or not os.listdir(mount_path):
+    script_path = os.path.join(os.path.dirname(PKG_DIR), "setup_gcsfuse.sh")
+    if not os.path.isfile(script_path):
+      raise FileNotFoundError(script_path)
+
+    exit_code = subprocess.call(
       ["bash", script_path, "DATASET_GCS_BUCKET=maxtext-dataset", f"MOUNT_PATH={os.path.join(temp_dir, 'gcsfuse')}"]
-  )
-  if exit_code != 0:
-    raise ValueError(f"Running setup_gcsfuse.sh failed with exit code: {exit_code}")
-  unittest.main()
+    )
+    if exit_code != os.EX_OK:
+      raise ValueError(f"Running setup_gcsfuse.sh failed with exit code: {exit_code}")
 
 
 if __name__ == "__main__":
-  main()
+  mount_gcsfuse()
+  unittest.main()

--- a/MaxText/tests/integration_tests/train_tests.py
+++ b/MaxText/tests/integration_tests/train_tests.py
@@ -267,6 +267,7 @@ class TrainTests(unittest.TestCase):
         r"dataset_path=gs://maxtext-dataset",
         "steps=10",
         "enable_checkpointing=False",
+        "enable_goodput_recording=False",
         "attention=cudnn_flash_te",
         "ici_fsdp_parallelism=-1",
         "ici_tensor_parallelism=2",


### PR DESCRIPTION
In https://github.com/AI-Hypercomputer/maxtext/pull/1693 we enabled GKE runners for CPU tests. In this PR, we are enabling them for TPU and GPU tests. 

The Grain tests no longer need to set up GCSFuse since this is done by the GKE runners before the tests are done (b/412986220).

What remains on our self-hosted runners are tasks that don't operate on a container, like the steps building TPU/GPU containers. Changing this is work in progress.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
