### PR TITLE
Fix passing bidirectional mask for multimodal

### DIFF
--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -257,7 +257,7 @@ class Gemma3ScannableBlock(nn.Module):
           previous_chunk=previous_chunk,
           page_state=page_state,
           slot=slot,
-          bidirectional_mask=None,
+          bidirectional_mask=bidirectional_mask,
       )
       if cfg.scan_layers:
         y = y[0]

--- a/MaxText/layers/llama4.py
+++ b/MaxText/layers/llama4.py
@@ -374,6 +374,7 @@ class Llama4DecoderLayer(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      bidirectional_mask=None,
       slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
       previous_chunk=None,
@@ -444,6 +445,7 @@ class Llama4DecoderLayer(nn.Module):
         slot=slot,
         page_state=page_state,
         previous_chunk=previous_chunk,
+        bidirectional_mask=bidirectional_mask,
     )
 
     attention_lnx = nn.with_logical_constraint(
@@ -548,6 +550,7 @@ class Llama4ScannableBlock(nn.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      bidirectional_mask=None,
       slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
       previous_chunk=None,
@@ -579,6 +582,7 @@ class Llama4ScannableBlock(nn.Module):
           previous_chunk=previous_chunk,
           page_state=page_state,
           slot=slot,
+          bidirectional_mask=bidirectional_mask,
       )
       if cfg.scan_layers:
         y = y[0]

--- a/MaxText/multimodal_utils.py
+++ b/MaxText/multimodal_utils.py
@@ -107,7 +107,7 @@ def load_image_from_path(image_path):
   try:
     image = Image.open(image_path).convert("RGB")
     image.load()  # Load image data to catch errors early
-    return jnp.asarray(np.array(image))
+    return np.asarray(image)
 
   except (IOError, OSError) as e:
     raise IOError(f"Error loading image from {image_path}") from e
@@ -322,7 +322,7 @@ def pre_process_gemma3_image(image):
   if pil_img.size[0] > target_size[0] or pil_img.size[1] > target_size[1]:
     resample_method = Image.Resampling.LANCZOS
   resized_pil_img = pil_img.resize(target_size, resample=resample_method)
-  image = np.array(resized_pil_img)
+  image = np.asarray(resized_pil_img, dtype=np.float32)
   image = _normalize_images(image, mean=GEMMA_IMAGE_MEAN, std=GEMMA_IMAGE_STD)
   image = np.clip(image, -1, 1)
   processor_output = PreprocessorOutput(
@@ -402,7 +402,7 @@ def pre_process_image(image, model_name):
   """
   if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
     return pre_process_gemma3_image(image)
-  elif model_name in ["llama4-17b-16e", "llama4-70b-16e"]:
+  elif model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
     return pre_process_llama4_image(image)
   else:
     raise ValueError(f"Model {model_name} does not support multimodal inference.")


### PR DESCRIPTION
# Description
The argument bidirectional_mask, which indicates the image placeholder tokens in the text input, was not passed correctly to text-image attention in some cases. 
After this change:

# Tests
* Verified by inserting jax.debug.print in the attention module.
* bidirectional_mask is passed correctly (tested) in: Gemma3 unscan, Llama4 unscan, Llama4 scan. 
* gemma3 scan is not tested, will test after gemma3 SFT is enabled.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
