### PR TITLE
Don't fail build if can't access test assets

### DIFF
--- a/.github/workflows/build_and_upload_images.sh
+++ b/.github/workflows/build_and_upload_images.sh
@@ -51,7 +51,9 @@ docker tag ${LOCAL_IMAGE_NAME} gcr.io/$PROJECT/${dependency_image_name}:${image_
 docker push gcr.io/$PROJECT/${dependency_image_name}:${image_date}
 
 # Download other test assets from GCS into MaxText/test_assets
-gcloud storage cp gs://maxtext-test-assets/* MaxText/test_assets
+if ! gcloud storage cp gs://maxtext-test-assets/* MaxText/test_assets; then
+  echo "WARNING: Failed to download test assets from GCS. These files are only used for end-to-end tests; you may not have access to the bucket."
+fi
 
 # Build then upload "dependencies + code" image
 docker build --build-arg BASEIMAGE=${LOCAL_IMAGE_NAME} -f ./maxtext_runner.Dockerfile -t ${LOCAL_IMAGE_NAME}_runner .

--- a/MaxText/kernels/splash_attention_kernel.py
+++ b/MaxText/kernels/splash_attention_kernel.py
@@ -1,4 +1,4 @@
-
+# pylint: skip-file
 from __future__ import annotations
 
 # Copyright 2025 Google LLC

--- a/docker_upload_runner.sh
+++ b/docker_upload_runner.sh
@@ -45,7 +45,9 @@ if [[ ! -v CLOUD_IMAGE_NAME ]]; then
 fi
 
 # Download other test assets from GCS into MaxText/test_assets
-gcloud storage cp gs://maxtext-test-assets/* MaxText/test_assets
+if ! gcloud storage cp gs://maxtext-test-assets/* MaxText/test_assets; then
+  echo "WARNING: Failed to download test assets from GCS. These files are only used for end-to-end tests; you may not have access to the bucket."
+fi
 
 docker build --build-arg BASEIMAGE=${LOCAL_IMAGE_NAME} -f ./maxtext_runner.Dockerfile -t ${LOCAL_IMAGE_NAME_RUNNER} .
 


### PR DESCRIPTION
# Description

Recently we removed golden logits files from MaxText and put them in a GCS bucket. When building images used for testing, we copy these files into the image. But now the build fails for users that don't have access to this bucket. This PR adds a warning message and makes the script continue in this case.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/417648118

# Tests


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
