### PR TITLE
Elastic Training Fast Resume

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -737,3 +737,12 @@ rope_theta_for_vit: 10000
 vision_output_dim_for_vit: 4096
 pixel_shuffle_ratio_for_vit: 0.5
 projector_dropout_for_vit: 0.0
+
+
+## Elastic training flags
+elastic_mode: "fast-resume"
+elastic_reshard_check_period: 1
+elastic_snapshot_period: 5
+elastic_max_elastic_down_event_count: 100
+elastic_max_reshard_retry_count: 3
+elastic_wait_period: 30

--- a/MaxText/tests/elastic_train_test.py
+++ b/MaxText/tests/elastic_train_test.py
@@ -62,7 +62,7 @@ class ElasticTrainTest(parameterized.TestCase):
 
     mock_sleep = self.enter_context(mock.patch.object(time, "sleep", create_autospec=True))
 
-    elastic_train.wait_for_all_slices(mock_manager)
+    elastic_train.wait_for_all_slices(mock_manager, 0)
 
     self.assertEqual(mock_sleep.call_count, len(slice_availability_side_effect) - 1)
 


### PR DESCRIPTION
# Description

These changes are for the fast resume mode of elastic training where training is paused if a slice is lost and resumes when the slice has returned. It is intended to make workload startup time after hardware failure much quicker because there is no need to communicate to GCS to restore from a checkpoint. It accomplishes this by not restarting the workload and only restarting the affected slices.

# Tests

It is not thoroughly tested at this state but it it has successfully fast resumed from a simulated slice failure.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
