### PR TITLE
Disable goodput by default

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -569,8 +569,8 @@ eval_steps: -1  # run this number of steps for eval, recommend setting this to p
 target_eval_loss: 0.  # early stop once reaching target eval_loss
 
 # Goodput parameters
-enable_goodput_recording: True
-monitor_goodput: True
+enable_goodput_recording: False
+monitor_goodput: False
 goodput_upload_interval_seconds: 30
 enable_pathways_goodput: False
 monitor_step_time_deviation: True


### PR DESCRIPTION
# Description

Disable goodput by default. Goodput starts a background thread that interacts with GCS, it should not run without the user explicitly setting it.

FIXES: b/418215414

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
