### PR TITLE
tighten up the buffer size for ra2a during expert sharding.

### DIFF
--- a/MaxText/layers/moe.py
+++ b/MaxText/layers/moe.py
@@ -758,16 +758,21 @@ class RoutedMoE(nn.Module):
               expert_shard_id,
               num_expert_parallelism,
           )
-          # TODO(ranran): For better performance, we could update output buffer
-          # to a smaller size to replace self.get_expert_parallelism_size() for
-          # efficiency, or we could apply capacity_factor for excessive experts.
-          # Note: Reducing buffer increase the risk of token dropping under
-          # unbalanced distribution.
+
+          # TODO(ranran): For better performance, we could update output buffer to a smaller
+          # size to replace self.get_expert_parallelism_size() for efficiency,
+          # Or we could apply capacity_factor for excessive experts.
+          # Note: Reducing buffer increase the risk of token dropping under unbalanced distribution.
+
+          # In the worst case, all of the global input data is assigned to each expert in the current shard.
+          # This would result in num_expert_shards * input_size * experts_per_shard assignments. However, if
+          # experts_per_shard > num_experts_per_tok we cannot assign more than num_experts_per_tok to all of the inputs.
+          max_local_experts_per_tok = min(local_expert_size, self.config.num_experts_per_tok)
           buffer_size = int(
               num_expert_parallelism
               * self.config.per_device_batch_size
               * self.config.max_target_length
-              * self.config.num_experts_per_tok
+              * max_local_experts_per_tok
           )
           output_shape = jnp.zeros((buffer_size, self.config.emb_dim), dtype=x.dtype)
 


### PR DESCRIPTION
# Description

Reduces the buffer size used for ragged_all_to_all when the number of experts per shard is less than number of experts per token. This helps if you have a large amount of expert sharding or large amount of experts per token.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
