### PR TITLE
Reduce integration tests run time

### DIFF
--- a/MaxText/tests/integration_tests/checkpoint_compatibility_test.py
+++ b/MaxText/tests/integration_tests/checkpoint_compatibility_test.py
@@ -29,6 +29,7 @@ before running tests locally.
 
 from datetime import datetime
 import json
+import os
 import pytest
 from MaxText.train import main as train_main
 from MaxText.tests.integration_tests.checkpointing_test import get_checkpointing_command
@@ -55,7 +56,7 @@ def run_checkpoint_compatibility(hardware, attention_type):
       get_checkpointing_command(
           run_date,
           hardware=hardware,
-          steps=3,
+          steps=1,
           metrics_file="run_1_metrics.txt",
           attention_type=attention_type,
           dataset_type="grain",
@@ -69,7 +70,7 @@ def run_checkpoint_compatibility(hardware, attention_type):
       get_checkpointing_command(
           run_date,
           hardware=hardware,
-          steps=5,
+          steps=2,
           metrics_file="run_2_metrics.txt",
           attention_type=attention_type,
           dataset_type="tfds",
@@ -77,22 +78,7 @@ def run_checkpoint_compatibility(hardware, attention_type):
       )
   )
 
-  # Resume training again using grain input pipeline
-  train_main(
-      get_checkpointing_command(
-          run_date,
-          hardware=hardware,
-          steps=7,
-          metrics_file="run_3_metrics.txt",
-          attention_type=attention_type,
-          dataset_type="grain",
-          dataset_path="/tmp/gcsfuse",
-      )
-      + grain_command
-  )
-
-  check_start_step("run_2_metrics.txt", 3.0)
-  check_start_step("run_3_metrics.txt", 5.0)
+  check_start_step("run_2_metrics.txt", 1.0)
 
 
 @pytest.mark.integration_test
@@ -104,4 +90,5 @@ def test_autoselected_attention():
 @pytest.mark.integration_test
 @pytest.mark.gpu_only
 def test_with_dot_product():
+  os.environ["NVTE_FUSED_ATTN"] = "1"  # Enable fused attention
   run_checkpoint_compatibility("gpu", "dot_product")

--- a/MaxText/tests/integration_tests/checkpointing_test.py
+++ b/MaxText/tests/integration_tests/checkpointing_test.py
@@ -91,7 +91,7 @@ def run_checkpointing(hardware, attention_type):
       get_checkpointing_command(
           run_date,
           hardware=hardware,
-          steps=5,
+          steps=1,
           metrics_file="saved_metrics.txt",
           attention_type=attention_type,
           dataset_type="grain",
@@ -104,7 +104,7 @@ def run_checkpointing(hardware, attention_type):
       get_checkpointing_command(
           run_date,
           hardware=hardware,
-          steps=10,
+          steps=2,
           metrics_file="restored_metrics.txt",
           attention_type=attention_type,
           dataset_type="grain",

--- a/MaxText/tests/integration_tests/gradient_accumulation_test.py
+++ b/MaxText/tests/integration_tests/gradient_accumulation_test.py
@@ -39,9 +39,7 @@ class GradientAccumulationTest(unittest.TestCase):
     random_suffix = generate_random_string()
     temp_dir = tempfile.gettempdir()
     run_accumulate_metrics_file = os.path.join(temp_dir, f"runner_grad_accumulate_{random_suffix}.txt")
-    print(f"{run_accumulate_metrics_file=}")
     run_regular_metrics_file = os.path.join(temp_dir, f"runner_regular_{random_suffix}.txt")
-    print(f"{run_regular_metrics_file=}")
     shared_maxtext_args = [
         None,
         os.path.join(PKG_DIR, "configs", "base.yml"),
@@ -53,7 +51,7 @@ class GradientAccumulationTest(unittest.TestCase):
         "base_emb_dim=256",
         "base_num_decoder_layers=4",
         rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
-        "steps=50",
+        "steps=20",
     ]
     # Run with gradient accumulation with accumulate_steps=10, per_device_batch=1 --> simulating per_device_batch=10
     train_main(


### PR DESCRIPTION
# Description

This PR reduces the run time for integration tests.

TPU integration tests run time before this PR:
![image](https://github.com/user-attachments/assets/bb5a28f7-f3b4-4a9a-9d02-16d7a458c615)

TPU integration tests run time after this PR:
![image](https://github.com/user-attachments/assets/401cba85-ed00-44e6-ac82-39084653f5b7)


GPU integration tests run time before this PR:
![image](https://github.com/user-attachments/assets/f00c844c-4769-4b8c-9749-9a4922bbd772)

GPU integration tests run time after this PR:
![image](https://github.com/user-attachments/assets/5c6d56b8-04d4-4592-9656-34376a3e8d21)


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
Integration tests passes

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
