### PR TITLE
Refactor profiler and fix profiling activation/deactivation only when enabled

### DIFF
--- a/MaxText/experimental/rl/grpo_trainer.py
+++ b/MaxText/experimental/rl/grpo_trainer.py
@@ -779,10 +779,6 @@ def train_loop(config, config_inference, recorder, state=None):
 
   start_step = get_first_step(state)  # this is the start_step for training
   prof = profiler.Profiler(config, offset_step=start_step)
-  first_profiling_step = prof.start_initial_profile_step
-  if config.profiler != "" and first_profiling_step >= config.steps:
-    raise ValueError("Profiling requested but initial profiling step set past training final step")
-  last_profiling_step = prof.finished_initial_profile_step
 
   example_batch = None
   last_step_completion = datetime.datetime.now()
@@ -799,9 +795,7 @@ def train_loop(config, config_inference, recorder, state=None):
   metric_logger = MetricLogger(writer, config)
   input_data_shardings = maxtext_utils.get_input_data_sharding(config, mesh)
   for step in np.arange(start_step, config.steps):
-    if step == first_profiling_step or prof.should_activate_periodic_profile(step):
-      optional_postfix = f"step_{step}" if config.profile_periodically_period > 0 else ""
-      prof.activate(blocking_object=state, optional_postfix=optional_postfix)
+    prof.maybe_activate_profiler(step, state)
 
     with jax.profiler.StepTraceAnnotation("train", step_num=step):
       with maybe_record_goodput(recorder, GoodputEvent.DATA_LOADING):
@@ -894,8 +888,7 @@ def train_loop(config, config_inference, recorder, state=None):
         prof.deactivate()
         break
 
-    if step == last_profiling_step or prof.should_deactivate_periodic_profile(step):
-      prof.deactivate(blocking_object=state)
+    prof.maybe_deactivate_profiler(step, state)
 
     if step == start_step:
       max_utils.print_mem_stats("After params initialized")

--- a/MaxText/sft_trainer.py
+++ b/MaxText/sft_trainer.py
@@ -137,10 +137,6 @@ def train_loop(config, recorder, state=None):
 
   start_step = get_first_step(state)  # this is the start_step for training
   prof = profiler.Profiler(config, offset_step=start_step)
-  first_profiling_step = prof.start_initial_profile_step
-  if config.profiler != "" and first_profiling_step >= config.steps:
-    raise ValueError("Profiling requested but initial profiling step set past training final step")
-  last_profiling_step = prof.finished_initial_profile_step
 
   example_batch = None
   last_step_completion = datetime.datetime.now()
@@ -157,9 +153,7 @@ def train_loop(config, recorder, state=None):
   metric_logger = MetricLogger(writer, config)
   input_data_shardings = maxtext_utils.get_input_data_sharding(config, mesh)
   for step in np.arange(start_step, config.steps):
-    if step == first_profiling_step or prof.should_activate_periodic_profile(step):
-      optional_postfix = f"step_{step}" if config.profile_periodically_period > 0 else ""
-      prof.activate(blocking_object=state, optional_postfix=optional_postfix)
+    prof.maybe_activate_profiler(step, state)
 
     with jax.profiler.StepTraceAnnotation("train", step_num=step):
       with maybe_record_goodput(recorder, GoodputEvent.DATA_LOADING):
@@ -243,8 +237,7 @@ def train_loop(config, recorder, state=None):
         prof.deactivate()
         break
 
-    if step == last_profiling_step or prof.should_deactivate_periodic_profile(step):
-      prof.deactivate(blocking_object=state)
+    prof.maybe_deactivate_profiler(step, state)
 
     if step == start_step:
       max_utils.print_mem_stats("After params initialized")


### PR DESCRIPTION
# Description
* This PR refactors profiler code that we have in all trainers.
* Additonally, activate and deactivate profiler only when profiling is enabled.

# Tests

Verified that the profile is uploaded successfully on TensorBoard: 
![image](https://github.com/user-attachments/assets/31648e15-5f78-4568-baef-45d2c2a415b6)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
