### PR TITLE
Update quantizations.py

### DIFF
--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -26,8 +26,6 @@ from aqt.jax.v2.flax import aqt_flax
 from aqt.jax.v2 import tiled_dot_general
 from aqt.jax.v2 import calibration
 
-import qwix
-
 import jax
 import jax.numpy as jnp
 from jax.tree_util import tree_flatten_with_path, tree_unflatten
@@ -548,6 +546,7 @@ def get_quant_mode(quant_mode_str: str = "train"):
 def configure_quantization(config: Config, quant_mode_str: str = "train"):
   """Configure quantization based on user config and quant mode."""
   if config.use_qwix_quantization:
+    import qwix
     return None
   quant_cfg = _get_quant_config(config)
   if quant_cfg:
@@ -657,6 +656,7 @@ def get_qt_provider(config):
 def maybe_quantize_model(model, config):
   """Quantize the model if quantization is enabled."""
   if config.use_qwix_quantization:
+    import qwix
     quantization_provider = get_qt_provider(config)
     if quantization_provider:
       model = qwix.quantize_model(model, quantization_provider)


### PR DESCRIPTION
# Description

This PR is to fix the incompatability of qwix with the MaxText docker image.

I found that the decode sample in quick start is broken. This can be reproduced as :

```
git clone https://github.com/AI-Hypercomputer/maxtext
cd maxtext/
gcloud config set project [PROJECT]
bash ./docker_build_dependency_image.sh MODE=stable
gcloud auth configure-docker
bash ./docker_upload_runner.sh CLOUD_IMAGE_NAME=maxtext_runner
```

Run decode:

```
docker run gcr.io/dataflow-autotuning/maxtext_runner:latest python3 -m MaxText.train MaxText/configs/base.yml \
base_output_directory=gs://dataflow-autotuning/remote_inference/maxtext/output \
run_name=max_decode \
per_device_batch_size=1
```

Output:
```
2025-08-02 17:48:43.326888: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1754156923.342441       1 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
E0000 00:00:1754156923.347112       1 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
W0000 00:00:1754156923.361459       1 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1754156923.361499       1 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1754156923.361505       1 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1754156923.361510       1 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 187, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/local/lib/python3.10/runpy.py", line 110, in _get_module_details
    __import__(pkg_name)
  File "/deps/MaxText/__init__.py", line 30, in <module>
    from MaxText import train_utils
  File "/deps/MaxText/train_utils.py", line 21, in <module>
    from MaxText.layers import quantizations
  File "/deps/MaxText/layers/quantizations.py", line 29, in <module>
    import qwix
  File "/usr/local/lib/python3.10/site-packages/qwix/__init__.py", line 21, in <module>
    from qwix._src.providers.lora import LoraProvider, LoraRule, apply_lora_to_model
  File "/usr/local/lib/python3.10/site-packages/qwix/_src/providers/lora.py", line 28, in <module>
    from qwix._src.core import einsum
  File "/usr/local/lib/python3.10/site-packages/qwix/_src/core/einsum.py", line 21, in <module>
    from qwix._src.core import dot_general
  File "/usr/local/lib/python3.10/site-packages/qwix/_src/core/dot_general.py", line 351
    return array[*indices]
                 ^
SyntaxError: invalid syntax
```

# Tests

The efficacy of the PR can be tested by:
```
git clone -b dannikay-conditionally-import-qwix https://github.com/dannikay/maxtext
cd maxtext/
gcloud config set project [PROJECT]
bash ./docker_build_dependency_image.sh MODE=stable
gcloud auth configure-docker
bash ./docker_upload_runner.sh CLOUD_IMAGE_NAME=maxtext_runner
```

Run:
```
docker run gcr.io/dataflow-autotuning/maxtext_runner:latest python3 -m MaxText.train MaxText/configs/base.yml \
base_output_directory=gs://dataflow-autotuning/remote_inference/maxtext/output \
run_name=max_decode \
per_device_batch_size=1
```

The qwix error is gone.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
