### PR TITLE
Change shardy to default + make shardy configurable

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -683,6 +683,8 @@ allow_split_physical_axes: False
 # Apply transformations to the mesh to optimize for TPU v6e
 optimize_mesh_for_tpu_v6e: False
 
+shardy: True # Whether to use shardy XLA backend (default in Jax starting 0.7.0), or GSPMD (to be fully deprecated ~2026)
+
 use_ragged_attention: False
 ragged_block_size: 256
 

--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -88,6 +88,7 @@ def main(argv: Sequence[str]) -> None:
 
   config = pyconfig.initialize(argv)
   _validate_config(config)
+  jax.config.update("jax_use_shardy_partitioner", config.shardy)
   max_utils.print_system_information()
 
   engine = maxengine.MaxEngine(config)

--- a/MaxText/elastic_train.py
+++ b/MaxText/elastic_train.py
@@ -370,6 +370,7 @@ def main(argv: Sequence[str]) -> None:
   elastic_manager = elastic_initialize(jax.devices())
 
   config = pyconfig.initialize(argv)
+  jax.config.update("jax_use_shardy_partitioner", config.shardy)
   max_utils.print_system_information()
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path or ""

--- a/MaxText/experimental/rl/grpo_trainer.py
+++ b/MaxText/experimental/rl/grpo_trainer.py
@@ -755,6 +755,7 @@ def main(argv: Sequence[str]) -> None:
   )
   if config.per_device_batch_size < 1.0 or config_inference.per_device_batch_size < 1.0:
     raise ValueError("GRPO does not support setting per_device_batch_size < 1.0")
+  jax.config.update("jax_use_shardy_partitioner", config.shardy)
   max_utils.print_system_information()
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path

--- a/MaxText/sft_trainer.py
+++ b/MaxText/sft_trainer.py
@@ -158,6 +158,7 @@ def main(argv: Sequence[str]) -> None:
   if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
     os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
   config = pyconfig.initialize(argv)
+  jax.config.update("jax_use_shardy_partitioner", config.shardy)
   max_utils.print_system_information()
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path

--- a/MaxText/tests/integration_tests/train_tests.py
+++ b/MaxText/tests/integration_tests/train_tests.py
@@ -330,6 +330,7 @@ class TrainTests(unittest.TestCase):
         "enable_goodput_recording=False",
         "attention=cudnn_flash_jax",
         "packing=False",
+        "shardy=False", # The cudnn kernel is not compatible with shardy, see (b/425746362).
         rf"tokenizer_path={os.path.join(os.path.dirname(PKG_DIR), 'assets', 'tokenizer.llama2')}",
     ]
     train_main(cudnn_flash_jax)
@@ -338,6 +339,10 @@ class TrainTests(unittest.TestCase):
   @pytest.mark.tpu_only
   def test_tpu_base_model_ag_once(self):
     train_main(TrainTests.CONFIGS["base"] + ["model_fsdp_ag_once=True"])
+
+  @pytest.mark.integration_test
+  def test_base_model_shardy_false(self):
+    train_main(TrainTests.CONFIGS["base"] + ["shardy=False"])
 
   @pytest.mark.integration_test
   @pytest.mark.gpu_only

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -701,6 +701,7 @@ def initialize(argv: Sequence[str]) -> Tuple[pyconfig.HyperParameters, Any, Any]
   # TODO: mazumdera@ : ensure missing mandatory fields in base.yml are filled in in argv,
   # or fill in here
   config = pyconfig.initialize(argv)
+  jax.config.update("jax_use_shardy_partitioner", config.shardy)
   max_utils.print_system_information()
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path or ""


### PR DESCRIPTION
# Description

Change the default XLA backend to shardy. Shardy is an alternative to GSPMD which should give higher performance in the majority of cases. There are no jax/user level changes needed to support shardy other than setting the jax config to use shardy `jax.config.update("jax_use_shardy_partitioner", True)`

Unfortunately the above line was added for all trainers (train.py, sft, etc), it is difficult to refactor into a shared initialize method until we clean up how we call `jax.distributed.initialize()` (tracked in b/432512350)

 
# Tests

Ran on some models, saw no regressions (actually identical performance, but can confirm shardy is used with verbose libtpu logs like `Using Shardy for XLA SPMD propagation`

| Model | Hardware | Shardy? | MFU | Peak HBM (GB) |
|---|---|---|---|---|
| **Llama405B** | 2x v6e-256 | Yes | 39% | 25.8 |
| **Llama405B** | 2x v6e-256 | No | 39% | 25.8 |
| **DeepSeekV3** | 1x v5p-512 | Yes | 29% | 81.6 |
| **DeepSeekV3** | 1x v5p-512 | No | 29% | 81.6 |

Also added unit test for the (new) non-default case so both cases stay protected

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
