### PR TITLE
fix minor issues in benchmarks folder

### DIFF
--- a/benchmarks/Getting_Started_Benchmarking.md
+++ b/benchmarks/Getting_Started_Benchmarking.md
@@ -85,6 +85,6 @@ for model in list_of_models:
   for xpk_workload_name, xpk_workload_cmd in zip(xpk_workload_names, xpk_workload_cmds):
     return_code = run_command_with_updates(xpk_workload_cmd, xpk_workload_name)
     if return_code != 0:
-      print('Unable to run xpk workload: {xpk_workload_name}')
+      print(f'Unable to run xpk workload: {xpk_workload_name}')
 
 ```

--- a/benchmarks/benchmark_utils.py
+++ b/benchmarks/benchmark_utils.py
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  """
- 
+
 import dataclasses
 import math
 import typing
@@ -35,9 +35,6 @@ class MaxTextModel:
 
 
 # Run this for new definitions that should be part of the library.
-def _add_to_model_dictionary(
-    model_dictionary: dict[str, MaxTextModel], maxtext_model: MaxTextModel
-) -> MaxTextModel:
-  print(maxtext_model.model_name.replace("-", "_"))
+def _add_to_model_dictionary(model_dictionary: dict[str, MaxTextModel], maxtext_model: MaxTextModel) -> MaxTextModel:
   model_dictionary[maxtext_model.model_name.replace("-", "_")] = maxtext_model
   return maxtext_model

--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -658,10 +658,10 @@ def generate_xpk_workload_cmd(
   all_xpk_storage = ""
   if wl_config.xpk_storage:
     all_xpk_storage = " ".join(f"--storage={storage_test}" for storage_test in wl_config.xpk_storage)
-  
-  hlo_dump = "" 
+
+  hlo_dump = ""
   if wl_config.hlo_dump:
-    # HLO dump gets saved in a subdirectory called "hlo_dump" of the base output directory. 
+    # HLO dump gets saved in a subdirectory called "hlo_dump" of the base output directory.
     hlo_dump = f'--debug-dump-gcs={wl_config.base_output_directory}/{wl_config.run_name}/hlo_dump'
 
   return (
@@ -755,7 +755,7 @@ def xpk_benchmark_runner(
       # If the workload fails to start, remove it from the disruption manager.
       # No-op if disruption manager does not contain the workload name.
       disruption_manager.remove_workload(xpk_workload_name)
-      print('Unable to run xpk workload: {xpk_workload_name}')
+      print(f"Unable to run xpk workload: {xpk_workload_name}")
 
   return disruption_manager
 
@@ -864,7 +864,7 @@ def main() -> int:
   for xpk_workload_name, xpk_workload_cmd in zip(xpk_workload_names, xpk_workload_cmds):
     return_code = run_command_with_updates(xpk_workload_cmd, xpk_workload_name)
     if return_code != 0:
-      print('Unable to run xpk workload: {xpk_workload_name}')
+      print(f"Unable to run xpk workload: {xpk_workload_name}")
 
   # Support Batch workloads one day. Note that this doesn't show the xpk logs per workload.
   # They are saved to file instead.


### PR DESCRIPTION
Removed an unnecessary print() and fixed two fstring print.

# Description

Removing a `print()` in func `_add_to_model_dictionary()` in file `benchmarks/benchmark_utils.py`  that will print the whole model list multiple times when submitting xpk workloads with `benchmark_runner.py`. And fix the message printed when xpk submission failed to print the correct run name.


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
