### PR TITLE
update unscanned ckpt path in mixtral test

### DIFF
--- a/end_to_end/tpu/mixtral/8x7b/2_test_mixtral.sh
+++ b/end_to_end/tpu/mixtral/8x7b/2_test_mixtral.sh
@@ -29,10 +29,7 @@ export DATASET_PATH=gs://maxtext-dataset
 export SCANNED_CHECKPOINT=${BASE_OUTPUT_PATH}/${MODEL_VARIATION}/scanned_ckpt/0/items
 
 # `UNSCANNED_CHECKPOINT` refers to run decoding
-# export UNSCANNED_CKPT_PATH=${BASE_OUTPUT_PATH}/unscanned_ckpt/checkpoints/0/items
-# TODO: investigate issue of latest generated unscanned checkpoints
-# Hard-code an old checkpoint for now.
-export UNSCANNED_CKPT_PATH=gs://ml-auto-solutions/output/sparsity_diffusion_devx/maxtext/chained_tests_mixtral-8x7b_nightly-2024-11-15-01-06-09/unscanned_ckpt/checkpoints/0/items
+export UNSCANNED_CKPT_PATH=${BASE_OUTPUT_PATH}/unscanned_ckpt/checkpoints/0/items
 
 # Run decoding with converted ckpt - matmul implementation
 # TODO(ranran): add decoding test for megablox implementation


### PR DESCRIPTION
# Description

We previously hard-coded an old unscanned ckpt. After testing the most recent unscanned ckpt, it turns out to be correct. Therefore, we update the unscanned ckpt path to be `UNSCANNED_CKPT_PATH=${BASE_OUTPUT_PATH}/unscanned_ckpt/checkpoints/0/items`

FIXES: b/410620775


# Tests

Tested unscanned ckpt `gs://ml-auto-solutions/output/sparsity_diffusion_devx/maxtext/chained_tests_mixtral-8x7b_stable-2025-07-25-01-00-45/unscanned_ckpt/checkpoints/0/items`
- it has the same structure as the hard-coded one  
- it can correctly decode
- See details in b/410620775#comment3

As a sanity check, the XLML test sets BASE_OUTPUT_PATH correctly [(SS)](https://screenshot.googleplex.com/BaVFK6DwK7BNJtZ): `BASE_OUTPUT_PATH=gs://ml-auto-solutions/output/sparsity_diffusion_devx/maxtext/chained_tests_mixtral-8x7b_stable-2025-07-25-01-00-45/`, where the timestamp `2025-07-25-01-00-45` is set dynamically by test




# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
