### PR TITLE
fix unit tests for check_llama4_layers (embeddings.LlamaVisionRotaryEmbedding)

### DIFF
--- a/MaxText/layers/embeddings.py
+++ b/MaxText/layers/embeddings.py
@@ -862,7 +862,7 @@ class LlamaVisionRotaryEmbedding(nnx.Module):
     inputs_complex = inputs_reshaped[..., 0] + 1j * inputs_reshaped[..., 1]
 
     # Reshape freqs_ci for broadcasting
-    freqs_ci = self.freqs_ci[jnp.newaxis, :, :, :]
+    freqs_ci = self.freqs_cis[jnp.newaxis, :, :, :]
 
     # Apply rotary transformation
     rotated = inputs_complex * freqs_ci

--- a/MaxText/layers/llama4.py
+++ b/MaxText/layers/llama4.py
@@ -283,7 +283,7 @@ class Llama4MultiModalProjector(nn.Module):
     cfg = self.config
     self.linear = linears.dense_general(
         in_features_shape=cfg.vision_output_dim_for_vit,
-        out_features_shape=cfg.hidden_size_for_vit,
+        out_features_shape=cfg.base_emb_dim,
         dtype=cfg.dtype_mm,
         name="vit_multi_modal_projector",
         use_bias=False,


### PR DESCRIPTION
# Description

Recent [linen-to-nnx refactor ](https://screenshot.googleplex.com/5LssGn9DeGftTpg)changes the structure of `embeddings.LlamaVisionRotaryEmbedding`. This PR fixes the naming, making the following three tests pass:

```
FAILED MaxText/tests/check_llama4_layers.py::Llama4VisionRotaryEmbeddingTest::test_rope_multiple_seq - AttributeError: 'LlamaVisionRotaryEmbedding' object has no attribute 'init'
FAILED MaxText/tests/check_llama4_layers.py::Llama4VisionAttentionTest::test_vision_attention - AttributeError: 'LlamaVisionRotaryEmbedding' object has no attribute 'freqs_ci'. Did you mean: 'freqs_cis'?
FAILED MaxText/tests/check_llama4_layers.py::Llama4VisionEncoderTest::test_vision_encoder - AttributeError: 'LlamaVisionRotaryEmbedding' object has no attribute 'freqs_ci'. Did you mean: 'freqs_cis'?
```

Together with https://github.com/AI-Hypercomputer/maxtext/pull/1950, now all six tests pass for `check_llama4_layers.py` (need to lower the num_hidden_layers_for_vit from 34 to 31 to make it pass, due to aggregated errors.)

FIXES: [b/430605239](https://b.corp.google.com/issues/430605239)

# Tests

```
pytest MaxText/tests/check_llama4_layers.py
```
<img width="389" alt="image" src="https://github.com/user-attachments/assets/d8a0bad1-1c0c-4ead-9a9b-b4d10d29e0ed" />

Another full model decode [command](https://paste.googleplex.com/4950482774392832), [workload](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22mlperf-v5p-256-2%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22htg-llama4-17b-16e-decode-mm-ep8-full-slice-job-0-0-%22%20severity%3E%3DDEFAULT%0Atimestamp%20%3E%3D%20%222025-07-10T05:28:50.809438708Z%22%20AND%20timestamp%20%3C%3D%20%222025-07-10T05:35:50.922769116Z%22;storageScope=project;cursorTimestamp=2025-07-10T05:29:19.779779380Z;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev&inv=1&invt=Ab2Wqg), [screenshot](https://screenshot.googleplex.com/4fb8kGgSBszfJi4).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
