### PR TITLE
Enable inference_microbenchmark_smoke_test

### DIFF
--- a/MaxText/prefill_packing.py
+++ b/MaxText/prefill_packing.py
@@ -15,17 +15,17 @@
 """Implementation of Prefill Packing feature"""
 
 from typing import Any, List, Tuple, Callable
-import warnings
-import logging
-
-from jetstream.engine import engine_api
-
-import numpy as np
 
 import jax
 import jax.numpy as jnp
+import numpy as np
+
+from jetstream.engine import engine_api
 
 from MaxText.maxengine import MaxEngine
+
+import warnings
+import logging
 
 warnings.simplefilter("ignore", category=FutureWarning)
 DecodeState = Any
@@ -128,7 +128,7 @@ class PrefillProcessor:
       self.process_func[padded_length] = (
           jax.jit(
               self._process,
-              in_shardings=(self.engine.param_layouts, None, None, None, self.engine.decode_state_layouts),
+              in_shardings=(self.engine.param_layouts, None, None, None, self.engine.decode_state_layouts, None),
               out_shardings=(
                   None,
                   self.engine.decode_state_layouts,
@@ -141,6 +141,7 @@ class PrefillProcessor:
               jax.ShapeDtypeStruct((), int),
               jax.ShapeDtypeStruct((), int),
               self.engine.decode_state_shapes,
+              jax.ShapeDtypeStruct([4], jax.numpy.dtype("uint32")),
           )
           .compile(compiler_options=None)
       )
@@ -153,10 +154,11 @@ class PrefillProcessor:
       slot: int,
       true_length: int,
       decode_state: DecodeState,
+      rng: PRNGKeyType,
   ) -> Tuple[engine_api.ResultTokens, DecodeState]:
     """Prefill and insert a request."""
 
-    prefill_result, first_token = self.engine.prefill(params=params, padded_tokens=tokens, true_length=true_length)
+    prefill_result, first_token = self.engine.prefill(params=params, padded_tokens=tokens, true_length=true_length, rng=rng)
     decode_state = self.engine.insert(prefill_result, decode_state, slot)
     return first_token, decode_state
 

--- a/MaxText/tests/integration_tests/inference_microbenchmark_smoke_test.py
+++ b/MaxText/tests/integration_tests/inference_microbenchmark_smoke_test.py
@@ -14,6 +14,7 @@ limitations under the License.
 """
 
 """ Smoke test for inference microbenchmark"""
+import jax
 import os.path
 import pytest
 import unittest
@@ -22,7 +23,6 @@ from absl.testing import absltest
 from MaxText import pyconfig
 from MaxText.globals import PKG_DIR
 from MaxText.inference_microbenchmark import run_benchmarks
-from MaxText.tests.globals import TEST_DISABLE_SUBPROCESS_STR, TEST_DISABLE_SUBPROCESS
 
 
 class Inference_Microbenchmark(unittest.TestCase):
@@ -30,8 +30,8 @@ class Inference_Microbenchmark(unittest.TestCase):
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only
-  @pytest.mark.skipif(TEST_DISABLE_SUBPROCESS, reason=TEST_DISABLE_SUBPROCESS_STR)
   def test(self):
+    jax.config.update("jax_default_prng_impl", "unsafe_rbg")
     config = pyconfig.initialize(
         [
             None,
@@ -43,6 +43,7 @@ class Inference_Microbenchmark(unittest.TestCase):
             "max_target_length=2048",
             "scan_layers=false",
             "weight_dtype=bfloat16",
+            "attention=dot_product",
         ]
     )
     run_benchmarks(config)


### PR DESCRIPTION
# Description
This PR enables `inference_microbenchmark_smoke_test` which was disabled during linting effort [here](https://github.com/AI-Hypercomputer/maxtext/pull/1482).

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
`pytest MaxText/tests/integration_tests/inference_microbenchmark_smoke_test.py` 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
