### PR TITLE
Move jit compilation of train and eval step into train_utils

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -726,6 +726,27 @@ def print_cpu_ram_stats(label: str):
     max_logging.log(f"\tRAM stats unavailable, error: {ex}")
 
 
+def print_compiled_memory_stats(compiled_stats):
+  """Prints a summary of the compiled memory statistics."""
+  if compiled_stats is None:
+    return
+
+  def bytes_to_gb(num_bytes):
+    return num_bytes / (1024**3)
+
+  output_gb = bytes_to_gb(compiled_stats.output_size_in_bytes)
+  temp_gb = bytes_to_gb(compiled_stats.temp_size_in_bytes)
+  argument_gb = bytes_to_gb(compiled_stats.argument_size_in_bytes)
+  alias_gb = bytes_to_gb(compiled_stats.alias_size_in_bytes)
+  host_temp_gb = bytes_to_gb(compiled_stats.host_temp_size_in_bytes)
+  total_gb = output_gb + temp_gb + argument_gb - alias_gb
+
+  max_logging.log(
+      f"Total memory size: {total_gb:.1f} GB, Output size: {output_gb:.1f} GB, Temp size: {temp_gb:.1f} GB, "
+      f"Argument size: {argument_gb:.1f} GB, Host temp size: {host_temp_gb:.1f} GB."
+  )
+
+
 def print_system_information():
   """Print system information of the current environment.
   Note that this will initialize the JAX backend."""

--- a/MaxText/sft_trainer.py
+++ b/MaxText/sft_trainer.py
@@ -32,10 +32,11 @@ from flax.linen import partitioning as nn_partitioning
 from MaxText import checkpointing
 from MaxText import exceptions
 from MaxText import max_utils
-from MaxText import maxtext_utils
 from MaxText import max_logging
+from MaxText import maxtext_utils
 from MaxText import profiler
 from MaxText import pyconfig
+from MaxText import train_utils
 from MaxText.data_loader import DataLoader
 from MaxText.metric_logger import MetricLogger
 from MaxText.train import (
@@ -71,57 +72,18 @@ def train_loop(config, recorder, state=None):
       state,
   ) = setup_train_loop(config, recorder)
 
-  # pylint: disable=line-too-long
-  (
-      functional_train,
-      in_shard_train,
-      out_shard_train,
-      static_argnums_train,
-      donate_argnums_train,
-  ) = maxtext_utils.get_functional_train_with_signature(train_step, mesh, state_mesh_shardings, model, config)
+  p_train_step, p_eval_step = train_utils.jit_train_and_eval_step(
+      config, model, mesh, state, state_mesh_shardings, train_step, eval_step, eval_data_iterator
+  )
 
-  if eval_data_iterator:
-    # pylint: disable=line-too-long
-    (
-        functional_eval,
-        in_shard_eval,
-        out_shard_eval,
-        static_argnums_eval,
-        donate_argnums_eval,
-    ) = maxtext_utils.get_functional_eval_with_signature(eval_step, mesh, state_mesh_shardings, model, config)
-
-  # Define the compilation of functional_train, either by loading the compiled version or wrapping a new one in a jit
-  if config.compiled_trainstep_file != "":
-    print("Loading the compiled function...", flush=True)
-    # Need to pass train signature and state to determine i/o shapes of train_state for now.
-    p_train_step = maxtext_utils.load_compiled(config, functional_train, state)
-    # TODO: p_eval_step is not yet supported in load_compiled
-    p_eval_step = None
-    print("Loaded compiled function!", flush=True)
-  else:
-    p_train_step = jax.jit(
-        functional_train,
-        in_shardings=in_shard_train,
-        out_shardings=out_shard_train,
-        static_argnums=static_argnums_train,
-        donate_argnums=donate_argnums_train,
-    )
-
-    p_eval_step = None
-    if eval_data_iterator:
-      p_eval_step = jax.jit(
-          functional_eval,
-          in_shardings=in_shard_eval,
-          out_shardings=out_shard_eval,
-          static_argnums=static_argnums_eval,
-          donate_argnums=donate_argnums_eval,
-      )
+  with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
+    shaped_batch = maxtext_utils.get_shaped_batch(config)
+    compiled = p_train_step.lower(state, shaped_batch, init_rng).compile()
+    compiled_stats = compiled.memory_analysis()
+    max_utils.print_compiled_memory_stats(compiled_stats)
 
   start_step = get_first_step(state)  # this is the start_step for training
   prof = profiler.Profiler(config, offset_step=start_step)
-
-  example_batch = None
-
   data_loader = DataLoader(config, mesh, data_iterator, recorder)
   metric_logger = MetricLogger(config=config, learning_rate_schedule=learning_rate_schedule)
 
@@ -202,17 +164,6 @@ def train_loop(config, recorder, state=None):
     checkpoint_manager.wait_until_finished()
   metric_logger.cleanup()
 
-  if example_batch:
-    with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
-      compiled = p_train_step.lower(state, example_batch, nextrng).compile()
-      compiled_stats = compiled.memory_analysis()
-      if compiled_stats is not None:
-        max_logging.log(
-            f"Output size: {compiled_stats.output_size_in_bytes}, "
-            f"temp size: {compiled_stats.temp_size_in_bytes}, "
-            f"argument size: {compiled_stats.argument_size_in_bytes}, "
-            f"host temp size: {compiled_stats.host_temp_size_in_bytes}, in bytes."
-        )
   return state
 
 

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -652,58 +652,18 @@ def train_loop(config, recorder, state=None):
       state = _merge_dpo_state(state, reference_params)
     state_mesh_shardings = _merge_dpo_state(state_mesh_shardings, state_mesh_shardings.params["params"])
 
-  # pylint: disable=line-too-long
-  (
-      functional_train,
-      in_shard_train,
-      out_shard_train,
-      static_argnums_train,
-      donate_argnums_train,
-  ) = maxtext_utils.get_functional_train_with_signature(train_step, mesh, state_mesh_shardings, model, config)
+  p_train_step, p_eval_step = train_utils.jit_train_and_eval_step(
+      config, model, mesh, state, state_mesh_shardings, train_step, eval_step, eval_data_iterator
+  )
 
-  if eval_data_iterator:
-    # pylint: disable=line-too-long
-    (
-        functional_eval,
-        in_shard_eval,
-        out_shard_eval,
-        static_argnums_eval,
-        donate_argnums_eval,
-    ) = maxtext_utils.get_functional_eval_with_signature(eval_step, mesh, state_mesh_shardings, model, config)
-
-  # Define the compilation of functional_train, either by loading the compiled version or wrapping a new one in a jit
-  if config.compiled_trainstep_file != "":
-    print("Loading the compiled function...", flush=True)
-    # Need to pass train signature and state to determine i/o shapes of train_state for now.
-    p_train_step = maxtext_utils.load_compiled(config, functional_train, state)
-    # TODO: p_eval_step is not yet supported in load_compiled
-    p_eval_step = None
-    print("Loaded compiled function!", flush=True)
-  else:
-    p_train_step = jax.jit(
-        functional_train,
-        in_shardings=in_shard_train,
-        out_shardings=out_shard_train,
-        static_argnums=static_argnums_train,
-        donate_argnums=donate_argnums_train,
-    )
-
-    if eval_data_iterator:
-      p_eval_step = jax.jit(
-          functional_eval,
-          in_shardings=in_shard_eval,
-          out_shardings=out_shard_eval,
-          static_argnums=static_argnums_eval,
-          donate_argnums=donate_argnums_eval,
-      )
-    else:
-      p_eval_step = None
+  with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
+    shaped_batch = maxtext_utils.get_shaped_batch(config)
+    compiled = p_train_step.lower(state, shaped_batch, init_rng).compile()
+    compiled_stats = compiled.memory_analysis()
+    max_utils.print_compiled_memory_stats(compiled_stats)
 
   start_step = get_first_step(state)  # this is the start_step for training
   prof = profiler.Profiler(config, offset_step=start_step)
-
-  example_batch = None
-
   data_loader = DataLoader(config, mesh, data_iterator, recorder)
   metric_logger = MetricLogger(config=config, learning_rate_schedule=learning_rate_schedule)
 
@@ -792,18 +752,6 @@ def train_loop(config, recorder, state=None):
     checkpoint_manager.wait_until_finished()
   metric_logger.cleanup()
 
-  if example_batch:
-    with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
-      # pytype: disable=attribute-error
-      compiled = p_train_step.lower(state, example_batch, nextrng).compile()
-      compiled_stats = compiled.memory_analysis()
-      if compiled_stats is not None:
-        max_logging.log(
-            f"Output size: {compiled_stats.output_size_in_bytes}, "
-            f"temp size: {compiled_stats.temp_size_in_bytes}, "
-            f"argument size: {compiled_stats.argument_size_in_bytes}, "
-            f"host temp size: {compiled_stats.host_temp_size_in_bytes}, in bytes."
-        )
   return state
 
 

--- a/MaxText/train_compile.py
+++ b/MaxText/train_compile.py
@@ -157,9 +157,12 @@ def main(argv: Sequence[str]) -> None:
   # Get shaped inputs
   shaped_train_args, shaped_train_kwargs, state_mesh_shardings, model = get_shaped_inputs(topology_mesh, config)
 
+  # Get data sharding
+  data_sharding = maxtext_utils.get_input_data_sharding(config, topology_mesh)
+
   # Get function to compile and shardings
   func_to_compile, in_shard, out_shard, static_argnums, donate_argnums = maxtext_utils.get_functional_train_with_signature(
-      train.train_step, topology_mesh, state_mesh_shardings, model, config
+      train.train_step, data_sharding, state_mesh_shardings, model, config
   )
 
   # Compile


### PR DESCRIPTION
# Description
This PR refactors the JIT compilation logic for the training and evaluation steps. Previously, the JIT compilation for the train_step and eval_step was not modularized, leading to duplicated code. This refactoring introduces a single, generalized helper function in `train_utils.py` that handles the JIT compilation for both, making the code more concise and easier to maintain. The calls to this logic from the various trainer scripts have been updated to use this new, unified function. 

This also incorporates the changes from https://github.com/AI-Hypercomputer/maxtext/pull/1813.

# Tests

E2E testing
```
Total memory size: 29.4 GB, Output size: 18.8 GB, Temp size: 10.6 GB, Argument size: 18.8 GB, Host temp size: 0.0 GB.
Per train step:
 Total TFLOPs: 42.24 
 split as 96.10% learnable weight flops and 3.90% attention flops
number parameters: 6.738 billion
completed step: 0, seconds: 27.213, TFLOP/s/device: 1.552, Tokens/s/device: 37.629, total_weights: 3573, loss: 0.993
completed step: 1, seconds: 0.974, TFLOP/s/device: 43.355, Tokens/s/device: 1050.953, total_weights: 3253, loss: 0.993
completed step: 2, seconds: 0.978, TFLOP/s/device: 43.184, Tokens/s/device: 1046.799, total_weights: 1692, loss: 0.912
completed step: 3, seconds: 0.982, TFLOP/s/device: 43.017, Tokens/s/device: 1042.766, total_weights: 2944, loss: 1.105
completed step: 4, seconds: 0.977, TFLOP/s/device: 43.217, Tokens/s/device: 1047.609, total_weights: 3466, loss: 0.948
completed step: 5, seconds: 0.977, TFLOP/s/device: 43.231, Tokens/s/device: 1047.951, total_weights: 2420, loss: 0.946
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
