### PR TITLE
Fix mask shape for TPU attention for inference 

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -764,7 +764,7 @@ class AttentionOp(nnx.Module):
         v_layout=splash_attention_kernel.QKVLayout[global_v_layout],
     )
 
-    mask_shape = (self.config.max_target_length, self.config.max_target_length)
+    mask_shape = (query.shape[2], key.shape[2])  # (q_seq_len, kv_seq_len)
     if self.attention_type == AttentionType.FULL:
       mask = splash_attention_mask.FullMask(mask_shape)
     else:


### PR DESCRIPTION
# Description

This PR fixes the shape mismatch if we are using `max_prefill_predict_length=1024` so that our input is shorter than `max_target_length`, we need to use the mask shape dynamically and not hardcode to `max_target_length`.


FIXES: https://github.com/AI-Hypercomputer/maxtext/issues/1993



# Tests
I ran the following on a `v6e-8` and am able to successfully start the max_engine server. I didn't load a checkpoint since I don't have a gemma-7b checkpoint at the moment

```
python3 -m MaxText.maxengine_server   \
MaxText/configs/base.yml   \
tokenizer_path=assets/tokenizer.gemma    \
max_prefill_predict_length=1024   max_target_length=2048   \
model_name=gemma-7b   ici_fsdp_parallelism=1   \
ici_autoregressive_parallelism=1   ici_tensor_parallelism=8   \
scan_layers=false   weight_dtype=bfloat16   \
per_device_batch_size=11
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
