### PR TITLE
Enable gemma3 multimodal SFT

### DIFF
--- a/MaxText/tests/multimodal_utils_test.py
+++ b/MaxText/tests/multimodal_utils_test.py
@@ -17,7 +17,6 @@ limitations under the License.
 """ Tests for the common MaxText utilities """
 import unittest
 import numpy as np
-import jax.numpy as jnp
 
 from MaxText import multimodal_utils
 
@@ -75,8 +74,8 @@ class TestLlama4ImageProcessing(unittest.TestCase):
     self.NUM_IMAGE_CHANNELS = 3
 
   def test_get_best_resolution(self):
-    image_1 = jnp.ones((224, 300, self.NUM_IMAGE_CHANNELS))
-    image_2 = jnp.ones((536, 640, self.NUM_IMAGE_CHANNELS))
+    image_1 = np.ones((224, 300, self.NUM_IMAGE_CHANNELS))
+    image_2 = np.ones((536, 640, self.NUM_IMAGE_CHANNELS))
 
     possible_resolutions = multimodal_utils.find_supported_resolutions(
         max_num_chunks=self.LLAMA4_TILES_NUM, patch_size=self.LLAMA4_TILE_SIZE
@@ -97,14 +96,14 @@ class TestLlama4ImageProcessing(unittest.TestCase):
     self.assertEqual(best_resolution_2, (672, 672))
 
   def test_pad_to_best_fit_jax(self):
-    image = jnp.zeros((536, 640, self.NUM_IMAGE_CHANNELS))
+    image = np.zeros((536, 640, self.NUM_IMAGE_CHANNELS))
     best_resolution = (672, 672)
     padded_image = multimodal_utils.pad_to_best_fit_jax(image, best_resolution)
     self.assertEqual(padded_image.shape, (672, 672, self.NUM_IMAGE_CHANNELS))
-    self.assertTrue(jnp.all(padded_image == 0))
+    self.assertTrue(np.all(padded_image == 0))
 
   def test_split_to_tiles(self):
-    image = jnp.ones((672, 672, self.NUM_IMAGE_CHANNELS))
+    image = np.ones((672, 672, self.NUM_IMAGE_CHANNELS))
     best_resolution = (672, 672)
     ratio_h, ratio_w = (
         best_resolution[0] // self.LLAMA4_TILE_SIZE,
@@ -133,7 +132,7 @@ class TestLlama4PostProcessing(unittest.TestCase):
     self.model_name = "llama4-17b-16e"
 
   def test_image_tokens_for_single_image(self):
-    this_aspect_ratio = jnp.array([2, 2])
+    this_aspect_ratio = np.array([2, 2])
     num_patches_per_chunk = 4
     image_tokens = multimodal_utils.get_tokens_for_this_image(this_aspect_ratio, num_patches_per_chunk)
     expected_tokens = [
@@ -168,11 +167,11 @@ class TestLlama4PostProcessing(unittest.TestCase):
     self.assertEqual(image_tokens, expected_tokens)
 
   def test_post_process_image_tokens(self):
-    dummy_pixel_values = jnp.ones(
+    dummy_pixel_values = np.ones(
         (5, multimodal_utils.NUM_IMAGE_CHANNELS, multimodal_utils.LLAMA4_TILE_SIZE, multimodal_utils.LLAMA4_TILE_SIZE)
     )
-    dummy_aspect_ratios = jnp.array([[2, 2]])
-    dummy_tokens = jnp.array([1, 2, self.LLAMA4_FAKE_IMAGE_TOKEN, 4, 5])
+    dummy_aspect_ratios = np.array([[2, 2]])
+    dummy_tokens = np.array([1, 2, self.LLAMA4_FAKE_IMAGE_TOKEN, 4, 5])
     processor_output = multimodal_utils.PreprocessorOutput(
         pixel_values=dummy_pixel_values,
         aspect_ratios=dummy_aspect_ratios,

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -543,7 +543,8 @@ def setup_train_loop(config, recorder, devices=None):
         model, data_iterator, tx, config, init_rng, mesh, checkpoint_manager
     )
 
-    if not config.using_pipeline_parallelism:
+    # TODO(aireenmei, hengtaoguo): support sharding in vit for multimodal
+    if not config.using_pipeline_parallelism and not config.use_multimodal:
       # The vocab tensor(s) of shape [vocab, embed] (and transpose) are not sharded by stage
       maxtext_utils.assert_params_sufficiently_sharded(state.params, mesh, config.sharding_tolerance)
 


### PR DESCRIPTION
# Description
This PR supports gemma3 SFT on chartQA dataset, the main changes in multimodal_utils are migrating functions we want to run on CPU from jnp to np. Note that the following existing limitations on the gemma3 support won't be addressed in this PR, but I worked around it and added TODO comments for the future:
* vision encoder does not support scan yet, so the scan_layers flag only applies to text model
* vision encoder is not sharded.


b/433982967

# Tests

tested gemma3-4b on v5p with scan_layer= {true, false}

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
