### PR TITLE
Add ReadMe about MFU

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Key supported features:
 * Models: Llama 2, Llama 3, Llama 4, Mistral and Mixtral family, Gemma, Gemma 2, Gemma 3, and DeepSeek family
 
 ## Announcements
+* [July 27, 2025] We have updated our TFLOPS/s calculation to account for causal attention, dividing the attention flops in half in this [PR](https://github.com/AI-Hypercomputer/maxtext/pull/1988). Also we account for sliding window and chunked attention reduced attention flops in [PR](https://github.com/AI-Hypercomputer/maxtext/pull/2009) and [PR](https://github.com/AI-Hypercomputer/maxtext/pull/2030). These changes especially impact large sequence configs, since attention flops grow quadratically with sequence length, as explained in this [ReadMe](https://github.com/AI-Hypercomputer/maxtext/blob/main/getting_started/Performance_Metrics.md)
 * [July 16, 2025] We will be restructuring the MaxText repository for improved organization and clarity. Please review the [proposed structure](RESTRUCTURE.md) and provide feedback.
 * [July 11, 2025] Multi-Token Prediction (MTP) training is now supported! This feature adds an auxiliary loss based on predicting multiple future tokens, inspired by the [DeepSeek-V3 paper](https://arxiv.org/html/2412.19437v1), to enhance training efficiency.
 * [June 25, 2025] DeepSeek R1-0528 variant is now supported!

--- a/getting_started/Performance_Metrics.md
+++ b/getting_started/Performance_Metrics.md
@@ -1,0 +1,79 @@
+# Performance Metrics
+
+## MFU
+
+Model Flops Utilization (MFU) is one of the most commonly used metrics to summarize performance, along with step time or tokens per second.
+
+### Definition
+
+
+
+
+$$ MFU:= \frac{\text{model flops/s}}{\text{peak hardware flops/s}} $$
+
+
+
+
+Model flops are the theoretical number of flops needed to execute the computation (both forward and backward passes for training). This is generally easy to calculate/estimate theoretically since the model is mostly performing matmuls, and so we can just sum up the flops of each matmul. For example a $[A,B] \times [B,C] = [A,C]$ matmul has $2ABC$ flops.
+
+### MaxText Calculating + Reporting 
+In MaxText, we calculate MFU by calculating the theoretical number of flops and measuring step time.
+
+We calculate theoretical model flops per step as described above, summing all of the matmuls needed in detail, see [calculate_tflops_per_device](https://github.com/AI-Hypercomputer/maxtext/blob/e969faabbb571285a51545530f34d8f0a9f237e9/MaxText/maxtext_utils.py#L297)
+We divide this by the measured step time (measured via python `time.time()`), to get the Model Flops per second that we print each step [`per_device_tflops_seconds`](https://github.com/AI-Hypercomputer/maxtext/blob/e969faabbb571285a51545530f34d8f0a9f237e9/MaxText/metric_logger.py#L193-L194). You can get the MFU by dividing this number by the peak tflops of the hardware (e,g. $918e^{12}$ FLOPS/s for Trillium)
+
+ $$ MFU = \frac{\text{model flops/s}}{\text{peak hardware flops/s}} = \frac{\text{theoretical model flops}}{\text{measured step time} \times \text{peak hardware flops/s}}$$
+
+This is also equivalent to the ratio of the theoretically optimal step time and measured step time:
+
+$$\text{theoretically optimal step time} = \frac{\text{theoretical model flops}}{\text{peak hardware flops/s }} $$
+
+$$\frac{\text{theoretically optimal step}}{\text{measured step time}} = \frac{\text{theoretical model flops}}{\text{measured step time} \times \text{peak hardware flops/s }} = MFU$$
+
+
+### Causal Attention
+Due to causality only half of the (query, key) pairs need to be computed, those with query_idx >= key_idx. This accounts for the fact only prior tokens can be used to predict future ones. Prior to https://github.com/AI-Hypercomputer/maxtext/pull/1988 MaxText did not account for sparsity for theoretical flops, and used
+
+Attention Flops ~= 4 * sequence^2 * batch * heads * head_dim
+
+
+When accounting for causal masking, this should be halved
+
+Attention Flops ~= 2 * sequence^2 * batch * heads * head_dim
+
+Which maxtext now uses since this [PR/1988](https://github.com/AI-Hypercomputer/maxtext/pull/1988)
+
+Note that
+
+$$ \text{Total Flops} =  \text{Attention (quadratic in sequence) + Non-attention  (linear)}$$ 
+
+Thus the distinction between causal vs non causal flops is particularly important for long sequence when the attention flops dominate / are a significant fraction of the total flops. For 8k sequence length, the attention flops are generally around 10% of total flops (depending on exact model dims), whereas for 128k seq, the attention flops may be around 90%. Note however the attention flops also vary by attention type, e.g. sliding window flops are not quadratic in sequence, but are only linear in both sequence length and window length. We updated our model flops calculation to account for sliding window attention and chunked attention in [PR 2009](https://github.com/AI-Hypercomputer/maxtext/pull/2009) and [PR 2030](https://github.com/AI-Hypercomputer/maxtext/pull/2030).
+
+
+
+### Why MFU
+MFU is a very useful metric to understand your systems performance, but like step time or tokens/s, there are pros and cons of summarizing the system’s performance to a single number.
+
+**Pros**
+* Clearly shows room left to improve, how much more the hardware is capable of. (e.g. 25% MFU means its possible to get 4x more performance and 4x smaller step times). Note that achieving 100% is not practical due to many factors, but MFU score effectively shows how much room is left for optimization.
+* Generalizable across hardwares, model, configs (e.g. batch sizes)
+
+**Cons**
+* Care needs to be token to compare MFU across codebases that the model flops calculation are identcail (e.g. was causality taken into account in both code bases?)
+
+Step time, tokens/s, and MFU all can be used to calculate how long training will take (e.g. how long will it take to train my model on $T$ tokens given $C$ chips?)
+
+
+
+$$\begin{align*}
+\text{training time} &= \text{step time} \times \text{num steps} \\
+                     &= \frac{T tokens}{\text{measured tokens per second per chip} \times C} \\
+                     &= \frac{\text{theoretical flops to train T tokens}}{\text{MFU} \times C \times \text{chip peak speed}}
+\end{align*}$$
+
+
+This shows any of step time, tokens/s or MFU can be used to determine how long training will take and are proportionally (or inversely prortionally) related. MFU is most useful to compare across different models/hardwares and while optimizing performance, wheres step time or tokens/second may be more useful when these are fixed.
+
+## Why not Hardware Flops?
+
+Hardware (e.g., XLA reported) FLOPs do not accurately reflect computation efficiency as they depend on the program / implementation, not just on the model and its inherent computations (higher hardware FLOPs does not necessarily mean less room for improvement). For example, they includes remat and potentially auxilliary operations (such as reshaping for dropless moe [here](https://github.com/AI-Hypercomputer/maxtext/blob/4b6142950aff5d9ba42d830efc5ce4c4ac9d4135/MaxText/layers/moe.py#L1267)), which are an implementation detail and not part of the model. In addition, XLA reported FLOPs may not be accurate with pallas kernels. Hardware flops utilization is not (inversely) proprtional to step time as opposed to MFU, since hardware flops can change with implementation details like remat policies. 


### PR DESCRIPTION
# Description

Add a ReadMe section discussing Model flops utilization MFU (definition and how we report it).

We may want to add sections to this in the future (e.g. hardware utilizations or memory usage)

This is meant to help clarify the recent change about our attention flop calculation change (accounting for causality) in https://github.com/AI-Hypercomputer/maxtext/pull/1988 

Note for reviewers: Click on display rich diff to see resultant markdown: https://screenshot.googleplex.com/9WxhjW8EV6PWJ9B



# Tests

N/A readme

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
