### PR TITLE
Migrating docker build Github Actions for unit tests and daily image builds to GKE runners

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -49,6 +49,7 @@ jobs:
     with:
       device_type: tpu
       device_name: v4-8
+      cloud_runner: linux-x86-n2-16-buildkit
       build_mode: jax_ai_image
       base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:latest
 
@@ -58,6 +59,7 @@ jobs:
     with:
       device_type: gpu
       device_name: a100-40gb-4
+      cloud_runner: linux-x86-n2-16-buildkit
       build_mode: jax_ai_image
       base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/gpu:latest
 
@@ -145,6 +147,7 @@ jobs:
       run: gcloud container images delete gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:tpu --force-delete-tags --quiet
 
   notify:
+    if: ${{ always() }}
     name: Notify failed build # creates an issue or modifies last open existing issue for failed build
     needs: [cpu_unit_tests, gpu_unit_tests, gpu_integration_tests, tpu_unit_tests, tpu_integration_tests]
     runs-on: ubuntu-latest

--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -20,73 +20,153 @@ name: Build Images
 on:
   schedule:
     # Run the job daily at 12AM UTC
-    - cron:  '0 0 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
-    # Trigger Manual run
-    branches:
-      - main
     inputs:
       target_device:
-        description: 'Specify target device (tpu or gpu)'
-        required: false
+        description: 'Specify target device (all, tpu, or gpu)'
+        required: true
         type: choice
+        default: 'all'
         options:
+          - all
           - tpu
           - gpu
-      run_all_jobs:
-        description: 'Run all TPU and GPU build jobs (overrides target_device)'
-        required: false
-        type: boolean
-        default: false
 
 jobs:
-  tpu:
+  build-tpu:
+    # This job will only run for 'tpu', 'all', schedule, or PR triggers.
+    if: >
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request' ||
+      github.event.inputs.target_device == 'all' ||
+      github.event.inputs.target_device == 'tpu'
+    
+    runs-on: linux-x86-n2-16-buildkit
+    container: google/cloud-sdk:524.0.0
+
+    # Use Github Actions matrix to run image builds in parallel
     strategy:
       fail-fast: false
       matrix:
-        device-type: ["v4-8"]
-    runs-on: ["self-hosted", "tpu", "${{ matrix.device-type }}"]
+        include:
+          # TPU Image Builds
+          - image_name: maxtext_jax_stable
+            dockerfile: ./maxtext_dependencies.Dockerfile
+            build_args: |
+              MODE=stable
+              JAX_VERSION=NONE
+              LIBTPU_GCS_PATH=NONE
+          - image_name: maxtext_jax_nightly
+            dockerfile: ./maxtext_dependencies.Dockerfile
+            build_args: |
+              MODE=nightly
+              JAX_VERSION=NONE
+              LIBTPU_GCS_PATH=NONE
+          # TPU Image builds using JAX AI Image
+          - image_name: maxtext_jax_stable_stack
+            dockerfile: ./maxtext_jax_ai_image.Dockerfile
+            base_image: us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:latest
+          - image_name: maxtext_stable_stack_nightly_jax
+            dockerfile: ./maxtext_jax_ai_image.Dockerfile
+            base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/tpu/jax_nightly:latest
+          - image_name: maxtext_stable_stack_candidate
+            dockerfile: ./maxtext_jax_ai_image.Dockerfile
+            base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:latest
+
+    # Setup for GKE runners per b/412986220#comment82 and b/412986220#comment90
     steps:
-    - uses: actions/checkout@v3
-    - name: Cleanup old docker images
-      run: docker system prune --all --force
-    - name: Authenticate gcloud
-      run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-    - name: build jax stable image
-      run : |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_jax_stable MODE=stable DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_jax_stable
-    - name: build jax nightly image
-      run : |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_jax_nightly MODE=nightly DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_jax_nightly
-    - name: build jax AI image
-      run : |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_jax_stable_stack MODE=jax_ai_image DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_jax_stable_stack BASEIMAGE=us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:latest
-    - name: build image with JAX AI nightly jax
-      run: |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_stable_stack_nightly_jax MODE=jax_ai_image DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_tpu_jax_stable_stack_nightly BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/tpu/jax_nightly:latest
-    - name: build image with jax AI release candidate image
-      run: |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_stable_stack_candidate MODE=jax_ai_image DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_stable_stack_candidate BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:latest
-  gpu:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Mark git repository as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Configure Docker
+        run: gcloud auth configure-docker us-docker.pkg.dev,gcr.io -q
+      - name: Set up Docker BuildX
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        with:
+          driver: remote
+          endpoint: tcp://localhost:1234
+      # Env variables to be passed to Dockerfile
+      - name: Get short commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Get current date
+        id: date
+        run: echo "image_date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+      # Docker BuildX command config
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: ${{ matrix.dockerfile }}
+          tags: |
+            gcr.io/tpu-prod-env-multipod/${{ matrix.image_name }}:${{ steps.date.outputs.image_date }}
+            gcr.io/tpu-prod-env-multipod/${{ matrix.image_name }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            ${{ matrix.build_args }}
+            JAX_AI_IMAGE_BASEIMAGE=${{ matrix.base_image }}
+            COMMIT_HASH=${{ steps.vars.outputs.sha_short }}
+            DEVICE=tpu
+
+  # Same as tpu-build step but mirrored for GPUs
+  build-gpu:
+    if: >
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request' ||
+      github.event.inputs.target_device == 'all' ||
+      github.event.inputs.target_device == 'gpu'
+
+    runs-on: linux-x86-n2-16-buildkit
+    container: google/cloud-sdk:524.0.0
+
     strategy:
       fail-fast: false
       matrix:
-        device-type: ["a100-40gb-4"]
-    runs-on: ["self-hosted", "gpu", "${{ matrix.device-type }}"]
+        # GPU Image Builds using JAX AI Image
+        include:
+          - image_name: maxtext_gpu_jax_stable_stack
+            dockerfile: ./maxtext_jax_ai_image.Dockerfile
+            base_image: us-central1-docker.pkg.dev/deeplearning-images/jax-ai-image/gpu:latest
+          - image_name: maxtext_gpu_stable_stack_nightly_jax
+            dockerfile: ./maxtext_jax_ai_image.Dockerfile
+            base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/gpu/jax_nightly:latest
+          - image_name: maxtext_stable_stack_candidate_gpu
+            dockerfile: ./maxtext_jax_ai_image.Dockerfile
+            base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/gpu:latest
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Cleanup old docker images
-      run: docker system prune --all --force
-    - name: Authenticate gcloud
-      run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-    - name: build jax stable image
-      run : |
-    - name: build jax AI image
-      run : |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_gpu_jax_stable_stack MODE=jax_ai_image DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_gpu_jax_stable_stack BASEIMAGE=us-central1-docker.pkg.dev/deeplearning-images/jax-ai-image/gpu:latest
-    - name: build image with JAX AI nightly jax
-      run: |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_gpu_stable_stack_nightly_jax MODE=jax_ai_image DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_gpu_jax_stable_stack_nightly BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/gpu/jax_nightly:latest
-    - name: build image with jax AI release candidate image
-      run: |
-        bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_stable_stack_candidate_gpu MODE=jax_ai_image DEVICE=gpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_stable_stack_candidate_gpu BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/gpu:latest
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Mark git repository as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Configure Docker
+        run: gcloud auth configure-docker us-docker.pkg.dev,gcr.io,us-central1-docker.pkg.dev -q
+      - name: Set up Docker BuildX
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        with:
+          driver: remote
+          endpoint: tcp://localhost:1234
+      - name: Get short commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Get current date
+        id: date
+        run: echo "image_date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: ${{ matrix.dockerfile }}
+          tags: |
+            gcr.io/tpu-prod-env-multipod/${{ matrix.image_name }}:${{ steps.date.outputs.image_date }}
+            gcr.io/tpu-prod-env-multipod/${{ matrix.image_name }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            ${{ matrix.build_args }}
+            JAX_AI_IMAGE_BASEIMAGE=${{ matrix.base_image }}
+            COMMIT_HASH=${{ steps.vars.outputs.sha_short }}
+            DEVICE=gpu

--- a/.github/workflows/build_upload_internal.yml
+++ b/.github/workflows/build_upload_internal.yml
@@ -31,28 +31,39 @@ on:
       base_image:
         required: false
         type: string
+      cloud_runner:
+        required: false
+        type: string
 
 jobs:
   build_and_upload:
     name: Build and upload image (${{ inputs.device_name }})
-    runs-on: ["self-hosted", "${{ inputs.device_type }}", "${{ inputs.device_name }}"]
+    runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
+    container: google/cloud-sdk:524.0.0
     steps:
-      - name: Authenticate gcloud
-        continue-on-error: true
-        run: |
-          # configure registries as root and as runner
-          sudo gcloud auth configure-docker --quiet
-          gcloud auth configure-docker --quiet
-          sudo gcloud auth configure-docker us-docker.pkg.dev --quiet
-          gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - uses: actions/checkout@v4
-      - name: Build an image
-        run: |
-          bash docker_build_dependency_image.sh MODE=${{ inputs.build_mode }} DEVICE=${{ inputs.device_type }} BASEIMAGE=${{ inputs.base_image }}
-      - name: Tag the image
-        run: |
-          docker tag maxtext_base_image gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:${{ inputs.device_type }}
-      - name: Upload the image
-        run: |
-          docker push gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:${{ inputs.device_type }}
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Mark git repository as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Configure Docker
+        run: gcloud auth configure-docker us-docker.pkg.dev,gcr.io,us-central1-docker.pkg.dev -q
+      - name: Set up Docker BuildX
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        with:
+          driver: remote
+          endpoint: tcp://localhost:1234
+      - name: Get short commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: ./maxtext_jax_ai_image.Dockerfile
+          tags: gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:${{ inputs.device_type }}
+          build-args: |
+            JAX_AI_IMAGE_BASEIMAGE=${{ inputs.base_image }}
+            COMMIT_HASH=${{ steps.vars.outputs.sha_short }}
+            DEVICE=${{ inputs.device_type }}
+
 


### PR DESCRIPTION
# Description

For building maxtext docker images, we still using self-hosted Github runners. Now there is a specific GKE runner available for building docker containers. This pr migrates the maxtext docker image builds from the old self-hosted runners to the new GKE runner that use Docker BuildX. 

Some new key features to note with this pr:
- Use of docker BuildX instead of docker build commands. This means our scripts such as build_and_upload_images.sh is not needed anymore as it is incompatible with BuildX. Will have a follow-up pr to clean up maxtext dockerfiles and build scripts.
- XLML builds now happen in parallel vs sequentially. This means one image build no longer causes all other image builds to fail and builds finish much quicker. We see image build times for xlml tests at ~10 min total.
- Caching using docker BuildX integrated with [Github Actions Cache](https://docs.docker.com/build/cache/backends/gha/). This would make some of the image builds quicker based on how much the layers of the docker build changes
- Fixed small bug in notify step of RunTests.yml to create buganizer issue in case of build failure

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: [b/412986220](https://b.corp.google.com/issues/412986220#comment82)
FIXES: [b/421909781](https://b.corp.google.com/issues/421909781)

# Tests

Will update with a screenshot of using GKE runner for image builds in the unit tests

Image builds for Unit Tests: https://screenshot.googleplex.com/BRZidEP3mNkRQUy
Link to Github Action: https://github.com/AI-Hypercomputer/maxtext/actions/runs/15596030910/job/43926535013

Image builds for daily XLML E2E tests: https://screenshot.googleplex.com/7dBHUowk2NVUtsw
Link to Github Action: https://github.com/AI-Hypercomputer/maxtext/actions/runs/15596030910
- Also verified images successfully pushed to Artifact Registry

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
