### PR TITLE
Enable scan for gemma3

### DIFF
--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -16,9 +16,9 @@ limitations under the License.
 
 from typing import Optional
 
+import jax
 from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
-import jax.debug
 import jax.numpy as jnp
 
 from flax import linen as nn
@@ -55,6 +55,215 @@ def get_query_pre_attn_scalar(config) -> float:
     return (config.base_emb_dim // config.base_num_query_heads) ** -0.5
   else:
     raise ValueError(f"Unsupported model name: {config.model_name}")
+
+
+# Gemma3 Decoder Layer
+class Gemma3DecoderLayer(nn.Module):
+  """Transformer decoder layer that attends to the encoder."""
+
+  config: Config
+  mesh: Mesh
+  quant: Optional[Quant] = None
+  attention_type: AttentionType = AttentionType.LOCAL_SLIDING
+
+  @nn.compact
+  def __call__(
+      self,
+      inputs,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      previous_chunk=None,
+      page_state=None,
+      slot=None,
+      bidirectional_mask=None,
+  ):
+    cfg = self.config
+    mesh = self.mesh
+    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
+    # inputs: embedded inputs to the decoder with shape [batch, length, emb_dim]
+    lnx = rms_norm(
+        num_features=inputs.shape[-1],
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        name="pre_self_attention_norm",
+        kernel_axes=("norm",),
+    )(inputs)
+
+    lnx = nn.with_logical_constraint(lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+    query_pre_attn_scalar = get_query_pre_attn_scalar(cfg)
+
+    attention_layer = Attention(
+        config=cfg,
+        num_query_heads=cfg.num_query_heads,
+        num_kv_heads=cfg.num_kv_heads,
+        head_dim=cfg.head_dim,
+        max_target_length=cfg.max_target_length,
+        max_prefill_predict_length=cfg.max_prefill_predict_length,
+        attention_kernel=cfg.attention,
+        mesh=mesh,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        dropout_rate=cfg.dropout_rate,
+        name="self_attention",
+        float32_qk_product=cfg.float32_qk_product,
+        float32_logits=cfg.float32_logits,
+        quant=self.quant,
+        kv_quant=quantizations.configure_kv_quant(cfg),
+        attention_type=self.attention_type,
+        sliding_window_size=cfg.sliding_window_size,
+        attn_logits_soft_cap=cfg.attn_logits_soft_cap,
+        use_qk_norm=True,  # Gemma 3 models use query, key normalizations
+        query_pre_attn_scalar=query_pre_attn_scalar,
+    )
+
+    attention_lnx = attention_layer(
+        lnx,
+        lnx,
+        decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        deterministic=deterministic,
+        model_mode=model_mode,
+        bidirectional_mask=bidirectional_mask,
+    )
+    if cfg.use_post_attn_norm:
+      attention_lnx = rms_norm(
+          num_features=attention_lnx.shape[-1],
+          dtype=cfg.dtype,
+          weight_dtype=cfg.weight_dtype,
+          name="post_self_attention_norm",
+          kernel_axes=("norm",),
+      )(attention_lnx)
+
+    attention_lnx = nn.with_logical_constraint(
+        attention_lnx, ("activation_batch", "activation_norm_length", "activation_embed")
+    )
+    attention_lnx += inputs
+    residual = attention_lnx
+
+    attn_output = rms_norm(
+        num_features=attention_lnx.shape[-1],
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        name="pre_ffw_norm",
+        kernel_axes=("norm",),
+    )(attention_lnx)
+
+    # MLP block.
+    mlp_lnx = MlpBlock(
+        intermediate_dim=cfg.mlp_dim,
+        activations=cfg.mlp_activations,
+        intermediate_dropout_rate=cfg.dropout_rate,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        name="mlp",
+        config=cfg,
+        quant=self.quant,
+    )(attn_output, deterministic=deterministic)
+
+    if cfg.use_post_ffw_norm:
+      mlp_lnx = rms_norm(
+          num_features=mlp_lnx.shape[-1],
+          dtype=cfg.dtype,
+          weight_dtype=cfg.weight_dtype,
+          name="post_ffw_norm",
+          kernel_axes=("norm",),
+      )(mlp_lnx)
+
+    mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+    next_layer_addition = mlp_lnx + residual
+    next_layer_addition_dropped_out = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(
+        next_layer_addition, deterministic=deterministic
+    )
+
+    layer_output = next_layer_addition_dropped_out
+    layer_output = nn.with_logical_constraint(
+        layer_output,
+        ("activation_batch", "activation_norm_length", "activation_embed"),
+    )
+
+    if cfg.record_internal_nn_metrics:
+      self.sow("intermediates", "activation_mean", jnp.mean(layer_output))
+      self.sow("intermediates", "activation_stdev", jnp.std(layer_output))
+      self.sow(
+          "intermediates",
+          "activation_fraction_zero",
+          jnp.sum(layer_output == 0) / jnp.size(layer_output),
+      )
+
+    if cfg.scan_layers:
+      return layer_output, None
+    else:
+      return layer_output
+
+
+class Gemma3ScannableBlock(nn.Module):
+  """A repeatable block of Gemma3 decoder layers.
+
+    This block applies multiple decoder layers sequentially, using the attention
+    pattern defined by GEMMA3_ATTENTION_PATTERN. It's designed to be
+    used with `nn.scan` for efficient compilation.
+
+  Attributes:
+    config: Config, MaxText model config
+    mesh: Mesh, JAX device mesh (used for sharding)
+    quant: Optional[Quant], quantization config
+    num_of_layers: int, number of decoder layers in the block
+  """
+
+  config: Config
+  mesh: Mesh
+  quant: Optional[Quant] = None
+  num_of_layers: int = 1
+
+  @nn.compact
+  def __call__(
+      self,
+      inputs,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      slot=None,
+      page_state=None,
+      previous_chunk=None,
+      bidirectional_mask=None,
+  ):
+
+    cfg = self.config
+    mesh = self.mesh
+
+    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
+    y = inputs
+    for layer_id in range(self.num_of_layers):
+      attention_type = get_attention_type(layer_id)
+      layer = Gemma3DecoderLayer(
+          config=cfg,
+          mesh=mesh,
+          name=f"layers_{layer_id}",
+          quant=self.quant,
+          attention_type=attention_type,
+      )
+      y = layer(
+          y,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          previous_chunk=previous_chunk,
+          page_state=page_state,
+          slot=slot,
+          bidirectional_mask=None,
+      )
+      if cfg.scan_layers:
+        y = y[0]
+    if cfg.scan_layers:
+      return y, None
+    else:
+      return y
 
 
 def _posemb_sincos_2d(
@@ -339,145 +548,3 @@ class Gemma3VisionEncoderLayer(nn.Module):
     bn, l, c = x.shape
     x = jnp.reshape(x, [b, n, l, c])
     return x
-
-
-# Gemma3 Decoder Layer
-class Gemma3DecoderLayer(nn.Module):
-  """Transformer decoder layer that attends to the encoder."""
-
-  config: Config
-  mesh: Mesh
-  quant: Optional[Quant] = None
-  attention_type: AttentionType = AttentionType.LOCAL_SLIDING
-
-  @nn.compact
-  def __call__(
-      self,
-      inputs,
-      decoder_segment_ids,
-      decoder_positions,
-      deterministic,
-      model_mode,
-      previous_chunk=None,
-      page_state=None,
-      slot=None,
-      bidirectional_mask=None,
-  ):
-    cfg = self.config
-    mesh = self.mesh
-    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
-    inputs = checkpoint_name(inputs, "decoder_layer_input")
-    # inputs: embedded inputs to the decoder with shape [batch, length, emb_dim]
-    lnx = rms_norm(
-        num_features=inputs.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="pre_self_attention_norm",
-        kernel_axes=("norm",),
-    )(inputs)
-
-    lnx = nn.with_logical_constraint(lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
-    query_pre_attn_scalar = get_query_pre_attn_scalar(cfg)
-
-    attention_layer = Attention(
-        config=cfg,
-        num_query_heads=cfg.num_query_heads,
-        num_kv_heads=cfg.num_kv_heads,
-        head_dim=cfg.head_dim,
-        max_target_length=cfg.max_target_length,
-        max_prefill_predict_length=cfg.max_prefill_predict_length,
-        attention_kernel=cfg.attention,
-        mesh=mesh,
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        dropout_rate=cfg.dropout_rate,
-        name="self_attention",
-        float32_qk_product=cfg.float32_qk_product,
-        float32_logits=cfg.float32_logits,
-        quant=self.quant,
-        kv_quant=quantizations.configure_kv_quant(cfg),
-        attention_type=self.attention_type,
-        sliding_window_size=cfg.sliding_window_size,
-        attn_logits_soft_cap=cfg.attn_logits_soft_cap,
-        use_qk_norm=True,  # Gemma 3 models use query, key normalizations
-        query_pre_attn_scalar=query_pre_attn_scalar,
-    )
-
-    attention_lnx = attention_layer(
-        lnx,
-        lnx,
-        decoder_positions,
-        decoder_segment_ids=decoder_segment_ids,
-        deterministic=deterministic,
-        model_mode=model_mode,
-        bidirectional_mask=bidirectional_mask,
-    )
-    if cfg.use_post_attn_norm:
-      attention_lnx = rms_norm(
-          num_features=attention_lnx.shape[-1],
-          dtype=cfg.dtype,
-          weight_dtype=cfg.weight_dtype,
-          name="post_self_attention_norm",
-          kernel_axes=("norm",),
-      )(attention_lnx)
-
-    attention_lnx = nn.with_logical_constraint(
-        attention_lnx, ("activation_batch", "activation_norm_length", "activation_embed")
-    )
-    attention_lnx += inputs
-    residual = attention_lnx
-
-    attn_output = rms_norm(
-        num_features=attention_lnx.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="pre_ffw_norm",
-        kernel_axes=("norm",),
-    )(attention_lnx)
-
-    # MLP block.
-    mlp_lnx = MlpBlock(
-        intermediate_dim=cfg.mlp_dim,
-        activations=cfg.mlp_activations,
-        intermediate_dropout_rate=cfg.dropout_rate,
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="mlp",
-        config=cfg,
-        quant=self.quant,
-    )(attn_output, deterministic=deterministic)
-
-    if cfg.use_post_ffw_norm:
-      mlp_lnx = rms_norm(
-          num_features=mlp_lnx.shape[-1],
-          dtype=cfg.dtype,
-          weight_dtype=cfg.weight_dtype,
-          name="post_ffw_norm",
-          kernel_axes=("norm",),
-      )(mlp_lnx)
-
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
-    next_layer_addition = mlp_lnx + residual
-    next_layer_addition_dropped_out = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(
-        next_layer_addition, deterministic=deterministic
-    )
-
-    layer_output = next_layer_addition_dropped_out
-    layer_output = nn.with_logical_constraint(
-        layer_output,
-        ("activation_batch", "activation_norm_length", "activation_embed"),
-    )
-
-    if cfg.record_internal_nn_metrics:
-      self.sow("intermediates", "activation_mean", jnp.mean(layer_output))
-      self.sow("intermediates", "activation_stdev", jnp.std(layer_output))
-      self.sow(
-          "intermediates",
-          "activation_fraction_zero",
-          jnp.sum(layer_output == 0) / jnp.size(layer_output),
-      )
-
-    if cfg.scan_layers:
-      return layer_output, None
-    else:
-      return layer_output


### PR DESCRIPTION
# Description

Enable scan support for Gemma3 models which use a repeating pattern of local and global attention defined by GEMMA3_ATTENTION_PATTERN.

The approach uses a new Gemma3ScannableBlock, which encapsulates this repeating pattern. The decoder processes full blocks within an nn.scan operation and applies any remainder layers separately, ensuring the model is correct for any number of layers.

# Tests

Tested 12b and 27b configs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
