### PR TITLE
Moving device_put for the kernel earlier to avoid a host convert op

### DIFF
--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -172,12 +172,12 @@ class DenseGeneral(nnx.Module):
       kernel_shape = self.in_features_shape + self.out_features_shape
       kernel = jnp.zeros(kernel_shape, dtype=self.dtype)
     else:
-      kernel = jnp.asarray(self.kernel[...], self.dtype)
-
-    # Move logit_dense kernel to device if parameter offloading is enabled
-    if self.parameter_memory_host_offload:
-      max_logging.log("linear.py: Moving parameter logits_dense kernel to device")
-      kernel = jax.device_put(kernel, jax._src.sharding_impls.TransferToMemoryKind("device"))
+      kernel = self.kernel
+      # Move logit_dense kernel to device if parameter offloading is enabled
+      if self.parameter_memory_host_offload:
+        max_logging.log("linear.py: Moving parameter logits_dense kernel to device")
+        kernel = jax.device_put(kernel, jax._src.sharding_impls.TransferToMemoryKind("device"))
+      kernel = jnp.asarray(kernel[...], self.dtype)
 
     contract_ind = tuple(range(0, len(self.axis)))
     output = _compute_dot_general(

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -172,12 +172,12 @@ class DenseGeneral(nnx.Module):
       kernel_shape = self.in_features_shape + self.out_features_shape
       kernel = jnp.zeros(kernel_shape, dtype=self.dtype)
     else:
-      kernel = self.kernel
+      kernel = self.kernel[...]
       # Move logit_dense kernel to device if parameter offloading is enabled
       if self.parameter_memory_host_offload:
         max_logging.log("linear.py: Moving parameter logits_dense kernel to device")
         kernel = jax.device_put(kernel, jax._src.sharding_impls.TransferToMemoryKind("device"))
-      kernel = jnp.asarray(kernel[...], self.dtype)
+      kernel = jnp.asarray(kernel, self.dtype)
 
     contract_ind = tuple(range(0, len(self.axis)))
     output = _compute_dot_general(


### PR DESCRIPTION
Fix a bug with parameter_memory_host_offload: "Found an instruction ("convert.610") which does device compute in host memory space." The issue was caused by self.kernel in linear.py being on the host and undergoing a data type conversion before being moved to the device. This commit moves device_put() earlier to resolve the issue.