### PR TITLE
[MaxText/inference_microbenchmark.py] Ensure correct exit code

### DIFF
--- a/MaxText/inference_microbenchmark.py
+++ b/MaxText/inference_microbenchmark.py
@@ -19,6 +19,7 @@ import datetime
 import jax
 import json
 import os
+import sys
 
 from absl import app
 from collections.abc import MutableMapping
@@ -426,9 +427,13 @@ def run_benchmarks(config):
   return results
 
 
-def main(config, **kwargs):
+def run_benchmarks_with_unsafe_rbg(config, **kwargs):
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   return run_benchmarks(pyconfig.initialize(config, **kwargs))
+
+
+def main(config, **kwargs):
+  json.dump(run_benchmarks_with_unsafe_rbg(config, **kwargs), sys.stdout)
 
 
 if __name__ == "__main__":

--- a/MaxText/inference_microbenchmark_sweep.py
+++ b/MaxText/inference_microbenchmark_sweep.py
@@ -123,7 +123,9 @@ def main():
         **inference_metadata,
     }
     try:
-      microbenchmark_results = inference_microbenchmark.main(config, inference_metadata=inference_metadata)
+      microbenchmark_results = inference_microbenchmark.run_benchmarks_with_unsafe_rbg(
+          config, inference_metadata=inference_metadata
+      )
       if microbenchmark_results:
         metrics = microbenchmark_results["flattened_results"]
         metrics = {k.lower(): v for k, v in metrics.items()}


### PR DESCRIPTION
# Description

Earlier change accidentally made the exit code not `EXIT_SUCCESS`… this fixes that issue and also enables the output to be used by other tools.

Closes #1742

FIXES: #1742

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
