### PR TITLE
Add max-prefill-length argument in distillation dataset generation script

### DIFF
--- a/MaxText/generate_distillation_data.py
+++ b/MaxText/generate_distillation_data.py
@@ -24,20 +24,26 @@ Example command:
     --dataset-path HuggingFaceH4/ultrachat_200k --data-split train_sft --data-columns messages \
     --tokenizer-path deepseek-ai/DeepSeek-V2-Lite-chat \
     --hf-access-token <access token> \
-    --batch-size 1024 --num-batches 100 \
+    --batch-size 1024 --num-batches 10 \
     --num-generations 2 \
-    --max-output-length 128 --max-target-length 256 \
+    --max-prefill-length 256 --max-target-length 2048 \
     --use-chat-template --remove-local-dataset-files \
     upload-to-hf --hf-repo-id <hf repository id>
 
-Running this command executes 100 processing steps.
-In each step, it generates completions for a batch of 40 prompts.
-This results in inference running on 4000 prompts overall, producing 2 samples per prompt.
+Running this command executes 10 processing steps.
+In each step, it generates completions for a batch of 1024 prompts.
+This results in inference running on 10240 prompts overall, producing 2 unique samples per prompt.
+Some prompts may be filtered out if prompt tokens are longer than `max-prefill-length`.
+`max-target-length` is the max length of prompt tokens and expected completion tokens.
+Set `--remove-local-dataset-files` to remove dataset files created locally after uploading to Hugging Face or GCS.
+`upload-to-hf` will upload the dataset to Hugging Face and `upload-to-gcs` will upload the dataset to GCS.
+For more information, check out `python3 -m MaxText.generate_distillation_data --help`.
 Note:
 Make sure to run maxengine server in a new terminal before executing this command. Example command to run maxengine server:
   python3 -m MaxText.maxengine_server MaxText/configs/base.yml \
     model_name=deepseek2-16b tokenizer_path=deepseek-ai/DeepSeek-V2-Lite-chat tokenizer_type=huggingface \
     load_parameters_path=<unscanned checkpoint path> \
+    max_target_length=2048 max_prefill_predict_length=256 \
     per_device_batch_size=10 multi_sampling=True ici_tensor_parallelism=4 \
     decode_sampling_strategy=weighted scan_layers=False
 """
@@ -92,7 +98,7 @@ async def send_request(config, request, stub, tokenizer, progress_bar):  # pylin
 
   outputs = []
   for tokens in completion_tokens:
-    completion = tokenizer.decode(tokens, skip_special_tokens=True)
+    completion = tokenizer.decode(tokens, skip_special_tokens=True).strip()
     outputs.append(
         {
             "prompt": [{"role": "user", "content": prompt}],
@@ -256,9 +262,7 @@ if __name__ == "__main__":
   )
   parser.add_argument("--tokenizer-path", type=str, required=True, help="Path to Hugging Face tokenizer.")
   parser.add_argument("--use-chat-template", action="store_true", help="Enable tokenizer to apply a chat template.")
-  parser.add_argument(
-      "--max-output-length", type=int, required=True, help="The maximum completion tokens to generate for a prompt."
-  )
+  parser.add_argument("--max-prefill-length", type=int, default=256, help="The maximum prompt length.")
   parser.add_argument(
       "--max-target-length", type=int, default=2048, help="The maximum prompt length plus the output completion length."
   )
@@ -293,6 +297,6 @@ if __name__ == "__main__":
   config = parser.parse_args()
 
   assert (
-      config.max_output_length < config.max_target_length
-  ), "Maximum output length of completion should be less than maximum target length."
+      config.max_prefill_length < config.max_target_length
+  ), "Maximum length of prompt should be less than maximum target length."
   generate_data(config)


### PR DESCRIPTION
# Description

This PR introduces `max-prefill-length` argument to the script that is used to generate dataset for distillation. This argument will be used to filter out prompt sequences that are larger than `max-prefill-length` before running inference.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
* Tested with generate_distillation_dataset.py

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
