### PR TITLE
Sharding Validator Improvement

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -874,13 +874,12 @@ class AttentionOp(nn.Module):
       decoder_segment_ids: Array | None,
       model_mode: str = MODEL_MODE_TRAIN,
   ) -> Array:
-    """CUDNN Flash Attention with JAX SDPA API.
-    """
+    """CUDNN Flash Attention with JAX SDPA API."""
     # These imports are only meant to work in a GPU build.
     # pylint: disable=import-outside-toplevel
     from jax._src.cudnn.fused_attention_stablehlo import (
-      dot_product_attention,
-      MaskType,
+        dot_product_attention,
+        MaskType,
     )
 
     _, _, _, head_dim = query.shape  # pylint: disable=unused-variable
@@ -898,7 +897,7 @@ class AttentionOp(nn.Module):
           scale=1.0,
           dropout_rate=self.dropout_rate,
           qkv_layout="BTNH",
-          return_residual=True
+          return_residual=True,
       )
     else:
       return dot_product_attention(
@@ -909,7 +908,7 @@ class AttentionOp(nn.Module):
           scale=1.0 / math.sqrt(head_dim),
           dropout_rate=self.dropout_rate,
           qkv_layout="BTNH",
-          return_residual=True
+          return_residual=True,
       )
 
   def compute_local_attention(
@@ -1124,8 +1123,9 @@ class AttentionOp(nn.Module):
     stat1 = local_stats[1].reshape((*local_stats[1].shape, 1))
     global_stat = jnp.log(jnp.exp(stat0) + jnp.exp(stat1))
     # # transpose stat to have shape [b, t, n, 1] for elemenwise multiplication
-    attn_out = local_outs[0].astype(jnp.float32) * jnp.exp(stat0 - global_stat).transpose((0, 2, 1, 3)) \
-      + local_outs[1].astype(jnp.float32) * jnp.exp(stat1 - global_stat).transpose((0, 2, 1, 3))
+    attn_out = local_outs[0].astype(jnp.float32) * jnp.exp(stat0 - global_stat).transpose((0, 2, 1, 3)) + local_outs[
+        1
+    ].astype(jnp.float32) * jnp.exp(stat1 - global_stat).transpose((0, 2, 1, 3))
     return attn_out.astype(local_stats[0].dtype)
 
   def normalize_attention(self, local_outs, local_maxes, local_sums):

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -419,9 +419,10 @@ class Decoder(nn.Module):
 
   def get_pipeline_stage_module(self, decoder_blocks):
     """get pipeline stage module"""
+
     def get_layer_to_pipeline(blocks, cfg):
       if cfg.decoder_block == DecoderBlockType.DEEPSEEK:
-        return blocks[1] # return the sparse block
+        return blocks[1]  # return the sparse block
       else:
         return blocks[0]
 
@@ -530,14 +531,9 @@ class Decoder(nn.Module):
                 model_mode,
             )
         y = self.pipeline_module(
-          y,
-          decoder_segment_ids,
-          decoder_positions,
-          deterministic,
-          model_mode,
-          partition_spec=partition_spec
+            y, decoder_segment_ids, decoder_positions, deterministic, model_mode, partition_spec=partition_spec
         )
-      else: # Not DeepSeek
+      else:  # Not DeepSeek
         y = self.pipeline_module(
             y, decoder_segment_ids, decoder_positions, deterministic, model_mode, partition_spec=partition_spec
         )

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -30,8 +30,10 @@ import numpy as np
 from jax.experimental import mesh_utils
 from jax.experimental.serialize_executable import deserialize_and_load
 from jax.sharding import PartitionSpec as P
+from pprint import pprint 
 import jax
 import jax.numpy as jnp
+import jax.tree_util as jtu
 
 import optax
 
@@ -342,26 +344,87 @@ def calculate_prefill_tflops_per_device(num_model_parameters, prefill_length, co
     )
   return total_tflops, learnable_weight_tflops, causal_attention_tflops
 
+def printParamData(params,mesh):
+  """
+  A debugging utility to print a structred overview of the mesh and model paramters.
 
-def assert_params_sufficiently_sharded(params, mesh, tolerance):
-  """Checks whether most params are sharded across sharding axis.
-
-  This function determines whether the majority of parameters  are distributed
-  across a specified sharding axes with an acceptable tolerance. It compares the
-  current distribution to a scenario where all parameters are fully sharded
-  across the 'fsdp', 'fsdp_transpose', 'sequence', and 'tensor' axes.
+  It displays the mesh's shape, axis names, and device layout. It then recursively 
+  maps over the entire 'params' PyTree to print the shape of each parameter leaf, 
+  which is useful for verifying model structure.
 
   Args:
-    params: params of the model state
-    mesh: mesh constructed from config
-    tolerance: float between 0.0 and 1.0 representing the allowed percentage of
-    non-sharded parameters.
-  Returns:
-    bool: True if the majority of parameters are sufficiently sharded
+    params: The PyTree of model parameters.
+    mesh: The JAX device mesh.
   """
+
+  print("*******************PrintParamData****************************")
+  def inspect_param(x): # Getting shape from array
+    return{"Shape":x.shape}
+  # Getting the shape of mesh that helps me to get which type of tensor have how many dimensions
+  print("Mesh Shape", mesh.shape)
+  print("Mesh Axis",mesh.axis_names)
+  print("Mesh Device",mesh.devices)
+  print("Param Info")
+  # Show the shape of all parameters and what devices has been assigned
+  pprint(jax.tree_util.tree_map(inspect_param,params))
+  print("******************************************************************")
+
+def get_mesh_axes_used_by_tensor_spec(tensor_sharding_spec, all_mesh_axis_names):
+  """
+  Parses a tensor's sharding specification to find which mesh axes it's sharded on.
+
+  This helper function takes a PartionSpec and compares it against all availble
+  mesh axes to return a set of axes that are actively used for sharding this tensor.
+  A fully replicated tensor (spec is None or contains no valid axis names)
+  will result in an empty set.
+
+  Args:
+    tensor_sharding_spec: The PartitionSpec Object (e.g., from 'param.sharding.spec').
+    all_mesh_axis_names: A list or tuple of all axis names defined in the mesh.
+  
+  Returns:
+    A set of strings, where each strong is a mesh axis name used by the tensor.
+  """
+  if tensor_sharding_spec is None:
+    return set()
+  
+  # Use a set comprehension for an efficient way to find the intersection
+  # It iterates through the spec, keeping only the names that are valid mesh axes.
+  used_axes = set(axis for axis in tensor_sharding_spec if axis is not None and axis in all_mesh_axis_names)
+  return used_axes
+
+
+def assert_params_sufficiently_sharded(params, mesh, tolerance):
+  """Checks that parameter are explicitly sharded and that the total size of any 
+    fully replicated parameters remains within a given tolerance.
+
+    This function enforces two rules:
+    1. Strict Sharding Policy: Every parameter in the PyTree MUST have an
+      explicit sharding specification ('.sharding.spec'). The fucntion will fail 
+      immediately if any parameter is a raw, unsharded array.
+    2. Replication Tolerance: It identifies parameters that are not sharded across
+      ANY of a predefined set of "target" sharding axes (e.g., 'fsdp', 'tensor').
+      It calculates the total size of these replicated parameters and asserts that
+      this size does not exceed a percentage ('tolerance') of the total model size.
+    
+    Args:
+      params: The PyTree of model state parameters.
+      mesh: The device mesh constructed from the config.
+      tolerance: A float between 0.0 to 1.0. Represents the allowed percentage of the model (by size)
+      that can be replicated. 
+  """
+  # Call the debug printer to display parameter info when this function runs.
+  printParamData(params,mesh)
+
+  # Calculate the total number of parameters in the model.
   total_num_params = max_utils.calculate_num_params_from_pytree(params)
-  product_num_devices_for_weight_sharding = 1
-  for axis in [
+  if total_num_params == 0:
+    return # nothing to check
+  
+  # product_num_devices_for_weight_sharding = 1
+
+  # Define the list of ideal mesh axes that weights are expected to be sharded on.
+  target_sharding_axes_config = [
       "fsdp",
       "fsdp_transpose",
       "sequence",
@@ -372,20 +435,103 @@ def assert_params_sufficiently_sharded(params, mesh, tolerance):
       "tensor_sequence",
       "stage",
       "expert",
-  ]:
-    product_num_devices_for_weight_sharding *= mesh.shape[axis]
-  total_num_params_per_chip = max_utils.calculate_total_params_per_chip(params)
-  perfectly_sharded_params_per_chip = total_num_params / product_num_devices_for_weight_sharding
-  assert total_num_params_per_chip >= perfectly_sharded_params_per_chip, (
-      "Number of parameters per chip must not be less than in the ideal sharded "
-      "scenario across `fsdp`, `fsdp_transpose`, `context`, `sequence`, `tensor`, `tensor_transpose`, "
-      "`tensor_sequence`, `stage`, `expert` axes."
-  )
-  unsharded_param_perc = total_num_params_per_chip / perfectly_sharded_params_per_chip - 1
-  assert unsharded_param_perc < tolerance, (
-      f"Number of unsharded parameters exceeds tolerance {tolerance * 100}% "
-      f"of total parameters with a value of {unsharded_param_perc * 100}%."
-  )
+  ]
+
+  # Filter the ideal list to get axes that are actually present in the current
+  # mesh and have a dimension > 1, meaning they can actually be used for sharding.
+  valid_target_mesh_axes = {
+    axis for axis in target_sharding_axes_config
+    if axis in mesh.axis_names and mesh.shape[axis] > 1
+    }
+  
+  # If none of the target axes are available for sharding in this mesh, we cannot 
+  # perform the check.
+  if not valid_target_mesh_axes:
+    return 
+  
+  # Initialize counters and lists to track replicated parameters.
+  unsharded_params_total_size = 0
+  problematic_tensors_details = []
+
+  # Iterate through every parameter (leaf) in the Pytree along with its path (name).
+  all_params_leaves = jtu.tree_leaves_with_path(params)
+  for path,p_leaf in all_params_leaves:
+    param_name_str = jtu.keystr(path)
+
+    # CRITICAL CHECK: Assert that the parameter has explicit sharding information.
+    # This fails immediately if a parameter is missing its '.sharding.spec' attribute.
+    has_sharding_spec = hasattr(p_leaf, 'sharding') and hasattr(p_leaf.sharding, 'spec')
+    assert has_sharding_spec, (
+      f"Parameter '{param_name_str}' is missing sharding information."
+      "All parameters must have an explicit '.sharding.spec' attribute."
+    )
+
+    # Get the parameter's sharding spec and find out which mesh axis it actually uses.
+    current_sharding_spec = p_leaf.sharding.spec
+    mesh_axes_used = get_mesh_axes_used_by_tensor_spec(current_sharding_spec, mesh.axis_names)
+
+    # Check if the parameter is sharded on AT LEAST ONE of the valid target axes.
+    is_sharded_on_any_target_axis = any(axis in mesh_axes_used for axis in valid_target_mesh_axes)
+
+    # If a parameter is not sharded on any of the target axes, it's considered 
+    # "unsharded" or "replicated" for the purpose of this check.
+    if not is_sharded_on_any_target_axis:
+      # Add its size to the running total of unsharded parameter memory.
+      unsharded_params_total_size += p_leaf.size
+      # Record its details for the potential error message.
+      problematic_tensors_details.append({
+        'name': param_name_str,
+        'size': p_leaf.size,
+        'spec': str(current_sharding_spec),
+        'available_axes': sorted(list(valid_target_mesh_axes))
+      })
+  
+  # Calculate the percentage of the model that is considered "unsharded".
+  unsharded_param_perc = unsharded_params_total_size / total_num_params if total_num_params > 0 else 0.0
+
+  # If the percentage of unsharded parameters exceeds the allowed tolerance
+  if unsharded_param_perc > tolerance:
+    # Sort the problematic tensors by size to show the largest offenders first.
+    problematic_tensors_details.sort(key=lambda x: x['size'], reverse=True)
+    # (Error message)
+    error_msg_lines = [
+      f"Unsharded parameter percentage ({unsharded_param_perc:.2%})"
+      f"exceeds tolerance ({tolerance:.2%})."
+    ]
+    error_msg_lines.append(
+      "The following large tensors are unsharded but could be sharded on at least one of the axes:"
+    )
+    # List the top 5 largest replicated tensors.
+    for detail in problematic_tensors_details[:5]:
+      error_msg_lines.append(
+        f" - Name: {detail['name']} (Size: {detail['size']}, Spec: {detail['spec']})"
+        f" could be sharded on: {detail['available_axes']}"
+      )
+    
+    # Raise an assertion error with the formated message.
+    raise AssertionError("\n".join(error_msg_lines))
+  
+  # product_num_devices_for_weight_sharding *= mesh.shape[axis]
+  # total_num_params_per_chip = max_utils.calculate_total_params_per_chip(params)
+  # perfectly_sharded_params_per_chip = total_num_params / product_num_devices_for_weight_sharding
+  
+  # # Add Breakpoint here to debug the case when the program fails.
+  # if total_num_params_per_chip<perfectly_sharded_params_per_chip:
+  #   breakpoint()
+  
+  # assert total_num_params_per_chip >= perfectly_sharded_params_per_chip, (
+  #     "Number of parameters per chip must not be less than in the ideal sharded "
+  #     "scenario across `fsdp`, `fsdp_transpose`, `context`, `sequence`, `tensor`, `tensor_transpose`, "
+  #     "`tensor_sequence`, `stage`, `expert` axes."
+  # )
+  # unsharded_param_perc = total_num_params_per_chip / perfectly_sharded_params_per_chip - 1
+  # # Add Breakpoint here to debug the case when the program fails
+  # if unsharded_param_perc>=tolerance:
+  #   breakpoint()
+  # assert unsharded_param_perc < tolerance, (
+  #     f"Number of unsharded parameters exceeds tolerance {tolerance * 100}% "
+  #     f"of total parameters with a value of {unsharded_param_perc * 100}%."
+  # )
 
 
 def apply_gradient_clipping(raw_grads, state, clipping_threshold):

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -460,7 +460,7 @@ def _analyze_sharding(params, mesh, valid_target_mesh_axes):
           {
               "name": param_name_str,  # Tensor name
               "size": p_leaf.size,  # tensor size
-              "shape": p_leaf.shape, # tensor shape
+              "shape": p_leaf.shape,  # tensor shape
               "spec": str(current_sharding_spec),  # Tensor sharding spec as string
               "available_axes": sorted(list(valid_target_mesh_axes)),  # Axes that could be used for sharding
               "unsharded_axes": sorted(list(unsharded_axes)),  # Unsharded axes
@@ -490,9 +490,9 @@ def _raise_if_unsharded_exceeds_tolerance(unsharded_size, total_size, tolerance,
   """
   if total_size <= 0:
     raise ValueError("Total size must be greater than zero.")
-  
+
   # Calculate the percentage of unsharded parameters.
-  unsharded_param_perc = unsharded_size / total_size 
+  unsharded_param_perc = unsharded_size / total_size
 
   # If the percentage is over the tolerance, prepare and raise an error.
   if unsharded_param_perc > tolerance:

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -829,17 +829,17 @@ def set_and_validate_pipeline_config(raw_keys):
     raw_keys = pipeline_first_axis(raw_keys)
     num_stages = int(raw_keys["ici_pipeline_parallelism"] * raw_keys["dcn_pipeline_parallelism"])
     if raw_keys["pipeline_parallel_layers"] == -1:
-      if raw_keys["decoder_block"]=="deepseek":
+      if raw_keys["decoder_block"] == "deepseek":
         moe_layers = raw_keys["num_decoder_layers"] - raw_keys["first_num_dense_layers"]
         raw_keys["pipeline_parallel_layers"] = moe_layers
       else:
         raw_keys["pipeline_parallel_layers"] = raw_keys["num_decoder_layers"]
     else:
-      if raw_keys["decoder_block"]=="deepseek":
+      if raw_keys["decoder_block"] == "deepseek":
         moe_layers = raw_keys["num_decoder_layers"] - raw_keys["first_num_dense_layers"]
         assert (
-          raw_keys["pipeline_parallel_layers"] <= moe_layers
-      ), f"You can only pipeline a subset of the moe decoder layers for deepseek, but you requested to pipeline {raw_keys['pipeline_parallel_layers']} with pipeline_parallel_layers and there are only {moe_layers} decoder layers."
+            raw_keys["pipeline_parallel_layers"] <= moe_layers
+        ), f"You can only pipeline a subset of the moe decoder layers for deepseek, but you requested to pipeline {raw_keys['pipeline_parallel_layers']} with pipeline_parallel_layers and there are only {moe_layers} decoder layers."
       else:
         assert (
             raw_keys["pipeline_parallel_layers"] <= raw_keys["num_decoder_layers"]

--- a/MaxText/tests/integration_tests/train_tests.py
+++ b/MaxText/tests/integration_tests/train_tests.py
@@ -334,5 +334,6 @@ class TrainTests(unittest.TestCase):
     ]
     train_main(cudnn_flash_jax)
 
+
 if __name__ == "__main__":
   absltest.main()

--- a/MaxText/tests/maxtext_utils_test.py
+++ b/MaxText/tests/maxtext_utils_test.py
@@ -339,27 +339,6 @@ class TestAssertParamsSufficientlySharded(unittest.TestCase):
       with self.assertRaises(AssertionError):
         assert_params_sufficiently_sharded(params, self.mesh, tolerance=0.2)
 
-  def test_4d_tensor_fully_sharded(self):
-    """
-    Tests that a 4D tensor that is sharded across valid axes passes.
-    """
-    with self.mesh:
-      pspec = PartitionSpec("fsdp", "tensor", None, None)
-      params = {"conv4d_layer": jax.device_put(jnp.ones((8, 8, 2, 2)), NamedSharding(self.mesh, pspec))}
-
-      # This should pass
-      assert_params_sufficiently_sharded(params, self.mesh, tolerance=0.1)
-
-  def test_4d_tensor_unsharded_fails(self):
-    """
-    Tests that a completely unsharded 4D tensor fails the assertion.
-    """
-    with self.mesh:
-      params = {"conv4d_layer": jnp.ones((8, 8, 2, 2))}
-
-      with self.assertRaises(AssertionError):
-        assert_params_sufficiently_sharded(params, self.mesh, tolerance=0.1)
-
   def test_multi_axis_sharding_pass(self):
     """
     Tests that a tensor sharded with a valid axis ('fsdp') on a complex,

--- a/MaxText/tests/train_compile_test.py
+++ b/MaxText/tests/train_compile_test.py
@@ -572,14 +572,14 @@ class TrainCompile(unittest.TestCase):
             "compile_topology_num_slices=8",
             "use_iota_embed=true",
             "model_name=deepseek3-671b",
-            "megablox=False", # dropless not yet supported (b/418313093)
-            "sparse_matmul=False", 
+            "megablox=False",  # dropless not yet supported (b/418313093)
+            "sparse_matmul=False",
             "capacity_factor=1",
             "per_device_batch_size=1",
             "max_target_length=2048",
             "pipeline_parallel_layers=56",
             "ici_expert_parallelism=16",
-            "dcn_pipeline_parallelism=8"
+            "dcn_pipeline_parallelism=8",
         )
     )
 


### PR DESCRIPTION
# Description
This change significantly enhances the sharding validation utility by providing detailed, actionable error messages. The previous version only indicates that some matrices were not fully sharded, but it failed to specify which matrices were unsharded by which axis. This forced developers into a tedious manual search to find the unsharded matrices. This improvement is able to show a more readable error message with large matrices that has not been fully sharded by which axes.

Specifically, for each replicated tensor, the error now shows:

**Which Matrix:** The full name of the parameter (e.g., layers.10.attention.query.kernel).
**Its Current (Problematic) Sharding Status:** The parameter's current PartitionSpec is displayed (e.g., PartitionSpec(None, 'expert')), making it clear why it's considered replicated on the main data-parallel axes.
**Which Axes are not sharded:** A list of available mesh axes that could have been used for sharding (e.g., could be sharded on: ['fsdp', 'tensor']), giving the developer an immediate hint for a valid solution.


FIXES: b/367055330


# Tests
This change was validated using a comprehensive unit test suite, <em>TestAssertParamsSufficientlySharded</em>, which ensures the new validation logic is both correct and robust. The tests cover a wide variety of sharding configurations to confirm that the assertions pass and fail as expected.


**Test Coverage**
The test suite validates the following key scenarios:
**Correctly Passing Scenarios:**
Fully Sharded: A tensor that is fully sharded across all available primary mesh axes passes the assertion.
Sufficiently Sharded: A tensor sharded on at least one valid target axis (e.g., fsdp) passes, even if its other dimensions are replicated.
Complex Mesh: A tensor correctly sharded on a valid axis within a complex, multi-dimensional mesh also passes.
**Correctly Failing Scenarios:**
Completely Unsharded: A fully replicated parameter with no sharding specification correctly triggers an AssertionError.
Incorrectly Sharded: A tensor that is sharded, but not along any of the required target axes (e.g., sharded on 'sequence' but not on 'fsdp'), correctly fails.
Mixed Sharding: A model containing both correctly sharded and fully replicated parameters fails when the total size of replicated parameters exceeds the specified tolerance.

Each failing test case implicitly verifies that the raised AssertionError contains the new, detailed diagnostic message, including the names of problematic tensors and the sharding axes they could be mapped to. The tests also confirm that the companion utility, get_formatted_sharding_annotations, runs without error in all configurations.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
