### PR TITLE
Add name to linen modules for RotaryEmbedding and LLaMARotaryEmbedding

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -1609,6 +1609,7 @@ class Attention(nn.Module):
           max_timescale=self.config.rope_max_timescale,
           embedding_dims=rope_embedding_dims,
           fprop_dtype=self.dtype,
+          name=name,
           use_scale=rope_use_scale,
       )
     elif rope_type.startswith("yarn"):
@@ -1633,6 +1634,7 @@ class Attention(nn.Module):
           max_timescale=max_timescale,
           embedding_dims=rope_embedding_dims,
           fprop_dtype=self.dtype,
+          name=name,
       )
     inputs = rotary_embedding(inputs, inputs_positions)
     return inputs

--- a/MaxText/layers/embeddings.py
+++ b/MaxText/layers/embeddings.py
@@ -129,7 +129,8 @@ def rotary_embedding_as_linen(
     max_timescale: int,
     embedding_dims: int = 0,
     cast_as_fprop_dtype: bool = True,
-    fprop_dtype: DType = jnp.bfloat16
+    fprop_dtype: DType = jnp.bfloat16,
+    name: str | None = None
 ):
   """Initializes the RotaryEmbedding module and returns it as a Linen module.
 
@@ -141,6 +142,7 @@ def rotary_embedding_as_linen(
     embedding_dims: Dimension of the embedding to be generated.
     cast_as_fprop_dtype: Whether to cast the output to the fprop dtype.
     fprop_dtype: The dtype of the output.
+    name: Name of the Linen module.
   """
   return nnx.bridge.to_linen(
     RotaryEmbedding,
@@ -149,7 +151,8 @@ def rotary_embedding_as_linen(
     embedding_dims=embedding_dims,
     cast_as_fprop_dtype=cast_as_fprop_dtype,
     fprop_dtype=fprop_dtype,
-    metadata_fn=variable_to_logically_partitioned
+    metadata_fn=variable_to_logically_partitioned,
+    name=name
   )
 
 
@@ -244,7 +247,8 @@ def llama_rotary_embedding_as_linen(
     embedding_dims: int = 0,
     cast_as_fprop_dtype: bool = True,
     fprop_dtype: DType = jnp.bfloat16,
-    use_scale: bool = True
+    use_scale: bool = True,
+    name: str | None = None
 ):
   """Initializes the LLaMARotaryEmbedding module and returns it as a Linen module.
 
@@ -257,6 +261,7 @@ def llama_rotary_embedding_as_linen(
     cast_as_fprop_dtype: Whether to cast the output to the fprop dtype.
     fprop_dtype: The dtype of the output.
     use_scale: Whether to apply LLaMA3.1 scaling factor.
+    name: Name of the Linen module.
   """
   return nnx.bridge.to_linen(
     LLaMARotaryEmbedding,
@@ -266,7 +271,8 @@ def llama_rotary_embedding_as_linen(
     cast_as_fprop_dtype=cast_as_fprop_dtype,
     fprop_dtype=fprop_dtype,
     use_scale=use_scale,
-    metadata_fn=variable_to_logically_partitioned
+    metadata_fn=variable_to_logically_partitioned,
+    name=name
   )
 
 


### PR DESCRIPTION
# Description

Add name to the Linen bridges for these modules. Adding these back to keep them consistent with how they were before. In general this could impact checkpoint loading, but don't think that is happening here because there are no params in these modules (our checkpoint test is still passing)

# Tests

Ran MaxText base model on a v6e-8 devbox. Also ran Llama3.1-8b and got an OOM as expected (but did not fail before the OOM):

```
python3 -m MaxText.train MaxText/configs/base.yml \
    run_name=<run_name> \
    base_output_directory=gs://<gcs_bucket> \
    dataset_type=synthetic \
    steps=10    # model_name=llama3.1-8b (gives OOM as expected)
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
