### PR TITLE
Add support for EP to context parallelism in self-attention

### DIFF
--- a/MaxText/common_types.py
+++ b/MaxText/common_types.py
@@ -31,14 +31,18 @@ AxisNames = tuple[str, ...]
 AxisIdxes = tuple[int, ...]
 
 BATCH = "activation_batch"
+BATCH_NO_EXP = "activation_batch_no_exp"
 LENGTH = "activation_length"
+LENGTH_NO_EXP = "activation_length_no_exp"
 PREFILL_LENGTH = "prefill_activation_length"
 Q_LENGTH = "activation_q_length"
+Q_LENGTH_NO_EXP = "activation_q_length_no_exp"
 KV_LENGTH = "activation_kv_length"
 EMBED = "activation_embed"
 HEAD = "activation_heads"
 PREFILL_KV_BATCH = "activation_prefill_kv_batch"
 KV_BATCH = "activation_kv_batch"
+KV_BATCH_NO_EXP = "activation_kv_batch_no_exp"
 KV_HEAD = "activation_kv_heads"
 KV_HEAD_DIM = "activation_kv_head_dim"
 D_KV = "activation_kv"
@@ -59,6 +63,9 @@ MODEL_MODE_AUTOREGRESSIVE = "autoregressive"
 MODEL_MODE_PREFILL = "prefill"
 MODEL_MODE_TRAIN = "train"
 MODEL_MODE_INSERT = "insert"
+
+# expert_shard_attention_option
+EP_AS_CONTEXT = "context"
 
 DECODING_ACTIVE_SEQUENCE_INDICATOR = 1
 

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -169,6 +169,11 @@ tile_batch_seq: 512
 tile_activation_dim: 1024
 tile_weight_dim: 1024
 
+# How the expert axis is used to shard attention weights and activations
+# "fsdp" (ep acts as fsdp parallelism)
+# "context" (ep acts as context parallelism, training only)
+expert_shard_attention_option: "fsdp"
+
 # deepseek moe
 base_moe_mlp_dim: 7168 # intermediate dimension at MoE layer (use base_mlp_dim if not DeepSeek style)
 first_num_dense_layers: 0 # number of initial dense layers in the model
@@ -183,7 +188,7 @@ topk_routing_group: -1 # number of top groups to route inputs. For EP,
 # For complex architectures like llama4 there are repeated sets of
 # inhomogeneous layers. E.g. maverick uses [dense+rope, moe+rope, dense+rope, moe+nope]
 # which can only be scanned together in one large block of inhomogeneous_layer_cycle_interval=4 layers.
-inhomogeneous_layer_cycle_interval: 1 
+inhomogeneous_layer_cycle_interval: 1
 
 # pipeline parallelism
 # The number of decoder layers is equal to the product of num_stages, num_layers_per_pipeline_stage and num_pipeline_repeats.
@@ -317,18 +322,22 @@ logical_axis_rules: [
                       ['activation_embed_and_logits_batch', ['data', 'stage', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_heads', ['tensor', 'tensor_transpose', 'sequence','tensor_sequence','autoregressive']],
                       ['activation_kv_heads', ['tensor', 'tensor_transpose', 'sequence','tensor_sequence']],
-                      ['activation_length', ['sequence', 'context']],
-                      ['prefill_activation_length', ['sequence', 'context']],
-                      ['activation_length', ['context']],
+                      ['activation_length', ['sequence', 'context', 'expert']],
+                      ['activation_length', ['context', 'expert']],
+                      ['activation_length_no_exp', ['sequence', 'context']],
+                      ['activation_length_no_exp', ['context']],
                       ['activation_norm_length', ['tensor_sequence', 'context', 'sequence']],
+                      ['activation_q_length', ['context', 'expert']],
+                      ['activation_q_length_no_exp', ['context']],
+                      ['prefill_activation_length', ['sequence', 'context']],
                       ['prefill_activation_norm_length', ['tensor_sequence', 'context', 'sequence']],
-                      ['activation_q_length', ['context']],
                       ['activation_kv_length', []],
                       ['activation_embed', ['tensor', 'tensor_transpose']],
                       ['activation_mlp', ['tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['activation_kv', ['tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['activation_prefill_kv_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_kv_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
+                      ['activation_kv_batch_no_exp', ['data', 'fsdp', 'fsdp_transpose']],
                       ['activation_kv_head_dim', ['tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['activation_vocab', ['tensor', 'tensor_transpose', 'sequence', 'tensor_sequence']],
                       ['activation_vocab', ['tensor', 'tensor_transpose']],
@@ -766,7 +775,7 @@ image_path: "" # Local image path used for decoding
 image_placeholder: "<|image|>"
 
 ### llama4 multi modal configs
-hidden_size_for_vit: 1408 
+hidden_size_for_vit: 1408
 intermediate_size_for_vit: 5632
 num_attention_heads_for_vit: 16
 num_channels_for_vit: 3

--- a/MaxText/tests/attention_test.py
+++ b/MaxText/tests/attention_test.py
@@ -31,8 +31,10 @@ import jax
 import jax.numpy as jnp
 
 from flax import nnx
+from flax.linen import partitioning as nn_partitioning
 
 from MaxText import maxtext_utils
+from MaxText import max_utils
 from MaxText import pyconfig
 from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN
 from MaxText.globals import PKG_DIR
@@ -257,7 +259,7 @@ class ChunkedCausalMaskTest(unittest.TestCase):
       attentions._generate_chunk_attention_mask(mask_shape=(4, 4), chunk_size=0)
 
 
-class AttentionTest(unittest.TestCase):
+class AttentionTest(parameterized.TestCase):
   """Test for the Attention"""
 
   # Note: if you are changing these configs, please make sure to change the configs in
@@ -280,6 +282,7 @@ class AttentionTest(unittest.TestCase):
   }
 
   def setUp(self):
+    """Initializes the configuration for each test"""
     super().setUp()
     config = pyconfig.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
@@ -287,22 +290,11 @@ class AttentionTest(unittest.TestCase):
     )
     self.cfg = config
 
-    config_cp = pyconfig.initialize(
-        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
-        **self.config_arguments,
-        ici_context_parallelism=4,  # use context parallelism of 4
-        context_parallel_load_balance=False,  # set load_balancing to False such that
-        # there's no need for reordering the input/output
-    )
-
-    self.cfg_cp = config_cp
     self.rng = jax.random.PRNGKey(0)
     self.nnx_rng = nnx.Rngs(params=0, dropout=jax.random.PRNGKey(42))
 
     devices_array = maxtext_utils.create_device_mesh(self.cfg)
     self.mesh = Mesh(devices_array, self.cfg.mesh_axes)
-    devices_array_cp = maxtext_utils.create_device_mesh(self.cfg_cp)  # for context parallelism
-    self.mesh_cp = Mesh(devices_array_cp, self.cfg_cp.mesh_axes)  # for context parallelism
     self.global_batch_size = self.cfg.global_batch_size_to_train_on
     self.num_kv_heads = self.cfg.num_kv_heads
     self.num_query_heads = self.cfg.num_query_heads
@@ -500,8 +492,8 @@ class AttentionTest(unittest.TestCase):
     mha_generic_output = attention_as_mha_generic(
         lnx,
         lnx,
-        decoder_segment_ids=decoder_positions,
-        inputs_positions=decoder_segment_ids,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
         deterministic=True,
         model_mode=MODEL_MODE_TRAIN,
     )
@@ -528,8 +520,8 @@ class AttentionTest(unittest.TestCase):
     mha_generic_flash_output = attention_as_mha_flash(
         lnx,
         lnx,
-        decoder_segment_ids=decoder_positions,
-        inputs_positions=decoder_segment_ids,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
         deterministic=True,
         model_mode=MODEL_MODE_TRAIN,
     )
@@ -538,44 +530,106 @@ class AttentionTest(unittest.TestCase):
         jax.numpy.allclose(mha_generic_output, mha_generic_flash_output, rtol=1e-01, atol=1e-01, equal_nan=False)
     )
 
+  @parameterized.named_parameters(
+      {
+          "testcase_name": "cp_no_load_balance",
+          "ici_context_parallelism": 4,
+          "context_parallel_load_balance": False,
+          "ici_expert_parallelism": 1,
+          "expert_shard_attention_option": "fsdp",
+      },
+      {
+          "testcase_name": "cp_with_load_balance",
+          "ici_context_parallelism": 4,
+          "context_parallel_load_balance": True,
+          "ici_expert_parallelism": 1,
+          "expert_shard_attention_option": "fsdp",
+      },
+      {
+          "testcase_name": "cp_ep_no_load_balance",
+          "ici_context_parallelism": 2,
+          "context_parallel_load_balance": False,
+          "ici_expert_parallelism": 2,
+          "expert_shard_attention_option": "context",
+      },
+      {
+          "testcase_name": "cp_ep_with_load_balance",
+          "ici_context_parallelism": 2,
+          "context_parallel_load_balance": True,
+          "ici_expert_parallelism": 2,
+          "expert_shard_attention_option": "context",
+      },
+      {
+          "testcase_name": "ep_no_load_balance",
+          "ici_context_parallelism": 1,
+          "context_parallel_load_balance": False,
+          "ici_expert_parallelism": 4,
+          "expert_shard_attention_option": "context",
+      },
+      {
+          "testcase_name": "ep_with_load_balance",
+          "ici_context_parallelism": 1,
+          "context_parallel_load_balance": True,
+          "ici_expert_parallelism": 4,
+          "expert_shard_attention_option": "context",
+      },
+  )
+  @pytest.mark.tpu_only
+  def test_tpu_flash_attention_context_parallel(
+      self, ici_context_parallelism, context_parallel_load_balance, ici_expert_parallelism, expert_shard_attention_option
+  ):
+    """Test equivalence between dot_product and flash attention + context/expert parallelism"""
+    num_kv_heads = self.num_kv_heads
+    lnx, decoder_segment_ids, decoder_positions = self.get_data(self.dtype)
+    # Dot product
+    mha_generic_output = self._attention_as_mha_generic(
+        lnx,
+        lnx,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    generic_state = nnx.state(self._attention_as_mha_generic)
+
     # Test with Context Parallelism
+    cfg_cp = pyconfig.initialize(
+        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
+        **self.config_arguments,
+        ici_context_parallelism=ici_context_parallelism,
+        context_parallel_load_balance=context_parallel_load_balance,
+        ici_expert_parallelism=ici_expert_parallelism,
+        expert_shard_attention_option=expert_shard_attention_option,
+    )
+    devices_array_cp = maxtext_utils.create_device_mesh(cfg_cp)
+    mesh_cp = Mesh(devices_array_cp, cfg_cp.mesh_axes)
     attention_as_mha_flash_cp = Attention(
-        config=self.cfg_cp,  # we pass the context parallelism in the config
-        num_query_heads=self.cfg_cp.num_query_heads,
+        config=cfg_cp,
+        num_query_heads=cfg_cp.num_query_heads,
         num_kv_heads=num_kv_heads,
-        head_dim=self.cfg_cp.head_dim,
-        max_target_length=self.cfg_cp.max_target_length,
-        max_prefill_predict_length=self.cfg_cp.max_prefill_predict_length,
-        inputs_q_shape=dummy_inputs_q.shape,
-        inputs_kv_shape=dummy_inputs_kv.shape,
-        mesh=self.mesh_cp,
+        head_dim=cfg_cp.head_dim,
+        max_target_length=cfg_cp.max_target_length,
+        max_prefill_predict_length=cfg_cp.max_prefill_predict_length,
+        inputs_q_shape=lnx.shape,
+        inputs_kv_shape=lnx.shape,
+        mesh=mesh_cp,
         attention_kernel="flash",
         dtype=self.dtype,
-        dropout_rate=self.cfg_cp.dropout_rate,
+        dropout_rate=cfg_cp.dropout_rate,
         model_mode=MODEL_MODE_PREFILL,
         rngs=self.nnx_rng,
     )
     nnx.update(attention_as_mha_flash_cp, generic_state)
 
-    mha_generic_flash_cp_output = attention_as_mha_flash_cp(
-        lnx,
-        lnx,
-        decoder_segment_ids=decoder_positions,
-        inputs_positions=decoder_segment_ids,
-        deterministic=True,
-        model_mode=MODEL_MODE_TRAIN,
+    mha_generic_flash_cp_output = _forward_with_context_expert_parallelism(
+        cfg_cp, mesh_cp, attention_as_mha_flash_cp, lnx, decoder_segment_ids, decoder_positions
     )
 
-    # Assert that the logits generated by the generic flash and flash attention+context parallelism are close
-    self.assertTrue(
-        jax.numpy.allclose(mha_generic_flash_output, mha_generic_flash_cp_output, rtol=1e-01, atol=1e-01, equal_nan=False),
-        msg="Logits from generic flash and flash attention+context parallelism are not close.",
-    )
-
-    # Assert that the logits generated by the generic dot product and flash attention+context parallelism are close
     self.assertTrue(
         jax.numpy.allclose(mha_generic_output, mha_generic_flash_cp_output, rtol=1e-01, atol=1e-01, equal_nan=False),
-        msg="Logits from generic dot product and flash attention+context parallelism are not close.",
+        msg="Logits from generic dot product and flash attention + context/expert parallelism are not close.\n"
+        f"ici_context_parallelism={ici_context_parallelism}, context_parallel_load_balance={context_parallel_load_balance},"
+        f" ici_expert_parallelism={ici_expert_parallelism}, expert_shard_attention_option={expert_shard_attention_option}.",
     )
 
   @pytest.mark.tpu_only
@@ -968,80 +1022,84 @@ class AttentionTest(unittest.TestCase):
 class MLATest(parameterized.TestCase):
   """Test for the Multi-Headed Latent Attention"""
 
-  def init_mla(self, rope_type):
+  config_arguments = {
+      "per_device_batch_size": 1.0,
+      "run_name": "test",
+      "enable_checkpointing": False,
+      "max_target_length": 128,
+      "max_prefill_predict_length": 16,
+      "attention_type": attentions.AttentionType.MLA.value,
+      "head_dim": 192,
+      "q_lora_rank": 10,
+      "kv_lora_rank": 20,
+      "qk_nope_head_dim": 128,
+      "qk_rope_head_dim": 64,
+      "v_head_dim": 192,
+  }
+
+  def setUp(self):
+    """Initializes the configuration for each test"""
+    self.rng = jax.random.PRNGKey(0)
+    self.nnx_rng = nnx.Rngs(params=0, dropout=jax.random.PRNGKey(42))
+
+  def init_mla(self, config_arguments, rope_type):
     """Helper function to initialize MLA with different model names."""
     cfg = pyconfig.initialize(
         [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
-        per_device_batch_size=1.0,
-        run_name="test",
-        enable_checkpointing=False,
-        max_target_length=128,
-        max_prefill_predict_length=16,
-        attention_type=attentions.AttentionType.MLA.value,
+        **config_arguments,
         rope_type=rope_type,
     )
-    rng = jax.random.PRNGKey(0)
-    nnx_rng = nnx.Rngs(params=0, dropout=jax.random.PRNGKey(42))
 
     devices_array = maxtext_utils.create_device_mesh(cfg)
     mesh = Mesh(devices_array, cfg.mesh_axes)
 
-    global_batch_size = cfg.global_batch_size_to_train_on
-    num_kv_heads = cfg.num_kv_heads
-    num_query_heads = cfg.num_query_heads
-    max_target_length = cfg.max_target_length
-    max_prefill_predict_length = cfg.max_prefill_predict_length
-    embed_dim = cfg.base_emb_dim
-    dtype = cfg.dtype
-    attention_type = cfg.attention_type
-
-    dummy_inputs_q = jnp.ones((global_batch_size, max_target_length, embed_dim))
-    dummy_inputs_kv = jnp.ones((global_batch_size, max_target_length, embed_dim))
+    dummy_inputs_q = jnp.ones((cfg.global_batch_size_to_train_on, cfg.max_target_length, cfg.base_emb_dim))
+    dummy_inputs_kv = jnp.ones((cfg.global_batch_size_to_train_on, cfg.max_target_length, cfg.base_emb_dim))
 
     mla = MLA(
         config=cfg,
-        num_query_heads=num_query_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=192,
+        num_query_heads=cfg.num_query_heads,
+        num_kv_heads=cfg.num_kv_heads,
+        head_dim=cfg.head_dim,
         inputs_q_shape=dummy_inputs_q.shape,
         inputs_kv_shape=dummy_inputs_kv.shape,
-        max_target_length=max_target_length,
-        max_prefill_predict_length=max_prefill_predict_length,
+        max_target_length=cfg.max_target_length,
+        max_prefill_predict_length=cfg.max_prefill_predict_length,
         mesh=mesh,
         attention_kernel="dot_product",
-        dtype=dtype,
+        dtype=cfg.dtype,
         dropout_rate=cfg.dropout_rate,
-        attention_type=attention_type,
-        q_lora_rank=10,
-        kv_lora_rank=20,
-        qk_nope_head_dim=128,
-        qk_rope_head_dim=64,
-        v_head_dim=192,
+        attention_type=cfg.attention_type,
+        q_lora_rank=cfg.q_lora_rank,
+        kv_lora_rank=cfg.kv_lora_rank,
+        qk_nope_head_dim=cfg.qk_nope_head_dim,
+        qk_rope_head_dim=cfg.qk_rope_head_dim,
+        v_head_dim=cfg.v_head_dim,
         model_mode=MODEL_MODE_PREFILL,
-        rngs=nnx_rng,
+        rngs=self.nnx_rng,
     )
 
-    return cfg, mla, rng
+    return cfg, mla
 
-  def get_data(self, cfg, rng, dtype):
+  def get_data(self, cfg, dtype):
     """get data"""
     lnx = jax.random.normal(
-        rng,
+        self.rng,
         shape=(cfg.global_batch_size_to_train_on, cfg.max_target_length, cfg.base_emb_dim),
         dtype=dtype,
     )
 
-    decoder_segment_ids = jax.random.randint(rng, (cfg.global_batch_size_to_train_on, cfg.max_target_length), 0, 4)
+    decoder_segment_ids = jax.random.randint(self.rng, (cfg.global_batch_size_to_train_on, cfg.max_target_length), 0, 4)
     decoder_positions = jax.random.randint(
-        rng, (cfg.global_batch_size_to_train_on, cfg.max_target_length), 0, cfg.max_target_length
+        self.rng, (cfg.global_batch_size_to_train_on, cfg.max_target_length), 0, cfg.max_target_length
     )
 
     return lnx, decoder_segment_ids, decoder_positions
 
-  def get_structured_data(self, cfg, rng, dtype):
+  def get_structured_data(self, cfg, dtype):
     """get structured data"""
     lnx = jax.random.normal(
-        rng,
+        self.rng,
         shape=(
             cfg.global_batch_size_to_train_on,
             cfg.max_target_length,
@@ -1066,10 +1124,10 @@ class MLATest(parameterized.TestCase):
   )
   @pytest.mark.tpu_only
   def test_autoregression(self, rope_type):
-    cfg, mla, rng = self.init_mla(rope_type)
+    cfg, mla = self.init_mla(self.config_arguments, rope_type)
     prefill_length = cfg.max_prefill_predict_length
     decode_total_length = cfg.max_target_length
-    lnx, decoder_segment_ids, decoder_positions = self.get_structured_data(cfg, rng, cfg.dtype)
+    lnx, decoder_segment_ids, decoder_positions = self.get_structured_data(cfg, cfg.dtype)
 
     mla_full = mla(
         lnx,
@@ -1112,6 +1170,167 @@ class MLATest(parameterized.TestCase):
       self.assertEqual(mla_full_this_idx.shape, mla_idx.shape)
       # TODO (b/394626702) uncomment last check when decode and kv_cache are implemented for MLA
       # self.assertTrue(jax.numpy.allclose(mla_full_this_idx, mla_idx, rtol=1e-02, atol=1e-02, equal_nan=False))
+
+  @parameterized.named_parameters(
+      {
+          "testcase_name": "cp_no_load_balance",
+          "ici_context_parallelism": 4,
+          "context_parallel_load_balance": False,
+          "ici_expert_parallelism": 1,
+          "expert_shard_attention_option": "fsdp",
+      },
+      {
+          "testcase_name": "cp_with_load_balance",
+          "ici_context_parallelism": 4,
+          "context_parallel_load_balance": True,
+          "ici_expert_parallelism": 1,
+          "expert_shard_attention_option": "fsdp",
+      },
+      {
+          "testcase_name": "cp_ep_no_load_balance",
+          "ici_context_parallelism": 2,
+          "context_parallel_load_balance": False,
+          "ici_expert_parallelism": 2,
+          "expert_shard_attention_option": "context",
+      },
+      {
+          "testcase_name": "cp_ep_with_load_balance",
+          "ici_context_parallelism": 2,
+          "context_parallel_load_balance": True,
+          "ici_expert_parallelism": 2,
+          "expert_shard_attention_option": "context",
+      },
+      {
+          "testcase_name": "ep_no_load_balance",
+          "ici_context_parallelism": 1,
+          "context_parallel_load_balance": False,
+          "ici_expert_parallelism": 4,
+          "expert_shard_attention_option": "context",
+      },
+      {
+          "testcase_name": "ep_with_load_balance",
+          "ici_context_parallelism": 1,
+          "context_parallel_load_balance": True,
+          "ici_expert_parallelism": 4,
+          "expert_shard_attention_option": "context",
+      },
+  )
+  @pytest.mark.tpu_only
+  def test_tpu_flash_attention_context_parallel(
+      self, ici_context_parallelism, context_parallel_load_balance, ici_expert_parallelism, expert_shard_attention_option
+  ):
+    """Test equivalence between dot_product and flash attention + context/expert parallelism"""
+
+    config_arguments = {
+        "per_device_batch_size": 1.0,
+        "run_name": "test",
+        "enable_checkpointing": False,
+        "max_target_length": 512,
+        "sa_block_q": 128,
+        "sa_block_kv": 128,
+        "sa_block_kv_compute": 128,
+        "sa_block_q_dkv": 128,
+        "sa_block_kv_dkv": 128,
+        "sa_block_kv_dkv_compute": 128,
+        "sa_block_q_dq": 128,
+        "sa_block_kv_dq": 128,
+        "attention_type": attentions.AttentionType.MLA.value,
+        "q_lora_rank": 4,
+        "kv_lora_rank": 4,
+        "qk_nope_head_dim": 128,
+        "qk_rope_head_dim": 64,
+        "v_head_dim": 128,
+    }
+
+    cfg, mla = self.init_mla(config_arguments, rope_type="default")
+    lnx, decoder_segment_ids, decoder_positions = self.get_data(cfg, cfg.dtype)
+    # Dot product
+    mla_generic_output = mla(
+        lnx,
+        lnx,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    generic_state = nnx.state(mla)
+
+    # Test with Context Parallelism
+    cfg_cp = pyconfig.initialize(
+        [sys.argv[0], os.path.join(PKG_DIR, "configs", "base.yml")],
+        **config_arguments,
+        rope_type=cfg.rope_type,
+        ici_context_parallelism=ici_context_parallelism,
+        context_parallel_load_balance=context_parallel_load_balance,
+        ici_expert_parallelism=ici_expert_parallelism,
+        expert_shard_attention_option=expert_shard_attention_option,
+    )
+    devices_array_cp = maxtext_utils.create_device_mesh(cfg_cp)
+    mesh_cp = Mesh(devices_array_cp, cfg_cp.mesh_axes)
+    attention_as_mla_flash_cp = MLA(
+        config=cfg_cp,
+        num_query_heads=cfg_cp.num_query_heads,
+        num_kv_heads=cfg_cp.num_kv_heads,
+        head_dim=cfg_cp.head_dim,
+        inputs_q_shape=lnx.shape,
+        inputs_kv_shape=lnx.shape,
+        max_target_length=cfg_cp.max_target_length,
+        max_prefill_predict_length=cfg_cp.max_prefill_predict_length,
+        mesh=mesh_cp,
+        attention_kernel="flash",
+        dtype=cfg_cp.dtype,
+        dropout_rate=cfg_cp.dropout_rate,
+        attention_type=cfg_cp.attention_type,
+        q_lora_rank=cfg_cp.q_lora_rank,
+        kv_lora_rank=cfg_cp.kv_lora_rank,
+        qk_nope_head_dim=cfg_cp.qk_nope_head_dim,
+        qk_rope_head_dim=cfg_cp.qk_rope_head_dim,
+        v_head_dim=cfg_cp.v_head_dim,
+        model_mode=MODEL_MODE_PREFILL,
+        rngs=self.nnx_rng,
+    )
+    nnx.update(attention_as_mla_flash_cp, generic_state)
+    mla_generic_flash_cp_output = _forward_with_context_expert_parallelism(
+        cfg_cp, mesh_cp, attention_as_mla_flash_cp, lnx, decoder_segment_ids, decoder_positions
+    )
+
+    self.assertTrue(
+        jax.numpy.allclose(mla_generic_output, mla_generic_flash_cp_output, rtol=1e-01, atol=1e-01, equal_nan=False),
+        msg="MLA Logits from generic dot product and flash attention + context/expert parallelism are not close.\n"
+        f"ici_context_parallelism={ici_context_parallelism}, context_parallel_load_balance={context_parallel_load_balance},"
+        f" ici_expert_parallelism={ici_expert_parallelism}, expert_shard_attention_option={expert_shard_attention_option}.",
+    )
+
+
+def _forward_with_context_expert_parallelism(cfg_cp, mesh_cp, attention_cp, lnx, decoder_segment_ids, decoder_positions):
+  """Get logits from attention under context/expert parallelism."""
+  # If load balanced cp, shuffle along seq dim for input
+  # This correponds to the pre-shuffle step in training
+  context_parallel_size = cfg_cp.context_parallel_size
+  if context_parallel_size > 1 and cfg_cp.context_parallel_load_balance:
+    batch = {"inputs": lnx, "inputs_segmentation": decoder_segment_ids, "inputs_position": decoder_positions}
+    with mesh_cp:
+      reordered_batch = max_utils.get_reorder_callable(context_parallel_size)(batch)
+    lnx = reordered_batch["inputs"]
+    decoder_segment_ids = reordered_batch["inputs_segmentation"]
+    decoder_positions = reordered_batch["inputs_position"]
+  # apply attention with sharding
+  with mesh_cp, nn_partitioning.axis_rules(cfg_cp.logical_axis_rules):
+    attention_cp_output = attention_cp(
+        lnx,
+        lnx,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+  # If load balanced cp, de-shuffle and gather along seq dim for output
+  # Note training does not need post-shuffle. Since the target seq is also pre-shuffled, the loss remains correct
+  if context_parallel_size > 1 and cfg_cp.context_parallel_load_balance:
+    attention_cp_output = max_utils.reorder_sequence(
+        tensor=attention_cp_output, cp_size=context_parallel_size, seq_dim=1, to_contiguous=True
+    )
+  return attention_cp_output
 
 
 if __name__ == "__main__":

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -523,7 +523,7 @@ def setup_train_loop(config, recorder, devices=None):
 
   with maybe_record_goodput(recorder, GoodputEvent.TRAINING_PREPARATION):
     data_iterator, eval_data_iterator = create_data_iterator(config, mesh)
-    context_parallel_size = mesh.shape["context"]
+    context_parallel_size = config.context_parallel_size
     # Check if context parallelism is being used with sequence packing
     if context_parallel_size > 1 and config.packing and config.dataset_type != "synthetic":
       raise ValueError(

--- a/getting_started/Sharding.md
+++ b/getting_started/Sharding.md
@@ -347,7 +347,7 @@ $$BE_x \times E_xM = BM_x$$
 
 Shard expert feed forward computation (both weights and activations) by expert!
 
-The feedforward layer is the only one that has experts - for this layer we shard the weights and the activations on the experts dimensions by `EP`. For attention operations (including projections) the `EP` dimension acts like `FSDP`. This is a choice by MaxText, we may implement more options in the future where instead `EP` could act like `DP` or `CP/SP` as well.
+The feedforward layer is the only one that has experts - for this layer we shard the weights and the activations on the experts dimensions by `EP`. For attention operations (including projections) the `EP` dimension acts like `FSDP`. This is the default choice by MaxText. There is an option for `EP` to act like `CP` in training. We may implement more options in the future where instead `EP` could act like `DP` or `SP` as well.
 
 When using dropless strategies you may want to ensure that the shards are balanced. The balance can be improved by using less `EP` so that each shard is averaged over more experts. For instance imagine a scenario where expert 1 gets 10x more tokens routed to it than the rest. If `EP = # experts = 64`  than we will get terrible performance waiting for this one expert to finish its computation which is 3x slower. However if we set `EP = 1/4 * # experts` than the EP rank with expert 1 will have 4 experts, so we will have `3 + 1 + 1 + 1 = 6` compute to do compared to the average of `1 + 1 + 1 + 1 = 4`, a ratio of `6/4 = 1.5x` slower, which is a huge improvement over the `3x` slower.
 


### PR DESCRIPTION
# Description

**Goal**

For mixture of expert models, we may use expert parallelism. For attention layer, EP acts as FSDP currently. Built upon [previous context parallelism work](https://github.com/AI-Hypercomputer/maxtext/pull/1445), this PR is to introduce the option of using EP as CP for attention. This is joint effort with @RissyRan.

FIXES: b/418396648

**Main code changes**
- `attentions.py`
  - MHA, MLA, tpu_flash_attention
  - changed logical_axis

- `base.yml`
  - change logical_axis_rules
  - add a flag to customize expert sharding behavior in attention `expert_shard_attention_option`:  fsdp or context

- unit test: `tests.attention_test`
  - `AttentionTest.test_tpu_flash_attention_cp_and_ep` &  `MLATest.test_tpu_flash_attention_cp_and_ep` (extended from [cp test](https://screenshot.googleplex.com/499pjxu8HiV8z23))
  - using cp/ep with tpu_flash_attention, with or without context_parallel_load_balance
  - compare logit against dot_product without sharding
 

**Use case**
- training, MoE with MHA / MLA attention
- cp_load_balance={true, false}, tpu_flash_attention
- Example (ep_as_cp): `ici_expert_parallelism=4, ici_context_parallelism=1, expert_shard_attention_option=context`, shard context by 4 in attention, shard expert by 4 for moe
- Example (ep_as_cp + native cp): `ici_expert_parallelism=2, ici_context_parallelism=2, expert_shard_attention_option=context`, shard context by 4 in attention, shard expert by 2 and context by 2 for moe


# Tests

Tested on v5p-8

Verify sharding shape
- end-to-end pretraining: reduced version of Mixtral-8x7b (for MHA) and reduced DeepSeek3-671b (for MLA)
- tpu_flash_kernel, `context_parallel_load_balance=True`, parallelism: `ici_expert_parallelism=2, ici_context_parallelism=2, expert_shard_attention_option=context` and `ici_expert_parallelism=2, ici_context_parallelism=2, expert_shard_attention_option=fsdp`
- See test details in  b/418396648#comment7

Verify attention output logit against dot product
- use the added unit test 
- tpu_flash_kernel, attention {MHA, MLA}, `context_parallel_load_balance={True, False}`, parallelism: {`ici_expert_parallelism=4, expert_shard_attention_option=context`, `ici_expert_parallelism=2, expert_shard_attention_option=context, ici_context_parallelism=2`} 


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
