### PR TITLE
Add preprocessing functions for Llama4 multimodal (tiles)

### DIFF
--- a/MaxText/multimodal_utils.py
+++ b/MaxText/multimodal_utils.py
@@ -16,7 +16,8 @@ limitations under the License.
 
 """Utils needed by multimodal pipelines for image processing."""
 
-from typing import List
+from typing import List, Tuple, Union
+from collections import defaultdict
 import os
 
 import numpy as np
@@ -28,6 +29,7 @@ import jax.numpy as jnp
 
 NUM_IMAGE_CHANNELS = 3
 
+# TODO(hengtaoguo): Move following constants to a separate file
 # Constants for Gemma3-specific processing
 GEMMA_DEFAULT_IMAGE_SIZE = 896
 GEMMA_IMAGE_MEAN = (127.5,) * 3
@@ -41,6 +43,13 @@ GEMMA_NUM_PLACEHOLDER_TOKENS_PER_IMAGE = 256
 # +4 means 4 extra tokens to pad around image: \n\n, <start_of_image>, <end_of_image>, \n\n
 # One MEDIA means one image or multiple images in one video, but now we only support one image
 GEMMA_NUM_TOKENS_PER_MEDIA = GEMMA_NUM_PLACEHOLDER_TOKENS_PER_IMAGE + 4
+
+# Constants for Llama4-specific processing
+LLAMA4_TILE_SIZE = 336
+LLAMA4_TILES_NUM = 16
+LLAMA4_PIXEL_VALUE_RESCALE_FACTOR = 1.0 / 255.0
+LLAMA4_IMAGE_MEAN = (0.5,) * 3
+LLAMA4_IMAGE_STD = (0.5,) * 3
 
 
 def load_image_from_path(image_path):
@@ -70,6 +79,191 @@ def _normalize_images(images, mean, std):
   return images
 
 
+def get_factors(dividend: int):
+  """
+  Calculate all factors of a given number, i.e. a divisor that leaves
+  no remainder. For example, if dividend=12, it will return {1, 2, 3, 4, 6, 12}.
+  Args:
+      dividend (int): The number to find factors for.
+  Returns:
+      set: A set containing all factors of the number.
+  """
+  factors_set = set()
+
+  for i in range(1, int(dividend**0.5) + 1):
+    if dividend % i == 0:
+      factors_set.add(i)
+      factors_set.add(dividend // i)
+  return factors_set
+
+
+def find_supported_resolutions(max_num_chunks=LLAMA4_TILES_NUM, patch_size=LLAMA4_TILE_SIZE):
+  """Find all possible resolutions for the image based on the number of chunks."""
+  asp_dict = defaultdict(list)
+  for chunk_size in range(max_num_chunks, 0, -1):
+    _factors = sorted(get_factors(chunk_size))
+    _asp_ratios = [(factor, chunk_size // factor) for factor in _factors]
+    for height, width in _asp_ratios:
+      ratio_float = height / width
+      asp_dict[ratio_float].append((height, width))
+
+  # Get the resolutions multiplied by the patch_size
+  possible_resolutions = []
+  for _, value in asp_dict.items():
+    for height, depth in value:
+      possible_resolutions.append((height * patch_size, depth * patch_size))
+
+  return possible_resolutions
+
+
+def get_best_resolution(img_height, image_width, possible_resolutions, resize_to_max_canvas=False):
+  """
+  Get the best resolution for the image based on the possible resolutions.
+  Args:
+      img_height (int): The height of the image.
+      image_width (int): The width of the image.
+      possible_resolutions (list): A list of possible resolutions.
+      resize_to_max_canvas (bool): Whether to resize to max canvas or not.
+  Returns:
+      tuple: The best resolution for the image.
+  """
+  if resize_to_max_canvas:
+    return max(possible_resolutions, key=lambda x: x[0] * x[1])
+  else:
+    # Find the resolution closest to the original image dimensions (minimizing padding/cropping)
+    return min(possible_resolutions, key=lambda x: abs(x[0] - img_height) + abs(x[1] - image_width))
+
+
+def pad_to_best_fit_jax(
+    images: jnp.ndarray,
+    target_size: Tuple[int, int],
+    background_color: Union[int, Tuple[int, ...]] = 0,
+) -> jnp.ndarray:
+  """
+  Pads and/or crops an image or batch of images to a target size using JAX.
+  If the image is larger than the target size, it's cropped from the top-left.
+  If smaller, it's padded on the right and bottom.
+
+  Args:
+      images (jnp.ndarray):
+          The images to process. Expected shape (..., H, W, C).
+      target_size (Tuple[int, int]):
+          The target (height, width).
+      background_color (Union[int, Tuple[int, ...]], optional):
+          The color to use for padding.
+          If int, it's used for the first channel and subsequent channels are padded with 0.
+          If tuple, its length must match the number of channels in the image.
+          Defaults to 0.
+
+  Returns:
+      jnp.ndarray: The processed images of shape (..., target_height, target_width, C).
+  """
+  original_shape = images.shape
+  num_dims = len(original_shape)
+
+  if num_dims < 3:
+    raise ValueError("Images tensor must have at least 3 dimensions (..., H, W, C)")
+
+  img_height, img_width, num_channels = original_shape[-3], original_shape[-2], original_shape[-1]
+  target_height, target_width = target_size
+
+  # Prepare background_color_array: shape (C,)
+  if isinstance(background_color, int):
+    # Mimics the PyTorch version's behavior: [val, 0, 0, ...]
+    bg_list = [background_color] + [0] * (num_channels - 1)
+    background_color_array = jnp.array(bg_list, dtype=images.dtype)
+  elif isinstance(background_color, (tuple, list)):
+    if len(background_color) != num_channels:
+      raise ValueError(
+          f"background_color tuple/list length {len(background_color)} " f"must match number of channels {num_channels}"
+      )
+    background_color_array = jnp.array(background_color, dtype=images.dtype)
+  else:
+    raise TypeError("background_color must be int or tuple/list of ints")
+
+  # Create the full target canvas filled with background colors
+  batch_dims = original_shape[:-3]
+  target_canvas_shape = batch_dims + (target_height, target_width, num_channels)
+
+  # Reshape background_color_array for broadcasting
+  # e.g., for (H,W,C) -> (1,1,C); for (B,H,W,C) -> (1,1,1,C)
+  broadcastable_bg_shape = tuple([1] * len(batch_dims)) + (1, 1, num_channels)
+  background_fill = jnp.reshape(background_color_array, broadcastable_bg_shape)
+
+  padded_output = jnp.ones(target_canvas_shape, dtype=images.dtype) * background_fill
+
+  # Determine the region of the original image to copy
+  h_to_copy = min(img_height, target_height)
+  w_to_copy = min(img_width, target_width)
+
+  # Create slices for selecting the part of the original image
+  src_slicer_dims = []
+  for _ in batch_dims:
+    src_slicer_dims.append(slice(None))  # Ellipsis for batch dimensions
+  src_slicer_dims.extend([slice(0, h_to_copy), slice(0, w_to_copy), slice(None)])
+
+  image_data_to_place = images[tuple(src_slicer_dims)]
+
+  # Create slices for placing the image data onto the canvas
+  dest_slicer_dims = []
+  for _ in batch_dims:
+    dest_slicer_dims.append(slice(None))  # Ellipsis for batch dimensions
+  dest_slicer_dims.extend([slice(0, h_to_copy), slice(0, w_to_copy), slice(None)])
+
+  padded_output = padded_output.at[tuple(dest_slicer_dims)].set(image_data_to_place)
+
+  return padded_output
+
+
+def split_to_tiles_jax(images: jnp.ndarray, num_tiles_height: int, num_tiles_width: int) -> jnp.ndarray:
+  """
+  Splits an image tensor into tiles using JAX.
+
+  Args:
+      images: The input image tensor with shape (batch_size, num_channels, height, width).
+      num_tiles_height: The number of tiles along the height dimension.
+      num_tiles_width: The number of tiles along the width dimension.
+
+  Returns:
+      The tiled image tensor with shape:
+      (batch_size * num_tiles_height * num_tiles_width, num_channels, height // num_tiles_height, width // num_tiles_width).
+  """
+  images = jnp.transpose(images, (2, 0, 1))  # Change to (num_channels, height, width)
+  num_channels, height, width = images.shape
+
+  # Ensure the image dimensions are divisible by the number of tiles
+  if height % num_tiles_height != 0 or width % num_tiles_width != 0:
+    raise ValueError("Image dimensions must be divisible by the number of tiles.")
+
+  # Reshape to introduce tile dimensions
+  reshaped = jnp.reshape(
+      images,
+      (
+          num_channels,
+          num_tiles_height,
+          height // num_tiles_height,
+          num_tiles_width,
+          width // num_tiles_width,
+      ),
+  )
+
+  # Permute dimensions to group tiles together
+  permuted = jnp.transpose(reshaped, (1, 3, 0, 2, 4))
+
+  # Reshape to combine batch and tile dimensions
+  tiled_images = jnp.reshape(
+      permuted,
+      (
+          num_tiles_height * num_tiles_width,
+          num_channels,
+          height // num_tiles_height,
+          width // num_tiles_width,
+      ),
+  )
+
+  return tiled_images
+
+
 def pre_process_gemma3_image(image):
   """Performs a bi-linear resize (with anti-aliasing) and normalizes the image."""
   image_shape = (GEMMA_DEFAULT_IMAGE_SIZE, GEMMA_DEFAULT_IMAGE_SIZE, NUM_IMAGE_CHANNELS)
@@ -84,6 +278,60 @@ def pre_process_gemma3_image(image):
   return image
 
 
+def pre_process_llama4_image(image):
+  """
+  Pre-process image for Llama4 model. Find best resolution and split into tiles with an additional global tile.
+  Original implementation from image_processing_llama4.py: http://shortn/_VXLgQ1lmkz
+  Args:
+    image: The jnp.array image [H, W, C] to pre-process.
+  Returns:
+    The pre-processed image in jnp.array [NUM_TILES, C, TILE_SIZE, TILE_SIZE].
+  Example:
+    image of (536, 640, 3), its best_resolution = (672, 672), image split into 4 tiles of (336, 336)
+    Additional global tile of (336, 336) is added, and the final output image_tiles is (5, 3, 336, 336).
+  """
+  # Find the best resolution canvas for the image
+  possible_resolutions = find_supported_resolutions(max_num_chunks=LLAMA4_TILES_NUM, patch_size=LLAMA4_TILE_SIZE)
+  best_resolution = get_best_resolution(
+      img_height=image.shape[0],
+      image_width=image.shape[1],
+      possible_resolutions=possible_resolutions,
+      resize_to_max_canvas=False,
+  )
+
+  # Pad the image to the best resolution and normalize it
+  image_padded = pad_to_best_fit_jax(image, best_resolution)
+  image_normalized = _normalize_images(
+      images=image_padded * LLAMA4_PIXEL_VALUE_RESCALE_FACTOR,
+      mean=LLAMA4_IMAGE_MEAN,
+      std=LLAMA4_IMAGE_STD,
+  )
+
+  # Split the image into tiles
+  ratio_h, ratio_w = (
+      best_resolution[0] // LLAMA4_TILE_SIZE,
+      best_resolution[1] // LLAMA4_TILE_SIZE,
+  )
+  image_tiles = split_to_tiles_jax(image_normalized, ratio_h, ratio_w)
+
+  # If more than one tile, add a global tile by resizing the image to the tile size
+  if ratio_h * ratio_w > 1:
+    global_tiles = jax.image.resize(
+        image,
+        shape=(LLAMA4_TILE_SIZE, LLAMA4_TILE_SIZE, NUM_IMAGE_CHANNELS),
+        method="bilinear",
+        antialias=True,
+    )
+    global_tiles = _normalize_images(
+        global_tiles * LLAMA4_PIXEL_VALUE_RESCALE_FACTOR, mean=LLAMA4_IMAGE_MEAN, std=LLAMA4_IMAGE_STD
+    )
+    global_tiles = jnp.transpose(global_tiles, (2, 0, 1))
+    global_tiles = jnp.expand_dims(global_tiles, axis=0)
+    image_tiles = jnp.concatenate((image_tiles, global_tiles), axis=0)
+
+  return image_tiles
+
+
 def pre_process_image(image, model_name):
   """Pre-process image according to different model's requirements.
   Args:
@@ -94,6 +342,8 @@ def pre_process_image(image, model_name):
   """
   if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
     return pre_process_gemma3_image(image)
+  elif model_name in ["llama4-17b-16e", "llama4-70b-16e"]:
+    return pre_process_llama4_image(image)
   else:
     raise ValueError(f"Model {model_name} does not support multimodal inference.")
 

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -311,6 +311,8 @@ def validate_multimodal_model_name(s: str) -> bool:
       "gemma3-4b",
       "gemma3-12b",
       "gemma3-27b",
+      "llama4-17b-16e",
+      "llama4-17b-128e",
   )
   if s not in valid_model_names:
     raise ValueError(

--- a/MaxText/tests/pyconfig_test.py
+++ b/MaxText/tests/pyconfig_test.py
@@ -120,7 +120,7 @@ class PyconfigTest(unittest.TestCase):
         skip_jax_distributed_system=True,
         model_name="gemma-7b",
         override_model_config=True,
-        base_emb_dim=1024, # Defined as 3072 in gemma-7b
+        base_emb_dim=1024,  # Defined as 3072 in gemma-7b
     )
 
     self.assertEqual(config.base_emb_dim, 1024)


### PR DESCRIPTION
# Description

Image preprocessing utils for Llama4 multimodal. Core workflow in `pre_process_llama4_image()`. Input example: jnp.array of (536, 640, 3); Output example: (5, 3, 336, 336).
- Find best Resolution Canvas: `get_best_resolution` determines the best canvas resolution for the input image from a list of supported resolutions.
- Padding: `pad_to_best_fit_jax` pads the image to fit the determined best resolution canvas.
- Normalization: Normalizes the pixel values of the padded image.
- Tiling: `split_to_tiles_jax` Splits the processed image into a number of tiles.
- Global Tile Addition: If the image is split into multiple tiles, an additional global tile (a resized/normalized version of the original image) is added to the set of tiles.

# Tests

Passing unit tests, processed images match with Llama4 from HuggingFace transformers.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
