### PR TITLE
Fix bug with chunked attention masking

### DIFF
--- a/MaxText/benchmark_chunked_prefill.py
+++ b/MaxText/benchmark_chunked_prefill.py
@@ -354,6 +354,23 @@ def benchmark_prefix_cache(
 
 
 def prepare_setting(argv: Sequence[str]):
+  """
+    Constructs the necessary components for benchmarking chunked prefill with prefix caching.
+  q
+    Args:
+      argv: The command-line arguments.
+
+    Returns:
+      engine (maxengine.MaxEngine): The MaxEngine instance.
+      params (Any): The model parameters.
+      tokens (jax.Array): The input token sequence.
+      chunked_tokens_list (list[chunked_prefill.ChunkedTokens]): A list of ChunkedTokens objects representing the
+        input sequence split into chunks.
+      prefix_caching_hbm_byte (int): The size of the HBM layer in the prefix cache.
+      prefix_caching_dram_byte (int): The size of the DRAM layer in the prefix cache.
+      chunk_size (int): The chunk size used for prefilling.
+      max_prefill_length (int): The maximum length of the prefill sequence.
+  """
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   config = pyconfig.initialize(argv)

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -448,7 +448,8 @@ class AttentionOp(nn.Module):
     elif causal_mask is not None:
       output_mask = causal_mask
 
-    is_seq_len_greater_than_chunk_window = output_mask.shape[-1] > self.chunk_attn_window_size
+    if output_mask is not None and self.chunk_attn_window_size is not None:
+      is_seq_len_greater_than_chunk_window = output_mask.shape[-1] > self.chunk_attn_window_size
 
     if self.attention_type == AttentionType.LOCAL_SLIDING and output_mask is not None:
       if self.sliding_window_size is None:


### PR DESCRIPTION
# Description

This PR fixes a bug where, due to either of the `output_mask` or `chunk_attn_window_size` not being set, a [TypeError](https://screenshot.googleplex.com/HzqDAiTe88FHwKt) was being thrown in our E2E testing.

# Tests

Verified through local re-run of `gpt3-v4-8` test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
