### PR TITLE
fix runtime errors in colocated python dataloader

### DIFF
--- a/MaxText/input_pipeline/_tfds_data_processing.py
+++ b/MaxText/input_pipeline/_tfds_data_processing.py
@@ -48,9 +48,10 @@ def get_datasets(
     shuffle_seed,
     dataloading_host_index,
     dataloading_host_count,
+    dataset_path=None,
 ):
   """Load a TFDS dataset."""
-  ds_builder = tfds.builder(dataset_name)
+  ds_builder = tfds.builder(dataset_name, data_dir=dataset_path)
 
   if shuffle_files:
     read_config = tfds.ReadConfig(shuffle_seed=shuffle_seed)
@@ -227,8 +228,8 @@ def make_tfds_train_iterator(
         use_dpo=config.use_dpo,
         hf_access_token=config.hf_access_token,
     )
-    return multihost_dataloading.RemoteIterator(get_ds_fn, preprocessing_fn, config, global_mesh)
-
+    global_shape = (config.global_batch_size_to_load, config.max_target_length)
+    return multihost_dataloading.RemoteIterator(get_ds_fn, preprocessing_fn, global_mesh, global_shape)
 
 def make_tfds_eval_iterator(
     config: ml_collections.ConfigDict,

--- a/MaxText/multihost_dataloading.py
+++ b/MaxText/multihost_dataloading.py
@@ -200,7 +200,7 @@ class RemoteIterator:
 
     out = jax.device_get(init(self.dummy_array))
     if out is not None:
-      max_logging.log("RemoteIterator initiated.")
+      max_logging.log(f"RemoteIterator initiated. Test output: {out}")
 
   def __iter__(self):
     return self
@@ -210,9 +210,10 @@ class RemoteIterator:
 
     def put_to_tpu_devices(path, array, sharding):
       try:
-        jax.device_put(array, sharding)
+        return jax.device_put(array, sharding)
       except Exception as e:  # pylint: disable=broad-exception-caught
         max_logging.log(f"Error putting data to TPU device path{path}, exception={e}")
+        raise
 
     input_gdas = jtu.tree_map_with_path(partial(put_to_tpu_devices, sharding=self.tpu_sharding), out)
 


### PR DESCRIPTION
### Title

Fix: Resolve runtime errors in colocated TFDS dataloader

### Description
fixes:

*   **`_tfds_data_processing.py`**:
    *   The `tfds.builder` now correctly uses the `dataset_path` variable, which is needed for tfds.
    *   The constructor for `RemoteIterator` has been updated to pass `global_shape` as argument, fixing an interface mismatch.

*   **`multihost_dataloading.py`**:
    *   The `put_to_tpu_devices` function now correctly returns the array after it has been placed on the TPU device. Otherwise the iterator would have empty data.
    *   Initialization logging for `RemoteIterator` is now more informative, including a test output to aid in debugging and validation.

### Tests

This patch was used in the last round of scale tests, validated up to 4 slice scale.

### Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.