### PR TITLE
Enable Gemma3 MaxText-to-Huggingface Conversion

### DIFF
--- a/MaxText/tests/hf_checkpoint_conversion_check.py
+++ b/MaxText/tests/hf_checkpoint_conversion_check.py
@@ -13,17 +13,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
-from typing import Sequence
-import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM
 import os
-from absl import app  # Removed flags
+import torch
+import torch.nn.functional as F
+import argparse
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from tabulate import tabulate
 
 from MaxText.utils.ckpt_conversion.utils.hf_utils import (
-    check_predicted_tokens_match,
+    # check_predicted_tokens_match,
     check_arrays_match,
 )
+from MaxText import max_logging
 # Read Hugging Face token from environment variable
 hf_token = os.environ.get("HF_AUTH_TOKEN")
 
@@ -40,6 +41,7 @@ Extra Requirements:
     huggingface_hub
     transformers
     accelerate
+    tabulate
 """
 
 
@@ -70,46 +72,180 @@ def get_logits(inputs, model, golden_model):
   return logits, golden_logits
 
 
-def main(argv: Sequence[str]) -> None:
-  # Parse arguments from argv
-  # Default values
-  parsed_args = {"golden_model_id": "google/gemma-2-2b-it", "hf_checkpoint_path": os.path.expanduser("~/.hf_output/")}
-  for arg in argv[1:]:
-    if "=" in arg:
-      key, value = arg.split("=", 1)
-      if key in parsed_args:
-        parsed_args[key] = value
-      else:
-        print(f"Warning: Unknown argument '{key}' found in argv. Ignoring.")
+def get_top_k_tokens_scores(logits_tensor, tokenizer_instance, k=10, description=""):
+  """Get the top-k tokens and their scores from a given logits tensor."""
+  max_logging.log(f"\n--- {description} top {k} tokens ---")
+  collected_tokens = []
+  tokens = []
+  # Ensure logits_tensor is on CPU for operations like topk and item()
+  logits_tensor = logits_tensor.cpu()
+  topk_results = torch.topk(logits_tensor[0, -1], k=k)
+  for i in range(k):
+    tok_id = topk_results.indices[i].item()
+    score = topk_results.values[i].item()
+    tok = tokenizer_instance.decode(tok_id)
+    collected_tokens.append({"id": int(tok_id), "token": tok.strip(), "score": float(score)})
+    tokens.append({"id": int(tok_id), "token": tok.strip(), "score": float(score)})
 
-  golden_model = AutoModelForCausalLM.from_pretrained(parsed_args["golden_model_id"], torch_dtype=torch.float32)
+  # Prepare data for tabulate: a list of lists
+  table_data = [[d["id"], d["token"], d["score"]] for d in collected_tokens]
+  max_logging.log(tabulate(table_data, headers=["Token ID", "Token", "Score"], tablefmt="orgtbl"))
+  return tokens
 
-  tokenizer = AutoTokenizer.from_pretrained(parsed_args["hf_checkpoint_path"])
-  model = AutoModelForCausalLM.from_pretrained(parsed_args["hf_checkpoint_path"], torch_dtype=torch.float32)
 
-  # TODO: (@yixuannwang) use 3 prompts to verify
-  input_text = "I love to"
-  inputs = tokenizer(input_text, return_tensors="pt")
-  # --- Generate Output ---
-  with torch.no_grad():
-    outputs = model.generate(**inputs, max_new_tokens=8)
-  # --- Decode and Print ---
-  print(tokenizer.decode(outputs[0], skip_special_tokens=True))
+def compare_top_tokens(converted_tokens, golden_tokens):
+  """
+  Compares two lists of top tokens and calculates similarity metrics.
 
-  # Check weights match
-  print("########### check weights match ############### ")
+  Args:
+      converted_tokens: top tokens from the converted model.
+      golden_tokens:  top tokens from the golden model.
+  """
+  # Extract the sets of token IDs for comparison
+  converted_ids = {token["id"] for token in converted_tokens}
+  golden_ids = {token["id"] for token in golden_tokens}
+
+  # --- Metric 1: Overlap Count & Jaccard Similarity ---
+  intersection = converted_ids.intersection(golden_ids)
+  union = converted_ids.union(golden_ids)
+
+  overlap_count = len(intersection)
+  jaccard_similarity = overlap_count / len(union) if union else 0.0
+
+  # --- Metric 2: Rank Agreement ---
+  rank_matches = 0
+  min_len = min(len(converted_tokens), len(golden_tokens))
+  for i in range(min_len):
+    if converted_tokens[i]["id"] == golden_tokens[i]["id"]:
+      rank_matches += 1
+
+  rank_agreement = (rank_matches / min_len) * 100 if min_len > 0 else 0.0
+
+  metrics = {
+      "overlap_count": f"{overlap_count}/{min_len}",
+      "jaccard_similarity": jaccard_similarity,
+      "rank_agreement_percentage": rank_agreement,
+  }
+
+  max_logging.log("\n--- Similarity Metrics of Top Tokens ---")
+  table = [[key, value] for key, value in metrics.items()]
+  max_logging.log(tabulate(table, headers=["Metric", "Value"], tablefmt="orgtbl"))
+
+
+def check_kl_divergence(model_logits, golden_logits, atol=0.02):
+  """
+  Calculates KL divergence D_KL(P_golden || Q_model) over a batch of sequences.
+
+  Args:
+      model_logits: Logits from the converted model (Batch, SeqLen, VocabSize).
+      golden_logits: Logits from the golden model (Batch, SeqLen, VocabSize).
+      token_size: The number of vocabulary entries to consider for the comparison.
+                  (Effectively vocab_size_to_compare).
+  """
+  # 1. Select the relevant vocabulary slice from the logits.
+  token_size = min(model_logits.shape[2], golden_logits.shape[2])
+  model_logits_sliced = model_logits[..., :token_size]
+  golden_logits_sliced = golden_logits[..., :token_size]
+
+  # 2. Reshape
+  b, s, v = model_logits_sliced.shape
+  model_logits_reshaped = model_logits_sliced.view(b * s, v)
+  golden_logits_reshaped = golden_logits_sliced.view(b * s, v)
+
+  # 3. Get the probability distributions.
+  golden_probabilities = F.softmax(golden_logits_reshaped, dim=-1)
+  model_log_probabilities = F.log_softmax(model_logits_reshaped, dim=-1)
+
+  # 4. Calculate avg KL divergence for all token distributions.
+  # use 'batchmean'; the sum of the KL divergences for each token in the batch
+  # and then divides by the number of tokens (b * s)
+  kl_div_value = F.kl_div(
+      input=model_log_probabilities,
+      target=golden_probabilities,
+      reduction="batchmean",  # Use 'batchmean' for the average KL per token.
+      log_target=False,
+  )
+
+  max_logging.log(f"\nAverage KL divergence per token (D_KL(P_golden || Q_model)): {kl_div_value.item():.6f}")
+
+  # To find the max KL divergence for any single token in the set
+  # use reduction='none'.
+  kl_divs_per_token = F.kl_div(
+      input=model_log_probabilities, target=golden_probabilities, reduction="none", log_target=False
+  ).sum(
+      dim=-1
+  )  # Sum over the vocab dim to get a single KL value per token
+
+  max_kl_div = kl_divs_per_token.max()
+  max_logging.log(f"\nMax KL divergence for a single token in the set: {max_kl_div.item():.6f}")
+
+  assert max_kl_div < atol, f"KL divergence values {max_kl_div.item():.6f} exceed the threshold {atol}"
+
+
+def run_prompts(args: argparse.Namespace) -> None:
+  """
+  Args:
+      - golden_model_id (str): HF model ID for the golden model.
+      - hf_checkpoint_path (str): Path to the converted HF checkpoint.
+      - max_kl_div (float): Maximum allowed KL divergence.
+  """
+  golden_model = AutoModelForCausalLM.from_pretrained(args.golden_model_id, torch_dtype=torch.bfloat16)
+  golden_tokenizer = AutoTokenizer.from_pretrained(args.golden_model_id)
+
+  tokenizer = AutoTokenizer.from_pretrained(args.hf_checkpoint_path)
+  model, _ = AutoModelForCausalLM.from_pretrained(
+      args.hf_checkpoint_path, trust_remote_code=True, torch_dtype=torch.bfloat16, output_loading_info=True
+  )
+
+  # max_logging.log(loading_info)
+
+  prompts = ["I love to", "Today is a", "What is the"]
+  for input_text in prompts:
+    max_logging.log(f"\n--- Prompt: {input_text} ---")
+    inputs = tokenizer(input_text, return_tensors="pt")
+    # --- Generate Output ---
+    with torch.no_grad():
+      outputs = model.generate(**inputs, max_new_tokens=15, do_sample=False)
+    # --- Decode and Print ---
+    max_logging.log(f"Output: {tokenizer.decode(outputs[0], skip_special_tokens=True)}")
+
+    # --- Compare tokens ---
+    model_logits, golden_model_logits = get_logits(inputs, model, golden_model)
+    tokens = get_top_k_tokens_scores(model_logits, tokenizer, k=10, description="converted model")
+    golden_tokens = get_top_k_tokens_scores(golden_model_logits, golden_tokenizer, k=10, description="golden model")
+    compare_top_tokens(converted_tokens=tokens, golden_tokens=golden_tokens)
+
+    check_kl_divergence(model_logits, golden_model_logits, atol=args.max_kl_div)
+
+  """
+  if the model's structure is exactly the same as the golden model (layers, vocab_size, etc.), 
+  you can check more weights details using the following steps:
+
   check_weights_match(model, golden_model)
 
-  # Run forward pass to get logits
-  logits, golden_logits = get_logits(inputs, model, golden_model)
-
   # Check logits from the first 5 tokens match
-  print("########### check logits match ############### ")
-  check_arrays_match(logits[0, :5, :], golden_logits[0, :5, :], atol=0.2)
+  check_arrays_match(model_logits[0, :5, :], golden_model_logits[0, :5, :], atol=0.2)
 
-  print("########### check predicted token match ############### ")
-  check_predicted_tokens_match(logits, golden_logits)
+  check_predicted_tokens_match(model_logits, golden_model_logits)
+  """
 
 
 if __name__ == "__main__":
-  app.run(main)
+  parser = argparse.ArgumentParser(description="Verify HuggingFace checkpoints converted from MaxText.")
+  parser.add_argument(
+      "--golden_model_id",
+      type=str,
+      default="google/gemma-2-2b-it",
+      help="The HuggingFace model ID for the golden/reference model.",
+  )
+  parser.add_argument(
+      "--hf_checkpoint_path",
+      type=str,
+      default=os.path.expanduser("~/.hf_output/"),
+      help="Path to the converted HuggingFace checkpoint directory.",
+  )
+  parser.add_argument("--max_kl_div", type=float, default=0.02, help="Maximum allowed KL divergence between model logits.")
+
+  parsed_args = parser.parse_args()
+
+  run_prompts(parsed_args)

--- a/MaxText/utils/ckpt_conversion/examples/convert_gemma3_to_hf.sh
+++ b/MaxText/utils/ckpt_conversion/examples/convert_gemma3_to_hf.sh
@@ -7,33 +7,34 @@ export HF_AUTH_TOKEN=""
 
 DATE=$(date +%Y-%m-%d)
 # Define variables for paths and arguments
-HF_CHECKPOINT_GCS_PATH="gs://maxtext-model-checkpoints/HuggingFace/gemma2-2b/${DATE}" # (optional)GCS path for HF model
-MAXTEXT_CHECKPOINT_DIR="gs://maxtext-model-checkpoints/gemma2-2b-it/2025-02-20-18-01/unscanned/checkpoints/0/items"
-LOCAL_HF_CHECKPOINT_DIR="/tmp/hf_gemma2-2b_output" # HF requires a local dir
-GOLDEN_MODEL_ID="google/gemma-2-2b-it"
+HF_CHECKPOINT_GCS_PATH="gs://maxtext-model-checkpoints/HuggingFace/gemma3-4b/${DATE}" # (optional)GCS path for HF model
+MAXTEXT_CHECKPOINT_DIR="gs://maxtext-model-checkpoints/gemma3-4b/2025-03-18-19-03/unscanned/checkpoints/0/items"
+LOCAL_HF_CHECKPOINT_DIR="/tmp/hf_gemma3-4b_output" # HF requires a local dir
+GOLDEN_MODEL_ID="google/gemma-3-4b-it"
 
 CONVERT_MODULE="MaxText.utils.ckpt_conversion.to_huggingface"
 CONVERT_ARGS=(
-    "MaxText/configs/base.yml"
-    "model_name=gemma2-2b"
-    "tokenizer_path=assets/tokenizer.gemma"
-    "load_parameters_path=${MAXTEXT_CHECKPOINT_DIR}"
-    "per_device_batch_size=1"
-    "max_prefill_predict_length=8"
-    "max_target_length=16"
-    "steps=1"
-    "async_checkpointing=false"
-    "scan_layers=false"
-    "prompt='I love to'"
-    "attention='dot_product'"
+    "MaxText/configs/base.yml",
+    "model_name=gemma3-4b",
+    "tokenizer_path=assets/tokenizer.gemma3",
+    "load_parameters_path=${MAXTEXT_CHECKPOINT_DIR}",
+    "per_device_batch_size=1",
+    "run_name=ht_test",
+    "max_prefill_predict_length=8",
+    "max_target_length=16",
+    "steps=1",
+    "async_checkpointing=false",
+    "prompt='I love to'",
+    "scan_layers=false",
+    "attention='dot_product'",
     "base_output_directory=${HF_CHECKPOINT_GCS_PATH}"
 )
 
 VERIFY_MODULE="MaxText.tests.hf_ckpt_conversion_check"
 
 VERIFY_ARGS=(
-    "golden_model_id=${GOLDEN_MODEL_ID}"
-    "hf_checkpoint_path=${LOCAL_HF_CHECKPOINT_DIR}" # Updated to local path
+    "--golden_model_id=${GOLDEN_MODEL_ID}"
+    "--hf_checkpoint_path=${LOCAL_HF_CHECKPOINT_DIR}" # Updated to local path
 )
 
 

--- a/MaxText/utils/ckpt_conversion/to_huggingface.py
+++ b/MaxText/utils/ckpt_conversion/to_huggingface.py
@@ -34,7 +34,7 @@ from MaxText.utils.ckpt_conversion.utils.param_mapping import (
 )
 from MaxText.utils.ckpt_conversion.utils.shape_mapping import SHAPE_MAPPING
 from MaxText.utils.ckpt_conversion.utils.hf_model_configs import HF_MODEL_CONFIGS
-from MaxText.utils.ckpt_conversion.utils.utils import (process_leaf_param, save_model_files, TOKENIZER_HF_IDS)
+from MaxText.utils.ckpt_conversion.utils.utils import (process_leaf_param, save_model_files, HF_IDS)
 
 """Convert MaxText unscanned ckpt into HF format"""
 
@@ -83,9 +83,9 @@ def main(argv: Sequence[str]) -> None:
   hf_config_obj = HF_MODEL_CONFIGS[model_key]
 
   # 2. Load Tokenizer
-  if model_key not in TOKENIZER_HF_IDS:
+  if model_key not in HF_IDS:
     raise ValueError(f"HF Tokenizer ID not found for model key: {model_key}")
-  hf_tokenizer_id = TOKENIZER_HF_IDS[model_key]
+  hf_tokenizer_id = HF_IDS[model_key]
   tokenizer = AutoTokenizer.from_pretrained(hf_tokenizer_id, token=hf_token)
 
   # 3. Get parameter mappings

--- a/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -22,6 +22,59 @@ This config defines the architectural configurations of the Hugging Face version
 import transformers
 
 
+gemma3text_4b_config = transformers.Gemma3TextConfig(
+    vocab_size=262144,
+    hidden_size=2560,
+    intermediate_size=10240,
+    num_hidden_layers=34,
+    num_attention_heads=8,
+    num_key_value_heads=4,
+    head_dim=256,
+    hidden_activation="gelu",
+    max_position_embeddings=163840,
+    rms_norm_eps=1e-06,
+    rope_theta=10000,
+    sliding_window=1024,
+    tie_word_embeddings=True,
+    torch_dtype="bfloat16",
+)
+
+gemma3text_12b_config = transformers.Gemma3TextConfig(
+    vocab_size=262144,
+    hidden_size=3840,
+    intermediate_size=15360,
+    num_attention_heads=16,
+    num_hidden_layers=48,
+    num_key_value_heads=8,
+    head_dim=256,
+    hidden_activation="gelu",
+    max_position_embeddings=163840,
+    rms_norm_eps=1e-06,
+    rope_theta=10000,
+    sliding_window=1024,
+    tie_word_embeddings=True,
+    torch_dtype="bfloat16",
+)
+
+gemma3text_27b_config = transformers.Gemma3TextConfig(
+    vocab_size=262144,
+    hidden_size=5376,
+    intermediate_size=21504,
+    num_attention_heads=32,
+    num_hidden_layers=62,
+    num_key_value_heads=16,
+    head_dim=128,
+    hidden_activation="gelu",
+    max_position_embeddings=163840,
+    rms_norm_eps=1e-06,
+    rope_theta=10000,
+    sliding_window=1024,
+    tie_word_embeddings=True,
+    torch_dtype="bfloat16",
+    query_pre_attn_scalar=168,
+)
+
+
 gemma2_2b_config = transformers.Gemma2Config(
     num_hidden_layers=26,
     num_attention_heads=8,
@@ -58,7 +111,10 @@ gemma2_27b_config = transformers.Gemma2Config(
 
 
 HF_MODEL_CONFIGS = {
-    "GEMMA2_2B": gemma2_2b_config,
-    "GEMMA2_9B": gemma2_9b_config,
-    "GEMMA2_27B": gemma2_27b_config,
+    "gemma2-2b": gemma2_2b_config,
+    "gemma2-9b": gemma2_9b_config,
+    "gemma2-27b": gemma2_27b_config,
+    "gemma3-4b": gemma3text_4b_config,
+    "gemma3-12b": gemma3text_12b_config,
+    "gemma3-27b": gemma3text_27b_config,
 }

--- a/MaxText/utils/ckpt_conversion/utils/shape_mapping.py
+++ b/MaxText/utils/ckpt_conversion/utils/shape_mapping.py
@@ -70,8 +70,60 @@ def GEMMA2_HF_WEIGHTS_TO_SHAPE_MAPPING(config):
   return mapping
 
 
+def GEMMA3TEXT_HF_WEIGHTS_TO_SHAPE_MAPPING(config):
+  """Returns mapping between HuggingFace Gemma3Text weights path and weights shape.
+
+  Args:
+      config (dict): Model configuration dictionary (from HF Gemma3TextConfig.to_dict())
+
+  Returns:
+      dict: A mapping where:
+          - Keys are HuggingFace model parameter paths
+          - Values are parameter shape as a List
+  """
+  head_dim = config["head_dim"]
+
+  mapping = {
+      "model.embed_tokens.weight": [config["vocab_size"], config["hidden_size"]],
+      "model.norm.weight": [config["hidden_size"]],
+  }
+  for layer_idx in range(config["num_hidden_layers"]):
+    layer_mapping = {
+        f"model.layers.{layer_idx}.input_layernorm.weight": [config["hidden_size"]],
+        f"model.layers.{layer_idx}.self_attn.q_proj.weight": [
+            config["num_attention_heads"] * head_dim,
+            config["hidden_size"],
+        ],
+        f"model.layers.{layer_idx}.self_attn.k_proj.weight": [
+            config["num_key_value_heads"] * head_dim,
+            config["hidden_size"],
+        ],
+        f"model.layers.{layer_idx}.self_attn.v_proj.weight": [
+            config["num_key_value_heads"] * head_dim,
+            config["hidden_size"],
+        ],
+        f"model.layers.{layer_idx}.self_attn.o_proj.weight": [
+            config["hidden_size"],
+            config["num_attention_heads"] * head_dim,
+        ],
+        f"model.layers.{layer_idx}.self_attn.q_norm.weight": [head_dim],
+        f"model.layers.{layer_idx}.self_attn.k_norm.weight": [head_dim],
+        f"model.layers.{layer_idx}.post_attention_layernorm.weight": [config["hidden_size"]],
+        f"model.layers.{layer_idx}.pre_feedforward_layernorm.weight": [config["hidden_size"]],
+        f"model.layers.{layer_idx}.mlp.gate_proj.weight": [config["intermediate_size"], config["hidden_size"]],
+        f"model.layers.{layer_idx}.mlp.up_proj.weight": [config["intermediate_size"], config["hidden_size"]],
+        f"model.layers.{layer_idx}.mlp.down_proj.weight": [config["hidden_size"], config["intermediate_size"]],
+        f"model.layers.{layer_idx}.post_feedforward_layernorm.weight": [config["hidden_size"]],
+    }
+    mapping.update(layer_mapping)
+  return mapping
+
+
 SHAPE_MAPPING = {
     "gemma2-2b": GEMMA2_HF_WEIGHTS_TO_SHAPE_MAPPING,
     "gemma2-9b": GEMMA2_HF_WEIGHTS_TO_SHAPE_MAPPING,
     "gemma2-27b": GEMMA2_HF_WEIGHTS_TO_SHAPE_MAPPING,
+    "gemma3-4b": GEMMA3TEXT_HF_WEIGHTS_TO_SHAPE_MAPPING,
+    "gemma3-12b": GEMMA3TEXT_HF_WEIGHTS_TO_SHAPE_MAPPING,
+    "gemma3-27b": GEMMA3TEXT_HF_WEIGHTS_TO_SHAPE_MAPPING,
 }

--- a/MaxText/utils/ckpt_conversion/utils/utils.py
+++ b/MaxText/utils/ckpt_conversion/utils/utils.py
@@ -41,10 +41,13 @@ DEFAULT_MAX_SHARD_SIZE = 1024 * 1024 * 1024 * 3  # 3GB default
 
 
 # Mapping from MaxText model key to Hugging Face tokenizer identifiers
-TOKENIZER_HF_IDS = {
+HF_IDS = {
     "gemma2-2b": "google/gemma-2-2b",
     "gemma2-9b": "google/gemma-2-9b",
     "gemma2-27b": "google/gemma-2-27b",
+    "gemma3-4b": "google/gemma-3-4b-it",  # hf multi-modal should also support the pure-text
+    "gemma3-12b": "google/gemma-3-12b",
+    "gemma3-27b": "google/gemma-3-27b",
 }
 
 


### PR DESCRIPTION
# Description

Enable Gemma3 models checkpoint conversion; from Maxtext to HuggingFace.  

- Added param mapping, shape mapping, model config of gemma3 models
- Added top token comparisons and kl divergence check
- Added more test prompts
- Minor fix about shell script path, max_logging usage, etc.

# Tests

Due to vocab_size difference between Maxtext model and Huggingface model, we can not [compare the weights directly](https://screenshot.googleplex.com/6eNZ8qaU5Kdc3MG). Instead, we compared the top tokens and tokens kl divergence. [Example](https://screenshot.googleplex.com/87TQWbfFrWgFu9L). 
We tested the Gemma3-4b model. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
