### PR TITLE
Enable SFT for multimodal llama4

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -414,7 +414,9 @@ expansion_factor_real_data: -1 # if -1 then all hosts will load real data, else 
 eval_per_device_batch_size: 0.0
 max_corpus_chars: 10_000_000
 train_data_columns: ['text'] # for DPO dataset containing "chosen" and "rejected"
+train_image_column: 'image'
 eval_data_columns: ['text'] # for DPO dataset containing "chosen" and "rejected"
+eval_image_column: 'image'
 packing: True
 num_epoch: 1  # only grain and tfds pipeline supports num_epoch > 1
 
@@ -737,7 +739,7 @@ dtype_mm: "float32"  # Data type for multimodal model's vision encoder
 remat_policy_for_vit: "minimal"  # Remat policy for multimodal model's vision encoder. Check `remat_policy` for options.
 image_size_for_vit: 896 # Default for Gemma3, and should be overwritten by model's config
 image_path: "" # Local image path used for decoding
-
+image_placeholder: "<|image|>"
 
 ### llama4 multi modal configs
 hidden_size_for_vit: 1408 

--- a/MaxText/configs/sft-vision-chartqa.yml
+++ b/MaxText/configs/sft-vision-chartqa.yml
@@ -1,0 +1,31 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+base_config: "base.yml"
+
+use_sft: True
+use_multimodal: True
+# For vision, the prompt contains image, we only train on completion tokens
+sft_train_on_completion_only: True
+packing: False  # packing is not supported yet
+freeze_vision_encoder_params: True
+learning_rate: 2.e-5
+
+# -------------- HF pipeline --------------
+dataset_type: hf
+hf_path: 'HuggingFaceM4/ChartQA'
+train_split: 'train'
+hf_eval_split: 'val'
+train_data_columns: ['query', 'label']  # the first column is prompt, second column is completion
+eval_data_columns: ['query', 'label']  # the first column is prompt, second column is completion

--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -100,7 +100,7 @@ def main(argv: Sequence[str]) -> None:
   prefill_length = config.max_prefill_predict_length
   processor_output = multimodal_utils.PreprocessorOutput()
   if config.use_multimodal:
-    text = multimodal_utils.reformat_prompt(text, config.model_name)
+    text = multimodal_utils.reformat_prompt(text, image_placeholder=config.image_placeholder, model_name=config.model_name)
     # TODO(hengtaoguo): Support multiple images as input.
     images = multimodal_utils.load_image_from_path(config.image_path)
     processor_output = multimodal_utils.pre_process_image(images, model_name=config.model_name)

--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -27,6 +27,7 @@ import numpy as np
 import tensorflow as tf
 from MaxText import max_logging
 from MaxText import tokenizer
+from MaxText import multimodal_utils
 
 Features = Dict[str, tf.Tensor]
 AUTOTUNE = tf.data.experimental.AUTOTUNE
@@ -66,6 +67,37 @@ def add_segmentation_and_position(x, data_columns, padding_token=0):
 
 
 ########## Functions used by HF pipeline
+
+
+def reformat_prompt(example, column, image_placeholder, model_name):
+  """reformat prompt for multimodal SFT"""
+  example[column] = multimodal_utils.reformat_prompt(example[column], image_placeholder, model_name)
+  return example
+
+
+def reformat_response(example, column, model_name):
+  """reformat response for multimodal SFT"""
+  example[column] = multimodal_utils.reformat_response(example[column], model_name)
+  return example
+
+
+def pre_process_image_sft(example, image_column, model_name):
+  """pre-process image for multimodal SFT"""
+  image = multimodal_utils.convert_to_RGB(example[image_column])
+  # TODO(aireenmei, hengtaoguo): add support for different image sizes
+  image = multimodal_utils.resize_image(image, model_name)
+  image = np.array(image)
+  example[image_column] = multimodal_utils.pre_process_image(image, model_name)
+  return example
+
+
+def prepare_text_for_image_fusion(example, column_name, model_name):
+  """prepare text for image fusion for multimodal SFT"""
+  example[column_name] = multimodal_utils.prepare_text_for_image_fusion(
+      example[column_name], model_name, processor_output=example["images"]
+  )
+  example["images"] = example["images"].pixel_values
+  return example
 
 
 def combine_columns(example, columns, data_column):
@@ -189,6 +221,26 @@ class SFTPromptMasking(grain.MapTransform):
     return {
         "inputs": np.asarray(inputs[: self.max_target_length], dtype=np.int32),
         "targets": np.asarray(targets[: self.max_target_length], dtype=np.int32),
+    }
+
+
+@dataclasses.dataclass
+class SFTPromptMaskingVision(grain.MapTransform):
+  """SFT prompt masking for multimodal"""
+
+  def __init__(self, query_column, response_column, max_target_length, unk_id):
+    self.query_column = query_column
+    self.response_column = response_column
+    self.max_target_length = max_target_length
+    self.unk_id = unk_id
+
+  def map(self, element):
+    inputs = np.concatenate((element[self.query_column], element[self.response_column]))
+    targets = np.concatenate((np.asarray([self.unk_id] * len(element[self.query_column])), element[self.response_column]))
+    return {
+        "inputs": np.asarray(inputs[: self.max_target_length], dtype=np.int32),
+        "targets": np.asarray(targets[: self.max_target_length], dtype=np.int32),
+        "images": element["images"],
     }
 
 
@@ -413,10 +465,12 @@ class PadToMaxLength(grain.MapTransform):
 
     data_columns = list(element.keys())
     for data_column in data_columns:
-      element[f"{data_column}_segmentation"] = (element[data_column] != self.pad_id).astype(np.int32)
-      element[f"{data_column}_position"] = np.arange(element[data_column].shape[0], dtype=np.int32)
+      if data_column != "images":
+        element[f"{data_column}_segmentation"] = (element[data_column] != self.pad_id).astype(np.int32)
+        element[f"{data_column}_position"] = np.arange(element[data_column].shape[0], dtype=np.int32)
     for key, _ in element.items():
-      element[key] = _pad(element[key], self.max_length, self.pad_id)
+      if key != "images":
+        element[key] = _pad(element[key], self.max_length, self.pad_id)
     return element
 
 

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -93,6 +93,9 @@ def get_shaped_batch(config):
   shaped_batch["targets"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
   shaped_batch["targets_position"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
   shaped_batch["targets_segmentation"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+  if config.use_multimodal:
+    image_shape = get_dummy_image_shape_for_init(config)
+    shaped_batch["images"] = jax.ShapeDtypeStruct(image_shape, jnp.int32)
   return shaped_batch
 
 

--- a/MaxText/multimodal_utils.py
+++ b/MaxText/multimodal_utils.py
@@ -36,6 +36,7 @@ NUM_IMAGE_CHANNELS = 3
 GEMMA_DEFAULT_IMAGE_SIZE = 896
 GEMMA_IMAGE_MEAN = (127.5,) * 3
 GEMMA_IMAGE_STD = (127.5,) * 3
+GEMMA_IMAGE_PLACEHOLDER_IN_PROMPT = "<start_of_image>"
 GEMMA_BEGIN_IMAGE_TOKEN = 255999
 GEMMA_END_IMAGE_TOKEN = 262144
 GEMMA_NEW_LINE_TOKEN = 108
@@ -53,6 +54,7 @@ LLAMA4_PIXEL_VALUE_RESCALE_FACTOR = 1.0 / 255.0
 LLAMA4_IMAGE_MEAN = (0.5,) * 3
 LLAMA4_IMAGE_STD = (0.5,) * 3
 LLAMA4_PATCH_SIZE = 14
+LLAMA4_IMAGE_PLACEHOLDER_IN_PROMPT = "<|image|>"
 LLAMA4_FAKE_IMAGE_TOKEN = 200090  # <|image|>
 LLAMA4_BEGIN_IMAGE_TOKEN = 200080  # <|image_start|>
 LLAMA4_END_IMAGE_TOKEN = 200081  # <|image_end|>
@@ -77,18 +79,36 @@ class PreprocessorOutput:
                    images by tiling.
   """
 
-  pixel_values: Optional[jnp.ndarray] = None
-  aspect_ratios: Optional[jnp.ndarray] = None
+  pixel_values: Optional[np.ndarray] = None
+  aspect_ratios: Optional[np.ndarray] = None
+
+
+def resize_image(image, model_name):
+  image_sizes = {
+    "gemma3": (GEMMA_DEFAULT_IMAGE_SIZE, GEMMA_DEFAULT_IMAGE_SIZE),
+    "llama4": (LLAMA4_TILE_SIZE, LLAMA4_TILE_SIZE),
+  }
+  target_size = image_sizes[model_name.split('-')[0]]
+  if target_size:
+    image = image.resize(target_size)
+  return image
+
+
+def convert_to_RGB(image):
+  if image.mode != "RGB":
+    image = image.convert("RGB")
+  return image
 
 
 def load_image_from_path(image_path):
-  """Loads an image from a given file path and returns a jnp.array."""
+  """Loads an image from a given file path and returns a np.array."""
   if not os.path.isfile(image_path):
     raise FileNotFoundError(f"Image not found at path {image_path}. Please specify a valid image path")
   try:
     image = Image.open(image_path).convert("RGB")
     image.load()  # Load image data to catch errors early
     return jnp.asarray(np.array(image))
+
   except (IOError, OSError) as e:
     raise IOError(f"Error loading image from {image_path}") from e
 
@@ -103,8 +123,8 @@ def _normalize_images(images, mean, std):
   Returns:
     The normalized images.
   """
-  images -= jnp.asarray(mean)
-  images /= jnp.asarray(std)
+  images -= np.asarray(mean)
+  images /= np.asarray(std)
   return images
 
 
@@ -164,17 +184,17 @@ def get_best_resolution(img_height, image_width, possible_resolutions, resize_to
 
 
 def pad_to_best_fit_jax(
-    images: jnp.ndarray,
+    images: np.ndarray,
     target_size: Tuple[int, int],
     background_color: Union[int, Tuple[int, ...]] = 0,
-) -> jnp.ndarray:
+) -> np.ndarray:
   """
   Pads and/or crops an image or batch of images to a target size using JAX.
   If the image is larger than the target size, it's cropped from the top-left.
   If smaller, it's padded on the right and bottom.
 
   Args:
-      images (jnp.ndarray):
+      images (np.ndarray):
           The images to process. Expected shape (..., H, W, C).
       target_size (Tuple[int, int]):
           The target (height, width).
@@ -185,7 +205,7 @@ def pad_to_best_fit_jax(
           Defaults to 0.
 
   Returns:
-      jnp.ndarray: The processed images of shape (..., target_height, target_width, C).
+      np.ndarray: The processed images of shape (..., target_height, target_width, C).
   """
   original_shape = images.shape
   num_dims = len(original_shape)
@@ -200,13 +220,13 @@ def pad_to_best_fit_jax(
   if isinstance(background_color, int):
     # Mimics the PyTorch version's behavior: [val, 0, 0, ...]
     bg_list = [background_color] + [0] * (num_channels - 1)
-    background_color_array = jnp.array(bg_list, dtype=images.dtype)
+    background_color_array = np.array(bg_list, dtype=images.dtype)
   elif isinstance(background_color, (tuple, list)):
     if len(background_color) != num_channels:
       raise ValueError(
           f"background_color tuple/list length {len(background_color)} " f"must match number of channels {num_channels}"
       )
-    background_color_array = jnp.array(background_color, dtype=images.dtype)
+    background_color_array = np.array(background_color, dtype=images.dtype)
   else:
     raise TypeError("background_color must be int or tuple/list of ints")
 
@@ -217,9 +237,9 @@ def pad_to_best_fit_jax(
   # Reshape background_color_array for broadcasting
   # e.g., for (H,W,C) -> (1,1,C); for (B,H,W,C) -> (1,1,1,C)
   broadcastable_bg_shape = tuple([1] * len(batch_dims)) + (1, 1, num_channels)
-  background_fill = jnp.reshape(background_color_array, broadcastable_bg_shape)
+  background_fill = np.reshape(background_color_array, broadcastable_bg_shape)
 
-  padded_output = jnp.ones(target_canvas_shape, dtype=images.dtype) * background_fill
+  padded_output = np.ones(target_canvas_shape, dtype=images.dtype) * background_fill
 
   # Determine the region of the original image to copy
   h_to_copy = min(img_height, target_height)
@@ -239,12 +259,12 @@ def pad_to_best_fit_jax(
     dest_slicer_dims.append(slice(None))  # Ellipsis for batch dimensions
   dest_slicer_dims.extend([slice(0, h_to_copy), slice(0, w_to_copy), slice(None)])
 
-  padded_output = padded_output.at[tuple(dest_slicer_dims)].set(image_data_to_place)
+  padded_output[tuple(dest_slicer_dims)] = image_data_to_place
 
   return padded_output
 
 
-def split_to_tiles_jax(images: jnp.ndarray, num_tiles_height: int, num_tiles_width: int) -> jnp.ndarray:
+def split_to_tiles(images: np.ndarray, num_tiles_height: int, num_tiles_width: int) -> np.ndarray:
   """
   Splits an image tensor into tiles using JAX.
 
@@ -257,7 +277,7 @@ def split_to_tiles_jax(images: jnp.ndarray, num_tiles_height: int, num_tiles_wid
       The tiled image tensor with shape:
       (batch_size * num_tiles_height * num_tiles_width, num_channels, height // num_tiles_height, width // num_tiles_width).
   """
-  images = jnp.transpose(images, (2, 0, 1))  # Change to (num_channels, height, width)
+  images = np.transpose(images, (2, 0, 1))  # Change to (num_channels, height, width)
   num_channels, height, width = images.shape
 
   # Ensure the image dimensions are divisible by the number of tiles
@@ -265,7 +285,7 @@ def split_to_tiles_jax(images: jnp.ndarray, num_tiles_height: int, num_tiles_wid
     raise ValueError("Image dimensions must be divisible by the number of tiles.")
 
   # Reshape to introduce tile dimensions
-  reshaped = jnp.reshape(
+  reshaped = np.reshape(
       images,
       (
           num_channels,
@@ -277,10 +297,10 @@ def split_to_tiles_jax(images: jnp.ndarray, num_tiles_height: int, num_tiles_wid
   )
 
   # Permute dimensions to group tiles together
-  permuted = jnp.transpose(reshaped, (1, 3, 0, 2, 4))
+  permuted = np.transpose(reshaped, (1, 3, 0, 2, 4))
 
   # Reshape to combine batch and tile dimensions
-  tiled_images = jnp.reshape(
+  tiled_images = np.reshape(
       permuted,
       (
           num_tiles_height * num_tiles_width,
@@ -295,15 +315,16 @@ def split_to_tiles_jax(images: jnp.ndarray, num_tiles_height: int, num_tiles_wid
 
 def pre_process_gemma3_image(image):
   """Performs a bi-linear resize (with anti-aliasing) and normalizes the image."""
-  image_shape = (GEMMA_DEFAULT_IMAGE_SIZE, GEMMA_DEFAULT_IMAGE_SIZE, NUM_IMAGE_CHANNELS)
-  image = jax.image.resize(
-      image,
-      shape=image_shape,
-      method="bilinear",
-      antialias=True,
-  )
+  target_size = (GEMMA_DEFAULT_IMAGE_SIZE, GEMMA_DEFAULT_IMAGE_SIZE)
+  pil_img = Image.fromarray(image)
+  resample_method = Image.Resampling.BILINEAR
+  # Use a higher quality downsampling filter to approximate antialias=True
+  if pil_img.size[0] > target_size[0] or pil_img.size[1] > target_size[1]:
+    resample_method = Image.Resampling.LANCZOS
+  resized_pil_img = pil_img.resize(target_size, resample=resample_method)
+  image = np.array(resized_pil_img)
   image = _normalize_images(image, mean=GEMMA_IMAGE_MEAN, std=GEMMA_IMAGE_STD)
-  image = jnp.clip(image, -1, 1)
+  image = np.clip(image, -1, 1)
   processor_output = PreprocessorOutput(
       pixel_values=image,
   )
@@ -315,9 +336,9 @@ def pre_process_llama4_image(image):
   Pre-process image for Llama4 model. Find best resolution and split into tiles with an additional global tile.
   Original implementation from image_processing_llama4.py: http://shortn/_VXLgQ1lmkz
   Args:
-    image: The jnp.array image [H, W, C] to pre-process.
+    image: The np.array image [H, W, C] to pre-process.
   Returns:
-    The pre-processed image in jnp.array [NUM_TILES, C, TILE_SIZE, TILE_SIZE].
+    The pre-processed image in np.array [NUM_TILES, C, TILE_SIZE, TILE_SIZE].
   Example:
     image of (536, 640, 3), its best_resolution = (672, 672), image split into 4 tiles of (336, 336)
     Additional global tile of (336, 336) is added, and the final output image_tiles is (5, 3, 336, 336).
@@ -344,25 +365,26 @@ def pre_process_llama4_image(image):
       best_resolution[0] // LLAMA4_TILE_SIZE,
       best_resolution[1] // LLAMA4_TILE_SIZE,
   )
-  image_tiles = split_to_tiles_jax(image_normalized, ratio_h, ratio_w)
+  image_tiles = split_to_tiles(image_normalized, ratio_h, ratio_w)
 
   # If more than one tile, add a global tile by resizing the image to the tile size
   if ratio_h * ratio_w > 1:
-    global_tiles = jax.image.resize(
-        image,
-        shape=(LLAMA4_TILE_SIZE, LLAMA4_TILE_SIZE, NUM_IMAGE_CHANNELS),
-        method="bilinear",
-        antialias=True,
-    )
+    pil_img = Image.fromarray(image)
+    resample_method = Image.Resampling.BILINEAR
+    # Use a higher quality downsampling filter to approximate antialias=True
+    if pil_img.size[0] > LLAMA4_TILE_SIZE or pil_img.size[1] > LLAMA4_TILE_SIZE:
+      resample_method = Image.Resampling.LANCZOS
+    global_tiles_pil = pil_img.resize((LLAMA4_TILE_SIZE, LLAMA4_TILE_SIZE), resample=resample_method)
+    global_tiles = np.array(global_tiles_pil)
     global_tiles = _normalize_images(
         global_tiles * LLAMA4_PIXEL_VALUE_RESCALE_FACTOR, mean=LLAMA4_IMAGE_MEAN, std=LLAMA4_IMAGE_STD
     )
-    global_tiles = jnp.transpose(global_tiles, (2, 0, 1))
-    global_tiles = jnp.expand_dims(global_tiles, axis=0)
-    image_tiles = jnp.concatenate((image_tiles, global_tiles), axis=0)
+    global_tiles = np.transpose(global_tiles, (2, 0, 1))
+    global_tiles = np.expand_dims(global_tiles, axis=0)
+    image_tiles = np.concatenate((image_tiles, global_tiles), axis=0)
 
   # TODO(hengtaoguo): Add support for multiple images with aspect ratios size of [num_images, 2]
-  aspect_ratios_array = jnp.array([[ratio_h, ratio_w]], dtype=jnp.int32)
+  aspect_ratios_array = np.array([[ratio_h, ratio_w]], dtype=np.int32)
   processor_output = PreprocessorOutput(
       pixel_values=image_tiles,
       aspect_ratios=aspect_ratios_array,
@@ -373,10 +395,10 @@ def pre_process_llama4_image(image):
 def pre_process_image(image, model_name):
   """Pre-process image according to different model's requirements.
   Args:
-    image: The jnp.array image [H, W, C] to pre-process.
+    image: The np.array image [H, W, C] to pre-process.
     model_name: The config.model_name that specifies the image preprocess ways.
   Returns:
-    The pre-processed image in jnp.array [H, W, C].
+    The pre-processed image in np.array [H, W, C].
   """
   if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
     return pre_process_gemma3_image(image)
@@ -386,18 +408,35 @@ def pre_process_image(image, model_name):
     raise ValueError(f"Model {model_name} does not support multimodal inference.")
 
 
-def reformat_prompt(prompt, model_name):
+def reformat_prompt(prompt, image_placeholder, model_name):
   """Reformat prompt for different models."""
   if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+    if image_placeholder in prompt:
+      prompt = prompt.replace(image_placeholder, GEMMA_IMAGE_PLACEHOLDER_IN_PROMPT)
+    if not GEMMA_IMAGE_PLACEHOLDER_IN_PROMPT in prompt:
+      prompt = GEMMA_IMAGE_PLACEHOLDER_IN_PROMPT + prompt
     formatted_prompt = f"<start_of_turn>user\n{prompt}<end_of_turn>\n<start_of_turn>model\n"
     return formatted_prompt
   elif model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+    if image_placeholder in prompt:
+      prompt =prompt.replace(image_placeholder, LLAMA4_IMAGE_PLACEHOLDER_IN_PROMPT)
+    if not LLAMA4_IMAGE_PLACEHOLDER_IN_PROMPT in prompt:
+      prompt = LLAMA4_IMAGE_PLACEHOLDER_IN_PROMPT + prompt
     formatted_prompt = (
         f"<|begin_of_text|><|header_start|>user<|header_end|>\n\n{prompt}<|eot|><|header_start|>assistant<|header_end|>\n\n"
     )
     return formatted_prompt
   else:
     return prompt
+
+
+def reformat_response(response, model_name):
+  """Reformat response for different models."""
+  if model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+    formatted_response = f"{response}<|eot|>"
+    return formatted_response
+  else:
+    return response
 
 
 def get_image_offsets(model_name, processor_output: PreprocessorOutput | None):
@@ -431,9 +470,10 @@ def prepare_text_for_image_fusion(texts, model_name, processor_output=None):
 
 def add_extra_tokens_for_images_llama4(tokens, processor_output: PreprocessorOutput):
   """Add the extra image tokens to the text tokens for Llama4."""
-  tokens_list = tokens.tolist()
+  if not isinstance(tokens, list):
+    tokens = tokens.tolist()
 
-  grouped = groupby(tokens_list, lambda x: x == 200090)
+  grouped = groupby(tokens, lambda x: x == 200090)
 
   sublists = []
   for is_splitter, group in grouped:
@@ -455,8 +495,8 @@ def add_extra_tokens_for_images_llama4(tokens, processor_output: PreprocessorOut
     if local_image_index < aspect_ratio.shape[0]:
       new_tokens += get_tokens_for_this_image(aspect_ratio[image_index], num_patches_per_chunk)
       image_index += 1
-  new_tokens_jnp = jnp.array(new_tokens, dtype=jnp.int32)
-  return new_tokens_jnp
+  new_tokens_np = np.array(new_tokens, dtype=np.int32)
+  return new_tokens_np
 
 
 def get_tokens_for_this_image(this_aspect_ratio, num_patches_per_chunk):

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -194,6 +194,12 @@ def validate_keys(keys):
 
   if keys["use_multimodal"]:
     validate_multimodal_model_name(keys["model_name"])
+    if keys["use_sft"]:
+      assert keys[
+          "sft_train_on_completion_only"
+      ], "In multimodal SFT (use_multimodal=True, use_sft=True), sft_train_on_completion_only must be set to True"
+      # TODO(aireenmei, hengtaoguo): support packing
+      assert not keys["packing"], "In multimodal SFT (use_multimodal=True, use_sft=True), packing is not supported yet"
 
   if keys["decoder_block"] == "llama4":
     validate_llama4_config(keys)

--- a/MaxText/tests/multimodal_utils_test.py
+++ b/MaxText/tests/multimodal_utils_test.py
@@ -103,14 +103,14 @@ class TestLlama4ImageProcessing(unittest.TestCase):
     self.assertEqual(padded_image.shape, (672, 672, self.NUM_IMAGE_CHANNELS))
     self.assertTrue(jnp.all(padded_image == 0))
 
-  def test_split_to_tiles_jax(self):
+  def test_split_to_tiles(self):
     image = jnp.ones((672, 672, self.NUM_IMAGE_CHANNELS))
     best_resolution = (672, 672)
     ratio_h, ratio_w = (
         best_resolution[0] // self.LLAMA4_TILE_SIZE,
         best_resolution[1] // self.LLAMA4_TILE_SIZE,
     )
-    image_tiles = multimodal_utils.split_to_tiles_jax(image, ratio_h, ratio_w)
+    image_tiles = multimodal_utils.split_to_tiles(image, ratio_h, ratio_w)
     self.assertEqual(
         image_tiles.shape, (ratio_h * ratio_w, self.NUM_IMAGE_CHANNELS, self.LLAMA4_TILE_SIZE, self.LLAMA4_TILE_SIZE)
     )


### PR DESCRIPTION
# Description

Vanilla SFT support for multimodal llama4
* Using "HuggingFaceM4/ChartQA" dataset and hf data pipeline, some preprocessing steps are specific to this dataset, serves as demo for other custom preprocessing.
* Update multimodal_utils to have preprocessing functions using np instead of jax, so that it won't try to access TPU. Because we want these preprocessing functions to run on CPU while TPU is doing model computation. 

# Tests
* Tested pre-train with reduced-layer model on v5p, with this [command](https://paste.googleplex.com/4685869688291328). [training output](https://paste.googleplex.com/5770489523601408)

# TODOs for future PRs:
* unit tests
* doc
* script for testing on TPU cluseters

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
