### PR TITLE
Update DenseGeneral in_feature and feature arg names

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -1389,7 +1389,7 @@ class Attention(nn.Module):
     )
     query_proj = dense_general(
         inputs_shape=inputs_q.shape,
-        features=(self.num_query_heads, self.head_dim),
+        out_features_shape=(self.num_query_heads, self.head_dim),
         axis=-1,
         kernel_init=query_init,
         kernel_axes=kernel_axes,
@@ -1427,7 +1427,7 @@ class Attention(nn.Module):
 
     kv_proj = dense_general(
         inputs_shape=inputs_kv.shape,
-        features=(self.num_kv_heads, self.head_dim),
+        out_features_shape=(self.num_kv_heads, self.head_dim),
         axis=-1,
         kernel_init=self.kernel_init,
         kernel_axes=kernel_axes,
@@ -1445,7 +1445,7 @@ class Attention(nn.Module):
 
     qkv_proj = dense_general(
         inputs_shape=inputs.shape,
-        features=(3, self.num_query_heads, self.head_dim),
+        out_features_shape=(3, self.num_query_heads, self.head_dim),
         axis=-1,
         kernel_init=self.kernel_init,
         kernel_axes=("embed", "qkv", "heads", "kv"),
@@ -1467,7 +1467,7 @@ class Attention(nn.Module):
     )
     out_proj = dense_general(
         inputs_shape=out.shape,
-        features=output_dim,
+        out_features_shape=output_dim,
         axis=(-2, -1),
         kernel_init=self.kernel_init,
         kernel_axes=out_kernel_axis,  # trade speed with memory
@@ -1734,8 +1734,8 @@ class MLA(Attention):
     if self.q_lora_rank == 0:
       # Standard Q projection (without LoRA).
       self.query_proj = dense_general(
-          in_features=self.config.emb_dim,
-          features=(self.num_query_heads, self.qk_head_dim),
+          in_features_shape=self.config.emb_dim,
+          out_features_shape=(self.num_query_heads, self.qk_head_dim),
           axis=-1,
           kernel_init=self.kernel_init,
           kernel_axes=("embed", "q_heads", "kv"),
@@ -1748,8 +1748,8 @@ class MLA(Attention):
     else:
       # LoRA path for Q.
       self.wq_a = dense_general(
-          in_features=self.config.emb_dim,
-          features=self.q_lora_rank,
+          in_features_shape=self.config.emb_dim,
+          out_features_shape=self.q_lora_rank,
           axis=-1,
           kernel_init=self.kernel_init,
           kernel_axes=("embed", "q_lora"),
@@ -1767,8 +1767,8 @@ class MLA(Attention):
           kernel_axes=("norm",),
       )
       self.wq_b = dense_general(
-          in_features=self.q_lora_rank,
-          features=(self.num_query_heads, self.qk_head_dim),
+          in_features_shape=self.q_lora_rank,
+          out_features_shape=(self.num_query_heads, self.qk_head_dim),
           axis=-1,
           kernel_init=self.kernel_init,
           kernel_axes=("q_lora", "q_heads", "kv"),
@@ -1781,8 +1781,8 @@ class MLA(Attention):
 
     # KV LoRA path.
     self.wkv_a = dense_general(
-        in_features=self.config.emb_dim,
-        features=self.kv_lora_rank + self.qk_rope_head_dim,
+        in_features_shape=self.config.emb_dim,
+        out_features_shape=self.kv_lora_rank + self.qk_rope_head_dim,
         axis=-1,
         kernel_init=self.kernel_init,
         kernel_axes=("embed", "kv_lora"),
@@ -1800,8 +1800,8 @@ class MLA(Attention):
         kernel_axes=("norm",),
     )
     self.wkv_b = dense_general(
-        in_features=self.kv_lora_rank,
-        features=(
+        in_features_shape=self.kv_lora_rank,
+        out_features_shape=(
             self.num_query_heads,
             (self.qk_nope_head_dim + self.v_head_dim),
         ),

--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -146,7 +146,7 @@ class Gpt3MultiHeadAttention(nn.Module):
 
     qkv_proj = dense_general(
         inputs_shape=inputs.shape,
-        features=(3, self.num_heads, self.head_dim),
+        out_features_shape=(3, self.num_heads, self.head_dim),
         axis=-1,
         kernel_init=self.kernel_init,
         kernel_axes=("embed", "qkv", "heads", "kv"),
@@ -165,7 +165,7 @@ class Gpt3MultiHeadAttention(nn.Module):
     """individual projection for one of q, k and v."""
     proj = dense_general(
         inputs_shape=inputs.shape,
-        features=(self.num_heads, self.head_dim),
+        out_features_shape=(self.num_heads, self.head_dim),
         axis=-1,
         kernel_init=self.kernel_init,
         kernel_axes=("embed", "heads", "kv"),
@@ -182,7 +182,7 @@ class Gpt3MultiHeadAttention(nn.Module):
     """output projection"""
     out_proj = dense_general(
         inputs_shape=out.shape,
-        features=output_dim,
+        out_features_shape=output_dim,
         axis=(-2, -1),
         kernel_init=self.kernel_init,
         kernel_axes=("heads", "kv", "embed"),

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -79,8 +79,8 @@ class DenseGeneral(nnx.Module):
 
   def __init__(
       self,
-      in_features: Union[Iterable[int], int],
-      out_features: Union[Iterable[int], int],
+      in_features_shape: Union[Iterable[int], int],
+      out_features_shape: Union[Iterable[int], int],
       axis: Union[Iterable[int], int] = -1,
       weight_dtype: DType = jnp.float32,
       dtype: DType = jnp.float32,
@@ -98,9 +98,9 @@ class DenseGeneral(nnx.Module):
     """Initializes the DenseGeneral module.
 
     Args:
-      features: tuple with numbers of output features.
-      in_features: tuple with numbers of input features for axes specified in
+      in_features_shape: tuple with numbers of input features for axes specified in
         'axis'.
+      out_features_shape: tuple with numbers of output features.
       axis: tuple with axes to apply the transformation on.
       weight_dtype: the dtype of the weights (default: float32).
       dtype: the dtype of the computation (default: float32).
@@ -112,8 +112,8 @@ class DenseGeneral(nnx.Module):
       parameter_memory_host_offload: Determines whether to offload params to host
       rngs: RNG state for initialization in nnx.
     """
-    self.in_features = _canonicalize_tuple(in_features)
-    self.out_features = _canonicalize_tuple(out_features)
+    self.in_features_shape = _canonicalize_tuple(in_features_shape)
+    self.out_features_shape = _canonicalize_tuple(out_features_shape)
     self.axis = _canonicalize_tuple(axis)
     self.weight_dtype = weight_dtype
     self.dtype = dtype
@@ -125,10 +125,10 @@ class DenseGeneral(nnx.Module):
     self.parameter_memory_host_offload = parameter_memory_host_offload
 
     # Parameter initialization
-    kernel_shape = self.in_features + self.out_features
+    kernel_shape = self.in_features_shape + self.out_features_shape
     kernel_in_axis = np.arange(len(self.axis))
     kernel_out_axis = np.arange(
-        len(self.axis), len(self.axis) + len(self.out_features)
+        len(self.axis), len(self.axis) + len(self.out_features_shape)
     )
 
     if not quantizations.in_serve_mode(self.quant):
@@ -144,8 +144,8 @@ class DenseGeneral(nnx.Module):
       )
 
     if self.use_bias:
-      bias_axes = self.kernel_axes[-len(self.out_features) :]
-      bias_shape = kernel_shape[-len(self.out_features) :]
+      bias_axes = self.kernel_axes[-len(self.out_features_shape) :]
+      bias_shape = kernel_shape[-len(self.out_features_shape) :]
       self.bias = nnx.Param(
           default_bias_init(rngs.params(), bias_shape, self.weight_dtype),
           sharding=bias_axes,
@@ -166,14 +166,14 @@ class DenseGeneral(nnx.Module):
     norm_axis = _normalize_axes(self.axis, inputs.ndim)
 
     for i, ax in enumerate(norm_axis):
-      if inputs.shape[ax] != self.in_features[i]:
+      if inputs.shape[ax] != self.in_features_shape[i]:
         raise ValueError(
             f"Input dimension {inputs.shape[ax]} at axis {ax} "
-            f"does not match expected input feature size {self.in_features[i]}"
+            f"does not match expected input feature size {self.in_features_shape[i]}"
         )
 
     if quantizations.in_serve_mode(self.quant):
-      kernel_shape = self.in_features + self.out_features
+      kernel_shape = self.in_features_shape + self.out_features_shape
       kernel = jnp.zeros(kernel_shape, dtype=self.dtype)
     else:
       kernel = jnp.asarray(self.kernel[...], self.dtype)
@@ -213,8 +213,8 @@ def variable_to_logically_partitioned(variable: nnx.VariableState):
 def dense_general(
     *,
     inputs_shape: tuple[int, ...] | None = None,
-    in_features: tuple[int, ...] | int | None = None,
-    features: Union[Iterable[int], int],
+    in_features_shape: tuple[int, ...] | int | None = None,
+    out_features_shape: Union[Iterable[int], int],
     axis: Union[Iterable[int], int] = -1,
     weight_dtype: DType = jnp.float32,
     dtype: DType = jnp.float32,
@@ -232,9 +232,9 @@ def dense_general(
 
   Args:
     inputs_shape: tuple with the shape of the inputs
-    in_features: tuple with numbers of input features for axes specified in
+    in_features_shape: tuple with numbers of input features for axes specified in
       'axis'.
-    features: tuple with numbers of output features.
+    out_features_shape: tuple with numbers of output features.
     axis: tuple with axes to apply the transformation on.
     weight_dtype: the dtype of the weights (default: float32).
     dtype: the dtype of the computation (default: float32).
@@ -246,22 +246,22 @@ def dense_general(
     parameter_memory_host_offload: Determines whether to offload params to host
     name: name passed to the ToLinen Module
   """
-  if not (inputs_shape is not None) ^ (in_features is not None):
+  if not (inputs_shape is not None) ^ (in_features_shape is not None):
     raise ValueError(
         "Exactly one of inputs_shape or in_features must be specified."
     )
 
   if inputs_shape is not None:
     axis = _canonicalize_tuple(axis)
-    in_features = tuple(
+    in_features_shape = tuple(
         inputs_shape[ax] for ax in _normalize_axes(axis, len(inputs_shape))
     )
   else:
-    assert in_features is not None
+    assert in_features_shape is not None
   module = nnx.bridge.to_linen(
       DenseGeneral,
-      in_features=in_features,
-      out_features=features,
+      in_features_shape=in_features_shape,
+      out_features_shape=out_features_shape,
       axis=axis,
       weight_dtype=weight_dtype,
       dtype=dtype,
@@ -344,7 +344,7 @@ class MlpBlock(nn.Module):
     if cfg.fused_mlp:
       x = dense_general(
           inputs_shape=inputs.shape,
-          features=(len(self.activations), self.intermediate_dim),
+          out_features_shape=(len(self.activations), self.intermediate_dim),
           dtype=self.dtype,
           weight_dtype=self.weight_dtype,
           kernel_init=self.kernel_init,
@@ -363,7 +363,7 @@ class MlpBlock(nn.Module):
         dense_name = "wi" if len(self.activations) == 1 else f"wi_{idx}"
         x = dense_general(
             inputs_shape=inputs.shape,
-            features=self.intermediate_dim,
+            out_features_shape=self.intermediate_dim,
             dtype=self.dtype,
             weight_dtype=self.weight_dtype,
             kernel_init=self.kernel_init,
@@ -388,7 +388,7 @@ class MlpBlock(nn.Module):
     x = nn.with_logical_constraint(x, ("activation_batch", "activation_length", "activation_mlp"))
     output = dense_general(
         inputs_shape=x.shape,
-        features=inputs.shape[-1],
+        out_features_shape=inputs.shape[-1],
         dtype=self.dtype,
         weight_dtype=self.weight_dtype,
         kernel_init=self.kernel_init,

--- a/MaxText/layers/llama4.py
+++ b/MaxText/layers/llama4.py
@@ -65,8 +65,8 @@ class Llama4UnfoldConvolution(nn.Module):
     # patches sent to dense_general with shape:
     # [batch_size, num_patches, num_channels * patch_size * patch_size]
     self.linear = linears.dense_general(
-        in_features=(cfg.num_channels_for_vit * cfg.patch_size_for_vit * cfg.patch_size_for_vit),
-        features=cfg.hidden_size_for_vit,
+        in_features_shape=(cfg.num_channels_for_vit * cfg.patch_size_for_vit * cfg.patch_size_for_vit),
+        out_features_shape=cfg.hidden_size_for_vit,
         dtype=cfg.dtype_mm,
         name="vit_unfold_linear",
         use_bias=False,
@@ -148,16 +148,16 @@ class Llama4VisionMLP(nn.Module):
   def setup(self):
     cfg = self.config
     self.fc1 = linears.dense_general(
-        in_features=cfg.hidden_size_for_vit,
-        features=cfg.intermediate_size_for_vit,
+        in_features_shape=cfg.hidden_size_for_vit,
+        out_features_shape=cfg.intermediate_size_for_vit,
         dtype=cfg.dtype_mm,
         name="vit_encoder_layer_mlp_fc1",
         use_bias=True,
         matmul_precision=cfg.matmul_precision,
     )
     self.fc2 = linears.dense_general(
-        in_features=cfg.intermediate_size_for_vit,
-        features=cfg.hidden_size_for_vit,
+        in_features_shape=cfg.intermediate_size_for_vit,
+        out_features_shape=cfg.hidden_size_for_vit,
         dtype=cfg.dtype_mm,
         name="vit_encoder_layer_mlp_fc2",
         use_bias=True,
@@ -194,16 +194,16 @@ class Llama4VisionMLP2(nn.Module):
     """
     cfg = self.config
     self.fc1 = linears.dense_general(
-        in_features=cfg.intermediate_size_for_vit,
-        features=cfg.projector_input_dim_for_vit,
+        in_features_shape=cfg.intermediate_size_for_vit,
+        out_features_shape=cfg.projector_input_dim_for_vit,
         dtype=cfg.dtype_mm,
         name="vit_pixel_shuffle_mlp_fc1",
         use_bias=False,
         matmul_precision=cfg.matmul_precision,
     )
     self.fc2 = linears.dense_general(
-        in_features=cfg.projector_input_dim_for_vit,
-        features=cfg.projector_output_dim_for_vit,
+        in_features_shape=cfg.projector_input_dim_for_vit,
+        out_features_shape=cfg.projector_output_dim_for_vit,
         dtype=cfg.dtype_mm,
         name="vit_pixel_shuffle_mlp_fc2",
         use_bias=False,
@@ -282,8 +282,8 @@ class Llama4MultiModalProjector(nn.Module):
   def setup(self):
     cfg = self.config
     self.linear = linears.dense_general(
-        in_features=cfg.vision_output_dim_for_vit,
-        features=cfg.emb_dim,
+        in_features_shape=cfg.vision_output_dim_for_vit,
+        out_features_shape=cfg.emb_dim,
         dtype=cfg.dtype_mm,
         name="vit_multi_modal_projector",
         use_bias=False,

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -664,7 +664,7 @@ class Decoder(nn.Module):
     else:
       logits = linears.dense_general(
           inputs_shape=y.shape,
-          features=cfg.vocab_size,
+          out_features_shape=cfg.vocab_size,
           weight_dtype=cfg.weight_dtype,
           dtype=jnp.float32
           if cfg.logits_dot_in_fp32

--- a/MaxText/layers/multi_token_prediction.py
+++ b/MaxText/layers/multi_token_prediction.py
@@ -115,7 +115,7 @@ class MultiTokenPredictionLayer(nn.Module):
     # Projects from 2*H back down to H
     projection_layer = dense_general(
         inputs_shape=concatenated_features.shape,
-        features=cfg.base_emb_dim,
+        out_features_shape=cfg.base_emb_dim,
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
         kernel_axes=("concat_embed", "embed"),


### PR DESCRIPTION
# Description

Update DenseGeneral `in_features` and `features` argument names to `in_features_shape` and `out_features_shape`. This was based on a design doc comment from @shralex around name clarity. Let me know if anyone has ideas for better names here

# Tests

* Trained 100 steps with the MaxText default 1B model on a TPU devbox:

```
python3 -m MaxText.train MaxText/configs/base.yml \
    run_name=<run_name> \
    base_output_directory=gs://<gcs_bucket> \
    dataset_type=synthetic \
    steps=100
```

* Asked Gemini to review these changes. The AI didn't have better name suggestions and agreed that the changes look correct

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
