### PR TITLE
Added bash script/documentation to run maxtest models via a small script

### DIFF
--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -26,7 +26,7 @@ import argparse
 import os
 import time
 
-from MaxText.inference_utils import str2bool
+from benchmarks.benchmark_utils import str2bool
 from benchmarks.maxtext_trillium_model_configs import trillium_model_dict
 from benchmarks.maxtext_v5p_model_configs import v5p_model_dict
 from benchmarks.maxtext_v5e_model_configs import v5e_model_dict
@@ -228,37 +228,71 @@ def add_on_device_runner_arguments(custom_parser: argparse.ArgumentParser):
       help='Number of steps to run the workload for.',
   )
 
+def add_healthscan_runner_arguments(custom_parser: argparse.ArgumentParser):
+  """Add arguments to the healthscan runner parser.
+
+  Args:
+    custom_parser: parser to add shared arguments to.
+  """
+  custom_parser.add_argument(
+      '--base_output_directory',
+      type=str,
+      default=None, required=True,
+      help='gcloud bucket to store artifacts.',
+  )
+  custom_parser.add_argument(
+      '--device_type',
+      type=str,
+      default=None, required=True,
+      help='tpu device type command.',
+  )
+  custom_parser.add_argument(
+      '--run_name',
+      type=str,
+      default=None,
+      help='run_name for model run',
+  )
+  custom_parser.add_argument(
+      '--num_steps',
+      type=int,
+      default=20,
+      help='Number of steps to run the workload for.',
+  )
+
 def main() -> None:
   parser = argparse.ArgumentParser(
       prog='benchmark runner', usage='%(prog)s [options]'
   )
+
   subparsers = parser.add_subparsers(help="", dest="runner")
   xpk_runner_parser = subparsers.add_parser("xpk")
   on_device_runner_parser = subparsers.add_parser("on-device")
+  healthscan_runner_parser = subparsers.add_parser("healthscan")
   add_xpk_runner_arguments(xpk_runner_parser)
   add_on_device_runner_arguments(on_device_runner_parser)
   add_pathways_arguments(parser)
+  add_healthscan_runner_arguments(healthscan_runner_parser)
   options = parser.parse_args()
 
   # Check that there are no duplicate model configs
   duplicates = (trillium_model_dict.keys() & v5p_model_dict.keys() & v5e_model_dict.keys() & c4_pretrain_model_dict.keys())
   assert len(duplicates) == 0 , f'Found duplicate model config {duplicates}'
 
-  model = trillium_model_dict.get(options.model_name)
-  if model is None:
-    model = v5e_model_dict.get(options.model_name)
-  if model is None:
-    model = v5p_model_dict.get(options.model_name)
-  if model is None:
-    model = c4_pretrain_model_dict.get(options.model_name)
-  libtpu_type = None
-  match options.libtpu_type:
-    case LibTpuType.NIGHTLY.value:
-      libtpu_type = LibTpuType.NIGHTLY
-    case LibTpuType.CUSTOM.value:
-      libtpu_type = LibTpuType.CUSTOM
-    case LibTpuType.MAXTEXT.value:
-      libtpu_type = LibTpuType.MAXTEXT
+  if options.runner != "healthscan":
+    model = (
+      trillium_model_dict.get(options.model_name)
+      or v5e_model_dict.get(options.model_name)
+      or v5p_model_dict.get(options.model_name)
+      or c4_pretrain_model_dict.get(options.model_name)
+    )
+    libtpu_type = None
+    match options.libtpu_type:
+      case LibTpuType.NIGHTLY.value:
+        libtpu_type = LibTpuType.NIGHTLY
+      case LibTpuType.CUSTOM.value:
+        libtpu_type = LibTpuType.CUSTOM
+      case LibTpuType.MAXTEXT.value:
+        libtpu_type = LibTpuType.MAXTEXT
 
   # Set up pathways configs
   pw_config = None
@@ -322,6 +356,41 @@ def main() -> None:
       generate_metrics_and_upload_to_big_query=False,
     )
     on_device_benchmark_runner(workload_configs=[workload_config])
+  elif options.runner == "healthscan":
+
+    # Pick a model to run based on device_type to stress test
+    models = {
+        "v5p-128" : v5p_model_dict.llama2_70b_v5p_128,
+        "v5p-256" : v5p_model_dict.llama4_scout_dropless_v5p_256,
+        "v5p-512" : v5p_model_dict.deepseek_v3_ep_256_v5p_512,
+        "v5p-1024" : v5p_model_dict.deepseek_v3_ep_256_v5p_512,
+        "v5p-2048" : v5p_model_dict.deepseek_v3_ep_256_v5p_512,
+
+        "v6e-8" :   trillium_model_dict.llama2_7b_4096,
+        "v6e-16" :  trillium_model_dict.llama2_7b_4096,
+        "v6e-32" :  trillium_model_dict.llama2_7b_4096,
+        "v6e-64" :  trillium_model_dict.llama2_7b_4096,
+        "v6e-128" : trillium_model_dict.llama2_70b_4096,
+        "v6e-256" : trillium_model_dict.llama2_70b_4096,
+    }
+
+    curr_date = time.strftime('%Y%m%d')
+    workload_config = WorkloadConfig(
+      model=models[options.device_type],
+      num_slices=None,
+      device_type=options.device_type,
+      libtpu_type=LibTpuType.MAXTEXT,
+      base_docker_image=None,
+      num_steps=options.num_steps,
+      base_output_directory=options.base_output_directory,
+      run_name=f'{curr_date}-health-test',
+      # Internal only support, not for customers
+      generate_metrics_and_upload_to_big_query=False,
+    )
+
+    workload_config.model.tuning_params["gcs_metrics"] = False
+    on_device_benchmark_runner(workload_configs=[workload_config])
+
 
 
 if __name__ == '__main__':

--- a/benchmarks/benchmark_utils.py
+++ b/benchmarks/benchmark_utils.py
@@ -35,9 +35,6 @@ class MaxTextModel:
 
 
 # Run this for new definitions that should be part of the library.
-def _add_to_model_dictionary(
-    model_dictionary: dict[str, MaxTextModel], maxtext_model: MaxTextModel
-) -> MaxTextModel:
-  print(maxtext_model.model_name.replace("-", "_"))
+def _add_to_model_dictionary(model_dictionary: dict[str, MaxTextModel], maxtext_model: MaxTextModel) -> MaxTextModel:
   model_dictionary[maxtext_model.model_name.replace("-", "_")] = maxtext_model
   return maxtext_model

--- a/benchmarks/maxtest/getting_started.md
+++ b/benchmarks/maxtest/getting_started.md
@@ -1,0 +1,88 @@
+### Getting starting with using the maxtest tool
+
+*Note: This is currently in preview stage and only supported for v5p and v6e*
+
+The main intent of this tool is to quickly verify whether the provisioned TPU
+nodepool can run a Maxtext workload **without having to
+use XPK**. This is useful for debugging provisioned nodepools for potential hardware issues.
+
+```shell
+bash maxtest.sh \
+    --project tpu-test-project \
+    --cluster tpu-cluster \
+    --region asia-east1 \
+    --nodepool tpu-nodepool \
+    --num_workers 8 # the nodepool here is a v5p-128 so 8 workers
+
+Fetching cluster endpoint and auth data.
+kubeconfig entry generated for bodaborg-v6e-32-td-c.
+Applying generated configuration to the cluster:
+service/headless-svc-87e0b-maxtest created job.batch/87e0b-maxtest created
+
+Job started, visit https://console.cloud.google.com/logs/query;query=resource.labels.pod_name%3D~%2287e0b-maxtest%22;duration=PT1H?project=tpu-test-project to view logs
+or run: 'kubectl logs job.batch/87e0b-maxtest'
+```
+
+-   After running the job, you can check the logs and the exit code to determine
+    the outcome. A successful job will end with `EXIT_CODE=0` as well as the
+    TFLOPs and step time of each step.
+
+```
+I0731 09:47:48.898259     514 isa_program_util_common.cc:493] (HLO module jit__where): Host transfer fingerprint:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+I0731 09:47:48.898413     139 2a886c8_compiler_base.cc:7540] END_TO_END stage duration: 10.6394605ms
+completed step: 0, seconds: 1.353, TFLOP/s/device: 1674.038, Tokens/s/device: 36325.072, total_weights: 1572864, loss: 10.874
+completed step: 1, seconds: 12.444, TFLOP/s/device: 182.028, Tokens/s/device: 3949.842, total_weights: 1572864, loss: 10.410
+...
+completed step: 2, seconds: 0.002, TFLOP/s/device: 917442.589, Tokens/s/device: 19907654.921, total_weights: 1572864, loss: 10.043
+...
+completed step: 3, seconds: 11.715, TFLOP/s/device: 193.354, Tokens/s/device: 4195.595, total_weights: 1572864, loss: 9.774
+completed step: 4, seconds: 11.645, TFLOP/s/device: 194.526, Tokens/s/device: 4221.032, total_weights: 1572864, loss: 9.610
+Unified tuning params for model are: {'per_device_batch_size': 12, 'ici_fsdp_parallelism': -1, 'remat_policy': 'full', 'max_target_length': 4096, 'attention': 'flash', 'gcs_metrics': False, 'use_iota_embed': True, 'dataset_path': 'gs://max-datasets-rogue', 'dataset_type': 'synthetic', 'reuse_example_batch': 1, 'enable_checkpointing': False, 'profiler': 'xplane', 'sa_block_q': 1024, 'sa_block_q_dkv': 2048, 'sa_block_q_dq': 2048}
+Job End: Thu Jul 31 09:48:56 UTC 2025
+EXIT_CODE=0
+```
+
+-   maxtest.sh will generate a YAML file in the directory that is passed to kubectl. This file can be modified and re-used by running `kubectl apply -f maxtest.yaml`
+
+### Debugging common job errors ###
+
+If the job does not exit with `EXIT_CODE=0`, there is a failure among one of
+the workers or the coordinator VM, this can be debugged by checking the specific
+worker logs.
+
+Modify the `pod_name` in Cloud Logs Explorer to the specific worker to view its logs
+by hyphenating the `JOB_NAME` with the index of the worker:
+
+```
+resource.labels.pod_name=~"87e0b-maxtest-0" #Here 0 indicates the coordinator VM (VM 0) logs and '87e0b-maxtext' is the job name
+```
+
+#### Slice Failure / Chip Driver Error ####
+
+A `SLICE_FAILURE_CHIP_DRIVER_ERROR` indicates a problem with one of the TPU workers. The logs from `worker_0` (the coordinator) will show which worker missed the health check.
+
+```
+I0511 18:18:30.779521     915 session_master.cc:211] Worker Address: tpu-job-jax-v6e-8-5-53.headless-svc:8471                                                                                                                                        
+I0511 18:18:30.779522     915 session_master.cc:211] Worker Address: tpu-job-jax-v6e-8-5-38.headless-svc:8471                                                                                                                                        
+W0511 18:18:50.796322     914 session_master.cc:539] The task with address tpu-job-jax-v6e-8-5-38.headless-svc:8471 missed 1 health checks.The most recent health check failed with the following error: UNAVAILABLE: failed to connect to all addres
+ses; last error: UNKNOWN: ipv4:10.200.16.4:8471: Failed to connect to remote host: Timeout occurred: FD Shutdown                                                                                                                                     
+=== Source Location Trace: ===                                                                                                                                                                                                                       
+third_party/grpc/include/grpcpp/impl/status.h:112                                                                                                                                                                                                    
+E0511 18:18:50.796514     915 session_master.cc:505] Session is failing with the following status: Session master detected TPU session error from worker tpu-job-jax-v6e-8-5-15.headless-svc:8471. The reporting TPU chip locations are:tpu31:pe4:3, 
+tpu31:pe4:2                                                                                                                                                                                                                                          
+E0511 18:18:50.796852     915 tpunetd_client.cc:311] Detected failure SLICE_FAILURE_CHIP_DRIVER_ERROR in session e6c885828b538167; Start failure handling                                                                                            
+W0511 18:18:50.796885     915 session_master.cc
+```
+
+Use Logs Explorer to view the logs for that specific worker. For example, for worker 38, use the query `resource.labels.pod_name=~"tpu-job-jax-v6e-8-5-38"`. Where `38` is the VM that missed the health check and `tpu-job-jax-v6e-8-5` is the name of the job.
+
+#### An XLA compiler bug or your job hit a bad TPU hardware ####
+
+```
+6x2x0_SC1: *** A program or fatal error occurred, all pending programs will fail, and results may be corrupted. This is likely an XLA compiler bug or your job hit a bad TPU hardware. If you suspect a compiler bug please file a bug to xla-tpu@ and CC tfrt-devs@. If the error is repeatedly happening on the same machine and you suspect faulty hardware, consider reporting a bad machine. Physical location: tpu3:pe2:2
+```
+
+Action: If you see this error, likely you have a bad TPU hardware issue, attempt to retry the workload a few times to confirm. The bad hardware will be on the same VM as the log is reported on. Delete and recreate the nodepool in this situation.
+
+
+

--- a/benchmarks/maxtest/maxtest.sh
+++ b/benchmarks/maxtest/maxtest.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+function usage() {
+  echo "error: $1"
+  echo "Usage: $0 [--project [--cluster] [--region] [--nodepool] [--num_workers]"
+  echo "  --num_workers        Number of VMs in a TPU nodepool"
+  echo ""
+  echo "Example for a v5p-128 nodepool: $0 --project tpu-test-project --cluster tpu-cluster --region asia-east1 --num_workers 16"
+  exit 1
+}
+
+while [[ "$#" > 0 ]]; do case $1 in
+  -n|--project) GKE_PROJECT="$2"; shift;shift;;
+  -s|--cluster) GKE_CLUSTER="$2";shift;shift;;
+  -r|--region)  GKE_REGION="$2";shift;shift;;
+  --nodepool)   NODEPOOL="$2";shift;shift;;
+  --num_workers)   NUM_WORKERS="$2";shift;shift;;
+  *) usage "Unknown parameter passed: $1"; shift; shift;;
+esac; done
+
+if [ -z "$GKE_PROJECT" ]; then usage "--project not set"; fi;
+if [ -z "$GKE_CLUSTER" ]; then usage "--cluster not set"; fi;
+if [ -z "$GKE_REGION" ]; then usage "--region not set"; fi;
+if [ -z "$NODEPOOL" ]; then usage "--nodepool not set"; fi;
+if [ -z "$NUM_WORKERS" ]; then usage "--num_workers not set"; fi;
+
+
+TPU_TOPOLOGY=$(gcloud container node-pools describe $NODEPOOL --region=$GKE_REGION --cluster=$GKE_CLUSTER --project=$GKE_PROJECT | grep "tpuTopology" | awk '{print $2}')
+if [ -z "$TPU_TOPOLOGY" ]; then exit; fi;
+TPU_ACCELERATOR=$(gcloud container node-pools describe $NODEPOOL --region=$GKE_REGION --cluster=$GKE_CLUSTER --project=$GKE_PROJECT | grep "goog-gke-accelerator-type" | awk '{print $2}')
+if [ -z "$TPU_ACCELERATOR" ]; then exit; fi;
+
+UUID=$(uuidgen)
+export JOB_NAME="${UUID:0:5}-maxtest"
+export DOCKER_IMAGE="gcr.io/cloud-tpu-images-public/tpu/healthscan"
+export NODEPOOL
+export TPU_TOPOLOGY
+export TPU_ACCELERATOR
+export GKE_PROJECT
+export GKE_REGION
+export GKE_CLUSTER
+
+export MEMORY_PER_HOST="407Gi"
+export TPU_CHIPS_PER_HOST=4
+export COMPLETIONS=$NUM_WORKERS # Number of VMs in the nodepool (v6e -> 2 VMs for v6e-8, v5p -> 1 VM for a v5p-8)
+
+YAML_VARS='$JOB_NAME $DOCKER_IMAGE $NODEPOOL $TPU_TOPOLOGY $TPU_ACCELERATOR $COMPLETIONS $MEMORY_PER_HOST $TPU_CHIPS_PER_HOST $GKE_PROJECT $GKE_REGION $GKE_CLUSTER'
+
+envsubst "${YAML_VARS}" < maxtest.yaml.template > maxtest.yaml
+
+# --- Execution ---
+gcloud container clusters get-credentials $GKE_CLUSTER --region=$GKE_REGION --project=$GKE_PROJECT
+echo "Applying generated configuration to the cluster:"
+STATUS=$(kubectl apply -f maxtest.yaml)
+echo $STATUS
+
+if [[ $STATUS =~ "unchanged"|"created" ]]; then
+  echo ""
+  echo "Job started, visit https://console.cloud.google.com/logs/query;query=resource.labels.pod_name%3D~%22${JOB_NAME}%22;duration=PT1H?project=${GKE_PROJECT} to view logs"
+  echo "or run: 'kubectl logs job.batch/${JOB_NAME}'";
+fi

--- a/benchmarks/maxtest/maxtest.yaml.template
+++ b/benchmarks/maxtest/maxtest.yaml.template
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc-${JOB_NAME}
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+spec:
+  backoffLimit: 0
+  completions: ${COMPLETIONS}
+  parallelism: ${COMPLETIONS}
+  completionMode: Indexed
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: ${NODEPOOL}
+        cloud.google.com/gke-tpu-topology: ${TPU_TOPOLOGY}
+        cloud.google.com/gke-tpu-accelerator: ${TPU_ACCELERATOR}
+      hostNetwork: false
+      subdomain: headless-svc-${JOB_NAME}
+      restartPolicy: Never
+      containers:
+      - name: tpu-job
+        image: ${DOCKER_IMAGE}
+        ports:
+        - containerPort: 8471
+        - containerPort: 8431
+        securityContext:
+          privileged: true
+        env:
+        command:
+        - bash
+        - -c
+        - |
+          printenv
+          _sigterm() (kill -SIGTERM $! 2>/dev/null;);
+          trap _sigterm SIGTERM;
+
+          (export TPU_STDERR_LOG_LEVEL=0 && export TPU_MIN_LOG_LEVEL=0 && export TF_CPP_MIN_LOG_LEVEL=0 && python3 -m benchmarks.benchmark_runner healthscan --device_type=$TPU_ACCELERATOR_TYPE --base_output_directory=gke-healthscan-output --num_steps=5) & PID=$1;
+
+          while kill -0 $PID 2>/dev/null;
+              do sleep 5;
+          done;
+          wait $PID;
+          EXIT_CODE=$?;
+
+          echo Job End: $(date);
+          echo EXIT_CODE=$EXIT_CODE;
+
+           if [ "$EXIT_CODE" = 143 ]; then
+            exit $EXIT_CODE
+          fi
+        resources:
+          requests:
+            memory: ${MEMORY_PER_HOST}
+            google.com/tpu: ${TPU_CHIPS_PER_HOST}
+          limits:
+            memory: ${MEMORY_PER_HOST}
+            google.com/tpu: ${TPU_CHIPS_PER_HOST}


### PR DESCRIPTION
# Description

Added bash script/documentation to run maxtest models via a small script

Changes:
1. Modifies benchmark_runner.py to include a new healthscan entrypoint.

This change allows end users to simply provide a 1 line command in their YAML that will run a model on the TPU nodepool by calling kubectl. I've also attached what a sample YAML file looks like. This is useful for quickly verifying whether a nodepool has a hardware issue or not. The reason I added a new entrypoint instead of using on-device is because the healthscan entrypoint will pick a default model for the slice size. In the future, I want to add more diagnostic flags into this entrypoint and other changes without bloating on-device.

2. Added a wrapper script called 'maxtest.sh' and documentation in a folder under benchmarks.

This script allows users to quickly verify whether their nodepool job is failing due to user error or bad hardware with a simple 1 line call. This is convenient if a user doesn't want to provision via XPK or have a provisioned nodepool already. Also an already built pinned Docker image means the user wont have to build their image.  b/430561678 tracks exposing this image.
```
$:bash maxtest.sh --project tpu-prod-env-one-vm --cluster bodaborg-v6e-32-td-c --region asia-east1 --nodepool bodaborg-v6e-32-td-c-np-0 --num_workers 8
Fetching cluster endpoint and auth data.
kubeconfig entry generated for bodaborg-v6e-32-td-c.
Applying generated configuration to the cluster:
service/headless-svc-a1c2a-maxtest created job.batch/a1c2a-maxtest created

Job started, visit https://pantheon.corp.google.com/logs/query;query=resource.labels.pod_name%3D~%22a1c2a-quiktest%22;duration=PT1H?project=tpu-prod-env-one-vm to view logs
or run: 'kubectl logs job.batch/a1c2a-maxtest'
```

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Tested this change e2e on a v5p-512/v5p-128/v6e-32/v6e-256.  
Attached some test results.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
- =
[v5p-128_test.txt](https://github.com/user-attachments/files/21493935/v5p-128_test.txt)
[v6e-32_test.txt](https://github.com/user-attachments/files/21493936/v6e-32_test.txt)
