### PR TITLE
Migrate Gpt3 to NNX.

### DIFF
--- a/MaxText/layers/decoders.py
+++ b/MaxText/layers/decoders.py
@@ -347,7 +347,7 @@ class Decoder(nn.Module):
       case DecoderBlockType.GEMMA3:
         return [gemma3.Gemma3DecoderLayer]
       case DecoderBlockType.GPT3:
-        return [gpt3.Gpt3DecoderLayer]
+        return [gpt3.gpt3_decoder_layer_class()]
       case DecoderBlockType.QWEN3:
         return [qwen3.Qwen3DecoderLayer]
       case DecoderBlockType.SIMPLE:


### PR DESCRIPTION
# Description

Migrate Gpt3 implementation from Linen to NNX.
Including the following classes:
- Gpt3MultiHeadAttention
- Gpt3DecoderLayer

# Tests

Ran train command to train gpt3-52k for 10 steps:

```
python3 -m MaxText.train  MaxText/configs/base.yml run_name=gpt3-train-run base_output_directory=gs://maxtext-test/train_gpt3/1/ model_name=gpt3-52k dataset_type=synthetic steps=10
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
