### PR TITLE
fix github clone link

### DIFF
--- a/MaxText/inference_mlperf/README.md
+++ b/MaxText/inference_mlperf/README.md
@@ -61,7 +61,7 @@ mv 09292024_mixtral_15k_mintoken2_v1.pkl mixtral-processed-data.pkl
 ### Install Maxtext
 ```
 cd ~
-git clone git@github.com:google/maxtext.git
+git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
 bash setup.sh
 python3 -m pip install -r MaxText/inference_mlperf/requirements.txt

--- a/getting_started/Run_MaxText_via_xpk.md
+++ b/getting_started/Run_MaxText_via_xpk.md
@@ -67,7 +67,7 @@ after which log out and log back in to the machine.
 1. Git clone maxtext locally
 
     ```shell
-    git clone https://github.com/google/maxtext.git
+    git clone https://github.com/AI-Hypercomputer/maxtext.git
     cd maxtext
     ```
 2. Build local Maxtext docker image


### PR DESCRIPTION
# Description

Fix the maxtext repo link in clone cli.
Users without maintainer access to the repo cannot clone with the cli.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
N/A

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
Local run.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
