### PR TITLE
add fp8 recipe

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -84,6 +84,8 @@ dtype: "bfloat16"
 # 'fp8' for 8-bit floating-point GeMMs on NVIDIA GPUs.
 # 'nanoo_fp8' for 8-bit floating-point GeMMs on AMD MI300/MI325 GPUs.
 quantization: ""
+# Used to configure constant_bound_config in aqt lib for static scaling, e.g. constant_bound_config='0.5, 0.5, 0.5, 0.5, 0.5, 0.5'
+constant_bound_config: ""
 # Choose one of default, high, and highest.
 # https://kolonist26-jax-kr.readthedocs.io/en/latest/jax.lax.html#jax.lax.Precision
 matmul_precision: "default"

--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -302,6 +302,143 @@ def _get_int8_quant_config(config):
   )
 
 
+@dataclass(frozen=True)
+class ConstantBoundConfig:
+  fwd_lhs_bound: float | None = None
+  fwd_rhs_bound: float | None = None
+  dlhs_lhs_bound: float | None = None
+  dlhs_rhs_bound: float | None = None
+  drhs_lhs_bound: float | None = None
+  drhs_rhs_bound: float | None = None
+
+
+def _build_const_scale_config(
+    aqt_dg: aqt_config.DotGeneral,
+    cst_bound_config: ConstantBoundConfig,
+) -> aqt_config.DotGeneral:
+  """Build a constant scale config for AQT dot general.
+
+  Args:
+    aqt_dg: The AQT dot general config.
+    cst_bound_config: The constant bound config.
+
+  Returns:
+    The AQT dot general config with constant scale config.
+  """
+  if cst_bound_config.fwd_lhs_bound is not None:
+    aqt_dg.fwd.dg_quantizer.lhs.calibration = functools.partial(
+        calibration.ConstantCalibration, bound=cst_bound_config.fwd_lhs_bound
+    )
+  if cst_bound_config.fwd_rhs_bound is not None:
+    aqt_dg.fwd.dg_quantizer.rhs.calibration = functools.partial(
+        calibration.ConstantCalibration, bound=cst_bound_config.fwd_rhs_bound
+    )
+  if cst_bound_config.dlhs_lhs_bound:
+    aqt_dg.dlhs.dg_quantizer.lhs.calibration = functools.partial(
+        calibration.ConstantCalibration, bound=cst_bound_config.dlhs_lhs_bound
+    )
+
+  if cst_bound_config.dlhs_rhs_bound is not None:
+    aqt_dg.dlhs.dg_quantizer.rhs.calibration = functools.partial(
+        calibration.ConstantCalibration, bound=cst_bound_config.dlhs_rhs_bound
+    )
+
+  if cst_bound_config.drhs_lhs_bound is not None:
+    aqt_dg.drhs.dg_quantizer.lhs.calibration = functools.partial(
+        calibration.ConstantCalibration, bound=cst_bound_config.drhs_lhs_bound
+    )
+
+  if cst_bound_config.drhs_rhs_bound is not None:
+    aqt_dg.drhs.dg_quantizer.rhs.calibration = functools.partial(
+        calibration.ConstantCalibration, bound=cst_bound_config.drhs_rhs_bound
+    )
+
+  return aqt_dg
+
+@dataclass
+class PerTensorScales:
+  fwd_lhs: bool = False
+  fwd_rhs: bool = False
+  dlhs_lhs: bool = False
+  dlhs_rhs: bool = False
+  drhs_lhs: bool = False
+  drhs_rhs: bool = False
+
+def _build_per_tensor_config(
+    aqt_dg: aqt_config.DotGeneral, per_tensor_scales: PerTensorScales,
+) -> aqt_config.DotGeneral:
+  """Build a per tensor config for AQT dot general.
+
+  Args:
+    aqt_dg: The AQT dot general config.
+    per_tensor_scales: The per tensor scales config.
+
+  Returns:
+    The AQT dot general config with per tensor config.
+  """
+  if per_tensor_scales.fwd_lhs:
+    aqt_dg.fwd.dg_quantizer.lhs.calib_shared_axes = "per_tensor"
+  if per_tensor_scales.fwd_rhs:
+    aqt_dg.fwd.dg_quantizer.rhs.calib_shared_axes = "per_tensor"
+  if per_tensor_scales.dlhs_lhs:
+    aqt_dg.dlhs.dg_quantizer.lhs.calib_shared_axes = "per_tensor"
+  if per_tensor_scales.dlhs_rhs:
+    aqt_dg.dlhs.dg_quantizer.rhs.calib_shared_axes = "per_tensor"
+  if per_tensor_scales.drhs_lhs:
+    aqt_dg.drhs.dg_quantizer.lhs.calib_shared_axes = "per_tensor"
+  if per_tensor_scales.drhs_rhs:
+    aqt_dg.drhs.dg_quantizer.rhs.calib_shared_axes = "per_tensor"
+  return aqt_dg
+
+
+# fp8 training recipe of dynmaic scaling with configurable constant_bound_config for static scaling option
+def _get_aqt_fp8_default_config(config):
+  """Get aqt for 8-bit floating point quantization configuration."""
+  aqt_dg = aqt_config.config_v4(
+      fwd_bits="e4m3",
+      dlhs_bits="e5m2",
+      drhs_bits="e5m2",
+      use_dummy_static_bound=False,
+      fwd_accumulator_dtype=jnp.bfloat16,
+      dlhs_accumulator_dtype=jnp.bfloat16,
+      drhs_accumulator_dtype=jnp.bfloat16,
+      dlhs_use_fwd_quant=False,
+      drhs_use_fwd_quant=False,
+  )
+  constant_bound_config = None
+
+  if len(config.constant_bound_config) == 6:
+    fwd_lhs_bound, fwd_rhs_bound, dlhs_lhs_bound, dlhs_rhs_bound, drhs_lhs_bound, drhs_rhs_bound = (
+        config.constant_bound_config
+    )
+    constant_bound_config = ConstantBoundConfig(
+        fwd_lhs_bound=fwd_lhs_bound,
+        fwd_rhs_bound=fwd_rhs_bound,
+        dlhs_lhs_bound=dlhs_lhs_bound,
+        dlhs_rhs_bound=dlhs_rhs_bound,
+        drhs_lhs_bound=drhs_lhs_bound,
+        drhs_rhs_bound=drhs_rhs_bound,
+    )
+    aqt_dg = _build_const_scale_config(aqt_dg, constant_bound_config)
+
+  aqt_config.set_stochastic_rounding(
+      aqt_dg,
+      vjp_lhs_stochastic_rounding=False,
+      vjp_rhs_stochastic_rounding=False,
+      implementation="jax.uniform",
+  )
+
+  per_tensor_scales = PerTensorScales(
+      fwd_lhs=True,
+      fwd_rhs=True,
+      dlhs_lhs=True,
+      dlhs_rhs=True,
+      drhs_lhs=True,
+      drhs_rhs=True,
+  )
+  return _build_per_tensor_config(aqt_dg, per_tensor_scales)
+
+
 def _get_aqt_fp8_quant_config(config):
   """get aqt for 8-bit floating point quantization configuration"""
   cfg = aqt_config.config_v4(fwd_bits="e4m3", dlhs_bits=None, drhs_bits=None, fwd_accumulator_dtype=jnp.bfloat16)
@@ -362,6 +499,9 @@ def _get_quant_config(config):
     return "nanoo_fp8"
   if config.quantization == "aqt_fp8":
     return _get_aqt_fp8_quant_config(config)
+  if config.quantization == "aqt_fp8_full":
+    return _get_aqt_fp8_default_config(config)
+
   raise ValueError(f"Invalid value configured for quantization {config.quantization}.")
 
 

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -202,6 +202,17 @@ def validate_tokenizer(keys):
   ], "Please provide tokenizer_path. Even if using pre-tokenized data, tokenizer is required to process special tokens."
 
 
+def validate_constant_bound(keys):
+  if keys["constant_bound_config"] == "":
+    keys["constant_bound_config"]=[]
+  else:
+    value_list = keys["constant_bound_config"].split(',')
+    keys["constant_bound_config"] = list(map(float, value_list))
+  assert (
+      len(keys["constant_bound_config"]) == 0 or len(keys["constant_bound_config"]) == 6
+  ), "Please specify competete constant bound or none"
+
+
 def validate_data_input(keys):
   """validate provided parameters for data input"""
   if not keys["hf_access_token"]:
@@ -589,6 +600,7 @@ class _HyperParameters:
     validate_keys(raw_keys)
     validate_tokenizer(raw_keys)
     validate_data_input(raw_keys)
+    validate_constant_bound(raw_keys)
 
     raw_keys["decoder_block"] = DecoderBlockType(raw_keys["decoder_block"])
 


### PR DESCRIPTION
# Description
Add fp8 training recipe:
1) aqt_fp8_full:
  * Quantize all matmuls 
  * rounding: rounding to nearest even
  * fwd: e4m3fn
  * bwd:e5m2
  * Scaling granuarity: per-tensor
  * Scaling mode: dynamic
  * with optional constant_bound_config for static weight and activation scaling
usage:
1) quantization='aqt_fp8_full' constant_bound_config=''
2) quantization='aqt_fp8_full' constant_bound_config='0.5, 0.5, 0.5, 0.5, 0.5, 0.5'

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/427492988

# Tests
both recipes are verified on deepseek v3 finetuning.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
