### PR TITLE
Refactor image preprocessor output class for better structure

### DIFF
--- a/MaxText/tests/quantizations_test.py
+++ b/MaxText/tests/quantizations_test.py
@@ -18,6 +18,8 @@ limitations under the License.
 import unittest
 import os.path
 
+import pytest
+
 import numpy as np
 
 from jax import numpy as jnp
@@ -103,6 +105,7 @@ class QuantizationTest(unittest.TestCase):
       quant = _configure_quantization(quant_str="int8", mode_str=quant_mode)
       self.assertNotEqual(quant, None)
 
+  @pytest.mark.tpu_only  # b/421002974
   def test_aqt_quantization(self):
     # Without quantization
     inputs, res_einsum, res_dg = _apply()


### PR DESCRIPTION
# Description

This PR refactors the output class used during the image preprocessing:

- New dataclass `PreprocessorOutput` holds the output of a model-specific preprocessor, with pixel_values as mandatory, and aspect_ratios optional for models like Llama4 that process images by tiling and require aspect ratio information for proper handling. In the future, we could freely add more optional fields to this dataclass for new models requiring different intermediate results.
- Add `aspect_ratios` for the Llama4 downstream processings.


# Tests

Passing unit tests, tested with command with Gemma3:
```
python -m MaxText.decode MaxText/configs/base.yml model_name=gemma3-4b tokenizer_path=assets/tokenizer.gemma3 load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/gemma3-4b/vit/unscanned/2025-05-21-23-23-59/checkpoints/0/items per_device_batch_size=1 run_name=ht_test max_prefill_predict_length=272 max_target_length=300 steps=10 async_checkpointing=false scan_layers=false use_multimodal=true prompt=\'Describe\ image\ \<start_of_image\>\' image_path=\'/home/hengtaoguo/projects/maxtext/MaxText/test_assets/test_image.jpg\' attention=\'dot_product\'
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
