### PR TITLE
Add comment that docker_upload_runner script needs bash version >= 4.2

### DIFF
--- a/docker_upload_runner.sh
+++ b/docker_upload_runner.sh
@@ -22,6 +22,7 @@
 
 # Example command:
 # bash docker_upload_runner.sh CLOUD_IMAGE_NAME=${USER}_runner
+# This script needs bash version >= 4.2 to execute correctly.
 
 set -e
 


### PR DESCRIPTION
# Description

`[[ ! -v VARIABLE ]]` only works on bash of version >= 4.2

The default Bash version on older macOS systems (specifically before macOS Catalina) is often 3.2, which does not support the -v option within the [[ ]] conditional construct. We should remind users of upgrading Bash version for this script to work.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
