### PR TITLE
Add Llama4 benchmark config

### DIFF
--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -201,7 +201,7 @@ def add_on_device_runner_arguments(custom_parser: argparse.ArgumentParser):
   custom_parser.add_argument(
       '--model_name',
       type=str,
-      choices=list(trillium_model_dict.keys()) + list(v5e_model_dict.keys()),
+      choices=list(trillium_model_dict.keys()) + list(v5p_model_dict.keys()) + list(v5e_model_dict.keys()),
       default=list(trillium_model_dict.keys())[0],
       help=(
         'model to be benchmarked, supported models are the command choices.'

--- a/benchmarks/maxtext_v5p_model_configs.py
+++ b/benchmarks/maxtext_v5p_model_configs.py
@@ -105,3 +105,92 @@ c4_deepseek_v3_ep_256_v5p_512 = _add_to_model_dictionary(
         ),
     ),
 )
+
+llama4_scout_dropless_v5p_256  = _add_to_model_dictionary(
+    v5p_model_dict,
+    MaxTextModel(
+        model_name="llama4_scout_dropless_v5p_256",
+        model_type="llama4-17b-16e",
+        tuning_params={
+            "per_device_batch_size": 8,
+            "max_target_length": 8192,
+            "ici_fsdp_parallelism": -1,
+            "enable_checkpointing": False,
+            "dtype": "bfloat16",
+            "weight_dtype": "float32",
+            "megablox": True,
+            "sparse_matmul": True,
+            "dataset_type": "synthetic",
+            "opt_type": "adamw",
+            "skip_first_n_steps_for_profiler": 5,
+            "profiler_steps": 3,
+            "profiler": "xplane",
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "reuse_example_batch": 1,
+            "sa_block_q": 2048,
+            "sa_block_kv": 2048,
+            "sa_block_kv_compute": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_kv_dkv": 2048,
+            "sa_block_kv_dkv_compute": 2048,
+            "sa_block_q_dq": 2048,
+            "sa_block_kv_dq": 2048,
+            "tokenizer_path": "meta-llama/Llama-4-Scout-17B-16E",
+        },
+        xla_flags=(
+            xla_flags_library.MOE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+            + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+            + xla_flags_library.HOST_OFFLOAD_FLAGS
+        ),
+    ),
+)
+
+llama4_maverick_dropless_v5p_256  = _add_to_model_dictionary(
+    v5p_model_dict,
+    MaxTextModel(
+        model_name="llama4_maverick_dropless_v5p_256",
+        model_type="llama4-17b-128e",
+        tuning_params={
+            "per_device_batch_size": 4,
+            "max_target_length": 8192,
+            "ici_fsdp_parallelism": 32,
+            "ici_tensor_parallelism": 4,
+            "enable_checkpointing": False,
+            "dtype": "bfloat16",
+            "weight_dtype": "float32",
+            "megablox": True,
+            "sparse_matmul": True,
+            "dataset_type": "synthetic",
+            "opt_type": "adamw",
+            "skip_first_n_steps_for_profiler": 5,
+            "profiler_steps": 3,
+            "profiler": "xplane",
+            "remat_policy": "custom",
+            "decoder_layer_input": "offload",
+            "out_proj": "offload",
+            "query_proj": "offload",
+            "key_proj": "offload",
+            "value_proj": "offload",
+            "reuse_example_batch": 1,
+            "sa_block_q": 2048,
+            "sa_block_kv": 2048,
+            "sa_block_kv_compute": 2048,
+            "sa_block_q_dkv": 2048,
+            "sa_block_kv_dkv": 2048,
+            "sa_block_kv_dkv_compute": 2048,
+            "sa_block_q_dq": 2048,
+            "sa_block_kv_dq": 2048,
+            "tokenizer_path": "meta-llama/Llama-4-Maverick-17B-128E",
+        },
+        xla_flags=(
+            xla_flags_library.MOE_VMEM_LIMIT_FLAG
+            + xla_flags_library.CF_FOR_ALL_GATHER
+            + xla_flags_library.DATA_PARALLEL_OVERLAP
+            + xla_flags_library.LAYOUT_FOR_ALL_REDUCE_SCATTER
+            + xla_flags_library.HOST_OFFLOAD_FLAGS
+        ),
+    ),
+)


### PR DESCRIPTION
# Description

Add training benchmark configs for Llama4 scout and maverick

* source configs of scout: https://paste.googleplex.com/5487863095099392
* source configs of maverick: https://paste.googleplex.com/6218446930706432

Benchmark [sheet](https://docs.google.com/spreadsheets/d/1EA8xEOXK_z-iNxfhxVloHiB5-SmoFLxJyAJuQRAMcNU/edit?gid=1790235300#gid=1790235300).

# Tests

* Scout reproduce: [link](https://screenshot.googleplex.com/ANfwoBXJJEZTHNW) - 54.6% MFU
* Maverick reproduce: [link](https://screenshot.googleplex.com/8Pom9jLMDxDaTEL) - 34.8% MFU

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
