### PR TITLE
Removed pinned gpu image build flow

### DIFF
--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -81,9 +81,6 @@ jobs:
       run: gcloud auth configure-docker us-docker.pkg.dev --quiet
     - name: build jax stable image
       run : |
-    - name: build jax pinned image
-      run : |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_gpu_jax_pinned MODE=pinned DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_gpu_local_jax_pinned
     - name: build jax stable stack image
       run : |
         bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_gpu_jax_stable_stack MODE=stable_stack DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_gpu_jax_stable_stack BASEIMAGE=us-central1-docker.pkg.dev/deeplearning-images/jax-stable-stack/gpu:latest MAXTEXT_REQUIREMENTS_FILE=requirements_with_jax_stable_stack.txt


### PR DESCRIPTION
# Description

Currently the GPU pinned image flow is broken which is causing all of the other image build states to fail. In general we should deprecate the pinned image flow. This would take 2 steps:

- Remove the image build flow in maxtext UploadDockerImages.yml
- Update the XLML DAGs that use the gpu_pinned image to the maxtext + JAII gpu candidate image

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/419545810

# Tests



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
