### PR TITLE
Migrate Embed module to NNX

### DIFF
--- a/MaxText/layers/embeddings.py
+++ b/MaxText/layers/embeddings.py
@@ -26,59 +26,106 @@ from flax import linen as nn
 from flax import nnx
 
 from MaxText import max_logging
-from MaxText.common_types import MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, Config, DType, Array
-from MaxText.layers.initializers import Initializer, default_embed_init
+from MaxText.common_types import MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, Array, Config, DType
+from MaxText.layers.initializers import Initializer, default_embed_init, variable_to_logically_partitioned
 
 _MAX_WAVELENGTH = 10_000
 
 
-class Embed(nn.Module):
-  """A parameterized function from integers [0, n) to d-dimensional vectors.
+def _maybe_move_embedding_to_device(embedding_table: Array, config: Config) -> Array:
+  """Moves embedding table to device if parameter offloading is enabled."""
+  if config.parameter_memory_host_offload:
+    max_logging.log("embeddings.py: Moving embedding parameter to device")
+    # pylint: disable=protected-access
+    return jax.device_put(embedding_table, jax._src.sharding_impls.TransferToMemoryKind("device"))
+  return embedding_table
 
-  Attributes:
-    num_embeddings: number of embeddings.
-    features: number of feature dimensions for each embedding.
-    dtype: the dtype of the embedding vectors (default: float32).
-    embedding_init: embedding initializer.
+
+def embed_as_linen(
+    *,
+    num_embeddings: int,
+    num_features: int,
+    config: Config,
+    cast_input_dtype: Optional[DType] = None,
+    dtype: DType = jnp.float32,
+    attend_dtype: Optional[DType] = None,
+    embedding_init: Initializer = default_embed_init,
+    name: str | None = None,
+):
+  """Initializes the Embed NNX module and returns it as a Linen module.
+
+  This function serves as a bridge to use the NNX-based `Embed` module within
+  a Linen model. It wraps the `Embed` module using `nnx.bridge.to_linen`,
+  making it compatible with the Linen API.
+
+  Args:
+    num_embeddings: The number of embeddings.
+    num_features: The number of feature dimensions for each embedding.
+    config: The model configuration.
+    cast_input_dtype: The dtype to cast the input to, if any.
+    dtype: The dtype of the embedding vectors.
+    attend_dtype: The dtype for the `attend` method.
+    embedding_init: The initializer for the embedding matrix.
+    name: The name of the Linen module.
+
+  Returns:
+    A Linen module that wraps the NNX `Embed` module.
   """
+  return nnx.bridge.to_linen(
+      Embed,
+      num_embeddings=num_embeddings,
+      num_features=num_features,
+      config=config,
+      cast_input_dtype=cast_input_dtype,
+      dtype=dtype,
+      attend_dtype=attend_dtype,
+      embedding_init=embedding_init,
+      metadata_fn=variable_to_logically_partitioned,
+      name=name,
+  )
 
-  # pylint: disable=attribute-defined-outside-init
-  config: Config
-  num_embeddings: int
-  features: int
-  cast_input_dtype: Optional[DType] = None
-  dtype: DType = jnp.float32
-  attend_dtype: Optional[DType] = None
-  embedding_init: Initializer = default_embed_init
 
-  def setup(self):
+class Embed(nnx.Module):
+  """A parameterized function from integers [0, n) to d-dimensional vectors."""
+
+  def __init__(
+      self,
+      num_embeddings: int,
+      num_features: int,
+      config: Config,
+      cast_input_dtype: Optional[DType] = None,
+      dtype: DType = jnp.float32,
+      attend_dtype: Optional[DType] = None,
+      embedding_init: Initializer = default_embed_init,
+      *,
+      # Not used in Embed but passed in by nnx.bridge.to_linen.
+      # TODO: Remove when bridge no longer needed
+      rngs: nnx.Rngs,
+  ):
+    """Initializes the Embed module.
+
+    Args:
+      num_embeddings: The number of embeddings.
+      num_features: The number of feature dimensions for each embedding.
+      config: The model configuration.
+      cast_input_dtype: The dtype to cast the input to, if any.
+      dtype: The dtype of the embedding vectors.
+      attend_dtype: The dtype for the `attend` method.
+      embedding_init: The initializer for the embedding matrix.
+      rngs: The random number generators for initialization.
     """
-    Sets up the embedding parameters for the model.
+    self.num_embeddings = num_embeddings
+    self.num_features = num_features
+    self.config = config
+    self.cast_input_dtype = cast_input_dtype
+    self.dtype = dtype
+    self.attend_dtype = attend_dtype
 
-    This method initializes the embedding parameters with logical partitioning.
-    The embedding is represented as a parameter with the specified shape and data type.
-
-    Parameters:
-    - embedding: The embedding parameter initialized using the specified method,
-                 partitioned logically along the 'vocab' and 'embed' dimensions.
-
-    Returns:
-    None
-    """
-
-    embedding = self.param(
-        "embedding",
-        nn.with_logical_partitioning(self.embedding_init, ("vocab", "embed")),
-        (self.num_embeddings, self.features),
-        self.config.weight_dtype,
+    self.embedding = nnx.Param(
+        embedding_init(rngs.params(), (self.num_embeddings, self.num_features), self.config.weight_dtype),
+        sharding=("vocab", "embed"),
     )
-    # Move embeddings to device if parameter offloading is enabled
-    if self.config.parameter_memory_host_offload:
-      max_logging.log("embeddings.py: Moving embedding parameter to device")
-      # pylint: disable=protected-access
-      self.embedding = jax.device_put(embedding, jax._src.sharding_impls.TransferToMemoryKind("device"))
-    else:
-      self.embedding = embedding
+
 
   def __call__(self, inputs: Array, model_mode: str = MODEL_MODE_TRAIN) -> Array:
     """Embeds the inputs along the last dimension.
@@ -88,7 +135,7 @@ class Embed(nn.Module):
 
     Returns:
       Output which is embedded input data.  The output shape follows the input,
-      with an additional `features` dimension appended.
+      with an additional `num_features` dimension appended.
     """
     cfg = self.config
     if self.cast_input_dtype:
@@ -96,12 +143,14 @@ class Embed(nn.Module):
     if not jnp.issubdtype(inputs.dtype, jnp.integer):
       raise ValueError("Input type must be an integer or unsigned integer.")
 
+    embedding = _maybe_move_embedding_to_device(self.embedding.value, self.config)
+
     if cfg.use_iota_embed:
       iota = lax.iota(jnp.int32, self.num_embeddings)
       one_hot = jnp.array(inputs[..., jnp.newaxis] == iota, dtype=self.dtype)
-      output = jnp.dot(one_hot, jnp.asarray(self.embedding, self.dtype))
+      output = jnp.dot(one_hot, jnp.asarray(embedding, self.dtype))
     else:
-      output = jnp.asarray(self.embedding, self.dtype)[inputs]
+      output = jnp.asarray(embedding, self.dtype)[inputs]
 
     output_prefill_axis_names = ("activation_embed_and_logits_batch", "prefill_activation_length", "activation_embed")
     output_default_axis_names = ("activation_embed_and_logits_batch", "activation_length", "activation_embed")
@@ -116,7 +165,7 @@ class Embed(nn.Module):
     """Attend over the embedding using a query array.
 
     Args:
-      query: array with last dimension equal the feature depth `features` of the
+      query: array with last dimension equal the feature depth `num_features` of the
         embedding.
 
     Returns:
@@ -125,8 +174,28 @@ class Embed(nn.Module):
       Commonly used for weight-sharing between embeddings and logit transform
       in NLP models.
     """
-    dtype = self.attend_dtype if self.attend_dtype is not None else self.dtype
-    return jnp.dot(query, jnp.asarray(self.embedding, jnp.bfloat16).T, preferred_element_type=dtype)
+    embedding = self.embedding.value
+    attend_dtype = self.attend_dtype if self.attend_dtype is not None else self.dtype
+    return attend_on_embedding(query, embedding, attend_dtype, self.config)
+
+
+def attend_on_embedding(query: Array, embedding_table: Array, attend_dtype: DType, config: Config) -> Array:
+  """Attend over an embedding table using a query array.
+
+  TODO: Remove this method when Embed bridge to Linen is no longer needed
+
+  Args:
+    query: An array with a last dimension equal to the feature depth of the embedding.
+    embedding_table: The embedding table to attend over.
+    attend_dtype: The data type for the attention computation.
+    config: The model configuration, used to check for parameter offloading.
+
+  Returns:
+    An array with a final dimension equal to `num_embeddings`, corresponding to the
+    batched inner-product of the query vectors against each embedding.
+  """
+  embedding_table = _maybe_move_embedding_to_device(embedding_table, config)
+  return jnp.dot(query, jnp.asarray(embedding_table, jnp.bfloat16).T, preferred_element_type=attend_dtype)
 
 
 def rotary_embedding_as_linen(
@@ -807,13 +876,3 @@ class LlamaVisionRotaryEmbedding(nnx.Module):
       output = output.astype(self.fprop_dtype)
 
     return output
-
-
-def variable_to_logically_partitioned(variable: nnx.VariableState):
-  metadata = variable.get_metadata()
-  return nn.LogicallyPartitioned(  # type: ignore[wrong-keyword-args]
-      variable.value,
-      variable.sharding,
-      mesh=metadata.get("mesh"),
-      rules=metadata.get("rules"),
-  )


### PR DESCRIPTION
# Description

Use NNX for the Embed module.
* Change module to NNX
* Move setup logic to init
* Move host offloading to call/attend methods
* Create bridge to linen function and use it where the Embed module is invoked
* Reimplemented `attend` logic where it is used since only the __call__ function is wrapped in the bridge to linen (@cgarciae has made a [change in Flax](https://github.com/google/flax/pull/4808) to allow other methods in the future)

# Tests

Ran MaxText on base on a v6e-8 devbox and got the same perf before/after this change:

```
python3 -m MaxText.train MaxText/configs/base.yml \
    run_name=<run_name> \
    base_output_directory=gs://<gcs_bucket> \
    dataset_type=synthetic \
    steps=10
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
