### PR TITLE
Add version guard for jax.memory.Space.Device

### DIFF
--- a/MaxText/layers/decoders.py
+++ b/MaxText/layers/decoders.py
@@ -29,6 +29,7 @@ from flax.linen.partitioning import ScanIn
 
 from MaxText.common_types import DecoderBlockType, Config, MODEL_MODE_TRAIN, MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
 from MaxText import max_logging
+from MaxText import max_utils
 from MaxText.inference import page_manager
 from MaxText.layers import linears
 from MaxText.layers import quantizations
@@ -375,7 +376,7 @@ class Decoder(nn.Module):
           def map_fn(path, value):
             max_logging.log(f"models.py: Moving parameter {path} to device")
             return jax.device_put(
-                value, jax.memory.Space.Device
+                value, max_utils.device_space()
             )
 
           return jax.tree_util.tree_map_with_path(map_fn, variables)

--- a/MaxText/layers/embeddings.py
+++ b/MaxText/layers/embeddings.py
@@ -26,6 +26,7 @@ from flax import linen as nn
 from flax import nnx
 
 from MaxText import max_logging
+from MaxText import max_utils
 from MaxText.common_types import MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, Array, Config, DType
 from MaxText.layers import nnx_wrappers
 from MaxText.layers.initializers import Initializer, default_embed_init, variable_to_logically_partitioned
@@ -37,7 +38,7 @@ def _maybe_move_embedding_to_device(embedding_table: Array, config: Config) -> A
   """Moves embedding table to device if parameter offloading is enabled."""
   if config.parameter_memory_host_offload:
     max_logging.log("embeddings.py: Moving embedding parameter to device")
-    return jax.device_put(embedding_table, jax.memory.Space.Device)
+    return jax.device_put(embedding_table, max_utils.device_space())
   return embedding_table
 
 

--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -30,6 +30,7 @@ from flax import linen as nn
 from flax import nnx
 
 from MaxText import max_logging
+from MaxText import max_utils
 from MaxText.common_types import Config, DType, AxisNames, BATCH, LENGTH, EMBED, HEAD, D_KV, Array, MODEL_MODE_TRAIN
 from MaxText.layers import initializers, nnx_wrappers
 from MaxText.layers.linears import mlp_block
@@ -96,7 +97,7 @@ class Gpt3LayerNorm(nnx.Module):
     # Move scale to device if parameter offloading is enabled
     if self.parameter_memory_host_offload:
       max_logging.log("gpt3.py: Moving scale parameter to device")
-      scale = jax.device_put(scale, jax.memory.Space.Device)
+      scale = jax.device_put(scale, max_utils.device_space())
 
     scale = jnp.asarray(scale, self.dtype)
     output = normed_inputs * (scale + 1)

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -29,6 +29,7 @@ from flax import nnx
 import flax.linen as nn
 
 from MaxText import max_logging
+from MaxText import max_utils
 from MaxText.common_types import MODEL_MODE_PREFILL, DecoderBlockType, DType, Array, Config
 from MaxText.layers import nnx_wrappers, quantizations
 from MaxText.layers import normalizations
@@ -211,7 +212,7 @@ class DenseGeneral(nnx.Module):
       # Move logit_dense kernel to device if parameter offloading is enabled
       if self.parameter_memory_host_offload:
         max_logging.log("linear.py: Moving parameter logits_dense kernel to device")
-        kernel = jax.device_put(kernel, jax.memory.Space.Device)
+        kernel = jax.device_put(kernel, max_utils.device_space())
       kernel = jnp.asarray(kernel, self.dtype)
 
     contract_ind = tuple(range(0, len(self.axis)))

--- a/MaxText/layers/normalizations.py
+++ b/MaxText/layers/normalizations.py
@@ -22,6 +22,7 @@ from jax import lax
 import jax
 import jax.numpy as jnp
 from MaxText import max_logging
+from MaxText import max_utils
 from MaxText.layers import nnx_wrappers
 from MaxText.layers.initializers import Initializer, variable_to_logically_partitioned
 
@@ -62,7 +63,7 @@ class RMSNorm(nnx.Module):
     # Move scale to device if parameter offloading is enabled
     if self.parameter_memory_host_offload:
       max_logging.log("normalizations.py: Moving scale parameter to device")
-      scale = jax.device_put(scale, jax.memory.Space.Device)
+      scale = jax.device_put(scale, max_utils.device_space())
 
     scale = jnp.asarray(scale, self.dtype)
     return y * scale

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -80,6 +80,14 @@ def calculate_num_params_from_pytree(params):
   assert total_parameters >= 0
   return total_parameters
 
+def device_space():
+  """ Version guard for jax.memory.Space.Device."""
+  # See b/436565838 for more.
+  if jax.__version__ >= "0.7.1":
+    return jax.memory.Space.Device # pytype: disable=module-attr
+  else:
+    # pytype: disable=module-attr
+    return jax._src.sharding_impls.TransferToMemoryKind("device") # pylint: disable=protected-access 
 
 def calculate_total_params_per_chip(params):
   """Calculate total params per chip."""

--- a/MaxText/tests/integration_tests/train_tests.py
+++ b/MaxText/tests/integration_tests/train_tests.py
@@ -298,7 +298,6 @@ class TrainTests(unittest.TestCase):
 
   @pytest.mark.integration_test
   @pytest.mark.gpu_only
-  @pytest.mark.skip(reason="Requires jax 0.7.0 or later, see b/436565838 for more.")
   def test_gpu_parameter_offload(self):
     os.environ["NVTE_FUSED_ATTN"] = "1"  # Enable fused attention
     parameter_offload = [  # tests base config on GPU with parameter offload"""


### PR DESCRIPTION
# Description

Add version guard for jax.memory.Space.Device, which is necessary for a recent breaking change in jax

* Breaking jax [PR](https://github.com/jax-ml/jax/commit/15094a2e7c6b5117352231e4216770578ff37449)
* MaxText [PR](https://github.com/AI-Hypercomputer/maxtext/pull/2077) that relies on post-breakage behavior (won't be available until next jax stable release 0.7.1)

FIXES: b/436565838

# Tests
Relying on unit tests passing

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
