### PR TITLE
Migrate AttentionOp to use NNX

### DIFF
--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -34,7 +34,7 @@ from MaxText.layers import initializers
 from MaxText.layers import linears
 from MaxText.layers import models
 from MaxText.layers import quantizations
-from MaxText.layers.attentions import AttentionOp, KVQuant, dense_general
+from MaxText.layers.attentions import KVQuant, attention_op_as_linen, dense_general
 from MaxText.layers.initializers import Initializer, NdInitializer, nd_dense_init
 from MaxText.layers.quantizations import AqtQuantization as Quant
 
@@ -223,7 +223,7 @@ class Gpt3MultiHeadAttention(nn.Module):
     value = nn.with_logical_constraint(value, self.value_axis_names)
     value = checkpoint_name(value, "value_proj")
 
-    attention_op = AttentionOp(
+    attention_op = attention_op_as_linen(
         config=self.config,
         mesh=self.mesh,
         attention_kernel=self.attention_kernel,


### PR DESCRIPTION
# Description

Update the `AttentionOp` module to use NNX instead of Linen.

`AttentionOp` has no dependencies/params. `Attention` and `Gpt3MultiHeadAttention` both depend on it.

# Tests

Successfully trained MaxText base on a TPU VM for 10 steps:

```
python3 -m MaxText.train MaxText/configs/base.yml \
    run_name=<run_name> \
    base_output_directory=gs://<gcs_bucket> \
    dataset_type=synthetic \
    steps=10
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
