### PR TITLE
Add parameter_memory_host_offload to gpt3 norm layer

### DIFF
--- a/MaxText/tests/train_compile_test.py
+++ b/MaxText/tests/train_compile_test.py
@@ -580,3 +580,18 @@ class TrainCompile(unittest.TestCase):
             "ici_tensor_parallelism=4",
         )
     )
+
+  @pytest.mark.cpu_only
+  def test_gpt3_6b(self):
+    compiled_trainstep_file = "/tmp/test_gpt3_6b"
+    train_compile_main(
+        (
+            None,
+            os.path.join(PKG_DIR, "configs", "base.yml"),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "compile_topology_num_slices=1",
+            "model_name=gpt3-6b",
+            "per_device_batch_size=1",
+        )
+    )


### PR DESCRIPTION
# Description

Plumb in parameter_memory_host_offload to gpt3 norm layer, missed in https://github.com/AI-Hypercomputer/maxtext/pull/1484

FIXES: b/417531226

# Tests

Manually ran gpt3-6b and added an AOT test for it

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
