### PR TITLE
Init encoder_images only when use_multimodal=True

### DIFF
--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -465,7 +465,7 @@ def init_initial_state(model, tx, config, is_training, key):
       {"params": key, "dropout": key, "aqt": key},
       np.ones(input_shape, dtype=jnp.int32),
       np.ones(input_shape, dtype=jnp.int32),
-      encoder_images=np.ones(image_shape, dtype=jnp.int32),
+      encoder_images=np.ones(image_shape, dtype=jnp.int32) if config.use_multimodal else None,
   )
   if is_training:
     return init_training_state(model.apply, model_vars, tx)


### PR DESCRIPTION
# Description

Current code initializes a numpy array on the local JAX client which scales as the number of slices increases (because of dependency on the global batch size). This happens even for non image use cases.

Fixing this such that it is more inline with the PR that introduced this change: https://github.com/AI-Hypercomputer/maxtext/commit/2fd27e27f141199f2529a90fa03ae0aae53332e4

FIXES: b/419899001

# Tests

See the above bug for RCA

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
