### PR TITLE
Gemma2 MaxText to HuggingFace checkpoint conversion

### DIFF
--- a/MaxText/tests/hf_checkpoint_conversion_check.py
+++ b/MaxText/tests/hf_checkpoint_conversion_check.py
@@ -1,0 +1,115 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Sequence
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
+import os
+from absl import app  # Removed flags
+
+from MaxText.utils.ckpt_conversion.utils.hf_utils import (
+    check_predicted_tokens_match,
+    check_arrays_match,
+)
+# Read Hugging Face token from environment variable
+hf_token = os.environ.get("HF_AUTH_TOKEN")
+
+"""
+This script is to verify HuggingFace (HF) checkpoints that have been converted from MaxText. 
+
+It loads the converted HF model and a "golden" (reference) HF model, and:
+    1. runs a foward pass of the converted ckpt model
+    2. compares their weights, output logits for a given input
+    3. Compare the predicted token sequences
+    
+Extra Requirements:
+    torch
+    huggingface_hub
+    transformers
+    accelerate
+"""
+
+
+def get_all_modules(model):
+  """Get all weights names from a HF model."""
+  modules = []
+  for name, _ in model.named_modules():
+    if name and hasattr(model.get_submodule(name), "weight"):
+      modules.append(name)
+  return modules
+
+
+def check_weights_match(model, golden_model, tol=0.1):
+  """Compare weights between two HF models."""
+  modules = get_all_modules(golden_model)
+
+  for module in modules:
+    golden_weights = golden_model.get_submodule(module).state_dict()["weight"]
+    model_weight = model.get_submodule(module).state_dict()["weight"]
+    check_arrays_match(golden_weights, model_weight, tol)
+
+
+def get_logits(inputs, model, golden_model):
+  """Get logits from two HF models for comparison."""
+  logits = model(**inputs, output_hidden_states=True).logits
+  golden_logits = golden_model(**inputs, output_hidden_states=True).logits
+
+  return logits, golden_logits
+
+
+def main(argv: Sequence[str]) -> None:
+  # Parse arguments from argv
+  # Default values
+  parsed_args = {"golden_model_id": "google/gemma-2-2b-it", "hf_checkpoint_path": os.path.expanduser("~/.hf_output/")}
+  for arg in argv[1:]:
+    if "=" in arg:
+      key, value = arg.split("=", 1)
+      if key in parsed_args:
+        parsed_args[key] = value
+      else:
+        print(f"Warning: Unknown argument '{key}' found in argv. Ignoring.")
+
+  golden_model = AutoModelForCausalLM.from_pretrained(parsed_args["golden_model_id"], torch_dtype=torch.float32)
+
+  tokenizer = AutoTokenizer.from_pretrained(parsed_args["hf_checkpoint_path"])
+  model = AutoModelForCausalLM.from_pretrained(parsed_args["hf_checkpoint_path"], torch_dtype=torch.float32)
+
+  # TODO: (@yixuannwang) use 3 prompts to verify
+  input_text = "I love to"
+  inputs = tokenizer(input_text, return_tensors="pt")
+  # --- Generate Output ---
+  with torch.no_grad():
+    outputs = model.generate(**inputs, max_new_tokens=8)
+  # --- Decode and Print ---
+  print(tokenizer.decode(outputs[0], skip_special_tokens=True))
+
+  # Check weights match
+  print("########### check weights match ############### ")
+  check_weights_match(model, golden_model)
+
+  # Run forward pass to get logits
+  logits, golden_logits = get_logits(inputs, model, golden_model)
+
+  # Check logits from the first 5 tokens match
+  print("########### check logits match ############### ")
+  check_arrays_match(logits[0, :5, :], golden_logits[0, :5, :], atol=0.2)
+
+  print("########### check predicted token match ############### ")
+  check_predicted_tokens_match(logits, golden_logits)
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/MaxText/utils/ckpt_conversion/examples/convert_gemma2_to_hf.sh
+++ b/MaxText/utils/ckpt_conversion/examples/convert_gemma2_to_hf.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+export HF_AUTH_TOKEN=""
+
+DATE=$(date +%Y-%m-%d)
+# Define variables for paths and arguments
+HF_CHECKPOINT_GCS_PATH="gs://maxtext-model-checkpoints/HuggingFace/gemma2-2b/${DATE}" # (optional)GCS path for HF model
+MAXTEXT_CHECKPOINT_DIR="gs://maxtext-model-checkpoints/gemma2-2b-it/2025-02-20-18-01/unscanned/checkpoints/0/items"
+LOCAL_HF_CHECKPOINT_DIR="/tmp/hf_gemma2-2b_output" # HF requires a local dir
+GOLDEN_MODEL_ID="google/gemma-2-2b-it"
+
+CONVERT_MODULE="MaxText.ckpt_conversion.to_huggingface"
+CONVERT_ARGS=(
+    "MaxText/configs/base.yml"
+    "model_name=gemma2-2b"
+    "tokenizer_path=assets/tokenizer.gemma"
+    "load_parameters_path=${MAXTEXT_CHECKPOINT_DIR}"
+    "per_device_batch_size=1"
+    "max_prefill_predict_length=8"
+    "max_target_length=16"
+    "steps=1"
+    "async_checkpointing=false"
+    "scan_layers=false"
+    "prompt='I love to'"
+    "attention='dot_product'"
+    "base_output_directory=${HF_CHECKPOINT_GCS_PATH}"
+)
+
+VERIFY_MODULE="MaxText.tests.huggingface_ckpt_conversion_check"
+
+VERIFY_ARGS=(
+    "golden_model_id=${GOLDEN_MODEL_ID}"
+    "hf_checkpoint_path=${LOCAL_HF_CHECKPOINT_DIR}" # Updated to local path
+)
+
+
+# --- Step 1: Run the Hugging Face Conversion ---
+echo "Starting Hugging Face model conversion for gemma2-2b..."
+cd "$MAXTEXT_PROJECT_DIR"
+
+# Construct the command
+CONVERT_CMD=("python3" -m "$CONVERT_MODULE")
+for arg in "${CONVERT_ARGS[@]}"; do
+    CONVERT_CMD+=("$arg")
+done
+
+# Execute the command
+"${CONVERT_CMD[@]}"
+
+echo "Hugging Face model conversion finished."
+
+# --- Step 2: Run the Verification Script ---
+echo "Starting verification for the converted gemma2-2b model..."
+
+# Create local directory for checkpoints and download from GCS
+echo "Creating local directory for HF checkpoints: ${LOCAL_HF_CHECKPOINT_DIR}"
+mkdir -p "${LOCAL_HF_CHECKPOINT_DIR}"
+echo "Downloading HF checkpoints from ${HF_CHECKPOINT_GCS_PATH} to ${LOCAL_HF_CHECKPOINT_DIR}..."
+gsutil -m cp -r "${HF_CHECKPOINT_GCS_PATH}/*" "${LOCAL_HF_CHECKPOINT_DIR}/"
+echo "Download complete."
+
+# Construct the command
+VERIFY_CMD=("python3" -m "$VERIFY_MODULE")
+if [ ${#VERIFY_ARGS[@]} -ne 0 ]; then
+    for arg in "${VERIFY_ARGS[@]}"; do
+        VERIFY_CMD+=("$arg")
+    done
+fi
+
+# Execute the command
+"${VERIFY_CMD[@]}"
+
+# Optional: Clean up the local checkpoint directory
+echo "Cleaning up local HF checkpoint directory: ${LOCAL_HF_CHECKPOINT_DIR}"
+rm -rf "${LOCAL_HF_CHECKPOINT_DIR}"
+echo "Cleanup complete."
+
+echo "Verification script finished. Please check the above generated text"
+echo "All steps completed."

--- a/MaxText/utils/ckpt_conversion/to_huggingface.py
+++ b/MaxText/utils/ckpt_conversion/to_huggingface.py
@@ -1,0 +1,131 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import jax
+import os
+from typing import Sequence, Dict, Any
+import jax.numpy as jnp
+import numpy as np
+from transformers import AutoTokenizer
+from absl import app
+import flax
+
+from MaxText import max_utils
+from MaxText import maxengine
+from MaxText import pyconfig
+from MaxText import max_logging
+
+from MaxText.utils.ckpt_conversion.utils.param_mapping import (
+    HOOK_FNS,
+    PARAM_MAPPING,
+)
+from MaxText.utils.ckpt_conversion.utils.shape_mapping import SHAPE_MAPPING
+from MaxText.utils.ckpt_conversion.utils.hf_model_configs import HF_MODEL_CONFIGS
+from MaxText.utils.ckpt_conversion.utils.utils import (process_leaf_param, save_model_files, TOKENIZER_HF_IDS)
+
+"""Convert MaxText unscanned ckpt into HF format"""
+
+
+def _get_model_mappings(model_name: str, scan_layers: bool, config_dict: dict):  # Changed config to config_dict
+  """Retrieves parameter, shape, and hook function mappings for the model."""
+  if model_name not in PARAM_MAPPING or model_name not in SHAPE_MAPPING or model_name not in HOOK_FNS:
+    raise ValueError(f"Mappings not found for model: {model_name}. Available PARAM_MAPPING keys: {PARAM_MAPPING.keys()}")
+
+  return {
+      "param_mapping": PARAM_MAPPING[model_name](config_dict, scan_layers),
+      "shape_mapping": SHAPE_MAPPING[model_name](config_dict),
+      "hook_fn_mapping": HOOK_FNS[model_name](config_dict, scan_layers, saving_to_hf=True),
+  }
+
+
+# Read Hugging Face token from environment variable
+hf_token = os.environ.get("HF_AUTH_TOKEN")
+
+
+def main(argv: Sequence[str]) -> None:
+  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
+  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
+
+  config = pyconfig.initialize(argv)
+  assert (
+      config.load_full_state_path == ""
+  ), "This script expects parameters, not a full state. Use generate_param_only_checkpoint first if needed."
+  max_utils.print_system_information()
+
+  engine = maxengine.MaxEngine(config)
+  rng = jax.random.PRNGKey(1234)
+  rng, rng_load_params = jax.random.split(rng)
+  # load params from maxengine
+  loaded_params_from_engine = engine.load_params(rng_load_params)
+
+  if not config.base_output_directory:
+    output_directory = os.path.expanduser("~/.hf_output/")
+  else:
+    output_directory = config.base_output_directory
+
+  # 1. Get HuggingFace Model Configuration
+  model_key = config.model_name
+  if model_key not in HF_MODEL_CONFIGS:
+    raise ValueError(f"HF configuration not found for model key: {model_key}")
+  hf_config_obj = HF_MODEL_CONFIGS[model_key]
+
+  # 2. Load Tokenizer
+  if model_key not in TOKENIZER_HF_IDS:
+    raise ValueError(f"HF Tokenizer ID not found for model key: {model_key}")
+  hf_tokenizer_id = TOKENIZER_HF_IDS[model_key]
+  tokenizer = AutoTokenizer.from_pretrained(hf_tokenizer_id, token=hf_token)
+
+  # 3. Get parameter mappings
+  mappings = _get_model_mappings(model_key, config.scan_layers, hf_config_obj.to_dict())
+  param_map = mappings["param_mapping"]
+  shape_map = mappings["shape_mapping"]  # HF target shapes
+  hook_fn_map = mappings["hook_fn_mapping"]
+
+  # 4. Transform Weights
+  transformed_hf_weights: Dict[str, Any] = {}
+
+  # MaxText `engine.load_params()` returns `state.params` (a FrozenDict).
+  # The actual weights are typically under `state.params['params']`.
+  actual_weights_dict = loaded_params_from_engine.get("params")
+  if actual_weights_dict is None:
+    raise ValueError("Loaded parameters from engine do not contain a 'params' key. Structure might be unexpected.")
+
+  leaves_with_paths = jax.tree_util.tree_leaves_with_path(actual_weights_dict)
+
+  # traverse leavse to build: mt_param_key:mt_weights
+  processed_params_list = []
+  for path_tuple_iter, leaf_value_iter in leaves_with_paths:
+    processed_params_list.extend(
+        process_leaf_param(path_tuple_iter, leaf_value_iter, param_map, shape_map, hook_fn_map, config)
+    )
+  transformed_hf_weights = dict(processed_params_list)
+
+  # 5. Save in HuggingFace Format
+  if not transformed_hf_weights:
+    print("Error: No weights were transformed. Check mappings and parameter paths.")
+    return
+
+  save_model_files(
+      weight_arrays=transformed_hf_weights,
+      config=hf_config_obj,
+      tokenizer=tokenizer,
+      output_dir=output_directory,
+  )
+  max_logging.log(f"✅ MaxText model successfully saved in HuggingFace format at {output_directory}")
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -1,0 +1,64 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""
+This config defines the architectural configurations of the Hugging Face version of a model.
+"""
+
+
+import transformers
+
+
+gemma2_2b_config = transformers.Gemma2Config(
+    num_hidden_layers=26,
+    num_attention_heads=8,
+    num_key_value_heads=4,
+    hidden_size=2304,
+    intermediate_size=9216,
+)
+
+gemma2_9b_config = transformers.Gemma2Config(
+    num_hidden_layers=42,
+    num_attention_heads=16,
+    num_key_value_heads=8,
+    hidden_size=3584,
+    intermediate_size=14336,
+    final_logit_softcapping=30.0,
+    attn_logit_softcapping=50.0,
+    head_dim=256,
+    sliding_window=4096,
+    query_pre_attn_scalar=224,
+)
+
+gemma2_27b_config = transformers.Gemma2Config(
+    num_hidden_layers=46,
+    num_attention_heads=32,
+    num_key_value_heads=16,
+    hidden_size=4608,
+    intermediate_size=36864,
+    final_logit_softcapping=30.0,
+    attn_logit_softcapping=50.0,
+    head_dim=128,
+    sliding_window=4096,
+    query_pre_attn_scalar=144,
+)
+
+
+HF_MODEL_CONFIGS = {
+    "GEMMA2_2B": gemma2_2b_config,
+    "GEMMA2_9B": gemma2_9b_config,
+    "GEMMA2_27B": gemma2_27b_config,
+}

--- a/MaxText/utils/ckpt_conversion/utils/hf_utils.py
+++ b/MaxText/utils/ckpt_conversion/utils/hf_utils.py
@@ -1,0 +1,200 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax.experimental import multihost_utils
+import torch.nn.functional as F
+from tabulate import tabulate
+from typing import Optional
+
+"""
+Utility functions to support the HF checkpoint conversion and verification process in test_hf.py.
+"""
+
+
+def convert_jax_weight_to_torch(weight: "jax.Array", dtype: Optional[str] = None) -> torch.Tensor:
+  expected_dtype = str(weight.dtype) if dtype is None else dtype
+  expected_shape = weight.shape
+  weight = multihost_utils.process_allgather(weight)
+  weight = np.array(weight, dtype="float32")
+  torch_dtype = getattr(torch, expected_dtype)
+  torch_array = torch.from_numpy(weight).to(torch_dtype).reshape(expected_shape)
+  return torch_array
+
+
+def check_arrays_match(arrayA, arrayB, atol=0.01, rtol=1e-5):
+  """
+  Compare two sets of arrays for equality within the specified absolute and relative tolerances.
+
+  This function handles both PyTorch tensors and JAX arrays, automatically
+  converting between the two if necessary. If the arrays don't match within
+  the specified tolerance, it prints detailed information about the mismatches.
+
+  Args:
+      arrayA (Union[torch.Tensor, jax.Array]): First set of arrays to compare
+      arrayB (Union[torch.Tensor, jax.Array]): Second set of arrays to compare
+      atol (float, optional): Absolute tolerance for comparison. Defaults to 0.01.
+      rtol (float, optional): Relative tolerance for comparison. Defaults to 1e-5.
+
+  Returns:
+      bool: True if the arrays match within the specified tolerances, False otherwise.
+  """
+  # Determine types and convert if needed
+  is_A_torch = isinstance(arrayA, torch.Tensor)
+  is_B_torch = isinstance(arrayB, torch.Tensor)
+
+  # If one is torch and one is jax, convert jax to torch
+  if is_A_torch and not is_B_torch:
+    arrayB = convert_jax_weight_to_torch(arrayB)
+  elif is_B_torch and not is_A_torch:
+    arrayA = convert_jax_weight_to_torch(arrayA)
+
+  # If both are now torch tensors
+  if isinstance(arrayA, torch.Tensor):
+    if not torch.allclose(arrayA, arrayB, rtol=rtol, atol=atol):
+      # Calculate absolute and relative differences for detailed reporting
+      abs_diff = torch.abs(arrayA - arrayB)
+      # Element-wise mismatch condition: abs(a-b) > atol + rtol * abs(b)
+      mismatch_indices = abs_diff > (atol + rtol * torch.abs(arrayB))
+      num_mismatched_elements = mismatch_indices.sum().item()
+      max_abs_diff_val = torch.max(abs_diff).item()
+      print(f"Arrays do not match within rtol={rtol}, atol={atol}.")
+      print(f"Maximum absolute difference: {max_abs_diff_val:.6f}")
+      print(f"Number of mismatched elements in {arrayB.shape}: {num_mismatched_elements}")
+
+      # Print a few examples of mismatched elements
+      if num_mismatched_elements > 0:
+        print("Examples of mismatched elements (ArrayA vs ArrayB, limited to first 5):")
+        limit_print = 5
+        actual_limit = min(num_mismatched_elements, limit_print)
+        # Get the actual mismatched values using the indices
+        mismatched_A_samples = arrayA[mismatch_indices].flatten()[:actual_limit]
+        mismatched_B_samples = arrayB[mismatch_indices].flatten()[:actual_limit]
+        for i in range(len(mismatched_A_samples)):
+          print(
+              f"  A: {mismatched_A_samples[i].item():.6f}, B: {mismatched_B_samples[i].item():.6f}, Diff: {(mismatched_A_samples[i]-mismatched_B_samples[i]).item():.6f}"
+          )
+      return False
+
+  # If both are still jax arrays
+  else:
+    if not jnp.allclose(arrayA, arrayB, rtol=rtol, atol=atol):
+      abs_diff = jnp.abs(arrayA - arrayB)
+      # Element-wise mismatch condition: abs(a-b) > atol + rtol * abs(b)
+      mismatch_indices = abs_diff > (atol + rtol * jnp.abs(arrayB))
+      num_mismatched_elements = jnp.sum(mismatch_indices).item()
+      max_abs_diff_val = jnp.max(abs_diff).item()
+      print(f"JAX arrays do not match within rtol={rtol}, atol={atol}.")
+      print(f"Maximum absolute difference: {max_abs_diff_val:.6f}")
+      print(f"Number of mismatched elements in {arrayB.shape}: {num_mismatched_elements}")
+      return False
+  return True
+
+
+def check_predicted_tokens_match(logits_a, logits_b, tolerance=0.1):
+  """Compares the top predicted tokens from each set of logits and ensures their
+  disagreement rate doesn't exceed the tolerance threshold. Raises an AssertionError
+  if the disagreement is too high.
+
+  Args:
+      logits_a (jax.Array | torch.Tensor | np.ndarray): First set of model output logits
+      logits_b (jax.Array | torch.Tensor | np.ndarray): Second set of model output logits to compare against logits_a
+      tolerance (float, optional): Maximum allowed fraction of token prediction disagreements,
+          must be between 0.0 and 1.0. Defaults to 0.05 (5%).
+
+  Examples:
+      >>> logits1 = get_model_output(input1)
+      >>> logits2 = get_model_output(input2)
+      >>> check_predicted_tokens_match(logits1, logits2, tolerance=0.03)  # Allows 3% disagreement
+  """
+  # Validate tolerance input
+  if not 0.0 <= tolerance <= 1.0:
+    raise ValueError("Tolerance must be between 0.0 and 1.0")
+
+  metrics = get_logits_comparison_metrics(logits_a, logits_b)
+  disagreement_rate = metrics["disagreement_top1"]
+
+  if disagreement_rate > tolerance:
+    raise AssertionError(
+        f"Token prediction mismatch: {disagreement_rate:.1%} of tokens disagree " f"(exceeds tolerance of {tolerance:.1%})"
+    )
+
+
+def get_logits_comparison_metrics(logitsA, logitsB):
+  """
+  Calculate various comparison metrics between two sets of logits.
+
+  This function computes several metrics to compare the similarity and differences
+  between two sets of logits, including KL divergence, absolute differences,
+  and agreement in top-k predictions.
+
+  Args:
+      logitsA (jax.Array | torch.Tensor | np.ndarray): First set of logits to compare
+      logitsB (jax.Array | torch.Tensor | np.ndarray): Second set of logits to compare
+
+  Returns:
+      dict: A dictionary containing the following metrics:
+          - max_kl_div: Maximum KL divergence between probability distributions
+          - abs_diff: Maximum absolute difference between probabilities
+          - disagreement_top5: Proportion of positions where top-5 predictions differ
+          - disagreement_top1: Proportion of positions where top-1 predictions differ
+
+  Notes:
+      The function also prints a formatted table of the metrics using tabulate.
+  """
+
+  if isinstance(logitsA, jax.Array):
+    logitsA = convert_jax_weight_to_torch(logitsA)
+  if isinstance(logitsA, np.ndarray):
+    logitsA = torch.tensor(logitsA)
+  if isinstance(logitsB, jax.Array):
+    logitsB = convert_jax_weight_to_torch(logitsB)
+  if isinstance(logitsB, np.ndarray):
+    logitsB = torch.tensor(logitsB)
+
+  # Calculate probabilities
+  probs_A = F.softmax(logitsA, dim=-1)
+  probs_B = F.softmax(logitsB, dim=-1)
+
+  # Calculate metrics
+  kl_div = F.kl_div(torch.log(probs_B), probs_A, reduction="none", log_target=False)
+  max_kl_div = torch.max(kl_div.sum(dim=-1))
+
+  max_abs_diff = torch.abs(probs_A - probs_B).max()
+
+  # Calculate top-k agreement metrics
+  sorted_logits_A = torch.argsort(logitsA, dim=1)
+  sorted_logits_B = torch.argsort(logitsB, dim=1)
+  ranking_A_top5 = sorted_logits_A[:, -5:]
+  ranking_B_top5 = sorted_logits_B[:, -5:]
+  disagreement_top5 = torch.mean(((torch.abs(ranking_B_top5 - ranking_A_top5) > 0).sum(dim=1) > 0).float())
+
+  ranking_A_top1 = sorted_logits_A[:, -1:]
+  ranking_B_top1 = sorted_logits_B[:, -1:]
+  disagreement_top1 = torch.mean(((torch.abs(ranking_B_top1 - ranking_A_top1) > 0).sum(dim=1) > 0).float())
+
+  metrics = {
+      "max_kl_div": float(max_kl_div),
+      "abs_diff": float(max_abs_diff),
+      "disagreement_top5": float(disagreement_top5),
+      "disagreement_top1": float(disagreement_top1),
+  }
+
+  table = [[key, value] for key, value in metrics.items()]
+  print(tabulate(table, headers=["Metric", "Value"], tablefmt="orgtbl"))
+  return metrics

--- a/MaxText/utils/ckpt_conversion/utils/param_mapping.py
+++ b/MaxText/utils/ckpt_conversion/utils/param_mapping.py
@@ -1,0 +1,348 @@
+"""
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import numpy as np
+import jax
+
+
+def GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
+  """Returns mapping between MaxText and HuggingFace Gemma2 weight paths.
+
+  Args:
+      config (dict): Model configuration dictionary containing at least 'num_hidden_layers'.
+      scan_layers (bool, optional): Whether the MaxText model uses layer scanning optimization.
+          When True, decoder layers are stacked into a single tensor [dim1, #layers, dim2].
+          Defaults to False.
+
+  Returns:
+      dict: A mapping where:
+          - Keys are MaxText parameter paths
+          - Values are either:
+              - Single strings (HF parameter path) for unscanned parameters
+              - Lists of strings (HF parameter paths) for stacked layers when scan_layers=True
+
+  Notes:
+      - MaxText uses a paired layer approach where two HF decoder layers are treated as
+          one MaxText decoder layer.
+      - MaxText layer i corresponds to HF layers 2i and 2i+1
+      - Local components map to even-numbered HF decoder layers (0, 2, 4...)
+      - Global components map to odd-numbered HF decoder layers (1, 3, 5...)
+  """
+
+  nlayers = config["num_hidden_layers"]
+  mapping = {
+      "params-token_embedder-embedding": "model.embed_tokens.weight",
+      "params-decoder-decoder_norm-scale": "model.norm.weight",
+  }
+  if scan_layers:
+    mapping = {
+        **mapping,
+        "params-decoder-layers-pre_self_attention_norm_global-scale": [
+            f"model.layers.{i}.input_layernorm.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-mlp_global-wo-kernel": [
+            f"model.layers.{i}.mlp.down_proj.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-mlp_global-wi_1-kernel": [
+            f"model.layers.{i}.mlp.up_proj.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-mlp_global-wi_0-kernel": [
+            f"model.layers.{i}.mlp.gate_proj.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-post_self_attention_norm_global-scale": [
+            f"model.layers.{i}.post_attention_layernorm.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-post_ffw_norm_global-scale": [
+            f"model.layers.{i}.post_feedforward_layernorm.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-pre_ffw_norm_global-scale": [
+            f"model.layers.{i}.pre_feedforward_layernorm.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-self_attention_global-key-kernel": [
+            f"model.layers.{i}.self_attn.k_proj.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-self_attention_global-out-kernel": [
+            f"model.layers.{i}.self_attn.o_proj.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-self_attention_global-query-kernel": [
+            f"model.layers.{i}.self_attn.q_proj.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-self_attention_global-value-kernel": [
+            f"model.layers.{i}.self_attn.v_proj.weight" for i in range(1, nlayers, 2)
+        ],
+        "params-decoder-layers-pre_self_attention_norm_local-scale": [
+            f"model.layers.{i}.input_layernorm.weight" for i in range(0, nlayers, 2)
+        ],
+        "params-decoder-layers-mlp_local-wo-kernel": [
+            f"model.layers.{i}.mlp.down_proj.weight" for i in range(0, nlayers, 2)
+        ],
+        "params-decoder-layers-mlp_local-wi_1-kernel": [
+            f"model.layers.{i}.mlp.up_proj.weight" for i in range(0, nlayers, 2)
+        ],
+        "params-decoder-layers-mlp_local-wi_0-kernel": [
+            f"model.layers.{i}.mlp.gate_proj.weight" for i in range(0, nlayers, 2)
+        ],
+        "params-decoder-layers-post_self_attention_norm_local-scale": [
+            f"model.layers.{i}.post_attention_layernorm.weight" for i in range(0, nlayers, 2)
+        ],
+        "params-decoder-layers-post_ffw_norm_local-scale": [
+            f"model.layers.{i}.post_feedforward_layernorm.weight" for i in range(0, nlayers, 2)
+        ],
+        "params-decoder-layers-pre_ffw_norm_local-scale": [
+            f"model.layers.{i}.pre_feedforward_layernorm.weight" for i in range(0, nlayers, 2)
+        ],
+        "params-decoder-layers-self_attention_local-key-kernel": [
+            f"model.layers.{i}.self_attn.k_proj.weight" for i in range(0, nlayers, 2)
+        ],
+        "params-decoder-layers-self_attention_local-out-kernel": [
+            f"model.layers.{i}.self_attn.o_proj.weight" for i in range(0, nlayers, 2)
+        ],
+        "params-decoder-layers-self_attention_local-query-kernel": [
+            f"model.layers.{i}.self_attn.q_proj.weight" for i in range(0, nlayers, 2)
+        ],
+        "params-decoder-layers-self_attention_local-value-kernel": [
+            f"model.layers.{i}.self_attn.v_proj.weight" for i in range(0, nlayers, 2)
+        ],
+    }
+  # Case 2: scan_layer=False
+  else:
+    for maxtext_layer_idx in range(0, nlayers // 2):
+      local_layer_idx = maxtext_layer_idx * 2
+      global_layer_idx = maxtext_layer_idx * 2 + 1
+      layer_mapping = {
+          f"params-decoder-layers_{maxtext_layer_idx}-pre_self_attention_norm_global-scale": f"model.layers.{global_layer_idx}.input_layernorm.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_global-wo-kernel": f"model.layers.{global_layer_idx}.mlp.down_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_global-wi_1-kernel": f"model.layers.{global_layer_idx}.mlp.up_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_global-wi_0-kernel": f"model.layers.{global_layer_idx}.mlp.gate_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-post_self_attention_norm_global-scale": f"model.layers.{global_layer_idx}.post_attention_layernorm.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-post_ffw_norm_global-scale": f"model.layers.{global_layer_idx}.post_feedforward_layernorm.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-pre_ffw_norm_global-scale": f"model.layers.{global_layer_idx}.pre_feedforward_layernorm.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_global-key-kernel": f"model.layers.{global_layer_idx}.self_attn.k_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_global-out-kernel": f"model.layers.{global_layer_idx}.self_attn.o_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_global-query-kernel": f"model.layers.{global_layer_idx}.self_attn.q_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_global-value-kernel": f"model.layers.{global_layer_idx}.self_attn.v_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-pre_self_attention_norm_local-scale": f"model.layers.{local_layer_idx}.input_layernorm.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_local-wo-kernel": f"model.layers.{local_layer_idx}.mlp.down_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_local-wi_1-kernel": f"model.layers.{local_layer_idx}.mlp.up_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_local-wi_0-kernel": f"model.layers.{local_layer_idx}.mlp.gate_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-post_self_attention_norm_local-scale": f"model.layers.{local_layer_idx}.post_attention_layernorm.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-post_ffw_norm_local-scale": f"model.layers.{local_layer_idx}.post_feedforward_layernorm.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-pre_ffw_norm_local-scale": f"model.layers.{local_layer_idx}.pre_feedforward_layernorm.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_local-key-kernel": f"model.layers.{local_layer_idx}.self_attn.k_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_local-out-kernel": f"model.layers.{local_layer_idx}.self_attn.o_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_local-query-kernel": f"model.layers.{local_layer_idx}.self_attn.q_proj.weight",
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_local-value-kernel": f"model.layers.{local_layer_idx}.self_attn.v_proj.weight",
+      }
+      mapping = {**mapping, **layer_mapping}
+  return mapping
+
+
+def GEMMA2_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=False):
+  """Creates parameter transformation functions for converting between MaxText and
+  HuggingFace formats.
+
+  This function generates a mapping of transformation functions that handle the necessary
+  conversions between MaxText and HuggingFace parameter formats, including operations like
+  padding, reshaping, and scaling.
+
+  Args:
+      config (dict): Model configuration dictionary that must contain:
+          - num_hidden_layers (int): Number of layers in the model
+          - head_dim (int): Dimension of attention heads
+          - hidden_size (int): Model's hidden dimension size
+
+      scan_layers (bool, optional): Controls the output format for layer parameters:
+          - True: Returns transformation functions for batched layer parameters
+          - False: Returns transformation functions for individual layer parameters
+          Defaults to False.
+
+      saving_to_hf (bool, optional): Determines the direction of transformation:
+          - True: MaxText → HuggingFace conversion
+          - False: HuggingFace → MaxText conversion
+          Defaults to False.
+
+  Returns:
+      dict: Parameter transformation mapping where:
+          - Keys: MaxText parameter names (str)
+          - Values: Either:
+              - callable: Single transformation function
+              - list[callable]: List of transformation functions to be applied in sequence
+
+  Transformation Details:
+      The function handles several types of parameter transformations:
+      1. Embedding layer padding:
+          - HF shape: [256000, d_model]
+          - MaxText shape: [256128, d_model] (padded for performance)
+      2. Layer normalization scaling:
+          - Adds/subtracts 1.0 depending on direction
+      3. Attention query scaling:
+          - Scales by sqrt(head_dim) or its inverse
+
+      4. Kernel reshaping:
+          - Handles dimension transposition and reshaping between formats
+  """
+  nlayers = config["num_hidden_layers"]
+
+  def pad_hf_embedding_layer(input_tensor, target_shape):
+    """
+    Note:
+        HF embedding weights shape =  [256000,d_model]
+        MaxText embedding weights shape = [256128,d_model]
+        MaxText pad Gemma2 embedding to 256128 for better performance.
+    """
+    # TODO(wenxindongwork), Perhaps, this dtype should be the activation dtype
+    normalizer = np.dtype("float32").type(config["hidden_size"] ** 0.5)
+
+    def to_hf():
+      target_tensor = input_tensor[: target_shape[0], : target_shape[1]]
+      target_tensor = target_tensor / normalizer
+      target_tensor = target_tensor.astype(input_tensor.dtype)
+      return target_tensor
+
+    def from_hf():
+      target_tensor = np.zeros(target_shape, dtype=input_tensor.dtype)
+      target_tensor[: input_tensor.shape[0], : input_tensor.shape[1]] = input_tensor
+      target_tensor = target_tensor * normalizer
+      target_tensor = target_tensor.astype(input_tensor.dtype)
+      return target_tensor
+
+    if saving_to_hf:
+      return to_hf()
+    else:
+      return from_hf()
+
+  def reshape_kernel(input_tensor, target_shape):
+    def to_hf():
+      flipped_target_shape = np.flip(np.array(target_shape))
+      return input_tensor.reshape(flipped_target_shape).transpose()
+
+    def from_hf():
+      return input_tensor.T.reshape(target_shape)
+
+    if saving_to_hf:
+      return to_hf()
+    else:
+      return from_hf()
+
+  def scale_rmsnorm_layer(input_tensor, target_shape):
+    def to_hf():
+      return (input_tensor - 1.0).reshape(target_shape)
+
+    def from_hf():
+      return (input_tensor + 1.0).reshape(target_shape)
+
+    if saving_to_hf:
+      return to_hf()
+    else:
+      return from_hf()
+
+  def scale_query_layer(input_tensor, target_shape):
+    def to_hf():
+      depth_scale = np.dtype("float32").type(np.sqrt(config["head_dim"]))
+      return (input_tensor * depth_scale).astype(input_tensor.dtype)
+
+    def from_hf():
+      depth_scale = np.dtype("float32").type(1 / np.sqrt(config["head_dim"]))
+      return (input_tensor * depth_scale).astype(input_tensor.dtype)
+
+    if saving_to_hf:
+      return to_hf()
+    else:
+      return from_hf()
+
+  mapping = {
+      "params-token_embedder-embedding": pad_hf_embedding_layer,
+      "params-decoder-decoder_norm-scale": scale_rmsnorm_layer,
+  }
+  if scan_layers:
+    mapping = {
+        **mapping,
+        f"params-decoder-layers-self_attention_global-query-kernel": [
+            reshape_kernel,
+            scale_query_layer,
+        ],
+        f"params-decoder-layers-self_attention_local-query-kernel": [
+            reshape_kernel,
+            scale_query_layer,
+        ],
+        f"params-decoder-layers-self_attention_global-key-kernel": reshape_kernel,
+        f"params-decoder-layers-self_attention_local-key-kernel": reshape_kernel,
+        f"params-decoder-layers-self_attention_global-value-kernel": reshape_kernel,
+        f"params-decoder-layers-self_attention_local-value-kernel": reshape_kernel,
+        f"params-decoder-layers-mlp_global-wo-kernel": reshape_kernel,
+        f"params-decoder-layers-mlp_global-wi_1-kernel": reshape_kernel,
+        f"params-decoder-layers-mlp_global-wi_0-kernel": reshape_kernel,
+        f"params-decoder-layers-self_attention_global-out-kernel": reshape_kernel,
+        f"params-decoder-layers-mlp_local-wo-kernel": reshape_kernel,
+        f"params-decoder-layers-mlp_local-wi_1-kernel": reshape_kernel,
+        f"params-decoder-layers-mlp_local-wi_0-kernel": reshape_kernel,
+        f"params-decoder-layers-self_attention_local-out-kernel": reshape_kernel,
+        f"params-decoder-layers-pre_self_attention_norm_global-scale": scale_rmsnorm_layer,
+        f"params-decoder-layers-post_self_attention_norm_global-scale": scale_rmsnorm_layer,
+        f"params-decoder-layers-post_ffw_norm_global-scale": scale_rmsnorm_layer,
+        f"params-decoder-layers-pre_ffw_norm_global-scale": scale_rmsnorm_layer,
+        f"params-decoder-layers-pre_self_attention_norm_local-scale": scale_rmsnorm_layer,
+        f"params-decoder-layers-post_self_attention_norm_local-scale": scale_rmsnorm_layer,
+        f"params-decoder-layers-post_ffw_norm_local-scale": scale_rmsnorm_layer,
+        f"params-decoder-layers-pre_ffw_norm_local-scale": scale_rmsnorm_layer,
+    }
+  else:
+    for maxtext_layer_idx in range(nlayers // 2):
+      mapping = {
+          **mapping,
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_global-query-kernel": [
+              reshape_kernel,
+              scale_query_layer,
+          ],
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_local-query-kernel": [
+              reshape_kernel,
+              scale_query_layer,
+          ],
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_global-key-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_local-key-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_global-value-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_local-value-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_global-wo-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_global-wi_1-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_global-wi_0-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_global-out-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_local-wo-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_local-wi_1-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-mlp_local-wi_0-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-self_attention_local-out-kernel": reshape_kernel,
+          f"params-decoder-layers_{maxtext_layer_idx}-pre_self_attention_norm_global-scale": scale_rmsnorm_layer,
+          f"params-decoder-layers_{maxtext_layer_idx}-post_self_attention_norm_global-scale": scale_rmsnorm_layer,
+          f"params-decoder-layers_{maxtext_layer_idx}-post_ffw_norm_global-scale": scale_rmsnorm_layer,
+          f"params-decoder-layers_{maxtext_layer_idx}-pre_ffw_norm_global-scale": scale_rmsnorm_layer,
+          f"params-decoder-layers_{maxtext_layer_idx}-pre_self_attention_norm_local-scale": scale_rmsnorm_layer,
+          f"params-decoder-layers_{maxtext_layer_idx}-post_self_attention_norm_local-scale": scale_rmsnorm_layer,
+          f"params-decoder-layers_{maxtext_layer_idx}-post_ffw_norm_local-scale": scale_rmsnorm_layer,
+          f"params-decoder-layers_{maxtext_layer_idx}-pre_ffw_norm_local-scale": scale_rmsnorm_layer,
+      }
+  return mapping
+
+
+PARAM_MAPPING = {
+    "gemma2-2b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "gemma2-9b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "gemma2-27b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
+}
+
+HOOK_FNS = {
+    "gemma2-2b": GEMMA2_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "gemma2-9b": GEMMA2_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "gemma2-27b": GEMMA2_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+}

--- a/MaxText/utils/ckpt_conversion/utils/shape_mapping.py
+++ b/MaxText/utils/ckpt_conversion/utils/shape_mapping.py
@@ -1,0 +1,77 @@
+"""
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+
+def GEMMA2_HF_WEIGHTS_TO_SHAPE_MAPPING(config):
+  """Returns mapping between HuggingFace weights path and weights shape.
+
+  Args:
+      config (dict): Model configuration dictionary, defined in `model_configs.py`
+
+  Returns:
+      dict: A mapping where:
+          - Keys are HuggingFace model parameter paths
+          - Values are parameter shape as a List
+  """
+
+  mapping = {
+      "model.embed_tokens.weight": [config["vocab_size"], config["hidden_size"]],
+      "model.norm.weight": [config["hidden_size"]],
+  }
+  for layer_idx in range(config["num_hidden_layers"]):
+    layer_mapping = {
+        f"model.layers.{layer_idx}.input_layernorm.weight": [config["hidden_size"]],
+        f"model.layers.{layer_idx}.mlp.down_proj.weight": [
+            config["hidden_size"],
+            config["intermediate_size"],
+        ],
+        f"model.layers.{layer_idx}.mlp.up_proj.weight": [
+            config["intermediate_size"],
+            config["hidden_size"],
+        ],
+        f"model.layers.{layer_idx}.mlp.gate_proj.weight": [
+            config["intermediate_size"],
+            config["hidden_size"],
+        ],
+        f"model.layers.{layer_idx}.post_attention_layernorm.weight": [config["hidden_size"]],
+        f"model.layers.{layer_idx}.post_feedforward_layernorm.weight": [config["hidden_size"]],
+        f"model.layers.{layer_idx}.pre_feedforward_layernorm.weight": [config["hidden_size"]],
+        f"model.layers.{layer_idx}.self_attn.k_proj.weight": [
+            config["num_key_value_heads"] * config["head_dim"],
+            config["hidden_size"],
+        ],
+        f"model.layers.{layer_idx}.self_attn.o_proj.weight": [
+            config["hidden_size"],
+            config["num_attention_heads"] * config["head_dim"],
+        ],
+        f"model.layers.{layer_idx}.self_attn.q_proj.weight": [
+            config["num_attention_heads"] * config["head_dim"],
+            config["hidden_size"],
+        ],
+        f"model.layers.{layer_idx}.self_attn.v_proj.weight": [
+            config["num_key_value_heads"] * config["head_dim"],
+            config["hidden_size"],
+        ],
+    }
+    mapping = {**mapping, **layer_mapping}
+  return mapping
+
+
+SHAPE_MAPPING = {
+    "gemma2-2b": GEMMA2_HF_WEIGHTS_TO_SHAPE_MAPPING,
+    "gemma2-9b": GEMMA2_HF_WEIGHTS_TO_SHAPE_MAPPING,
+    "gemma2-27b": GEMMA2_HF_WEIGHTS_TO_SHAPE_MAPPING,
+}

--- a/MaxText/utils/ckpt_conversion/utils/utils.py
+++ b/MaxText/utils/ckpt_conversion/utils/utils.py
@@ -1,0 +1,529 @@
+"""
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import contextlib
+import time
+import os
+import jax
+import jax.numpy as jnp
+import jax.tree_util
+from jaxtyping import Array
+import numpy as np
+import json
+from jax.experimental import multihost_utils
+from typing import Optional, List, Dict, Tuple, Callable, Any
+from google.cloud.storage import Client, transfer_manager
+from safetensors.numpy import save_file as numpy_save_file
+from huggingface_hub import HfApi, repo_exists
+from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+from concurrent.futures import ThreadPoolExecutor
+
+from MaxText import max_logging
+
+
+SAFE_TENSORS_CONFIG_FILE = "config.json"
+SAFE_TENSORS_WEIGHTS_FILE = "model.safetensors"
+SAFE_TENSORS_INDEX_FILE = "model.safetensors.index.json"
+DEFAULT_MAX_SHARD_SIZE = 1024 * 1024 * 1024 * 3  # 3GB default
+
+
+# Mapping from MaxText model key to Hugging Face tokenizer identifiers
+TOKENIZER_HF_IDS = {
+    "gemma2-2b": "google/gemma-2-2b",
+    "gemma2-9b": "google/gemma-2-9b",
+    "gemma2-27b": "google/gemma-2-27b",
+}
+
+
+def _get_local_directory(output_dir: str) -> str:
+  """Determines the local directory for saving files."""
+  if output_dir.startswith("gs://") or output_dir.startswith("hf://"):
+    # Fallback to a generic temp directory name if used directly
+    local_dir = os.path.join(os.path.expanduser("~/.cache/maxtext_hf_conversion_temp"), "temp_files")
+  else:
+    local_dir = output_dir
+  os.makedirs(local_dir, exist_ok=True)
+  return local_dir
+
+
+def process_leaf_param(
+    path_tuple: Any,
+    leaf_value: jax.Array,
+    param_map_local: Dict[str, Any],
+    shape_map_local: Dict[str, Any],
+    hook_fn_map_local: Dict[str, Any],
+    current_config: Any,
+) -> list[tuple[str, np.ndarray]]:
+  """Processes a single leaf from the MaxText parameter tree."""
+  # Construct maxtext_param_key from path_tuple
+  key_parts = []
+  for p_entry in path_tuple:
+    if isinstance(p_entry, jax.tree_util.DictKey):
+      key_parts.append(p_entry.key)
+    else:
+      max_logging.log(f"Warning: Path tuple {path_tuple} contains non-DictKey entry '{p_entry}'. Skipping this path.")
+      return []  # Skip this parameter
+
+  maxtext_param_key = "params-" + "-".join(key_parts)
+
+  if not isinstance(leaf_value, (jax.Array, np.ndarray)):
+    max_logging.log(f"Warning: Leaf value for {maxtext_param_key} is not an array. Type: {type(leaf_value)}. Skipping.")
+    return []
+
+  if maxtext_param_key not in param_map_local:
+    max_logging.log(f"Warning: MaxText param key '{maxtext_param_key}' not found in param_map. Skipping.")
+    return []
+
+  hf_target_paths = param_map_local[maxtext_param_key]
+  if not isinstance(hf_target_paths, list):
+    hf_target_paths = [hf_target_paths]
+
+  if not hf_target_paths:
+    max_logging.log(f"Warning: No HF target paths found for MaxText key '{maxtext_param_key}'. Skipping.")
+    return []
+
+  current_hook_fns = hook_fn_map_local.get(maxtext_param_key)
+  output_weights = []
+
+  if len(hf_target_paths) == 1:
+    hf_path = hf_target_paths[0]
+    if hf_path not in shape_map_local:
+      max_logging.log(
+          f"Warning: HF path '{hf_path}' not found in shape_map for MaxText key '{maxtext_param_key}'. Skipping."
+      )
+      return []
+    target_hf_shape = shape_map_local[hf_path]
+
+    processed_weight = leaf_value
+    if current_hook_fns:
+      processed_weight = apply_hook_fns(processed_weight, target_hf_shape, current_hook_fns)
+    numpy_weight = convert_jax_weight_to_numpy(processed_weight)
+    output_weights.append((hf_path, numpy_weight))
+  else:  # Stacked MaxText weight
+    if not (leaf_value.ndim > 0 and leaf_value.shape[current_config.param_scan_axis] == len(hf_target_paths)):
+      max_logging.log(
+          f"Warning: Mismatch for stacked layer {maxtext_param_key}. MaxText shape {leaf_value.shape}, expected {len(hf_target_paths)} slices on axis {current_config.param_scan_axis}. Skipping."
+      )
+      return []
+    for i, hf_path in enumerate(hf_target_paths):
+      if hf_path not in shape_map_local:
+        max_logging.log(
+            f"Warning: HF path '{hf_path}' for slice {i} of MaxText key '{maxtext_param_key}' not found in shape_map. Skipping slice."
+        )
+        continue
+      current_slice_target_hf_shape = shape_map_local[hf_path]
+      weight_slice = jax.lax.index_in_dim(leaf_value, i, axis=current_config.param_scan_axis, keepdims=False)
+      processed_slice = weight_slice
+      if current_hook_fns:
+        processed_slice = apply_hook_fns(processed_slice, current_slice_target_hf_shape, current_hook_fns)
+      numpy_slice = convert_jax_weight_to_numpy(processed_slice)
+      output_weights.append((hf_path, numpy_slice))
+  return output_weights
+
+
+def convert_jax_weight_to_numpy(weight: "jax.Array", dtype_str: Optional[str] = None) -> np.ndarray:
+  """Converts a JAX array to a NumPy array with the specified dtype."""
+  final_dtype_str = str(weight.dtype) if dtype_str is None else dtype_str
+  # JAX dtypes like 'bfloat16', 'float32' are understood by np.dtype()
+  target_np_dtype = np.dtype(final_dtype_str)
+  expected_shape = weight.shape
+
+  # Gather the array across devices if it's sharded.
+  # process_allgather typically returns the array on the host.
+  weight = multihost_utils.process_allgather(weight)
+
+  # Convert JAX array to NumPy array.
+  np_array = np.array(weight)
+
+  # Cast to the target NumPy dtype if it's different.
+  if np_array.dtype != target_np_dtype:
+    np_array = np_array.astype(target_np_dtype)
+
+  return np_array.reshape(expected_shape)  # Reshape for safety, though usually preserved.
+
+
+def apply_hook_fns(weight, target_shape, hook_fns):
+  if hook_fns is None:
+    return weight
+  if not isinstance(hook_fns, list):
+    hook_fns = [hook_fns]
+  for hook_fn in hook_fns[::-1]:
+    weight = hook_fn(weight, target_shape)
+  return weight
+
+
+def create_huggingface_hub_repo_if_not_exist(repo_id, repo_type):
+  if not repo_exists(repo_id, repo_type=repo_type):
+    api = HfApi()
+    api.create_repo(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        exist_ok=True,
+        private=True,
+    )
+    max_logging.log(f"\n Created new HuggingFace Hub {repo_type} repo: {repo_id}.")
+
+
+def save_config_file(
+    config, local_path_to_save_to: str, output_dir_final: str, file_name: str, remove_local_copy_after_upload: bool = False
+):
+  """Saves the model configuration file(config.json)."""
+  if jax.process_index() == 0:
+    actual_local_file_path = os.path.join(local_path_to_save_to, file_name)
+    config.architectures = [MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]]
+    config.to_json_file(actual_local_file_path)
+    max_logging.log(f"   Saved {file_name} to {actual_local_file_path}")
+
+    if output_dir_final.startswith("gs://"):
+      upload_file_to_gcs(
+          actual_local_file_path,
+          os.path.join(output_dir_final, file_name),
+          remove_local_file_after_upload=remove_local_copy_after_upload,
+      )
+    elif output_dir_final.startswith("hf://"):
+      repo_id = output_dir_final.lstrip("hf://")
+      api = HfApi()
+      api.upload_file(
+          path_or_fileobj=actual_local_file_path,
+          path_in_repo=file_name,
+          repo_id=repo_id,
+          repo_type="model",
+      )
+      if remove_local_copy_after_upload:
+        os.remove(actual_local_file_path)
+        max_logging.log(f"   Removed local copy: {actual_local_file_path}")
+
+
+def shard_checkpoint(
+    weights_dict: Dict[str, Array],
+    max_shard_size: int = DEFAULT_MAX_SHARD_SIZE,
+    weights_name: str = "model.safetensors",
+) -> Tuple[Dict[str, Dict[str, Array]], Optional[Dict]]:
+  """Shards a model checkpoint into smaller pieces based on size constraints.
+
+  Args:
+      weights_dict: Model weights dictionary to shard
+      max_shard_size: Maximum size in bytes for each shard
+      weights_name: Base filename for the shards
+
+  Returns:
+      Tuple of (sharded weights dict, optional index dict)
+      Index contains metadata and weight mapping information
+  """
+  # Track current shard and accumulated sizes
+  current_shard: Dict[str, Array] = {}
+  shards: List[Dict[str, Array]] = [current_shard]
+  current_size = 0
+  total_size = 0
+
+  # Iterate through weights in sorted order for deterministic sharding
+  for key, tensor in sorted(weights_dict.items()):
+    weight_size = tensor.size * tensor.itemsize
+    # Start new shard if current one would exceed size limit
+    if (current_size + weight_size > max_shard_size) and len(current_shard.items()):
+      current_shard = {}
+      shards.append(current_shard)
+      current_size = 0
+
+    # Add weight to current shard and update sizes
+    current_shard[key] = tensor
+    current_size += weight_size
+    total_size += weight_size
+
+  # Return single shard without index if no sharding needed
+  if len(shards) == 1:
+    return {weights_name: shards[0]}, None
+
+  # Generate shard filenames and build index
+  shard_dict = {}
+  weight_map = {}
+
+  for idx, shard in enumerate(shards, 1):
+    # Create numbered shard filename
+    shard_name = weights_name.replace(".safetensors", f"-{idx:05d}-of-{len(shards):05d}.safetensors")
+    shard_dict[shard_name] = shard
+
+    # Map each weight to its shard file
+    for key in shard:
+      weight_map[key] = shard_name
+
+  return shard_dict, {
+      "metadata": {"total_size": total_size},
+      "weight_map": weight_map,
+  }
+
+
+def save_safetensor_file(
+    state_dict,
+    local_dir_to_save_to: str,
+    output_dir_final: str,
+    file_name: str,
+    remove_local_copy_after_upload: bool = False,
+):
+  """Saves a single safetensor file."""
+  if jax.process_index() == 0:
+    state_dict = {k: v for k, v in state_dict.items() if v is not None}
+    local_path = os.path.join(local_dir_to_save_to, file_name)
+    numpy_save_file(state_dict, local_path, metadata={"format": "pt"})
+    max_logging.log(f"   Saved {file_name} to {local_path}")
+
+    if output_dir_final.startswith("gs://"):
+      cloud_path = os.path.join(output_dir_final, file_name)
+      upload_file_to_gcs(local_path, cloud_path, remove_local_file_after_upload=remove_local_copy_after_upload)
+    elif output_dir_final.startswith("hf://"):
+      repo_id = output_dir_final.lstrip("hf://")
+      api = HfApi()
+      api.upload_file(path_or_fileobj=local_path, path_in_repo=file_name, repo_id=repo_id, repo_type="model")
+      if remove_local_copy_after_upload:
+        os.remove(local_path)
+        max_logging.log(f"   Removed local copy: {local_path}")
+
+
+def save_index_file(
+    index: dict,
+    local_dir_to_save_to: str,
+    output_dir_final: str,
+    file_name: str,
+    remove_local_copy_after_upload: bool = False,
+):
+  """Saves the model index json file (model.safetensors.index.json)."""
+  if jax.process_index() == 0:
+    local_path = os.path.join(local_dir_to_save_to, file_name)
+    with open(local_path, "w") as f:
+      json.dump(index, f)
+    max_logging.log(f"   Saved {file_name} to {local_path}")
+
+    if output_dir_final.startswith("gs://"):
+      upload_file_to_gcs(
+          local_path,
+          os.path.join(output_dir_final, file_name),
+          remove_local_file_after_upload=remove_local_copy_after_upload,
+      )
+    elif output_dir_final.startswith("hf://"):
+      repo_id = output_dir_final.lstrip("hf://")
+      api = HfApi()
+      api.upload_file(
+          path_or_fileobj=local_path,
+          path_in_repo=file_name,
+          repo_id=repo_id,
+          repo_type="model",
+      )
+      if remove_local_copy_after_upload:
+        os.remove(local_path)
+        max_logging.log(f"   Removed local copy: {local_path}")
+
+
+def save_weight_files(
+    shards,
+    index,
+    local_dir_to_save_to: str,
+    output_dir_final: str,
+    parallel_threads=8,
+    remove_local_copy_after_upload: bool = False,
+):
+  """Saves weight files and index if needed.
+
+  Requires local system to have at least `parallel_threads * DEFAULT_MAX_SHARD_SIZE`
+  free disk space, as each thread will maintain a local cache of its shard during processing.
+  """
+  if index is None:
+    # 'shards' is actually the single state_dict here
+    save_safetensor_file(
+        shards, local_dir_to_save_to, output_dir_final, SAFE_TENSORS_WEIGHTS_FILE, remove_local_copy_after_upload
+    )
+  else:
+    # Save sharded weights in parallel
+    with ThreadPoolExecutor(max_workers=parallel_threads) as executor:
+      shard_items = list(shards.items())
+      futures = [
+          executor.submit(
+              save_safetensor_file,
+              shard_dict,
+              local_dir_to_save_to,
+              output_dir_final,
+              shard_name,
+              remove_local_copy_after_upload,
+          )
+          for shard_name, shard_dict in shard_items
+      ]
+      for future in futures:
+        future.result()
+
+    # Save index file
+    save_index_file(index, local_dir_to_save_to, output_dir_final, SAFE_TENSORS_INDEX_FILE, remove_local_copy_after_upload)
+
+
+@contextlib.contextmanager
+def get_local_save_path_manager(output_dir: str):
+  """
+  Context manager to provide a local path for saving files.
+  If output_dir is remote (GCS/HF), a temporary local directory is created.
+  If output_dir is local, it's used directly.
+  Yields:
+      tuple: (path_to_use_for_saving: str, is_temporary: bool)
+  """
+  import tempfile  # Local import to keep it contained
+
+  if output_dir.startswith("gs://") or output_dir.startswith("hf://"):
+    with tempfile.TemporaryDirectory(prefix="maxtext_hf_save_") as temp_dir:
+      max_logging.log(f"   Using temporary local staging directory: {temp_dir}")
+      yield temp_dir, True  # path, is_temporary
+  else:
+    os.makedirs(output_dir, exist_ok=True)
+    max_logging.log(f"   Using local directory: {output_dir}")
+    yield output_dir, False  # path, is_temporary
+
+
+def save_model_files(
+    weight_arrays: Dict,
+    config,  # HF config object
+    tokenizer: Optional[Any],  # transformers.PreTrainedTokenizerBase
+    output_dir: str,
+    parallel_threads=8,
+):
+  """Saves model files (config and weights) to the specified directory."""
+
+  if output_dir.startswith("hf://"):
+    create_huggingface_hub_repo_if_not_exist(repo_id=output_dir.lstrip("hf://"), repo_type="model")
+    repo_id = output_dir.lstrip("hf://")
+  else:
+    repo_id = None
+
+  max_logging.log(f"\n-> Saving model and tokenizer (if provided) to {output_dir}...")
+
+  with get_local_save_path_manager(output_dir) as (current_save_path, is_temp_path):
+    remove_local_copy = is_temp_path
+
+    if jax.process_index() == 0:
+      # Save tokenizer files
+      if tokenizer is not None:
+        max_logging.log(f"   Saving tokenizer files to {current_save_path}...")
+        # save_pretrained returns a tuple of saved file names (full paths)
+        saved_tokenizer_files = tokenizer.save_pretrained(current_save_path)
+        max_logging.log(f" Tokenizer files saved locally: {saved_tokenizer_files}")
+
+        if output_dir.startswith("gs://"):
+          for local_file_path in saved_tokenizer_files:
+            if not os.path.exists(local_file_path):
+              max_logging.log(f"   Warning: Tokenizer file {local_file_path} not found locally. Skipping upload to GCS.")
+              continue
+            file_name = os.path.basename(local_file_path)
+            upload_file_to_gcs(
+                local_file_path,
+                os.path.join(output_dir, file_name),
+                remove_local_file_after_upload=remove_local_copy,
+            )
+        elif output_dir.startswith("hf://") and repo_id:
+          api = HfApi()
+          for local_file_path in saved_tokenizer_files:
+            if not os.path.exists(local_file_path):
+              max_logging.log(f"   Warning: Tokenizer file {local_file_path} not found locally. Skipping upload to HF Hub.")
+              continue
+            file_name = os.path.basename(local_file_path)
+            api.upload_file(
+                path_or_fileobj=local_file_path,
+                path_in_repo=file_name,
+                repo_id=repo_id,
+                repo_type="model",
+            )
+            if remove_local_copy:
+              os.remove(local_file_path)
+              max_logging.log(f"   Removed local copy: {local_file_path}")
+
+      # Save config.json
+      save_config_file(config, current_save_path, output_dir, SAFE_TENSORS_CONFIG_FILE, remove_local_copy)
+
+    # Save .safetensors files (sharding can be outside process guard if weights are replicated)
+    # The actual file saving within save_weight_files is guarded.
+    shards, index = shard_checkpoint(weight_arrays)
+    save_weight_files(shards, index, current_save_path, output_dir, parallel_threads, remove_local_copy)
+
+  if jax.process_index() == 0:
+    max_logging.log(f"✅ Model and tokenizer (if provided) successfully processed for {output_dir}")
+
+
+def upload_file_to_gcs(local_file: str, gs_bucket_path: str, remove_local_file_after_upload=False):
+  """Uploads a single file to Google Cloud Storage.
+
+  Args:
+      local_file: Path to local file
+      gs_bucket_path: GCS destination (e.g. "gs://my-bucket/path/file.txt" or "my-bucket/path/file.txt")
+  """
+  # Standardize bucket path format
+  gs_bucket_path = gs_bucket_path.removeprefix("gs://")
+  bucket_name = gs_bucket_path.split("/")[0]
+  blob_name = gs_bucket_path[len(bucket_name) :].lstrip("/")
+
+  max_logging.log(f"-> Uploading {local_file} to {gs_bucket_path}...")
+  # Upload file
+  storage_client = Client()
+  bucket = storage_client.bucket(bucket_name)
+  blob = bucket.blob(blob_name)
+  # set large timeout to support large safetensors
+  blob.upload_from_filename(local_file, timeout=600)
+
+  max_logging.log(f"✅ Uploaded {local_file} to {bucket.name}/{blob_name}")
+
+  if remove_local_file_after_upload:
+    os.remove(local_file)
+    max_logging.log(f"✅ Deleted {local_file}")
+
+
+def upload_folder_to_gcs(local_folder: str, gs_bucket_path: str, num_workers: int = 4):
+  """Uploads all files from a local folder to Google Cloud Storage.
+
+  Args:
+      local_folder: Path to local folder (e.g. "data/images")
+      gs_bucket_path: GCS destination (e.g. "gs://my-bucket/images" or "my-bucket/images")
+      num_workers: Number of parallel upload workers
+  """
+  start_time = time.time()
+
+  # Standardize bucket path format
+  gs_bucket_path = gs_bucket_path.removeprefix("gs://")
+  bucket_name = gs_bucket_path.split("/")[0]
+  # Ensure destination ends with "/"
+  destination_dir = gs_bucket_path[len(bucket_name) :]
+  if destination_dir.startswith("/"):
+    destination_dir = destination_dir[1:]
+  if destination_dir != "" and not destination_dir.endswith("/"):
+    destination_dir += "/"
+
+  # Get files to upload
+  files_in_local_folder = os.listdir(local_folder)
+  # Set up GCS client
+  storage_client = Client()
+  bucket = storage_client.bucket(bucket_name)
+
+  # Upload files in parallel
+  results = transfer_manager.upload_many_from_filenames(
+      bucket,
+      files_in_local_folder,
+      source_directory=local_folder,
+      max_workers=num_workers,
+      blob_name_prefix=destination_dir,
+      timeout=600,
+      deadline=None,
+  )
+
+  # Report results
+  for name, result in zip(files_in_local_folder, results):
+    if isinstance(result, Exception):
+      max_logging.log(f"Failed to upload {name}: {result}")
+    else:
+      max_logging.log(f"✅ Uploaded {name} to {bucket.name}/{destination_dir}{name}")
+
+  max_logging.log(f"Upload completed in {time.time() - start_time}s")


### PR DESCRIPTION
# Description

This PR introduces a tool to convert MaxText model checkpoints into the Hugging Face (HF) .safetensors format, derived from the conversion code in [Kithara](https://github.com/AI-Hypercomputer/kithara/tree/main/kithara/model/maxtext/ckpt_compatibility). Currently, Gemma2 models are supported.

- Scripts for converting MaxText checkpoints to the HF format.
- Verification scripts to validate the functionality of converted checkpoints by running a forward pass and comparing them against established "golden" models from the Hugging Face Hub.
- Utility functions to support the conversion and verification processes.
- Automated shell scripts to streamline the end-to-end conversion and verification workflow.

# Testing

Offline evaluated by the provided shell scripts, which automate the conversion and subsequent verification against golden models ([example of success test](https://screenshot.googleplex.com/4jkL9Xpn3LkQUTo)). 

Unit test is to perform the check between JAX and Numpy arrays . And this PR doesn't impact the existing unit tests.

Tested Model variants:
Gemma2-2B

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
