### PR TITLE
Ensure correct module path when calling nnx.

### DIFF
--- a/MaxText/layers/nnx_wrappers.py
+++ b/MaxText/layers/nnx_wrappers.py
@@ -314,6 +314,31 @@ def _get_module_method(module, method: tp.Callable[..., Any] | str | None):
   return method
 
 
+def _enable_linen_module_paths(module: Module):
+  """Ensure that linen module_path is correct when in NNX."""
+  def wrap(call_fn, name: str):
+    def wrapped(*args, **kwargs):
+      if not linen.module._context.module_stack:  # pylint: disable=W0212
+        return call_fn(*args, **kwargs)
+      nn_module = linen.module._context.module_stack[-1]  # pylint: disable=W0212
+      old_path = nn_module.path
+      # We modify the path of the current nn module in place. This is a litte
+      # bit hacky but should be good as a temporary solution.
+      nn_module.scope.path += (name,)
+      try:
+        return call_fn(*args, **kwargs)
+      finally:
+        nn_module.scope.path = old_path
+    return wrapped
+
+  for path, node in nnx.iter_graph(module):
+    # Only enable it on non-root nnx modules.
+    if path and isinstance(node, nnx.Module):
+      node.__class__ = type(node.__class__.__name__, (node.__class__,), {
+        '__call__': wrap(node.__class__.__call__, str(path[-1])),
+      })
+
+
 class ToLinen(linen.Module):
   """A wrapper to turn any NNX module into a Linen module.
 
@@ -376,6 +401,7 @@ class ToLinen(linen.Module):
     # init codepath
     if self.is_initializing():
       module = self.nnx_class(*self.args, **_module_kwargs())
+      _enable_linen_module_paths(module)
       # TODO: add lazy_init here in case there's an `ToNNX` submodule under `module`.
       # update linen variables before call module to save initial state
       self._update_variables(module)
@@ -385,6 +411,7 @@ class ToLinen(linen.Module):
 
     # create the nnx module
     module = self.nnx_class(*self.args, **_module_kwargs())
+    _enable_linen_module_paths(module)
     # update nnx module from linen variables
     def maybe_unbox(x):
       if isinstance(x, meta.AxisMetadata):

--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -613,7 +613,14 @@ def configure_kv_quant(config):
 
 
 def get_basic_config(config, dtype):
+  """Basic Qwix config that only quantizes forward passes."""
   rules = [
+      # Dot-product attention is not quantized for now.
+      qwix.QtRule(
+        module_path='decoder/.*layers.*/self_attention/attention_op',
+        weight_qtype=None,
+        act_qtype=None,
+      ),
       qwix.QtRule(
         module_path='decoder/.*layers.*',  # Apply to all modules
         weight_qtype=dtype,
@@ -628,6 +635,12 @@ def get_fp8_config(config):
   """ fp8 config rules with per-tensor calibration.
   """
   rules = [
+      # Dot-product attention is not quantized for now.
+      qwix.QtRule(
+        module_path='decoder/.*layers.*/self_attention/attention_op',
+        weight_qtype=None,
+        act_qtype=None,
+      ),
       qwix.QtRule(
         module_path='decoder/.*layers.*',  # Apply to all modules
         weight_qtype=jnp.float8_e4m3fn,


### PR DESCRIPTION
Qwix relies on the linen module paths to apply the correct quantization configs. The module path is broken when part of the model is converted to nnx. This patch introduces a mechanism to update the linen module paths when calling a nnx module.

This patch also disables the quantization of dot-product attentions, which follows the same behavior as before.

For model_name=default, before:

```
[QWIX] module='decoder/layers/self_attention/query' op=dot_general0 rule=0
[QWIX] module='decoder/layers/self_attention/key' op=dot_general0 rule=0
[QWIX] module='decoder/layers/self_attention/value' op=dot_general0 rule=0
[QWIX] module='decoder/layers/self_attention/attention_op' op=einsum0 rule=0
[QWIX] module='decoder/layers/self_attention/attention_op' op=einsum1 rule=0
[QWIX] module='decoder/layers/self_attention/out' op=dot_general0 rule=0
[QWIX] module='decoder/layers/mlp' op=dot_general0 rule=0
[QWIX] module='decoder/layers/mlp' op=dot_general1 rule=0
[QWIX] module='decoder/layers/mlp' op=dot_general2 rule=0
[QWIX] module='decoder/logits_dense' op=dot_general0 rule=None
```

after:

```
[QWIX] module='decoder/layers/self_attention/query' op=dot_general0 rule=1
[QWIX] module='decoder/layers/self_attention/key' op=dot_general0 rule=1
[QWIX] module='decoder/layers/self_attention/value' op=dot_general0 rule=1
[QWIX] module='decoder/layers/self_attention/attention_op' op=einsum0 rule=0
[QWIX] module='decoder/layers/self_attention/attention_op' op=einsum1 rule=0
[QWIX] module='decoder/layers/self_attention/out' op=dot_general0 rule=1
[QWIX] module='decoder/layers/mlp/wi_0' op=dot_general0 rule=1
[QWIX] module='decoder/layers/mlp/wi_1' op=dot_general1 rule=1
[QWIX] module='decoder/layers/mlp/wo' op=dot_general2 rule=1
[QWIX] module='decoder/logits_dense' op=dot_general0 rule=None
```

For model_name=deepseek3-671b, before:

```
[QWIX] module='decoder/dense_layers/self_attention/wq_a' op=dot_general0 rule=0
[QWIX] module='decoder/dense_layers/self_attention/wq_b' op=dot_general0 rule=0
[QWIX] module='decoder/dense_layers/self_attention/wkv_a' op=dot_general0 rule=0
[QWIX] module='decoder/dense_layers/self_attention/wkv_b' op=dot_general0 rule=0
[QWIX] module='decoder/dense_layers/self_attention/attention_op' op=einsum0 rule=0
[QWIX] module='decoder/dense_layers/self_attention/attention_op' op=einsum1 rule=0
[QWIX] module='decoder/dense_layers/self_attention/out' op=dot_general0 rule=0
[QWIX] module='decoder/dense_layers/mlp' op=dot_general0 rule=0
[QWIX] module='decoder/dense_layers/mlp' op=dot_general1 rule=0
[QWIX] module='decoder/dense_layers/mlp' op=dot_general2 rule=0
[QWIX] module='decoder/moe_layers/self_attention/wq_a' op=dot_general0 rule=0
[QWIX] module='decoder/moe_layers/self_attention/wq_b' op=dot_general0 rule=0
[QWIX] module='decoder/moe_layers/self_attention/wkv_a' op=dot_general0 rule=0
[QWIX] module='decoder/moe_layers/self_attention/wkv_b' op=dot_general0 rule=0
[QWIX] module='decoder/moe_layers/self_attention/attention_op' op=einsum0 rule=0
[QWIX] module='decoder/moe_layers/self_attention/attention_op' op=einsum1 rule=0
[QWIX] module='decoder/moe_layers/self_attention/out' op=dot_general0 rule=0
[QWIX] module='decoder/moe_layers/DeepSeekMoeBlock_0/MoeBlock_0/gate' op=dot_general0 rule=0
[QWIX] module='decoder/moe_layers/DeepSeekMoeBlock_0/MoeBlock_0' op=einsum0 rule=0
[QWIX] module='decoder/moe_layers/DeepSeekMoeBlock_0/shared_experts' op=dot_general0 rule=0
[QWIX] module='decoder/moe_layers/DeepSeekMoeBlock_0/shared_experts' op=dot_general1 rule=0
[QWIX] module='decoder/moe_layers/DeepSeekMoeBlock_0/shared_experts' op=dot_general2 rule=0
[QWIX] module='decoder/logits_dense' op=dot_general0 rule=None
```

after:

```
[QWIX] module='decoder/dense_layers/self_attention/wq_a' op=dot_general0 rule=1
[QWIX] module='decoder/dense_layers/self_attention/wq_b' op=dot_general0 rule=1
[QWIX] module='decoder/dense_layers/self_attention/wkv_a' op=dot_general0 rule=1
[QWIX] module='decoder/dense_layers/self_attention/wkv_b' op=dot_general0 rule=1
[QWIX] module='decoder/dense_layers/self_attention/attention_op' op=einsum0 rule=0
[QWIX] module='decoder/dense_layers/self_attention/attention_op' op=einsum1 rule=0
[QWIX] module='decoder/dense_layers/self_attention/out' op=dot_general0 rule=1
[QWIX] module='decoder/dense_layers/mlp/wi_0' op=dot_general0 rule=1
[QWIX] module='decoder/dense_layers/mlp/wi_1' op=dot_general1 rule=1
[QWIX] module='decoder/dense_layers/mlp/wo' op=dot_general2 rule=1
[QWIX] module='decoder/moe_layers/self_attention/wq_a' op=dot_general0 rule=1
[QWIX] module='decoder/moe_layers/self_attention/wq_b' op=dot_general0 rule=1
[QWIX] module='decoder/moe_layers/self_attention/wkv_a' op=dot_general0 rule=1
[QWIX] module='decoder/moe_layers/self_attention/wkv_b' op=dot_general0 rule=1
[QWIX] module='decoder/moe_layers/self_attention/attention_op' op=einsum0 rule=0
[QWIX] module='decoder/moe_layers/self_attention/attention_op' op=einsum1 rule=0
[QWIX] module='decoder/moe_layers/self_attention/out' op=dot_general0 rule=1
[QWIX] module='decoder/moe_layers/DeepSeekMoeBlock_0/MoeBlock_0/gate' op=dot_general0 rule=1
[QWIX] module='decoder/moe_layers/DeepSeekMoeBlock_0/MoeBlock_0' op=einsum0 rule=1
[QWIX] module='decoder/moe_layers/DeepSeekMoeBlock_0/shared_experts/wi_0' op=dot_general0 rule=1
[QWIX] module='decoder/moe_layers/DeepSeekMoeBlock_0/shared_experts/wi_1' op=dot_general1 rule=1
[QWIX] module='decoder/moe_layers/DeepSeekMoeBlock_0/shared_experts/wo' op=dot_general2 rule=1
[QWIX] module='decoder/logits_dense' op=dot_general0 rule=None
```

I also tested with PR #2066 (migrating attention to nnx) and the module paths are the same.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
