### PR TITLE
Fix Spelling mistake in codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ MaxText/layers/pipeline.py @gobbleturk @richjames0
 MaxText/layers/moe.py @RissyRan @michelle-yooh @gagika @richjames0
 MaxText/layers/multi_token_prediction.py @parambole @RissyRan @gagika @richjames0
 MaxText/elastic_train.py @lukebaumann @shauryagup @RoshaniN
-MaxText/layers/quantization.py @khatwanimohit @jshin1394 @liudangyi @richjames0
+MaxText/layers/quantizations.py @khatwanimohit @jshin1394 @liudangyi @richjames0
 
 # Inference
 MaxText/tests/inference @vipannalla @mitalisi @gpolovets1 @mailvijayasingh @jrplatin @patemotter @lumosis @richjames0


### PR DESCRIPTION
# Description

spelling mistake 

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

n/a

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
