### PR TITLE
Add option to override model args via CLI

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -17,6 +17,7 @@
 run_name: ""
 
 model_name: "default" # override config settings to match a specific model. other than the override, nothing should use this!
+override_model_config: False # When set to true allows overriding model parameters via CLI for the purpose of debugging/testing.
 normalization_layer_epsilon: 1.e-05
 
 ################################## CHECKPOINTING ##################################

--- a/MaxText/tests/pyconfig_test.py
+++ b/MaxText/tests/pyconfig_test.py
@@ -114,6 +114,18 @@ class PyconfigTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       config_inference.ici_fsdp_parallelism = 4
 
+  def test_overriding_model(self):
+    config = pyconfig.initialize(
+        [os.path.join(PKG_DIR, "train.py"), os.path.join(PKG_DIR, "configs", "base.yml")],
+        skip_jax_distributed_system=True,
+        model_name="gemma-7b",
+        override_model_config=True,
+        base_emb_dim=1024, # Defined as 3072 in gemma-7b
+    )
+
+    self.assertEqual(config.base_emb_dim, 1024)
+    self.assertEqual(config.base_mlp_dim, 24576)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description

Add an option to override model args via CLI. Some users want to use most of a model definition except for one or two arguments, and they don't care if they break the contract of using the model. We give them the option of breaking this contract by setting a new flag override_model_config=True, in which case CLI arguments will take precedence over model arguments.

FIXES: b/418006060


# Tests
Ran with `model_name=gemma-7b base_emb_dim=1024 override_model_config=True` and confirmed expected config (base_emb_dim=1024, but inherted other gemma properties). Also added this as a test case for our CI.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
