### PR TITLE
Fix variable name typo in KVCache

### DIFF
--- a/MaxText/inference/kvcache.py
+++ b/MaxText/inference/kvcache.py
@@ -298,7 +298,7 @@ class KVCache(nnx.Module):
     self.max_prefill_length = max_prefill_length
     self.max_target_length = max_target_length
     self.batch = batch
-    self.val_seq_len = key_seq_len
+    self.key_seq_len = key_seq_len
     self.value_seq_len = value_seq_len
     self.key_heads = key_heads
     self.value_heads = value_heads


### PR DESCRIPTION
# Description

* Fix variable name `self.val_seq_len` --> `self.key_seq_len`
* Did not appear to have actual impact since all KVCache unit tests + perf tests were still passing

# Tests

* Same perf in inference microbenchmark test: https://diff.googleplex.com/#key=U1qlrWuQVIAi
    * `pytest MaxText/tests/integration_tests/inference_microbenchmark_smoke_test.py::Inference_Microbenchmark::test`
* Ran decode on v6e-8 devbox for `llama3.1-8B` (standard KVCache) and `deepseek3-test` (MlaKVCache). Got output for both.

```
python3 -m MaxText.decode MaxText/configs/base.yml \
    model_name=deepseek3-test \
    tokenizer_path=assets/tokenizer_llama3.tiktoken \
    tokenizer_type=tiktoken \
    scan_layers=false \
    per_device_batch_size=1 \
    ici_fsdp_parallelism=1 \
    ici_autoregressive_parallelism=-1 \
    max_prefill_predict_length=128 \
    max_target_length=256 \
    prompt="I love to" \
    attention=dot_product \
    mla_naive_kvcache=False
```
```
python3 -m MaxText.decode MaxText/configs/base.yml \
    model_name=llama3.1-8b \
    tokenizer_path=assets/tokenizer_llama3.tiktoken \
    tokenizer_type=tiktoken \
    scan_layers=false \
    per_device_batch_size=1 \
    ici_fsdp_parallelism=1 \
    ici_autoregressive_parallelism=-1 \
    max_prefill_predict_length=128 \
    max_target_length=256 \
    prompt="I love to" \
    attention=dot_product
```
* kvcache_test.py: `python3 -m pytest MaxText/tests/inference/kvcache_test.py`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
