### PR TITLE
Disable failing gpu parameter offload test

### DIFF
--- a/MaxText/tests/integration_tests/train_tests.py
+++ b/MaxText/tests/integration_tests/train_tests.py
@@ -298,6 +298,7 @@ class TrainTests(unittest.TestCase):
 
   @pytest.mark.integration_test
   @pytest.mark.gpu_only
+  @pytest.mark.skip(reason="Requires jax 0.7.0 or later, see b/436565838 for more.")
   def test_gpu_parameter_offload(self):
     os.environ["NVTE_FUSED_ATTN"] = "1"  # Enable fused attention
     parameter_offload = [  # tests base config on GPU with parameter offload"""


### PR DESCRIPTION
# Description

Disable failing gpu parameter offload test, broken by https://github.com/AI-Hypercomputer/maxtext/pull/2077

This test can re-enabled once our gpu unit tests run on 0.7.1, or alternatively we may version guard as proposed in https://github.com/AI-Hypercomputer/maxtext/pull/2087

FIXES: b/436565838

# Tests
Relying on unit tests passing

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
