### PR TITLE
Change the fp8 einsum from fake quantization to direct quantization op

### DIFF
--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -203,7 +203,7 @@ class Fp8Quantization(Quantization):
     return nn.Fp8DirectDotGeneralOp
 
   def einsum(self, dtype: DType = jnp.float32):
-    return Fp8Einsum(dtype=dtype)
+    return nn.Fp8Einsum(dtype=dtype)
 
 
 class Fp8Einsum(nn.Module):


### PR DESCRIPTION
# Description
This is also related to https://github.com/AI-Hypercomputer/maxtext/pull/1541
Currently the FP8 einsum in maxtext is using maxtext self-defined Einsum which is a fake quantization pattern for FP8 einsum. This pattern is not trivial to capture in the XLA compiler and could silently fall back to high precision if the pattern was broken. It also causes some performance regressions in NV workloads.
The Einsum API in flax ensures the FP8 ops are emitted during the XLA compilation.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
