### PR TITLE
Buffer metrics before writing to GCS/Tensorboard

### DIFF
--- a/MaxText/experimental/rl/grpo_trainer.py
+++ b/MaxText/experimental/rl/grpo_trainer.py
@@ -732,8 +732,8 @@ def train_loop(config, config_inference, recorder, state=None):
   metric_logger.write_setup_info_to_tensorboard(state.params)
 
   try:
+    last_step_completion = datetime.datetime.now()
     for step in np.arange(start_step, config.steps):
-      step_start_time = datetime.datetime.now()
       prof.maybe_activate_profiler(step, state)
 
       with jax.profiler.StepTraceAnnotation("train", step_num=step):
@@ -747,6 +747,9 @@ def train_loop(config, config_inference, recorder, state=None):
           # TODO: ensure this partitioning is correct
           with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
             state, metrics = p_train_step(state, example_batch, rng)
+
+      step_time_delta = datetime.datetime.now() - last_step_completion
+      last_step_completion = datetime.datetime.now()
 
       state_to_save = _split_grpo_state(state)[0]
       checkpointing.maybe_save_checkpoint(checkpoint_manager, state_to_save, config, data_iterator, step)
@@ -783,17 +786,14 @@ def train_loop(config, config_inference, recorder, state=None):
       if step == start_step:
         max_utils.print_mem_stats("After params initialized")
 
-      jax.block_until_ready(state)  # ensure training step is completed
-
-      step_time_delta = datetime.datetime.now() - step_start_time
-      metric_logger.record_train_metrics(metrics, step, step_time_delta)
+      metric_logger.buffer_and_write_train_metrics(metrics, step, step_time_delta)
 
     state_to_save = _split_grpo_state(state)[0]
     checkpointing.maybe_save_final_checkpoint(checkpoint_manager, state_to_save, config, data_iterator)
   except exceptions.StopTraining as e:
     max_logging.log(f"Training stopped: {str(e)}")
   finally:
-    metric_logger.cleanup()
+    metric_logger.flush_metrics_and_cleanup()
 
   return state
 

--- a/MaxText/sft_trainer.py
+++ b/MaxText/sft_trainer.py
@@ -89,8 +89,8 @@ def train_loop(config, recorder, state=None):
   metric_logger.write_setup_info_to_tensorboard(state.params)
 
   try:
+    last_step_completion = datetime.datetime.now()
     for step in np.arange(start_step, config.steps):
-      step_start_time = datetime.datetime.now()
       prof.maybe_activate_profiler(step, state)
 
       with jax.profiler.StepTraceAnnotation("train", step_num=step):
@@ -100,6 +100,9 @@ def train_loop(config, recorder, state=None):
         with maybe_record_goodput(recorder, GoodputEvent.STEP, step):
           with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
             state, metrics = p_train_step(state, example_batch, nextrng)
+
+      step_time_delta = datetime.datetime.now() - last_step_completion
+      last_step_completion = datetime.datetime.now()
 
       checkpointing.maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator, step)
 
@@ -135,16 +138,13 @@ def train_loop(config, recorder, state=None):
       if step == start_step:
         max_utils.print_mem_stats("After params initialized")
 
-      jax.block_until_ready(state)  # ensure training step is completed
-
-      step_time_delta = datetime.datetime.now() - step_start_time
-      metric_logger.record_train_metrics(metrics, step, step_time_delta)
+      metric_logger.buffer_and_write_train_metrics(metrics, step, step_time_delta)
 
     checkpointing.maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator)
   except exceptions.StopTraining as e:
     max_logging.log(f"Training stopped: {str(e)}")
   finally:
-    metric_logger.cleanup()
+    metric_logger.flush_metrics_and_cleanup()
 
   return state
 


### PR DESCRIPTION
# Description

This PR adjusts how we calculate step time, reverting to the method used before https://github.com/AI-Hypercomputer/maxtext/pull/1815. Our previous attempt to precisely measure step time involved adding `jax.block_until_ready()`, which, while accurate for individual steps, introduced an undesirable delay between `train_steps` during profiling. This delay stemmed from JAX being prevented from queuing up the next training step. To improve training performance, we're now prioritizing the ability for JAX to queue steps efficiently, even if it means a slight compromise in the precision of individual step time reports.

# Tests

```
completed step: 0, seconds: 18.665, TFLOP/s/device: 2.263, Tokens/s/device: 54.862, total_weights: 3573, loss: 0.993
completed step: 1, seconds: 9.720, TFLOP/s/device: 4.346, Tokens/s/device: 105.355, total_weights: 3253, loss: 0.993
completed step: 2, seconds: 0.164, TFLOP/s/device: 256.874, Tokens/s/device: 6226.779, total_weights: 1692, loss: 0.912
completed step: 3, seconds: 0.834, TFLOP/s/device: 50.645, Tokens/s/device: 1227.665, total_weights: 2944, loss: 1.105
completed step: 4, seconds: 0.957, TFLOP/s/device: 44.151, Tokens/s/device: 1070.256, total_weights: 3466, loss: 0.948
completed step: 5, seconds: 0.961, TFLOP/s/device: 43.949, Tokens/s/device: 1065.339, total_weights: 2420, loss: 0.946
completed step: 6, seconds: 16.063, TFLOP/s/device: 2.630, Tokens/s/device: 63.748, total_weights: 1655, loss: 1.058
completed step: 7, seconds: 0.013, TFLOP/s/device: 3333.582, Tokens/s/device: 80808.081, total_weights: 3335, loss: 1.000
completed step: 8, seconds: 0.964, TFLOP/s/device: 43.820, Tokens/s/device: 1062.227, total_weights: 1676, loss: 0.850
completed step: 9, seconds: 0.962, TFLOP/s/device: 43.895, Tokens/s/device: 1064.035, total_weights: 1676, loss: 0.965
```

Gap between two `jit_train_steps` reduced from 30ms 
<img width="967" height="698" alt="image" src="https://github.com/user-attachments/assets/bd40e755-5977-4516-abc4-9c4d40e99f27" />

to 13.8us 
<img width="1194" height="658" alt="image" src="https://github.com/user-attachments/assets/b3616f76-959f-47a0-8f11-e5f747978292" />


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
