### PR TITLE
Deepseek-v3 MTP enhancements  

### DIFF
--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -136,6 +136,7 @@ class Transformer(nn.Module):
         dummy_shape = decoder_input_tokens.shape
         decoder_target_tokens = jnp.ones(dummy_shape, dtype=jnp.int32)
         decoder_target_mask = jnp.ones(dummy_shape, dtype=jnp.int32)
+        decoder_segment_ids = jnp.ones(dummy_shape, dtype=jnp.int32)
 
     # The Multi-Token Prediction (MTP) block functions as a "side-car" to the main
     # model, active only during training. It computes an auxiliary loss based on

--- a/MaxText/layers/multi_token_prediction.py
+++ b/MaxText/layers/multi_token_prediction.py
@@ -137,7 +137,7 @@ class MultiTokenPredictionLayer(nn.Module):
 
     # --- 2. Concatenate Normalized Representations ---
     # Shape: [B, S, 2*H]
-    concatenated_features = jnp.concatenate([hidden_state_norm, embedding_norm], axis=-1)
+    concatenated_features = jnp.concatenate([embedding_norm, hidden_state_norm], axis=-1)
 
     # --- 3. Project Concatenated Features ---
     # Projects from 2*H back down to H
@@ -146,6 +146,7 @@ class MultiTokenPredictionLayer(nn.Module):
         out_features_shape=cfg.base_emb_dim,
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
+        use_bias=False,
         kernel_axes=("concat_embed", "embed"),
         name=f"mtp_{k}_projection",
     )
@@ -225,7 +226,7 @@ class MultiTokenPredictionBlock(nn.Module):
       )
 
       next_mtp_hidden_state = mtp_layer(
-          mtp_hidden_state, target_token_embedding, rolled_position_id, decoder_segment_ids, deterministic, model_mode
+          mtp_hidden_state, target_token_embedding, position_ids, decoder_segment_ids, deterministic, model_mode
       )
 
       # Project to logits using the shared embedding transpose

--- a/MaxText/metric_logger.py
+++ b/MaxText/metric_logger.py
@@ -59,6 +59,10 @@ class MetricLogger:
     self.cumulative_eval_metrics = {"scalar": defaultdict(float)}
     self.buffered_train_metrics = None
 
+  def reset_eval_metrics(self):
+    """Resets the cumulative metrics dictionary for a new evaluation run."""
+    self.cumulative_eval_metrics = {"scalar": defaultdict(float)}
+
   def write_metrics(self, metrics, step, is_training=True):
     """Entry point for all metrics writing in Train's Main."""
     if metrics:
@@ -77,7 +81,7 @@ class MetricLogger:
     """Logs metrics via max_logging."""
 
     if is_training:
-      loss = metrics['scalar']['learning/loss']
+      loss = metrics["scalar"]["learning/loss"]
       log_message = (
           f"completed step: {step}, seconds: {metrics['scalar']['perf/step_time_seconds']:.3f}, "
           f"TFLOP/s/device: {metrics['scalar']['perf/per_device_tflops_per_sec']:.3f}, "

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -656,6 +656,10 @@ def train_loop(config, recorder, state=None):
 
       if config.eval_interval > 0 and step > start_step and (step + 1) % config.eval_interval == 0:
         assert eval_data_iterator
+
+        # Explicitly reset the eval counters before starting the eval loop
+        metric_logger.reset_eval_metrics()
+
         eval_step_count = 0
         # pylint: disable=not-callable
         for eval_batch in eval_data_iterator:

--- a/end_to_end/tpu/deepseek/Run_DeepSeek.md
+++ b/end_to_end/tpu/deepseek/Run_DeepSeek.md
@@ -19,7 +19,7 @@
 DeepSeek is a novel family of open-weights sparse MoE models by DeepSeek AI. DeepSeek-V3 features advanced techniques, including Multi-Head Latent Attention (MLA), finer-grained and shared experts, Multi-Token Prediction (MTP), and FP8 mixed precision designed for enhanced efficiency and performance. The currently supported models are DeepSeek V3 (671B) and DeepSeek V2-Lite (16B).
 
 Please note:
-* MTP and FP8 mixed precision is not supported yet.
+* FP8 mixed precision is not supported yet.
 * To leverage MLA with Flash Attention, ensure you have the latest JAX version.
 * The provided TPU configurations are examples and not mandatory.
 
@@ -51,7 +51,7 @@ python3 -m MaxText.train MaxText/configs/base.yml \
 
 ## Checkpoint conversion
 To get started, follow the instructions at HuggingFace ([V3](https://huggingface.co/deepseek-ai/DeepSeek-V3), [V2-Lite](https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite)) to download the model. Currently, for V3, please convert it from FP8 to BF16 using script [here](https://github.com/deepseek-ai/DeepSeek-V3/blob/a878eada08ea6913f5a2ae80a43afeffdef082ef/inference/fp8_cast_bf16.py). Once downloaded and converted to BF16:
-* run [convert_deepseek_ckpt.py](../../../MaxText/convert_deepseek_ckpt.py) to convert the checkpoint for MaxText compatibility in [Orbax](https://orbax.readthedocs.io/en/latest/guides/checkpoint/orbax_checkpoint_101.html) for training and fine-tuning.
+* run [convert_deepseek_ckpt.py](../../../MaxText/convert_deepseek_ckpt.py) to convert the checkpoint for MaxText compatibility in [Orbax](https://orbax.readthedocs.io/en/latest/guides/checkpoint/orbax_checkpoint_101.html) for training and fine-tuning. When converting a checkpoint with MTP layers (like DeepSeek-V3), be sure to add the `--enable_mtp` flag to process them correctly.
 * run [convert_deepseek_unscanned_ckpt.py](../../../MaxText/convert_deepseek_unscanned_ckpt.py) to convert the checkpoint to unscanned version in Orbax for decoding.
 
 
@@ -82,6 +82,27 @@ python3 -m MaxText.train MaxText/configs/base.yml \
     enable_checkpointing=true \
     ici_expert_parallelism=128 \
     ici_fsdp_parallelism=1
+```
+
+Fine-tuning with MTP on v5p-256
+
+```sh
+python3 -m MaxText.train MaxText/configs/base.yml \
+    base_output_directory=gs://your-output-bucket/ \
+    dataset_path=gs://your-dataset-bucket/ \
+    load_parameters_path=gs://your-bucket/deepseek-v3/0/items \
+    run_name=deepseek_mtp_finetuning \
+    per_device_batch_size=4 \
+    model_name=deepseek3-671b \
+    steps=10000 \
+    max_target_length=2048 \
+    ici_fsdp_parallelism=128 \
+    attention=flash \
+    tokenizer_type=huggingface \
+    tokenizer_path=deepseek-ai/DeepSeek-V3 \
+    # MTP-specific flags
+    mtp_num_layers=1 \
+    mtp_loss_scaling_factor=0.1
 ```
 
 One example command to run supervised finetuning with V3 on v5p-256. Supervised fine-tuning is only working with HuggingFace conversational datasets. And, you can customize the dataset path using the `hf_path` config and provide your access token with `hf_access_token` config.

--- a/end_to_end/tpu/deepseek/v3-671b/test_deepseek_mtp.sh
+++ b/end_to_end/tpu/deepseek/v3-671b/test_deepseek_mtp.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This file is documentation for how to get started with DeepSeek v3 MTP on v5p-256.
+
+# The flow of this file is as follows:
+# 1. Convert the checkpoint downloaded from HuggingFace to a MaxText-compatible format, including MTP layers.
+# 2. Run fine-tuning with MTP enabled.
+
+set -ex
+idx=$(date +%Y-%m-%d-%H-%M)
+export MODEL_NAME='deepseek3-671b'
+export TOKENIZER_PATH='deepseek-ai/DeepSeek-V3'
+
+# Step 1: Convert the HuggingFace Checkpoint with MTP Enabled
+# Note: Non-Googlers should use their own GCS buckets.
+# The --enable_mtp flag is crucial for processing the MTP-specific layers.
+export CHKPT_BUCKET=gs://maxtext-deepseek/deepseek3-671b/hf
+export MODEL_BUCKET=gs://maxtext-deepseek/deepseek3-671b
+JAX_PLATFORMS=cpu python3 -m MaxText.convert_deepseek_ckpt \
+    --base_model_path ${CHKPT_BUCKET} \
+    --maxtext_model_path ${MODEL_BUCKET}/${idx} \
+    --model_size ${MODEL_NAME} \
+    --enable_mtp
+
+# Step 2: Set up Checkpoint Path
+# We will use the 'scanned' checkpoint directly for fine-tuning.
+export CONVERTED_CHECKPOINT=${MODEL_BUCKET}/${idx}/0/items
+
+# Step 3: Run Training
+# Note: Non-Googlers should point DATASET_PATH and BASE_OUTPUT_DIRECTORY to their own GCS buckets.
+export DATASET_PATH=gs://maxtext-dataset
+export BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs
+
+# Run fine-tuning with MTP enabled
+# We add `mtp_num_layers=1` and `mtp_loss_scaling_factor=0.1` to activate the MTP block.
+python3 -m MaxText.train MaxText/configs/base.yml \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY} \
+    dataset_path=${DATASET_PATH} \
+    load_parameters_path=${CONVERTED_CHECKPOINT} \
+    run_name=mtp_fine_tuning_${idx} \
+    per_device_batch_size=4 \
+    model_name=${MODEL_NAME} \
+    ici_fsdp_parallelism=128 \
+    steps=10000 \
+    max_target_length=2048 \
+    tokenizer_type=huggingface \
+    tokenizer_path=${TOKENIZER_PATH} \
+    attention=flash \
+    dtype=bfloat16 \
+    weight_dtype=bfloat16 \
+    enable_checkpointing=true \
+    mtp_num_layers=1 \
+    mtp_loss_scaling_factor=0.1


### PR DESCRIPTION
### Description

This PR provides enhancements to the recently added Multi-Token Prediction (MTP) support. 

The key changes in this pull request include:

-   **Corrects MTP Projection Layer:** Adds `use_bias=False` to the `dense_general` projection layer within the MTP block.

-   **Fixes Positional Encoding Logic:** Ensures the internal MTP attention block receives the original, un-rolled `position_ids`.

-   **Resolves Cumulative Metric Bug:** Implements a `reset_eval_metrics()` method in `MetricLogger` and calls it from the main training loop. This prevents the `avg_mtp_acceptance_rate` and other evaluation statistics from accumulating incorrectly across multiple eval runs.

-   **Adds Documentation and Testing:** Includes a new end-to-end test script (`test_deepseek_mtp.sh`) and updates the `Run_DeepSeek.md` documentation with clear instructions on how to use the MTP feature.

-   **Fixes:** Includes fixes like standardizing the MTP input concatenation order.

### Tests

**Evaluation Metrics:** The `avg_mtp_acceptance_rate` was observed over multiple evaluation intervals and confirmed to report correctly without erroneous accumulation.

### Checklist

Before submitting this PR, please make sure (put X in square brackets):

-   [X] I have performed a self-review of my code.
-   [X] I have necessary comments in my code, particularly in hard-to-understand areas.
-   [X] I have run end-to-end tests tests and provided workload links above if applicable.
-   [X] I have made or will make corresponding changes to the doc if needed.