### PR TITLE
[Qwix] int8 config

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -110,7 +110,9 @@ save_quantized_params_path: ""
 # when left as is, corresponds to training
 # accepted values are "inference"
 model_call_mode: ""
-
+qwix: False # Whether to use qwix for quantization. If set to True, the model will be quantized using qwix.
+# Quantization calibration method used for weights and activations. Supported methods can be found in https://github.com/google/qwix/blob/dc2a0770351c740e5ab3cce7c0efe9f7beacce9e/qwix/qconfig.py#L70-L80
+quantization_calibration_method: "absmax"
 # Shard the range finding operation for quantization. By default this is set to number of slices.
 quantization_local_shard_count: -1
 

--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -26,6 +26,8 @@ from aqt.jax.v2.flax import aqt_flax
 from aqt.jax.v2 import tiled_dot_general
 from aqt.jax.v2 import calibration
 
+import qwix
+
 import jax
 import jax.numpy as jnp
 from jax.tree_util import tree_flatten_with_path, tree_unflatten
@@ -545,6 +547,8 @@ def get_quant_mode(quant_mode_str: str = "train"):
 
 def configure_quantization(config: Config, quant_mode_str: str = "train"):
   """Configure quantization based on user config and quant mode."""
+  if config.qwix:
+    return None
   quant_cfg = _get_quant_config(config)
   if quant_cfg:
     if quant_cfg == "fp8":
@@ -606,3 +610,44 @@ def remove_quantized_params(params, aqt_vars):
 
 def configure_kv_quant(config):
   return None if not config.quantize_kvcache else KVQuant(config)
+
+
+def get_basic_config(config, dtype):
+  rules = [
+      qwix.qt.QtRule(
+        module_path='.*',  # Apply to all modules
+        weight_qtype=dtype,
+        act_qtype=dtype,
+        bwd_weight_grad_tile_size = 1 / config.quantization_local_shard_count
+      )
+    ]
+  return rules
+
+
+def get_fp8_config(config):
+  rules = [
+      qwix.qt.QtRule(
+        module_path='.*',  # Apply to all modules
+        weight_qtype=jnp.float8_e5m2,
+        act_qtype=jnp.float8_e5m2,
+        bwd_qtype=jnp.float8_e4m3fn,
+        bwd_use_original_residuals=True,
+        disable_channelwise_axes=True, # per_tensor calibration
+        weight_calibration_method = config.quantization_calibration_method,
+        act_calibration_method = config.quantization_calibration_method,
+        bwd_calibration_method = config.quantization_calibration_method,
+      )
+    ]
+  return rules
+
+def get_rules(config):
+  """Get quantization rules based on the config."""
+  if config.quantization == "int8":
+    return get_basic_config(config, jnp.int8)
+  if config.quantization == "fp8":
+    return get_basic_config(config, jnp.float8_e4m3fn)
+  if config.quantization == "fp8_full":
+    return get_fp8_config(config)
+  return None
+
+

--- a/MaxText/train_utils.py
+++ b/MaxText/train_utils.py
@@ -24,6 +24,8 @@ from MaxText import optimizers
 from MaxText import checkpointing
 from MaxText import maxtext_utils
 
+import qwix
+
 
 def get_transformer_model(config, mesh, quant):
   if config.model_fsdp_ag_once:
@@ -37,6 +39,11 @@ def create_model(config, mesh):
   # Model definition
   quant = quantizations.configure_quantization(config)
   model = get_transformer_model(config, mesh, quant)
+  if config.qwix:
+    assert quant is None, "Using Qwix, quantizations.configure_quantization should return None."
+    quantization_rules = quantizations.get_rules(config)
+    if quantization_rules:
+      model = qwix.quantize_model(model, qwix.QtProvider(quantization_rules))
   return model
 
 


### PR DESCRIPTION
# Description

This PR adds an option to use Qwix for quantization and adds an int8 config similar to its AQT counterpart `_get_int8_quant_config`

AQT Config we are replacing in this PR:
```
def _get_int8_quant_config(config):
  drhs_bits = None
  drhs_accumulator_dtype = None
  drhs_local_aqt = None
  if config.quantization_local_shard_count != 0:
    drhs_bits = 8
    drhs_accumulator_dtype = jnp.int32
    drhs_local_aqt = aqt_config.LocalAqt(contraction_axis_shard_count=config.quantization_local_shard_count)
  return aqt_config.config_v3(
      fwd_bits=8,
      dlhs_bits=8,
      drhs_bits=drhs_bits,
      rng_type="jax.uniform",
      dlhs_local_aqt=None,
      drhs_local_aqt=drhs_local_aqt,
      fwd_accumulator_dtype=jnp.int32,
      dlhs_accumulator_dtype=jnp.int32,
      drhs_accumulator_dtype=drhs_accumulator_dtype,
  )
  ```

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
