### PR TITLE
Fix Cloud checkpointing Logging APIs for newer orbax versions

### DIFF
--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -45,15 +45,6 @@ PyTreeCheckpointHandler = ocp.PyTreeCheckpointHandler
 LocalCheckpointOptions = emergency_checkpoint_manager.LocalCheckpointOptions
 PersistentCheckpointOptions = emergency_checkpoint_manager.PersistentCheckpointOptions
 
-# Starting from Orbax 0.11.7, these must be refactored like commit ff1c3e8.
-# See b/401509894 for more details.
-try:
-  abstract_logger = ocp.logging.abstract_logger  # pytype: disable=module-attr
-  cloud_logger = ocp.logging.cloud_logger  # pytype: disable=module-attr
-except AttributeError:
-  abstract_logger = None  # pytype: disable=attribute-error
-  cloud_logger = None  # pytype: disable=attribute-error
-
 
 def create_orbax_checkpoint_manager(
     checkpoint_dir: str,
@@ -383,10 +374,10 @@ def setup_checkpoint_logger(config) -> Any | None:  # pytype: disable=attribute-
   max_logging.log("Setting up checkpoint logger...")
   if config.enable_checkpoint_cloud_logger:
     logger_name = f"goodput_{config.run_name}"
-    options = cloud_logger.CloudLoggerOptions(
+    options = ocp.logging.CloudLoggerOptions(
         job_name=config.run_name, logger_name=logger_name
-    )  # pytype: disable=attribute-error
-    orbax_cloud_logger = cloud_logger.CloudLogger(options=options)  # pytype: disable=attribute-error
+    )
+    orbax_cloud_logger = ocp.logging.CloudLogger(options=options)
     max_logging.log("Successfully set up checkpoint cloud logger.")
     return orbax_cloud_logger
 


### PR DESCRIPTION
Pair programmed with @abhinavclemson

# Description

Orbax upgraded the APIs for cloud checkpointing logging a while ago (orbax-checkpoint 0.11.7), this PR updates maxtext to use the new APIs

FIXES: b/401509894



# Tests

Manually ran on single host devbox with checkpoint cloud logging enabled

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
