### PR TITLE
Refactor metrics related code and fix calculation for step time metrics

### DIFF
--- a/MaxText/elastic_train.py
+++ b/MaxText/elastic_train.py
@@ -43,7 +43,6 @@ import logging
 import os
 import sys
 import time
-import queue
 
 from absl import app
 
@@ -68,13 +67,11 @@ from MaxText import maxtext_utils
 from MaxText import max_logging
 from MaxText import profiler
 from MaxText import pyconfig
-from MaxText.gcp_workload_monitor import GCPWorkloadMonitor
 from MaxText.input_pipeline.input_pipeline_interface import create_data_iterator
 from MaxText.metric_logger import MetricLogger
 from MaxText.train import check_example_batch
 from MaxText.train import get_first_step
 from MaxText.train import load_next_batch
-from MaxText.train import record_scalar_metrics
 from MaxText.train import save_checkpoint
 from MaxText.train import setup_mesh_and_model
 from MaxText.train import setup_train_loop
@@ -120,7 +117,7 @@ def elastic_handler(
     checkpoint_manager.close()
 
   with jax.default_device(elastic_manager.default_device):
-    init_rng, writer, checkpoint_manager, mesh, model, learning_rate_schedule, tx = setup_mesh_and_model(
+    init_rng, checkpoint_manager, mesh, model, learning_rate_schedule, tx = setup_mesh_and_model(
         config, elastic_manager.good_devices
     )
     with mesh:
@@ -171,7 +168,7 @@ def elastic_handler(
       )
 
       example_batch = None
-      metric_logger = MetricLogger(writer, config)
+      metric_logger = MetricLogger(config=config, learning_rate_schedule=learning_rate_schedule)
 
       jax.block_until_ready(state)
 
@@ -186,7 +183,6 @@ def elastic_handler(
       example_batch,
       learning_rate_schedule,
       metric_logger,
-      writer,
   )
 
 
@@ -194,7 +190,6 @@ def train_loop(config, elastic_manager, recorder, state=None):
   """Main Training loop."""
   (
       init_rng,
-      writer,
       checkpoint_manager,
       state_mesh_shardings,
       model,
@@ -214,16 +209,6 @@ def train_loop(config, elastic_manager, recorder, state=None):
       donate_argnums_train,
   ) = maxtext_utils.get_functional_train_with_signature(train_step, mesh, state_mesh_shardings, model, config)
 
-  num_model_parameters = max_utils.calculate_num_params_from_pytree(state.params)
-  max_logging.log(f"number parameters: {num_model_parameters/1e9:.3f} billion")
-  per_device_tflops, _, _ = maxtext_utils.calculate_tflops_training_per_device(config)
-  per_device_tokens = maxtext_utils.calculate_tokens_training_per_device(config)
-
-  # Write train config params, num model params, and XLA flags to tensorboard
-  max_utils.add_text_to_summary_writer("num_model_parameters", str(num_model_parameters), writer)
-  max_utils.add_text_to_summary_writer("libtpu_init_args", os.environ["LIBTPU_INIT_ARGS"], writer)
-  maxtext_utils.add_config_to_summary_writer(config, writer)
-
   p_train_step = jax.jit(
       functional_train,
       in_shardings=in_shard_train,
@@ -231,25 +216,11 @@ def train_loop(config, elastic_manager, recorder, state=None):
       static_argnums=static_argnums_train,
       donate_argnums=donate_argnums_train,
   )
-  running_gcs_metrics = [] if config.gcs_metrics else None
-  metrics = None
 
   start_step = get_first_step(state)  # this is the start_step for training
   prof = profiler.Profiler(config, offset_step=start_step)
 
   example_batch = None
-  last_step_completion = datetime.datetime.now()
-
-  performance_metric_queue = None
-  if config.report_heartbeat_metric_for_gcp_monitoring or config.report_performance_metric_for_gcp_monitoring:
-    gcp_workload_monitor = GCPWorkloadMonitor(config.run_name)
-    if config.report_heartbeat_metric_for_gcp_monitoring:
-      gcp_workload_monitor.start_heartbeat_reporting_thread(config.heartbeat_reporting_interval_in_seconds)
-    if config.report_performance_metric_for_gcp_monitoring:
-      performance_metric_queue = queue.Queue()
-      gcp_workload_monitor.start_performance_reporting_thread(performance_metric_queue)
-
-  metric_logger = MetricLogger(writer, config)
   step = start_step
 
   elastic_manager.maybe_snapshot(
@@ -263,10 +234,17 @@ def train_loop(config, elastic_manager, recorder, state=None):
   )
 
   input_data_shardings = maxtext_utils.get_input_data_sharding(config, mesh)
+
+  metric_logger = MetricLogger(config=config, learning_rate_schedule=learning_rate_schedule)
+
+  # Write train config params, num model params, and XLA flags to tensorboard
+  metric_logger.write_setup_info_to_tensorboard(state.params)
+
   # Using while loop instead of a for loop because with elasticity
   # the step is restored back to the latest snapshot when a slice is lost
   while step < config.steps:
     try:
+      step_start_time = datetime.datetime.now()
       prof.maybe_activate_profiler(step, state)
 
       max_logging.log(f"{step=} {elastic_manager.elastic_down_event_count=} {elastic_manager.good_slice_count=}")
@@ -286,12 +264,6 @@ def train_loop(config, elastic_manager, recorder, state=None):
           with maybe_record_goodput(recorder, GoodputEvent.STEP, step):
             state, metrics = p_train_step(state, example_batch, nextrng)
 
-        step_time_delta = datetime.datetime.now() - last_step_completion
-        last_step_completion = datetime.datetime.now()
-        record_scalar_metrics(metrics, step_time_delta, per_device_tflops, learning_rate_schedule(step), per_device_tokens)
-        if performance_metric_queue:
-          performance_metric_queue.put(step_time_delta.total_seconds())
-
         if checkpoint_manager is not None:
           state_to_save = state
           if save_checkpoint(checkpoint_manager, int(step), state_to_save, config.dataset_type, data_iterator, config):
@@ -301,8 +273,6 @@ def train_loop(config, elastic_manager, recorder, state=None):
           if checkpoint_manager.reached_preemption(step):
             checkpoint_manager.wait_until_finished()
             sys.exit()
-
-        metric_logger.write_metrics(running_gcs_metrics, metrics, step)
 
         prof.maybe_deactivate_profiler(step, state)
 
@@ -340,11 +310,15 @@ def train_loop(config, elastic_manager, recorder, state=None):
             example_batch,
             learning_rate_schedule,
             metric_logger,
-            writer,
         ) = ret
 
       if step == start_step:
         max_utils.print_mem_stats("After params initialized")
+
+      jax.block_until_ready(state)  # ensure training step is completed
+
+      step_time_delta = datetime.datetime.now() - step_start_time
+      metric_logger.record_train_metrics(metrics, step, step_time_delta)
 
       step += 1
 
@@ -370,7 +344,6 @@ def train_loop(config, elastic_manager, recorder, state=None):
             example_batch,
             learning_rate_schedule,
             metric_logger,
-            writer,
         ) = ret
 
   if checkpoint_manager is not None:
@@ -391,8 +364,7 @@ def train_loop(config, elastic_manager, recorder, state=None):
         max_logging.log(f"Checkpoint is already saved for step {int(state.step)-1}.")
 
     checkpoint_manager.wait_until_finished()
-  metric_logger.write_metrics(running_gcs_metrics, metrics, config.steps - 1)  # final step metrics
-  max_utils.close_summary_writer(writer)
+  metric_logger.cleanup()
 
   if example_batch:
     with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):

--- a/MaxText/globals.py
+++ b/MaxText/globals.py
@@ -16,6 +16,8 @@ limitations under the License.
 
 import os.path
 
-PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+PKG_DIR = os.path.dirname(os.path.abspath(__file__))  # MaxText directory path
+EPS = 1e-8  # Epsilon to calculate loss
+DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE = 2 * 1024**3  # Default checkpoint file size
 
-__all__ = ["PKG_DIR"]
+__all__ = ["DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE", "EPS", "PKG_DIR"]

--- a/MaxText/metric_logger.py
+++ b/MaxText/metric_logger.py
@@ -19,13 +19,20 @@ limitations under the License.
 
 import json
 import os
+import queue
 
 import numpy as np
 
 import jax
 
 from MaxText import max_logging
+from MaxText import max_utils
+from MaxText import maxtext_utils
 from MaxText.utils import gcs_utils
+from MaxText.gcp_workload_monitor import GCPWorkloadMonitor
+from MaxText.globals import EPS
+
+from collections import defaultdict
 
 
 def _prepare_metrics_for_json(metrics, step, run_name):
@@ -41,56 +48,49 @@ class MetricLogger:
   Logger for saving metrics to a local file, GCS and TensorBoard.
   """
 
-  def __init__(self, writer, config):
-    self.buffered_step = None
-    self.buffered_metrics = None
-    self.writer = writer
+  def __init__(self, config, learning_rate_schedule):
+    self.writer = max_utils.initialize_summary_writer(config.tensorboard_dir, config.run_name)
     self.config = config
+    self.metadata = {}
+    self.running_gcs_metrics = [] if config.gcs_metrics else None
+    self.performance_metric_queue = self.get_performance_metric_queue(config)
+    self.learning_rate_schedule = learning_rate_schedule
+    self.cumulative_eval_metrics = {"scalar": defaultdict(float)}
 
-  def write_metrics(self, running_gcs_metrics, metrics, step, is_training=True):
-    """Entry point for all metrics writing in Train's Main.
+  def write_metrics(self, metrics, step, is_training=True):
+    """Entry point for all metrics writing in Train's Main."""
+    if metrics:
+      self.log_metrics(metrics, step, is_training)
 
-    To avoid introducing an unnecessary dependency, we "double buffer" -- we hold
-    onto the last metrics and step and only publish when we receive a new metrics and step.
-    The logic is that this ensures that Jax is able to queues train_steps and we
-    don't block when turning "lazy" Jax arrays into real Python numbers.
-    """
-    metrics_to_write, steps_to_write = None, None
-    if is_training:
-      if self.buffered_metrics is not None:
-        if self.buffered_step is None:
-          raise ValueError(f"When writing metrics, {self.buffered_step=} was none")
-        metrics_to_write = self.buffered_metrics
-        steps_to_write = self.buffered_step
-        self.log_metrics(metrics_to_write, steps_to_write)
-      self.buffered_metrics = metrics
-      self.buffered_step = step
-    else:
-      metrics_to_write = metrics
-      steps_to_write = step
-
-    if metrics_to_write:
       if self.config.enable_tensorboard:
-        self.write_metrics_to_tensorboard(metrics_to_write, steps_to_write, is_training)
+        self.write_metrics_to_tensorboard(metrics, step, is_training)
 
       if self.config.metrics_file:
-        self.write_metrics_locally(metrics_to_write, steps_to_write)
+        self.write_metrics_locally(metrics, step)
 
       if self.config.gcs_metrics and jax.process_index() == 0:
-        running_gcs_metrics = self.write_metrics_for_gcs(metrics_to_write, steps_to_write, running_gcs_metrics, is_training)
+        self.write_metrics_for_gcs(metrics, step, is_training)
 
-  def log_metrics(self, metrics, step):
-    """Logs metrics via max_logging"""
-    max_logging.log(
-        f"completed step: {step}, seconds: {metrics['scalar']['perf/step_time_seconds']:.3f}, "
-        f"TFLOP/s/device: {metrics['scalar']['perf/per_device_tflops_per_sec']:.3f}, "
-        f"Tokens/s/device: {metrics['scalar']['perf/per_device_tokens_per_sec']:.3f}, "
-        f"total_weights: {metrics['scalar']['learning/total_weights']}, "
-        f"loss: {metrics['scalar']['learning/loss']:.3f}"
-    )
+  def log_metrics(self, metrics, step, is_training):
+    """Logs metrics via max_logging."""
+    if is_training:
+      max_logging.log(
+          f"completed step: {step}, seconds: {metrics['scalar']['perf/step_time_seconds']:.3f}, "
+          f"TFLOP/s/device: {metrics['scalar']['perf/per_device_tflops_per_sec']:.3f}, "
+          f"Tokens/s/device: {metrics['scalar']['perf/per_device_tokens_per_sec']:.3f}, "
+          f"total_weights: {metrics['scalar']['learning/total_weights']}, "
+          f"loss: {metrics['scalar']['learning/loss']:.3f}"
+      )
+    else:
+      max_logging.log(
+          f"eval metrics after step: {step},"
+          f" loss={self.cumulative_eval_metrics['scalar']['eval/avg_loss']:.3f},"
+          f" total_weights={self.cumulative_eval_metrics['scalar']['eval/total_weights']},"
+          f" step_time_seconds={self.cumulative_eval_metrics['scalar']['eval/step_time_seconds']:.3f}"
+      )
 
   def write_metrics_locally(self, metrics, step):
-    """Writes metrics locally for testing"""
+    """Writes metrics locally for testing."""
     with open(self.config.metrics_file, "a", encoding="utf8") as local_metrics_file:
       if step == 0:
         local_metrics_file.truncate(0)
@@ -98,26 +98,25 @@ class MetricLogger:
       metrics_dict = _prepare_metrics_for_json(metrics, step, self.config.run_name)
       local_metrics_file.write(str(json.dumps(metrics_dict)) + "\n")
 
-  def write_metrics_for_gcs(self, metrics, step, running_metrics, is_training):
-    """Writes metrics to gcs"""
+  def write_metrics_for_gcs(self, metrics, step, is_training):
+    """Writes metrics to GCS."""
     metrics_dict_step = _prepare_metrics_for_json(metrics, step, self.config.run_name)
-    running_metrics.append(metrics_dict_step)
+    self.running_gcs_metrics.append(metrics_dict_step)
     if is_training and (step + 1) % self.config.log_period == 0 or step == self.config.steps - 1:
       start_step = (step // self.config.log_period) * self.config.log_period
       metrics_filename = f"metrics_step_{start_step:06}_to_step_{step:06}.txt"
       with open(metrics_filename, "wt", encoding="utf8") as metrics_for_gcs:
-        for metrics_step in running_metrics:
+        for metrics_step in self.running_gcs_metrics:
           metrics_for_gcs.write(str(json.dumps(metrics_step)) + "\n")
 
       gcs_filename = os.path.join(self.config.metrics_dir, metrics_filename)
       max_logging.log(f"Moving file {metrics_filename} to GCS...")
       gcs_utils.upload_blob(gcs_filename, metrics_filename)
       max_logging.log(f"File {metrics_filename} moved successfully!")
-      running_metrics = []  # reset running_metrics to empty list
-    return running_metrics
+      self.running_gcs_metrics = []  # reset running_metrics to empty list
 
   def write_metrics_to_tensorboard(self, metrics, step, is_training):
-    """Writes metrics to TensorBoard"""
+    """Writes metrics to TensorBoard."""
     if jax.process_index() == 0:
       for metric_name in metrics.get("scalar", []):
         self.writer.add_scalar(metric_name, np.array(metrics["scalar"][metric_name]), step)
@@ -130,3 +129,81 @@ class MetricLogger:
       if full_log and jax.process_index() == 0:
         max_logging.log(f"To see full metrics 'tensorboard --logdir={self.config.tensorboard_dir}'")
         self.writer.flush()
+
+  def write_setup_info_to_tensorboard(self, params):
+    """Writes setup information like train config params, num model params, and XLA flags to TensorBoard."""
+    num_model_parameters = max_utils.calculate_num_params_from_pytree(params)
+    self.metadata["per_device_tflops"], _, _ = maxtext_utils.calculate_tflops_training_per_device(self.config)
+    self.metadata["per_device_tokens"] = maxtext_utils.calculate_tokens_training_per_device(self.config)
+    max_logging.log(f"number parameters: {num_model_parameters/1e9:.3f} billion")
+    max_utils.add_text_to_summary_writer("num_model_parameters", str(num_model_parameters), self.writer)
+    max_utils.add_text_to_summary_writer("libtpu_init_args", os.environ["LIBTPU_INIT_ARGS"], self.writer)
+    maxtext_utils.add_config_to_summary_writer(self.config, self.writer)
+
+  def get_performance_metric_queue(self, config):
+    """Records heartbeat metrics and performance metrics to GCP."""
+    performance_metric_queue = None
+    if config.report_heartbeat_metric_for_gcp_monitoring or config.report_performance_metric_for_gcp_monitoring:
+      gcp_workload_monitor = GCPWorkloadMonitor(config.run_name)
+      if config.report_heartbeat_metric_for_gcp_monitoring:
+        gcp_workload_monitor.start_heartbeat_reporting_thread(config.heartbeat_reporting_interval_in_seconds)
+      if config.report_performance_metric_for_gcp_monitoring:
+        performance_metric_queue = queue.Queue()
+        gcp_workload_monitor.start_performance_reporting_thread(performance_metric_queue)
+    return performance_metric_queue
+
+  def record_train_metrics(self, metrics, step, step_time_delta):
+    """Records training metrics and writes the metrics to GCS and/or to TensorBoard."""
+    metrics["scalar"].update({"perf/step_time_seconds": step_time_delta.total_seconds()})
+    metrics["scalar"].update({"perf/per_device_tflops": self.metadata["per_device_tflops"]})
+    metrics["scalar"].update(
+        {"perf/per_device_tflops_per_sec": self.metadata["per_device_tflops"] / step_time_delta.total_seconds()}
+    )
+    metrics["scalar"].update({"perf/per_device_tokens": self.metadata["per_device_tokens"]})
+    metrics["scalar"].update(
+        {"perf/per_device_tokens_per_sec": self.metadata["per_device_tokens"] / step_time_delta.total_seconds()}
+    )
+    metrics["scalar"].update({"learning/current_learning_rate": self.learning_rate_schedule(step)})
+    if self.performance_metric_queue:
+      self.performance_metric_queue.put(step_time_delta.total_seconds())
+
+    self.write_metrics(metrics, step)
+
+  def record_eval_metrics(self, step, metrics=None, eval_step_count=None):
+    """Records eval metrics and writes the metrics to GCS and/or to TensorBoard."""
+    if metrics:
+      self.cumulative_eval_metrics["scalar"]["eval/total_loss"] += float(metrics["scalar"].get("evaluation/total_loss", 0.0))
+      self.cumulative_eval_metrics["scalar"]["eval/total_weights"] += float(
+          metrics["scalar"].get("evaluation/total_weights", 0.0)
+      )
+      self.cumulative_eval_metrics["scalar"]["eval/moe_lb_loss"] += float(
+          metrics["scalar"].get("evaluation/moe_lb_loss", 0.0)
+      )
+      if self.config.use_dpo:
+        self.cumulative_eval_metrics["scalar"]["eval/dpo_reward_accuracy"] += float(
+            metrics["scalar"].get("evaluation/dpo_reward_accuracy", 0.0)
+        )
+
+    if eval_step_count:
+      eval_loss = self.cumulative_eval_metrics["scalar"]["eval/total_loss"] / (
+          self.cumulative_eval_metrics["scalar"]["eval/total_weights"] + EPS
+      )
+      self.cumulative_eval_metrics["scalar"]["eval/avg_loss"] = eval_loss
+      self.cumulative_eval_metrics["scalar"]["eval/avg_moe_lb_loss"] = (
+          self.cumulative_eval_metrics["scalar"]["eval/moe_lb_loss"] / eval_step_count
+      )
+      if self.config.use_dpo:
+        self.cumulative_eval_metrics["scalar"]["eval/dpo_reward_accuracy"] = (
+            self.cumulative_eval_metrics["scalar"]["eval/dpo_reward_accuracy"] / eval_step_count
+        )
+
+      self.write_metrics(self.cumulative_eval_metrics, step, is_training=False)
+
+  def cleanup(self):
+    """
+    This is a terminal operation. Once called, the logger instance should
+    not be used to add or write more metrics as the underlying writer
+    objects (e.g., TensorBoard SummaryWriter) will be closed.
+    """
+
+    max_utils.close_summary_writer(self.writer)

--- a/MaxText/sft_trainer.py
+++ b/MaxText/sft_trainer.py
@@ -17,7 +17,6 @@
 import datetime
 import os
 import sys
-import queue
 from typing import Sequence
 
 from absl import app
@@ -36,15 +35,12 @@ from MaxText import maxtext_utils
 from MaxText import max_logging
 from MaxText import profiler
 from MaxText import pyconfig
-from MaxText.gcp_workload_monitor import GCPWorkloadMonitor
 from MaxText.metric_logger import MetricLogger
 from MaxText.train import (
     check_example_batch,
     eval_step,
-    EPS,
     get_first_step,
     load_next_batch,
-    record_scalar_metrics,
     save_checkpoint,
     setup_train_loop,
     train_step,
@@ -65,7 +61,6 @@ def train_loop(config, recorder, state=None):
 
   (
       init_rng,
-      writer,
       checkpoint_manager,
       state_mesh_shardings,
       model,
@@ -95,16 +90,6 @@ def train_loop(config, recorder, state=None):
         donate_argnums_eval,
     ) = maxtext_utils.get_functional_eval_with_signature(eval_step, mesh, state_mesh_shardings, model, config)
 
-  num_model_parameters = max_utils.calculate_num_params_from_pytree(state.params)
-  max_logging.log(f"number parameters: {num_model_parameters/1e9:.3f} billion")
-  per_device_tflops, _, _ = maxtext_utils.calculate_tflops_training_per_device(config)
-  per_device_tokens = maxtext_utils.calculate_tokens_training_per_device(config)
-
-  # Write train config params, num model params, and XLA flags to tensorboard
-  max_utils.add_text_to_summary_writer("num_model_parameters", str(num_model_parameters), writer)
-  max_utils.add_text_to_summary_writer("libtpu_init_args", os.environ["LIBTPU_INIT_ARGS"], writer)
-  maxtext_utils.add_config_to_summary_writer(config, writer)
-
   # Define the compilation of functional_train, either by loading the compiled version or wrapping a new one in a jit
   if config.compiled_trainstep_file != "":
     print("Loading the compiled function...", flush=True)
@@ -132,27 +117,20 @@ def train_loop(config, recorder, state=None):
           donate_argnums=donate_argnums_eval,
       )
 
-  running_gcs_metrics = [] if config.gcs_metrics else None
-  metrics = None
-
   start_step = get_first_step(state)  # this is the start_step for training
   prof = profiler.Profiler(config, offset_step=start_step)
 
   example_batch = None
-  last_step_completion = datetime.datetime.now()
 
-  performance_metric_queue = None
-  if config.report_heartbeat_metric_for_gcp_monitoring or config.report_performance_metric_for_gcp_monitoring:
-    gcp_workload_monitor = GCPWorkloadMonitor(config.run_name)
-    if config.report_heartbeat_metric_for_gcp_monitoring:
-      gcp_workload_monitor.start_heartbeat_reporting_thread(config.heartbeat_reporting_interval_in_seconds)
-    if config.report_performance_metric_for_gcp_monitoring:
-      performance_metric_queue = queue.Queue()
-      gcp_workload_monitor.start_performance_reporting_thread(performance_metric_queue)
-
-  metric_logger = MetricLogger(writer, config)
   input_data_shardings = maxtext_utils.get_input_data_sharding(config, mesh)
+
+  metric_logger = MetricLogger(config=config, learning_rate_schedule=learning_rate_schedule)
+
+  # Write train config params, num model params, and XLA flags to tensorboard
+  metric_logger.write_setup_info_to_tensorboard(state.params)
+
   for step in np.arange(start_step, config.steps):
+    step_start_time = datetime.datetime.now()
     prof.maybe_activate_profiler(step, state)
 
     with jax.profiler.StepTraceAnnotation("train", step_num=step):
@@ -171,12 +149,6 @@ def train_loop(config, recorder, state=None):
         with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
           state, metrics = p_train_step(state, example_batch, nextrng)
 
-    step_time_delta = datetime.datetime.now() - last_step_completion
-    last_step_completion = datetime.datetime.now()
-    record_scalar_metrics(metrics, step_time_delta, per_device_tflops, learning_rate_schedule(step), per_device_tokens)
-    if performance_metric_queue:
-      performance_metric_queue.put(step_time_delta.total_seconds())
-
     if checkpoint_manager is not None:
       if save_checkpoint(checkpoint_manager, int(step), state, config.dataset_type, data_iterator, config):
         checkpointing.print_save_message(step, config.async_checkpointing)
@@ -185,8 +157,6 @@ def train_loop(config, recorder, state=None):
       if checkpoint_manager.reached_preemption(step):
         checkpoint_manager.wait_until_finished()
         sys.exit()
-
-    metric_logger.write_metrics(running_gcs_metrics, metrics, step)
 
     if config.dump_hlo and step == start_step:
       jax.block_until_ready(state)  # Ensure compilation has finished.
@@ -200,14 +170,6 @@ def train_loop(config, recorder, state=None):
 
     if config.eval_interval > 0 and step > start_step and (step + 1) % config.eval_interval == 0:
       assert eval_data_iterator
-      cumulative_eval_metrics = {
-          "scalar": {
-              "eval/total_loss": 0.0,
-              "eval/total_weights": 0.0,
-              "eval/avg_loss": 0.0,
-              "eval/moe_lb_loss": 0.0,
-          }
-      }
       eval_step_count = 0
       # pylint: disable=not-callable
       for eval_batch in eval_data_iterator:
@@ -215,24 +177,11 @@ def train_loop(config, recorder, state=None):
           break
         with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
           eval_metrics = p_eval_step(state, eval_batch, nextrng)
-        cumulative_eval_metrics["scalar"]["eval/total_loss"] += float(eval_metrics["scalar"]["evaluation/total_loss"])
-        cumulative_eval_metrics["scalar"]["eval/total_weights"] += float(eval_metrics["scalar"]["evaluation/total_weights"])
-        cumulative_eval_metrics["scalar"]["eval/moe_lb_loss"] += float(eval_metrics["scalar"]["evaluation/moe_lb_loss"])
+        metric_logger.record_eval_metrics(step, metrics=eval_metrics)
         max_logging.log(f"Completed eval step {eval_step_count}")
         eval_step_count += 1
-      eval_loss = cumulative_eval_metrics["scalar"]["eval/total_loss"] / (
-          cumulative_eval_metrics["scalar"]["eval/total_weights"] + EPS
-      )
-      cumulative_eval_metrics["scalar"]["eval/avg_loss"] = eval_loss
-      cumulative_eval_metrics["scalar"]["eval/avg_moe_lb_loss"] = (
-          cumulative_eval_metrics["scalar"]["eval/moe_lb_loss"] / eval_step_count
-      )
-      metric_logger.write_metrics(running_gcs_metrics, cumulative_eval_metrics, step, is_training=False)
-      max_logging.log(
-          f"average loss after {step=}: {eval_step_count=}, {eval_loss=},"
-          f" total_weights={cumulative_eval_metrics['scalar']['eval/total_weights']}"
-      )
-      if eval_loss <= config.target_eval_loss:
+      metric_logger.record_eval_metrics(step, eval_step_count=eval_step_count)
+      if metric_logger.cumulative_eval_metrics["scalar"]["eval/avg_loss"] <= config.target_eval_loss:
         max_logging.log(f"Early stop and exit loop after reaching {config.target_eval_loss=}")
         prof.deactivate()
         break
@@ -241,6 +190,11 @@ def train_loop(config, recorder, state=None):
 
     if step == start_step:
       max_utils.print_mem_stats("After params initialized")
+
+    jax.block_until_ready(state)  # ensure training step is completed
+
+    step_time_delta = datetime.datetime.now() - step_start_time
+    metric_logger.record_train_metrics(metrics, step, step_time_delta)
 
   if checkpoint_manager is not None:
     if ((int(state.step) - 1) % config.checkpoint_period != 0) and (int(state.step) != 0):
@@ -253,8 +207,7 @@ def train_loop(config, recorder, state=None):
         max_logging.log(f"Checkpoint already saved for step {int(state.step)-1}.")
 
     checkpoint_manager.wait_until_finished()
-  metric_logger.write_metrics(running_gcs_metrics, metrics, config.steps - 1)  # final step metrics
-  max_utils.close_summary_writer(writer)
+  metric_logger.cleanup()
 
   if example_batch:
     with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):

--- a/MaxText/standalone_checkpointer.py
+++ b/MaxText/standalone_checkpointer.py
@@ -52,7 +52,7 @@ def checkpoint_loop(config, state=None):
     ckpt_path:
   Returns:
   """
-  init_rng, _, checkpoint_manager, mesh, model, _, tx = setup_mesh_and_model(config)
+  init_rng, checkpoint_manager, mesh, model, _, tx = setup_mesh_and_model(config)
 
   unboxed_abstract_state, _, _ = maxtext_utils.get_abstract_state(model, tx, config, init_rng, mesh, is_training=True)
   # A barrier to sync all hosts before starting to restore checkpoint

--- a/MaxText/standalone_dataloader.py
+++ b/MaxText/standalone_dataloader.py
@@ -35,7 +35,7 @@ def data_load_loop(config, state=None):
   """Main data loader loop.
   Loads batches of data for each training step.
   """
-  _, _, _, _, _, _, _, data_iterator, _, state = setup_train_loop(config, recorder=None)
+  _, _, _, _, _, _, data_iterator, _, state = setup_train_loop(config, recorder=None)
 
   example_batch = None
 

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -24,7 +24,6 @@ from typing import Sequence
 import datetime
 import functools
 import os
-import queue
 import sys
 import time
 
@@ -63,8 +62,8 @@ from MaxText import maxtext_utils
 from MaxText import optimizers
 from MaxText import profiler
 from MaxText import pyconfig
-from MaxText.gcp_workload_monitor import GCPWorkloadMonitor
 from MaxText.input_pipeline.input_pipeline_interface import create_data_iterator
+from MaxText.globals import DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE, EPS
 from MaxText.layers import quantizations
 from MaxText.layers.models import Transformer
 from MaxText.metric_logger import MetricLogger
@@ -79,9 +78,6 @@ from MaxText.vertex_tensorboard import VertexTensorboardManager
 # Placeholder: internal
 
 # pylint: disable=too-many-positional-arguments
-
-EPS = 1e-8
-_DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE = 2 * 1024**3
 
 
 def validate_train_config(config):
@@ -124,16 +120,6 @@ def load_next_batch(train_iter, example_batch, config):
     return next(train_iter)
 
 
-def record_scalar_metrics(metrics, step_time_delta, per_device_tflops, lr, per_device_tokens):
-  """Records scalar metrics to be written to tensorboard"""
-  metrics["scalar"].update({"perf/step_time_seconds": step_time_delta.total_seconds()})
-  metrics["scalar"].update({"perf/per_device_tflops": per_device_tflops})
-  metrics["scalar"].update({"perf/per_device_tflops_per_sec": per_device_tflops / step_time_delta.total_seconds()})
-  metrics["scalar"].update({"perf/per_device_tokens": per_device_tokens})
-  metrics["scalar"].update({"perf/per_device_tokens_per_sec": per_device_tokens / step_time_delta.total_seconds()})
-  metrics["scalar"].update({"learning/current_learning_rate": lr})
-
-
 def save_checkpoint(
     checkpoint_manager,
     step,
@@ -161,7 +147,7 @@ def save_checkpoint(
       )
 
   # specify chunk_byte_size to force orbax to control maximum file size in checkpoint
-  chunk_byte_size = _DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE
+  chunk_byte_size = DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE
   if config:
     chunk_byte_size = config.checkpoint_storage_target_data_file_size_bytes
   save_args = jax.tree.map(lambda _: orbax.checkpoint.SaveArgs(chunk_byte_size=chunk_byte_size), state)
@@ -584,7 +570,6 @@ def setup_mesh_and_model(config, devices=None):
 
   Returns:
     init_rng: RNG key
-    writer: Summary writer for tensorboard
     checkpoint_manager: Orbax checkpointer
     state_mesh_annotations: the mesh annotations for the train state
     model:
@@ -594,7 +579,6 @@ def setup_mesh_and_model(config, devices=None):
   """
 
   init_rng = random.PRNGKey(config.init_weights_seed)
-  writer = max_utils.initialize_summary_writer(config.tensorboard_dir, config.run_name)
 
   # Mesh definition
   devices_array = maxtext_utils.create_device_mesh(config, devices)
@@ -641,7 +625,7 @@ def setup_mesh_and_model(config, devices=None):
         use_zarr3,
     )
 
-  return init_rng, writer, checkpoint_manager, mesh, model, learning_rate_schedule, tx
+  return init_rng, checkpoint_manager, mesh, model, learning_rate_schedule, tx
 
 
 def setup_train_loop(config, recorder):
@@ -655,7 +639,6 @@ def setup_train_loop(config, recorder):
 
   Returns:
     init_rng:
-    writer: Summary writer for tensorboard
     checkpoint_manager: Orbax checkpointer
     state_mesh_annotations: the mesh annotations for the train state
     model:
@@ -666,7 +649,7 @@ def setup_train_loop(config, recorder):
   """
 
   with maybe_record_goodput(recorder, GoodputEvent.TPU_INIT):
-    init_rng, writer, checkpoint_manager, mesh, model, learning_rate_schedule, tx = setup_mesh_and_model(config)
+    init_rng, checkpoint_manager, mesh, model, learning_rate_schedule, tx = setup_mesh_and_model(config)
 
   with maybe_record_goodput(recorder, GoodputEvent.TRAINING_PREPARATION):
     data_iterator, eval_data_iterator = create_data_iterator(config, mesh)
@@ -723,7 +706,6 @@ def setup_train_loop(config, recorder):
 
   return (
       init_rng,
-      writer,
       checkpoint_manager,
       state_mesh_shardings,
       model,
@@ -739,7 +721,6 @@ def train_loop(config, recorder, state=None):
   """Main Training loop."""
   (
       init_rng,
-      writer,
       checkpoint_manager,
       state_mesh_shardings,
       model,
@@ -775,16 +756,6 @@ def train_loop(config, recorder, state=None):
         donate_argnums_eval,
     ) = maxtext_utils.get_functional_eval_with_signature(eval_step, mesh, state_mesh_shardings, model, config)
 
-  num_model_parameters = max_utils.calculate_num_params_from_pytree(state.params)
-  max_logging.log(f"number parameters: {num_model_parameters/1e9:.3f} billion")
-  per_device_tflops, _, _ = maxtext_utils.calculate_tflops_training_per_device(config)
-  per_device_tokens = maxtext_utils.calculate_tokens_training_per_device(config)
-
-  # Write train config params, num model params, and XLA flags to tensorboard
-  max_utils.add_text_to_summary_writer("num_model_parameters", str(num_model_parameters), writer)
-  max_utils.add_text_to_summary_writer("libtpu_init_args", os.environ["LIBTPU_INIT_ARGS"], writer)
-  maxtext_utils.add_config_to_summary_writer(config, writer)
-
   # Define the compilation of functional_train, either by loading the compiled version or wrapping a new one in a jit
   if config.compiled_trainstep_file != "":
     print("Loading the compiled function...", flush=True)
@@ -813,27 +784,20 @@ def train_loop(config, recorder, state=None):
     else:
       p_eval_step = None
 
-  running_gcs_metrics = [] if config.gcs_metrics else None
-  metrics = None
-
   start_step = get_first_step(state)  # this is the start_step for training
   prof = profiler.Profiler(config, offset_step=start_step)
 
   example_batch = None
-  last_step_completion = datetime.datetime.now()
 
-  performance_metric_queue = None
-  if config.report_heartbeat_metric_for_gcp_monitoring or config.report_performance_metric_for_gcp_monitoring:
-    gcp_workload_monitor = GCPWorkloadMonitor(config.run_name)
-    if config.report_heartbeat_metric_for_gcp_monitoring:
-      gcp_workload_monitor.start_heartbeat_reporting_thread(config.heartbeat_reporting_interval_in_seconds)
-    if config.report_performance_metric_for_gcp_monitoring:
-      performance_metric_queue = queue.Queue()
-      gcp_workload_monitor.start_performance_reporting_thread(performance_metric_queue)
-
-  metric_logger = MetricLogger(writer, config)
   input_data_shardings = maxtext_utils.get_input_data_sharding(config, mesh)
+
+  metric_logger = MetricLogger(config=config, learning_rate_schedule=learning_rate_schedule)
+
+  # Write train config params, num model params, and XLA flags to tensorboard
+  metric_logger.write_setup_info_to_tensorboard(state.params)
+
   for step in np.arange(start_step, config.steps):
+    step_start_time = datetime.datetime.now()
     prof.maybe_activate_profiler(step, state)
 
     with jax.profiler.StepTraceAnnotation("train", step_num=step):
@@ -853,12 +817,6 @@ def train_loop(config, recorder, state=None):
         with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
           state, metrics = p_train_step(state, example_batch, nextrng)
 
-    step_time_delta = datetime.datetime.now() - last_step_completion
-    last_step_completion = datetime.datetime.now()
-    record_scalar_metrics(metrics, step_time_delta, per_device_tflops, learning_rate_schedule(step), per_device_tokens)
-    if performance_metric_queue:
-      performance_metric_queue.put(step_time_delta.total_seconds())
-
     if checkpoint_manager is not None:
       state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]
       if save_checkpoint(checkpoint_manager, int(step), state_to_save, config.dataset_type, data_iterator, config):
@@ -868,8 +826,6 @@ def train_loop(config, recorder, state=None):
       if checkpoint_manager.reached_preemption(step):
         checkpoint_manager.wait_until_finished()
         sys.exit()
-
-    metric_logger.write_metrics(running_gcs_metrics, metrics, step)
 
     if config.dump_hlo and step == (config.dump_step if config.dump_step >= 0 else start_step):
       jax.block_until_ready(state)  # Ensure compilation has finished.
@@ -883,15 +839,6 @@ def train_loop(config, recorder, state=None):
 
     if config.eval_interval > 0 and step > start_step and (step + 1) % config.eval_interval == 0:
       assert eval_data_iterator
-      cumulative_eval_metrics = {
-          "scalar": {
-              "eval/total_loss": 0.0,
-              "eval/total_weights": 0.0,
-              "eval/avg_loss": 0.0,
-              "eval/moe_lb_loss": 0.0,
-          }
-      }
-      eval_dpo_reward_accuracy = 0.0
       eval_step_count = 0
       # pylint: disable=not-callable
       for eval_batch in eval_data_iterator:
@@ -899,27 +846,11 @@ def train_loop(config, recorder, state=None):
           break
         with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
           eval_metrics = p_eval_step(state, eval_batch, nextrng)
-        cumulative_eval_metrics["scalar"]["eval/total_loss"] += float(eval_metrics["scalar"]["evaluation/total_loss"])
-        cumulative_eval_metrics["scalar"]["eval/total_weights"] += float(eval_metrics["scalar"]["evaluation/total_weights"])
-        cumulative_eval_metrics["scalar"]["eval/moe_lb_loss"] += float(eval_metrics["scalar"]["evaluation/moe_lb_loss"])
-        eval_dpo_reward_accuracy += float(eval_metrics["scalar"].get("evaluation/dpo_reward_accuracy", 0.0))  # for dpo only
+        metric_logger.record_eval_metrics(step, metrics=eval_metrics)
         max_logging.log(f"Completed eval step {eval_step_count}")
         eval_step_count += 1
-      eval_loss = cumulative_eval_metrics["scalar"]["eval/total_loss"] / (
-          cumulative_eval_metrics["scalar"]["eval/total_weights"] + EPS
-      )
-      cumulative_eval_metrics["scalar"]["eval/avg_loss"] = eval_loss
-      cumulative_eval_metrics["scalar"]["eval/avg_moe_lb_loss"] = (
-          cumulative_eval_metrics["scalar"]["eval/moe_lb_loss"] / eval_step_count
-      )
-      if config.use_dpo:
-        cumulative_eval_metrics["scalar"]["eval/dpo_reward_accuracy"] = eval_dpo_reward_accuracy / eval_step_count
-      metric_logger.write_metrics(running_gcs_metrics, cumulative_eval_metrics, step, is_training=False)
-      max_logging.log(
-          f"average loss after {step=}: {eval_step_count=}, {eval_loss=},"
-          f" total_weights={cumulative_eval_metrics['scalar']['eval/total_weights']}"
-      )
-      if eval_loss <= config.target_eval_loss:
+      metric_logger.record_eval_metrics(step, eval_step_count=eval_step_count)
+      if metric_logger.cumulative_eval_metrics["scalar"]["eval/avg_loss"] <= config.target_eval_loss:
         max_logging.log(f"Early stop and exit loop after reaching {config.target_eval_loss=}")
         prof.deactivate()
         break
@@ -928,6 +859,11 @@ def train_loop(config, recorder, state=None):
 
     if step == start_step:
       max_utils.print_mem_stats("After params initialized")
+
+    jax.block_until_ready(state)  # ensure training step is completed
+
+    step_time_delta = datetime.datetime.now() - step_start_time
+    metric_logger.record_train_metrics(metrics, step, step_time_delta)
 
   if checkpoint_manager is not None:
     if ((int(state.step) - 1) % config.checkpoint_period != 0) and (int(state.step) != 0):
@@ -947,8 +883,7 @@ def train_loop(config, recorder, state=None):
         max_logging.log(f"Checkpoint is already saved for step {int(state.step)-1}.")
 
     checkpoint_manager.wait_until_finished()
-  metric_logger.write_metrics(running_gcs_metrics, metrics, config.steps - 1)  # final step metrics
-  max_utils.close_summary_writer(writer)
+  metric_logger.cleanup()
 
   if example_batch:
     with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):


### PR DESCRIPTION
# Description

* This PR removes `writer` from the list of values returned by `setup_mesh_and_model`. This simiplifies `setup_mesh_and_model` as it is unnecessary to create a TensorBoard summary writer object in that method. 
* This PR also refactors the metrics related code in all trainers (train.py, sft_trainer.py, grpo_trainer.py, elastic_train.py).
* This PR also fixes the calculation for metric `perf/step_time_seconds` for training. Currently, this metric for step `x` includes the time taken for checkpointing + HLO dump + eval + profiling by step `x-1`. This PR fixes this by ensuring that time taken by checkpointing + HLO dump + eval + profiling by step `x` is added to metric `perf/step_time_seconds` for step `x` only. Depends on profiling fixes [#1833](https://github.com/AI-Hypercomputer/maxtext/pull/1833).

Thanks to @richjames0 for contributing!

# Tests
E2E testing with train.py and sft_trainer.py - verified the metrics are correctly uploaded to TensorBoard

### Logs for refactored code with metric fix:
```
steps=10 profiler=xplane checkpoint_period=7

# training + checkpointing
completed step: 0, seconds: 27.544, TFLOP/s/device: 1.534, Tokens/s/device: 37.177, total_weights: 3573, loss: 0.993

# training + profiling activated
completed step: 1, seconds: 1.105, TFLOP/s/device: 38.242, Tokens/s/device: 927.006, total_weights: 3253, loss: 0.993

# training
completed step: 2, seconds: 0.996, TFLOP/s/device: 42.403, Tokens/s/device: 1027.874, total_weights: 1692, loss: 0.912
completed step: 3, seconds: 0.996, TFLOP/s/device: 42.426, Tokens/s/device: 1028.421, total_weights: 2944, loss: 1.105
completed step: 4, seconds: 0.994, TFLOP/s/device: 42.517, Tokens/s/device: 1030.628, total_weights: 3466, loss: 0.948

# training + profiling deactivated
completed step: 5, seconds: 16.416, TFLOP/s/device: 2.573, Tokens/s/device: 62.376, total_weights: 2420, loss: 0.947

# training
completed step: 6, seconds: 0.982, TFLOP/s/device: 43.037, Tokens/s/device: 1043.238, total_weights: 1655, loss: 1.059

# training + checkpointing
completed step: 7, seconds: 35.911, TFLOP/s/device: 1.176, Tokens/s/device: 28.515, total_weights: 3335, loss: 1.000

# training
completed step: 8, seconds: 0.981, TFLOP/s/device: 43.063, Tokens/s/device: 1043.866, total_weights: 1676, loss: 0.851
completed step: 9, seconds: 0.986, TFLOP/s/device: 42.833, Tokens/s/device: 1038.301, total_weights: 1676, loss: 0.965
```

### Logs for current codebase:
```
steps=10 profiler=xplane checkpoint_period=7

# training
completed step: 0, seconds: 18.461, TFLOP/s/device: 2.288, Tokens/s/device: 55.468, total_weights: 3573, loss: 0.993

# training + checkpointing at step=0 + profiling activated at step=1
completed step: 1, seconds: 9.213, TFLOP/s/device: 4.585, Tokens/s/device: 111.152, total_weights: 3253, loss: 0.993

# training
completed step: 2, seconds: 0.155, TFLOP/s/device: 271.907, Tokens/s/device: 6591.186, total_weights: 1692, loss: 0.912
completed step: 3, seconds: 0.844, TFLOP/s/device: 50.029, Tokens/s/device: 1212.730, total_weights: 2944, loss: 1.105
completed step: 4, seconds: 0.969, TFLOP/s/device: 43.616, Tokens/s/device: 1057.288, total_weights: 3466, loss: 0.948
completed step: 5, seconds: 0.970, TFLOP/s/device: 43.543, Tokens/s/device: 1055.509, total_weights: 2420, loss: 0.947

# training + profiling deactivated at step=5
completed step: 6, seconds: 16.443, TFLOP/s/device: 2.569, Tokens/s/device: 62.277, total_weights: 1655, loss: 1.059

# training
completed step: 7, seconds: 0.015, TFLOP/s/device: 2803.873, Tokens/s/device: 67967.609, total_weights: 3335, loss: 1.000

# training + checkpointing at step=7
completed step: 8, seconds: 34.001, TFLOP/s/device: 1.242, Tokens/s/device: 30.117, total_weights: 1676, loss: 0.851

# training
completed step: 9, seconds: 0.013, TFLOP/s/device: 3224.914, Tokens/s/device: 78173.906, total_weights: 1676, loss: 0.965

```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
