### PR TITLE
Upgrade Flax to 0.11.0

### DIFF
--- a/MaxText/layers/pipeline.py
+++ b/MaxText/layers/pipeline.py
@@ -424,7 +424,7 @@ class Pipeline(nn.Module):
         in_axes=(0, 0, 0, None, None),
         spmd_axis_name="stage",
         variable_axes={"params": 0, "_overwrite_with_gradient": 0},
-        split_rngs={"params": self.is_initializing()},
+        split_rngs={"params": self.is_initializing(), "dropout": self.config.enable_dropout},
         metadata_params={
             nn.PARTITION_NAME: "layers",
             "sub_weight_split_dims_mapping": (None),
@@ -450,7 +450,7 @@ class Pipeline(nn.Module):
         in_axes=(0, 0, 0, 0, None, None),
         spmd_axis_name="stage",
         variable_axes={"params": 0},
-        split_rngs={"params": self.is_initializing()},
+        split_rngs={"params": self.is_initializing(), "dropout": self.config.enable_dropout},
         metadata_params={
             nn.PARTITION_NAME: "layers",
             "sub_weight_split_dims_mapping": (None),
@@ -682,7 +682,7 @@ class Pipeline(nn.Module):
                 "non_trainable": 0,
                 "hyper_params": 0,
             },
-            split_rngs={"params": True},
+            split_rngs={"params": True, "dropout": self.config.enable_dropout},
             metadata_params={
                 nn.PARTITION_NAME: "circular_repeats",
                 "sub_weight_split_dims_mapping": (None,),

--- a/MaxText/tests/maxengine_test.py
+++ b/MaxText/tests/maxengine_test.py
@@ -116,7 +116,11 @@ class MaxEngineTest(unittest.TestCase):
     ids, decoder_segment_ids, decoder_positions = self.get_data()
 
     transformer_vars = model.init(
-        {"params": self.rng, "aqt": self.rng}, ids, decoder_positions, decoder_segment_ids, enable_dropout=False
+        {"params": self.rng, "aqt": self.rng, "dropout": self.rng},
+        ids,
+        decoder_positions,
+        decoder_segment_ids,
+        enable_dropout=False,
     )
     input_tokens = jnp.array([1, 306, 5360, 304, 0, 0, 0, 0])
     true_length = 4
@@ -140,7 +144,11 @@ class MaxEngineTest(unittest.TestCase):
     ids, decoder_segment_ids, decoder_positions = self.get_data()
 
     transformer_vars = model.init(
-        {"params": self.rng, "aqt": self.rng}, ids, decoder_positions, decoder_segment_ids, enable_dropout=False
+        {"params": self.rng, "aqt": self.rng, "dropout": self.rng},
+        ids,
+        decoder_positions,
+        decoder_segment_ids,
+        enable_dropout=False,
     )
     input_tokens = jnp.array([1, 306, 5360, 304])
     engine = MaxEngine(self.cfg, jax.devices())

--- a/MaxText/tests/model_test.py
+++ b/MaxText/tests/model_test.py
@@ -87,7 +87,11 @@ class TestModel(unittest.TestCase):
     ids, decoder_segment_ids, decoder_positions = self.get_data()
 
     transformer_vars = model.init(
-        {"params": self.rng, "aqt": self.rng}, ids, decoder_positions, decoder_segment_ids, enable_dropout=False
+        {"params": self.rng, "aqt": self.rng, "dropout": self.rng},
+        ids,
+        decoder_positions,
+        decoder_segment_ids,
+        enable_dropout=False,
     )
 
     logits = jax.eval_shape(
@@ -126,11 +130,19 @@ class TestModel(unittest.TestCase):
     ids, decoder_segment_ids, decoder_positions = self.get_data()
 
     train_transformer_vars = train_model.init(
-        {"params": self.rng, "aqt": self.rng}, ids, decoder_positions, decoder_segment_ids, enable_dropout=False
+        {"params": self.rng, "aqt": self.rng, "dropout": self.rng},
+        ids,
+        decoder_positions,
+        decoder_segment_ids,
+        enable_dropout=False,
     )
 
     prefill_transformer_vars = prefill_model.init(
-        {"params": self.rng, "aqt": self.rng}, ids, decoder_positions, decoder_segment_ids, enable_dropout=False
+        {"params": self.rng, "aqt": self.rng, "dropout": self.rng},
+        ids,
+        decoder_positions,
+        decoder_segment_ids,
+        enable_dropout=False,
     )
 
     full_train_logits = train_model.apply(

--- a/MaxText/tests/moe_test.py
+++ b/MaxText/tests/moe_test.py
@@ -159,6 +159,7 @@ class TokenDroppingTest(unittest.TestCase):
     self.assertTrue((expected_dispatch_mask == actual_dispatch_mask).all())
     self.assertTrue(jax.numpy.allclose(expected_combine_mask, actual_combine_mask, rtol=1e-02, atol=1e-02))
 
+
 class MlpBlockTest(unittest.TestCase):
 
   def setUp(self):
@@ -187,12 +188,13 @@ class MlpBlockTest(unittest.TestCase):
         weight_dtype=jnp.bfloat16,
         name="mlp",
         quant=quant,
-        use_bias=True
+        use_bias=True,
     )
 
   def test_init(self):
     x = jnp.array([1.0, 2.0])
     self.model.init({"params": self.rng, "dropout": self.rng}, x)
+
 
 class DeepSeekRoutingTest(unittest.TestCase):
 
@@ -325,7 +327,8 @@ class RoutedMoeTest(unittest.TestCase):
         dtype=cfg.dtype,
     )
     variables = model.init(
-        rng, jax.random.normal(rng, (int(cfg.per_device_batch_size), cfg.max_target_length, cfg.base_emb_dim))
+        {"params": rng, "dropout": rng},
+        jax.random.normal(rng, (int(cfg.per_device_batch_size), cfg.max_target_length, cfg.base_emb_dim)),
     )
 
     output = jax.jit(model.apply)(variables, hidden_states)  # pylint: disable=not-callable

--- a/MaxText/tests/multi_token_prediction_test.py
+++ b/MaxText/tests/multi_token_prediction_test.py
@@ -71,7 +71,7 @@ class MultiTokenPredictionLayerTest(unittest.TestCase):
     self.decoder_segment_ids = jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32)
 
     # Initialize Layer Parameters
-    init_rngs = {"params": init_rng}
+    init_rngs = {"params": init_rng, "dropout": init_rng}
     self.variables = self.mtp_layer.init(
         init_rngs,
         self.prev_hidden_state,

--- a/MaxText/tests/quantizations_test.py
+++ b/MaxText/tests/quantizations_test.py
@@ -279,18 +279,25 @@ class QuantTest(unittest.TestCase):
     return all(jnp.abs(y - x).mean() / jnp.abs(x).mean() < tolerance for x, y in zip(leaves_a, leaves_b))
 
   def quantization_config(self, quant):
-    """ Run forward pass and backward pass for quantized model and compare with base model.
-    """
+    """Run forward pass and backward pass for quantized model and compare with base model."""
     cfg = self.init_pyconfig(quantization=quant)
     model = train_utils.create_model(self.cfg, self.mesh)
     qt_model = train_utils.create_model(cfg, self.mesh)
 
     ids, decoder_segment_ids, decoder_positions = self.get_data()
     var = model.init(
-        {"params": self.rng, "aqt": self.rng}, ids, decoder_positions, decoder_segment_ids, enable_dropout=False
+        {"params": self.rng, "aqt": self.rng, "dropout": self.rng},
+        ids,
+        decoder_positions,
+        decoder_segment_ids,
+        enable_dropout=False,
     )
     quantized_vars = qt_model.init(
-        {"params": self.rng, "aqt": self.rng}, ids, decoder_positions, decoder_segment_ids, enable_dropout=False
+        {"params": self.rng, "aqt": self.rng, "dropout": self.rng},
+        ids,
+        decoder_positions,
+        decoder_segment_ids,
+        enable_dropout=False,
     )
 
     def loss_base(params, inputs):

--- a/constraints_gpu.txt
+++ b/constraints_gpu.txt
@@ -46,7 +46,7 @@ exceptiongroup==1.2.2
 fastapi==0.115.3
 filelock==3.16.1
 flatbuffers==24.3.25
-flax==0.10.6
+flax==0.11.0
 frozenlist==1.5.0
 fsspec==2024.9.0
 gast==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ array-record
 cloud-accelerator-diagnostics
 cloud-tpu-diagnostics
 datasets>=4.0.0
-flax==0.10.6
+flax>=0.11.0
 gcsfs
 google-api-python-client
 google-cloud-aiplatform==1.61.0

--- a/requirements_with_jax_ai_image.txt
+++ b/requirements_with_jax_ai_image.txt
@@ -1,7 +1,7 @@
 # Requirements for Building the MaxText Docker Image
 # These requirements are additional to the dependencies present in the JAX AI base image.
 datasets
-flax==0.10.6
+flax>=0.11.0
 google-api-python-client
 google-jetstream@git+https://github.com/AI-Hypercomputer/JetStream.git
 grain[parquet]>=0.2.6

--- a/requirements_with_jax_stable_stack_0_6_1_pipreqs.txt
+++ b/requirements_with_jax_stable_stack_0_6_1_pipreqs.txt
@@ -7,7 +7,7 @@ cloud_tpu_diagnostics==0.1.5
 datasets==3.6.0
 etils==1.12.2
 evaluate==0.4.4
-flax==0.10.6
+flax==0.11.0
 grain==0.2.10
 grpcio==1.72.0rc1
 huggingface_hub==0.33.0


### PR DESCRIPTION
# Description

1. Upgrade Flax to 0.11.0

2. In 3.11, there was a change that makes `nnx.Dropout` fork the `dropout` RngStream on `__init__` so it makes it a requirement if `rngs` is passed. This PR adds a `dropout` key when initializing a model.

# Tests

Unit tests/integration tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
