### PR TITLE
Migrate three embedding modules to NNX

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -46,8 +46,12 @@ from MaxText.inference import paged_attention
 from MaxText.inference.kvcache import KVQuant, KVTensor
 from MaxText.kernels.ragged_attention import ragged_gqa
 from MaxText.kernels.ragged_attention import ragged_mha
-from MaxText.layers import embeddings
-from MaxText.layers.embeddings import YarnRotaryEmbedding, rotary_embedding_as_linen
+from MaxText.layers.embeddings import (
+    llama_rotary_embedding_as_linen,
+    llama_vision_rotary_embedding_as_linen,
+    rotary_embedding_as_linen,
+    yarn_rotary_embedding_as_linen,
+)
 from MaxText.layers.initializers import nd_dense_init, NdInitializer
 from MaxText.layers.linears import dense_general
 from MaxText.layers.normalizations import rms_norm
@@ -1596,7 +1600,7 @@ class Attention(nn.Module):
     rope_type = self.config.rope_type.lower()
     rope_use_scale = self.config.rope_use_scale
     if self.is_vision:
-      rotary_embedding = embeddings.LlamaVisionRotaryEmbedding(
+      rotary_embedding = llama_vision_rotary_embedding_as_linen(
           image_size=self.config.image_size_for_vit,
           patch_size=self.config.patch_size_for_vit,
           hidden_size=self.config.hidden_size_for_vit,
@@ -1604,7 +1608,7 @@ class Attention(nn.Module):
           rope_theta=self.config.rope_theta_for_vit,
       )
     elif self.config.model_name.startswith("llama3.1") or rope_type.startswith("llama3.1"):
-      rotary_embedding = embeddings.llama_rotary_embedding_as_linen(
+      rotary_embedding = llama_rotary_embedding_as_linen(
           min_timescale=self.config.rope_min_timescale,
           max_timescale=self.config.rope_max_timescale,
           embedding_dims=rope_embedding_dims,
@@ -1613,7 +1617,7 @@ class Attention(nn.Module):
           use_scale=rope_use_scale,
       )
     elif rope_type.startswith("yarn"):
-      rotary_embedding = YarnRotaryEmbedding(
+      rotary_embedding = yarn_rotary_embedding_as_linen(
           max_position_embeddings=self.config.max_position_embeddings,
           original_max_position_embeddings=self.config.original_max_position_embeddings,
           beta_fast=self.config.beta_fast,

--- a/MaxText/layers/embeddings.py
+++ b/MaxText/layers/embeddings.py
@@ -14,6 +14,7 @@
 
 """Embedding Layers."""
 
+import dataclasses
 import math
 from typing import Optional
 
@@ -416,7 +417,50 @@ class LLaMARotaryEmbedding(RotaryEmbedding):
     return outputs
 
 
-class YarnRotaryEmbedding(nn.Module):
+def yarn_rotary_embedding_as_linen(
+    *,
+    embedding_dims: int,
+    max_position_embeddings: int = 4096 * 4,
+    original_max_position_embeddings: int = 4096,
+    beta_fast: float = 32,
+    beta_slow: float = 1,
+    rope_theta: float = 10000.0,
+    rope_factor: float = 40,
+    cast_as_fprop_dtype: bool = True,
+    fprop_dtype: DType = jnp.bfloat16,
+    name: str | None = None,
+):
+  """Initializes the YarnRotaryEmbedding module and returns it as a Linen module.
+
+  Args:
+    embedding_dims: The dimension of the embeddings.
+    max_position_embeddings: The maximum number of positions.
+    original_max_position_embeddings: The original maximum number of positions.
+    beta_fast: The fast beta parameter for YaRN.
+    beta_slow: The slow beta parameter for YaRN.
+    rope_theta: The base for the rotary frequencies.
+    rope_factor: The scaling factor for RoPE.
+    cast_as_fprop_dtype: Whether to cast the output to `fprop_dtype`.
+    fprop_dtype: The forward pass dtype.
+    name: The name of the module.
+  """
+  return nnx.bridge.to_linen(
+      YarnRotaryEmbedding,
+      embedding_dims=embedding_dims,
+      max_position_embeddings=max_position_embeddings,
+      original_max_position_embeddings=original_max_position_embeddings,
+      beta_fast=beta_fast,
+      beta_slow=beta_slow,
+      rope_theta=rope_theta,
+      rope_factor=rope_factor,
+      cast_as_fprop_dtype=cast_as_fprop_dtype,
+      fprop_dtype=fprop_dtype,
+      metadata_fn=variable_to_logically_partitioned,
+      name=name,
+  )
+
+
+class YarnRotaryEmbedding(nnx.Module):
   """Yarn rotary embedding.
 
   Based on https://arxiv.org/abs/2309.00071
@@ -431,23 +475,42 @@ class YarnRotaryEmbedding(nn.Module):
     beta_slow: Upper bound parameter for correction.
     rope_theta: The base theta value for the frequency computation.
     rope_factor: Factor applied to adjust the frequencies.
+    cast_as_fprop_dtype: Whether to cast the output to `fprop_dtype`.
+    fprop_dtype: The forward pass dtype.
+    rngs: rng keys passed in by nnx.bridge.to_linen.
   """
+  def __init__(
+      self,
+      embedding_dims: int,
+      max_position_embeddings: int = 4096 * 4,
+      original_max_position_embeddings: int = 4096,
+      beta_fast: float = 32,
+      beta_slow: float = 1,
+      rope_theta: float = 10000.0,
+      rope_factor: float = 40,
+      cast_as_fprop_dtype: bool = True,
+      fprop_dtype: DType = jnp.bfloat16,
+      # Not used in YarnRotaryEmbedding but passed in by nnx.bridge.to_linen.
+      # TODO: Remove when bridge no longer needed
+      rngs: nnx.Rngs = None,
+  ):
+    """Initializes the YarnRotaryEmbedding module."""
+    self.embedding_dims = embedding_dims
+    self.max_position_embeddings = max_position_embeddings
+    self.original_max_position_embeddings = original_max_position_embeddings
+    self.beta_fast = beta_fast
+    self.beta_slow = beta_slow
+    self.rope_theta = rope_theta
+    self.rope_factor = rope_factor
+    self.cast_as_fprop_dtype = cast_as_fprop_dtype
+    self.fprop_dtype = fprop_dtype
 
-  embedding_dims: int
-  max_position_embeddings: int = 4096 * 4
-  original_max_position_embeddings: int = 4096
-  beta_fast: float = 32
-  beta_slow: float = 1
-  rope_theta: float = 10000.0
-  rope_factor: float = 40
-  cast_as_fprop_dtype: bool = True
-  fprop_dtype: DType = jnp.bfloat16
-
-  def setup(self) -> None:
-    """init with freqs_cis"""
     if self.embedding_dims % 2:
       raise ValueError("Embedding dim for rotary position embedding must be a multiple of 2.")
 
+  @property
+  def freqs_cis(self):
+    """Frequencies for rotary embedding."""
     half_dim = self.embedding_dims // 2
     # Compute base frequencies for each (even-indexed) dimension.
     # (Note: We use jnp.arange with float32 for precision.)
@@ -464,8 +527,9 @@ class YarnRotaryEmbedding(nn.Module):
     t = jnp.arange(self.max_position_embeddings, dtype=jnp.float32)  # shape [max_position_embeddings]
     # This gives a [max_position_embeddings, half_dim] tensor with rows as time steps.
     freqs = jnp.outer(t, freqs)
+
     # Compute the complex “cis” values: exp(i * theta).
-    self.freqs_cis = jnp.exp(1j * freqs)  # shape [max_position_embeddings, half_dim]
+    return jnp.exp(1j * freqs)  # shape [max_position_embeddings, half_dim]
 
   def _find_correction_dim(self, num_rotations: float, dim: int, base: float, max_position_embeddings: int) -> float:
     """Compute the correction dimension for a given number of rotations."""
@@ -549,11 +613,39 @@ class YarnRotaryEmbedding(nn.Module):
     return output
 
 
-class PositionalEmbedding(nn.Module):
-  """positional embedding layer."""
+def positional_embedding_as_linen(
+    *,
+    embedding_dims: int,
+    max_wavelength: int = _MAX_WAVELENGTH
+):
+  """Initializes the PositionalEmbedding module and returns it as a Linen module.
+
+  Args:
+    embedding_dims: The dimension of the embeddings.
+    max_wavelength: The maximum wavelength for the sinusoidal positional embeddings.
+  """
+  return nnx.bridge.to_linen(
+    PositionalEmbedding,
+    embedding_dims=embedding_dims,
+    max_wavelength=max_wavelength,
+    metadata_fn=variable_to_logically_partitioned
+)
+
+
+@dataclasses.dataclass(repr=False)
+class PositionalEmbedding(nnx.Module):
+  """A layer that adds sinusoidal positional embeddings to the input.
+
+  Attributes:
+    embedding_dims: The dimension of the embeddings.
+    max_wavelength: The maximum wavelength for the sinusoidal positional embeddings.
+    rngs: RNG state passed in by nnx.bridge.to_linen, not used in this module.
+  """
 
   embedding_dims: int
   max_wavelength: int = _MAX_WAVELENGTH
+
+  rngs: nnx.Rngs = None # Not used in PositionalEmbedding but passed in by nnx.bridge.to_linen
 
   def __call__(
       self,  # pytype: disable=signature-mismatch  # overriding-parameter-count-checks
@@ -574,7 +666,45 @@ class PositionalEmbedding(nn.Module):
     return input_embedding + position_embedding
 
 
-class LlamaVisionRotaryEmbedding(nn.Module):
+def llama_vision_rotary_embedding_as_linen(
+    *,
+    image_size: int,
+    patch_size: int,
+    hidden_size: int,
+    num_attention_heads: int,
+    rope_theta: float = 10000.0,
+    cast_as_fprop_dtype: bool = True,
+    fprop_dtype: DType = jnp.bfloat16,
+    name: str | None = None,
+):
+  """Initializes the LlamaVisionRotaryEmbedding module and returns it as a Linen module.
+
+  Args:
+    image_size: The size of the input image.
+    patch_size: The size of the image patches.
+    hidden_size: The size of the hidden dimension.
+    num_attention_heads: The number of attention heads.
+    rope_theta: The base theta value for the frequency computation.
+    cast_as_fprop_dtype: Whether to cast the output to the fprop dtype.
+    fprop_dtype: The dtype of the output.
+    name: The name of the Linen module.
+  """
+  return nnx.bridge.to_linen(
+      LlamaVisionRotaryEmbedding,
+      image_size=image_size,
+      patch_size=patch_size,
+      hidden_size=hidden_size,
+      num_attention_heads=num_attention_heads,
+      rope_theta=rope_theta,
+      cast_as_fprop_dtype=cast_as_fprop_dtype,
+      fprop_dtype=fprop_dtype,
+      metadata_fn=variable_to_logically_partitioned,
+      name=name,
+  )
+
+
+@dataclasses.dataclass(repr=False)
+class LlamaVisionRotaryEmbedding(nnx.Module):
   """Rotary position embedding for Llama4 vision encoder.
 
   Based on Pytorch Reference
@@ -590,6 +720,7 @@ class LlamaVisionRotaryEmbedding(nn.Module):
     rope_theta: float = 10000.0 base theta value for the frequency computation
     cast_as_fprop_dtype: bool = True whether to cast the output to the fprop dtype
     fprop_dtype: DType = jnp.bfloat16 the dtype of the output
+    rngs: RNG state passed in by nnx.bridge.to_linen, not used in this module.
   Returns:
     jax.Array of shape [batch_size_times_tiles, num_patches_incl_cls, num_heads, head_dim]
     where vision rotary position embeddings are applied.
@@ -602,9 +733,14 @@ class LlamaVisionRotaryEmbedding(nn.Module):
   rope_theta: float = 10000.0
   cast_as_fprop_dtype: bool = True
   fprop_dtype: DType = jnp.bfloat16
+  # Not used in LlamaVisionRotaryEmbedding but passed in by nnx.bridge.to_linen.
+  # TODO: Remove when bridge no longer needed
+  rngs: nnx.Rngs = None
 
-  def setup(self):
-    """Initializes the rotary embedding parameters."""
+
+  @property
+  def freqs_cis(self):
+    """Frequencies for rotary embedding."""
     idx = self.image_size // self.patch_size
     img_idx = jnp.arange(idx**2, dtype=jnp.int32).reshape(idx**2, 1)
     img_idx = jnp.concatenate([img_idx, img_idx[:1]], axis=0)
@@ -633,7 +769,7 @@ class LlamaVisionRotaryEmbedding(nn.Module):
     # Mask out invalid positions
     freqs = jnp.where(img_idx.reshape(-1, 1, 1) < 0, 0, freqs)
     # Convert to complex representation
-    self.freqs_ci = jnp.exp(1j * freqs)
+    return jnp.exp(1j * freqs)
 
   def __call__(self, inputs: Array, position: Optional[Array] = None) -> Array:
     """Applies rotary embeddings to the input tensor for Llama4 vision encoder.

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -37,7 +37,7 @@ from MaxText import maxtext_utils
 from MaxText import multimodal_utils
 from MaxText.layers.attentions import Attention
 from MaxText.layers.normalizations import rms_norm
-from MaxText.layers.embeddings import PositionalEmbedding, Embed
+from MaxText.layers.embeddings import positional_embedding_as_linen, Embed
 from MaxText.layers.quantizations import AqtQuantization as Quant
 
 
@@ -490,7 +490,7 @@ class Decoder(nn.Module):
     y = y.astype(cfg.dtype)
 
     if cfg.use_untrainable_positional_embedding:
-      y = PositionalEmbedding(cfg.base_emb_dim)(y, decoder_positions)
+      y = positional_embedding_as_linen(embedding_dims=cfg.base_emb_dim)(y, decoder_positions)
 
     if cfg.trainable_position_size > 0:
       y += Embed(


### PR DESCRIPTION
# Description

Use NNX for YarnRotaryEmbedding, LlamaVisionRotaryEmbedding, and PositionalEmbedding

* Change modules to NNX
* Move setup logic to init functions
* Create property for `freqs_cis` in both modules. The module change caused the types to change from DynamicJaxprTracer --> ShapeDtypeStruct during the training loop. This fixes that and is equivalent to Linen (similar to the last PR)
* Create nnx.bridge.to_linen bridge functions and use them where these modules get invoked

# Tests

Ran MaxText base with Yarn on a v6e-8 devbox. Got the same perf before/after:

```
python3 -m MaxText.train MaxText/configs/base.yml \
    run_name=<run_name> \
    base_output_directory=gs://<gcs_bucket> \
    dataset_type=synthetic \
    steps=10 \
    rope_type=yarn
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
