### PR TITLE
Fix XLML failure for Mistral 

### DIFF
--- a/MaxText/tests/forward_pass_logit_checker.py
+++ b/MaxText/tests/forward_pass_logit_checker.py
@@ -203,8 +203,6 @@ def get_data(golden_data, golden_data_index, config):
       [np.arange(config.max_target_length, dtype=np.int32) for _ in range(config.global_batch_size_to_train_on)]
   )
 
-  max_logging.log(f"ids={ids}, decoder_segment_ids = {decoder_segment_ids}, decoder_positions= {decoder_positions}")
-
   return ids, decoder_segment_ids, decoder_positions, logits, seq_len
 
 
@@ -249,6 +247,9 @@ def main(config, test_args):  # pylint: disable=W0621
         )
 
       full_train_logits = jax.experimental.multihost_utils.process_allgather(full_train_logits)
+      # if full_train_logits shape is [num_hosts, batch_size, seq_len, vocab_size]
+      if full_train_logits.ndim == 4:
+        full_train_logits = jnp.reshape(full_train_logits, (-1, config.max_target_length, config.vocab_size))
       # Slice to original sequence length
       full_train_logits = full_train_logits[:, :seq_len, :]
 


### PR DESCRIPTION
# Description

Checking for an extra axis which is added for num_hosts when doing `jax.experimental.multihost_utils.process_allgather` on logits. 



*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

https://paste.googleplex.com/5659445652357120

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
