### PR TITLE
Restore flag name --base-docker-image for XPK workload create

### DIFF
--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -643,7 +643,7 @@ def generate_xpk_workload_cmd(
         f'--docker-image={pw_config.runner_image}'
     )
   else:
-    docker_image_flag = f'--docker-image="{wl_config.base_docker_image}"'
+    docker_image_flag = f'--base-docker-image="{wl_config.base_docker_image}"'
 
   upload_metrics_to_bq_cmd = ""
   if wl_config.generate_metrics_and_upload_to_big_query and not is_pathways_headless_enabled:


### PR DESCRIPTION
# Description

Rename the flag --docker-image back to --base-docker-image to enable XPK workload create commands to work again.

### Why is this change being made?
The flag --base-docker-image is required when running XPK's workload create command. If missing, the XPK workload on GKE fails with error "ImagePullBackOff Cannot pull image 'maxtext_base_image' from the registry".

### What's the problem being solved and any relevant context?
PR #1823 renamed the flag --base-docker-image to --docker-image, probably trying to be consistent with the flag expected by XPK's workload create-pathways command.

### Why this is a good solution?
Reverting to the correct flag will make XPK's commands to be correctly formatted (e.g. from maxtext_xpk_runner.py code)

### What would be some information about the specific implementation?
Simple flag rename.

### What are the shortcomings of the solution and possible future improvements?
We should check if we can effectively standardize the name of this flag in future for both workload create and create-pathways in XPK's code.

FIXES: b/426661326

# Tests

The change was tested by running several Llama 3.1 8B and 70B workloads using the benchmarks/benchmark_runner script. We verified that the workloads completed successfully and the ImagePullBackOff error went away.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
