### PR TITLE
Add test comment to only run grpo_trainer_correctness_test on v4-8

### DIFF
--- a/MaxText/tests/grpo_trainer_correctness_test.py
+++ b/MaxText/tests/grpo_trainer_correctness_test.py
@@ -13,6 +13,11 @@
 #  limitations under the License.
 
 """
+ATTENTION: This unit test should only be run on TPU v4-8. The test
+may fail on different versions like v5p-8, v6e-8
+
+TODO: b/413146740 - Match logits on other TPU versions
+
 Runs GRPO trainer unit test correctness with golden logits generated
   from maxtext/MaxText/scratch_code/generate_grpo_golden_logits.py
 
@@ -125,7 +130,7 @@ class GrpoTrainerTest(unittest.TestCase):
     )
     self.tokenizer_model.add_special_tokens({"pad_token": "<pad>"})
 
-  @pytest.mark.tpu_only
+  @pytest.mark.tpu_only # ATTENTION: Only run on TPU V4-8
   def test_grpo_trainer_correctness(self):
     # Get the expected (golden) data.
     golden_data = get_golden_data(self.config)


### PR DESCRIPTION
# Description

This test should only be run on TPU v4-8. Saw failures on v6e-8 even with a clean MaxText workspace and fresh virtual env.

See b/413146740. The reason is not currently known. But adding this comment for others who may run into this issue

# Tests

Adding comments only, no code changes. Will rely on this unit test passing in the PR

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
