### PR TITLE
Initialize jax system with any checkpointing

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -132,6 +132,12 @@ def maybe_initialize_jax_distributed_system(raw_keys):
   if raw_keys["skip_jax_distributed_system"]:
     max_logging.log("Skipping jax distributed system due to skip_jax_distributed_system=True flag.")
     return
+  if raw_keys["enable_single_controller"]:
+    max_logging.log("Skipping jax distributed system since its not needed for single controller.")
+    return
+  if jax.distributed.is_initialized():
+    max_logging.log("Jax distributed system is already initialized.")
+    return
   if raw_keys["inference_benchmark_test"]:
     # Disable initialization for inference benmark test.
     return
@@ -148,9 +154,7 @@ def maybe_initialize_jax_distributed_system(raw_keys):
     max_logging.log("Jax distributed system initialized on CPUs!")
   elif (
       raw_keys["enable_checkpointing"]
-      and raw_keys["async_checkpointing"]
       and raw_keys["compile_topology_num_slices"] == -1
-      and not raw_keys["enable_single_controller"]
   ) or raw_keys["hardware"] == "gpu_multiprocess":
     max_logging.log("Attempting to initialize the jax distributed system...")
     if not raw_keys["enable_emergency_checkpoint"]:

--- a/MaxText/tests/integration_tests/inference_microbenchmark_smoke_test.py
+++ b/MaxText/tests/integration_tests/inference_microbenchmark_smoke_test.py
@@ -44,6 +44,7 @@ class Inference_Microbenchmark(unittest.TestCase):
             "scan_layers=false",
             "weight_dtype=bfloat16",
             "attention=dot_product",
+            "skip_jax_distributed_system=True",
         ]
     )
     run_benchmarks(config)

--- a/MaxText/tests/integration_tests/standalone_dl_ckpt_test.py
+++ b/MaxText/tests/integration_tests/standalone_dl_ckpt_test.py
@@ -76,6 +76,7 @@ class Standalone_DL_CKPT(unittest.TestCase):
             "checkpoint_period=50",
             "async_checkpointing=False",
             "enable_goodput_recording=False",
+            "skip_jax_distributed_system=True",
         )
     )
     # restore at 50 and checkpoint at 100
@@ -96,6 +97,7 @@ class Standalone_DL_CKPT(unittest.TestCase):
             "checkpoint_period=50",
             "async_checkpointing=False",
             "enable_goodput_recording=False",
+            "skip_jax_distributed_system=True",
         )
     )
 


### PR DESCRIPTION
# Description

Initialize the jax distributed system on TPUs with any checkpointer (not just async). At some point a newer orbax also requires the jax distributed system even for synchronous checkpointers.

Also don't initialize the jax distributed system if its already initialized

Longer term the user should explicitly initialize if they want, but we will leave that for a larger future refactor (b/417998330)

FIXES: b/413423342, b/407047411

# Tests

Locally ran with a sync checkpointer.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
