### PR TITLE
fix context parallelism without load balancing

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -880,7 +880,8 @@ class AttentionOp(nnx.Module):
               decoder_segment_ids_q, decoder_segment_ids_unpermuted
           )
         else:
-          decoder_segment_ids_tuple = splash_attention_kernel.SegmentIds(decoder_segment_ids_q, decoder_segment_ids_q)
+          # if cp=1, decoder_segment_ids_q is the same as decoder_segment_ids_kv
+          decoder_segment_ids_tuple = splash_attention_kernel.SegmentIds(decoder_segment_ids_q, decoder_segment_ids_kv)
       else:
         decoder_segment_ids_tuple = None
       attention_output = jax.vmap(splash_kernel)(query, key, value, segment_ids=decoder_segment_ids_tuple)


### PR DESCRIPTION
# Description

Pretraining with flash attention on tpu: context parallelism, with no load balancing

Produces error: `ValueError: Invalid shape for kv segment_ids: (512,). Expected: (2048,)`

Experiment: 
- Using `ici_context_parallelism=4` and `context_parallel_load_balance=False` on v5p-8 
- This run uses gemma-2b. (Same error when replacing with llama2-7b.)
```
BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs && RUNNAME=cp-test-$(date +%Y-%m-%d-%H-%M-%S) && clear 
python3 -m MaxText.train MaxText/configs/base.yml base_output_directory=$BASE_OUTPUT_DIRECTORY dataset_path=gs://maxtext-dataset run_name=$RUNNAME per_device_batch_size=1 enable_checkpointing=false model_name=gemma-2b max_target_length=2048 async_checkpointing=false attention=flash dtype=bfloat16 weight_dtype=bfloat16 opt_type=sgd \
steps=5 packing=False ici_context_parallelism=4 context_parallel_load_balance=False 
```





# Tests

on local v5p-8

1 end-to-end test with the same command. can run without error.
log: https://paste.googleplex.com/5953543772831744

2 unit test can still pass. [MaxText.tests.attention_test.AttentionTest.test_tpu_kernel_attention_mha](https://github.com/AI-Hypercomputer/maxtext/blob/2adc3bab1cea2e5a335b9e4c053c868155da2089/MaxText/tests/attention_test.py#L479)
```
clear && python3 -m unittest MaxText.tests.attention_test.AttentionTest.test_tpu_kernel_attention_mha
```
log: https://paste.googleplex.com/6407937152778240

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
