### PR TITLE
[Qwix] gpu fp8 configs

### DIFF
--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -245,7 +245,7 @@ def validate_quantization_methods(keys):
   """Validate quantization methods
   """
   valid_quant_methods = (
-    "", "int8", "fp8", "fp8_full"
+    "", "int8", "fp8", "fp8_full", "fp8_gpu", "fp8_nanoo"
   )
   if keys["use_qwix_quantization"]:
     if keys["quantization"] not in valid_quant_methods:


### PR DESCRIPTION
# Description

This PR adds support fp8 and nanoo_fp8 configs for GPU. 


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Added unit tests for logits and gradients comparison before and after this change

```
relative error in logits: 0.14237932860851288
['decoder']/['decoder_norm']/['scale']/.value: relative error = 0.011346928775310516
['decoder']/['layers']/['mlp']/['mlp_layer_norm']/['scale']/.value: relative error = 0.99775630235672
['decoder']/['layers']/['mlp']/['wi_0']/['kernel']/.value: relative error = 0.9926397800445557
['decoder']/['layers']/['mlp']/['wi_1']/['kernel']/.value: relative error = 0.9936865568161011
['decoder']/['layers']/['mlp']/['wo']/['kernel']/.value: relative error = 0.9968506693840027
['decoder']/['layers']/['pre_self_attention_layer_norm']/['scale']/.value: relative error = 0.9989339113235474
['decoder']/['layers']/['self_attention']/['key']/['kernel']/.value: relative error = 0.9885572791099548
['decoder']/['layers']/['self_attention']/['out']/['kernel']/.value: relative error = 0.9989104270935059
['decoder']/['layers']/['self_attention']/['query']/['kernel']/.value: relative error = 0.9989496469497681
['decoder']/['layers']/['self_attention']/['value']/['kernel']/.value: relative error = 0.9989122152328491
['decoder']/['logits_dense']/['kernel']/.value: relative error = 0.1505425125360489
['token_embedder']/['embedding']/.value: relative error = 0.7164885401725769
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
