### PR TITLE
Update FLOPs calculation for multimodal models

### DIFF
--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -77,7 +77,7 @@ def reformat_prompt(example, column, image_placeholder, model_name):
 
 def reformat_response(example, column, model_name):
   """reformat response for multimodal SFT"""
-  example[column] = multimodal_utils.reformat_response(example[column], model_name)
+  example[column] = multimodal_utils.reformat_response(example[column][0], model_name)
   return example
 
 

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -87,7 +87,7 @@ def device_space():
     return jax.memory.Space.Device # pytype: disable=module-attr
   else:
     # pytype: disable=module-attr
-    return jax._src.sharding_impls.TransferToMemoryKind("device") # pylint: disable=protected-access 
+    return jax._src.sharding_impls.TransferToMemoryKind("device") # pylint: disable=protected-access
 
 def calculate_total_params_per_chip(params):
   """Calculate total params per chip."""


### PR DESCRIPTION
# Description

This PR adds a TFLOPs calculation for the vision layers in Gemma3 and Llama4.

The calculation focuses on high-impact operations like matmuls and convolutions. Minor operations (e.g., layernorm, residual adds, gelu) are intentionally excluded since they are negligible comparing to the attention layers and for simplicity.

[b/436137221](https://b.corp.google.com/issues/436137221)

# Tests

[Gemma3-4b](https://screenshot.googleplex.com/m6bH2kCDamcB3Lj), [Llama4-Scout](https://screenshot.googleplex.com/BfMvurJ33pBovNa)

For the vision encoder, we apply approximation rule as a reference `2 * seq_len * num_params / 10*12`, this should be close to our learnable_weights_tflops calculation.

<img width="829" height="74" alt="image" src="https://github.com/user-attachments/assets/66d12a0e-1ffa-489e-afe9-a568234d844f" />


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
