### PR TITLE
fix mixtral unscanned ckpt test

### DIFF
--- a/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
+++ b/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
@@ -37,5 +37,5 @@ fusermount -u "$PARAM_DIR"
 # Generate unscanned ckpt for efficient decoding test
 export SCANNED_CHECKPOINT=${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt/0/items
 export RUN_NAME=unscanned_ckpt
-JAX_PLATFORMS=cpu python3 -m MaxText.generate_param_only_checkpoint MaxText/configs/base.yml async_checkpointing=false base_output_directory=${BASE_OUTPUT_PATH} load_parameters_path=${SCANNED_CHECKPOINT} run_name=${RUN_NAME} model_name='mixtral-8x7b' force_unroll=true
+JAX_PLATFORMS=cpu python3 -m MaxText.generate_param_only_checkpoint MaxText/configs/base.yml async_checkpointing=false base_output_directory=${BASE_OUTPUT_PATH} load_parameters_path=${SCANNED_CHECKPOINT} run_name=${RUN_NAME} model_name='mixtral-8x7b' force_unroll=true skip_jax_distributed_system=True
 echo "Wrote MaxText compatible unscanned checkpoint to ${BASE_OUTPUT_PATH}/${RUN_NAME}/checkpoints"


### PR DESCRIPTION
# Description

Add `skip_jax_distributed_system=True` flag to mixtral8x7b unscanned ckpt generation test 

FIXES: b/420959425

# Tests

Test details in b/420959425#comment3 (see A1)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
