### PR TITLE
Fix notify step and cleanup step for maxtext unit tests

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -125,38 +125,34 @@ jobs:
       container_resource_option: "--shm-size 2g --runtime=nvidia --gpus all --privileged"
 
   clean_up:
-    if: ${{ always() }}  # always execute, regardless of previous jobs or steps.
+    if: ${{ always() }}
     needs: [cpu_unit_tests, gpu_unit_tests, gpu_integration_tests, tpu_unit_tests, tpu_integration_tests]
     name: "Clean up"
     runs-on: ["self-hosted"]
     permissions:
       contents: read
-      issues: write  # for failed-build-issue
+      issues: write
     steps:
     - name: Authenticate gcloud
-      continue-on-error: true
       run: |
           # configure registries as root and as runner
-          sudo gcloud auth configure-docker --quiet
           gcloud auth configure-docker --quiet
-          sudo gcloud auth configure-docker us-docker.pkg.dev --quiet
           gcloud auth configure-docker us-docker.pkg.dev --quiet
-    - name: Delete GPU image
-      run: gcloud container images delete gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:gpu --force-delete-tags --quiet
-    - name: Delete TPU image
-      run: gcloud container images delete gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:tpu --force-delete-tags --quiet
+    - name: Delete the tpu image
+      run: gcloud container images delete "gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:tpu" --force-delete-tags --quiet
+    - name: Delete the gpu image
+      run: gcloud container images delete "gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:gpu" --force-delete-tags --quiet
 
-  notify:
-    if: ${{ always() }}
+  notify_failure:
     name: Notify failed build # creates an issue or modifies last open existing issue for failed build
     needs: [cpu_unit_tests, gpu_unit_tests, gpu_integration_tests, tpu_unit_tests, tpu_integration_tests]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - name: Check whether one of the jobs failed
-      if: ${{ failure() && github.event.pull_request == null }}
+      if: ${{ contains(needs.*.result, 'failure') && github.event.pull_request == null }}
       uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Log message if dependent job succeeded
-      if: ${{ ! (failure() && github.event.pull_request == null) }}
-      run: echo "Conditions for creating/updating issue not met. Skipping."

--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -105,11 +105,13 @@ jobs:
             gcr.io/tpu-prod-env-multipod/${{ matrix.image_name }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
           build-args: |
             ${{ matrix.build_args }}
             JAX_AI_IMAGE_BASEIMAGE=${{ matrix.base_image }}
             COMMIT_HASH=${{ steps.vars.outputs.sha_short }}
             DEVICE=tpu
+            TEST_TYPE=xlml
 
   # Same as tpu-build step but mirrored for GPUs
   build-gpu:
@@ -165,8 +167,10 @@ jobs:
             gcr.io/tpu-prod-env-multipod/${{ matrix.image_name }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
           build-args: |
             ${{ matrix.build_args }}
             JAX_AI_IMAGE_BASEIMAGE=${{ matrix.base_image }}
             COMMIT_HASH=${{ steps.vars.outputs.sha_short }}
             DEVICE=gpu
+            TEST_TYPE=xlml

--- a/.github/workflows/build_upload_internal.yml
+++ b/.github/workflows/build_upload_internal.yml
@@ -61,9 +61,11 @@ jobs:
           context: .
           file: ./maxtext_jax_ai_image.Dockerfile
           tags: gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:${{ inputs.device_type }}
+          provenance: false
           build-args: |
             JAX_AI_IMAGE_BASEIMAGE=${{ inputs.base_image }}
             COMMIT_HASH=${{ steps.vars.outputs.sha_short }}
             DEVICE=${{ inputs.device_type }}
+            TEST_TYPE=unit_test
 
 

--- a/maxtext_jax_ai_image.Dockerfile
+++ b/maxtext_jax_ai_image.Dockerfile
@@ -5,7 +5,6 @@ FROM $JAX_AI_IMAGE_BASEIMAGE
 ARG JAX_AI_IMAGE_BASEIMAGE
 
 ARG COMMIT_HASH
-
 ENV COMMIT_HASH=$COMMIT_HASH
 
 RUN mkdir -p /deps
@@ -40,6 +39,14 @@ RUN python3 -m pip install -r /deps/requirements_with_jax_ai_image.txt
 # Now copy the remaining code (source files that may change frequently)
 COPY . .
 RUN ls .
+
+ARG TEST_TYPE
+# Copy over test assets if building image for end-to-end tests or unit tests
+RUN if [ "$TEST_TYPE" = "xlml" ] || [ "$TEST_TYPE" = "unit_test" ]; then \
+      if ! gcloud storage cp -r gs://maxtext-test-assets/* MaxText/test_assets; then \
+        echo "WARNING: Failed to download test assets from GCS. These files are only used for end-to-end tests; you may not have access to the bucket."; \
+      fi; \
+    fi
 
 # Run the script available in JAX AI base image to generate the manifest file
 RUN bash /jax-stable-stack/generate_manifest.sh PREFIX=maxtext COMMIT_HASH=$COMMIT_HASH


### PR DESCRIPTION
# Description

The notify step does not create an issue upon unit tests failure. The cleanup step doesn't delete the maxtext image created in artifact registry. This pr fixes both of these issues.

Also fixed another small bug where test_assets for xlml and unit_tests were not getting copied over from gcs bucket into the maxtext image. Added the copy command in maxtext_with_jaii.Dockerfile and added a build-arg to only run the command when building an image for xlml or unit_tests.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/428713269
FIXES: b/421909781
FIXES: b/426642909

# Tests

Testing autogenerating an issue when one of the "needs" of notify step fails. Test issues were generated successfully and look like this:
- https://github.com/AI-Hypercomputer/maxtext/issues/1899
- https://github.com/AI-Hypercomputer/maxtext/issues/1898

Testing the clean-up step by verifying that the images in AR repo were deleted for each unit test run. For example, the repo that is now empty from this pr unit tests: [link](https://pantheon.corp.google.com/artifacts/docker/tpu-prod-env-multipod/us/gcr.io/maxtext_15969098795?e=13802955&inv=1&invt=Ab1fLw&mods=allow_workbench_image_override&project=tpu-prod-env-multipod)

Tested the changes and verified the test_assets got copied over to the maxtext image generated
Assets copied over in logs: https://screenshot.googleplex.com/56ftMQbqSwtXdiG

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
