### PR TITLE
Add deepseek c4 convergence test and v5p recipe

### DIFF
--- a/MaxText/input_pipeline/_tfds_data_processing_c4_mlperf.py
+++ b/MaxText/input_pipeline/_tfds_data_processing_c4_mlperf.py
@@ -277,8 +277,20 @@ def preprocess_eval_dataset(
     eval_global_batch_size_to_load: int,
     max_target_length: int,
     num_examples: Optional[int] = None,
+    is_tokenized_dataset: bool = True,
 ) -> tf.data.Dataset:
   """Preprocess the evaluation dataset."""
+  # group text up to max_target_length if the dataset is not pre-tokenized/pre-processed
+  if not is_tokenized_dataset:
+    eval_ds = eval_ds.map(
+        lambda x: tokenizer.TokenizeOp(tokenizer=sp_tokenizer, features=x, data_keys=("targets",)),
+        num_parallel_calls=AUTOTUNE,
+    )
+    # hardcode batch_sizes 24567 i.e. the exp size in split validation_24567exp
+    #   to avoid padding tokens inserted in group text
+    eval_ds = reduce_concat_tokens(eval_ds, feature_key="targets", batch_size=24567)
+    eval_ds = split_tokens_to_targets_length(eval_ds, max_target_length)
+
   if sp_tokenizer.pad_id is not None:
     pad_id = sp_tokenizer.pad_id
   elif sp_tokenizer.unk_id is not None:
@@ -340,16 +352,40 @@ def make_c4_mlperf_eval_iterator(
     process_indices,
 ):
   """Make eval iterator of customized C4 dataset for mlperf gpt3 training."""
-  eval_ds = get_dataset(
-      dataset_name=config.eval_dataset_name,
-      split="validation_tokenized_5662seqs",
-      dataloading_host_index=process_indices.index(jax.process_index()),
-      dataloading_host_count=len(process_indices),
-      enable_data_shuffling=False,
-  )
-  # note validation_tokenized_5662seqs split is pre tokenized, reduce_concated and split to target_length
-  #   mainly to avoid eval sequences change depending on the number of hosts
-  eval_ds = rekey(eval_ds, {"inputs": None, "targets": "ids"})
+  eval_slit = "None"
+  if config.eval_dataset_name == "c4/en:3.0.5":
+    is_tokenized_dataset = True
+  elif config.eval_dataset_name == "c4/en:3.0.4":
+    is_tokenized_dataset = False
+    eval_slit = "validation_24567exp"
+  elif config.eval_dataset_name in ["c4/en:3.0.1", "c4/en:3.0.8", "c4/en:3.0.9"]:
+    is_tokenized_dataset = False
+    eval_slit = "validation"
+  else:
+    raise ValueError(f"{config.eval_dataset_name=} should be one of ('c4/en:3.0.1', 'c4/en:3.0.4', 'c4/en:3.0.5')")
+
+  if is_tokenized_dataset:
+    eval_ds = get_dataset(
+        dataset_name=config.eval_dataset_name,
+        split="validation_tokenized_5662seqs",
+        dataloading_host_index=process_indices.index(jax.process_index()),
+        dataloading_host_count=len(process_indices),
+        enable_data_shuffling=False,
+    )
+    # note validation_tokenized_5662seqs split is pre tokenized, reduce_concated and split to target_length
+    #   mainly to avoid eval sequences change depending on the number of hosts
+    eval_ds = rekey(eval_ds, {"inputs": None, "targets": "ids"})
+  else:
+    eval_ds = get_dataset(
+        dataset_name=config.eval_dataset_name,
+        split=eval_slit,
+        dataloading_host_index=process_indices.index(jax.process_index()),
+        dataloading_host_count=len(process_indices),
+        enable_data_shuffling=False,
+    )
+
+    eval_ds = rekey(eval_ds, {"inputs": None, "targets": "text"})
+
   sp_tokenizer = get_tokenizer(
       config.tokenizer_path, config.tokenizer_type, config.add_bos, config.add_eos, config.hf_access_token
   )
@@ -358,6 +394,7 @@ def make_c4_mlperf_eval_iterator(
       sp_tokenizer=sp_tokenizer,
       eval_global_batch_size_to_load=config.global_batch_size_to_load_eval,
       max_target_length=config.max_target_length,
+      is_tokenized_dataset=is_tokenized_dataset,
   )
 
   eval_multihost_gen = multihost_dataloading.MultiHostDataLoadIterator(eval_ds, global_mesh)

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -480,6 +480,9 @@ class _HyperParameters:
     if raw_keys["dataset_type"] == "c4_mlperf" and raw_keys["model_name"] == "gpt3-175b":
       _HyperParameters.configure_gpt3_task(raw_keys)
 
+    if raw_keys["dataset_type"] == "c4_mlperf" and raw_keys["model_name"] != "gpt3-175b":
+      _HyperParameters.configure_c4_mlperf_task(raw_keys)
+
     if not os.path.isfile(raw_keys["tokenizer_path"]):
       # Try and find the tokenizer path relative to the config file.
       tokenizer_path = os.path.join(
@@ -604,6 +607,25 @@ class _HyperParameters:
     raw_keys["learning_rate_schedule_steps"] = decay_end_step
     raw_keys["warmup_steps_fraction"] = warmup_steps / decay_end_step
     raw_keys["eval_interval"] = math.ceil(24567 / global_batch_size_to_train_on)
+
+  @staticmethod
+  def configure_c4_mlperf_task(raw_keys):
+    """dynamically configure based on training rules"""
+    # follow https://github.com/google/paxml/blob/19db52eed85ae0d2365339b83a97cd0b873bbf73/paxml/tasks/lm/params/c4.py#L280
+    #   according to training_rules of mlperf
+    global_batch_size_to_train_on = raw_keys["global_batch_size_to_train_on"]
+    global_batch_size_to_eval_on = raw_keys["global_batch_size_to_eval_on"]
+    max_target_length = raw_keys["max_target_length"]
+
+    learning_rate = (8.0e-5 * global_batch_size_to_train_on) / 1152
+    warmup_steps = math.ceil(8000.0 * 1152 / global_batch_size_to_train_on - 1e-6)
+    decay_end_step = math.ceil(1200000.0 * 1152 / global_batch_size_to_train_on - 1e-6)
+    raw_keys["learning_rate"] = learning_rate
+    raw_keys["learning_rate_schedule_steps"] = decay_end_step
+    raw_keys["warmup_steps_fraction"] = warmup_steps / decay_end_step
+
+    raw_keys["eval_steps"] = math.ceil(5760 * 8192 / max_target_length / global_batch_size_to_eval_on)
+    raw_keys["eval_interval"] = math.ceil(377487360 / max_target_length / global_batch_size_to_train_on)
 
   @staticmethod
   def update_model_vars(base_config_path, raw_keys, config_name: str):

--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -28,6 +28,7 @@ import time
 
 from MaxText.inference_utils import str2bool
 from benchmarks.maxtext_trillium_model_configs import trillium_model_dict
+from benchmarks.maxtext_v5p_model_configs import v5p_model_dict
 from benchmarks.maxtext_v5e_model_configs import v5e_model_dict
 from benchmarks.maxtext_xpk_runner import PathwaysConfig
 from benchmarks.maxtext_xpk_runner import WorkloadConfig
@@ -123,7 +124,7 @@ def add_xpk_runner_arguments(custom_parser: argparse.ArgumentParser):
   custom_parser.add_argument(
       '--model_name',
       type=str,
-      choices=list(trillium_model_dict.keys()) + list(v5e_model_dict.keys()),
+      choices=list(trillium_model_dict.keys()) + list(v5p_model_dict.keys()) + list(v5e_model_dict.keys()),
       default=list(trillium_model_dict.keys())[0],
       help='model to be benchmarked, supported models are the command choices.',
   )
@@ -239,12 +240,14 @@ def main() -> None:
   options = parser.parse_args()
 
   # Check that there are no duplicate model configs
-  duplicates = (trillium_model_dict.keys() & v5e_model_dict.keys())
+  duplicates = (trillium_model_dict.keys() & v5p_model_dict.keys() & v5e_model_dict.keys())
   assert len(duplicates) == 0 , f'Found duplicate model config {duplicates}'
 
   model = trillium_model_dict.get(options.model_name)
   if model is None:
     model = v5e_model_dict.get(options.model_name)
+  if model is None:
+    model = v5p_model_dict.get(options.model_name)
 
   libtpu_type = None
   match options.libtpu_type:

--- a/benchmarks/maxtext_v5p_model_configs.py
+++ b/benchmarks/maxtext_v5p_model_configs.py
@@ -1,0 +1,107 @@
+"""
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+"""Shared Benchmark config for v6e orchestrations."""
+
+import os.path
+from benchmarks import xla_flags_library
+from benchmarks.maxtext_trillium_model_configs import MaxTextModel, _add_to_model_dictionary
+
+
+v5p_model_dict = {}
+
+deepseek_v3_ep_256_v5p_512  = _add_to_model_dictionary(
+    v5p_model_dict,
+    MaxTextModel(
+        model_name="deepseek_v3_ep_256_v5p_512",
+        model_type="deepseek3-671b",
+        tuning_params={
+            "per_device_batch_size": 4,
+            "max_target_length": 8192,
+            "ici_fsdp_parallelism": 1,
+            "ici_expert_parallelism": -1,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "dataset_path": "gs://max-datasets-rogue",
+            "dataset_type": "synthetic",
+            "reuse_example_batch": 1,
+            "enable_checkpointing": False,
+            "skip_first_n_steps_for_profiler": 5,
+            "profiler_steps": 5,
+            "profiler": "xplane",
+            "sa_block_q": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+            "megablox": False,
+            "sparse_matmul": False,
+            "capacity_factor": 1.0,
+            "tokenizer_type": "huggingface",
+            "tokenizer_path": "deepseek-ai/DeepSeek-V3",
+            "dtype": "bfloat16",
+            "opt_type": "adam_pax",
+            "attention": "flash",
+        },
+        xla_flags=(
+            xla_flags_library.MOE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+        ),
+    ),
+)
+
+c4_deepseek_v3_ep_256_v5p_512 = _add_to_model_dictionary(
+    v5p_model_dict,
+    MaxTextModel(
+        model_name="c4_deepseek_v3_ep_256_v5p_512",
+        model_type="deepseek3-671b",
+        tuning_params={
+            "per_device_batch_size": 4,
+            "max_target_length": 8192,
+            "ici_fsdp_parallelism": 1,
+            "ici_expert_parallelism": -1,
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "gcs_metrics": True,
+            "use_iota_embed": True,
+            "enable_checkpointing": True,
+            "load_parameters_path": "gs://maxtext-model-checkpoints/deepseek3-671b/0/items",
+            "dataset_path": "gs://max-datasets-rogue",
+            "skip_first_n_steps_for_profiler": 5,
+            "profiler_steps": 5,
+            "profiler": "xplane",
+            "sa_block_q": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_q_dq": 2048,
+            "megablox": False,
+            "sparse_matmul": False,
+            "capacity_factor": 1.0,
+            "dataset_type": "c4_mlperf",
+            "dataset_name": "c4/en:3.0.7",
+            "eval_dataset_name": "c4/en:3.0.9",
+            "opt_type": "adam_pax",
+            "tokenizer_type": "huggingface",
+            "tokenizer_path": "deepseek-ai/DeepSeek-V3",
+            "dtype": "bfloat16",
+            "attention": "flash",
+        },
+        xla_flags=(
+            xla_flags_library.MOE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+        ),
+    ),
+)


### PR DESCRIPTION
# Description

1. to support different c4 variance version in c4_mperf datatype
2. add deepseek v3 convergence configs.
3. add deepseek v5p recipe 

# Tests
validate #2 convergence run and #3 configs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
