### PR TITLE
pyconfig → pydantic

### DIFF
--- a/MaxText/benchmark_chunked_prefill.py
+++ b/MaxText/benchmark_chunked_prefill.py
@@ -46,7 +46,7 @@ from absl import app
 
 from MaxText import max_utils
 from MaxText import maxengine
-from MaxText import pyconfig
+import MaxText.configs.loader
 
 _WARMUP_ITERS = 2
 _BENCHMARK_ITERS = 5
@@ -373,7 +373,7 @@ def prepare_setting(argv: Sequence[str]):
   """
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   max_utils.print_system_information()
 
   prefix_caching_hbm_byte = config.prefix_caching_hbm_byte

--- a/MaxText/configs/__init__.py
+++ b/MaxText/configs/__init__.py
@@ -1,0 +1,15 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""

--- a/MaxText/configs/loader.py
+++ b/MaxText/configs/loader.py
@@ -1,0 +1,89 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+from typing import Sequence
+
+import yaml
+
+from MaxText.configs.types import MaxTextConfig
+
+def load_config_from_yaml_and_argv(argv: Sequence[str]) -> MaxTextConfig:
+    """
+    Loads the MaxTextConfig from a YAML file specified in argv[1]
+    and applies any command line overrides of the form key=value.
+
+    Args:
+        argv: sys.argv-like list of arguments.
+            argv[1] should be path to YAML file.
+            Subsequent arguments optionally in key=value format as overrides.
+
+    Returns:
+        An instance of MaxTextConfig.
+    """
+
+    if len(argv) < 2:
+        raise ValueError("Please specify config YAML path as first argument")
+
+    config_path = argv[1]
+
+    # Load YAML config file into dictionary
+    with open(config_path, "r") as f:
+        config_dict = yaml.safe_load(f)
+
+    # Parse overrides from argv (key=value)
+    for arg in argv[2:]:
+        if "=" not in arg:
+            continue
+        key, val = arg.split("=", 1)
+        # Convert val to proper type
+        try:
+            # Use yaml to parse val to proper python types (int, float, bool, etc)
+            parsed_val = yaml.safe_load(val)
+        except yaml.YAMLError:
+            parsed_val = val
+        # Support nested keys separated by dots
+        apply_override(config_dict, key.strip(), parsed_val)
+
+    # pydantic config object with applied overrides
+    return MaxTextConfig(**config_dict)
+
+def apply_override(config_dict: dict, key: str, value):
+    """
+    Modifies config_dict in-place to apply override given a "dot" separated key.
+
+    Example:
+        key="model.base_emb_dim"
+        value=1024
+
+        Will set config_dict['model']['base_emb_dim'] = 1024
+    """
+    keys = key.split(".")
+    d = config_dict
+    for k in keys[:-1]:
+        if k not in d or not isinstance(d[k], dict):
+            d[k] = {}
+        d = d[k]
+    d[keys[-1]] = value
+
+initialize = load_config_from_yaml_and_argv
+
+if __name__ == "__main__":
+    # Simple CLI demo
+    cfg = load_config_from_yaml_and_argv(sys.argv)
+    print(cfg.model_dump_json(indent=4))
+
+__all__ = ["initialize", "load_config_from_yaml_and_argv"]

--- a/MaxText/configs/loader.py
+++ b/MaxText/configs/loader.py
@@ -21,96 +21,97 @@ from MaxText.configs.types import (
 
 
 def _merge_dicts(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively merge two dicts, with `override` taking priority."""
-    merged = dict(base)
-    for k, v in override.items():
-        if k in merged and isinstance(merged[k], dict) and isinstance(v, dict):
-            merged[k] = _merge_dicts(merged[k], v)
-        else:
-            merged[k] = v
-    return merged
+  """Recursively merge two dicts, with `override` taking priority."""
+  merged = dict(base)
+  for k, v in override.items():
+    if k in merged and isinstance(merged[k], dict) and isinstance(v, dict):
+      merged[k] = _merge_dicts(merged[k], v)
+    else:
+      merged[k] = v
+  return merged
 
 
 def load_yaml(path: str) -> Dict[str, Any]:
-    with open(path, "rt", encoding="utf8") as f:
-        return yaml.safe_load(f) or {}
+  with open(path, "rt", encoding="utf8") as f:
+    return yaml.safe_load(f) or {}
 
 
 def load_config(
-        config_path: str, overrides: Optional[Dict[str, Any]] = None, base_dir: Optional[str] = None
+    config_path: str, overrides: Optional[Dict[str, Any]] = None, base_dir: Optional[str] = None
 ) -> MaxTextConfig:
-    """
-    Load config YAML file, recursively apply `base_config`, merge overrides,
-    construct and return a validated MaxTextConfig pydantic object.
-    """
+  """
+  Load config YAML file, recursively apply `base_config`, merge overrides,
+  construct and return a validated MaxTextConfig pydantic object.
+  """
 
-    base_dir = base_dir or os.path.dirname(os.path.abspath(__file__))
-    if not os.path.isabs(config_path):
-        config_path = os.path.join(base_dir, config_path)
+  base_dir = base_dir or os.path.dirname(os.path.abspath(__file__))
+  if not os.path.isabs(config_path):
+    config_path = os.path.join(base_dir, config_path)
 
-    # Load the config YAML
-    config_data = load_yaml(config_path)
+  # Load the config YAML
+  config_data = load_yaml(config_path)
 
-    # Load and merge base config recursively
-    if "base_config" in config_data and config_data["base_config"]:
-        base_config_path = config_data.pop("base_config")
-        base_config_data = load_config(base_config_path, base_dir=base_dir).dict()
-        config_data = _merge_dicts(base_config_data, config_data)
+  # Load and merge base config recursively
+  if "base_config" in config_data and config_data["base_config"]:
+    base_config_path = config_data.pop("base_config")
+    base_config_data = load_config(base_config_path, base_dir=base_dir).dict()
+    config_data = _merge_dicts(base_config_data, config_data)
 
-    # Apply manual overrides if any
-    if overrides:
-        config_data = _merge_dicts(config_data, overrides)
+  # Apply manual overrides if any
+  if overrides:
+    config_data = _merge_dicts(config_data, overrides)
 
-    # Extract sub-config dicts from config_data
-    core_data = {k: v for k, v in config_data.items() if k in CoreConfig.__fields__}
-    # For other submodels stored flat in root config (e.g. model fields might be at root)
-    # We must extract by their declared fields
+  # Extract sub-config dicts from config_data
+  core_data = {k: v for k, v in config_data.items() if k in CoreConfig.__fields__}
+  # For other submodels stored flat in root config (e.g. model fields might be at root)
+  # We must extract by their declared fields
 
-    # model config fields are keys in ModelConfig.__fields__:
-    model_keys = set(ModelConfig.__fields__)
-    model_data = {k: v for k, v in config_data.items() if k in model_keys}
+  # model config fields are keys in ModelConfig.__fields__:
+  model_keys = set(ModelConfig.__fields__)
+  model_data = {k: v for k, v in config_data.items() if k in model_keys}
 
-    checkpoint_keys = set(CheckpointConfig.__fields__)
-    checkpoint_data = {k: v for k, v in config_data.items() if k in checkpoint_keys}
+  checkpoint_keys = set(CheckpointConfig.__fields__)
+  checkpoint_data = {k: v for k, v in config_data.items() if k in checkpoint_keys}
 
-    optimizer_keys = set(OptimizerConfig.__fields__)
-    optimizer_data = {k: v for k, v in config_data.items() if k in optimizer_keys}
+  optimizer_keys = set(OptimizerConfig.__fields__)
+  optimizer_data = {k: v for k, v in config_data.items() if k in optimizer_keys}
 
-    dataset_keys = set(DatasetConfig.__fields__)
-    dataset_data = {k: v for k, v in config_data.items() if k in dataset_keys}
+  dataset_keys = set(DatasetConfig.__fields__)
+  dataset_data = {k: v for k, v in config_data.items() if k in dataset_keys}
 
-    tokenizer_keys = set(TokenizerConfig.__fields__)
-    tokenizer_data = {k: v for k, v in config_data.items() if k in tokenizer_keys}
+  tokenizer_keys = set(TokenizerConfig.__fields__)
+  tokenizer_data = {k: v for k, v in config_data.items() if k in tokenizer_keys}
 
-    parallelism_keys = set(ParallelismConfig.__fields__)
-    parallelism_data = {k: v for k, v in config_data.items() if k in parallelism_keys}
+  parallelism_keys = set(ParallelismConfig.__fields__)
+  parallelism_data = {k: v for k, v in config_data.items() if k in parallelism_keys}
 
-    inference_keys = set(InferenceConfig.__fields__)
-    inference_data = {k: v for k, v in config_data.items() if k in inference_keys}
+  inference_keys = set(InferenceConfig.__fields__)
+  inference_data = {k: v for k, v in config_data.items() if k in inference_keys}
 
-    # Construct model subobjects
-    core = CoreConfig(**core_data)
-    model = ModelConfig(**model_data)
-    checkpoint = CheckpointConfig(**checkpoint_data)
-    optimizer = OptimizerConfig(**optimizer_data)
-    dataset = DatasetConfig(**dataset_data)
-    tokenizer = TokenizerConfig(**tokenizer_data)
-    parallelism = ParallelismConfig(**parallelism_data)
-    inference = InferenceConfig(**inference_data)
+  # Construct model subobjects
+  core = CoreConfig(**core_data)
+  model = ModelConfig(**model_data)
+  checkpoint = CheckpointConfig(**checkpoint_data)
+  optimizer = OptimizerConfig(**optimizer_data)
+  dataset = DatasetConfig(**dataset_data)
+  tokenizer = TokenizerConfig(**tokenizer_data)
+  parallelism = ParallelismConfig(**parallelism_data)
+  inference = InferenceConfig(**inference_data)
 
-    # Compose and construct final MaxTextConfig instance
-    final_config = MaxTextConfig(
-        **core.dict(),
-        model=model,
-        checkpoint=checkpoint,
-        optimizer=optimizer,
-        dataset=dataset,
-        tokenizer=tokenizer,
-        parallelism=parallelism,
-        inference=inference,
-    )
+  # Compose and construct final MaxTextConfig instance
+  final_config = MaxTextConfig(
+      **core.dict(),
+      model=model,
+      checkpoint=checkpoint,
+      optimizer=optimizer,
+      dataset=dataset,
+      tokenizer=tokenizer,
+      parallelism=parallelism,
+      inference=inference,
+  )
 
-    return final_config
+  return final_config
+
 
 initialize = load_config
 

--- a/MaxText/configs/types.py
+++ b/MaxText/configs/types.py
@@ -1,0 +1,585 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+class CoreConfig(BaseModel):
+  """Core general configuration fields, common to all config files.
+
+  Attributes:
+      run_name (str): User-defined name for run.
+      model_name (str): Model identifier name.
+      override_model_config (bool): Whether to allow CLI model param override.
+      base_config (Optional[str]): Relative path to base config if inherited.
+  """
+
+  run_name: str = ""
+  model_name: str = "default"
+  override_model_config: bool = False
+  base_config: Optional[str] = None
+
+
+class ModelConfig(BaseModel):
+  """Model architecture-specific configuration.
+
+  Attributes:
+      decoder_block (str): Style of decoder block used.
+      base_emb_dim (int): Base embedding dimension.
+      base_num_query_heads (int): Number of query attention heads.
+      base_num_kv_heads (int): Number of key-value attention heads.
+      base_mlp_dim (int): Dimension of MLP intermediate layers.
+      base_num_decoder_layers (int): Number of decoder layers.
+      head_dim (int): Head dimension size.
+      mlp_activations (list[str]): list of activations used in MLPs.
+      vocab_size (int): Vocabulary size.
+      normalization_layer_epsilon (float): Epsilon for normalization layers.
+      logits_via_embedding (bool): Whether to calculate logits via embedding.
+      enable_dropout (bool): Whether dropout is enabled.
+      shared_experts (Optional[int]): Number of shared experts in MoE.
+      num_experts (Optional[int]): Number of experts in MoE.
+      num_experts_per_tok (Optional[int]): Experts used per token.
+      base_moe_mlp_dim (Optional[int]): MoE mlp intermediate dim.
+      first_num_dense_layers (Optional[int]): Initial dense layers count.
+      routed_scaling_factor (Optional[float]): Routing score scaling factor.
+      routed_score_func (Optional[str]): Routing scoring function.
+      routed_bias (Optional[bool]): Whether routing adds a bias term.
+      n_routing_groups (Optional[int]): Number of routing groups.
+      topk_routing_group (Optional[int]): Top K routing groups count.
+      use_qk_norm (Optional[bool]): Use normalization on Q/K projections.
+      sliding_window_size (Optional[int]): Sliding window size for attention.
+      attn_logits_soft_cap (Optional[float]): Attention logits soft cap.
+      final_logits_soft_cap (Optional[float]): Final logits soft cap.
+      use_post_attn_norm (Optional[bool]): Whether to use norm after attention.
+      use_post_ffw_norm (Optional[bool]): Whether to use norm after FFN.
+      rope_type (Optional[str]): RoPE embedding type.
+      rope_max_timescale (Optional[int]): Maximum timescale for RoPE.
+      rope_use_scale (Optional[bool]): Whether to apply RoPE scaling.
+  """
+
+  decoder_block: str = "llama2"
+  base_emb_dim: int = 2048
+  base_num_query_heads: int = 16
+  base_num_kv_heads: int = 16
+  base_mlp_dim: int = 7168
+  base_num_decoder_layers: int = 16
+  head_dim: int = 128
+  mlp_activations: list[str] = Field(default_factory=lambda: ["silu", "linear"])
+  vocab_size: int = 32000
+  normalization_layer_epsilon: float = 1e-5
+  logits_via_embedding: bool = False
+  enable_dropout: bool = True
+
+  shared_experts: Optional[int] = None
+  num_experts: Optional[int] = None
+  num_experts_per_tok: Optional[int] = None
+  base_moe_mlp_dim: Optional[int] = None
+  first_num_dense_layers: Optional[int] = None
+  routed_scaling_factor: Optional[float] = None
+  routed_score_func: Optional[str] = None
+  routed_bias: Optional[bool] = None
+  n_routing_groups: Optional[int] = None
+  topk_routing_group: Optional[int] = None
+
+  use_qk_norm: Optional[bool] = None
+
+  sliding_window_size: Optional[int] = None
+  attn_logits_soft_cap: Optional[float] = None
+  final_logits_soft_cap: Optional[float] = None
+  use_post_attn_norm: Optional[bool] = None
+  use_post_ffw_norm: Optional[bool] = None
+
+  rope_type: Optional[str] = None
+  rope_max_timescale: Optional[int] = None
+  rope_use_scale: Optional[bool] = None
+
+
+class CheckpointConfig(BaseModel):
+  """Checkpointing related parameters controlling saving/loading model state.
+
+  Attributes:
+      enable_checkpointing (bool): Enable checkpointing.
+      async_checkpointing (bool): Use asynchronous checkpointing.
+      checkpoint_period (int): Steps between checkpointing.
+      load_parameters_path (str): Path for parameter-only checkpoint load.
+      load_full_state_path (str): Path for full state checkpoint load.
+      lora_input_adapters_path (str): GCS path for LoRA adapter input.
+      enable_single_replica_ckpt_restoring (bool): Use single replica checkpoint read.
+      checkpoint_storage_target_data_file_size_bytes (int): Target file size for checkpoint chunks.
+      checkpoint_storage_use_ocdbt (bool): Use OCDBT kvstore for checkpointing.
+      checkpoint_storage_use_zarr3 (bool): Use Zarr3 storage format.
+      checkpoint_storage_concurrent_gb (int): Concurrent GB for IO operations in checkpoint.
+  """
+
+  enable_checkpointing: bool = True
+  async_checkpointing: bool = True
+  checkpoint_period: int = 10_000
+  load_parameters_path: str = ""
+  load_full_state_path: str = ""
+  lora_input_adapters_path: str = ""
+  enable_single_replica_ckpt_restoring: bool = False
+  checkpoint_storage_target_data_file_size_bytes: int = 2147483648
+  checkpoint_storage_use_ocdbt: bool = True
+  checkpoint_storage_use_zarr3: bool = True
+  checkpoint_storage_concurrent_gb: int = 96
+
+
+class OptimizerConfig(BaseModel):
+  """Optimizer hyperparameters for the training run.
+
+  Attributes:
+      opt_type (str): Optimizer type ("adamw","adam_pax","sgd").
+      adam_b1 (float): Beta1 decay rate for Adam optimizer.
+      adam_b2 (float): Beta2 decay rate for Adam optimizer.
+      adam_eps (float): Epsilon value to prevent division by zero.
+      adam_eps_root (float): Additional epsilon for root variance.
+      adam_weight_decay (float): Weight decay coefficient for AdamW.
+      mu_dtype (str): Data type for first moment storage (optional).
+  """
+
+  opt_type: str = "adamw"
+  adam_b1: float = 0.9
+  adam_b2: float = 0.95
+  adam_eps: float = 1e-8
+  adam_eps_root: float = 0.0
+  adam_weight_decay: float = 0.1
+  mu_dtype: str = ""
+
+
+class DatasetConfig(BaseModel):
+  """Dataset loading and processing-related configuration.
+
+  Attributes:
+      dataset_type (str): Dataset pipeline type (e.g., "tfds", "hf", "grain", "synthetic").
+      dataset_path (str): Path or URI for dataset location.
+      dataset_name (str): Name/version for the training dataset.
+      eval_dataset_name (str): Name/version for evaluation dataset.
+      train_split (str): Train split name.
+      eval_split (str): Eval split name.
+      train_data_columns (list[str]): list of columns used for training data.
+      eval_data_columns (list[str]): list of columns used for eval data.
+      per_device_batch_size (float): Per device batch size for training.
+      eval_per_device_batch_size (float): Per device eval batch size.
+      num_epoch (int): Number of epochs to train.
+      packing (bool): If True, enable packing data batches.
+      expansion_factor_real_data (int): Host expansion factor for real data.
+      hf_path (str): Huggingface dataset path.
+      hf_data_dir (str): Huggingface data directory.
+      hf_train_files (str): Huggingface train files pattern.
+      hf_eval_split (str): Huggingface eval split name.
+      hf_eval_files (str): Huggingface eval files pattern.
+      hf_access_token (str): Huggingface access token.
+      grain_train_files (str): Grain pipeline train files.
+      grain_eval_files (str): Grain pipeline eval files.
+      grain_file_type (str): Grain file format ("arrayrecord" or "parquet").
+      grain_worker_count (int): Number of grain workers for training.
+      grain_worker_count_eval (int): Number of grain workers for evaluation.
+      colocated_python_data_input (bool): Use colocated python data input.
+  """
+
+  dataset_type: str = "tfds"
+  dataset_path: str = ""
+  dataset_name: str = "c4/en:3.0.1"
+  eval_dataset_name: str = "c4/en:3.0.1"
+  train_split: str = "train"
+  eval_split: str = "validation"
+  train_data_columns: list[str] = Field(default_factory=lambda: ["text"])
+  eval_data_columns: list[str] = Field(default_factory=lambda: ["text"])
+  per_device_batch_size: float = 12.0
+  eval_per_device_batch_size: float = 0.0
+  num_epoch: int = 1
+  packing: bool = True
+  expansion_factor_real_data: int = -1
+
+  hf_path: str = ""
+  hf_data_dir: str = ""
+  hf_train_files: str = ""
+  hf_eval_split: str = ""
+  hf_eval_files: str = ""
+  hf_access_token: str = ""
+
+  grain_train_files: str = ""
+  grain_eval_files: str = ""
+  grain_file_type: str = "arrayrecord"
+  grain_worker_count: int = 1
+  grain_worker_count_eval: int = 1
+
+  colocated_python_data_input: bool = False
+
+
+class TokenizerConfig(BaseModel):
+  """Tokenizer related configuration parameters.
+
+  Attributes:
+      tokenizer_path (str): Path to tokenizer assets.
+      tokenizer_type (str): Tokenizer type.
+      use_chat_template (bool): Use chat template tokenization.
+      tokenize_train_data (bool): Whether to tokenize train data.
+      tokenize_eval_data (bool): Whether to tokenize eval data.
+      add_bos (bool): Add beginning-of-sentence token.
+      add_eos (bool): Add end-of-sentence token.
+  """
+
+  tokenizer_path: str = "assets/tokenizer.llama2"
+  tokenizer_type: str = "sentencepiece"
+  use_chat_template: bool = False
+  tokenize_train_data: bool = True
+  tokenize_eval_data: bool = True
+  add_bos: bool = True
+  add_eos: bool = True
+
+
+class ParallelismConfig(BaseModel):
+  """Configuration related to model parallelism and mesh axes.
+
+  Attributes:
+      mesh_axes (list[str]): Names of axes in the device mesh.
+      logical_axis_rules (list[list[Union[str, list[str]]]]): Logical axis rules for sharding.
+      data_sharding (list[list[str]]): Lists specifying data sharding axes.
+      input_data_sharding_logical_axes (list[str]): Logical axes for input data sharding.
+      sharding_tolerance (float): Allowed percentage of non-sharded parameters.
+  """
+
+  mesh_axes: list[str] = Field(
+      default_factory=lambda: [
+          "data",
+          "stage",
+          "fsdp",
+          "fsdp_transpose",
+          "sequence",
+          "context",
+          "context_autoregressive",
+          "tensor",
+          "tensor_transpose",
+          "tensor_sequence",
+          "expert",
+          "autoregressive",
+      ]
+  )
+
+  logical_axis_rules: list[list[Union[str, list[str]]]] = Field(
+      default_factory=lambda: [
+          ["activation_batch", ["data", "fsdp", "fsdp_transpose", "expert"]],
+          ["activation_batch_no_exp", ["data", "fsdp", "fsdp_transpose"]],
+          ["activation_embed_and_logits_batch", ["data", "stage", "fsdp", "fsdp_transpose", "expert"]],
+          ["activation_heads", ["tensor", "tensor_transpose", "sequence", "tensor_sequence", "autoregressive"]],
+          ["activation_kv_heads", ["tensor", "tensor_transpose", "sequence", "tensor_sequence"]],
+          ["activation_length", ["sequence", "context"]],
+          ["activation_length", ["context"]],
+          ["activation_norm_length", ["tensor_sequence", "context", "sequence"]],
+          ["activation_q_length", ["context"]],
+          ["activation_kv_length", []],
+          ["activation_embed", ["tensor", "tensor_transpose"]],
+          ["activation_mlp", ["tensor", "tensor_transpose", "tensor_sequence"]],
+          ["activation_kv", ["tensor", "tensor_transpose", "tensor_sequence"]],
+          ["activation_prefill_kv_batch", ["data", "fsdp", "fsdp_transpose", "expert"]],
+          ["activation_kv_batch", ["data", "fsdp", "fsdp_transpose", "expert"]],
+          ["activation_kv_head_dim", ["tensor", "tensor_transpose", "tensor_sequence"]],
+          ["activation_vocab", ["tensor", "tensor_transpose", "sequence", "tensor_sequence"]],
+          ["activation_vocab", ["tensor", "tensor_transpose"]],
+          ["activation_vocab", "tensor_sequence"],
+          ["activation_vocab", ["sequence", "context"]],
+          ["activation_stage", "stage"],
+          ["activation_exp", ["expert"]],
+          ["decode_batch", ["data", "fsdp", "fsdp_transpose", "expert"]],
+          ["decode_length", ["sequence"]],
+          ["mlp", ["fsdp_transpose", "tensor", "tensor_sequence", "autoregressive"]],
+          ["vocab", ["tensor", "tensor_transpose", "tensor_sequence", "autoregressive"]],
+          ["heads", ["tensor", "tensor_transpose", "tensor_sequence", "autoregressive"]],
+          ["q_heads", ["tensor", "tensor_transpose", "tensor_sequence", "autoregressive"]],
+          ["kv_heads", ["tensor", "tensor_transpose", "tensor_sequence", "autoregressive"]],
+          ["embed", ["fsdp", "fsdp_transpose", "sequence", "tensor_transpose", "context", "expert"]],
+          ["embed", ["fsdp", "sequence", "tensor_transpose", "context", "expert"]],
+          ["embed", ["fsdp", "fsdp_transpose", "sequence", "context", "expert"]],
+          ["embed", ["fsdp", "sequence", "context", "expert"]],
+          ["embed_no_exp", ["fsdp", "fsdp_transpose", "sequence", "tensor_transpose", "context"]],
+          ["embed_no_exp", ["fsdp", "sequence", "tensor_transpose", "context"]],
+          ["embed_no_exp", ["fsdp", "fsdp_transpose", "sequence", "context"]],
+          ["embed_no_exp", ["fsdp", "sequence", "context"]],
+          ["q_lora", ["fsdp", "fsdp_transpose", "sequence", "context", "tensor_transpose", "expert"]],
+          ["q_lora", ["fsdp", "sequence", "context", "tensor_transpose", "expert"]],
+          ["q_lora", ["fsdp", "fsdp_transpose", "sequence", "context", "expert"]],
+          ["q_lora", ["fsdp", "sequence", "context", "expert"]],
+          ["kv_lora", ["fsdp", "fsdp_transpose", "sequence", "context", "tensor_transpose", "expert"]],
+          ["kv_lora", ["fsdp", "sequence", "context", "tensor_transpose", "expert"]],
+          ["kv_lora", ["fsdp", "fsdp_transpose", "sequence", "context", "expert"]],
+          ["kv_lora", ["fsdp", "sequence", "context", "expert"]],
+          ["norm", ["tensor", "tensor_transpose", "tensor_sequence"]],
+          ["layers", "stage"],
+          ["kv", []],
+          ["kv_head_dim", []],
+          ["cache_batch_prefill", []],
+          ["cache_batch", []],
+          ["cache_heads", ["autoregressive", "tensor", "tensor_transpose", "tensor_sequence"]],
+          ["cache_heads", ["autoregressive", "tensor", "tensor_sequence"]],
+          ["cache_kv", []],
+          ["cache_sequence", []],
+          ["exp", "expert"],
+          ["paged_kv_heads", ["tensor"]],
+          ["num_pages", []],
+          ["tokens_per_page", []],
+          ["paged_kv_head_dim_size", []],
+      ]
+  )
+
+  data_sharding: list[list[str]] = Field(
+      default_factory=lambda: [
+          [
+              "data",
+              "stage",
+              "fsdp",
+              "fsdp_transpose",
+              "sequence",
+              "context",
+              "context_autoregressive",
+              "tensor",
+              "tensor_transpose",
+              "tensor_sequence",
+              "expert",
+              "autoregressive",
+          ]
+      ]
+  )
+
+  input_data_sharding_logical_axes: list[str] = Field(
+      default_factory=lambda: ["activation_embed_and_logits_batch", "activation_norm_length"]
+  )
+
+  sharding_tolerance: float = 0.02
+
+
+class InferenceConfig(BaseModel):
+  """Inference-specific configuration parameters.
+
+  Attributes:
+      inference_server (str): Server to launch for inference.
+      inference_microbenchmark_prefill_lengths (str): Prefill lengths for benchmarking.
+      inference_microbenchmark_stages (str): Benchmarking stages.
+      inference_microbenchmark_loop_iters (int): Number iterations for microbenchmark loop.
+      inference_microbenchmark_log_file_path (str): File path for microbenchmark logs.
+      inference_microbenchmark_num_samples (list[int]): Number of samples for microbenchmarking.
+      inference_metadata_file (str): Path to metadata JSON.
+      prefill_slice (str): Slice to use for prefill in disaggregation.
+      generate_slice (str): Slice to use for generation in disaggregation.
+      inference_benchmark_test (bool): Flag to enable benchmark test.
+      enable_model_warmup (bool): Enable warmup before inference.
+      enable_llm_inference_pool (bool): Use LLM inference pool.
+      multi_sampling (bool): Multi-sample decoding.
+      return_log_prob (bool): Return log probabilities.
+      enable_prefix_caching (bool): Enable prefix caching optimizations.
+  """
+
+  inference_server: str = "MaxtextInterleavedServer"
+  inference_microbenchmark_prefill_lengths: str = "64,128,256,512,1024"
+  inference_microbenchmark_stages: str = "prefill,generate"
+  inference_microbenchmark_loop_iters: int = 10
+  inference_microbenchmark_log_file_path: str = ""
+  inference_microbenchmark_num_samples: list[int] = Field(default_factory=lambda: [1, 2, 3, 4, 5])
+  inference_metadata_file: str = ""
+
+  prefill_slice: str = "v5e-16"
+  generate_slice: str = "v5e-16"
+  inference_benchmark_test: bool = False
+  enable_model_warmup: bool = False
+  enable_llm_inference_pool: bool = False
+  multi_sampling: bool = False
+  return_log_prob: bool = False
+  enable_prefix_caching: bool = False
+
+
+class MaxTextConfig(CoreConfig):
+  """Top-level MaxText configuration aggregating all sub-configurations.
+
+  Attributes:
+      model (ModelConfig): Model architecture configuration.
+      checkpoint (CheckpointConfig): Checkpointing config.
+      optimizer (OptimizerConfig): Optimizer parameters.
+      dataset (DatasetConfig): Dataset input parameters.
+      tokenizer (TokenizerConfig): Tokenizer settings.
+      parallelism (ParallelismConfig): Parallelism and sharding.
+      inference (InferenceConfig): Inference-specific options.
+      hardware (str): Hardware type (e.g., "tpu").
+      steps (int): Number of training steps.
+      learning_rate (float): Learning rate for training.
+      dropout_rate (float): Dropout rate used.
+      gradient_clipping_threshold (float): Threshold for gradient clipping.
+      gradient_accumulation_steps (int): Accumulation steps for gradient.
+      log_period (int): Interval steps for logging.
+      use_dpo (bool): Use Direct Preference Optimization.
+      dpo_label_smoothing (float): Label smoothing for DPO.
+      dpo_beta (float): Beta parameter for DPO loss.
+      use_sft (bool): Use Supervised Fine Tuning.
+      sft_train_on_completion_only (bool): Train only on completion tokens.
+  """
+
+  model: ModelConfig = ModelConfig()
+  checkpoint: CheckpointConfig = CheckpointConfig()
+  optimizer: OptimizerConfig = OptimizerConfig()
+  dataset: DatasetConfig = DatasetConfig()
+  tokenizer: TokenizerConfig = TokenizerConfig()
+  parallelism: ParallelismConfig = ParallelismConfig()
+  inference: InferenceConfig = InferenceConfig()
+
+  hardware: str = "tpu"
+  steps: int = 150_001
+  learning_rate: float = 3e-5
+  dropout_rate: float = 0.0
+  gradient_clipping_threshold: float = 1.0
+  gradient_accumulation_steps: int = 1
+  log_period: int = 100
+
+  use_dpo: bool = False
+  dpo_label_smoothing: float = 0.0
+  dpo_beta: float = 0.1
+
+  use_sft: bool = False
+  sft_train_on_completion_only: bool = False
+
+
+class DPOConfig(MaxTextConfig):
+  """Configuration class customized for Direct Preference Optimization (DPO).
+
+  Attributes:
+      base_config (str): Path to base config.
+      use_dpo (bool): Enables DPO.
+      train_data_columns (list[str]): Columns specific for DPO training.
+      eval_data_columns (list[str]): Columns specific for DPO evaluation.
+      base_output_directory (str): Output directory path.
+      per_device_batch_size (float): Batch size per device.
+      steps (int): Number of steps to run.
+      max_target_length (int): Max sequence target length.
+      eval_interval (int): Interval between evaluation runs.
+      eval_steps (int): Number of evaluation steps.
+      dataset_type (str): Dataset pipeline type.
+      dataset_path (str): Dataset path.
+      dataset_name (str): Name/version of train dataset.
+      eval_dataset_name (str): Name/version of eval dataset.
+      eval_split (str): Evaluation split.
+      hf_eval_split (str): Huggingface eval split (if applicable).
+      gradient_clipping_threshold (float): Gradient clipping threshold.
+      learning_rate (float): Learning rate.
+      dpo_label_smoothing (float): Label smoothing (DPO).
+      dpo_beta (float): Beta parameter (DPO).
+      enable_goodput_recording (bool): Enable goodput recordings.
+      monitor_goodput (bool): Monitor goodput during training.
+      enable_checkpointing (bool): Enable checkpointing.
+  """
+
+  base_config: str = "base.yml"
+  use_dpo: bool = True
+  train_data_columns: list[str] = Field(default_factory=lambda: ["chosen", "rejected"])
+  eval_data_columns: list[str] = Field(default_factory=lambda: ["chosen", "rejected"])
+  base_output_directory: str = "gs://maxtext-external/logs"
+  per_device_batch_size: float = 2.0
+  steps: int = 10
+  max_target_length: int = 512
+  eval_interval: int = 5
+  eval_steps: int = 2
+  dataset_type: str = "tfds"
+  dataset_path: str = "gs://maxtext-dataset/dpo/anthropic_rlhf"
+  dataset_name: str = "tfds:1.0.0"
+  eval_dataset_name: str = "tfds:1.0.0"
+  eval_split: str = "test"
+  hf_eval_split: str = "test"
+  gradient_clipping_threshold: float = 10.0
+  learning_rate: float = 5e-7
+  dpo_label_smoothing: float = 0.0
+  dpo_beta: float = 0.1
+  enable_goodput_recording: bool = False
+  monitor_goodput: bool = False
+  enable_checkpointing: bool = True
+
+
+class GPUConfig(MaxTextConfig):
+  """GPU specific configuration overrides for smoke test or training on GPU.
+
+  Attributes:
+      base_config (str): Path to base config file.
+      hardware (str): Hardware is 'gpu'.
+      attention (str): Type of attention mechanism.
+      base_emb_dim (int): Model embedding dim.
+      base_num_query_heads (int): Number of query heads.
+      base_num_kv_heads (int): Number of key-value heads.
+      base_mlp_dim (int): Dimensionality of mlp/intermediate.
+      base_num_decoder_layers (int): Num decoder layers.
+      head_dim (int): Head dimension.
+      per_device_batch_size (float): Batch size per device.
+      max_target_length (int): Max sequence length for training.
+      dataset_type (str): Dataset platform.
+      steps (int): Number of training steps.
+  """
+
+  base_config: str = "base.yml"
+  hardware: str = "gpu"
+  attention: str = "dot_product"
+  base_emb_dim: int = 8
+  base_num_query_heads: int = 4
+  base_num_kv_heads: int = 4
+  base_mlp_dim: int = 32
+  base_num_decoder_layers: int = 8
+  head_dim: int = 16
+  per_device_batch_size: float = 2
+  max_target_length: int = 1024
+  dataset_type: str = "synthetic"
+  steps: int = 10
+
+
+class SFTConfig(MaxTextConfig):
+  """Supervised Fine-Tuning (SFT) configuration.
+
+  Attributes:
+      base_config (str): Path to base config.
+      use_sft (bool): Enable SFT.
+      sft_train_on_completion_only (bool): Train only on completion tokens.
+      packing (bool): Enable packing.
+      learning_rate (float): Learning rate for fine-tuning.
+      dataset_type (str): Dataset type (hf pipeline).
+      hf_path (str): Huggingface dataset path.
+      train_split (str): Train split.
+      hf_eval_split (str): Huggingface evaluation split.
+      train_data_columns (list[str]): Training data columns.
+      eval_data_columns (list[str]): Eval data columns.
+  """
+
+  base_config: str = "base.yml"
+  use_sft: bool = True
+  sft_train_on_completion_only: bool = True
+  packing: bool = True
+  learning_rate: float = 2e-5
+  dataset_type: str = "hf"
+  hf_path: str = "HuggingFaceH4/ultrachat_200k"
+  train_split: str = "train_sft"
+  hf_eval_split: str = "test_sft"
+  train_data_columns: list[str] = Field(default_factory=lambda: ["messages"])
+  eval_data_columns: list[str] = Field(default_factory=lambda: ["messages"])
+
+
+__all__ = [
+    "CheckpointConfig",
+    "CoreConfig",
+    "DPOConfig",
+    "DatasetConfig",
+    "GPUConfig",
+    "InferenceConfig",
+    "MaxTextConfig",
+    "ModelConfig",
+    "OptimizerConfig",
+    "ParallelismConfig",
+    "SFTConfig",
+    "TokenizerConfig",
+]

--- a/MaxText/configs/types_g.py
+++ b/MaxText/configs/types_g.py
@@ -1,0 +1,888 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import List, Optional, Any
+from enum import Enum
+
+from pydantic import BaseModel, Field, PositiveInt, NonNegativeInt, NonNegativeFloat, validator, RootModel
+
+
+class DecoderBlockType(Enum):
+  DEFAULT = "default"
+  LLAMA2 = "llama2"
+  MISTRAL = "mistral"
+  MIXTRAL = "mixtral"
+  DEEPSEEK = "deepseek"
+  GEMMA = "gemma"
+  GEMMA2 = "gemma2"
+  GEMMA3 = "gemma3"
+  GPT3 = "gpt3"
+  SIMPLE = "simple"
+  SIMPLE_MLP = "simple_mlp"
+  LLAMA4 = "llama4"
+
+
+class AttentionType(Enum):
+  GLOBAL = "global"
+  LOCAL_SLIDING = "local_sliding"
+  CHUNK = "chunk"
+  MLA = "mla"
+  FULL = "full"
+
+
+class OptimizerType(Enum):
+  ADAMW = "adamw"
+  ADAM_PAX = "adam_pax"
+  SGD = "sgd"
+
+
+class MatMulPrecision(Enum):
+  DEFAULT = "default"
+  HIGH = "high"
+  HIGHEST = "highest"
+
+
+class DatasetType(Enum):
+  SYNTHETIC = "synthetic"
+  HF = "hf"
+  GRAIN = "grain"
+  TFDS = "tfds"
+  C4_MLPERF = "c4_mlperf"
+
+
+class GrainFileType(Enum):
+  ARRAYRECORD = "arrayrecord"
+  PARQUET = "parquet"
+
+
+class HardwareType(Enum):
+  TPU = "tpu"
+  GPU = "gpu"
+  GPU_MULTIPROCESS = "gpu_multiprocess"
+  CPU = "cpu"
+
+
+class ProfilerType(Enum):
+  NONE = ""
+  XPLANE = "xplane"
+  NSYS = "nsys"
+
+
+class AttentionKernel(Enum):
+  AUTOSELECTED = "autoselected"
+  DOT_PRODUCT = "dot_product"
+  FLASH = "flash"
+  CUDNN_FLASH_TE = "cudnn_flash_te"
+  CUDNN_FLASH_JAX = "cudnn_flash_jax"
+  PAGED = "paged"
+
+
+class RematPolicy(Enum):
+  MINIMAL = "minimal"
+  SAVE_DOT_WITH_CONTEXT_EXCEPT_MLP = "save_dot_with_context_except_mlp"
+  SAVE_DOT_EXCEPT_MLPWI = "save_dot_except_mlpwi"
+  SAVE_DOT_EXCEPT_MLP = "save_dot_except_mlp"
+  SAVE_QKV_PROJ = "save_qkv_proj"
+  QKV_PROJ_OFFLOADED = "qkv_proj_offloaded"
+  CUSTOM = "custom"
+  MINIMAL_OFFLOADED = "minimal_offloaded"
+  SAVE_OUT_PROJ = "save_out_proj"
+  FULL = "full"
+  MINIMAL_FLASH = "minimal_flash"
+
+
+class RematTensorConfigValue(Enum):
+  REMAT = "remat"
+  DEVICE = "device"
+  OFFLOAD = "offload"
+
+
+class ModelCallMode(Enum):
+  TRAIN = ""
+  INFERENCE = "inference"
+
+
+class SamplingStrategy(Enum):
+  GREEDY = "greedy"
+  WEIGHTED = "weighted"
+  NUCLEUS = "nucleus"
+  TOPK = "topk"
+
+
+class RoPEType(Enum):
+  DEFAULT = "default"
+  LLAMA3_1 = "llama3.1"
+  YARN = "yarn"
+
+
+class TokenizerTypeEnum(Enum):
+  SENTENCEPIECE = "sentencepiece"
+  TIKTOKEN = "tiktoken"
+  HUGGINGFACE = "huggingface"
+
+
+class InferenceServerType(Enum):
+  MAXTEXT_INTERLEAVED = "MaxtextInterleavedServer"
+  EXPERIMENTAL_MAXTEXT_DISAGGREGATED = "ExperimentalMaxtextDisaggregatedServer"
+
+
+# Pydantic Models for Configuration Structure
+
+
+class RunConfig(BaseModel):
+  """Configuration related to a single run/experiment."""
+
+  run_name: str = Field(default="", description="Name of the run. Auto-populated if empty.")
+  base_output_directory: str = Field(description="Base directory for all outputs.")
+  metrics_file: Optional[str] = Field(default="", description="Local file for scalar metrics; empty means no local file.")
+  gcs_metrics: bool = Field(default=False, description="Save metrics to GCS.")
+  save_config_to_gcs: bool = Field(default=False, description="Save config to GCS.")
+  log_period: PositiveInt = Field(default=100, description="Frequency of TensorBoard flushes.")
+  steps: int = Field(default=150_001, description="Total training steps. -1 to use learning_rate_schedule_steps.")
+  enable_tensorboard: bool = Field(default=True, description="Enable TensorBoard logging.")
+  use_vertex_tensorboard: bool = Field(default=False, description="Use Vertex AI TensorBoard.")
+  vertex_tensorboard_project: Optional[str] = Field(default="", description="GCP project for Vertex AI TensorBoard.")
+  vertex_tensorboard_region: Optional[str] = Field(default="", description="Region for Vertex AI TensorBoard.")
+  log_config: bool = Field(default=True, description="Print the final configuration.")
+
+
+class CheckpointLoadingConfig(BaseModel):
+  """Configuration for loading checkpoints."""
+
+  load_parameters_path: Optional[str] = Field(default="", description="Path to load parameters-only checkpoint.")
+  lora_input_adapters_path: Optional[str] = Field(default="", description="GCS path for LoRA adapters directory.")
+  load_full_state_path: Optional[str] = Field(default="", description="Path to load full training state checkpoint.")
+  checkpoint_is_quantized: bool = Field(default=False, description="True if loading a quantized checkpoint.")
+
+
+class CheckpointSavingConfig(BaseModel):
+  """Configuration for saving checkpoints."""
+
+  enable_checkpointing: bool = Field(default=True, description="Enable checkpointing.")
+  async_checkpointing: bool = Field(default=True, description="Use asynchronous checkpointing.")
+  checkpoint_period: NonNegativeInt = Field(default=10_000, description="Checkpoint saving frequency in steps.")
+  force_unroll: bool = Field(default=False, description="Force unroll loop for generate_param_only_checkpoint.")
+  save_quantized_params_path: Optional[str] = Field(default="", description="Path to save on-the-fly quantized params.")
+
+
+class CheckpointStorageConfig(BaseModel):
+  """Configuration for checkpoint storage backend."""
+
+  checkpoint_storage_target_data_file_size_bytes: int = Field(
+      default=2147483648, description="Target file size for Orbax checkpoint sharding."
+  )
+  checkpoint_storage_use_ocdbt: bool = Field(default=True, description="Use OCDBT for checkpointing.")
+  checkpoint_storage_use_zarr3: bool = Field(default=True, description="Use Zarr3 for checkpointing.")
+  checkpoint_storage_concurrent_gb: int = Field(default=96, description="Concurrent GB for checkpoint I/O.")
+
+
+class EmergencyCheckpointConfig(BaseModel):
+  """Configuration for emergency (local) checkpointing."""
+
+  enable_emergency_checkpoint: bool = Field(default=False, description="Enable Orbax emergency checkpointing.")
+  local_checkpoint_directory: Optional[str] = Field(default="", description="Local directory for emergency checkpoints.")
+  local_checkpoint_period: NonNegativeInt = Field(default=0, description="Frequency for local emergency checkpoints.")
+  use_replicator_service: bool = Field(default=False, description="Use emergency checkpoint with replicator service.")
+  replicator_backup_interval_minutes: NonNegativeInt = Field(
+      default=0, description="Interval for backing up local checkpoints."
+  )
+
+
+class CheckpointLoggingMiscConfig(BaseModel):
+  """Miscellaneous checkpointing and logging configurations."""
+
+  enable_single_replica_ckpt_restoring: bool = Field(
+      default=False, description="Enable single replica checkpoint restoring."
+  )
+  enable_checkpoint_cloud_logger: bool = Field(default=False, description="Enable checkpoint cloud logger.")
+
+
+class CheckpointConfig(BaseModel):
+  """Container for all checkpoint related configurations."""
+
+  loading: CheckpointLoadingConfig = Field(default_factory=CheckpointLoadingConfig)
+  saving: CheckpointSavingConfig = Field(default_factory=CheckpointSavingConfig)
+  storage: CheckpointStorageConfig = Field(default_factory=CheckpointStorageConfig)
+  emergency: EmergencyCheckpointConfig = Field(default_factory=EmergencyCheckpointConfig)
+  logging_misc: CheckpointLoggingMiscConfig = Field(default_factory=CheckpointLoggingMiscConfig)
+
+
+class ModelIdentityConfig(BaseModel):
+  """Model identity configurations."""
+
+  model_name: str = Field(default="default", description="Name of the model configuration to use.")
+  override_model_config: bool = Field(default=False, description="Allow overriding model params via CLI.")
+
+
+class ModelCoreConfig(BaseModel):
+  """Core model configurations like decoder type and scaling."""
+
+  decoder_block: DecoderBlockType = Field(default=DecoderBlockType.LLAMA2, description="Type of decoder block to use.")
+  global_parameter_scale: int = Field(default=1, description="Global parameter scale (power of 2).")
+  weight_dtype: str = Field(default="float32", description="Data type for model weights.")
+  normalization_layer_epsilon: float = Field(default=1.0e-05, description="Epsilon for normalization layers.")
+  model_call_mode: ModelCallMode = Field(
+      default=ModelCallMode.TRAIN, description="Mode for model execution ('train', 'inference')."
+  )
+  param_scan_axis: int = Field(default=1, description="Axis for parameter scanning if scan_layers is true.")
+  inhomogeneous_layer_cycle_interval: int = Field(
+      default=1, description="Cycle interval for inhomogeneous layers (e.g., Llama4)."
+  )
+
+
+class ModelArchitectureConfig(BaseModel):
+  """Base model architecture parameters."""
+
+  base_emb_dim: PositiveInt = Field(default=2048, description="Base embedding dimension.")
+  base_num_query_heads: PositiveInt = Field(default=16, description="Base number of query heads.")
+  base_num_kv_heads: PositiveInt = Field(default=16, description="Base number of key/value heads.")
+  base_mlp_dim: PositiveInt = Field(default=7168, description="Base MLP dimension.")
+  base_num_decoder_layers: PositiveInt = Field(default=16, description="Base number of decoder layers.")
+  head_dim: Optional[PositiveInt] = Field(default=128, description="Dimension of each attention head.")
+
+
+class ModelActivationConfig(BaseModel):
+  """Configurations for activations, dropout, and logits behavior."""
+
+  mlp_activations: List[str] = Field(default_factory=lambda: ["silu", "linear"], description="MLP activation functions.")
+  dropout_rate: NonNegativeFloat = Field(default=0.0, description="Dropout rate.")
+  logits_via_embedding: bool = Field(default=False, description="Compute logits via embedding layer transpose.")
+  normalize_embedding_logits: bool = Field(
+      default=True, description="Normalize pre-softmax logits if logits_via_embedding is true."
+  )
+  logits_dot_in_fp32: bool = Field(default=False, description="Use fp32 for logits dot product for stability.")
+  cast_logits_to_fp32: bool = Field(default=True, description="Cast final logits to fp32.")
+  float32_qk_product: bool = Field(default=False, description="Use fp32 for QK product in attention.")
+  float32_logits: bool = Field(
+      default=False, description="Use fp32 for attention logits before softmax."
+  )  # Renamed from float32_logits_attn to avoid conflict
+  activations_in_float32: bool = Field(default=False, description="Cast activations to float32 before nonlinearity.")
+
+
+class ModelMiscBehaviorConfig(BaseModel):
+  """Miscellaneous model behavior configurations."""
+
+  record_internal_nn_metrics: NonNegativeInt = Field(default=0, description="Log internal NN metrics if > 0.")
+  use_iota_embed: bool = Field(default=False, description="Use iota operator in Embed layer.")
+  use_untrainable_positional_embedding: bool = Field(default=False, description="Use untrainable positional embeddings.")
+  trainable_position_size: int = Field(default=-1, description="Enable GPT3-style trainable positional embeddings if > 0.")
+
+
+class QuantizationConfig(BaseModel):
+  """Quantization configurations."""
+
+  dtype: str = Field(default="bfloat16", description="Data type for activations.")
+  quantization: Optional[str] = Field(default="", description="Quantization type (e.g., 'int8', 'fp8').")
+  matmul_precision: MatMulPrecision = Field(default=MatMulPrecision.DEFAULT, description="Precision for matmul operations.")
+  replicate_quant_scale: bool = Field(default=False, description="Replicate quantization scale for 2D sharding.")
+  quant_cfg_path: Optional[str] = Field(default="", description="Path to quantization config for 'intmp'.")
+  quantize_kvcache: bool = Field(default=False, description="Quantize KV Cache values.")
+  kv_quant_axis: str = Field(default="heads_and_dkv", description="Axis for KV cache quantization.")
+  kv_quant_dtype: str = Field(default="int8", description="Data type for KV cache quantization.")
+  quantization_local_shard_count: int = Field(default=-1, description="Local shard count for quantization range finding.")
+
+  @validator("kv_quant_axis")
+  def validate_kv_axis(cls, v, values):
+    if values.get("quantize_kvcache") and v == "":
+      raise ValueError("kv_quant_axis cannot be empty if quantize_kvcache is True")
+    return v
+
+
+class MoEConfig(BaseModel):
+  """Mixture of Experts configurations."""
+
+  num_experts: PositiveInt = Field(default=1, description="Number of experts.")
+  num_experts_per_tok: PositiveInt = Field(default=1, description="Number of experts per token.")
+  megablox: bool = Field(default=True, description="Use Megablox for MoE.")
+  sparse_matmul: bool = Field(default=True, description="Use sparse matmul for MoE.")
+  capacity_factor: float = Field(default=-1.0, description="Expert capacity factor for token dropping.")
+  load_balance_loss_weight: NonNegativeFloat = Field(default=0.01, description="Weight for load balance loss.")
+  use_random_routing: bool = Field(default=False, description="Use random routing for debug/test.")
+  tile_batch_seq: Optional[PositiveInt] = Field(default=512, description="Tunable tiling dimension for Megablox.")
+  tile_activation_dim: Optional[PositiveInt] = Field(default=1024, description="Tunable tiling dimension for Megablox.")
+  tile_weight_dim: Optional[PositiveInt] = Field(default=1024, description="Tunable tiling dimension for Megablox.")
+
+
+class DeepSeekMoEConfig(BaseModel):
+  """DeepSeek-specific MoE configurations."""
+
+  base_moe_mlp_dim: PositiveInt = Field(default=7168, description="Intermediate dimension at MoE layer for DeepSeek.")
+  first_num_dense_layers: NonNegativeInt = Field(default=0, description="Number of initial dense layers for DeepSeek.")
+  shared_experts: PositiveInt = Field(default=1, description="Number of shared experts for DeepSeek.")
+  routed_scaling_factor: float = Field(default=1.0, description="Scaling factor for routing scores for DeepSeek.")
+  routed_score_func: Optional[str] = Field(default="", description="Scoring function for routing for DeepSeek.")
+  routed_bias: bool = Field(default=False, description="Add bias term for routing for DeepSeek.")
+  n_routing_groups: int = Field(default=-1, description="Number of groups for routing for DeepSeek.")
+  topk_routing_group: int = Field(default=-1, description="Number of top groups to route inputs for DeepSeek.")
+
+
+class PipelineParallelConfig(BaseModel):
+  """Pipeline parallelism configurations."""
+
+  num_layers_per_pipeline_stage: PositiveInt = Field(default=1)
+  num_pipeline_repeats: int = Field(default=-1, description="Auto-computed if -1.")
+  pipeline_parallel_layers: int = Field(default=-1, description="All layers if -1.")
+  num_pipeline_microbatches: int = Field(default=-1, description="Auto-computed if -1.")
+  pipeline_delay_activation_forwarding: bool = Field(default=False)
+  pipeline_fsdp_ag_once: bool = Field(default=False)
+  scan_pipeline_iterations: bool = Field(default=True)
+  scan_layers_per_stage: bool = Field(default=False)
+  set_remat_policy_on_pipeline_iterations: bool = Field(default=True)
+  set_remat_policy_on_layers_per_stage: bool = Field(default=False)
+
+
+class RematConfig(BaseModel):
+  """Rematerialization (checkpointing) policy configurations."""
+
+  remat_policy: RematPolicy = Field(default=RematPolicy.FULL)
+  decoder_layer_input: RematTensorConfigValue = Field(default=RematTensorConfigValue.DEVICE)
+  context: RematTensorConfigValue = Field(default=RematTensorConfigValue.REMAT)
+  mlpwi: RematTensorConfigValue = Field(default=RematTensorConfigValue.REMAT)
+  mlpwi_0: RematTensorConfigValue = Field(default=RematTensorConfigValue.REMAT)
+  mlpwi_1: RematTensorConfigValue = Field(default=RematTensorConfigValue.REMAT)
+  mlpwo: RematTensorConfigValue = Field(default=RematTensorConfigValue.REMAT)
+  query_proj: RematTensorConfigValue = Field(default=RematTensorConfigValue.REMAT)
+  key_proj: RematTensorConfigValue = Field(default=RematTensorConfigValue.REMAT)
+  value_proj: RematTensorConfigValue = Field(default=RematTensorConfigValue.REMAT)
+  qkv_proj: RematTensorConfigValue = Field(default=RematTensorConfigValue.REMAT)
+  out_proj: RematTensorConfigValue = Field(default=RematTensorConfigValue.REMAT)
+
+
+class AttentionMechanismConfig(BaseModel):
+  """Configuration for attention mechanism types and fusion."""
+
+  attention: AttentionKernel = Field(default=AttentionKernel.AUTOSELECTED)
+  attention_type: AttentionType = Field(default=AttentionType.GLOBAL)
+  sliding_window_size: NonNegativeInt = Field(default=0)
+  chunk_attn_window_size: NonNegativeInt = Field(default=0)
+  fused_qkv: bool = Field(default=False)
+  fused_mlp: bool = Field(default=False)
+
+
+class AttentionBehaviorConfig(BaseModel):
+  """Configuration for attention behavior like soft capping and norms."""
+
+  attn_logits_soft_cap: NonNegativeFloat = Field(default=0.0)
+  final_logits_soft_cap: NonNegativeFloat = Field(default=0.0)
+  use_post_attn_norm: bool = Field(default=False)
+  use_post_ffw_norm: bool = Field(default=False)
+  stack_prefill_result_cache: bool = Field(default=False)
+  enable_padding_causal_mask: bool = Field(default=True)
+  use_ragged_attention: bool = Field(default=False)
+  ragged_block_size: PositiveInt = Field(default=256)
+
+
+class MLAConfig(BaseModel):
+  """Multi-Head Latent Attention (MLA) configurations."""
+
+  q_lora_rank: NonNegativeInt = Field(default=0)
+  kv_lora_rank: NonNegativeInt = Field(default=512)
+  qk_nope_head_dim: PositiveInt = Field(default=128)
+  qk_rope_head_dim: PositiveInt = Field(default=64)
+  v_head_dim: PositiveInt = Field(default=128)
+
+
+class HardwareConfig(BaseModel):
+  """Hardware and JAX distributed system configurations."""
+
+  hardware: HardwareType = Field(default=HardwareType.TPU)
+  num_slices: int = Field(default=-1, description="Auto-determined if -1.")
+  jax_cache_dir: str = Field(default="~/jax_cache")
+  jax_distributed_initialization_timeout: PositiveInt = Field(default=300)
+  jax_debug_log_modules: Optional[str] = Field(default="")
+  skip_jax_distributed_system: bool = Field(default=False)
+  enable_single_controller: bool = Field(default=False)
+  compiled_trainstep_file: Optional[str] = Field(default="")
+  compile_topology: Optional[str] = Field(default="")
+  compile_topology_num_slices: int = Field(default=-1)
+
+
+class MeshConfig(BaseModel):
+  """Mesh and sharding rule configurations."""
+
+  mesh_axes: List[str] = Field(
+      default_factory=lambda: [
+          "data",
+          "stage",
+          "fsdp",
+          "fsdp_transpose",
+          "sequence",
+          "context",
+          "context_autoregressive",
+          "tensor",
+          "tensor_transpose",
+          "tensor_sequence",
+          "expert",
+          "autoregressive",
+      ]
+  )
+  logical_axis_rules: List[List[Any]] = Field(
+      default_factory=lambda: [["activation_batch", ["data", "fsdp", "fsdp_transpose", "expert"]]]
+  )  # Simplified default
+  data_sharding: List[List[str]] = Field(
+      default_factory=lambda: [
+          [
+              "data",
+              "stage",
+              "fsdp",
+              "fsdp_transpose",
+              "sequence",
+              "context",
+              "context_autoregressive",
+              "tensor",
+              "tensor_transpose",
+              "tensor_sequence",
+              "expert",
+              "autoregressive",
+          ]
+      ]
+  )
+  input_data_sharding_logical_axes: List[str] = Field(
+      default_factory=lambda: ["activation_embed_and_logits_batch", "activation_norm_length"]
+  )
+  sharding_tolerance: float = Field(default=0.02, ge=0.0, le=1.0)
+  custom_mesh: Optional[str] = Field(default="")
+  allow_split_physical_axes: bool = Field(default=False)
+  optimize_mesh_for_tpu_v6e: bool = Field(default=False)
+  context_parallel_load_balance: bool = Field(default=True)
+
+
+class DCNParallelismConfig(BaseModel):
+  """Data Center Network (inter-slice) parallelism configurations."""
+
+  dcn_data_parallelism: int = Field(default=-1)
+  dcn_fsdp_parallelism: int = Field(default=1)
+  dcn_fsdp_transpose_parallelism: int = Field(default=1)
+  dcn_sequence_parallelism: int = Field(default=1)
+  dcn_context_parallelism: int = Field(default=1)
+  dcn_context_autoregressive_parallelism: int = Field(default=1)
+  dcn_tensor_parallelism: int = Field(default=1)
+  dcn_tensor_transpose_parallelism: int = Field(default=1)
+  dcn_tensor_sequence_parallelism: int = Field(default=1)
+  dcn_pipeline_parallelism: int = Field(default=1)
+  dcn_expert_parallelism: int = Field(default=1)
+  dcn_autoregressive_parallelism: int = Field(default=1)
+
+
+class ICIParallelismConfig(BaseModel):
+  """Inter-Chip Interconnect (intra-slice) parallelism configurations."""
+
+  ici_data_parallelism: int = Field(default=1)
+  ici_fsdp_parallelism: int = Field(default=-1)
+  ici_fsdp_transpose_parallelism: int = Field(default=1)
+  ici_sequence_parallelism: int = Field(default=1)
+  ici_context_parallelism: int = Field(default=1)
+  ici_context_autoregressive_parallelism: int = Field(default=1)
+  ici_tensor_parallelism: int = Field(default=1)
+  ici_tensor_transpose_parallelism: int = Field(default=1)
+  ici_tensor_sequence_parallelism: int = Field(default=1)
+  ici_autoregressive_parallelism: int = Field(default=1)
+  ici_pipeline_parallelism: int = Field(default=1)
+  ici_expert_parallelism: int = Field(default=1)
+
+
+class TokenizerConfig(BaseModel):
+  """Tokenizer configurations."""
+
+  vocab_size: PositiveInt = Field(default=32_000)
+  tokenizer_path: str = Field(default="assets/tokenizer.llama2")
+  tokenizer_type: TokenizerTypeEnum = Field(default=TokenizerTypeEnum.SENTENCEPIECE)
+  use_chat_template: bool = Field(default=False)
+  tokenize_train_data: bool = Field(default=True)
+  tokenize_eval_data: bool = Field(default=True)
+  add_bos: bool = Field(default=True)
+  add_eos: bool = Field(default=True)
+
+
+class BaseDatasetConfig(BaseModel):
+  """Base dataset configurations, common across types."""
+
+  per_device_batch_size: float = Field(default=12.0, gt=0.0)  # Can be < 1.0
+  expansion_factor_real_data: int = Field(default=-1)
+  eval_per_device_batch_size: NonNegativeFloat = Field(default=0.0)
+  max_corpus_chars: Optional[PositiveInt] = Field(default=10_000_000)
+  train_data_columns: List[str] = Field(default_factory=lambda: ["text"])
+  eval_data_columns: List[str] = Field(default_factory=lambda: ["text"])
+  packing: bool = Field(default=True)
+  num_epoch: PositiveInt = Field(default=1)
+  dataset_type: DatasetType = Field(default=DatasetType.TFDS)
+  colocated_python_data_input: bool = Field(default=False)
+
+
+class TFDSDatasetConfig(BaseModel):
+  """TFDS-specific dataset configurations."""
+
+  dataset_path: Optional[str] = Field(default="")
+  dataset_name: str = Field(default="c4/en:3.0.1")
+  eval_dataset_name: str = Field(default="c4/en:3.0.1")
+  train_split: str = Field(default="train")
+  eval_split: str = Field(default="validation")
+
+
+class HFDatasetConfig(BaseModel):
+  """HuggingFace dataset configurations."""
+
+  hf_path: Optional[str] = Field(default="")
+  hf_data_dir: Optional[str] = Field(default="")
+  hf_train_files: Optional[str] = Field(default="")
+  hf_eval_split: Optional[str] = Field(default="")
+  hf_eval_files: Optional[str] = Field(default="")
+  hf_access_token: Optional[str] = Field(default="")
+
+
+class GrainDatasetConfig(BaseModel):
+  """Grain dataset configurations."""
+
+  grain_train_files: Optional[str] = Field(default="")
+  grain_eval_files: Optional[str] = Field(default="")
+  grain_file_type: GrainFileType = Field(default=GrainFileType.ARRAYRECORD)
+  grain_worker_count: NonNegativeInt = Field(default=1)
+  grain_worker_count_eval: NonNegativeInt = Field(default=1)
+
+
+class DatasetNestingConfig(BaseModel):
+  """Container for all dataset configurations."""
+
+  base: BaseDatasetConfig = Field(default_factory=BaseDatasetConfig)
+  tfds: Optional[TFDSDatasetConfig] = None
+  hf: Optional[HFDatasetConfig] = None
+  grain: Optional[GrainDatasetConfig] = None
+
+
+class BasicTrainingConfig(BaseModel):
+  """Basic training loop configurations."""
+
+  reuse_example_batch: NonNegativeInt = Field(default=0)
+  max_target_length: PositiveInt = Field(default=2048)
+  max_prefill_predict_length: PositiveInt = Field(default=64)
+  enable_dropout: bool = Field(default=True)
+  enable_data_shuffling: bool = Field(default=True)
+  data_shuffle_seed: NonNegativeInt = Field(default=0)
+  init_weights_seed: NonNegativeInt = Field(default=0)
+  gradient_clipping_threshold: NonNegativeFloat = Field(default=1.0)
+  gradient_accumulation_steps: PositiveInt = Field(default=1)
+  optimizer_memory_host_offload: bool = Field(default=False)
+  parameter_memory_host_offload: bool = Field(default=False)
+  scan_layers: bool = Field(default=True)
+
+
+class LearningRateConfig(BaseModel):
+  """Learning rate schedule configurations."""
+
+  learning_rate: NonNegativeFloat = Field(default=3.0e-5)
+  cosine_learning_rate_final_fraction: NonNegativeFloat = Field(default=0.1)
+  warmup_steps_fraction: NonNegativeFloat = Field(default=0.1)
+  learning_rate_schedule_steps: int = Field(default=-1, description="Auto-computed if -1.")
+
+
+class PromptConfig(BaseModel):
+  """Prompt configurations for generation/decode."""
+
+  prompt: str = Field(default="I love to")
+  load_from_prefill_dir: bool = Field(default=False)
+  prefill_cache_dir: Optional[str] = Field(default="")
+  autoregressive_decode_assert: Optional[str] = Field(default="")
+
+
+class OptimizerConfig(BaseModel):
+  """Optimizer configurations (primarily AdamW)."""
+
+  opt_type: OptimizerType = Field(default=OptimizerType.ADAMW)
+  adam_b1: float = Field(default=0.9)
+  adam_b2: float = Field(default=0.95)
+  adam_eps: float = Field(default=1.0e-8)
+  adam_eps_root: NonNegativeFloat = Field(default=0.0)
+  adam_weight_decay: NonNegativeFloat = Field(default=0.1)
+  mu_dtype: Optional[str] = Field(default="", description="Data type for AdamW 'mu'. Inherits from weight_dtype if unset.")
+
+
+class RoPEConfig(BaseModel):
+  """Rotary Position Embedding configurations."""
+
+  rope_type: RoPEType = Field(default=RoPEType.DEFAULT)
+  rope_use_scale: bool = Field(default=True)
+  rope_min_timescale: PositiveInt = Field(default=1)
+  rope_max_timescale: PositiveInt = Field(default=10_000)
+  local_rope_max_timescale: int = Field(default=-1, description="Use rope_max_timescale if -1.")
+
+
+class YarnRoPEConfig(BaseModel):
+  """Yarn RoPE specific configurations."""
+
+  max_position_embeddings: PositiveInt = Field(default=163840)
+  original_max_position_embeddings: PositiveInt = Field(default=4096)
+  rope_factor: PositiveInt = Field(default=40)
+  beta_fast: PositiveInt = Field(default=32)
+  beta_slow: PositiveInt = Field(default=1)
+  mscale: NonNegativeFloat = Field(default=1.0)
+
+
+class DecodeAlgoConfig(BaseModel):
+  """Configurations for decoding algorithms."""
+
+  decode_sampling_strategy: SamplingStrategy = Field(default=SamplingStrategy.GREEDY)
+  decode_sampling_nucleus_p: float = Field(default=-1.0, ge=-1.0, le=1.0, description="Allow -1 for 'not set'.")
+  decode_sampling_top_k: NonNegativeInt = Field(default=0)
+  decode_sampling_temperature: NonNegativeFloat = Field(default=1.0)
+
+
+class EvalRunConfig(BaseModel):
+  """Evaluation run configurations."""
+
+  eval_interval: int = Field(default=-1)
+  eval_steps: int = Field(default=-1)
+  target_eval_loss: NonNegativeFloat = Field(default=0.0)
+
+
+class ProfilerRunConfig(BaseModel):
+  """Profiler configurations."""
+
+  profiler: ProfilerType = Field(default=ProfilerType.NONE)
+  upload_all_profiler_results: bool = Field(default=False)
+  skip_first_n_steps_for_profiler: NonNegativeInt = Field(default=1)
+  profiler_steps: PositiveInt = Field(default=5)
+  profile_cleanly: bool = Field(default=True)
+  profile_periodically_period: int = Field(default=-1)
+
+
+class HloDumpRunConfig(BaseModel):
+  """HLO dump configurations."""
+
+  dump_hlo: bool = Field(default=False)
+  dump_step: int = Field(default=-1)
+  dump_hlo_local_dir: str = Field(default="/tmp/xla_dump/")
+  dump_hlo_delete_local_after: bool = Field(default=True)
+  dump_hlo_gcs_dir: Optional[str] = Field(default="")
+  dump_hlo_module_name: str = Field(default="jit_train_step")
+  dump_hlo_xla_flags: Optional[str] = Field(default="")
+  dump_hlo_upload_all: bool = Field(default=False)
+
+
+class KVLayoutRunConfig(BaseModel):
+  """KV Cache and compute layout configurations."""
+
+  prefill_cache_axis_order: str = Field(default="1,2,0,3")
+  ar_cache_axis_order: str = Field(default="1,2,0,3")
+  compute_axis_order: str = Field(default="0,1,2,3")
+  reshape_q: bool = Field(default=False)
+
+  @validator("compute_axis_order")
+  def validate_compute_layout(cls, v):
+    if v not in ("0,1,2,3", "0,2,1,3"):
+      raise ValueError("compute_axis_order must be '0,1,2,3' or '0,2,1,3'")
+    return v
+
+
+class MaxEngineRunConfig(BaseModel):
+  """MaxEngine server specific configurations."""
+
+  prometheus_port: NonNegativeInt = Field(default=0)
+  enable_jax_profiler: bool = Field(default=False)
+  jax_profiler_port: PositiveInt = Field(default=9999)
+  inference_server: InferenceServerType = Field(default=InferenceServerType.MAXTEXT_INTERLEAVED)
+  prefill_slice: Optional[str] = Field(default="v5e-16", description="Slice for prefill in disaggregated server.")
+  generate_slice: Optional[str] = Field(default="v5e-16", description="Slice for generation in disaggregated server.")
+
+
+class SplashAttentionRunConfig(BaseModel):
+  """Splash attention block size configurations."""
+
+  sa_block_q: PositiveInt = Field(default=512)
+  sa_block_kv: PositiveInt = Field(default=512)
+  sa_block_kv_compute: PositiveInt = Field(default=512)
+  sa_block_q_dkv: PositiveInt = Field(default=512)
+  sa_block_kv_dkv: PositiveInt = Field(default=512)
+  sa_block_kv_dkv_compute: PositiveInt = Field(default=512)
+  sa_block_q_dq: PositiveInt = Field(default=512)
+  sa_block_kv_dq: PositiveInt = Field(default=512)
+  sa_use_fused_bwd_kernel: bool = Field(default=False)
+  sa_q_layout: str = Field(default="HEAD_DIM_MINOR")
+  sa_k_layout: str = Field(default="HEAD_DIM_MINOR")
+  sa_v_layout: str = Field(default="HEAD_DIM_MINOR")
+
+
+class PagedAttentionRunConfig(BaseModel):
+  """Paged attention configurations."""
+
+  pagedattn_num_pages: PositiveInt = Field(default=64)
+  pagedattn_tokens_per_page: PositiveInt = Field(default=32)
+  pagedattn_pages_per_compute_block: PositiveInt = Field(default=4)
+  pagedattn_max_pages_per_group: int = Field(default=-1, description="Auto-computed if -1.")
+
+
+class ChunkedPrefillRunConfig(BaseModel):
+  """Chunked prefill configurations."""
+
+  prefill_chunk_size: PositiveInt = Field(default=256)
+  use_chunked_prefill: bool = Field(default=False)
+
+
+class PrefixCachingRunConfig(BaseModel):
+  """Prefix caching configurations for JetStream."""
+
+  enable_prefix_caching: bool = Field(default=False)
+  prefix_caching_hbm_byte: PositiveInt = Field(default=10_000_000_000)  # 10 GB
+  prefix_caching_dram_byte: PositiveInt = Field(default=100_000_000_000)  # 100 GB
+
+
+class Llama4SpecificConfig(BaseModel):
+  """Llama4-specific configurations from base.yml."""
+
+  use_qk_norm: bool = Field(default=False)
+  nope_layer_interval: int = Field(default=-1)
+  interleave_moe_layer_step: PositiveInt = Field(default=1)
+  temperature_tuning: bool = Field(default=False)
+
+
+class MultimodalRunConfig(BaseModel):
+  """Multimodal configurations."""
+
+  use_multimodal: bool = Field(default=False)
+  freeze_vision_encoder_params: bool = Field(default=True)
+  dtype_mm: str = Field(default="float32", description="Data type for ViT.")
+  remat_policy_for_vit: RematPolicy = Field(default=RematPolicy.MINIMAL)
+  image_size_for_vit: PositiveInt = Field(default=896, description="Default for Gemma3.")
+  image_path: Optional[str] = Field(default="")
+
+
+class Llama4VitRunConfig(BaseModel):
+  """Llama4-specific Vision Transformer configurations from base.yml."""
+
+  hidden_size_for_vit: PositiveInt = Field(default=1408)
+  intermediate_size_for_vit: PositiveInt = Field(default=5632)
+  num_attention_heads_for_vit: PositiveInt = Field(default=16)
+  num_channels_for_vit: PositiveInt = Field(default=3)
+  patch_size_for_vit: PositiveInt = Field(default=14)
+  num_hidden_layers_for_vit: PositiveInt = Field(default=34)
+  projector_input_dim_for_vit: PositiveInt = Field(default=4096)
+  projector_output_dim_for_vit: PositiveInt = Field(default=4096)
+  rope_theta_for_vit: PositiveInt = Field(default=10000)
+  vision_output_dim_for_vit: PositiveInt = Field(default=4096)
+  pixel_shuffle_ratio_for_vit: float = Field(default=0.5, gt=0.0, lt=1.0)
+  projector_dropout_for_vit: NonNegativeFloat = Field(default=0.0)
+
+
+class DPOSpecificConfig(BaseModel):
+  """DPO-specific configurations."""
+
+  use_dpo: bool = Field(default=False)
+  dpo_label_smoothing: NonNegativeFloat = Field(default=0.0)
+  dpo_beta: NonNegativeFloat = Field(default=0.1)
+
+
+class SFTSpecificConfig(BaseModel):
+  """SFT-specific configurations."""
+
+  use_sft: bool = Field(default=False)
+  sft_train_on_completion_only: bool = Field(default=False)
+
+
+class StackTraceConfig(BaseModel):
+  """Stack trace collection configurations."""
+
+  collect_stack_trace: bool = Field(default=False)
+  stack_trace_to_cloud: bool = Field(default=False)
+  stack_trace_interval_seconds: PositiveInt = Field(default=600)
+
+
+class GCPWorkloadMonitorConfig(BaseModel):
+  """GCP workload monitoring configurations."""
+
+  report_heartbeat_metric_for_gcp_monitoring: bool = Field(default=False)
+  heartbeat_reporting_interval_in_seconds: PositiveInt = Field(default=5)
+  report_performance_metric_for_gcp_monitoring: bool = Field(default=False)
+
+
+class InferenceMicrobenchmarkConfig(BaseModel):
+  """Inference microbenchmark configurations."""
+
+  inference_microbenchmark_prefill_lengths: str = Field(default="64,128,256,512,1024")
+  inference_microbenchmark_stages: str = Field(default="prefill,generate")
+  inference_microbenchmark_loop_iters: PositiveInt = Field(default=10)
+  inference_microbenchmark_log_file_path: Optional[str] = Field(default="")
+  inference_microbenchmark_num_samples: List[PositiveInt] = Field(default_factory=lambda: [1, 2, 3, 4, 5])
+  inference_metadata_file: Optional[str] = Field(default="")  # Path to JSON, not in base.yml
+  inference_benchmark_test: bool = Field(default=False)
+  enable_model_warmup: bool = Field(default=False)
+  enable_llm_inference_pool: bool = Field(default=False)
+  multi_sampling: bool = Field(default=False)
+  return_log_prob: bool = Field(default=False)
+
+
+class MaxTextConfig(BaseModel):
+  """Top-level configuration model for MaxText, derived from YAML files."""
+
+  run_config: RunConfig = Field(default_factory=RunConfig)
+  checkpoint_config: CheckpointConfig = Field(default_factory=CheckpointConfig)
+
+  model_identity_config: ModelIdentityConfig = Field(default_factory=ModelIdentityConfig)
+  model_core_config: ModelCoreConfig = Field(default_factory=ModelCoreConfig)
+  model_architecture_config: ModelArchitectureConfig = Field(default_factory=ModelArchitectureConfig)
+  model_activation_config: ModelActivationConfig = Field(default_factory=ModelActivationConfig)
+  model_misc_behavior_config: ModelMiscBehaviorConfig = Field(default_factory=ModelMiscBehaviorConfig)
+
+  quantization_config: QuantizationConfig = Field(default_factory=QuantizationConfig)
+  moe_config: MoEConfig = Field(default_factory=MoEConfig)
+  deepseek_moe_config: Optional[DeepSeekMoEConfig] = None
+  pipeline_parallel_config: PipelineParallelConfig = Field(default_factory=PipelineParallelConfig)
+  remat_config: RematConfig = Field(default_factory=RematConfig)
+
+  attention_mechanism_config: AttentionMechanismConfig = Field(default_factory=AttentionMechanismConfig)
+  attention_behavior_config: AttentionBehaviorConfig = Field(default_factory=AttentionBehaviorConfig)
+
+  mla_config: Optional[MLAConfig] = None
+  hardware_config: HardwareConfig = Field(default_factory=HardwareConfig)
+  parallelism_config: ParallelismConfig = Field(default_factory=ParallelismConfig)
+  tokenizer_config: TokenizerConfig = Field(default_factory=TokenizerConfig)
+  dataset_nesting_config: DatasetNestingConfig = Field(default_factory=DatasetNestingConfig)
+
+  basic_training_config: BasicTrainingConfig = Field(default_factory=BasicTrainingConfig)
+  learning_rate_config: LearningRateConfig = Field(default_factory=LearningRateConfig)
+  prompt_config: PromptConfig = Field(default_factory=PromptConfig)
+
+  optimizer_config: OptimizerConfig = Field(default_factory=OptimizerConfig)
+  rope_config: RoPEConfig = Field(default_factory=RoPEConfig)
+  yarn_rope_config: Optional[YarnRoPEConfig] = None
+  decode_algo_config: DecodeAlgoConfig = Field(default_factory=DecodeAlgoConfig)
+  eval_run_config: EvalRunConfig = Field(default_factory=EvalRunConfig)
+  profiler_run_config: ProfilerRunConfig = Field(default_factory=ProfilerRunConfig)
+  hlo_dump_run_config: HloDumpRunConfig = Field(default_factory=HloDumpRunConfig)
+  kv_layout_run_config: KVLayoutRunConfig = Field(default_factory=KVLayoutRunConfig)
+  max_engine_run_config: MaxEngineRunConfig = Field(default_factory=MaxEngineRunConfig)
+  splash_attention_run_config: SplashAttentionRunConfig = Field(default_factory=SplashAttentionRunConfig)
+  paged_attention_run_config: PagedAttentionRunConfig = Field(default_factory=PagedAttentionRunConfig)
+  chunked_prefill_run_config: ChunkedPrefillRunConfig = Field(default_factory=ChunkedPrefillRunConfig)
+  prefix_caching_run_config: PrefixCachingRunConfig = Field(default_factory=PrefixCachingRunConfig)
+  llama4_specific_config: Optional[Llama4SpecificConfig] = None
+  multimodal_run_config: MultimodalRunConfig = Field(default_factory=MultimodalRunConfig)
+  llama4_vit_run_config: Optional[Llama4VitRunConfig] = None
+  dpo_specific_config: Optional[DPOSpecificConfig] = None
+  sft_specific_config: Optional[SFTSpecificConfig] = None
+  stack_trace_config: StackTraceConfig = Field(default_factory=StackTraceConfig)
+  gcp_workload_monitor_config: GCPWorkloadMonitorConfig = Field(default_factory=GCPWorkloadMonitorConfig)
+  inference_microbenchmark_config: InferenceMicrobenchmarkConfig = Field(default_factory=InferenceMicrobenchmarkConfig)
+
+  reuse_example_batch: NonNegativeInt = Field(default=0, description="For testing TPU performance, repeat the same batch.")
+  max_checkify: bool = Field(default=False, description="Enable extra checks using jax.checkify (affects performance).")
+
+  # Fields from `dpo.yml` etc. are typically booleans or simple types already covered,
+  # or they override values in the sub-configs. For example, `dpo.yml` has `use_dpo: true`.
+  # This would be loaded by setting `maxtext_config.dpo_specific_config.use_dpo = True`.
+  # Model specific parameters from `configs/models/*.yml` would populate the `model_architecture_config`, etc.
+
+  class Config:
+    extra = "forbid"
+    validate_assignment = True

--- a/MaxText/convert_gpt3_ckpt_from_paxml.py
+++ b/MaxText/convert_gpt3_ckpt_from_paxml.py
@@ -53,7 +53,7 @@ from MaxText import max_logging
 from MaxText import maxtext_utils
 from MaxText import max_utils
 from MaxText import optimizers
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText.layers import quantizations
 from MaxText.layers.models import Transformer
@@ -84,7 +84,7 @@ def convert(paxml_ckpt_path, maxtext_model_name, base_output_directory, run_name
       "checkpoint_period=1",
       "async_checkpointing=false",
   ]
-  cfg = pyconfig.initialize(base_args)
+  cfg = MaxText.configs.loader.initialize(base_args)
   init_rng, _ = random.split(random.PRNGKey(cfg.init_weights_seed), 2)
   devices_array = maxtext_utils.create_device_mesh(cfg)
   mesh = Mesh(devices_array, cfg.mesh_axes)

--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -26,7 +26,7 @@ from jetstream.engine import engine_api
 
 from MaxText import max_utils
 from MaxText import maxengine
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText import profiler
 from MaxText import multimodal_utils
 # Placeholder: internal
@@ -86,7 +86,7 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   _validate_config(config)
   max_utils.print_system_information()
 

--- a/MaxText/elastic_train.py
+++ b/MaxText/elastic_train.py
@@ -67,7 +67,7 @@ from MaxText import max_utils
 from MaxText import maxtext_utils
 from MaxText import max_logging
 from MaxText import profiler
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.gcp_workload_monitor import GCPWorkloadMonitor
 from MaxText.input_pipeline.input_pipeline_interface import create_data_iterator
 from MaxText.metric_logger import MetricLogger
@@ -476,7 +476,7 @@ def main(argv: Sequence[str]) -> None:
 
   elastic_manager = elastic_initialize(jax.devices())
 
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   max_utils.print_system_information()
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path or ""

--- a/MaxText/elastic_train.py
+++ b/MaxText/elastic_train.py
@@ -62,7 +62,7 @@ from pathwaysutils.debug import timing
 
 import tensorflow as tf
 
-from MaxText import checkpointing
+from MaxText import checkpointing, pyconfig
 from MaxText import max_utils
 from MaxText import maxtext_utils
 from MaxText import max_logging

--- a/MaxText/experimental/rl/grpo_trainer.py
+++ b/MaxText/experimental/rl/grpo_trainer.py
@@ -56,7 +56,7 @@ from MaxText import max_utils
 from MaxText import maxengine
 from MaxText import maxtext_utils
 from MaxText import profiler
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.common_types import Array
 from MaxText.experimental.rl import grpo_input_pipeline
 from MaxText.gcp_workload_monitor import GCPWorkloadMonitor
@@ -935,14 +935,14 @@ def main(argv: Sequence[str]) -> None:
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
     os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   if not config.use_grpo:
     raise ValueError("Please set the value of use_grpo to True")
   if config.decode_sampling_strategy == "greedy" or config.decode_sampling_temperature == 0.0:
     raise ValueError(
         "Please set decode_sampling_strategy as 'weighted' and decode_sampling_temperature as a positive number"
     )
-  config_inference = pyconfig.initialize(
+  config_inference = MaxText.configs.loader.initialize(
       list(argv)
       + ["ici_tensor_parallelism=4", "per_device_batch_size=" + str(config.per_device_batch_size * config.num_generations)]
   )

--- a/MaxText/generate_param_only_checkpoint.py
+++ b/MaxText/generate_param_only_checkpoint.py
@@ -39,7 +39,7 @@ from MaxText import max_logging
 from MaxText import max_utils
 from MaxText import maxtext_utils
 from MaxText import optimizers
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.common_types import DecoderBlockType
 from MaxText.layers import models, quantizations
 from MaxText.train import save_checkpoint
@@ -206,7 +206,7 @@ def generate_decode_checkpoint(config):
 
 def main(argv: Sequence[str]) -> None:
   print(argv)
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   generate_decode_checkpoint(config)
 
 

--- a/MaxText/inference/decode_multi.py
+++ b/MaxText/inference/decode_multi.py
@@ -44,7 +44,7 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   _validate_config(config)
   max_utils.print_system_information()
 

--- a/MaxText/inference_microbenchmark.py
+++ b/MaxText/inference_microbenchmark.py
@@ -29,7 +29,7 @@ from MaxText import maxengine
 from MaxText import maxtext_utils
 from MaxText import prefill_packing
 from MaxText import profiler
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.utils import gcs_utils
 
 import warnings
@@ -429,7 +429,7 @@ def run_benchmarks(config):
 
 def run_benchmarks_with_unsafe_rbg(config, **kwargs):
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
-  return run_benchmarks(pyconfig.initialize(config, **kwargs))
+  return run_benchmarks(MaxText.configs.loader.initialize(config, **kwargs))
 
 
 def main(config, **kwargs):

--- a/MaxText/inference_microbenchmark_sweep.py
+++ b/MaxText/inference_microbenchmark_sweep.py
@@ -25,7 +25,7 @@ import jsonlines
 import jax
 
 from MaxText import inference_microbenchmark
-from MaxText import pyconfig
+import MaxText.configs.loader
 
 try:
   JaxRuntimeError = jax.errors.JaxRuntimeError  # added in JAX 0.4.34
@@ -48,7 +48,7 @@ def main():
     - flatten_microbenchmark_results: Whether or not to flatten results. Should
       be true
   """
-  config = pyconfig.initialize(sys.argv)
+  config = MaxText.configs.loader.initialize(sys.argv)
   base_run_name = config.run_name
 
   with open(config.inference_metadata_file, "rt", encoding="utf-8") as json_file:

--- a/MaxText/input_pipeline/input_pipeline_interface.py
+++ b/MaxText/input_pipeline/input_pipeline_interface.py
@@ -28,7 +28,7 @@ import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
 
 from MaxText import multihost_dataloading
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.input_pipeline._grain_data_processing import make_grain_train_iterator, make_grain_eval_iterator
 from MaxText.input_pipeline._hf_data_processing import make_hf_train_iterator, make_hf_eval_iterator
 from MaxText.input_pipeline._tfds_data_processing import make_tfds_train_iterator, make_tfds_eval_iterator

--- a/MaxText/input_pipeline/input_pipeline_interface.py
+++ b/MaxText/input_pipeline/input_pipeline_interface.py
@@ -27,7 +27,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
 
-from MaxText import multihost_dataloading
+from MaxText import multihost_dataloading, pyconfig
 import MaxText.configs.loader
 from MaxText.input_pipeline._grain_data_processing import make_grain_train_iterator, make_grain_eval_iterator
 from MaxText.input_pipeline._hf_data_processing import make_hf_train_iterator, make_hf_eval_iterator

--- a/MaxText/layerwise_quantization.py
+++ b/MaxText/layerwise_quantization.py
@@ -43,7 +43,7 @@ from flax.linen import partitioning as nn_partitioning
 from MaxText import checkpointing
 from MaxText import max_utils
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText import common_types
 from MaxText.layers import models, quantizations, deepseek
 import orbax.checkpoint as ocp
@@ -178,7 +178,7 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   validate_config(config)
   max_utils.print_system_information()
 

--- a/MaxText/llama_mistral_mixtral_orbax_to_hf.py
+++ b/MaxText/llama_mistral_mixtral_orbax_to_hf.py
@@ -50,7 +50,7 @@ from MaxText import checkpointing
 from MaxText import llama_or_mistral_ckpt
 from MaxText import max_logging
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.generate_param_only_checkpoint import _read_train_checkpoint
 from MaxText.max_utils import unpermute_from_match_maxtext_rope
 
@@ -254,7 +254,7 @@ def convert_orbax_hf(hf_model_path, config):
 
 
 def main(argv: Sequence[str]):
-  config = pyconfig.initialize(argv[:-1])
+  config = MaxText.configs.loader.initialize(argv[:-1])
   hf_model_path = argv[-1].split("=")[1]
   print(f"Will save converted HuggingFace checkpoint to path = {hf_model_path}")
 

--- a/MaxText/load_and_quantize_checkpoint.py
+++ b/MaxText/load_and_quantize_checkpoint.py
@@ -23,14 +23,14 @@ import jax
 
 from MaxText import max_utils
 from MaxText import maxengine
-from MaxText import pyconfig
+import MaxText.configs.loader
 
 
 def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   validate_config(config)
   max_utils.print_system_information()
 

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -42,7 +42,7 @@ from jetstream.engine.tokenizer_pb2 import TokenizerType
 from MaxText import inference_utils
 from MaxText import max_utils
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.common_types import MODEL_MODE_PREFILL, DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE
 from MaxText.globals import PKG_DIR
 from MaxText.inference.page_manager import PageManager, PageState
@@ -1527,6 +1527,6 @@ def create_engine_from_config_flags(
     option = f"{k}={v}"
     updated_args.append(option)
   print(f"Invoking maxengine with args:\n \t{updated_args}")
-  cfg = pyconfig.initialize(updated_args)
+  cfg = MaxText.configs.loader.initialize(updated_args)
   engine = MaxEngine(cfg)
   return engine

--- a/MaxText/maxengine_server.py
+++ b/MaxText/maxengine_server.py
@@ -23,7 +23,7 @@ from jetstream.core import server_lib, config_lib
 
 import jax
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText import maxengine_config
 
 # _PORT = flags.DEFINE_integer('port', 9000, 'port to listen on')
@@ -84,5 +84,5 @@ def main(config):
 if __name__ == "__main__":
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
-  cfg = pyconfig.initialize(sys.argv)
+  cfg = MaxText.configs.loader.initialize(sys.argv)
   main(cfg)

--- a/MaxText/scratch_code/generate_grpo_golden_logits.py
+++ b/MaxText/scratch_code/generate_grpo_golden_logits.py
@@ -45,7 +45,7 @@ from datasets import load_dataset
 
 from MaxText import maxengine
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.experimental.rl.grpo_trainer import compute_log_probs, grpo_loss_fn, _merge_grpo_state, generate_completions
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
@@ -57,19 +57,19 @@ class GRPOTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.cfg = pyconfig.initialize(
+    self.cfg = MaxText.configs.loader.initialize(
         [None, "MaxText/experimental/rl/grpo_trainer_test.yml"],
         model_name="llama3.1-8b",
         run_name="generate_grpo_test_data",
         load_parameters_path="gs://maxtext-model-checkpoints/llama3.1-8b/2025-01-23-19-04/scanned/0/items",
         enable_checkpointing=True,
     )
-    self.cfg_no_ckpt_loading = pyconfig.initialize(
+    self.cfg_no_ckpt_loading = MaxText.configs.loader.initialize(
         [None, "MaxText/experimental/rl/grpo_trainer_test.yml"],
         run_name="generate_grpo_test_data_no_ckpt_loading",
         enable_checkpointing=False,
     )
-    self.cfg_no_ckpt_loading_inference = pyconfig.initialize(
+    self.cfg_no_ckpt_loading_inference = MaxText.configs.loader.initialize(
         [None, "MaxText/experimental/rl/grpo_trainer_test.yml"],
         run_name="generate_grpo_test_data_no_ckpt_loading_inference",
         enable_checkpointing=False,

--- a/MaxText/scratch_code/generate_sft_golden_data.py
+++ b/MaxText/scratch_code/generate_sft_golden_data.py
@@ -35,7 +35,7 @@ import torch
 from transformers import TrainingArguments, AutoModelForCausalLM, AutoTokenizer
 from trl import SFTConfig, SFTTrainer
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText.tests.integration_tests.sft_trainer_correctness_test import get_maxtext_logits, get_token_log_probs, prepare_maxtext_inputs
 
@@ -50,7 +50,7 @@ DATA = {
 
 def initialize_maxtext_config(config):
   """Initializes configuration for MaxText."""
-  cfg_with_ckpt = pyconfig.initialize(
+  cfg_with_ckpt = MaxText.configs.loader.initialize(
       [sys.argv[0], os.path.join(PKG_DIR, "configs", "sft.yml")],
       run_name="compare_maxtext_with_trl_logits",
       model_name=config.model_name,
@@ -66,7 +66,7 @@ def initialize_maxtext_config(config):
       logits_dot_in_fp32=True,
   )
 
-  cfg_without_ckpt = pyconfig.initialize(
+  cfg_without_ckpt = MaxText.configs.loader.initialize(
       [sys.argv[0], os.path.join(PKG_DIR, "configs", "sft.yml")],
       run_name="generate_sft_golden_data",
       model_name="default",

--- a/MaxText/sft_trainer.py
+++ b/MaxText/sft_trainer.py
@@ -35,7 +35,7 @@ from MaxText import max_utils
 from MaxText import maxtext_utils
 from MaxText import max_logging
 from MaxText import profiler
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.gcp_workload_monitor import GCPWorkloadMonitor
 from MaxText.metric_logger import MetricLogger
 from MaxText.train import (
@@ -285,7 +285,7 @@ def main(argv: Sequence[str]) -> None:
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
     os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   max_utils.print_system_information()
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path

--- a/MaxText/standalone_checkpointer.py
+++ b/MaxText/standalone_checkpointer.py
@@ -36,7 +36,7 @@ from flax.linen import partitioning as nn_partitioning
 from MaxText import checkpointing
 from MaxText import maxtext_utils
 from MaxText import max_logging
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.train import setup_mesh_and_model, get_first_step, validate_train_config, save_checkpoint
 from MaxText.layers import models
 
@@ -114,7 +114,7 @@ def add_entropy_to_checkpoint(state):
 def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_cpu_enable_gloo_collectives", True)
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   validate_train_config(config)
   print(f"Found {jax.device_count()} devices.")
   print(f"Found {jax.process_count()} processes.")

--- a/MaxText/standalone_dataloader.py
+++ b/MaxText/standalone_dataloader.py
@@ -27,7 +27,7 @@ import numpy as np
 import jax
 
 from MaxText import max_logging
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.train import validate_train_config, get_first_step, load_next_batch, setup_train_loop
 
 
@@ -61,7 +61,7 @@ def data_load_loop(config, state=None):
 def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_cpu_enable_gloo_collectives", True)
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   validate_train_config(config)
   max_logging.log(f"Found {jax.device_count()} devices.")
   max_logging.log(f"Found {jax.process_count()} processes.")

--- a/MaxText/tests/attention_test.py
+++ b/MaxText/tests/attention_test.py
@@ -33,7 +33,7 @@ import jax.numpy as jnp
 from flax.core import freeze
 
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN
 from MaxText.globals import PKG_DIR
 from MaxText.layers import attentions
@@ -281,13 +281,13 @@ class AttentionTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         **self.config_arguments,
     )
     self.cfg = config
 
-    config_cp = pyconfig.initialize(
+    config_cp = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         **self.config_arguments,
         ici_context_parallelism=4,  # use context parallelism of 4
@@ -630,7 +630,7 @@ class AttentionTest(unittest.TestCase):
 
     rtol, atol = 1e-02, 1e-02
 
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1.0,
         run_name="test",
@@ -730,7 +730,7 @@ class AttentionTest(unittest.TestCase):
 
     rtol, atol = 1e-02, 1e-02
 
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1.0,
         run_name="test",
@@ -1019,7 +1019,7 @@ class MLATest(parameterized.TestCase):
 
   def init_mla(self, rope_type):
     """Helper function to initialize MLA with different model names."""
-    cfg = pyconfig.initialize(
+    cfg = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1.0,
         run_name="test",

--- a/MaxText/tests/check_llama4_layers.py
+++ b/MaxText/tests/check_llama4_layers.py
@@ -27,7 +27,7 @@ import unittest
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText.globals import PKG_DIR
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText import maxtext_utils
 from MaxText.layers import attentions, embeddings, llama4
 import numpy as np
@@ -591,7 +591,7 @@ class Llama4VisionAttentionTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.cfg = pyconfig.initialize(
+    self.cfg = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         **self.config_arguments,
     )
@@ -859,7 +859,7 @@ class Llama4VisionEncoderTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.cfg = pyconfig.initialize(
+    self.cfg = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         **self.config_arguments,
     )

--- a/MaxText/tests/context_parallelism_test.py
+++ b/MaxText/tests/context_parallelism_test.py
@@ -26,7 +26,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, PartitionSpec, NamedSharding
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText import maxtext_utils
 
@@ -61,7 +61,7 @@ class ContextParallelismTest(unittest.TestCase):
   }
 
   def setUp(self):
-    config_cp = pyconfig.initialize(
+    config_cp = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         **self.config_arguments,
         ici_context_parallelism=4,  # use context parallelism of 4

--- a/MaxText/tests/elastic_train_test.py
+++ b/MaxText/tests/elastic_train_test.py
@@ -28,7 +28,7 @@ from pathwaysutils.elastic import manager
 
 from MaxText import elastic_train
 from MaxText import max_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 
 logging.basicConfig()
 logging.getLogger("pathwaysutils.elastic.manager").setLevel(logging.INFO)
@@ -111,7 +111,7 @@ class ElasticTrainTest(parameterized.TestCase):
 
     # Set checkpoint_period which should be unchanged.
     # Set enable_single_controller to avoid jax.distribute_initialize
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         argv=[
             "test",
             "MaxText/configs/base.yml",

--- a/MaxText/tests/forward_pass_logit_checker.py
+++ b/MaxText/tests/forward_pass_logit_checker.py
@@ -51,7 +51,7 @@ from transformers import AutoModelForCausalLM
 
 from MaxText import max_logging
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
@@ -170,5 +170,5 @@ if __name__ == "__main__":
   for arg in to_remove_args:
     model_args = [s for s in model_args if not s.startswith(arg)]
 
-  cfg = pyconfig.initialize(model_args)
+  cfg = MaxText.configs.loader.initialize(model_args)
   main(cfg, test_args)

--- a/MaxText/tests/goodput_utils_test.py
+++ b/MaxText/tests/goodput_utils_test.py
@@ -16,7 +16,7 @@
 
 import os
 import unittest
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from unittest import mock
 from MaxText.utils.goodput_utils import create_goodput_recorder, maybe_monitor_goodput, maybe_record_goodput, GoodputEvent
@@ -27,7 +27,7 @@ class GoodputUtilsTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.config = pyconfig.initialize(
+    self.config = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "configs", "base.yml")],
         base_output_directory="gs://runner-maxtext-logs",
         run_name="runner_test",

--- a/MaxText/tests/gpt3_test.py
+++ b/MaxText/tests/gpt3_test.py
@@ -27,7 +27,7 @@ import jax.numpy as jnp
 import jax
 
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
 from MaxText.layers import quantizations
@@ -59,7 +59,7 @@ class GPT3(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.cfg = pyconfig.initialize(
+    self.cfg = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         run_name="test",
         enable_checkpointing=False,

--- a/MaxText/tests/grain_data_processing_test.py
+++ b/MaxText/tests/grain_data_processing_test.py
@@ -24,7 +24,7 @@ import jax
 from jax.sharding import Mesh
 from jax.experimental import mesh_utils
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.input_pipeline import _grain_data_processing
 from MaxText.input_pipeline import input_pipeline_interface
 from MaxText.globals import PKG_DIR
@@ -40,7 +40,7 @@ class GrainArrayRecordProcessingTest(unittest.TestCase):
   def setUp(self):
     super().setUp()
     temp_dir = tempfile.gettempdir()
-    self.config = pyconfig.initialize(
+    self.config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1,
         run_name="test",
@@ -115,7 +115,7 @@ class GrainParquetProcessingTest(unittest.TestCase):
   def setUp(self):
     super().setUp()
     temp_dir = tempfile.gettempdir()
-    self.config = pyconfig.initialize(
+    self.config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1,
         run_name="test",

--- a/MaxText/tests/grpo_trainer_correctness_test.py
+++ b/MaxText/tests/grpo_trainer_correctness_test.py
@@ -47,7 +47,7 @@ import transformers
 
 from MaxText import maxengine
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.common_types import Array
 from MaxText.experimental.rl.grpo_trainer import compute_log_probs, grpo_loss_fn, _merge_grpo_state, generate_completions
 from MaxText.globals import PKG_DIR
@@ -109,13 +109,13 @@ class GrpoTrainerTest(unittest.TestCase):
     exit_code = subprocess.call(command, cwd=os.path.dirname(PKG_DIR))
     if exit_code != 0:
       raise ValueError(f"{command} failed with exit code: {exit_code}")
-    self.config = pyconfig.initialize(
+    self.config = MaxText.configs.loader.initialize(
         [None, "MaxText/experimental/rl/grpo_trainer_test.yml"],
         run_name="unit_test_grpo_trainer",
         tokenizer_path=os.path.join(os.path.dirname(PKG_DIR), "assets", "llama3.1-tokenizer"),
         enable_checkpointing=False,
     )
-    self.config_inference = pyconfig.initialize(
+    self.config_inference = MaxText.configs.loader.initialize(
         [None, "MaxText/experimental/rl/grpo_trainer_test.yml"],
         run_name="unit_test_grpo_trainer_inference",
         tokenizer_path=os.path.join(os.path.dirname(PKG_DIR), "assets", "llama3.1-tokenizer"),

--- a/MaxText/tests/hf_data_processing_test.py
+++ b/MaxText/tests/hf_data_processing_test.py
@@ -22,7 +22,7 @@ import jax
 from jax.sharding import Mesh
 from jax.experimental import mesh_utils
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText.input_pipeline import _hf_data_processing
 from MaxText.input_pipeline import input_pipeline_interface
@@ -32,7 +32,7 @@ class HfDataProcessingTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1,
         run_name="test",

--- a/MaxText/tests/inference/page_manager_test.py
+++ b/MaxText/tests/inference/page_manager_test.py
@@ -21,7 +21,7 @@ import unittest
 import jax
 import jax.numpy as jnp
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText.inference.page_manager import PageManager, PageState
 
@@ -37,7 +37,7 @@ class TestPageManager(unittest.TestCase):
     self.max_target_length = 256
     self.max_pages_per_group = (self.max_target_length + self.tokens_per_page - 1) // self.tokens_per_page
 
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1.0,
         run_name="test",

--- a/MaxText/tests/inference/page_manager_test.py
+++ b/MaxText/tests/inference/page_manager_test.py
@@ -37,14 +37,18 @@ class TestPageManager(unittest.TestCase):
     self.max_target_length = 256
     self.max_pages_per_group = (self.max_target_length + self.tokens_per_page - 1) // self.tokens_per_page
 
-    overrides = {'per_device_batch_size': 1.0, 'run_name': "test", 'enable_checkpointing': False,
-                 'max_prefill_predict_length': self.max_prefill_predict_length,
-                 'max_target_length': self.max_target_length, 'pagedattn_num_pages': self.num_pages,
-                 'pagedattn_tokens_per_page': self.tokens_per_page,
-                 'pagedattn_max_pages_per_group': self.max_pages_per_group}
+    overrides = {
+        "per_device_batch_size": 1.0,
+        "run_name": "test",
+        "enable_checkpointing": False,
+        "max_prefill_predict_length": self.max_prefill_predict_length,
+        "max_target_length": self.max_target_length,
+        "pagedattn_num_pages": self.num_pages,
+        "pagedattn_tokens_per_page": self.tokens_per_page,
+        "pagedattn_max_pages_per_group": self.max_pages_per_group,
+    }
 
     self.config = MaxText.configs.loader.load_config(os.path.join(PKG_DIR, "configs", "base.yml"), overrides=overrides)
-    self.config.
     self.max_page_groups = self.config.global_batch_size_to_load
 
     print("Note: Running PageManager tests locally without a JAX mesh.")

--- a/MaxText/tests/inference/page_manager_test.py
+++ b/MaxText/tests/inference/page_manager_test.py
@@ -37,18 +37,14 @@ class TestPageManager(unittest.TestCase):
     self.max_target_length = 256
     self.max_pages_per_group = (self.max_target_length + self.tokens_per_page - 1) // self.tokens_per_page
 
-    config = MaxText.configs.loader.initialize(
-        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
-        per_device_batch_size=1.0,
-        run_name="test",
-        enable_checkpointing=False,
-        max_prefill_predict_length=self.max_prefill_predict_length,
-        max_target_length=self.max_target_length,
-        pagedattn_num_pages=self.num_pages,
-        pagedattn_tokens_per_page=self.tokens_per_page,
-        pagedattn_max_pages_per_group=self.max_pages_per_group,
-    )
-    self.config = config
+    overrides = {'per_device_batch_size': 1.0, 'run_name': "test", 'enable_checkpointing': False,
+                 'max_prefill_predict_length': self.max_prefill_predict_length,
+                 'max_target_length': self.max_target_length, 'pagedattn_num_pages': self.num_pages,
+                 'pagedattn_tokens_per_page': self.tokens_per_page,
+                 'pagedattn_max_pages_per_group': self.max_pages_per_group}
+
+    self.config = MaxText.configs.loader.load_config(os.path.join(PKG_DIR, "configs", "base.yml"), overrides=overrides)
+    self.config.
     self.max_page_groups = self.config.global_batch_size_to_load
 
     print("Note: Running PageManager tests locally without a JAX mesh.")

--- a/MaxText/tests/integration_tests/grpo_correctness.py
+++ b/MaxText/tests/integration_tests/grpo_correctness.py
@@ -34,7 +34,7 @@ import transformers
 from datasets import load_dataset
 
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.experimental.rl.grpo_trainer import compute_log_probs, grpo_loss_fn, _merge_grpo_state
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
@@ -44,7 +44,7 @@ class GRPOTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.cfg = pyconfig.initialize(
+    self.cfg = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "experimental", "rl", "grpo.yml")],
         run_name="grpo_test",
         model_name="llama3.1-8b",

--- a/MaxText/tests/integration_tests/inference_microbenchmark_smoke_test.py
+++ b/MaxText/tests/integration_tests/inference_microbenchmark_smoke_test.py
@@ -20,7 +20,7 @@ import pytest
 import unittest
 from absl.testing import absltest
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText.inference_microbenchmark import run_benchmarks
 
@@ -32,7 +32,7 @@ class Inference_Microbenchmark(unittest.TestCase):
   @pytest.mark.tpu_only
   def test(self):
     jax.config.update("jax_default_prng_impl", "unsafe_rbg")
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [
             None,
             os.path.join(PKG_DIR, "configs", "tpu_smoke_test.yml"),

--- a/MaxText/tests/integration_tests/sft_trainer_correctness_test.py
+++ b/MaxText/tests/integration_tests/sft_trainer_correctness_test.py
@@ -39,7 +39,7 @@ from jax.sharding import Mesh
 from transformers import AutoTokenizer
 
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText.input_pipeline import _input_pipeline_utils
 from MaxText.layers import models
@@ -55,7 +55,7 @@ def get_golden_data(model_name):
 
 def initialize_config():
   """Initialize configurations."""
-  return pyconfig.initialize(
+  return MaxText.configs.loader.initialize(
       [sys.argv[0], os.path.join(PKG_DIR, "configs", "sft.yml")],
       run_name="test-sft-trainer-correctness",
       model_name="default",

--- a/MaxText/tests/integration_tests/vision_encoder_test.py
+++ b/MaxText/tests/integration_tests/vision_encoder_test.py
@@ -29,7 +29,7 @@ import jax.numpy as jnp
 
 from flax.core.scope import VariableDict
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText import multimodal_utils
 from MaxText.layers import models
 from MaxText.globals import PKG_DIR
@@ -70,7 +70,7 @@ class VisionEncoderEmbeddingTest(unittest.TestCase):
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
     """Correctness test for the gemma3-4b image embedding."""
     # Load weights from reference checkpoint
-    config = pyconfig.initialize(VisionEncoderEmbeddingTest.CONFIGS["gemma3-4b"])
+    config = MaxText.configs.loader.initialize(VisionEncoderEmbeddingTest.CONFIGS["gemma3-4b"])
     engine = maxengine.MaxEngine(config)
     rng = jax.random.PRNGKey(1234)
     rng, rng_load_params = jax.random.split(rng)

--- a/MaxText/tests/maxengine_test.py
+++ b/MaxText/tests/maxengine_test.py
@@ -29,7 +29,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 
 from MaxText import maxtext_utils
-from MaxText import pyconfig, maxengine
+import MaxText.configs.loader, maxengine
 from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
@@ -62,7 +62,7 @@ class MaxEngineTest(unittest.TestCase):
         "max_prefill_predict_length": 4,
         "return_log_prob": True,
     } | kwargs
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         **init_kwargs,
     )
@@ -80,7 +80,7 @@ class MaxEngineTest(unittest.TestCase):
     return ids, decoder_segment_ids, decoder_positions
 
   def test_stack_and_unstack_prefill_cache(self):
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         stack_prefill_result_cache=True,

--- a/MaxText/tests/maxengine_test.py
+++ b/MaxText/tests/maxengine_test.py
@@ -29,7 +29,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 
 from MaxText import maxtext_utils
-import MaxText.configs.loader, maxengine
+import MaxText.configs.loader
 from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
@@ -249,7 +249,7 @@ class MaxEngineTest(unittest.TestCase):
         true_length=4,
     )
 
-    existing_prefix = maxengine.ExistingPrefix(
+    existing_prefix = MaxText.maxengine.ExistingPrefix(
         cache=two_chunk_prefill_result["cache"], common_prefix_tokens=padding_tokens[:4]
     )
     two_chunk_prefill_result, two_chunk_first_token = engine.prefill(

--- a/MaxText/tests/maxtext_utils_test.py
+++ b/MaxText/tests/maxtext_utils_test.py
@@ -35,7 +35,7 @@ import optax
 
 from MaxText import max_utils
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
 from MaxText.layers import quantizations
@@ -173,7 +173,7 @@ class MaxUtilsInitStateWithMultipleCollections(unittest.TestCase):
   """test class for multiple collection state in maxutils"""
 
   def setUp(self):
-    self.config = pyconfig.initialize([None, os.path.join(PKG_DIR, "configs", "base.yml")], enable_checkpointing=False)
+    self.config = MaxText.configs.loader.initialize([None, os.path.join(PKG_DIR, "configs", "base.yml")], enable_checkpointing=False)
     self.model = ModelWithMultipleCollections()
     self.key1, self.key2, self.key3 = random.split(random.key(0), num=3)
     self.input = random.normal(self.key1, (self.config.global_batch_size_to_load, self.config.max_target_length))
@@ -209,7 +209,7 @@ class MaxUtilsInitTransformerState(unittest.TestCase):
   """Tests initialization of transformer states in max_utils.py"""
 
   def setUp(self):
-    self.config = pyconfig.initialize([None, os.path.join(PKG_DIR, "configs", "base.yml")], enable_checkpointing=False)
+    self.config = MaxText.configs.loader.initialize([None, os.path.join(PKG_DIR, "configs", "base.yml")], enable_checkpointing=False)
     devices_array = maxtext_utils.create_device_mesh(self.config)
     self.mesh = Mesh(devices_array, self.config.mesh_axes)
     quant = quantizations.configure_quantization(self.config)

--- a/MaxText/tests/model_test.py
+++ b/MaxText/tests/model_test.py
@@ -26,7 +26,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_TRAIN, MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
@@ -46,7 +46,7 @@ class TestModel(unittest.TestCase):
 
   def init_pyconfig(self, **kwargs):
     """Init pyconfig."""
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1.0,
         run_name="test",

--- a/MaxText/tests/moe_test.py
+++ b/MaxText/tests/moe_test.py
@@ -27,7 +27,7 @@ import flax.linen as nn
 from flax.linen import partitioning as nn_partitioning
 
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.common_types import Config, DType
 from MaxText.globals import PKG_DIR
 from MaxText.layers import linears
@@ -39,7 +39,7 @@ class TokenDroppingTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.cfg = pyconfig.initialize(
+    self.cfg = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "configs", "base.yml")],
         run_name="token_dropping_test",
         enable_checkpointing=False,
@@ -163,7 +163,7 @@ class DeepSeekRoutingTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.cfg = pyconfig.initialize(
+    self.cfg = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "configs", "base.yml")],
         run_name="deepseek_routing_test",
         enable_checkpointing=False,
@@ -340,7 +340,7 @@ class RoutedMoeTest(unittest.TestCase):
 
   @pytest.mark.tpu_only
   def test_megablox(self):
-    cfg = pyconfig.initialize(
+    cfg = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "configs", "base.yml")],
         run_name="moe_block_megablox_test",
         enable_checkpointing=False,
@@ -368,7 +368,7 @@ class RoutedMoeTest(unittest.TestCase):
 
   @pytest.mark.tpu_only
   def test_ragged_dot(self):
-    cfg = pyconfig.initialize(
+    cfg = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "configs", "base.yml")],
         run_name="moe_block_ragged_dot_test",
         enable_checkpointing=False,
@@ -396,7 +396,7 @@ class RoutedMoeTest(unittest.TestCase):
 
   @pytest.mark.tpu_only
   def test_dense(self):
-    cfg = pyconfig.initialize(
+    cfg = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "configs", "base.yml")],
         run_name="moe_block_dense_test",
         enable_checkpointing=False,
@@ -424,7 +424,7 @@ class RoutedMoeTest(unittest.TestCase):
 
   @pytest.mark.tpu_only
   def test_megablox_expert_parallelism(self):
-    cfg = pyconfig.initialize(
+    cfg = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "configs", "base.yml")],
         run_name="moe_block_megablox_ep_test",
         enable_checkpointing=False,
@@ -454,7 +454,7 @@ class RoutedMoeTest(unittest.TestCase):
 
   @pytest.mark.tpu_only
   def test_megablox_context_parallelism(self):
-    cfg = pyconfig.initialize(
+    cfg = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "configs", "base.yml")],
         run_name="moe_block_megablox_cp_test",
         enable_checkpointing=False,

--- a/MaxText/tests/multi_token_prediction_test.py
+++ b/MaxText/tests/multi_token_prediction_test.py
@@ -33,7 +33,7 @@ class MultiTokenPredictionLayerTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.cfg = pyconfig.initialize(
+    self.cfg = MaxText.configs.loader.initialize(
         [None, os.path.join(PKG_DIR, "configs", "base.yml")],
         run_name="multi_token_prediction_layer_test",
         skip_jax_distributed_system=True,

--- a/MaxText/tests/multihost_dataloading_test.py
+++ b/MaxText/tests/multihost_dataloading_test.py
@@ -30,7 +30,7 @@ from jax.sharding import PartitionSpec
 
 import tensorflow as tf
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText import multihost_dataloading
 from MaxText.globals import PKG_DIR
 
@@ -40,7 +40,7 @@ class MultihostDataloadingTest(unittest.TestCase):
   def setUp(self):
     super().setUp()
     batch_size = 4
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1,
         run_name="test",

--- a/MaxText/tests/pipeline_parallelism_test.py
+++ b/MaxText/tests/pipeline_parallelism_test.py
@@ -26,7 +26,7 @@ from flax.core import meta
 from flax import linen as nn
 
 from MaxText import maxtext_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.globals import PKG_DIR
 from MaxText.layers import pipeline
@@ -159,7 +159,7 @@ class PipelineParallelismTest(unittest.TestCase):
   @pytest.mark.tpu_only
   def test_circular_minimum_microbatches_same_output_and_grad(self):
     # 4 stages, 8 layers (2 repeats, 1 layer per stage), 4 microbatches
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         enable_goodput_recording=False,
@@ -176,7 +176,7 @@ class PipelineParallelismTest(unittest.TestCase):
   @pytest.mark.tpu_only
   def test_circular_extra_microbatches_same_output_and_grad(self):
     # 4 stages, 8 layers (2 repeats, 1 layer per stage), 8 microbatches
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         enable_goodput_recording=False,
@@ -193,7 +193,7 @@ class PipelineParallelismTest(unittest.TestCase):
   @pytest.mark.tpu_only
   def test_circular_deepseek_megablox_same_output_and_grad(self):
     # 4 stages, 8 layers (2 repeats, 1 layer per stage), 8 microbatches
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         enable_goodput_recording=False,
@@ -216,7 +216,7 @@ class PipelineParallelismTest(unittest.TestCase):
   @pytest.mark.tpu_only
   def test_circular_ag_once(self):
     # 2 stages, 8 microbatches, all gather once
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         enable_goodput_recording=False,
@@ -234,7 +234,7 @@ class PipelineParallelismTest(unittest.TestCase):
   @pytest.mark.tpu_only
   def test_non_circular_same_output_and_grad(self):
     # 4 stages, 4 layers (no circular repeats, 1 layer per stage), 4 microbatches
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         run_name="non_circular",
@@ -282,7 +282,7 @@ class PipelineParallelismTest(unittest.TestCase):
   @pytest.mark.tpu_only
   def test_delay_activation_forwarding_same_output_and_grad(self):
     # 4 stages, delayed activation forwarding, 8 layers (2 repeats, 1 layer per stage), 8 microbatches
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         enable_goodput_recording=False,

--- a/MaxText/tests/pipeline_parallelism_test.py
+++ b/MaxText/tests/pipeline_parallelism_test.py
@@ -26,13 +26,14 @@ from flax.core import meta
 from flax import linen as nn
 
 from MaxText import maxtext_utils
-import MaxText.configs.loader
 from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.globals import PKG_DIR
+from MaxText.layers import deepseek
 from MaxText.layers import pipeline
 from MaxText.layers import simple_layer
 from MaxText.train import main as train_main
-from MaxText.layers import deepseek
+import MaxText.configs.loader
+import MaxText.configs.types
 
 
 def assert_same_output_and_grad(f1, f2, *inputs):
@@ -234,7 +235,7 @@ class PipelineParallelismTest(unittest.TestCase):
   @pytest.mark.tpu_only
   def test_non_circular_same_output_and_grad(self):
     # 4 stages, 4 layers (no circular repeats, 1 layer per stage), 4 microbatches
-    config = MaxText.configs.loader.initialize(
+    config = MaxText.configs.types.MaxTextConfig(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         run_name="non_circular",

--- a/MaxText/tests/profiler_test.py
+++ b/MaxText/tests/profiler_test.py
@@ -21,7 +21,7 @@ import pytest
 import os.path
 
 from MaxText import profiler
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 
 
@@ -31,7 +31,7 @@ class ProfilerTest(unittest.TestCase):
   # These periodic proilfer tests can run on any platform (cpu, gpu or tpu)
   @pytest.mark.tpu_only
   def test_periodic_profiler_third_period_starts(self):
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         run_name="test_periodic_profiler_starts_after_regular_profile",
@@ -47,7 +47,7 @@ class ProfilerTest(unittest.TestCase):
 
   @pytest.mark.tpu_only
   def test_periodic_profiler_not_start_middle_period(self):
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         run_name="test_periodic_profiler_starts_after_regular_profile",
@@ -63,7 +63,7 @@ class ProfilerTest(unittest.TestCase):
 
   @pytest.mark.tpu_only
   def test_periodic_profiler_third_period_ends(self):
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         run_name="test_periodic_profiler_starts_after_regular_profile",
@@ -79,7 +79,7 @@ class ProfilerTest(unittest.TestCase):
 
   @pytest.mark.tpu_only
   def test_periodic_profiler_third_period_middle_not_end(self):
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         enable_checkpointing=False,
         run_name="test_periodic_profiler_starts_after_regular_profile",

--- a/MaxText/tests/pyconfig_test.py
+++ b/MaxText/tests/pyconfig_test.py
@@ -14,7 +14,7 @@ limitations under the License.
 import unittest
 import os.path
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 
 
@@ -30,7 +30,7 @@ class PyconfigTest(unittest.TestCase):
     self.assertEqual(raw_keys, {"megablox": None, "foo": ["x", "y"]})
 
   def test_empty_string_parse_as_empty_string(self):
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [os.path.join(PKG_DIR, "train.py"), os.path.join(PKG_DIR, "configs", "base.yml")],
         skip_jax_distributed_system=True,  # We should check for this automatically instead - b/407047411
         quantization="",
@@ -77,7 +77,7 @@ class PyconfigTest(unittest.TestCase):
     )
 
   def test_multiple_unmodifiable_configs(self):
-    config_train = pyconfig.initialize(
+    config_train = MaxText.configs.loader.initialize(
         [os.path.join(PKG_DIR, "train.py"), os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1.0,
         run_name="test",
@@ -92,7 +92,7 @@ class PyconfigTest(unittest.TestCase):
         ici_tensor_parallelism=-1,
         ici_fsdp_parallelism=4,
     )
-    config_inference = pyconfig.initialize(
+    config_inference = MaxText.configs.loader.initialize(
         [os.path.join(PKG_DIR, "decode.py"), os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1.0,
         run_name="test",
@@ -115,7 +115,7 @@ class PyconfigTest(unittest.TestCase):
       config_inference.ici_fsdp_parallelism = 4
 
   def test_overriding_model(self):
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [os.path.join(PKG_DIR, "train.py"), os.path.join(PKG_DIR, "configs", "base.yml")],
         skip_jax_distributed_system=True,
         model_name="gemma-7b",

--- a/MaxText/tests/quantizations_test.py
+++ b/MaxText/tests/quantizations_test.py
@@ -30,7 +30,7 @@ from flax import linen as nn
 from aqt.jax.v2 import aqt_tensor
 
 from MaxText.globals import PKG_DIR
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.layers import quantizations
 
 _QUERY_REGEX = ".*/query"
@@ -57,7 +57,7 @@ class QuantTestModule(nn.Module):
 
 
 def _configure_quantization(quant_str="", quant_cfg_path="", mode_str="train", replicate_scale=False):
-  config = pyconfig.initialize(
+  config = MaxText.configs.loader.initialize(
       [None, os.path.join(PKG_DIR, "configs", "base.yml")],
       enable_checkpointing=False,
       quantization=quant_str,

--- a/MaxText/tests/sft_data_processing_test.py
+++ b/MaxText/tests/sft_data_processing_test.py
@@ -29,7 +29,7 @@ from datasets import Dataset
 
 import transformers
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText.input_pipeline import _hf_data_processing
 from MaxText.input_pipeline import input_pipeline_interface
@@ -107,7 +107,7 @@ class SFTDataProcessingTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.config = pyconfig.initialize(
+    self.config = MaxText.configs.loader.initialize(
         [os.path.join(PKG_DIR, "sft_trainer"), os.path.join(PKG_DIR, "configs", "sft.yml")],
         per_device_batch_size=2,
         run_name="test",

--- a/MaxText/tests/state_dtypes_test.py
+++ b/MaxText/tests/state_dtypes_test.py
@@ -22,7 +22,7 @@ import jax
 from jax.sharding import Mesh
 import jax.numpy as jnp
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText import optimizers
 from MaxText.layers import models
 from MaxText.layers import quantizations
@@ -39,7 +39,7 @@ class StateDtypes(unittest.TestCase):
     """Gets model state including weights and optimizer state"""
 
     # Setup necessary inputs to build a model state
-    config = pyconfig.initialize(argv)
+    config = MaxText.configs.loader.initialize(argv)
     quant = quantizations.configure_quantization(config)
     devices_array = maxtext_utils.create_device_mesh(config)
     mesh = Mesh(devices_array, config.mesh_axes)

--- a/MaxText/tests/tfds_data_processing_test.py
+++ b/MaxText/tests/tfds_data_processing_test.py
@@ -26,7 +26,7 @@ from jax.experimental import mesh_utils
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.globals import PKG_DIR
 from MaxText.input_pipeline import _tfds_data_processing
 from MaxText.input_pipeline import input_pipeline_interface
@@ -36,7 +36,7 @@ class TfdsDataProcessingTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    config = pyconfig.initialize(
+    config = MaxText.configs.loader.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
         per_device_batch_size=1,
         run_name="test",

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -62,7 +62,6 @@ from MaxText import max_utils
 from MaxText import maxtext_utils
 from MaxText import optimizers
 from MaxText import profiler
-from MaxText import pyconfig
 from MaxText.gcp_workload_monitor import GCPWorkloadMonitor
 from MaxText.input_pipeline.input_pipeline_interface import create_data_iterator
 from MaxText.layers import quantizations
@@ -76,6 +75,8 @@ from MaxText.utils.goodput_utils import (
     maybe_record_goodput,
 )
 from MaxText.vertex_tensorboard import VertexTensorboardManager
+import MaxText.configs.loader
+
 # Placeholder: internal
 
 # pylint: disable=too-many-positional-arguments
@@ -981,7 +982,7 @@ def main(argv: Sequence[str]) -> None:
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
     os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   max_utils.print_system_information()
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path or ""

--- a/MaxText/train_compile.py
+++ b/MaxText/train_compile.py
@@ -41,7 +41,7 @@ from MaxText import train
 from MaxText import maxtext_utils
 from MaxText import optimizers
 from MaxText import max_utils
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText.layers import models
 from MaxText.layers import quantizations
 from MaxText.utils import gcs_utils
@@ -144,7 +144,7 @@ def main(argv: Sequence[str]) -> None:
   print("Starting train_compile.py...", flush=True)
 
   # Parse and validate configuration
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   validate_config(config)
 
   # Create target mesh

--- a/MaxText/utils/ckpt_conversion/to_huggingface.py
+++ b/MaxText/utils/ckpt_conversion/to_huggingface.py
@@ -25,7 +25,7 @@ import flax
 
 from MaxText import max_utils
 from MaxText import maxengine
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText import max_logging
 
 from MaxText.utils.ckpt_conversion.utils.param_mapping import (
@@ -59,7 +59,7 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
-  config = pyconfig.initialize(argv)
+  config = MaxText.configs.loader.initialize(argv)
   assert (
       config.load_full_state_path == ""
   ), "This script expects parameters, not a full state. Use generate_param_only_checkpoint first if needed."

--- a/benchmarks/mmlu/mmlu_eval.py
+++ b/benchmarks/mmlu/mmlu_eval.py
@@ -54,7 +54,7 @@ from mmlu_categories import subcategories
 
 from tqdm import tqdm
 
-from MaxText import pyconfig
+import MaxText.configs.loader
 from MaxText import max_logging
 from MaxText import max_utils
 from MaxText import maxengine
@@ -223,7 +223,7 @@ def validate_config(config):
 if __name__ == "__main__":
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   flags.FLAGS(sys.argv)
-  cfg = pyconfig.initialize(sys.argv)
+  cfg = MaxText.configs.loader.initialize(sys.argv)
   validate_config(cfg)
   max_utils.print_system_information()
   main(cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ ml-goodput-measurement==0.0.10
 numpy
 optax
 protobuf==3.20.3
+pydantic
 pylint
 pytest
 pyink


### PR DESCRIPTION
# Description

## Background

MaxText is currently engineered around pyconfig. Pyconfig—[https://pypi.org/project/pyconfig/](https://pypi.org/project/pyconfig/)—was last updated in 2017 and has [20k monthly downloads](https://pypistats.org/packages/pyconfig).

Pydantic—[https://pypi.org/project/pydantic/](https://pypi.org/project/pydantic/)—is constantly updated and has [hundreds of millions of monthly downloads](https://pypistats.org/packages/pydantic).

\> Pydantic is the most widely used data validation library for Python.

[https://docs.pydantic.dev](https://docs.pydantic.dev/latest/)

## Summary

The TL;DR version is:

* pydantic has become basically the standard for configuration formats, specifying the inputs and outputs (e.g., for REST APIs in FastAPI framework)  
* pydantic links in well with the Python type-checker so you can oft find errors before runtime  
* pydantic errors are clean and clear  
* with my python compiler, you can have clean CLIs with `--help` and GUIs and generate SQL models (SQLAlchemy) as desired  
* SDK documentation becomes much cleaner (which is good in preparation for the pypi release \+ hosted doc pages)

## Migration

Proposed changes to the MaxText codebase:

1. Completely remove the pyconfig dependency  
   1.  maybe not immediately so there’s a chance for people to easily migration of their existing setups, e.g., with new functions \`from\_pyconfig\_to\_pydantic\`  
2. Migrate all examples, and codebase occurrences with new pydantic types  
3. Put pydantic types on a computer+human understandable hierarchy, e.g.:  
   1. One global \`types.py\`, or  
   2. One \`types.py\` per config occurrence (e.g., one per module if each module has a different config)  
4. Create new CLI that uses common CLI syntax (e.g., this can be automatically created using my Python compiler [https://github.com/offscale/cdd-python](https://github.com/offscale/cdd-python))  
5. Migrate all shell scripts and docs to use this new CLI  
   1. TBD: remove the shell scripts in favour of Python SDK usage.

# Tests

Tested the change on your CI.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
