### PR TITLE
Copy test assets from GCS outside docker file

### DIFF
--- a/.github/workflows/build_and_upload_images.sh
+++ b/.github/workflows/build_and_upload_images.sh
@@ -21,7 +21,7 @@
 # If you want to create and push your own images you should instead use docker_build_dependency_image and
 # docker_upload_runner in the maxtext root directory.
 
-# Example command: 
+# Example command:
 # bash build_and_upload_images.sh PROJECT=<project> MODE=stable DEVICE=tpu CLOUD_IMAGE_NAME=${USER}_runner
 
 
@@ -49,6 +49,8 @@ docker tag ${LOCAL_IMAGE_NAME} gcr.io/$PROJECT/${dependency_image_name}:latest
 docker push gcr.io/$PROJECT/${dependency_image_name}:latest
 docker tag ${LOCAL_IMAGE_NAME} gcr.io/$PROJECT/${dependency_image_name}:${image_date}
 docker push gcr.io/$PROJECT/${dependency_image_name}:${image_date}
+
+gsutil -m cp gs://maxtext-test-assets/* ./MaxText/test_assets
 
 # Build then upload "dependencies + code" image
 docker build --build-arg BASEIMAGE=${LOCAL_IMAGE_NAME} -f ./maxtext_runner.Dockerfile -t ${LOCAL_IMAGE_NAME}_runner .

--- a/docker_upload_runner.sh
+++ b/docker_upload_runner.sh
@@ -44,6 +44,8 @@ if [[ ! -v CLOUD_IMAGE_NAME ]]; then
   exit 1
 fi
 
+gsutil -m cp gs://maxtext-test-assets/* ./MaxText/test_assets
+
 docker build --build-arg BASEIMAGE=${LOCAL_IMAGE_NAME} -f ./maxtext_runner.Dockerfile -t ${LOCAL_IMAGE_NAME_RUNNER} .
 
 docker tag ${LOCAL_IMAGE_NAME_RUNNER} gcr.io/$PROJECT/${CLOUD_IMAGE_NAME}:latest

--- a/maxtext_runner.Dockerfile
+++ b/maxtext_runner.Dockerfile
@@ -12,6 +12,3 @@ WORKDIR /deps
 # MaxText/test_assets which contain some of the reference "golden" data.
 COPY . .
 
-# Download other test assets from GCS into /deps/MaxText/test_assets
-RUN gsutil -m cp gs://maxtext-test-assets/* MaxText/test_assets
-


### PR DESCRIPTION
# Description

A recent change moved test_assets to GCS with the idea that they are needed for our systems tests, so can directly be copied into the docker container that is used for the tests. However due to auth issues, this copy command can't be done inside the docker file. This PR moves it out.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
