### PR TITLE
PP support for DeepSeek

### DIFF
--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -202,7 +202,7 @@ class Decoder(nn.Module):
     self.decoder_layer = self.get_decoder_layers()
     self.norm_layer = self.get_norm_layer()
     if self.config.using_pipeline_parallelism:
-      pipeline_stage_module = self.get_pipeline_stage_module(self.decoder_layer[0])
+      pipeline_stage_module = self.get_pipeline_stage_module(self.decoder_layer)
       remat_policy = self.get_remat_policy()
       self.pipeline_module = pipeline.Pipeline(
           config=self.config, mesh=self.mesh, layers=pipeline_stage_module, remat_policy=remat_policy
@@ -417,9 +417,16 @@ class Decoder(nn.Module):
     )
     return scan_fn(config=cfg, mesh=mesh, name=metdata_axis_name, quant=self.quant, **kwargs)
 
-  def get_pipeline_stage_module(self, base_stage):
+  def get_pipeline_stage_module(self, decoder_blocks):
     """get pipeline stage module"""
+    def get_layer_to_pipeline(blocks, cfg):
+      if cfg.decoder_block == DecoderBlockType.DEEPSEEK:
+        return blocks[1] # return the sparse block
+      else:
+        return blocks[0]
+
     cfg = self.config
+    base_stage = get_layer_to_pipeline(decoder_blocks, cfg)
     if cfg.set_remat_policy_on_layers_per_stage:
       policy = self.get_remat_policy()
       base_stage = self.set_remat_policy([base_stage], policy)[0]
@@ -498,20 +505,53 @@ class Decoder(nn.Module):
         )
       else:
         partition_spec = None  # This partition spec is only used for the fsdp_ag_once feature.
-      y = self.pipeline_module(
-          y, decoder_segment_ids, decoder_positions, deterministic, model_mode, partition_spec=partition_spec
-      )
-      remaining_layers = self.config.num_decoder_layers - self.config.pipeline_parallel_layers
-      if remaining_layers > 0:
+      if cfg.decoder_block == DecoderBlockType.DEEPSEEK:
+        assert len(RemattedBlockLayers) == 2, "Scanned layers must have a length of 2 using deepseek."
+        dense_layer = RemattedBlockLayers[0]
+        moe_layer = RemattedBlockLayers[1]
+        num_moe_layers = cfg.num_decoder_layers - cfg.first_num_dense_layers
+        num_moe_layers_outside_pp = num_moe_layers - self.config.pipeline_parallel_layers
         logical_axis_rules_pp_as_dp = maxtext_utils.logical_axis_rules_pp_act_as_dp(self.config.logical_axis_rules)
+        # We chose not to pipeline the dense layers, only sparse for SPMD.
         with self.mesh, nn.partitioning.axis_rules(logical_axis_rules_pp_as_dp):
-          y, _ = self.scan_decoder_layers(cfg, RemattedBlockLayers[0], remaining_layers, "layers", mesh)(
+          y, _ = self.scan_decoder_layers(cfg, dense_layer, cfg.first_num_dense_layers, "dense_layers", mesh)(
               y,
               decoder_segment_ids,
               decoder_positions,
               deterministic,
               model_mode,
           )
+          if num_moe_layers_outside_pp > 0:
+            y, _ = self.scan_decoder_layers(cfg, moe_layer, num_moe_layers_outside_pp, "moe_layers", mesh)(
+                y,
+                decoder_segment_ids,
+                decoder_positions,
+                deterministic,
+                model_mode,
+            )
+        y = self.pipeline_module(
+          y,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          partition_spec=partition_spec
+        )
+      else: # Not DeepSeek
+        y = self.pipeline_module(
+            y, decoder_segment_ids, decoder_positions, deterministic, model_mode, partition_spec=partition_spec
+        )
+        remaining_layers = self.config.num_decoder_layers - self.config.pipeline_parallel_layers
+        if remaining_layers > 0:
+          logical_axis_rules_pp_as_dp = maxtext_utils.logical_axis_rules_pp_act_as_dp(self.config.logical_axis_rules)
+          with self.mesh, nn.partitioning.axis_rules(logical_axis_rules_pp_as_dp):
+            y, _ = self.scan_decoder_layers(cfg, RemattedBlockLayers[0], remaining_layers, "layers", mesh)(
+                y,
+                decoder_segment_ids,
+                decoder_positions,
+                deterministic,
+                model_mode,
+            )
     else:
       if cfg.scan_layers:
         if cfg.decoder_block == DecoderBlockType.DEEPSEEK:

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -827,11 +827,21 @@ def set_and_validate_pipeline_config(raw_keys):
     raw_keys = pipeline_first_axis(raw_keys)
     num_stages = int(raw_keys["ici_pipeline_parallelism"] * raw_keys["dcn_pipeline_parallelism"])
     if raw_keys["pipeline_parallel_layers"] == -1:
-      raw_keys["pipeline_parallel_layers"] = raw_keys["num_decoder_layers"]
+      if raw_keys["decoder_block"]=="deepseek":
+        moe_layers = raw_keys["num_decoder_layers"] - raw_keys["first_num_dense_layers"]
+        raw_keys["pipeline_parallel_layers"] = moe_layers
+      else:
+        raw_keys["pipeline_parallel_layers"] = raw_keys["num_decoder_layers"]
     else:
-      assert (
-          raw_keys["pipeline_parallel_layers"] <= raw_keys["num_decoder_layers"]
-      ), f"You can only pipeline a subset of the decoder layers, but you requested to pipeline {raw_keys['pipeline_parallel_layers']} with pipeline_parallel_layers and there are only {raw_keys['num_decoder_layers']} decoder layers."
+      if raw_keys["decoder_block"]=="deepseek":
+        moe_layers = raw_keys["num_decoder_layers"] - raw_keys["first_num_dense_layers"]
+        assert (
+          raw_keys["pipeline_parallel_layers"] <= moe_layers
+      ), f"You can only pipeline a subset of the moe decoder layers for deepseek, but you requested to pipeline {raw_keys['pipeline_parallel_layers']} with pipeline_parallel_layers and there are only {moe_layers} decoder layers."
+      else:
+        assert (
+            raw_keys["pipeline_parallel_layers"] <= raw_keys["num_decoder_layers"]
+        ), f"You can only pipeline a subset of the decoder layers, but you requested to pipeline {raw_keys['pipeline_parallel_layers']} with pipeline_parallel_layers and there are only {raw_keys['num_decoder_layers']} decoder layers."
     assert (
         raw_keys["scan_layers"] or raw_keys["pipeline_parallel_layers"] == raw_keys["num_decoder_layers"]
     ), "Currently we only support scan_layers=True when pipelining a subset of layers."
@@ -872,8 +882,6 @@ def set_and_validate_pipeline_config(raw_keys):
 
 
 def validate_deepseek_moe(raw_keys):
-  if raw_keys["decoder_block"] == "deepseek" and using_pipeline_parallelism(raw_keys):
-    raise ValueError("Currently we do not support DeepSeek MoE with pipeline parallelism.")
   if raw_keys["n_routing_groups"] != -1:
     if raw_keys["topk_routing_group"] == -1:
       raise ValueError(f'config topk_routing_group: {raw_keys["topk_routing_group"]} is not defined')

--- a/MaxText/tests/pipeline_parallelism_test.py
+++ b/MaxText/tests/pipeline_parallelism_test.py
@@ -32,6 +32,7 @@ from MaxText.globals import PKG_DIR
 from MaxText.layers import pipeline
 from MaxText.layers import simple_layer
 from MaxText.train import main as train_main
+from MaxText.layers import deepseek
 
 
 def assert_same_output_and_grad(f1, f2, *inputs):
@@ -53,10 +54,14 @@ def assert_same_output_and_grad(f1, f2, *inputs):
 
 class PipelineParallelismTest(unittest.TestCase):
 
-  def assert_pipeline_same_output_and_grad(self, config):
+  def assert_pipeline_same_output_and_grad(self, config, single_pipeline_stage_class=None):
     """check that the output and gradient are the same"""
     devices_array = maxtext_utils.create_device_mesh(config)
     mesh = Mesh(devices_array, config.mesh_axes)
+    if single_pipeline_stage_class is None:
+      single_pipeline_stage = simple_layer.SimpleDecoderLayer(config=config, mesh=mesh)
+    else:
+      single_pipeline_stage = single_pipeline_stage_class(config=config, mesh=mesh)
 
     def get_inputs(batch_size, sequence, features):
       """Get random inputs, and random dummy targets
@@ -184,6 +189,29 @@ class PipelineParallelismTest(unittest.TestCase):
         per_device_batch_size=4,
     )
     self.assert_pipeline_same_output_and_grad(config)
+
+  @pytest.mark.tpu_only
+  def test_circular_deepseek_megablox_same_output_and_grad(self):
+    # 4 stages, 8 layers (2 repeats, 1 layer per stage), 8 microbatches
+    config = pyconfig.initialize(
+        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
+        enable_checkpointing=False,
+        enable_goodput_recording=False,
+        run_name="circular_moe",
+        max_target_length=128,
+        base_emb_dim=28,
+        ici_pipeline_parallelism=4,
+        base_num_decoder_layers=8,
+        num_pipeline_microbatches=8,
+        per_device_batch_size=4,
+        num_experts=4,
+        num_experts_per_tok=2,
+        megablox=False,
+        sparse_matmul=False,
+        capacity_factor=1,
+        decoder_block="deepseek",
+    )
+    self.assert_pipeline_same_output_and_grad(config, single_pipeline_stage_class=deepseek.DeepSeekMoELayer)
 
   @pytest.mark.tpu_only
   def test_circular_ag_once(self):

--- a/MaxText/tests/train_compile_test.py
+++ b/MaxText/tests/train_compile_test.py
@@ -561,6 +561,29 @@ class TrainCompile(unittest.TestCase):
     )
 
   @pytest.mark.cpu_only
+  def test_moe_deepseek_pipeline_subset(self):
+    compiled_trainstep_file = "/tmp/test_moe_deepseek_pipeline_subset.pickle"
+    train_compile_main(
+        (
+            None,
+            os.path.join(PKG_DIR, "configs", "base.yml"),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v6e-256",
+            "compile_topology_num_slices=8",
+            "use_iota_embed=true",
+            "model_name=deepseek3-671b",
+            "megablox=False", # dropless not yet supported (b/418313093)
+            "sparse_matmul=False", 
+            "capacity_factor=1",
+            "per_device_batch_size=1",
+            "max_target_length=2048",
+            "pipeline_parallel_layers=56",
+            "ici_expert_parallelism=16",
+            "dcn_pipeline_parallelism=8"
+        )
+    )
+
+  @pytest.mark.cpu_only
   def test_moe_llama4_17b_16e(self):
     compiled_trainstep_file = "/tmp/test_moe_llama4_17b_16e.pickle"
     train_compile_main(


### PR DESCRIPTION
# Description

Add support for SPMD pipelining deepseek with dropping.

This is achieved in this PR by building on this [PR](https://github.com/AI-Hypercomputer/maxtext/compare/main) which added support for SPMD pipelining only subset of layers. Here we pipeline only a subset of the sparse layers (since there are more sparse layers and those are the ones which need pipelining since the sparse DP comms are expensive). The layers that are not pipelined are executed via data parallelism.

Dropless is blocked on b/418313093

This is a modification of https://github.com/AI-Hypercomputer/maxtext/pull/1687

Pipeline parallelism offers performance benefits when data parallelism comms are too large - which occurs when the batch is too small and/or the model is very sparse. The experiments below on the smaller deepseek model show that the large data parallel comms are reduced when using PP with this PR.

# Tests

Ran some locally of smaller v2-16B model and added AOT test

* DeepSeekV2 16B local on v6e-8 with pdb=1, PP=8, pipeline_subset_layers=24 [xprof](https://xprof.corp.google.com/trace_viewer/mattdavidow-2021970820805495549?hosts=t1v-n-70a81276-w-0&host_index=0&trace_filter_config=%7B%7D&view_start=-2803.551&view_end=172.797)
* With pure FSDP step time is roughly 2x [xprof](https://xprof.corp.google.com/trace_viewer/mattdavidow-463037051654911153?hosts=t1v-n-70a81276-w-0&host_index=0&trace_filter_config=%7B%7D&view_start=-678.904&view_end=2265.952)
* Prior to this PR, PP could not be run at all with DeepSeek
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
