### PR TITLE
Support vision attention for Llama4

### DIFF
--- a/MaxText/input_pipeline/_hf_data_processing.py
+++ b/MaxText/input_pipeline/_hf_data_processing.py
@@ -98,7 +98,7 @@ def preprocessing_pipeline(
     data_column_names = list(dataset.features.keys())
     dataset = dataset.map(
         _input_pipeline_utils.apply_chat_template,
-        fn_kwargs={"tokenizer": tokenizer, "data_column_name": data_column_names[0]},
+        fn_kwargs={"tokenizer_model": tokenizer, "data_column_name": data_column_names[0]},
     )
   else:
     dataset = dataset.select_columns(data_column_names)

--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -101,14 +101,14 @@ def is_conversational(features, data_columns):
   return False
 
 
-def apply_chat_template(example, tokenizer, data_column_name):
+def apply_chat_template(example, tokenizer_model, data_column_name):
   """Formats conversational data by applying the tokenizer's chat template
   and identifying prompt/completion segments.
 
   Args:
     example: A dictionary containing conversational data. It is expected to have a key
       specified by `data_column_name` that holds a list of messages.
-    tokenizer: The tokenizer instance associated with the language model,
+    tokenizer_model: The tokenizer instance associated with the language model,
       which contains the specific chat template.
     data_column_name: The name of the column in the `example` dictionary
       that contains the list of messages.
@@ -128,16 +128,16 @@ def apply_chat_template(example, tokenizer, data_column_name):
     for message in example[data_column_name]:
       if message["role"] == "user":
         prompt = message
-        prompt_in_chat_template = tokenizer.apply_chat_template([prompt], add_generation_prompt=False, tokenize=False)
+        prompt_in_chat_template = tokenizer_model.apply_chat_template([prompt], add_generation_prompt=False, tokenize=False)
         messages.append(prompt_in_chat_template)
         is_prompt.append(True)
       elif message["role"] == "assistant":
-        prompt_completion_tokens = tokenizer.apply_chat_template(
+        prompt_completion_tokens = tokenizer_model.apply_chat_template(
             [prompt, message], add_generation_prompt=False, tokenize=True
         )
-        prompt_tokens = tokenizer.apply_chat_template([prompt], add_generation_prompt=False, tokenize=True)
+        prompt_tokens = tokenizer_model.apply_chat_template([prompt], add_generation_prompt=False, tokenize=True)
         completion_tokens = prompt_completion_tokens[len(prompt_tokens) :]
-        completion_in_chat_template = tokenizer.decode(completion_tokens, skip_special_tokens=False)
+        completion_in_chat_template = tokenizer_model.decode(completion_tokens, skip_special_tokens=False)
         messages.append(completion_in_chat_template)
         is_prompt.append(False)
   except ValueError as e:

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -55,10 +55,11 @@ from MaxText.layers.quantizations import AqtQuantization as Quant
 
 
 class AttentionType(enum.Enum):
-  GLOBAL = "global"
+  GLOBAL = "global"  # default, with causality
   LOCAL_SLIDING = "local_sliding"
   CHUNK = "chunk"
   MLA = "mla"
+  FULL = "full"
 
 
 # Used to pass in splash attention block sizes from config.
@@ -389,7 +390,7 @@ class AttentionOp(nn.Module):
 
     causal_mask = None
     # We enforce causality except for AUTOREGRESSION
-    if model_mode != MODEL_MODE_AUTOREGRESSIVE:
+    if model_mode != MODEL_MODE_AUTOREGRESSIVE and self.attention_type != AttentionType.FULL:
       mask_shape = (q_seq_len, kv_seq_len)
       # row_ids indicates the position of query
       # col_ids indicates the position of kv
@@ -673,7 +674,10 @@ class AttentionOp(nn.Module):
     )
 
     mask_shape = (self.config.max_target_length, self.config.max_target_length)
-    mask = splash_attention_mask.CausalMask(shape=mask_shape)
+    if self.attention_type == AttentionType.FULL:
+      mask = splash_attention_mask.FullMask(mask_shape)
+    else:
+      mask = splash_attention_mask.CausalMask(shape=mask_shape)
 
     # Create LoadBalancedCausalMask if cp and load_balancing
     if cp_size > 1 and load_balanced_context_parallel:
@@ -1212,6 +1216,7 @@ class Attention(nn.Module):
   ragged_block_size: int = 256
   use_qk_norm: bool = False
   query_pre_attn_scalar: float | None = None
+  use_bias_in_projections: bool = False  # Set to True will enable bias in q, k, v, o projections
   # Temperature tuning parameters used for Llama4
   temperature_tuning: bool = False
   temperature_tuning_scale: float = 0.1
@@ -1237,6 +1242,7 @@ class Attention(nn.Module):
   reshape_q: bool = False
 
   is_nope_layer: bool = False
+  is_vision: bool = False
 
   def setup(self):
     """init with attention_op and possibly paged_attention_op"""
@@ -1304,6 +1310,7 @@ class Attention(nn.Module):
         name="query",
         quant=self.quant,
         matmul_precision=self.config.matmul_precision,
+        use_bias=self.use_bias_in_projections,
     )(inputs_q)
     return query_proj
 
@@ -1340,6 +1347,7 @@ class Attention(nn.Module):
         name=proj_name,
         quant=self.quant,
         matmul_precision=self.config.matmul_precision,
+        use_bias=self.use_bias_in_projections,
     )(inputs_kv)
     return kv_proj
 
@@ -1356,6 +1364,7 @@ class Attention(nn.Module):
         name=proj_name,
         quant=self.quant,
         matmul_precision=self.config.matmul_precision,
+        use_bias=self.use_bias_in_projections,
     )(inputs)
     qkv_proj = checkpoint_name(qkv_proj, "qkv_proj")
     query, key, value = qkv_proj[:, :, 0, ...], qkv_proj[:, :, 1, ...], qkv_proj[:, :, 2, ...]
@@ -1376,10 +1385,11 @@ class Attention(nn.Module):
         name="out",
         quant=self.quant,
         matmul_precision=self.config.matmul_precision,
+        use_bias=self.use_bias_in_projections,
     )(out)
     return out_proj
 
-  def apply_rotary_embedding(self, inputs: Array, inputs_positions: Array, name: str):
+  def apply_rotary_embedding(self, inputs: Array, name: str, inputs_positions: Optional[Array | None] = None):
     """Applies rotary embeddings, handling different model types.
 
     Args:
@@ -1398,7 +1408,15 @@ class Attention(nn.Module):
 
     rope_type = self.config.rope_type.lower()
     rope_use_scale = self.config.rope_use_scale
-    if self.config.model_name.startswith("llama3.1") or rope_type.startswith("llama3.1"):
+    if self.is_vision:
+      rotary_embedding = embeddings.LlamaVisionRotaryEmbedding(
+          image_size=self.config.image_size_for_vit,
+          patch_size=self.config.patch_size_for_vit,
+          hidden_size=self.config.hidden_size_for_vit,
+          num_attention_heads=self.config.num_attention_heads_for_vit,
+          rope_theta=self.config.rope_theta_for_vit,
+      )
+    elif self.config.model_name.startswith("llama3.1") or rope_type.startswith("llama3.1"):
       rotary_embedding = embeddings.LLaMARotaryEmbedding(
           min_timescale=self.config.rope_min_timescale,
           max_timescale=self.config.rope_max_timescale,
@@ -1459,7 +1477,7 @@ class Attention(nn.Module):
       self,
       inputs_q: Array,
       inputs_kv: Array,
-      inputs_positions: Array,
+      inputs_positions: Array | None = None,
       decoder_segment_ids: Array | None = None,
       *,
       model_mode: str = MODEL_MODE_TRAIN,
@@ -1530,8 +1548,8 @@ class Attention(nn.Module):
     use_qk_norm = self.use_qk_norm and use_rope
 
     if use_rope:
-      query = self.apply_rotary_embedding(query, inputs_positions, name="query_rotary")
-      key = self.apply_rotary_embedding(key, inputs_positions, name="key_rotary")
+      query = self.apply_rotary_embedding(query, name="query_rotary", inputs_positions=inputs_positions)
+      key = self.apply_rotary_embedding(key, name="key_rotary", inputs_positions=inputs_positions)
 
     if use_qk_norm and is_llama4_decoder_block:
       l2_norm = L2Norm(self.config.normalization_layer_epsilon)
@@ -1716,7 +1734,7 @@ class MLA(Attention):
 
     # Split into non-positional and rotary parts.
     q_nope, q_pe = jnp.split(q, [self.qk_nope_head_dim], axis=-1)
-    q_pe = self.apply_rotary_embedding(q_pe, inputs_positions, name="query_rope")
+    q_pe = self.apply_rotary_embedding(q_pe, name="query_rope", inputs_positions=inputs_positions)
     # Query projection is scaled by self.softmax_scale to be consistent MaxText implementation.
     # DeepSeek v3 was doing it in attention score computation.
     query = jnp.concatenate([q_nope, q_pe], axis=-1) * self.softmax_scale
@@ -1786,7 +1804,7 @@ class MLA(Attention):
 
     # Apply rotary embedding to key_rope.
     key_rope = jnp.expand_dims(low_rank_rope, axis=2)
-    key_rope = self.apply_rotary_embedding(key_rope, inputs_positions, name="key_rope")
+    key_rope = self.apply_rotary_embedding(key_rope, name="key_rope", inputs_positions=inputs_positions)
 
     key, value = self.mla_get_key_value(low_rank_main, key_rope, model_mode)
     cached_values = [None, None]
@@ -1803,7 +1821,7 @@ class MLA(Attention):
       self,
       inputs_q: Array,
       inputs_kv: Array,
-      inputs_positions: Array,
+      inputs_positions: Array | None = None,
       decoder_segment_ids: Array | None = None,
       *,
       model_mode: str = MODEL_MODE_TRAIN,

--- a/MaxText/layers/embeddings.py
+++ b/MaxText/layers/embeddings.py
@@ -517,7 +517,7 @@ class LlamaVisionRotaryEmbedding(nn.Module):
     # Convert to complex representation
     self.freqs_ci = jnp.exp(1j * freqs)
 
-  def __call__(self, inputs: Array) -> Array:
+  def __call__(self, inputs: Array, position: Optional[Array] = None) -> Array:
     """Applies rotary embeddings to the input tensor for Llama4 vision encoder.
 
     Args:


### PR DESCRIPTION
# Description

Add more options to the existing Attention class to support the attention in vision encoder:
* Full attention (non-causal)
* use bias in qkvo projection
* add is_vision flag to attention module for vision specific settings
Future item: we may implement a separate VisionAttention, as the vision dimensions are different from text, which increases the complexity if reuse the current attention module. We are working on the design.

# Tests
Test by comparing outputs with Llama4 VisionAttention module
<img width="1205" alt="Screenshot 2025-05-14 at 3 50 43 PM" src="https://github.com/user-attachments/assets/79cb95ce-6dc2-4545-952e-82a9ae8fca68" />
Currently dot_product attention works as expected, there are some issues with flash attention. Will enable flash attention in future PRs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
