### PR TITLE
Dense Qwen3 support (0.6b, 4b, 8b)

### DIFF
--- a/MaxText/common_types.py
+++ b/MaxText/common_types.py
@@ -77,6 +77,7 @@ class DecoderBlockType(enum.Enum):
   GEMMA = "gemma"
   GEMMA2 = "gemma2"
   GEMMA3 = "gemma3"
+  QWEN3 = "qwen3"
   GPT3 = "gpt3"
   SIMPLE = "simple"
   SIMPLE_MLP = "simple_mlp"

--- a/MaxText/configs/models/qwen3-0.6b.yml
+++ b/MaxText/configs/models/qwen3-0.6b.yml
@@ -1,0 +1,37 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# model config for qwen3-0.6b
+
+base_emb_dim: 1024
+base_num_query_heads: 16
+base_num_kv_heads: 8
+base_mlp_dim: 3072
+base_num_decoder_layers: 28
+head_dim: 128
+mlp_activations: ["silu", "linear"] # "hidden_act": "silu" implies SwiGLU
+vocab_size: 151936
+
+decoder_block: "qwen3"
+
+normalization_layer_epsilon: 1.0e-6
+rope_max_timescale: 1000000
+
+use_qk_norm: True
+
+logits_via_embedding: True # from "tie_word_embeddings": true
+normalize_embedding_logits: False
+enable_dropout: False # deterministic for testing
+
+tokenizer_type: "huggingface"

--- a/MaxText/configs/models/qwen3-4b.yml
+++ b/MaxText/configs/models/qwen3-4b.yml
@@ -1,0 +1,37 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# model config for qwen3-0.6b
+
+base_emb_dim: 2560
+base_num_query_heads: 32
+base_num_kv_heads: 8
+base_mlp_dim: 9728
+base_num_decoder_layers: 36
+head_dim: 128
+mlp_activations: ["silu", "linear"] # "hidden_act": "silu" implies SwiGLU
+vocab_size: 151936
+
+decoder_block: "qwen3"
+
+normalization_layer_epsilon: 1.0e-6
+rope_max_timescale: 1000000
+
+use_qk_norm: True
+
+logits_via_embedding: True # from "tie_word_embeddings": true
+normalize_embedding_logits: False
+enable_dropout: False # deterministic for testing
+
+tokenizer_type: "huggingface"

--- a/MaxText/configs/models/qwen3-8b.yml
+++ b/MaxText/configs/models/qwen3-8b.yml
@@ -1,0 +1,38 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# model config for qwen3-0.6b
+
+base_emb_dim: 4096
+base_num_query_heads: 32
+base_num_kv_heads: 8
+base_mlp_dim: 12288
+base_num_decoder_layers: 36
+head_dim: 128
+mlp_activations: ["silu", "linear"] # "hidden_act": "silu" implies SwiGLU
+vocab_size: 151936
+
+decoder_block: "qwen3"
+
+normalization_layer_epsilon: 1.0e-6
+rope_max_timescale: 1000000
+
+use_qk_norm: True
+
+logits_via_embedding: False # different from smaller variants, "tie_word_embeddings": false
+normalize_embedding_logits: False
+enable_dropout: False # deterministic for testing
+
+tokenizer_type: "huggingface"
+

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -347,6 +347,10 @@ class Decoder(nn.Module):
       from MaxText.layers import gpt3  # pylint: disable=import-outside-toplevel
 
       return [gpt3.Gpt3DecoderLayer]
+    elif self.config.decoder_block == DecoderBlockType.QWEN3:
+      from MaxText.layers import qwen3  # pylint: disable=import-outside-toplevel
+
+      return [qwen3.Qwen3DecoderLayer]
     elif self.config.decoder_block == DecoderBlockType.SIMPLE:
       from MaxText.layers import simple_layer  # pylint: disable=import-outside-toplevel
 
@@ -376,6 +380,7 @@ class Decoder(nn.Module):
         DecoderBlockType.GEMMA,
         DecoderBlockType.GEMMA2,
         DecoderBlockType.GEMMA3,
+        DecoderBlockType.QWEN3,
         DecoderBlockType.SIMPLE,
         DecoderBlockType.SIMPLE_MLP,
         DecoderBlockType.LLAMA4,
@@ -804,4 +809,4 @@ class Transformer(nn.Module):
         image_embeddings=image_embeddings,
     )
     return logits
-  
+

--- a/MaxText/layers/qwen3.py
+++ b/MaxText/layers/qwen3.py
@@ -1,0 +1,159 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Qwen3 model decoder layer."""
+# pylint: disable=arguments-differ
+# pylint: disable=no-name-in-module
+
+from typing import Optional
+
+from jax.ad_checkpoint import checkpoint_name
+from jax.sharding import Mesh
+import jax.numpy as jnp
+
+from flax import linen as nn
+
+from MaxText.common_types import Config
+from MaxText.layers import attentions
+from MaxText.layers import initializers
+from MaxText.layers import linears
+from MaxText.layers import moe
+from MaxText.layers import quantizations
+from MaxText.layers.normalizations import RMSNorm
+from MaxText.layers.quantizations import AqtQuantization as Quant
+from MaxText.inference import page_manager
+
+
+class Qwen3DecoderLayer(nn.Module):
+  """Qwen3 Transformer decoder layer."""
+
+  config: Config
+  mesh: Mesh
+  quant: Optional[Quant] = None
+
+  @nn.compact
+  def __call__(
+      self,
+      inputs: jnp.ndarray,
+      decoder_segment_ids: Optional[jnp.ndarray],
+      decoder_positions: Optional[jnp.ndarray],
+      deterministic: bool,
+      model_mode: str,
+      previous_chunk=None,
+      page_state: Optional[page_manager.PageState] = None,
+      slot: Optional[int] = None,
+  ):
+    cfg = self.config
+    mesh = self.mesh
+
+    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_length", "activation_embed"))
+    inputs_checkpoint = checkpoint_name(inputs, "decoder_layer_input")
+
+    # Corresponds to Qwen3's `input_layernorm`
+    lnx = RMSNorm(
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        name="pre_self_attention_layer_norm",
+        epsilon=cfg.normalization_layer_epsilon,
+        kernel_axes=("norm",),
+    )(inputs_checkpoint)
+    lnx = nn.with_logical_constraint(lnx, ("activation_batch", "activation_length", "activation_embed"))
+
+    # Self-attention block
+    attention_layer = attentions.Attention(
+        config=cfg,
+        num_query_heads=cfg.num_query_heads,
+        num_kv_heads=cfg.num_kv_heads,
+        head_dim=cfg.head_dim,
+        max_target_length=cfg.max_target_length,
+        max_prefill_predict_length=cfg.max_prefill_predict_length,
+        attention_kernel=cfg.attention,
+        mesh=mesh,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        dropout_rate=cfg.dropout_rate,
+        name="self_attention",
+        quant=self.quant,
+        kv_quant=quantizations.configure_kv_quant(cfg),
+        use_qk_norm=cfg.use_qk_norm,
+        query_pre_attn_scalar=(cfg.head_dim**-0.5), # Qwen3 specific scaling
+    )
+
+    attention_output = attention_layer(
+        lnx,  # inputs_q
+        lnx,  # inputs_kv
+        decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        deterministic=deterministic,
+        model_mode=model_mode,
+    )
+    attention_output = nn.with_logical_constraint(
+        attention_output, ("activation_batch", "activation_length", "activation_embed")
+    )
+
+    # Residual connection after attention
+    residual_after_attention = inputs_checkpoint + attention_output
+
+    # Post Attention LayerNorm (corresponds to Qwen3's `post_attention_layernorm`)
+    mlp_input = RMSNorm(
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        name="post_self_attention_layer_norm", # Standard MaxText naming
+        epsilon=cfg.normalization_layer_epsilon,
+        kernel_axes=("norm",),
+    )(residual_after_attention)
+    mlp_input = nn.with_logical_constraint(mlp_input, ("activation_batch", "activation_length", "activation_embed"))
+
+    # MLP block
+    if cfg.num_experts is None or cfg.num_experts <= 1:  # Dense MLP
+      mlp_output = linears.MlpBlock(
+          intermediate_dim=cfg.mlp_dim,
+          activations=cfg.mlp_activations,
+          intermediate_dropout_rate=cfg.dropout_rate,
+          dtype=cfg.dtype,
+          weight_dtype=cfg.weight_dtype,
+          name="mlp",
+          config=cfg,
+          quant=self.quant,
+      )(mlp_input, deterministic=deterministic)
+    else:  # Mixture of Experts MLP -- not supported / tested in MaxText
+      mlp_output, _ = moe.RoutedMoE(
+          config=cfg,
+          num_experts=cfg.num_experts,
+          num_experts_per_tok=cfg.num_experts_per_tok,
+          mesh=self.mesh,
+          kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+          kernel_axes=("embed", None),
+          intermediate_dim=cfg.mlp_dim,
+          dtype=cfg.dtype,
+          weight_dtype=cfg.weight_dtype,
+          name="moe_block",
+          quant=self.quant,
+      )(mlp_input)
+
+    mlp_output = nn.with_logical_constraint(mlp_output, ("activation_batch", "activation_length", "activation_embed"))
+
+    # Final residual connection
+    layer_output = residual_after_attention + mlp_output
+    layer_output = nn.with_logical_constraint(
+        layer_output,
+        ("activation_batch", "activation_length", "activation_embed"),
+    )
+
+    if cfg.scan_layers:
+      return layer_output, None
+    else:
+      return layer_output

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -188,6 +188,7 @@ def validate_keys(keys):
   if keys["num_experts"] > 1:
     validate_sparse_matmul_parallelism(keys)
     validate_deepseek_moe(keys)
+    assert (keys["decoder_block"] != "qwen3"), "Qwen3 MoE mode has not been tested, please set num_experts to 1."
 
   if keys["use_multimodal"]:
     validate_multimodal_model_name(keys["model_name"])
@@ -295,6 +296,9 @@ def validate_model_name(s: str) -> bool:
       "gemma3-4b",
       "gemma3-12b",
       "gemma3-27b",
+      "qwen3-0.6b",
+      "qwen3-4b",
+      "qwen3-8b",
       "gpt3-175b",
       "gpt3-22b",
       "gpt3-6b",

--- a/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -109,6 +109,54 @@ gemma2_27b_config = transformers.Gemma2Config(
     query_pre_attn_scalar=144,
 )
 
+qwen3_0_6b_config = transformers.Qwen3Config(
+    vocab_size=151936,
+    hidden_size=1024,
+    intermediate_size=3072,
+    num_hidden_layers=28,
+    num_attention_heads=16,
+    num_key_value_heads=8,
+    head_dim=128,
+    hidden_act="silu",
+    max_position_embeddings=40960,
+    rms_norm_eps=1.0e-6,
+    rope_theta=1000000.0,
+    tie_word_embeddings=True,
+    torch_dtype="bfloat16",
+)
+
+qwen3_4b_config = transformers.Qwen3Config(
+    vocab_size=151936,
+    hidden_size=2560,
+    intermediate_size=9728,
+    num_hidden_layers=36,
+    num_attention_heads=32,
+    num_key_value_heads=8,
+    head_dim=128,
+    hidden_act="silu",
+    max_position_embeddings=40960,
+    rms_norm_eps=1.0e-6,
+    rope_theta=1000000.0,
+    tie_word_embeddings=True,
+    torch_dtype="bfloat16",
+)
+
+qwen3_8b_config = transformers.Qwen3Config(
+    vocab_size=151936,
+    hidden_size=4096,
+    intermediate_size=12288,
+    num_hidden_layers=36,
+    num_attention_heads=32,
+    num_key_value_heads=8,
+    head_dim=128,
+    hidden_act="silu",
+    max_position_embeddings=40960,
+    rms_norm_eps=1.0e-6,
+    rope_theta=1000000.0,
+    tie_word_embeddings=False,
+    torch_dtype="bfloat16",
+)
+
 
 HF_MODEL_CONFIGS = {
     "gemma2-2b": gemma2_2b_config,
@@ -117,4 +165,7 @@ HF_MODEL_CONFIGS = {
     "gemma3-4b": gemma3text_4b_config,
     "gemma3-12b": gemma3text_12b_config,
     "gemma3-27b": gemma3text_27b_config,
+    "qwen3-0.6b": qwen3_0_6b_config,
+    "qwen3-4b": qwen3_4b_config,
+    "qwen3-8b": qwen3_8b_config,
 }

--- a/MaxText/utils/ckpt_conversion/utils/param_mapping.py
+++ b/MaxText/utils/ckpt_conversion/utils/param_mapping.py
@@ -520,6 +520,148 @@ def GEMMA3TEXT_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_
   return mapping
 
 
+def QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
+  """
+  Returns mapping from MaxText to HuggingFace Qwen3 weight paths.
+  Handles both dense and MoE models.
+  """
+  n_layers = config["num_hidden_layers"]
+  num_experts = config.get("num_experts", 0)
+
+  mapping = {
+      "params-token_embedder-embedding": "model.embed_tokens.weight",
+      "params-decoder-decoder_norm-scale": "model.norm.weight",
+      "params-decoder-logits_dense-kernel": "lm_head.weight",
+  }
+
+  if scan_layers:
+    # Common Attention and Norms for both Dense and MoE
+    mapping.update({
+        "params-decoder-layers-pre_self_attention_layer_norm-scale": [f"model.layers.{i}.input_layernorm.weight" for i in range(n_layers)],
+        "params-decoder-layers-self_attention-query-kernel": [f"model.layers.{i}.self_attn.q_proj.weight" for i in range(n_layers)],
+        "params-decoder-layers-self_attention-key-kernel": [f"model.layers.{i}.self_attn.k_proj.weight" for i in range(n_layers)],
+        "params-decoder-layers-self_attention-value-kernel": [f"model.layers.{i}.self_attn.v_proj.weight" for i in range(n_layers)],
+        "params-decoder-layers-self_attention-out-kernel": [f"model.layers.{i}.self_attn.o_proj.weight" for i in range(n_layers)],
+        "params-decoder-layers-self_attention-query_norm-scale": [f"model.layers.{i}.self_attn.q_norm.weight" for i in range(n_layers)],
+        "params-decoder-layers-self_attention-key_norm-scale": [f"model.layers.{i}.self_attn.k_norm.weight" for i in range(n_layers)],
+        "params-decoder-layers-post_self_attention_layer_norm-scale": [f"model.layers.{i}.post_attention_layernorm.weight" for i in range(n_layers)],
+    })
+
+    if num_experts > 1:
+      # MoE MLP layers
+      mapping.update({
+          "params-decoder-layers-moe_block-gate-kernel": [f"model.layers.{i}.mlp.gate.weight" for i in range(n_layers)],
+          # NOTE: The conversion script needs to handle unstacking on both layer and expert axes.
+          "params-decoder-layers-moe_block-wi_0-kernel": [[f"model.layers.{i}.mlp.experts.{j}.gate_proj.weight" for j in range(num_experts)] for i in range(n_layers)],
+          "params-decoder-layers-moe_block-wi_1-kernel": [[f"model.layers.{i}.mlp.experts.{j}.up_proj.weight" for j in range(num_experts)] for i in range(n_layers)],
+          "params-decoder-layers-moe_block-wo-kernel": [[f"model.layers.{i}.mlp.experts.{j}.down_proj.weight" for j in range(num_experts)] for i in range(n_layers)],
+      })
+    else:
+      # Dense MLP layers
+      mapping.update({
+          "params-decoder-layers-mlp-wi_0-kernel": [f"model.layers.{i}.mlp.gate_proj.weight" for i in range(n_layers)],
+          "params-decoder-layers-mlp-wi_1-kernel": [f"model.layers.{i}.mlp.up_proj.weight" for i in range(n_layers)],
+          "params-decoder-layers-mlp-wo-kernel": [f"model.layers.{i}.mlp.down_proj.weight" for i in range(n_layers)],
+      })
+  else:  # not scan_layers
+    for i in range(n_layers):
+      # Common Attention and Norms
+      mapping.update({
+          f"params-decoder-layers_{i}-pre_self_attention_layer_norm-scale": f"model.layers.{i}.input_layernorm.weight",
+          f"params-decoder-layers_{i}-self_attention-query-kernel": f"model.layers.{i}.self_attn.q_proj.weight",
+          f"params-decoder-layers_{i}-self_attention-key-kernel": f"model.layers.{i}.self_attn.k_proj.weight",
+          f"params-decoder-layers_{i}-self_attention-value-kernel": f"model.layers.{i}.self_attn.v_proj.weight",
+          f"params-decoder-layers_{i}-self_attention-out-kernel": f"model.layers.{i}.self_attn.o_proj.weight",
+          f"params-decoder-layers_{i}-self_attention-query_norm-scale": f"model.layers.{i}.self_attn.q_norm.weight",
+          f"params-decoder-layers_{i}-self_attention-key_norm-scale": f"model.layers.{i}.self_attn.k_norm.weight",
+          f"params-decoder-layers_{i}-post_self_attention_layer_norm-scale": f"model.layers.{i}.post_attention_layernorm.weight",
+      })
+      if num_experts > 1:
+        # MoE MLP layers
+        # NOTE: The conversion script needs to handle splitting the expert tensor along axis 0.
+        mapping.update({
+            f"params-decoder-layers_{i}-moe_block-gate-kernel": f"model.layers.{i}.mlp.gate.weight",
+            f"params-decoder-layers_{i}-moe_block-wi_0-kernel": [f"model.layers.{i}.mlp.experts.{j}.gate_proj.weight" for j in range(num_experts)],
+            f"params-decoder-layers_{i}-moe_block-wi_1-kernel": [f"model.layers.{i}.mlp.experts.{j}.up_proj.weight" for j in range(num_experts)],
+            f"params-decoder-layers_{i}-moe_block-wo-kernel": [f"model.layers.{i}.mlp.experts.{j}.down_proj.weight" for j in range(num_experts)],
+        })
+      else:
+        # Dense MLP layers
+        mapping.update({
+            f"params-decoder-layers_{i}-mlp-wi_0-kernel": f"model.layers.{i}.mlp.gate_proj.weight",
+            f"params-decoder-layers_{i}-mlp-wi_1-kernel": f"model.layers.{i}.mlp.up_proj.weight",
+            f"params-decoder-layers_{i}-mlp-wo-kernel": f"model.layers.{i}.mlp.down_proj.weight",
+        })
+
+  return mapping
+
+
+def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=False):
+  """Creates parameter transformation functions for Qwen3."""
+  n_layers = config["num_hidden_layers"]
+  num_experts = config.get("num_experts", 0)
+
+  def pad_embedding_layer(input_tensor, target_shape):
+    """Pads or truncates embedding layer to match target vocab size."""
+    source_vocab_size = input_tensor.shape[0]
+    target_vocab_size = target_shape[0]
+
+    if source_vocab_size == target_vocab_size:
+      return input_tensor
+
+    if saving_to_hf:  # MaxText to HF, truncate
+      return input_tensor[:target_vocab_size, :]
+    else:  # HF to MaxText, pad
+      padded_tensor = np.zeros(target_shape, dtype=input_tensor.dtype)
+      padded_tensor[:source_vocab_size, :] = input_tensor
+      return padded_tensor
+
+  def reshape_kernel(input_tensor, target_shape):
+    """Reshapes and transposes kernel weights between MaxText and HF."""
+    if saving_to_hf:
+      flipped_target_shape = np.flip(np.array(target_shape))
+      return input_tensor.reshape(flipped_target_shape).T
+    else:
+      return input_tensor.T.reshape(target_shape)
+
+  mapping = {
+      "params-token_embedder-embedding": pad_embedding_layer,
+      "params-decoder-logits_dense-kernel": reshape_kernel,
+  }
+
+  kernel_hooks = [
+      "self_attention-query-kernel",
+      "self_attention-key-kernel",
+      "self_attention-value-kernel",
+      "self_attention-out-kernel",
+      "mlp-wi_0-kernel",
+      "mlp-wi_1-kernel",
+      "mlp-wo-kernel",
+  ]
+  moe_kernel_hooks = [
+      "moe_block-gate-kernel",
+      "moe_block-wi_0-kernel",
+      "moe_block-wi_1-kernel",
+      "moe_block-wo-kernel",
+  ]
+
+  if scan_layers:
+    for key in kernel_hooks:
+      mapping[f"params-decoder-layers-{key}"] = reshape_kernel
+    if num_experts > 1:
+      for key in moe_kernel_hooks:
+        mapping[f"params-decoder-layers-{key}"] = reshape_kernel
+  else:
+    for i in range(n_layers):
+      for key in kernel_hooks:
+        mapping[f"params-decoder-layers_{i}-{key}"] = reshape_kernel
+      if num_experts > 1:
+        for key in moe_kernel_hooks:
+          mapping[f"params-decoder-layers_{i}-{key}"] = reshape_kernel
+  return mapping
+
+
+
 PARAM_MAPPING = {
     "gemma2-2b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma2-9b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
@@ -527,6 +669,9 @@ PARAM_MAPPING = {
     "gemma3-4b": GEMMA3TEXT_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma3-12b": GEMMA3TEXT_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma3-27b": GEMMA3TEXT_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-0.6b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-4b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-8b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
 }
 
 HOOK_FNS = {
@@ -536,4 +681,7 @@ HOOK_FNS = {
     "gemma3-4b": GEMMA3TEXT_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "gemma3-12b": GEMMA3TEXT_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "gemma3-27b": GEMMA3TEXT_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-0.6b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-4b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-8b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
 }

--- a/MaxText/utils/ckpt_conversion/utils/shape_mapping.py
+++ b/MaxText/utils/ckpt_conversion/utils/shape_mapping.py
@@ -119,6 +119,96 @@ def GEMMA3TEXT_HF_WEIGHTS_TO_SHAPE_MAPPING(config):
   return mapping
 
 
+def QWEN3_HF_WEIGHTS_TO_SHAPE_MAPPING(config):
+  """Returns mapping between HuggingFace Qwen3 weights path and the HuggingFace weights shape.
+
+  To check this mapping, dump the huggingface model shapes:
+    import torch
+    from transformers import AutoTokenizer, AutoModelForCausalLM
+    model_name = "Qwen/Qwen3-0.6B"
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(
+      model_name,
+      torch_dtype="auto",
+    )
+    for name, val in model.named_parameters():
+      print(name, val.shape)
+
+  Args:
+      config (dict): Model configuration dictionary (from HF Qwen3TextConfig.to_dict())
+                     Expected keys: https://huggingface.co/Qwen/Qwen3-0.6B/blob/main/config.json
+
+  Returns:
+      dict: A mapping where:
+          - Keys are HuggingFace model parameter paths
+          - Values are parameter shape as a List
+  """
+  hidden_size = config["hidden_size"]
+  num_hidden_layers = config["num_hidden_layers"]
+  num_attention_heads = config["num_attention_heads"]
+  num_key_value_heads = config["num_key_value_heads"]
+  head_dim = config.get("head_dim", config["hidden_size"] // config["num_attention_heads"]) # head_dim might not always be present
+
+  mapping = {
+      "model.embed_tokens.weight": [config["vocab_size"], hidden_size],
+      "model.norm.weight": [hidden_size],
+      "lm_head.weight": [config["vocab_size"], hidden_size],
+  }
+
+  # Determine if the model is MoE based on config keys
+  num_experts = config.get("num_experts", 0)
+
+  for layer_idx in range(num_hidden_layers):
+    layer_prefix = f"model.layers.{layer_idx}"
+    layer_mapping = {
+        f"{layer_prefix}.input_layernorm.weight": [hidden_size],
+        f"{layer_prefix}.post_attention_layernorm.weight": [hidden_size],
+        # Attention projections
+        f"{layer_prefix}.self_attn.q_proj.weight": [num_attention_heads * head_dim, hidden_size],
+        f"{layer_prefix}.self_attn.k_proj.weight": [num_key_value_heads * head_dim, hidden_size],
+        f"{layer_prefix}.self_attn.v_proj.weight": [num_key_value_heads * head_dim, hidden_size],
+        f"{layer_prefix}.self_attn.o_proj.weight": [hidden_size, num_attention_heads * head_dim],
+        # QK Norm weights (applied per head to the head_dim dimension)
+        f"{layer_prefix}.self_attn.q_norm.weight": [head_dim],
+        f"{layer_prefix}.self_attn.k_norm.weight": [head_dim],
+    }
+
+    if num_experts > 1:
+      # MoE MLP layers
+      moe_ffn_intermediate_size = config.get("moe_intermediate_size")
+      if moe_ffn_intermediate_size is None:
+          # moe_intermediate_size refers to the intermediate size of the routed expert
+          # For Qwen MoE, moe_intermediate_size is distinct from intermediate_size (for dense layers)
+          # Fall back to intermediate_size
+          moe_ffn_intermediate_size = config.get("intermediate_size")
+          if moe_ffn_intermediate_size is None:
+              raise ValueError("MoE model detected (num_experts > 1) but 'moe_intermediate_size' or 'intermediate_size' not found in config.")
+
+      layer_mapping.update({
+          f"{layer_prefix}.mlp.gate.weight": [num_experts, hidden_size],
+      })
+      for expert_j in range(num_experts):
+        expert_prefix = f"{layer_prefix}.mlp.experts.{expert_j}"
+        layer_mapping.update({
+            f"{expert_prefix}.gate_proj.weight": [moe_ffn_intermediate_size, hidden_size],
+            f"{expert_prefix}.up_proj.weight": [moe_ffn_intermediate_size, hidden_size],
+            f"{expert_prefix}.down_proj.weight": [hidden_size, moe_ffn_intermediate_size],
+        })
+    else:
+      # Dense MLP layers
+      dense_ffn_intermediate_size = config.get("intermediate_size")
+      if dense_ffn_intermediate_size is None:
+          raise ValueError("'intermediate_size' not found in config for a dense MLP.")
+      layer_mapping.update({
+          f"{layer_prefix}.mlp.gate_proj.weight": [dense_ffn_intermediate_size, hidden_size],
+          f"{layer_prefix}.mlp.up_proj.weight": [dense_ffn_intermediate_size, hidden_size],
+          f"{layer_prefix}.mlp.down_proj.weight": [hidden_size, dense_ffn_intermediate_size],
+      })
+    mapping.update(layer_mapping)
+  return mapping
+
+
 SHAPE_MAPPING = {
     "gemma2-2b": GEMMA2_HF_WEIGHTS_TO_SHAPE_MAPPING,
     "gemma2-9b": GEMMA2_HF_WEIGHTS_TO_SHAPE_MAPPING,
@@ -126,4 +216,7 @@ SHAPE_MAPPING = {
     "gemma3-4b": GEMMA3TEXT_HF_WEIGHTS_TO_SHAPE_MAPPING,
     "gemma3-12b": GEMMA3TEXT_HF_WEIGHTS_TO_SHAPE_MAPPING,
     "gemma3-27b": GEMMA3TEXT_HF_WEIGHTS_TO_SHAPE_MAPPING,
+    "qwen3-0.6b": QWEN3_HF_WEIGHTS_TO_SHAPE_MAPPING,
+    "qwen3-4b": QWEN3_HF_WEIGHTS_TO_SHAPE_MAPPING,
+    "qwen3-8b": QWEN3_HF_WEIGHTS_TO_SHAPE_MAPPING,
 }

--- a/MaxText/utils/ckpt_conversion/utils/utils.py
+++ b/MaxText/utils/ckpt_conversion/utils/utils.py
@@ -48,6 +48,9 @@ HF_IDS = {
     "gemma3-4b": "google/gemma-3-4b-it",  # hf multi-modal should also support the pure-text
     "gemma3-12b": "google/gemma-3-12b",
     "gemma3-27b": "google/gemma-3-27b",
+    "qwen3-0.6b": "Qwen/Qwen3-0.6B",
+    "qwen3-4b": "Qwen/Qwen3-4B",
+    "qwen3-8b": "Qwen/Qwen3-8B",
 }
 
 
@@ -280,6 +283,8 @@ def save_safetensor_file(
   if jax.process_index() == 0:
     state_dict = {k: v for k, v in state_dict.items() if v is not None}
     local_path = os.path.join(local_dir_to_save_to, file_name)
+    if "model.safetensors" in state_dict and isinstance(state_dict["model.safetensors"], dict):
+        state_dict = state_dict["model.safetensors"]
     numpy_save_file(state_dict, local_path, metadata={"format": "pt"})
     max_logging.log(f"   Saved {file_name} to {local_path}")
 
@@ -451,6 +456,7 @@ def save_model_files(
 
     # Save .safetensors files (sharding can be outside process guard if weights are replicated)
     # The actual file saving within save_weight_files is guarded.
+    # Unwrap nested dict if needed
     shards, index = shard_checkpoint(weight_arrays)
     save_weight_files(shards, index, current_save_path, output_dir, parallel_threads, remove_local_copy)
 

--- a/assets/qwen3-tokenizer/tokenizer_config.json
+++ b/assets/qwen3-tokenizer/tokenizer_config.json
@@ -1,0 +1,239 @@
+{
+  "add_bos_token": false,
+  "add_prefix_space": false,
+  "added_tokens_decoder": {
+    "151643": {
+      "content": "<|endoftext|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151644": {
+      "content": "<|im_start|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151645": {
+      "content": "<|im_end|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151646": {
+      "content": "<|object_ref_start|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151647": {
+      "content": "<|object_ref_end|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151648": {
+      "content": "<|box_start|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151649": {
+      "content": "<|box_end|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151650": {
+      "content": "<|quad_start|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151651": {
+      "content": "<|quad_end|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151652": {
+      "content": "<|vision_start|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151653": {
+      "content": "<|vision_end|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151654": {
+      "content": "<|vision_pad|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151655": {
+      "content": "<|image_pad|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151656": {
+      "content": "<|video_pad|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "151657": {
+      "content": "<tool_call>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151658": {
+      "content": "</tool_call>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151659": {
+      "content": "<|fim_prefix|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151660": {
+      "content": "<|fim_middle|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151661": {
+      "content": "<|fim_suffix|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151662": {
+      "content": "<|fim_pad|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151663": {
+      "content": "<|repo_name|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151664": {
+      "content": "<|file_sep|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151665": {
+      "content": "<tool_response>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151666": {
+      "content": "</tool_response>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151667": {
+      "content": "<think>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    },
+    "151668": {
+      "content": "</think>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": false
+    }
+  },
+  "additional_special_tokens": [
+    "<|im_start|>",
+    "<|im_end|>",
+    "<|object_ref_start|>",
+    "<|object_ref_end|>",
+    "<|box_start|>",
+    "<|box_end|>",
+    "<|quad_start|>",
+    "<|quad_end|>",
+    "<|vision_start|>",
+    "<|vision_end|>",
+    "<|vision_pad|>",
+    "<|image_pad|>",
+    "<|video_pad|>"
+  ],
+  "bos_token": null,
+  "chat_template": "{%- if tools %}\n    {{- '<|im_start|>system\\n' }}\n    {%- if messages[0].role == 'system' %}\n        {{- messages[0].content + '\\n\\n' }}\n    {%- endif %}\n    {{- \"# Tools\\n\\nYou may call one or more functions to assist with the user query.\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>\" }}\n    {%- for tool in tools %}\n        {{- \"\\n\" }}\n        {{- tool | tojson }}\n    {%- endfor %}\n    {{- \"\\n</tools>\\n\\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\\n<tool_call>\\n{\\\"name\\\": <function-name>, \\\"arguments\\\": <args-json-object>}\\n</tool_call><|im_end|>\\n\" }}\n{%- else %}\n    {%- if messages[0].role == 'system' %}\n        {{- '<|im_start|>system\\n' + messages[0].content + '<|im_end|>\\n' }}\n    {%- endif %}\n{%- endif %}\n{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}\n{%- for message in messages[::-1] %}\n    {%- set index = (messages|length - 1) - loop.index0 %}\n    {%- if ns.multi_step_tool and message.role == \"user\" and message.content is string and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}\n        {%- set ns.multi_step_tool = false %}\n        {%- set ns.last_query_index = index %}\n    {%- endif %}\n{%- endfor %}\n{%- for message in messages %}\n    {%- if message.content is string %}\n        {%- set content = message.content %}\n    {%- else %}\n        {%- set content = '' %}\n    {%- endif %}\n    {%- if (message.role == \"user\") or (message.role == \"system\" and not loop.first) %}\n        {{- '<|im_start|>' + message.role + '\\n' + content + '<|im_end|>' + '\\n' }}\n    {%- elif message.role == \"assistant\" %}\n        {%- set reasoning_content = '' %}\n        {%- if message.reasoning_content is string %}\n            {%- set reasoning_content = message.reasoning_content %}\n        {%- else %}\n            {%- if '</think>' in content %}\n                {%- set reasoning_content = content.split('</think>')[0].rstrip('\\n').split('<think>')[-1].lstrip('\\n') %}\n                {%- set content = content.split('</think>')[-1].lstrip('\\n') %}\n            {%- endif %}\n        {%- endif %}\n        {%- if loop.index0 > ns.last_query_index %}\n            {%- if loop.last or (not loop.last and reasoning_content) %}\n                {{- '<|im_start|>' + message.role + '\\n<think>\\n' + reasoning_content.strip('\\n') + '\\n</think>\\n\\n' + content.lstrip('\\n') }}\n            {%- else %}\n                {{- '<|im_start|>' + message.role + '\\n' + content }}\n            {%- endif %}\n        {%- else %}\n            {{- '<|im_start|>' + message.role + '\\n' + content }}\n        {%- endif %}\n        {%- if message.tool_calls %}\n            {%- for tool_call in message.tool_calls %}\n                {%- if (loop.first and content) or (not loop.first) %}\n                    {{- '\\n' }}\n                {%- endif %}\n                {%- if tool_call.function %}\n                    {%- set tool_call = tool_call.function %}\n                {%- endif %}\n                {{- '<tool_call>\\n{\"name\": \"' }}\n                {{- tool_call.name }}\n                {{- '\", \"arguments\": ' }}\n                {%- if tool_call.arguments is string %}\n                    {{- tool_call.arguments }}\n                {%- else %}\n                    {{- tool_call.arguments | tojson }}\n                {%- endif %}\n                {{- '}\\n</tool_call>' }}\n            {%- endfor %}\n        {%- endif %}\n        {{- '<|im_end|>\\n' }}\n    {%- elif message.role == \"tool\" %}\n        {%- if loop.first or (messages[loop.index0 - 1].role != \"tool\") %}\n            {{- '<|im_start|>user' }}\n        {%- endif %}\n        {{- '\\n<tool_response>\\n' }}\n        {{- content }}\n        {{- '\\n</tool_response>' }}\n        {%- if loop.last or (messages[loop.index0 + 1].role != \"tool\") %}\n            {{- '<|im_end|>\\n' }}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|im_start|>assistant\\n' }}\n    {%- if enable_thinking is defined and enable_thinking is false %}\n        {{- '<think>\\n\\n</think>\\n\\n' }}\n    {%- endif %}\n{%- endif %}",
+  "clean_up_tokenization_spaces": false,
+  "eos_token": "<|im_end|>",
+  "errors": "replace",
+  "model_max_length": 131072,
+  "pad_token": "<|endoftext|>",
+  "split_special_tokens": false,
+  "tokenizer_class": "Qwen2Tokenizer",
+  "unk_token": null
+}


### PR DESCRIPTION
# Description
This PR adds initial Qwen3 support to MaxText. It is using a new checkpoint conversion method, which is being developed concurrently, and still needs to be merged to leverage this code.

The tokenizer (assets/qwen3-tokenizer/tokenizer.json) is being merged as part of a separate PR (https://github.com/AI-Hypercomputer/maxtext/pull/1901).

# Tests

I tested locally that conversion to and from HF works for the 0.6b, 4b, 8b variants.
For example, for 0.6b, to MaxText:
<img width="506" alt="Screenshot 2025-06-29 at 2 03 11 PM" src="https://github.com/user-attachments/assets/ace14ff3-c1e4-41c2-91d4-1d920528c3f9" />

and back to HuggingFace:
<img width="497" alt="Screenshot 2025-06-29 at 2 03 47 PM" src="https://github.com/user-attachments/assets/e0ad1a1c-1307-4e21-9656-51967e0b4128" />

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
