### PR TITLE
Fix get_input_data_sharding method name in trainers

### DIFF
--- a/MaxText/elastic_train.py
+++ b/MaxText/elastic_train.py
@@ -267,7 +267,7 @@ def train_loop(config, elastic_manager, state=None):
       block=True,
   )
 
-  input_data_shardings = maxtext_utils.get_input_data_shardings(config, mesh)
+  input_data_shardings = maxtext_utils.get_input_data_sharding(config, mesh)
   # Using while loop instead of a for loop because with elasticity
   # the step is restored back to the latest snapshot when a slice is lost
   while step < config.steps:

--- a/MaxText/experimental/rl/grpo_trainer.py
+++ b/MaxText/experimental/rl/grpo_trainer.py
@@ -806,7 +806,7 @@ def train_loop(config, config_inference, state=None):
       gcp_workload_monitor.start_performance_reporting_thread(performance_metric_queue)
 
   metric_logger = MetricLogger(writer, config)
-  input_data_shardings = maxtext_utils.get_input_data_shardings(config, mesh)
+  input_data_shardings = maxtext_utils.get_input_data_sharding(config, mesh)
   for step in np.arange(start_step, config.steps):
     if step == first_profiling_step or prof.should_activate_periodic_profile(step):
       optional_postfix = f"step_{step}" if config.profile_periodically_period > 0 else ""

--- a/MaxText/sft_trainer.py
+++ b/MaxText/sft_trainer.py
@@ -204,7 +204,7 @@ def train_loop(config, state=None):
       gcp_workload_monitor.start_performance_reporting_thread(performance_metric_queue)
 
   metric_logger = MetricLogger(writer, config)
-  input_data_shardings = maxtext_utils.get_input_data_shardings(config, mesh)
+  input_data_shardings = maxtext_utils.get_input_data_sharding(config, mesh)
   for step in np.arange(start_step, config.steps):
     if step == first_profiling_step or prof.should_activate_periodic_profile(step):
       optional_postfix = f"step_{step}" if config.profile_periodically_period > 0 else ""


### PR DESCRIPTION
# Description
Fix `get_input_data_shardings()` to `get_input_data_sharding()` as defined in `maxtext_utils` [here](https://github.com/AI-Hypercomputer/maxtext/blob/75c8ef6aa33bd5192f88b5c35786a624420866c3/MaxText/maxtext_utils.py#L56)

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
