### PR TITLE
Fix pipeline subset layers feature

### DIFF
--- a/MaxText/layers/decoders.py
+++ b/MaxText/layers/decoders.py
@@ -570,7 +570,7 @@ class Decoder(nn.Module):
         if remaining_layers > 0:
           logical_axis_rules_pp_as_dp = maxtext_utils.logical_axis_rules_pp_act_as_dp(self.config.logical_axis_rules)
           with self.mesh, nn.partitioning.axis_rules(logical_axis_rules_pp_as_dp):
-            y, _ = self.scan_decoder_layers(cfg, RemattedBlockLayers[0], remaining_layers, "layers", mesh)(
+            y, _ = self.scan_decoder_layers(cfg, RemattedBlockLayers[0], remaining_layers, "layers_outside_pipeline", mesh)(
                 y,
                 decoder_segment_ids,
                 decoder_positions,

--- a/MaxText/tests/train_compile_test.py
+++ b/MaxText/tests/train_compile_test.py
@@ -584,6 +584,26 @@ class TrainCompile(unittest.TestCase):
     )
 
   @pytest.mark.cpu_only
+  def test_pipeline_subset(self):
+    compiled_trainstep_file = "/tmp/test_pipeline_subset.pickle"
+    train_compile_main(
+        (
+            None,
+            os.path.join(PKG_DIR, "configs", "base.yml"),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v6e-256",
+            "compile_topology_num_slices=8",
+            "use_iota_embed=true",
+            "per_device_batch_size=1",
+            "max_target_length=2048",
+            "pipeline_parallel_layers=56",
+            "base_num_decoder_layers=61", # Remainder of 5 will fail when sharded incorrectly.
+            "ici_expert_parallelism=16",
+            "dcn_pipeline_parallelism=8",
+        )
+    )
+
+  @pytest.mark.cpu_only
   def test_moe_llama4_17b_16e(self):
     compiled_trainstep_file = "/tmp/test_moe_llama4_17b_16e.pickle"
     train_compile_main(


### PR DESCRIPTION
# Description

Fix pipelining subset of layers feature (previously broken/sharded incorrectly for non deepseek models)

To see more about pipelining subset of layers feature, see the PR that added it #1616

TL;DR this feature splits the layers into those that are in the pipeline, vs those that will outside the pipeline. The "stage" axis of the mesh will act like data parallelism for the layers outside of the pipeline. However there was a bug where the layers outside the pipeline were still sharded by stage, this PR fixes it so those layers are not sharded by stage.

This is particularly useful to run models like llama405B which has 126 layers. Although 126 does not have the friendliest divisors, with this feature you can use PP=12, pipeline_subset_layers=120 for example (the remaining 6 layers are outside the pipeline and the PP mesh axis will act like DP)


# Tests

```
smoke_train ici_pipeline_parallelism=8 pipeline_parallel_layers=16 base_num_decoder_layers=21 profiler=xplane
```
[xprof](https://xprof.corp.google.com/trace_viewer/mattdavidow-12989516961696272071?hosts=t1v-n-70a81276-w-0&host_index=0&trace_filter_config={}&view_start=-140.163&view_end=1621.441)

Also added a train compile test that should fail if sharded incorrectly

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
