### PR TITLE
Update add label based on code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-# Changes in this file should match with requiredReviewers in file .github/workflows/AddLabel.yml
 * @gobbleturk @khatwanimohit @bvandermoon @vipannalla @RissyRan @richjames0 @gagika @shralex @yangyuwei @SurbhiJainUSC @hengtaoguo @A9isha @aireenmei
 
 # Features

--- a/.github/workflows/AddLabel.yml
+++ b/.github/workflows/AddLabel.yml
@@ -50,57 +50,32 @@ jobs:
               console.log("This workflow is running within an invalid context")
               process.exit(1)
             }
-
-            // This list should match with CODEOWNERS.
-            let requiredReviewers = {
-              gobbleturk: "",
-              khatwanimohit: "",
-              bvandermoon: "",
-              vipannalla: "",
-              RissyRan: "",
-              richjames0: "",
-              rni418: "",
-              gagika: "",
-              shralex: "",
-              yangyuwei: "",
-              SurbhiJainUSC: "",
-              hengtaoguo: "",
-              A9isha: "",
-              wang2yn84: "",
-              wyzhang: "",
-              mitalisi: "",
-              gpolovets1: "",
-              mailvijayasingh: "",
-              jrplatin: "",
-              patemotter: "",
-              lumosis: "",
-              aireenmei: "",
-            }
             const reviews = await github.rest.pulls.listReviews({
               owner,
               repo,
               pull_number,
             })
-
-            const pullRequest = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number,
-            });
-            const pullRequester = pullRequest.data.user.login;
+            const decision_query = `
+              query($owner: String!, $repo: String!, $pull_number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pull_number) {
+                    reviewDecision # Fetches the overall review status
+                  }
+                }
+              }
+            `;
+            const decision_result = await github.graphql(decision_query, { owner, repo, pull_number });
 
             if (reviews.data.length === 0) {
               console.log("Not adding pull ready because the PR is not approved yet.")
               process.exit()
             }
-            let num_approved = 0
-            for (const review of reviews.data) {
-              if (review.state === "APPROVED" && review.user.login in requiredReviewers) {
-                num_approved = num_approved + 1
-              }
+            let is_approved = false
+            if (decision_result.repository.pullRequest.reviewDecision === "APPROVED") {
+              is_approved = true
             }
-            if (num_approved < 2) {
-              console.log("Not adding pull ready because the PR is not approved yet by 2 code owners.")
+            if (!is_approved) {
+              console.log("Not adding pull ready because the PR is not approved yet by sufficient code owners.")
               process.exit()
             }
 


### PR DESCRIPTION
# Description

Update the add label file based on recent code owner change: [PR](https://github.com/AI-Hypercomputer/maxtext/pull/1690)

* update to use GraphQL API [PullRequestReviewDecision](https://docs.github.com/en/graphql/reference/enums#pullrequestreviewdecision) to indicate if this PR is approved by right and sufficient code owners for specific files (# of approvers is set at GitHub settings, not in this file anymore)
* Available status: `APPROVED`, `CHANGES_REQUESTED`, or `REVIEW_REQUIRED`.


# Tests
**Please note:** the pull ready is already added in this PR, since it runs main branch automatically.

**Github manual tests in this `add_label` branch:**
1) Asked two reviewers in general code owners to approve add label file (not right code owner, but sufficient 2 approvers) - expect no pull_ready label is added
2) In the debug process, I am able to see the PR status is [REVIEW_REQUIRED](https://screenshot.googleplex.com/6dt2SPtnuXQo4XE) as we requested 2 approvals from code owner, with log `Not adding pull ready because the PR is not approved yet by sufficient code owners.` ([here](https://github.com/AI-Hypercomputer/maxtext/actions/runs/15407586788/job/43353130615))

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
