### PR TITLE
Update naming jax ai image

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -49,7 +49,7 @@ jobs:
     with:
       device_type: tpu
       device_name: v4-8
-      build_mode: stable_stack
+      build_mode: jax_ai_image
       base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:latest
 
   gpu_image:
@@ -58,7 +58,7 @@ jobs:
     with:
       device_type: gpu
       device_name: a100-40gb-4
-      build_mode: stable_stack
+      build_mode: jax_ai_image
       base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/gpu:latest
 
   cpu_unit_tests:

--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -58,15 +58,15 @@ jobs:
     - name: build jax nightly image
       run : |
         bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_jax_nightly MODE=nightly DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_jax_nightly
-    - name: build jax stable stack image
+    - name: build jax AI image
       run : |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_jax_stable_stack MODE=stable_stack DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_jax_stable_stack BASEIMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:latest MAXTEXT_REQUIREMENTS_FILE=requirements_with_jax_stable_stack.txt
-    - name: build image with stable stack nightly jax
+        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_jax_stable_stack MODE=jax_ai_nightly DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_jax_stable_stack BASEIMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:latest
+    - name: build image with JAX AI nightly
       run: |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_stable_stack_nightly_jax MODE=stable_stack DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_tpu_jax_stable_stack_nightly BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/tpu/jax_nightly:latest MAXTEXT_REQUIREMENTS_FILE=requirements_with_jax_stable_stack.txt
+        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_stable_stack_nightly_jax MODE=jax_ai_nightly DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_tpu_jax_stable_stack_nightly BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/tpu/jax_nightly:latest
     - name: build image with jax stable stack release candidate image
       run: |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_stable_stack_candidate MODE=stable_stack DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_stable_stack_candidate BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:latest MAXTEXT_REQUIREMENTS_FILE=requirements_with_jax_stable_stack.txt
+        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_stable_stack_candidate MODE=jax_ai_nightly DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_stable_stack_candidate BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:latest
   gpu:
     strategy:
       fail-fast: false
@@ -84,12 +84,12 @@ jobs:
     - name: build jax pinned image
       run : |
         bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_gpu_jax_pinned MODE=pinned DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_gpu_local_jax_pinned
-    - name: build jax stable stack image
+    - name: build jax AI image
       run : |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_gpu_jax_stable_stack MODE=stable_stack DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_gpu_jax_stable_stack BASEIMAGE=us-central1-docker.pkg.dev/deeplearning-images/jax-stable-stack/gpu:latest MAXTEXT_REQUIREMENTS_FILE=requirements_with_jax_stable_stack.txt
-    - name: build image with stable stack nightly jax
+        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_gpu_jax_stable_stack MODE=jax_ai_nightly DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_gpu_jax_stable_stack BASEIMAGE=us-central1-docker.pkg.dev/deeplearning-images/jax-ai-image/gpu:latest
+    - name: build image with JAX AI nightly
       run: |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_gpu_stable_stack_nightly_jax MODE=stable_stack DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_gpu_jax_stable_stack_nightly BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/gpu/jax_nightly:latest MAXTEXT_REQUIREMENTS_FILE=requirements_with_jax_stable_stack.txt
+        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_gpu_stable_stack_nightly_jax MODE=jax_ai_nightly DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_gpu_jax_stable_stack_nightly BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/gpu/jax_nightly:latest
     - name: build image with jax stable stack release candidate image
       run: |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_stable_stack_candidate_gpu MODE=stable_stack DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_stable_stack_candidate_gpu BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/gpu:latest MAXTEXT_REQUIREMENTS_FILE=requirements_with_jax_stable_stack.txt
+        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_stable_stack_candidate_gpu MODE=jax_ai_nightly DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_stable_stack_candidate_gpu BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/gpu:latest

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Key supported features:
 * **[April 7, 2025] 🚨🚨🚨 We support modular imports. This comes with an API change for `train.py`: Now you should invoke the script via `python3 -m MaxText.train MaxText/configs/base.yml run_name=...`. If you want the old behavior you can stick to an older commit `git checkout pre-module-v0.1.0` and use the older API `python MaxText/train.py MaxText/configs/base.yml run_name=...`.**
 * [March 24, 2025] We are excited to announce support for DeepSeek v3 (671B) and v2-Lite (16B), compatible with both TPUs and GPUs. We are actively working on further optimization.
 * [March 12, 2025] We are excited to announce support for Gemma 3: 4B, 12B, and 27B in text-only formats. Please see [Google Launch Blog](https://blog.google/technology/developers/gemma-3/) and [Developer Blog](https://developers.googleblog.com/en/introducing-gemma3/) for more information on Gemma 3.
-* [February, 2025] (Preview): We're excited to announce the preview of building Maxtext Docker images using the JAX Stable Stack base image, available for both TPUs and GPUs. This provides a more reliable and consistent build environment. Learn more [Here](getting_started/Run_MaxText_via_xpk.md)
+* [February, 2025] (Preview): We're excited to announce the preview of building Maxtext Docker images using the JAX AI Training Images, available for both TPUs and GPUs. This provides a more reliable and consistent build environment. Learn more [Here](getting_started/Run_MaxText_via_xpk.md)
 
 # Table of Contents
 

--- a/docker_build_dependency_image.sh
+++ b/docker_build_dependency_image.sh
@@ -66,30 +66,30 @@ if [[ -z ${DEVICE} ]]; then
   echo "Default DEVICE=${DEVICE}"
 fi
 
-# Function to build with MODE=stable-stack
-build_stable_stack() {
+# Function to build with MODE=jax_ai_image
+build_ai_image() {
     if [[ -z ${BASEIMAGE+x} ]]; then
         echo "Error: BASEIMAGE is unset, please set it!"
         exit 1
     fi
     COMMIT_HASH=$(git rev-parse --short HEAD)
-    echo "Building JAX Stable Stack MaxText at commit hash ${COMMIT_HASH}..."
+    echo "Building JAX AI MaxText Image at commit hash ${COMMIT_HASH}..."
 
     docker build --no-cache \
-        --build-arg JAX_STABLE_STACK_BASEIMAGE=${BASEIMAGE} \
+        --build-arg JAX_AI_IMAGE_BASEIMAGE=${BASEIMAGE} \
         --build-arg COMMIT_HASH=${COMMIT_HASH} \
         --build-arg DEVICE="$DEVICE" \
         --network=host \
         -t ${LOCAL_IMAGE_NAME} \
-        -f ./maxtext_jax_stable_stack.Dockerfile .
+        -f ./maxtext_jax_ai_image.Dockerfile .
 }
 
 if [[ -z ${LIBTPU_GCS_PATH+x} ]] ; then
   export LIBTPU_GCS_PATH=NONE
   echo "Default LIBTPU_GCS_PATH=${LIBTPU_GCS_PATH}"
   if [[ ${DEVICE} == "gpu" ]]; then
-    if [[ ${MODE} == "stable_stack" ]]; then
-      build_stable_stack
+    if [[ ${MODE} == "stable_stack" || ${MODE} == "jax_ai_image" ]]; then
+      build_ai_image
     else
       if [[ ${MODE} == "pinned" ]]; then
         export BASEIMAGE=ghcr.io/nvidia/jax:base-2024-12-04
@@ -99,8 +99,8 @@ if [[ -z ${LIBTPU_GCS_PATH+x} ]] ; then
       docker build --network host --build-arg MODE=${MODE} --build-arg JAX_VERSION=$JAX_VERSION --build-arg DEVICE=$DEVICE --build-arg BASEIMAGE=$BASEIMAGE -f ./maxtext_gpu_dependencies.Dockerfile -t ${LOCAL_IMAGE_NAME} .
     fi
   else
-    if [[ ${MODE} == "stable_stack" ]]; then
-      build_stable_stack
+    if [[ ${MODE} == "stable_stack" || ${MODE} == "jax_ai_image" ]]; then
+      build_ai_image
     elif [[ ${MANTARAY} == "true" ]]; then
       echo "Building with benchmark-db"
       docker build --network host --build-arg MODE=${MODE} --build-arg JAX_VERSION=$JAX_VERSION --build-arg LIBTPU_GCS_PATH=$LIBTPU_GCS_PATH --build-arg DEVICE=$DEVICE -f ./maxtext_db_dependencies.Dockerfile -t ${LOCAL_IMAGE_NAME} .

--- a/getting_started/Run_MaxText_via_xpk.md
+++ b/getting_started/Run_MaxText_via_xpk.md
@@ -79,34 +79,34 @@ after which log out and log back in to the machine.
     bash docker_build_dependency_image.sh
     ```
 
-    #### Build Maxtext Docker Image with JAX Stable Stack (Preview)
-    We're excited to announce the preview of building Maxtext Docker images using the JAX Stable Stack base image, available for both TPUs and GPUs. This provides a more reliable and consistent build environment.
+    #### Build Maxtext Docker Image with JAX AI Images
+    We're excited to announce the preview of building Maxtext Docker images using the JAX AI Training Images, available for both TPUs and GPUs. This provides a more reliable and consistent build environment.
 
-    ###### What is JAX Stable Stack?
-    JAX Stable Stack provides a consistent environment for Maxtext by bundling JAX with core packages like `orbax`, `flax`, and `optax`, along with Google Cloud utilities and other essential tools. These libraries are tested to ensure compatibility, providing a stable foundation for building and running Maxtext and eliminating potential conflicts due to incompatible package versions.
+    ###### What is JAX AI Images?
+    JAX AI Images provides a consistent environment for Maxtext by bundling JAX with core packages like `orbax`, `flax`, and `optax`, along with Google Cloud utilities and other essential tools. These libraries are tested to ensure compatibility, providing a stable foundation for building and running Maxtext and eliminating potential conflicts due to incompatible package versions.
 
     ###### How to Use It
-    Use the `docker_build_dependency_image.sh` script to build your Maxtext Docker image with JAX Stable Stack. Set MODE to `stable_stack` and specify the desired `BASEIMAGE`. The `DEVICE` variable determines whether to build for TPUs or GPUs.
+    Use the `docker_build_dependency_image.sh` script to build your Maxtext Docker image with JAX AI Images. Set MODE to `stable_stack` and specify the desired `BASEIMAGE`. The `DEVICE` variable determines whether to build for TPUs or GPUs.
 
     ###### For TPUs:
     
     ```
-    # Example: bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1
-    bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE={{JAX_STABLE_STACK_TPU_BASEIMAGE}}
+    # Example: bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.5.2-rev2
+    bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable_stack BASEIMAGE={{JAX_AI_IMAGE_TPU_BASEIMAGE}}
     ```
 
-    You can find a list of available JAX Stable Stack base images [here](https://us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu).
+    You can find a list of available JAX AI base images [here](https://us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu).
 
     ###### [New] For GPUs:
 
     ```
-    # Example bash docker_build_dependency_image.sh DEVICE=gpu MODE=stable_stack BASEIMAGE=us-central1-docker.pkg.dev/deeplearning-images/jax-stable-stack/gpu:jax0.4.37-cuda_dl24.10-rev1
-    bash docker_build_dependency_image.sh MODE=stable_stack BASEIMAGE={{JAX_STABLE_STACK_BASEIMAGE}}
+    # Example bash docker_build_dependency_image.sh DEVICE=gpu MODE=stable_stack BASEIMAGE=us-central1-docker.pkg.dev/deeplearning-images/jax-ai-image/gpu:jax0.4.37-cuda_dl24.10-rev1
+    bash docker_build_dependency_image.sh MODE=stable_stack BASEIMAGE={{JAX_AI_IMAGE_BASEIMAGE}}
     ```
 
-    You can find a list of available JAX Stable Stack base images [here](https://us-central1-docker.pkg.dev/deeplearning-images/jax-stable-stack/gpu).
+    You can find a list of available JAX AI images [here](https://us-central1-docker.pkg.dev/deeplearning-images/jax-ai-image/gpu).
 
-    **Important Note:** The JAX Stable Stack is currently in the experimental phase. We encourage you to try it out and provide feedback.
+    **Important Note:** The JAX AI Image is currently in the experimental phase. We encourage you to try it out and provide feedback.
 
 3. After building the dependency image `maxtext_base_image`, xpk can handle updates to the working directory when running `xpk workload create` and using `--base-docker-image`.
 

--- a/maxtext_db_dependencies.Dockerfile
+++ b/maxtext_db_dependencies.Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /deps
 
 # Copy setup files and dependency files separately for better caching
 COPY setup.sh ./
-COPY constraints_gpu.txt requirements.txt requirements_with_jax_stable_stack.txt ./
+COPY constraints_gpu.txt requirements.txt requirements_with_jax_ai_image.txt ./
 
 # Install dependencies - these steps are cached unless the copied files change
 RUN echo "Running command: bash setup.sh MODE=$ENV_MODE JAX_VERSION=$ENV_JAX_VERSION LIBTPU_GCS_PATH=${ENV_LIBTPU_GCS_PATH} DEVICE=${ENV_DEVICE}"

--- a/maxtext_dependencies.Dockerfile
+++ b/maxtext_dependencies.Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /deps
 
 # Copy setup files and dependency files separately for better caching
 COPY setup.sh ./
-COPY constraints_gpu.txt requirements.txt requirements_with_jax_stable_stack.txt ./
+COPY constraints_gpu.txt requirements.txt requirements_with_jax_ai_image.txt ./
 
 # Install dependencies - these steps are cached unless the copied files change
 RUN echo "Running command: bash setup.sh MODE=$ENV_MODE JAX_VERSION=$ENV_JAX_VERSION LIBTPU_GCS_PATH=${ENV_LIBTPU_GCS_PATH} DEVICE=${ENV_DEVICE}"

--- a/maxtext_gpu_dependencies.Dockerfile
+++ b/maxtext_gpu_dependencies.Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /deps
 
 # Copy setup files and dependency files separately for better caching
 COPY setup.sh ./
-COPY constraints_gpu.txt requirements.txt requirements_with_jax_stable_stack.txt ./
+COPY constraints_gpu.txt requirements.txt requirements_with_jax_ai_image.txt ./
 
 # Install dependencies - these steps are cached unless the copied files change
 RUN echo "Running command: bash setup.sh MODE=$ENV_MODE JAX_VERSION=$ENV_JAX_VERSION DEVICE=${ENV_DEVICE}"

--- a/maxtext_jax_ai_image.Dockerfile
+++ b/maxtext_jax_ai_image.Dockerfile
@@ -1,8 +1,8 @@
-ARG JAX_STABLE_STACK_BASEIMAGE
+ARG JAX_AI_IMAGE_BASEIMAGE
 
-# JAX Stable Stack Base Image
-FROM $JAX_STABLE_STACK_BASEIMAGE
-ARG JAX_STABLE_STACK_BASEIMAGE
+# JAX AI Base Image
+FROM $JAX_AI_IMAGE_BASEIMAGE
+ARG JAX_AI_IMAGE_BASEIMAGE
 
 ARG COMMIT_HASH
 
@@ -18,7 +18,7 @@ COPY . .
 RUN ls .
 
 
-# For stable stack tpu training images 0.4.37 AND 0.4.35
+# For JAX AI tpu training images 0.4.37 AND 0.4.35
 # Orbax checkpoint installs the latest version of JAX,
 # but the libtpu version in the base image is older.
 # This version mismatch can cause compatibility issues
@@ -28,14 +28,14 @@ RUN ls .
 ARG DEVICE
 ENV DEVICE=$DEVICE
 
-RUN if [ "$DEVICE" = "tpu" ] && ([ "$JAX_STABLE_STACK_BASEIMAGE" = "us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.37-rev1" ] || [ "$JAX_STABLE_STACK_BASEIMAGE" = "us-docker.pkg.dev/cloud-tpu-images/jax-stable-stack/tpu:jax0.4.35-rev1" ]); then \
+RUN if [ "$DEVICE" = "tpu" ] && ([ "$JAX_AI_IMAGE_BASEIMAGE" = "us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.4.37-rev1" ] || [ "$JAX_AI_IMAGE_BASEIMAGE" = "us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.4.35-rev1" ]); then \
         python3 -m pip install --no-cache-dir --upgrade jax[tpu]; fi
 
-# Install Maxtext requirements with Jax Stable Stack
+# Install Maxtext requirements with Jax AI Images
 RUN apt-get update && apt-get install --yes && apt-get install --yes dnsutils
 # TODO(bvandermoon, parambole): Remove this when it's added to JAX AI Image
 RUN pip install google-cloud-monitoring
-RUN python3 -m pip install -r /deps/requirements_with_jax_stable_stack.txt
+RUN python3 -m pip install -r /deps/requirements_with_jax_ai_image.txt
 
-# Run the script available in JAX Stable Stack base image to generate the manifest file
+# Run the script available in JAX AI base image to generate the manifest file
 RUN bash /jax-stable-stack/generate_manifest.sh PREFIX=maxtext COMMIT_HASH=$COMMIT_HASH

--- a/requirements_with_jax_ai_image.txt
+++ b/requirements_with_jax_ai_image.txt
@@ -1,5 +1,5 @@
 # Requirements for Building the MaxText Docker Image
-# These requirements are additional to the dependencies present in the JAX SS base image.
+# These requirements are additional to the dependencies present in the JAX AI base image.
 datasets
 grain[parquet]>=0.2.6
 orbax-checkpoint>=0.10.3


### PR DESCRIPTION
# Description

Migration from JAX STABLE STACK to JAX AI Images naming convention. 

- Updated the artifact registry repos to point to the new jax-ai-image repo instead of the old jax-stable-stack repo
- Changed files in readMe and tutorials to JAX AI Image
- Updated the maxtext_jax_ai_image Dockerfile with new base image argument
- Made sure consumers of the Dockerfile and jax ai image artifact registry also got updated


If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/418009488
FIXES: b/414612860

# Tests

Made sure changed links work and new artifact registry repos are publicly accessible with all the new images added. 

Built an image locally successfully with new MODE=jax_ai_image

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
