### PR TITLE
Migrate PagedAttentionOp to use NNX

### DIFF
--- a/MaxText/inference/paged_attention.py
+++ b/MaxText/inference/paged_attention.py
@@ -20,6 +20,7 @@ WARNING: THIS FILE IS A WORK IN PROGRESS.
 import functools
 from typing import Optional
 
+import jax
 import jax.numpy as jnp
 from jax.experimental.shard_map import shard_map
 from jax.experimental.pallas.ops.tpu.paged_attention import paged_attention_kernel
@@ -27,64 +28,173 @@ from jax.sharding import PartitionSpec as P
 from jax.sharding import Mesh
 
 from flax import linen as nn
+from flax import nnx
 
 from MaxText.inference import page_manager
 from MaxText.inference import paged_attention_kernel_v2
 from MaxText.common_types import Array, DType, AxisNames, BATCH, LENGTH, HEAD, D_KV, MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
+from MaxText.layers.initializers import variable_to_logically_partitioned
 
 _use_kernel_v2 = False
 
 
-class PagedAttentionOp(nn.Module):
-  """paged-attention op"""
+def paged_attention_op_as_linen(
+    *,
+    mesh: Mesh,
+    num_pages: int,
+    tokens_per_page: int,
+    max_pages_per_slot: int,
+    max_pages_per_prefill: int,
+    pages_per_compute_block: int,
+    num_kv_heads: int,
+    kv_head_dim_size: int,
+    dtype: DType = jnp.float32,
+    attn_logits_soft_cap: float | None = None,
+    query_axis_names: AxisNames = (BATCH, LENGTH, HEAD, D_KV),
+    kv_pages_axis_names: AxisNames = ("paged_kv_heads", "num_pages", "tokens_per_page", "paged_kv_head_dim_size"),
+):
+  """A factory function to create a PagedAttentionOp as a Linen module.
 
-  mesh: Mesh
-  num_pages: int
-  tokens_per_page: int
-  max_pages_per_slot: int
-  max_pages_per_prefill: int
-  pages_per_compute_block: int
+  This function serves as a bridge to use the NNX-based `PagedAttentionOp`
+  within a Linen model. It wraps the `PagedAttentionOp` module using
+  `nnx.bridge.to_linen`, making it compatible with the Linen API. This is
+  useful for gradual migration of a codebase from Linen to NNX.
 
-  num_kv_heads: int
-  kv_head_dim_size: int
-  dtype: DType = jnp.float32
-  attn_logits_soft_cap: float | None = None
+  Args:
+    mesh: The device mesh for sharding.
+    num_pages: The total number of pages in the KV cache.
+    tokens_per_page: The number of tokens each page can hold.
+    max_pages_per_slot: The maximum number of pages a single sequence can use.
+    max_pages_per_prefill: The maximum number of pages for a prefill sequence.
+    pages_per_compute_block: The number of pages processed in one kernel block.
+    num_kv_heads: The number of key/value heads.
+    kv_head_dim_size: The dimension of each key/value head.
+    dtype: The data type for computations.
+    attn_logits_soft_cap: The soft cap for attention logits.
+    query_axis_names: The logical axis names for the query tensor.
+    kv_pages_axis_names: The logical axis names for the KV cache pages.
 
-  query_axis_names: AxisNames = (BATCH, LENGTH, HEAD, D_KV)
-  kv_pages_axis_names: AxisNames = ("paged_kv_heads", "num_pages", "tokens_per_page", "paged_kv_head_dim_size")
+  Returns:
+    A Linen module that wraps the NNX `PagedAttentionOp` module.
+  """
 
-  def init_or_get_kv_pages(self, model_mode: str):
-    """Get paged attention op."""
-    # Get existing variables if they exist
-    if self.has_variable("cache", "key_pages"):
-      key_pages_var = self.variable("cache", "key_pages")
-      value_pages_var = self.variable("cache", "value_pages")
+  return nnx.bridge.to_linen(
+      PagedAttentionOp,
+      mesh=mesh,
+      num_pages=num_pages,
+      tokens_per_page=tokens_per_page,
+      max_pages_per_slot=max_pages_per_slot,
+      max_pages_per_prefill=max_pages_per_prefill,
+      pages_per_compute_block=pages_per_compute_block,
+      num_kv_heads=num_kv_heads,
+      kv_head_dim_size=kv_head_dim_size,
+      dtype=dtype,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      query_axis_names=query_axis_names,
+      kv_pages_axis_names=kv_pages_axis_names,
+      metadata_fn=variable_to_logically_partitioned,
+  )
 
-      required_ar_shape = (self.num_kv_heads, self.num_pages, self.tokens_per_page, self.kv_head_dim_size)
-      # For AR mode, if shape doesn't match, reinitialize values but not variables
-      if key_pages_var.value.shape != required_ar_shape:
-        key_pages_var.value = jnp.zeros(required_ar_shape, dtype=self.dtype)
-        value_pages_var.value = jnp.zeros(required_ar_shape, dtype=self.dtype)
-    else:
-      kv_pages_shape = (self.num_kv_heads, self.num_pages, self.tokens_per_page, self.kv_head_dim_size)
-      key_pages_var = self.variable(
-          "cache",
-          "key_pages",
-          nn.with_logical_partitioning(jnp.zeros, self.kv_pages_axis_names),
-          kv_pages_shape,
-          self.dtype,
+
+class PagedAttentionOp(nnx.Module):
+  """An NNX module for paged attention.
+
+  This module implements the paged attention mechanism, which is an efficient
+  method for handling attention in autoregressive models with long sequences.
+  It divides the KV cache into fixed-size "pages" to manage memory dynamically.
+  """
+
+  def __init__(
+      self,
+      mesh: Mesh,
+      num_pages: int,
+      tokens_per_page: int,
+      max_pages_per_slot: int,
+      max_pages_per_prefill: int,
+      pages_per_compute_block: int,
+      num_kv_heads: int,
+      kv_head_dim_size: int,
+      dtype: DType = jnp.float32,
+      attn_logits_soft_cap: float | None = None,
+      query_axis_names: AxisNames = (BATCH, LENGTH, HEAD, D_KV),
+      kv_pages_axis_names: AxisNames = ("paged_kv_heads", "num_pages", "tokens_per_page", "paged_kv_head_dim_size"),
+      *,
+      # Not used in Embed but passed in by nnx.bridge.to_linen.
+      # TODO: Remove when bridge no longer needed
+      rngs: nnx.Rngs,
+  ):
+    """Initializes the PagedAttentionOp module.
+
+    Args:
+      mesh: The device mesh for sharding.
+      num_pages: The total number of pages in the KV cache.
+      tokens_per_page: The number of tokens each page can hold.
+      max_pages_per_slot: The maximum number of pages a single sequence can use.
+      max_pages_per_prefill: The maximum number of pages for a prefill sequence.
+      pages_per_compute_block: The number of pages processed in one kernel block.
+      num_kv_heads: The number of key/value heads.
+      kv_head_dim_size: The dimension of each key/value head.
+      dtype: The data type for computations.
+      attn_logits_soft_cap: The soft cap for attention logits.
+      query_axis_names: The logical axis names for the query tensor.
+      kv_pages_axis_names: The logical axis names for the KV cache pages.
+      rngs: The random number generators for initialization (required by NNX).
+    """
+
+    self.mesh = mesh
+    self.num_pages = num_pages
+    self.tokens_per_page = tokens_per_page
+    self.max_pages_per_slot = max_pages_per_slot
+    self.max_pages_per_prefill = max_pages_per_prefill
+    self.pages_per_compute_block = pages_per_compute_block
+    self.num_kv_heads = num_kv_heads
+    self.kv_head_dim_size = kv_head_dim_size
+    self.dtype = dtype
+    self.attn_logits_soft_cap = attn_logits_soft_cap
+    self.query_axis_names = query_axis_names
+    self.kv_pages_axis_names = kv_pages_axis_names
+
+    self.kv_pages_shape = (self.num_kv_heads, self.num_pages, self.tokens_per_page, self.kv_head_dim_size)
+
+    self.key_pages = nnx.Cache(
+        jnp.zeros(self.kv_pages_shape, dtype=self.dtype),
+        sharding=self.kv_pages_axis_names,
+    )
+    self.value_pages = nnx.Cache(
+        jnp.zeros(self.kv_pages_shape, dtype=self.dtype),
+        sharding=self.kv_pages_axis_names,
+    )
+
+  def _maybe_materialize_cache(self, cache: nnx.Cache) -> nnx.Cache:
+    """Materializes the cache if it's currently a ShapeDtypeStruct."""
+    if isinstance(cache.value, jax.ShapeDtypeStruct):
+      # This is needed because the Linen bridge lazily creates this state. We
+      # need to ensure the cache state is accessible at runtime.
+      # TODO: Delete this function when the to_linen bridge is no longer needed.
+      return nnx.Cache(
+          jnp.zeros(self.kv_pages_shape, dtype=self.dtype),
+          sharding=cache.sharding,
       )
-      value_pages_var = self.variable(
-          "cache",
-          "value_pages",
-          nn.with_logical_partitioning(jnp.zeros, self.kv_pages_axis_names),
-          kv_pages_shape,
-          self.dtype,
-      )
-    # Apply logical constraints
-    key_pages_var.value = nn.with_logical_constraint(key_pages_var.value, self.kv_pages_axis_names)
-    value_pages_var.value = nn.with_logical_constraint(value_pages_var.value, self.kv_pages_axis_names)
-    return key_pages_var, value_pages_var
+    return cache
+
+  def get_kv_pages(self):
+    """Retrieves the key and value page caches.
+
+    This method ensures the KV cache pages are materialized (if they are abstract
+    ShapeDtypeStructs, a temporary state during Linen bridge initialization) and
+    applies the necessary sharding constraints.
+
+    Returns:
+      A tuple containing the key pages and value pages caches (`nnx.Cache`).
+    """
+
+    # TODO: Remove once to_linen bridge is no longer needed
+    self.key_pages = self._maybe_materialize_cache(self.key_pages)
+    self.value_pages = self._maybe_materialize_cache(self.value_pages)
+
+    self.key_pages.value = nn.with_logical_constraint(self.key_pages.value, self.kv_pages_axis_names)
+    self.value_pages.value = nn.with_logical_constraint(self.value_pages.value, self.kv_pages_axis_names)
+    return self.key_pages, self.value_pages
 
   def pad_qkv(self, *qkv):
     """Pad input to kv_head_dim_size"""
@@ -134,17 +244,17 @@ class PagedAttentionOp(nn.Module):
   def paged_attention_v2_prefill(
       self,
       query: Array,
-      key_pages_var: nn.Variable,
-      value_pages_var: nn.Variable,
+      key_pages_cache: nnx.Cache,
+      value_pages_cache: nnx.Cache,
       page_state: page_manager.PageState,
   ) -> Array:
     """Apply ragged input Paged Attention in prefill only. The assumption
     is the batch_size is only 1
     """
     assert query.shape[0] == 1  # ensure the batch size is 0
-    # shape of key_pages_var.value is [num_kv_heads, num_pages, tokens_per_page, head_dim]
-    k_p = jnp.permute_dims(key_pages_var.value, (1, 2, 0, 3))
-    v_p = jnp.permute_dims(value_pages_var.value, (1, 2, 0, 3))
+    # shape of key_pages_cache.value is [num_kv_heads, num_pages, tokens_per_page, head_dim]
+    k_p = jnp.permute_dims(key_pages_cache.value, (1, 2, 0, 3))
+    v_p = jnp.permute_dims(value_pages_cache.value, (1, 2, 0, 3))
     c_q_l = jnp.array([0, page_state.sequence_lengths[0]])  # [0, prefill_true_length]
     num_seqs = jnp.array([1])
     query = query[0]  # [batch_size, max_num_tokens, num_kv_heads, head_dim] to [max_num_tokens, num_kv_heads, head_dim]
@@ -165,15 +275,15 @@ class PagedAttentionOp(nn.Module):
   def paged_attention_v2_decode(
       self,
       query: Array,
-      key_pages_var: nn.Variable,
-      value_pages_var: nn.Variable,
+      key_pages_cache: nnx.Cache,
+      value_pages_cache: nnx.Cache,
       page_state: page_manager.PageState,
   ) -> Array:
     """Apply ragged input Paged Attention in decode only."""
     batch_size = query.shape[0]
     query = jnp.squeeze(query, axis=1)  # [batch_size, seq_len, n_kv_head, head_dim] to [batch_size, n_kv_head, head_dim]
-    k_p = jnp.permute_dims(key_pages_var.value, (1, 2, 0, 3))
-    v_p = jnp.permute_dims(value_pages_var.value, (1, 2, 0, 3))
+    k_p = jnp.permute_dims(key_pages_cache.value, (1, 2, 0, 3))
+    v_p = jnp.permute_dims(value_pages_cache.value, (1, 2, 0, 3))
     c_q_l = jnp.arange(batch_size + 1)  # one token per sequence
     num_seqs = jnp.array([batch_size])  # real number of requests, set it to batch_size
     result = paged_attention_kernel_v2.ragged_paged_attention(
@@ -192,8 +302,8 @@ class PagedAttentionOp(nn.Module):
   def paged_attention_v1_decode(
       self,
       query: Array,
-      key_pages_var: nn.Variable,
-      value_pages_var: nn.Variable,
+      key_pages_cache: nnx.Cache,
+      value_pages_cache: nnx.Cache,
       page_state: page_manager.PageState,
   ) -> Array:
     """Apply Paged Attention v1 in decode only."""
@@ -228,14 +338,13 @@ class PagedAttentionOp(nn.Module):
 
     return wrap_paged_attention(
         query,
-        key_pages_var.value,
-        value_pages_var.value,
+        key_pages_cache.value,
+        value_pages_cache.value,
         page_state.sequence_lengths,
         page_state.page_map,
         self.pages_per_compute_block,
     )
 
-  @nn.compact
   def __call__(
       self,
       query: Array,
@@ -247,33 +356,54 @@ class PagedAttentionOp(nn.Module):
       slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
   ):
-    """Apply paged attention mechanism.
+    """Applies the paged attention mechanism.
+
+    This is the main entry point for the module. It takes query, key, and value
+    tensors and performs paged attention based on the current model mode
+    (prefill or autoregressive).
+
+    Args:
+      query: The query tensor.
+      key: The key tensor for the current step.
+      value: The value tensor for the current step.
+      decoder_segment_ids: Segment IDs for the decoder, used for masking.
+      model_mode: The current operational mode, either 'prefill' or
+        'autoregressive'.
+      previous_chunk: Information about previously processed chunks, used for
+        chunked prefill.
+      slot: The batch slot index for the current request.
+      page_state: The current state of the page manager.
 
     Returns:
-        tuple: (output, exponentials_max, exponentials_sum) where the latter two
-              are None for autoregressive mode (handled by paged_attention kernel)
+        A tuple (output, exponentials_max, exponentials_sum) containing:
+        - The attention output tensor.
+        - The max of the exponentials (for prefill mode with dot-product attention).
+        - The sum of the exponentials (for prefill mode with dot-product attention).
+        The latter two are None for autoregressive mode, as this is handled
+        internally by the paged attention kernel.
     """
-    key_pages_var, value_pages_var = self.init_or_get_kv_pages(model_mode)
+
+    key_pages_cache, value_pages_cache = self.get_kv_pages()
     query, key, value = self.pad_qkv(query, key, value)
 
     # update kv pages and call page attention kernel
     if model_mode == MODEL_MODE_PREFILL:
-      self.update_prefill_step_pages(key_pages_var, value_pages_var, key, value, slot, page_state)
+      self.update_prefill_step_pages(key_pages_cache, value_pages_cache, key, value, slot, page_state)
       if _use_kernel_v2:
-        return self.paged_attention_v2_prefill(query, key_pages_var, value_pages_var, page_state), None, None
+        return self.paged_attention_v2_prefill(query, key_pages_cache, value_pages_cache, page_state), None, None
       return self.paged_dot_product_attention_with_max_and_sum(query, key, value)
     elif model_mode == MODEL_MODE_AUTOREGRESSIVE and page_state is not None:
-      self.update_decode_step_pages(key_pages_var, value_pages_var, key, value, page_state)
+      self.update_decode_step_pages(key_pages_cache, value_pages_cache, key, value, page_state)
       if _use_kernel_v2:
-        return self.paged_attention_v2_decode(query, key_pages_var, value_pages_var, page_state), None, None
-      return self.paged_attention_v1_decode(query, key_pages_var, value_pages_var, page_state), None, None
+        return self.paged_attention_v2_decode(query, key_pages_cache, value_pages_cache, page_state), None, None
+      return self.paged_attention_v1_decode(query, key_pages_cache, value_pages_cache, page_state), None, None
     else:
       raise NotImplementedError(model_mode)
 
   def update_prefill_step_pages(
       self,
-      key_pages_var: nn.Variable,  # [num_kv_heads, num_pages, tokens_per_page, head_dim]
-      value_pages_var: nn.Variable,
+      key_pages_cache: nnx.Cache,  # [num_kv_heads, num_pages, tokens_per_page, head_dim]
+      value_pages_cache: nnx.Cache,
       key: Array,
       value: Array,
       slot: int,
@@ -285,12 +415,12 @@ class PagedAttentionOp(nn.Module):
     ), f"prefill_step key/value should have the same shape, but getting {key.shape=} and {value.shape=} instead"
     batch_size, seq_len, n_kv_head, head_dim = key.shape
     assert seq_len % self.tokens_per_page == 0, f"seq_length {seq_len} and  tokens_per_page {self.tokens_per_page}"
-    assert key_pages_var.value.shape == value_pages_var.value.shape, (
-        f"prefill_step key/value_pages_var should have the same shape, but "
-        f"getting {key_pages_var.shape=} and {value_pages_var.shape=} instead"
+    assert key_pages_cache.value.shape == value_pages_cache.value.shape, (
+        f"prefill_step key/value_pages_cache should have the same shape, but "
+        f"getting {key_pages_cache.shape=} and {value_pages_cache.shape=} instead"
     )
 
-    v_n_kv, _, v_p, v_d = key_pages_var.value.shape
+    v_n_kv, _, v_p, v_d = key_pages_cache.value.shape
     assert v_n_kv == n_kv_head, f"{v_n_kv=} {n_kv_head=}"
     assert v_p == self.tokens_per_page, f"{v_p=} {self.tokens_per_page=}"
     assert v_d == head_dim, f"{v_d=} {head_dim=}"
@@ -310,13 +440,13 @@ class PagedAttentionOp(nn.Module):
     key = jnp.reshape(key, shape=(n_kv_head, max(1, seq_len // self.tokens_per_page), self.tokens_per_page, head_dim))
     value = jnp.reshape(value, shape=(n_kv_head, max(1, seq_len // self.tokens_per_page), self.tokens_per_page, head_dim))
 
-    key_pages_var.value = nn.with_logical_constraint(key, self.kv_pages_axis_names)
-    value_pages_var.value = nn.with_logical_constraint(value, self.kv_pages_axis_names)
+    key_pages_cache.value = nn.with_logical_constraint(key, self.kv_pages_axis_names)
+    value_pages_cache.value = nn.with_logical_constraint(value, self.kv_pages_axis_names)
 
-  def update_decode_step_pages(self, key_pages_var, value_pages_var, key, value, page_state):
+  def update_decode_step_pages(self, key_pages_cache, value_pages_cache, key, value, page_state):
     """Update decode-step pages"""
-    key_pages = key_pages_var.value
-    value_pages = value_pages_var.value
+    key_pages = key_pages_cache.value
+    value_pages = value_pages_cache.value
 
     batch_size, _, kv_heads, head_dim = key.shape
     kv_heads, _, _, head_dim = key_pages.shape
@@ -336,6 +466,6 @@ class PagedAttentionOp(nn.Module):
     key_pages_updated = key_pages.at[kv_indices, broadcast_pages, broadcast_pos].set(new_key)
     value_pages_updated = value_pages.at[kv_indices, broadcast_pages, broadcast_pos].set(new_value)
 
-    key_pages_var.value = key_pages_updated
-    value_pages_var.value = value_pages_updated
-    return key_pages_var, value_pages_var
+    key_pages_cache.value = key_pages_updated
+    value_pages_cache.value = value_pages_updated
+    return key_pages_cache, value_pages_cache

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -1460,7 +1460,7 @@ class Attention(nn.Module):
     # When paged attention is enabled, paged attention op is used for all model modes except TRAIN,
     # which uses default attention op.
     if self.config.attention == "paged":
-      self.paged_attention_op = paged_attention.PagedAttentionOp(
+      self.paged_attention_op = paged_attention.paged_attention_op_as_linen(
           mesh=self.mesh,
           num_pages=self.config.pagedattn_num_pages,
           tokens_per_page=self.config.pagedattn_tokens_per_page,
@@ -1942,7 +1942,7 @@ class MLA(Attention):
       if self.config.pagedattn_head_dim_alignment > 0:
         alignment = self.config.pagedattn_head_dim_alignment
         head_dim = (head_dim + alignment - 1) // alignment * alignment
-      self.ds_paged_attention_op = paged_attention.PagedAttentionOp(
+      self.ds_paged_attention_op = paged_attention.paged_attention_op_as_linen(
           mesh=self.mesh,
           num_pages=self.config.pagedattn_num_pages,
           tokens_per_page=self.config.pagedattn_tokens_per_page,


### PR DESCRIPTION
# Description

Use NNX for the PagedAttentionOp module.

* Change module to NNX
* Move `init_or_get_kv_pages` logic to `__init__` and `get_kv_pages`
* Create bridge to Linen function and use it where the PagedAttentionOp module is invoked

# Tests

Ran decode with `attention=paged` and the output is still generated. I didn't use a checkpoint but the text generation output matches main.

```
python3 -m MaxText.decode MaxText/configs/base.yml \
    model_name=llama3.1-8b \
    tokenizer_path=assets/tokenizer_llama3.tiktoken \
    tokenizer_type=tiktoken \
    attention=paged \
    scan_layers=false \
    per_device_batch_size=1 \
    ici_fsdp_parallelism=1 \
    ici_autoregressive_parallelism=-1 \
    max_prefill_predict_length=128 \
    max_target_length=256 \
    prompt="I love to"
```

@vipannalla @patemotter please let me know if there are better inference tests (besides the unit tests) to confirm this is still working properly.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
