### PR TITLE
Migrating Data Processing tests to CPU runners

### DIFF
--- a/MaxText/tests/tfds_data_processing_test.py
+++ b/MaxText/tests/tfds_data_processing_test.py
@@ -18,6 +18,7 @@ limitations under the License.
 import os
 import sys
 import unittest
+import pytest
 
 import jax
 from jax.sharding import Mesh
@@ -78,6 +79,7 @@ class TfdsDataProcessingTest(unittest.TestCase):
 
     return ds
 
+  @pytest.mark.cpu_only
   def test_train_ds(self):
     expected_shape = [jax.device_count(), self.config.max_target_length]
     # For training we pack multiple short examples in one example.
@@ -95,6 +97,7 @@ class TfdsDataProcessingTest(unittest.TestCase):
         },
     )
 
+  @pytest.mark.cpu_only
   def test_ds_determinism(self):
     train_ds1 = self.train_ds.batch(64)
     train_ds1 = next(train_ds1.as_numpy_iterator())
@@ -105,6 +108,7 @@ class TfdsDataProcessingTest(unittest.TestCase):
 
     self.assertCountEqual(train_ds1["tfds_id"], train_ds2["tfds_id"])
 
+  @pytest.mark.cpu_only
   def test_batch_determinism(self):
     batch1 = next(self.train_iter)
     train_iter = _tfds_data_processing.make_tfds_train_iterator(self.config, self.mesh, self.process_indices)
@@ -116,6 +120,7 @@ class TfdsDataProcessingTest(unittest.TestCase):
     self.assertTrue(tf.reduce_all(tf.equal(batch1["inputs_position"], batch2["inputs_position"])))
     self.assertTrue(tf.reduce_all(tf.equal(batch1["targets_position"], batch2["targets_position"])))
 
+  @pytest.mark.cpu_only
   def test_for_loop_repeatable(self):
     def get_first_batch(iterator):
       batch = None


### PR DESCRIPTION
# Description

The data processing tests right now run on TPU & GPU runners but the execute only on the host cpu. This is duplicate computation and can save time on the unit tests by offloading them to the CPU runners with the train_compile tests. Doing this would save ~2 min on the GPU and TPU unit tests.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
