### PR TITLE
Add Llama4VisionModel for multimodal decoding

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -737,6 +737,7 @@ hidden_size_for_vit: 1408
 intermediate_size_for_vit: 5632
 num_attention_heads_for_vit: 16
 num_channels_for_vit: 3
+tile_size_for_vit: 336
 patch_size_for_vit: 14
 num_hidden_layers_for_vit: 34
 projector_input_dim_for_vit: 4096


### PR DESCRIPTION
# Description

This PR implements a complete class `Llama4VisionModel`, by integrating all Llama4 basic vision components. It allows Llama4 multimodal decode by describing an input image. Joint by @hengtaoguo and @aireenmei .

- **Core change `Llama4VisionModel`**, which converts image tiles (batch_size, num_tiles, C, H, W) to feature activations (batch_size, num_tiles, num_patches, vision_output_dim_for_vit). Then `Llama4MultiModalProjector` projects it to (batch_size, num_tiles, num_patches, base_emb_dim). Example: (8, 5, 3, 336, 336) -> (8, 5, 144, 4096) -> (8, 5, 144, 5120). After that, the image tokens will be merged into text tokens by re-using `merge_mm_embeddings`. 
- Refactor by adding a `get_dummy_image_shape_for_init()` to create desired dummy images for different models, for jit init purpose.


# Tests

Tested full multimodal decode on v5p-16 cluster with this [command](https://paste.googleplex.com/6229393653104640), and [workload](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22mlperf-v5p-16%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22htg-llama4-17b-16e-decode-mm-full-ep8-slice-job-0-0-%22%20severity%3E%3DDEFAULT%0Atimestamp%20%3E%3D%20%222025-06-19T01:49:47.511191474Z%22%20AND%20timestamp%20%3C%3D%222025-06-19T01:56:47.705371521Z%22;storageScope=project;cursorTimestamp=2025-06-19T01:49:52.163035619Z;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev&inv=1&invt=Ab0mDQ) with [screenshot](https://screenshot.googleplex.com/6cqjHnUupQQniXY).
![image](https://github.com/user-attachments/assets/624240d0-92c2-4e50-8469-973aff38e2c1)




# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
