### PR TITLE
Fix check for dataset feature types after datasets got upgraded to 0.4.0

### DIFF
--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -94,8 +94,8 @@ def is_conversational(features, data_columns):
   """
   for column in data_columns:
     messages = features[column]
-    if isinstance(messages, list):
-      if isinstance(messages[0], dict) and "role" in messages[0] and "content" in messages[0]:
+    if isinstance(messages, datasets.Sequence):
+      if isinstance(messages.feature, dict) and "role" in messages.feature and "content" in messages.feature:
         return True
 
   return False


### PR DESCRIPTION
# Description

This PR fixes the check for dataset features type which changed in datasets==0.4.0.
Changed dataset features type from 
`[{'content': Value(dtype='string', id=None), 'role': Value(dtype='string', id=None)}]`
to
`List({'content': Value(dtype='string', id=None), 'role': Value(dtype='string', id=None)}])`

# Tests

Unit tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
