### PR TITLE
Added caching optimization in building Maxtext + JAII Image

### DIFF
--- a/docker_build_dependency_image.sh
+++ b/docker_build_dependency_image.sh
@@ -75,7 +75,7 @@ build_ai_image() {
     COMMIT_HASH=$(git rev-parse --short HEAD)
     echo "Building JAX AI MaxText Imageat commit hash ${COMMIT_HASH}..."
 
-    docker build --no-cache \
+    docker build \
         --build-arg JAX_AI_IMAGE_BASEIMAGE=${BASEIMAGE} \
         --build-arg COMMIT_HASH=${COMMIT_HASH} \
         --build-arg DEVICE="$DEVICE" \

--- a/maxtext_jax_ai_image.Dockerfile
+++ b/maxtext_jax_ai_image.Dockerfile
@@ -13,9 +13,9 @@ RUN mkdir -p /deps
 # Set the working directory in the container
 WORKDIR /deps
 
-# Copy all files from local workspace into docker container
-COPY . .
-RUN ls .
+# Copy setup files and dependency files separately for better caching
+COPY setup.sh ./
+COPY requirements.txt requirements_with_jax_ai_image.txt ./
 
 
 # For JAX AI tpu training images 0.4.37 AND 0.4.35
@@ -36,6 +36,10 @@ RUN apt-get update && apt-get install --yes && apt-get install --yes dnsutils
 # TODO(bvandermoon, parambole): Remove this when it's added to JAX AI Image
 RUN pip install google-cloud-monitoring
 RUN python3 -m pip install -r /deps/requirements_with_jax_ai_image.txt
+
+# Now copy the remaining code (source files that may change frequently)
+COPY . .
+RUN ls .
 
 # Run the script available in JAX AI base image to generate the manifest file
 RUN bash /jax-stable-stack/generate_manifest.sh PREFIX=maxtext COMMIT_HASH=$COMMIT_HASH


### PR DESCRIPTION
# Description

Optimization step to improve caching when building maxtext image using JAX AI Image. First copying over the setup.sh and dependency files which do not change too much and then installing the necessary requirements. Finally copying over the rest of the source code which changes frequently. This caching step is only possible when the dependency files are not changed or when the periodic cronjob on the runners have not performed docker prune.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/415383910

# Tests

Snapshot of build times of unit test:

Previous Time: https://screenshot.googleplex.com/VRy9xLL9i8Spihc
Improved Time: https://screenshot.googleplex.com/4bKzsF4epSGuLZD

Reduced image build times from ~2-4 min to sub 1 min when caching is possible

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
