### PR TITLE
seperate vision embedder for inference/training workloads and remove sharding

### DIFF
--- a/MaxText/convert_gemma3_chkpt.py
+++ b/MaxText/convert_gemma3_chkpt.py
@@ -108,13 +108,11 @@ def main(raw_args=None) -> None:
               },
               "pos_embedding": params["SigLiPFromPatches_0"]["siglip_encoder"]["pos_embedding"],
               "Transformer": params["SigLiPFromPatches_0"]["siglip_encoder"]["Transformer"],
-              "VisionEmbedder_0": {
-                  "mm_input_projection": params["transformer"]["embedder"]["mm_input_projection"],
-                  "mm_soft_embedding_norm": {
-                      "scale": params["transformer"]["embedder"]["mm_soft_embedding_norm"]["scale"] + 1
-                  },
-              },
-          }
+          },
+          "VisionEmbedder_0": {
+              "mm_input_projection": params["transformer"]["embedder"]["mm_input_projection"],
+              "mm_soft_embedding_norm": {"scale": params["transformer"]["embedder"]["mm_soft_embedding_norm"]["scale"] + 1},
+          },
       },
   }
   # Rename MlpBlock_0 to MlpBlockViT_0 in vision encoder

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -702,13 +702,21 @@ class VisionEncoder(nn.Module):
     if self.config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
       from MaxText.layers import gemma3  # pylint: disable=import-outside-toplevel
 
-      return [gemma3.Gemma3VisionEncoderLayer]
+      return [gemma3.Gemma3VisionEncoderLayer, gemma3.VisionEmbedder]
     else:
       raise ValueError(f"No VisionEncoder implemented for {self.config.model_name} yet")
 
   @nn.compact
   def __call__(self, input_images, deterministic=False):
-    embeddings = self.vision_encoder_layer[0](config=self.config)(input_images, deterministic=deterministic)
+    cfg = self.config
+    # vision encoder output, frozen params in many cases
+    embeddings = self.vision_encoder_layer[0](config=cfg)(input_images, deterministic=deterministic)
+    if cfg.freeze_vision_encoder_params:
+      embeddings = jax.lax.stop_gradient(embeddings)
+
+    if len(self.vision_encoder_layer) > 1:
+      # vision embedder / projection layer, not frozen in most cases, trained / finetuned together with main model
+      embeddings = self.vision_encoder_layer[1](config=cfg)(embeddings)
     return embeddings
 
 


### PR DESCRIPTION
# Description

+ seperate vision embedder for inference/training workloads (eg. some fine tuning workloads freezes ViT part and fine tunes main model + embedder projection layer [paper](https://arxiv.org/pdf/2503.19786))
+ remove sharding for designing (plan to add support of vision specific sharding after completion), currently the sharding uses the text ones however the [batch, seq_len, emb_dim] for ViT are different from text eg. seq_len is fixed

# Tests

tested decoding [Full Paste](https://paste.googleplex.com/6700312968298496)

```
Memstats: After load_params:
        Using (GB) 5.18 / 30.75 (16.845528%) on TPU_0(process=0,(0,0,0,0))
        Using (GB) 5.18 / 30.75 (16.845528%) on TPU_1(process=0,(1,0,0,0))
        Using (GB) 5.18 / 30.75 (16.845528%) on TPU_2(process=0,(0,1,0,0))
        Using (GB) 5.18 / 30.75 (16.845528%) on TPU_3(process=0,(1,1,0,0))

RAMstats: After load_params:
        Using (GB) 19.25 / 400.47 (4.806852%) -->  Available:378.58
normalizer.cc(51) LOG(INFO) precompiled_charsmap is empty. use identity normalization.
Input `<start_of_turn>user
Describe image <start_of_image><end_of_turn>
<start_of_turn>model
` -> `Here's a description of the image:

**Overall Impression:** The image is a bright, expansive cityscape view of Seattle, Washington, with`
2025-05-22 01:07:55.267462: I external/xla/xla/pjrt/distributed/client.cc:139] Distributed task shutdown initiated.
2025-05-22 01:07:55.268185: I external/xla/xla/tsl/distributed_runtime/coordination/coordination_service.cc:1708] Shutdown barrier in coordination service has passed.
2025-05-22 01:07:55.268275: I external/xla/xla/tsl/distributed_runtime/coordination/coordination_service.cc:647] /job:jax_worker/replica:0/task:0 has disconnected from coordination service.
2025-05-22 01:07:55.268556: I external/xla/xla/pjrt/distributed/client.cc:141] Distributed task shutdown result: OK
2025-05-22 01:07:55.268577: I external/xla/xla/pjrt/distributed/service.cc:121] Jax service shutting down
zhaoyuec_google_com@t1v-n-9dd93d8b-w-0:/mnt/disks/persist/maxtext$ 
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
