### PR TITLE
Reduce numerical difference in llama4 vision encoder test

### DIFF
--- a/MaxText/layers/llama4.py
+++ b/MaxText/layers/llama4.py
@@ -15,8 +15,7 @@ limitations under the License.
 """
 
 """Llama4 decoder layer definition."""
-# pylint: disable=arguments-differ
-# pylint: disable=no-name-in-module
+# pylint: disable=arguments-differ, disable=no-name-in-module, missing-function-docstring
 
 import math
 from typing import Optional
@@ -70,7 +69,8 @@ class Llama4UnfoldConvolution(nn.Module):
         features=cfg.hidden_size_for_vit,
         dtype=cfg.dtype_mm,
         name="vit_unfold_linear",
-        use_bias=False
+        use_bias=False,
+        matmul_precision=cfg.matmul_precision,
     )
 
   def __call__(self, inputs: Array) -> Array:
@@ -152,14 +152,16 @@ class Llama4VisionMLP(nn.Module):
         features=cfg.intermediate_size_for_vit,
         dtype=cfg.dtype_mm,
         name="vit_encoder_layer_mlp_fc1",
-        use_bias=True
+        use_bias=True,
+        matmul_precision=cfg.matmul_precision,
     )
     self.fc2 = linears.dense_general(
         in_features=cfg.intermediate_size_for_vit,
         features=cfg.hidden_size_for_vit,
         dtype=cfg.dtype_mm,
         name="vit_encoder_layer_mlp_fc2",
-        use_bias=True
+        use_bias=True,
+        matmul_precision=cfg.matmul_precision,
     )
 
   def __call__(self, hidden_states: Array) -> Array:
@@ -196,14 +198,16 @@ class Llama4VisionMLP2(nn.Module):
         features=cfg.projector_input_dim_for_vit,
         dtype=cfg.dtype_mm,
         name="vit_pixel_shuffle_mlp_fc1",
-        use_bias=False
+        use_bias=False,
+        matmul_precision=cfg.matmul_precision,
     )
     self.fc2 = linears.dense_general(
         in_features=cfg.projector_input_dim_for_vit,
         features=cfg.projector_output_dim_for_vit,
         dtype=cfg.dtype_mm,
         name="vit_pixel_shuffle_mlp_fc2",
-        use_bias=False
+        use_bias=False,
+        matmul_precision=cfg.matmul_precision,
     )
     self.dropout = nn.Dropout(rate=cfg.projector_dropout_for_vit)
 
@@ -283,6 +287,7 @@ class Llama4MultiModalProjector(nn.Module):
         dtype=cfg.dtype_mm,
         name="vit_multi_modal_projector",
         use_bias=False,
+        matmul_precision=cfg.matmul_precision,
     )
 
   def __call__(self, image_features: Array) -> Array:
@@ -610,6 +615,8 @@ class Llama4VisionEncoderLayer(nn.Module):
         head_dim=self.config.hidden_size_for_vit // self.config.num_attention_heads_for_vit,
         max_target_length=(self.config.image_size_for_vit // self.config.patch_size_for_vit) ** 2 + 1,
         attention_kernel="dot_product",
+        float32_qk_product=self.config.float32_qk_product,
+        float32_logits=self.config.float32_logits,
         mesh=self.mesh,
         dropout_rate=0,
         name="self_attention_vision",

--- a/MaxText/tests/check_llama4_layers.py
+++ b/MaxText/tests/check_llama4_layers.py
@@ -846,13 +846,15 @@ class Llama4VisionEncoderTest(unittest.TestCase):
     attention_dropout: int = 0
 
   config_arguments = {
-      "per_device_batch_size": 4.0,
       "run_name": "test",
       "enable_checkpointing": False,
       "model_name": "llama4-17b-16e",
       "scan_layers": False,
-      "num_hidden_layers_for_vit": 6,
+      "num_hidden_layers_for_vit": 34,
       "dtype": "float32",
+      "matmul_precision": "float32",
+      "float32_qk_product": True,
+      "float32_logits": True,
   }
 
   def setUp(self):
@@ -889,6 +891,7 @@ class Llama4VisionEncoderTest(unittest.TestCase):
     # Create test input using config dimensions
     batch_size = 4
     inputs = jnp.ones((batch_size, self.seq_len_for_vit, self.cfg.hidden_size_for_vit), dtype=jnp.float32)
+    inputs /= 10
 
     # Initialize JAX parameters
     params = jax_model.init(self.rng, inputs, deterministic=True)
@@ -913,7 +916,7 @@ class Llama4VisionEncoderTest(unittest.TestCase):
     jax_outputs = jax_model.apply(params, inputs, deterministic=True)
 
     # Compare outputs
-    np.testing.assert_allclose(jax_outputs, to_jax(pt_outputs), rtol=1e-3, atol=0.05)
+    np.testing.assert_allclose(jax_outputs, to_jax(pt_outputs), rtol=0.01, atol=0.05)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
- Update encoder layer number from 6 to 34, matching llama4 vision encoder
- Update the allclose criteria rtol from 1e-3 to 0.01, keep atol the same 0.05. Since rtol=1e-3, atol=0.05 is usually used for single layer testing, we loose this a bit for testing the 34-layer vision encoder. The end to end [logit_checker](https://github.com/AI-Hypercomputer/maxtext/blob/main/MaxText/tests/forward_pass_logit_checker.py#L159-L160) uses rto=0.1, atol=0.1
- Update precision and make the dummy test input in a more realistic range
  - before this change:
```
E           AssertionError: 
E           Not equal to tolerance rtol=0.01, atol=0.05
E           
E           Mismatched elements: 306285 / 3249664 (9.43%)
E           Max absolute difference among violations: 0.2326374
E           Max relative difference among violations: 3.343927
E            ACTUAL: array([[[11.217089, 12.195944,  6.685423, ...,  8.819061, 13.093238,
E                     8.150303],
E                   [11.21041 , 12.189107,  6.688676, ...,  8.817145, 13.097935,...
E            DESIRED: array([[[11.303663, 12.14169 ,  6.760583, ...,  8.844138, 13.108282,
E                     8.161341],
E                   [11.303666, 12.141687,  6.760585, ...,  8.844134, 13.108283,...
```

   - After this change: pass
 
If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/420952122

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
