### PR TITLE
Add support for Qwen3-MoE Model

### DIFF
--- a/MaxText/common_types.py
+++ b/MaxText/common_types.py
@@ -85,6 +85,7 @@ class DecoderBlockType(enum.Enum):
   GEMMA2 = "gemma2"
   GEMMA3 = "gemma3"
   QWEN3 = "qwen3"
+  QWEN3_MOE = "qwen3_moe"
   GPT3 = "gpt3"
   SIMPLE = "simple"
   SIMPLE_MLP = "simple_mlp"

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -169,6 +169,7 @@ use_random_routing: False # whether to use random routing for debug/test purpose
 tile_batch_seq: 512
 tile_activation_dim: 1024
 tile_weight_dim: 1024
+norm_topk_prob: False # Boolean to enable the top-k probability normalization. Qwen3-specific normalization of router weights.
 
 # How the expert axis is used to shard attention weights and activations
 # "fsdp" (ep acts as fsdp parallelism)

--- a/MaxText/configs/models/qwen3-235b-a22b.yml
+++ b/MaxText/configs/models/qwen3-235b-a22b.yml
@@ -1,0 +1,40 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Model config for Qwen3-235B-A22B
+
+# Core Architectural Parameters
+decoder_block: "qwen3_moe"
+base_emb_dim: 4096
+base_num_query_heads: 64
+base_num_kv_heads: 4
+base_num_decoder_layers: 94
+head_dim: 128
+mlp_activations: ["silu", "linear"]
+vocab_size: 151936
+normalization_layer_epsilon: 1.0e-6
+use_qk_norm: True
+
+# MoE Specific Parameters
+num_experts: 128
+num_experts_per_tok: 8
+base_moe_mlp_dim: 1536
+load_balance_loss_weight: 0.001
+norm_topk_prob: true
+
+# RoPE Settings
+rope_max_timescale: 5000000
+
+# General Model Settings
+enable_dropout: False

--- a/MaxText/convert_qwen3_moe.py
+++ b/MaxText/convert_qwen3_moe.py
@@ -1,0 +1,275 @@
+"""
+Copyright 2025 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+r"""Convert weights from a Qwen3-MoE style model to a MaxText one.
+
+This script rigorously follows the two-stage conversion process (map-then-transform)
+required for generating a MaxText checkpoint compatible with scanned model layers.
+
+Example cmd:
+
+python3 -m MaxText.convert_qwen3_moe_ckpt --base_model_path <path/to/hf/ckpt> \
+    --maxtext_model_path gs://<gcs_bucket>/<path/to/save/ckpt> --model_size qwen3-235b-a22b
+"""
+
+import argparse
+import gc
+import os
+import pathlib
+
+import numpy as np
+import torch
+from safetensors import safe_open
+from tqdm import tqdm
+
+from MaxText import llama_or_mistral_ckpt, max_logging
+from MaxText.inference_utils import str2bool
+
+# Static model parameters dictionary
+MODEL_PARAMS_DICT = {
+    "qwen3-235b-a22b": {
+        "num_hidden_layers": 94,
+        "num_attention_heads": 64,
+        "num_key_value_heads": 4,
+        "hidden_size": 4096,
+        "head_dim": 128,
+        "num_experts": 128,
+        "moe_intermediate_size": 1536,
+    }
+}
+
+
+def hf_to_maxtext_mapping(layer_idx: int, num_experts: int) -> dict:
+  """Creates a mapping from HF weight names to MaxText weight names."""
+  mapping = {
+      "model.embed_tokens.weight": "token_embedder.embedding",
+      "model.norm.weight": "decoder.decoder_norm.scale",
+      "lm_head.weight": "decoder.logits_dense.kernel",
+  }
+  # Layer-specific mappings for a pure MoE/scanned model
+  mapping.update({
+      f"model.layers.{layer_idx}.input_layernorm.weight": (
+          f"decoder.layers.{layer_idx}.pre_self_attention_layer_norm.scale"
+      ),
+      f"model.layers.{layer_idx}.post_attention_layernorm.weight": (
+          f"decoder.layers.{layer_idx}.post_self_attention_layer_norm.scale"
+      ),
+      f"model.layers.{layer_idx}.self_attn.q_proj.weight": f"decoder.layers.{layer_idx}.self_attention.query.kernel",
+      f"model.layers.{layer_idx}.self_attn.k_proj.weight": f"decoder.layers.{layer_idx}.self_attention.key.kernel",
+      f"model.layers.{layer_idx}.self_attn.v_proj.weight": f"decoder.layers.{layer_idx}.self_attention.value.kernel",
+      f"model.layers.{layer_idx}.self_attn.o_proj.weight": f"decoder.layers.{layer_idx}.self_attention.out.kernel",
+      f"model.layers.{layer_idx}.self_attn.q_norm.weight": f"decoder.layers.{layer_idx}.self_attention.query_norm.scale",
+      f"model.layers.{layer_idx}.self_attn.k_norm.weight": f"decoder.layers.{layer_idx}.self_attention.key_norm.scale",
+      f"model.layers.{layer_idx}.mlp.gate.weight": f"decoder.layers.{layer_idx}.moe_block.gate.kernel",
+  })
+
+  # MoE expert mappings
+  for i in range(num_experts):
+    mapping[f"model.layers.{layer_idx}.mlp.experts.{i}.gate_proj.weight"] = (
+        f"decoder.layers.{layer_idx}.moe_block.{i}.wi_0"
+    )
+    mapping[f"model.layers.{layer_idx}.mlp.experts.{i}.up_proj.weight"] = f"decoder.layers.{layer_idx}.moe_block.{i}.wi_1"
+    mapping[f"model.layers.{layer_idx}.mlp.experts.{i}.down_proj.weight"] = f"decoder.layers.{layer_idx}.moe_block.{i}.wo"
+
+  return mapping
+
+
+def convert_hf_to_maxtext(base_model_path: str, model_params: dict) -> dict:
+  """Converts a Hugging Face Qwen3-MoE checkpoint to a MaxText compatible format."""
+  num_layers = model_params["num_hidden_layers"]
+  num_experts = model_params["num_experts"]
+  hidden_size = model_params["hidden_size"]
+  num_heads = model_params["num_attention_heads"]
+  num_kv_heads = model_params["num_key_value_heads"]
+  head_dim = model_params["head_dim"]
+  moe_intermediate_size = model_params["moe_intermediate_size"]
+
+  # Part 1: Load all weights from safetensors into a flat dictionary with MaxText names
+  ckpt_paths = sorted(pathlib.Path(base_model_path).glob("*.safetensors"))
+  chkpt_vars = {}
+  for i, ckpt_path in enumerate(ckpt_paths):
+    max_logging.log(f"Loading checkpoint {i+1} of {len(ckpt_paths)}...")
+    with safe_open(ckpt_path, framework="pt", device="cpu") as f:
+      for key in f.keys():
+        if "layers" not in key and "embed_tokens" not in key and "norm" not in key and "lm_head" not in key:
+          continue
+
+        layer_idx_str = key.split(".")[2] if "layers" in key else "0"
+        layer_idx = int(layer_idx_str) if layer_idx_str.isdigit() else 0
+
+        maxtext_key = hf_to_maxtext_mapping(layer_idx, num_experts).get(key)
+        if maxtext_key:
+          chkpt_vars[maxtext_key] = f.get_tensor(key)
+
+  # Part 2: Initialize, populate, and transform the weights for MaxText
+  maxtext_weights = {
+      "decoder": {
+          "layers": {
+              "pre_self_attention_layer_norm": {"scale": None},
+              "post_self_attention_layer_norm": {"scale": None},
+              "self_attention": {
+                  "query": {"kernel": None},
+                  "key": {"kernel": None},
+                  "value": {"kernel": None},
+                  "out": {"kernel": None},
+                  "query_norm": {"scale": None},
+                  "key_norm": {"scale": None},
+              },
+              "moe_block": {
+                  "gate": {"kernel": None},
+                  "wi_0": None,
+                  "wi_1": None,
+                  "wo": None,
+              },
+          },
+          "decoder_norm": {"scale": None},
+          "logits_dense": {"kernel": None},
+      },
+      "token_embedder": {"embedding": None},
+  }
+
+  max_logging.log("Populating non-layer weights...")
+  maxtext_weights["token_embedder"]["embedding"] = chkpt_vars["token_embedder.embedding"].to(torch.float16).numpy()
+  maxtext_weights["decoder"]["decoder_norm"]["scale"] = chkpt_vars["decoder.decoder_norm.scale"].to(torch.float16).numpy()
+  maxtext_weights["decoder"]["logits_dense"]["kernel"] = (
+      chkpt_vars["decoder.logits_dense.kernel"].to(torch.float16).numpy().transpose()
+  )
+
+  max_logging.log("Allocating and stacking layer weights...")
+  ln = maxtext_weights["decoder"]["layers"]
+  s_attn = ln["self_attention"]
+  moe = ln["moe_block"]
+
+  # Pre-allocate stacked arrays with the 'layer' dimension first
+  ln["pre_self_attention_layer_norm"]["scale"] = np.zeros((num_layers, hidden_size), dtype=np.float16)
+  ln["post_self_attention_layer_norm"]["scale"] = np.zeros((num_layers, hidden_size), dtype=np.float16)
+  s_attn["query"]["kernel"] = np.zeros((num_layers, hidden_size, num_heads, head_dim), dtype=np.float16)
+  s_attn["key"]["kernel"] = np.zeros((num_layers, hidden_size, num_kv_heads, head_dim), dtype=np.float16)
+  s_attn["value"]["kernel"] = np.zeros((num_layers, hidden_size, num_kv_heads, head_dim), dtype=np.float16)
+  s_attn["out"]["kernel"] = np.zeros((num_layers, num_heads, head_dim, hidden_size), dtype=np.float16)
+  s_attn["query_norm"]["scale"] = np.zeros((num_layers, head_dim), dtype=np.float16)
+  s_attn["key_norm"]["scale"] = np.zeros((num_layers, head_dim), dtype=np.float16)
+  moe["gate"]["kernel"] = np.zeros((num_layers, hidden_size, num_experts), dtype=np.float16)
+  moe["wi_0"] = np.zeros((num_experts, num_layers, hidden_size, moe_intermediate_size), dtype=np.float16)
+  moe["wi_1"] = np.zeros((num_experts, num_layers, hidden_size, moe_intermediate_size), dtype=np.float16)
+  moe["wo"] = np.zeros((num_experts, num_layers, moe_intermediate_size, hidden_size), dtype=np.float16)
+
+  # Loop through layers and populate the stacked arrays
+  # pylint: disable=unsupported-assignment-operation
+  for l in tqdm(range(num_layers), desc="Stacking layer weights"):
+    ln["pre_self_attention_layer_norm"]["scale"][l, :] = (
+        chkpt_vars[f"decoder.layers.{l}.pre_self_attention_layer_norm.scale"].to(torch.float16).numpy()
+    )
+    ln["post_self_attention_layer_norm"]["scale"][l, :] = (
+        chkpt_vars[f"decoder.layers.{l}.post_self_attention_layer_norm.scale"].to(torch.float16).numpy()
+    )
+
+    s_attn["query"]["kernel"][l, ...] = (
+        chkpt_vars[f"decoder.layers.{l}.self_attention.query.kernel"]
+        .to(torch.float16)
+        .numpy()
+        .transpose()
+        .reshape(hidden_size, num_heads, head_dim)
+    )
+    s_attn["key"]["kernel"][l, ...] = (
+        chkpt_vars[f"decoder.layers.{l}.self_attention.key.kernel"]
+        .to(torch.float16)
+        .numpy()
+        .transpose()
+        .reshape(hidden_size, num_kv_heads, head_dim)
+    )
+    s_attn["value"]["kernel"][l, ...] = (
+        chkpt_vars[f"decoder.layers.{l}.self_attention.value.kernel"]
+        .to(torch.float16)
+        .numpy()
+        .transpose()
+        .reshape(hidden_size, num_kv_heads, head_dim)
+    )
+    s_attn["out"]["kernel"][l, ...] = (
+        chkpt_vars[f"decoder.layers.{l}.self_attention.out.kernel"]
+        .to(torch.float16)
+        .numpy()
+        .transpose()
+        .reshape(num_heads, head_dim, hidden_size)
+    )
+
+    s_attn["query_norm"]["scale"][l, ...] = (
+        chkpt_vars[f"decoder.layers.{l}.self_attention.query_norm.scale"].to(torch.float16).numpy()
+    )
+    s_attn["key_norm"]["scale"][l, ...] = (
+        chkpt_vars[f"decoder.layers.{l}.self_attention.key_norm.scale"].to(torch.float16).numpy()
+    )
+
+    moe["gate"]["kernel"][l, ...] = (
+        chkpt_vars[f"decoder.layers.{l}.moe_block.gate.kernel"].to(torch.float16).numpy().transpose()
+    )
+    for i in range(num_experts):
+      moe["wi_0"][i, l, ...] = chkpt_vars[f"decoder.layers.{l}.moe_block.{i}.wi_0"].to(torch.float16).numpy().transpose()
+      moe["wi_1"][i, l, ...] = chkpt_vars[f"decoder.layers.{l}.moe_block.{i}.wi_1"].to(torch.float16).numpy().transpose()
+      moe["wo"][i, l, ...] = chkpt_vars[f"decoder.layers.{l}.moe_block.{i}.wo"].to(torch.float16).numpy().transpose()
+
+  # Final transformations for scanned weights (swap layer and feature axes)
+  max_logging.log("Transposing layer weights for MaxText scanned format...")
+
+  ln["pre_self_attention_layer_norm"]["scale"] = np.transpose(ln["pre_self_attention_layer_norm"]["scale"], axes=(1, 0))
+  ln["post_self_attention_layer_norm"]["scale"] = np.transpose(ln["post_self_attention_layer_norm"]["scale"], axes=(1, 0))
+  s_attn["query_norm"]["scale"] = np.transpose(s_attn["query_norm"]["scale"], axes=(1, 0))
+  s_attn["key_norm"]["scale"] = np.transpose(s_attn["key_norm"]["scale"], axes=(1, 0))
+
+  s_attn["query"]["kernel"] = np.transpose(s_attn["query"]["kernel"], axes=(1, 0, 2, 3))
+  s_attn["key"]["kernel"] = np.transpose(s_attn["key"]["kernel"], axes=(1, 0, 2, 3))
+  s_attn["value"]["kernel"] = np.transpose(s_attn["value"]["kernel"], axes=(1, 0, 2, 3))
+  s_attn["out"]["kernel"] = np.transpose(s_attn["out"]["kernel"], axes=(1, 0, 2, 3))
+
+  moe["gate"]["kernel"] = np.transpose(moe["gate"]["kernel"], axes=(1, 0, 2))
+
+  gc.collect()
+  return maxtext_weights
+
+
+def main(args):
+  """Main function to run the conversion."""
+  # Set up JAX simulated environment
+  os.environ["JAX_PLATFORMS"] = "cpu"
+  os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={args.simulated_cpu_devices_count}"
+
+  if args.model_size not in MODEL_PARAMS_DICT:
+    raise ValueError(f"Model size '{args.model_size}' not found in MODEL_PARAMS_DICT.")
+
+  model_params = MODEL_PARAMS_DICT[args.model_size]
+  max_logging.log(f"Starting conversion for Qwen3-MoE model size: {args.model_size}")
+  jax_weights = convert_hf_to_maxtext(args.base_model_path, model_params)
+  max_logging.log(f"Conversion complete. Saving MaxText checkpoint to {args.maxtext_model_path}")
+  llama_or_mistral_ckpt.save_weights_to_checkpoint(
+      args.maxtext_model_path, jax_weights, args.simulated_cpu_devices_count, args.use_ocdbt, args.use_zarr3
+  )
+  max_logging.log("Checkpoint saved successfully.")
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description="Convert Qwen3-MoE HF weights to MaxText.")
+  parser.add_argument("--base_model_path", type=str, required=True, help="Path to the HF Qwen3-MoE checkpoint files.")
+  parser.add_argument(
+      "--maxtext_model_path", type=str, required=True, help="Path to save the MaxText checkpoint (local or GCS)."
+  )
+  parser.add_argument(
+      "--model_size", type=str, required=True, choices=MODEL_PARAMS_DICT.keys(), help="The model size to convert."
+  )
+  parser.add_argument(
+      "--simulated_cpu_devices_count", type=int, default=16, help="Number of simulated CPU devices for saving."
+  )
+  parser.add_argument("--use-ocdbt", type=str2bool, default=True, help="Use OCDBT format for saving.")
+  parser.add_argument("--use-zarr3", type=str2bool, default=True, help="Use Zarr3 format for saving.")
+
+  parsed_args = parser.parse_args()
+  main(parsed_args)

--- a/MaxText/layers/decoders.py
+++ b/MaxText/layers/decoders.py
@@ -359,6 +359,8 @@ class Decoder(nn.Module):
         return [gpt3.Gpt3DecoderLayer]
       case DecoderBlockType.QWEN3:
         return [qwen3.Qwen3DecoderLayer]
+      case DecoderBlockType.QWEN3_MOE:
+        return [qwen3.Qwen3MoeDecoderLayer]
       case DecoderBlockType.SIMPLE:
         return [simple_layer.SimpleDecoderLayer]
       case DecoderBlockType.SIMPLE_MLP:
@@ -411,6 +413,7 @@ class Decoder(nn.Module):
         DecoderBlockType.GEMMA2,
         DecoderBlockType.GEMMA3,
         DecoderBlockType.QWEN3,
+        DecoderBlockType.QWEN3_MOE,
         DecoderBlockType.SIMPLE,
         DecoderBlockType.SIMPLE_MLP,
         DecoderBlockType.LLAMA4,
@@ -443,14 +446,7 @@ class Decoder(nn.Module):
         length=length,
         metadata_params={nn.PARTITION_NAME: metadata_axis_name},
     )
-    return scan_fn(
-        config=cfg,
-        mesh=mesh,
-        name=metadata_axis_name,
-        quant=self.quant,
-        model_mode=model_mode,
-        **kwargs
-    )
+    return scan_fn(config=cfg, mesh=mesh, name=metadata_axis_name, quant=self.quant, model_mode=model_mode, **kwargs)
 
   def get_pipeline_stage_module(self, decoder_blocks):
     """get pipeline stage module"""

--- a/MaxText/layers/moe.py
+++ b/MaxText/layers/moe.py
@@ -342,6 +342,11 @@ class RoutedMoE(nnx.Module):
       top_k_weights = self.deepseek_scale_weights(top_k_weights)
     elif self.config.decoder_block != ctypes.DecoderBlockType.LLAMA4:
       top_k_weights = jax.nn.softmax(top_k_weights.astype(jnp.float32), axis=-1).astype(self.dtype)
+
+    # This is the Qwen3-specific normalization of router weights.
+    if self.config.norm_topk_prob:
+      top_k_weights /= top_k_weights.sum(axis=-1, keepdims=True)
+
     return top_k_weights, top_k_indices
 
   def deepseek_scale_weights(self, weights):

--- a/MaxText/layers/qwen3.py
+++ b/MaxText/layers/qwen3.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-"""Qwen3 model decoder layer."""
+"""Qwen3 family of model decoder layers."""
 # pylint: disable=arguments-differ
 # pylint: disable=no-name-in-module
 
@@ -36,9 +36,93 @@ from MaxText.layers.normalizations import rms_norm
 from MaxText.layers.quantizations import AqtQuantization as Quant
 from MaxText.inference import page_manager
 
+# -----------------------------------------
+# Helper functions for Qwen3 layers
+# -----------------------------------------
 
+
+def self_attention_with_norm(
+    inputs: jnp.ndarray,
+    cfg: Config,
+    mesh: Mesh,
+    quant: Optional[Quant],
+    decoder_segment_ids: Optional[jnp.ndarray],
+    decoder_positions: Optional[jnp.ndarray],
+    deterministic: bool,
+    model_mode: str,
+):
+  """A helper function for self-attention block with normalization."""
+
+  inputs_checkpoint = checkpoint_name(inputs, "decoder_layer_input")
+
+  # Corresponds to Qwen3's `input_layernorm`
+  lnx = rms_norm(
+      num_features=inputs.shape[-1],
+      dtype=cfg.dtype,
+      weight_dtype=cfg.weight_dtype,
+      name="pre_self_attention_layer_norm",
+      epsilon=cfg.normalization_layer_epsilon,
+      kernel_axes=("norm",),
+  )(inputs_checkpoint)
+  lnx = nn.with_logical_constraint(lnx, ("activation_batch", "activation_length", "activation_embed"))
+
+  # Self-attention block
+  attention_layer = attentions.attention_as_linen(
+      config=cfg,
+      num_query_heads=cfg.num_query_heads,
+      num_kv_heads=cfg.num_kv_heads,
+      head_dim=cfg.head_dim,
+      max_target_length=cfg.max_target_length,
+      max_prefill_predict_length=cfg.max_prefill_predict_length,
+      attention_kernel=cfg.attention,
+      inputs_q_shape=lnx.shape,
+      inputs_kv_shape=lnx.shape,
+      mesh=mesh,
+      dtype=cfg.dtype,
+      weight_dtype=cfg.weight_dtype,
+      dropout_rate=cfg.dropout_rate,
+      name="self_attention",
+      quant=quant,
+      kv_quant=quantizations.configure_kv_quant(cfg),
+      use_qk_norm=cfg.use_qk_norm,
+      query_pre_attn_scalar=(cfg.head_dim**-0.5),  # Qwen3 specific scaling
+      model_mode=model_mode,
+  )
+
+  attention_output = attention_layer(
+      lnx,  # inputs_q
+      lnx,  # inputs_kv
+      decoder_positions,
+      decoder_segment_ids=decoder_segment_ids,
+      deterministic=deterministic,
+      model_mode=model_mode,
+  )
+  attention_output = nn.with_logical_constraint(
+      attention_output, ("activation_batch", "activation_length", "activation_embed")
+  )
+
+  # Residual connection after attention
+  residual_after_attention = inputs_checkpoint + attention_output
+
+  # Post Attention LayerNorm (corresponds to Qwen3's `post_attention_layernorm`)
+  hidden_states = rms_norm(
+      num_features=residual_after_attention.shape[-1],
+      dtype=cfg.dtype,
+      weight_dtype=cfg.weight_dtype,
+      name="post_self_attention_layer_norm",
+      epsilon=cfg.normalization_layer_epsilon,
+      kernel_axes=("norm",),
+  )(residual_after_attention)
+  hidden_states = nn.with_logical_constraint(hidden_states, ("activation_batch", "activation_length", "activation_embed"))
+
+  return hidden_states, residual_after_attention
+
+
+# -----------------------------------------
+# The Dense Decoder Layer for Qwen3
+# -----------------------------------------
 class Qwen3DecoderLayer(nn.Module):
-  """Qwen3 Transformer decoder layer."""
+  """Qwen3 Transformer decoder layer (dense)."""
 
   config: Config
   mesh: Mesh
@@ -58,98 +142,97 @@ class Qwen3DecoderLayer(nn.Module):
       slot: Optional[int] = None,
   ):
     cfg = self.config
-    mesh = self.mesh
 
-    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_length", "activation_embed"))
-    inputs_checkpoint = checkpoint_name(inputs, "decoder_layer_input")
-
-    # Corresponds to Qwen3's `input_layernorm`
-    lnx = rms_norm(
-        num_features=inputs.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="pre_self_attention_layer_norm",
-        epsilon=cfg.normalization_layer_epsilon,
-        kernel_axes=("norm",),
-    )(inputs_checkpoint)
-    lnx = nn.with_logical_constraint(lnx, ("activation_batch", "activation_length", "activation_embed"))
-
-    # Self-attention block
-    attention_layer = attentions.attention_as_linen(
-        config=cfg,
-        num_query_heads=cfg.num_query_heads,
-        num_kv_heads=cfg.num_kv_heads,
-        head_dim=cfg.head_dim,
-        max_target_length=cfg.max_target_length,
-        max_prefill_predict_length=cfg.max_prefill_predict_length,
-        attention_kernel=cfg.attention,
-        inputs_q_shape=lnx.shape,
-        inputs_kv_shape=lnx.shape,
-        mesh=mesh,
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        dropout_rate=cfg.dropout_rate,
-        name="self_attention",
-        quant=self.quant,
-        kv_quant=quantizations.configure_kv_quant(cfg),
-        use_qk_norm=cfg.use_qk_norm,
-        query_pre_attn_scalar=(cfg.head_dim**-0.5),  # Qwen3 specific scaling
-        model_mode=model_mode,
-    )
-
-    attention_output = attention_layer(
-        lnx,  # inputs_q
-        lnx,  # inputs_kv
+    hidden_states, residual_after_attention = self_attention_with_norm(
+        inputs,
+        cfg,
+        self.mesh,
+        self.quant,
+        decoder_segment_ids,
         decoder_positions,
-        decoder_segment_ids=decoder_segment_ids,
-        deterministic=deterministic,
-        model_mode=model_mode,
-    )
-    attention_output = nn.with_logical_constraint(
-        attention_output, ("activation_batch", "activation_length", "activation_embed")
+        deterministic,
+        model_mode,
     )
 
-    # Residual connection after attention
-    residual_after_attention = inputs_checkpoint + attention_output
-
-    # Post Attention LayerNorm (corresponds to Qwen3's `post_attention_layernorm`)
-    mlp_input = rms_norm(
-        num_features=residual_after_attention.shape[-1],
+    # Dense MLP block
+    mlp_output = linears.mlp_block(
+        in_features=hidden_states.shape[-1],
+        intermediate_dim=cfg.mlp_dim,
+        activations=cfg.mlp_activations,
+        intermediate_dropout_rate=cfg.dropout_rate,
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
-        name="post_self_attention_layer_norm",  # Standard MaxText naming
-        epsilon=cfg.normalization_layer_epsilon,
-        kernel_axes=("norm",),
-    )(residual_after_attention)
-    mlp_input = nn.with_logical_constraint(mlp_input, ("activation_batch", "activation_length", "activation_embed"))
+        name="mlp",
+        config=cfg,
+        quant=self.quant,
+    )(hidden_states, deterministic=deterministic)
 
-    # MLP block
-    if cfg.num_experts is None or cfg.num_experts <= 1:  # Dense MLP
-      mlp_output = linears.mlp_block(
-          in_features=mlp_input.shape[-1],
-          intermediate_dim=cfg.mlp_dim,
-          activations=cfg.mlp_activations,
-          intermediate_dropout_rate=cfg.dropout_rate,
-          dtype=cfg.dtype,
-          weight_dtype=cfg.weight_dtype,
-          name="mlp",
-          config=cfg,
-          quant=self.quant,
-      )(mlp_input, deterministic=deterministic)
-    else:  # Mixture of Experts MLP -- not supported / tested in MaxText
-      mlp_output, _ = moe.get_routed_moe(
-          config=cfg,
-          num_experts=cfg.num_experts,
-          num_experts_per_tok=cfg.num_experts_per_tok,
-          mesh=self.mesh,
-          kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
-          kernel_axes=("embed", None),
-          intermediate_dim=cfg.mlp_dim,
-          dtype=cfg.dtype,
-          weight_dtype=cfg.weight_dtype,
-          name="moe_block",
-          quant=self.quant,
-      )(mlp_input)
+    # Final residual connection
+    layer_output = residual_after_attention + mlp_output
+    layer_output = nn.with_logical_constraint(
+        layer_output,
+        ("activation_batch", "activation_length", "activation_embed"),
+    )
+
+    if cfg.scan_layers:
+      return layer_output, None
+    else:
+      return layer_output
+
+
+# -----------------------------------------
+# The MoE Decoder Layer for Qwen3
+# -----------------------------------------
+class Qwen3MoeDecoderLayer(nn.Module):
+  """Qwen3 Transformer decoder layer (MoE)."""
+
+  config: Config
+  mesh: Mesh
+  model_mode: str
+  quant: Optional[Quant] = None
+
+  @nn.compact
+  def __call__(
+      self,
+      inputs: jnp.ndarray,
+      decoder_segment_ids: Optional[jnp.ndarray],
+      decoder_positions: Optional[jnp.ndarray],
+      deterministic: bool,
+      model_mode: str,
+      previous_chunk=None,
+      page_state: Optional[page_manager.PageState] = None,
+      slot: Optional[int] = None,
+  ):
+    cfg = self.config
+
+    hidden_states, residual_after_attention = self_attention_with_norm(
+        inputs,
+        cfg,
+        self.mesh,
+        self.quant,
+        decoder_segment_ids,
+        decoder_positions,
+        deterministic,
+        model_mode,
+    )
+
+    # Mixture of Experts block
+    mlp_output, load_balance_loss = moe.get_routed_moe(
+        config=cfg,
+        num_experts=cfg.num_experts,
+        num_experts_per_tok=cfg.num_experts_per_tok,
+        mesh=self.mesh,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed", None),
+        intermediate_dim=cfg.moe_mlp_dim,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        name="moe_block",
+        quant=self.quant,
+    )(hidden_states)
+
+    if load_balance_loss is not None:
+      self.sow("intermediates", "moe_lb_loss", load_balance_loss)
 
     mlp_output = nn.with_logical_constraint(mlp_output, ("activation_batch", "activation_length", "activation_embed"))
 

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -209,7 +209,6 @@ def validate_keys(keys):
     validate_ragged_dot(keys)
     validate_deepseek_moe(keys)
     validate_expert_shard_attention_option(keys["expert_shard_attention_option"])
-    assert keys["decoder_block"] != "qwen3", "Qwen3 MoE mode has not been tested, please set num_experts to 1."
 
   if keys["use_multimodal"]:
     validate_multimodal_model_name(keys["model_name"])
@@ -353,6 +352,7 @@ def validate_model_name(s: str) -> bool:
       "qwen3-8b",
       "qwen3-14b",
       "qwen3-32b",
+      "qwen3-235b-a22b",
       "gpt3-175b",
       "gpt3-22b",
       "gpt3-6b",
@@ -810,7 +810,9 @@ def set_and_validate_pipeline_config(raw_keys):
   if using_pipeline_parallelism(raw_keys):
     # For pipeline parallelism, model_fsdp_ag_once should be False, and pipeline_fsdp_ag_once is typically True.
     if raw_keys["model_fsdp_ag_once"]:
-      raise ValueError("You should only set pipeline_fsdp_once=True, leave model_fsdp_ag_once=False with pipeline parallelism.")
+      raise ValueError(
+          "You should only set pipeline_fsdp_once=True, leave model_fsdp_ag_once=False with pipeline parallelism."
+      )
 
     def modify_activation_embed_and_logits_batch(logical_axis_rules):
       for idx, logical_rule in enumerate(logical_axis_rules):
@@ -968,22 +970,15 @@ def validate_deepseek_moe(raw_keys):
 def validate_sparse_matmul_parallelism(raw_keys):
   # TODO: remove once b/434699033 resolved
   if raw_keys["sparse_matmul"] and (using_expert_parallelism(raw_keys) and using_pipeline_parallelism(raw_keys)):
-    raise ValueError(
-        "Sparse matmul doesn't support using expert and pipeline parallelism together."
-    )
+    raise ValueError("Sparse matmul doesn't support using expert and pipeline parallelism together.")
 
   # TODO: remove once b/435539039 resolved
-  if (
-      raw_keys["sparse_matmul"]
-      and (
-          using_fsdp_and_transpose_parallelism(raw_keys)
-          and using_expert_parallelism(raw_keys)
-          and using_tensor_parallelism(raw_keys)
-      )
+  if raw_keys["sparse_matmul"] and (
+      using_fsdp_and_transpose_parallelism(raw_keys)
+      and using_expert_parallelism(raw_keys)
+      and using_tensor_parallelism(raw_keys)
   ):
-    raise ValueError(
-        "Sparse matmul doesn't support using fsdp, expert, and tensor parallelism together."
-    )
+    raise ValueError("Sparse matmul doesn't support using fsdp, expert, and tensor parallelism together.")
   tensor_parallelism = (
       raw_keys["ici_tensor_parallelism"]
       * raw_keys["dcn_tensor_parallelism"]

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ We have used MaxText to [demonstrate high-performance, well-converging training 
 Key supported features:
 * TPUs and GPUs
 * Training and Inference
-* Models: Llama 2, Llama 3, Llama 4, Mistral and Mixtral family, Gemma, Gemma 2, Gemma 3, and DeepSeek family
+* Models: Llama 2, Llama 3, Llama 4, Mistral and Mixtral family, Gemma, Gemma 2, Gemma 3, DeepSeek, Qwen3 Dense and MoE family
 
 ## Announcements
+* [August 13, 2025] The Qwen3 MoE family of models is now supported. We are starting with Qwen3-235B-A22B-Thinking-2507, in addition to our existing Qwen3 Dense family of 0.6B, 4B, 8B, 14B, and 32B models.
 * [July 27, 2025] We have updated our TFLOPS/s calculation to account for causal attention, dividing the attention flops in half in this [PR](https://github.com/AI-Hypercomputer/maxtext/pull/1988). Also we account for sliding window and chunked attention reduced attention flops in [PR](https://github.com/AI-Hypercomputer/maxtext/pull/2009) and [PR](https://github.com/AI-Hypercomputer/maxtext/pull/2030). These changes especially impact large sequence configs, since attention flops grow quadratically with sequence length, as explained in this [ReadMe](https://github.com/AI-Hypercomputer/maxtext/blob/main/getting_started/Performance_Metrics.md)
 * [July 16, 2025] We will be restructuring the MaxText repository for improved organization and clarity. Please review the [proposed structure](RESTRUCTURE.md) and provide feedback.
 * [July 11, 2025] Multi-Token Prediction (MTP) training is now supported! This feature adds an auxiliary loss based on predicting multiple future tokens, inspired by the [DeepSeek-V3 paper](https://arxiv.org/html/2412.19437v1), to enhance training efficiency.

--- a/end_to_end/tpu/qwen/moe/qwen3-235b-a22b/1_test_qwen3_235b_a22b.sh
+++ b/end_to_end/tpu/qwen/moe/qwen3-235b-a22b/1_test_qwen3_235b_a22b.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# This script validates a pre-converted MaxText checkpoint against its original
+# HuggingFace counterpart to ensure numerical correctness.
+
+# ---
+# Example Usage:
+#
+# # (Required) Path to the converted MaxText checkpoint
+# export MAXTEXT_CHECKPOINT_PATH=gs://path/to/converted_ckpt/0/items/
+#
+# # (Optional) Override the default HF model
+# export HF_MODEL_PATH=MyCustom/Qwen3-variant
+#
+# bash end_to_end/tpu/qwen3/validate_qwen3_ckpt.sh
+# ---
+
+set -ex
+
+# --- Configuration & Input Validation ---
+
+if [ -z "${MAXTEXT_CHECKPOINT_PATH}" ]; then
+    echo "ERROR: The MAXTEXT_CHECKPOINT_PATH environment variable is not set."
+    echo "Please set it to the full GCS path of the pre-converted MaxText checkpoint weights."
+    exit 1
+fi
+
+# Set a default for the HF model path if it's not provided by the user
+if [ -z "${HF_MODEL_PATH}" ]; then
+    export HF_MODEL_PATH="Qwen/Qwen3-235B-A22B-Thinking-2507"
+    echo "HF_MODEL_PATH is not set, using default: ${HF_MODEL_PATH}"
+fi
+
+# Install dependencies required for the logit checker.
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# --- Run the Forward Pass Logit Checker ---
+
+echo "Validating MaxText checkpoint at ${MAXTEXT_CHECKPOINT_PATH}"
+echo "Against original HF model: ${HF_MODEL_PATH}"
+
+# This command runs the core validation logic.
+JAX_PLATFORMS=cpu python3 -m MaxText.tests.forward_pass_logit_checker MaxText/configs/base.yml \
+  tokenizer_path=assets/qwen3-tokenizer \
+  megablox=False \
+  sparse_matmul=False \
+  load_parameters_path=${MAXTEXT_CHECKPOINT_PATH} \
+  model_name=qwen3-235b-a22b \
+  checkpoint_storage_concurrent_gb=512 \
+  skip_jax_distributed_system=True \
+  --hf_model_path=${HF_MODEL_PATH} \
+  --max_kl_div=0.015 \
+  --run_hf_model=True
+
+echo "Validation complete."

--- a/end_to_end/tpu/qwen/moe/run_qwen_moe.md
+++ b/end_to_end/tpu/qwen/moe/run_qwen_moe.md
@@ -1,0 +1,90 @@
+Qwen3
+=====
+
+Qwen3 is a family of powerful, open-source large language models from the Qwen team at Alibaba Cloud. This documentation covers the integration of the **Qwen3-235B-A22B** Mixture-of-Experts (MoE) model into MaxText. For more details on the architecture, see the [Qwen3 Technical Report](https://arxiv.org/abs/2505.09388).
+
+* * * * *
+
+Checkpoint Conversion
+---------------------
+
+To get started, you first need a MaxText-compatible checkpoint.
+
+1.  **Download the Model**: Download the official model from Hugging Face: [Qwen/Qwen3-235B-A22B-Thinking-2507](https://huggingface.co/Qwen/Qwen3-235B-A22B-Thinking-2507). You can use a tool like `hf_transfer` for a fast download.
+
+
+    ```
+    hf_transfer download Qwen/Qwen3-235B-A22B-Thinking-2507 --local-dir /path/to/qwen3_hf_checkpoint
+
+    ```
+
+2.  **Convert the Checkpoint**: Run the `convert_qwen3_moe.py` script to convert the downloaded Hugging Face weights into the scanned Orbax format required by MaxText.
+
+    ```
+    python3 -m MaxText.convert_qwen3_moe\
+      --base_model_path /path/to/qwen3_hf_checkpoint\
+      --maxtext_model_path gs://your-gcs-bucket/qwen3_maxtext_ckpt\
+      --model_size qwen3-235b-a22b
+
+    ```
+
+* * * * *
+
+Pre-training and Fine-tuning
+----------------------------
+
+After converting the checkpoint, you can use it for fine-tuning or start a pre-training run from scratch. The command below is an example for fine-tuning on a v5p-256 slice. To pre-train, simply remove the `load_parameters_path` argument.
+
+```
+python3 -m MaxText.train MaxText/configs/base.yml\
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}\
+    dataset_path=${DATASET_PATH}\
+    load_parameters_path=gs://your-gcs-bucket/qwen3_maxtext_ckpt/0/items\
+    run_name=qwen3_finetuning\
+    per_device_batch_size=4\
+    model_name=qwen3-235b-a22b\
+    steps=500\
+    max_target_length=2048\
+    ici_fsdp_parallelism=128\
+    attention=flash\
+    tokenizer_path=assets/qwen3-tokenizer\
+```
+
+* * * * *
+
+Decoding
+--------
+
+To generate text with a trained model, use the `decode` command.
+
+```
+python3 -m MaxText.decode MaxText/configs/base.yml\
+    load_parameters_path=gs://your-gcs-bucket/qwen3_maxtext_ckpt/0/items\
+    tokenizer_path=assets/qwen3-tokenizer\
+    prompt="Today is a beautiful day to"\
+    model_name=qwen3-235b-a22b\
+    per_device_batch_size=1\
+    max_target_length=128
+
+```
+
+* * * * *
+
+Correctness Validation
+----------------------
+
+To verify that the MaxText implementation is numerically equivalent to the original Hugging Face model, run the end-to-end test script. This script automates the logit comparison test.
+
+Before running, you must set the `MAXTEXT_CHECKPOINT_PATH` environment variable. You can also optionally set `HF_MODEL_PATH` to point to a local copy of the Hugging Face model.
+
+```
+# Set the required path to your converted MaxText checkpoint
+export MAXTEXT_CHECKPOINT_PATH=gs://your-gcs-bucket/qwen3_maxtext_ckpt/0/items/
+
+# (Optional) Set the path to your local Hugging Face checkpoint
+# export HF_MODEL_PATH=/path/to/local/qwen3_hf_checkpoint
+
+# Execute the validation script
+bash MaxText/end_to_end/tpu/qwen/moe/qwen3-235b-a22b/1_test_qwen3_235b_a22b.sh
+
+```


### PR DESCRIPTION
### Feat: Add support for Qwen3-MoE Model

### TL;DR

-   **What**: This PR integrates the **Qwen3-MoE** architecture into MaxText, with a specific implementation for the **`Qwen3-235B-A22B`** model. It includes a new MoE decoder layer and a dedicated checkpoint conversion script.

-   **Why**: To enable the pre-training of the open-source Qwen3 family of Mixture-of-Experts models within the MaxText framework.

-   **How**: By introducing a `Qwen3MoeDecoderLayer`, adding a `qwen3-235b-a22b.yml` configuration file, implementing a `norm_topk_prob` flag for Qwen-specific router logic, and creating a new `convert_qwen3_moe.py` script to convert Hugging Face checkpoints.

* * * * *

### Detailed Description

#### Background and Motivation

This pull request adds support for the Qwen3-MoE family of models, as introduced in the technical report: **[Qwen3: A More Powerful and General Base Model Series](https://arxiv.org/abs/2505.09388)**. This initial integration focuses on the `Qwen3-235B-A22B` variant, a large-scale Mixture-of-Experts (MoE) model.

#### Architectural Changes

To support the Qwen3-MoE architecture, the following key changes have been implemented:

1.  **Qwen3 Decoder Layers (`MaxText/layers/qwen3.py`)**:

    -   The existing Qwen3 module has been refactored to support both dense and MoE variants.
    -   A `self_attention_with_norm` helper function was extracted to share the attention block logic between both decoder types.
    -   A new **`Qwen3MoeDecoderLayer`** has been added. It utilizes the shared self-attention block and integrates with the existing `moe.get_routed_moe` function for the expert layers.

2.  **MoE Router Normalization (`MaxText/layers/moe.py`)**:

    -   A new boolean configuration flag, **`norm_topk_prob`**, has been added.
    -   When enabled, this flag applies a Qwen-specific normalization to the router probabilities by dividing the softmax output by its sum. This is essential for matching the original model's behavior.

3.  **New Model Configuration (`MaxText/configs/models/qwen3-235b-a22b.yml`)**:

    -   A new YAML configuration file is provided to define the specific architectural parameters for the `Qwen3-235B-A22B` model, including `num_experts`, `num_experts_per_tok`, `base_moe_mlp_dim`, and `use_qk_norm`.

4.  **Checkpoint Conversion Script (`MaxText/convert_qwen3_moe.py`)**:

    -   A new, standalone conversion script has been added to convert official Hugging Face checkpoints for the `Qwen3-235B-A22B` model into the MaxText format.
    -   This script handles the mapping of weights, including the complex stacking of MoE layers, and performs the necessary transpositions to make them compatible with MaxText's scanned layer format.

5.  **Framework Integration (`MaxText/common_types.py`, `MaxText/layers/decoders.py`)**:

    -   The `DecoderBlockType` enum has been updated with `QWEN3_MOE`.
    -   The decoder factory in `decoders.py` has been updated to correctly instantiate `Qwen3MoeDecoderLayer` when `decoder_block: "qwen3_moe"` is set in the config.

* * * * *

### How to Use

#### 1\. Convert Hugging Face Checkpoint

First, convert the original Hugging Face checkpoint to the MaxText format using the new script.

```
python3 -m MaxText.convert_qwen3_moe\
  --base_model_path /path/to/hf/Qwen3-235B-A22B-Thinking-2507\
  --maxtext_model_path gs://your-gcs-bucket/qwen3/scanned/step_0/\
  --model_size qwen3-235b-a22b

```

#### 2\. Run Training

Once the checkpoint is converted, you can run  training workloads by specifying the model name and loading the converted weights.

Bash

```
# Example for running validation
JAX_PLATFORMS=cpu python3 -m MaxText.tests.forward_pass_logit_checker MaxText/configs/base.yml\
  tokenizer_path=assets/qwen3-tokenizer\
  load_parameters_path=gs://your-gcs-bucket/qwen3/scanned/step_0/items/\
  model_name=qwen3-235b-a22b\
  --hf_model_path=Qwen/Qwen3-235B-A22B-Thinking-2507

```

* * * * *

### Testing Strategy & Validation

The correctness of the implementation and the conversion script was validated by comparing the logits produced by the MaxText model against the original Hugging Face model (`Qwen/Qwen3-235B-A22B-Thinking-2507`).

The `forward_pass_logit_checker` test was used with several prompts.

**Key Validation Metrics:**

| Prompt | Overlap Count | Jaccard Similarity | Rank Agreement % | Avg KL Divergence |
| --- | --- | --- | --- | --- |
| "I love to" | **10/10** | **1.0** | 40.0% | 0.000254 |
| "Today is a" | **10/10** | **1.0** | 80.0% | 0.001808 |
| "What is the" | **10/10** | **1.0** | 100.0% | -0.000182 |

* * * * *

### Checklist

Before submitting this PR, please make sure (put X in square brackets):

-   [X] I have performed a self-review of my code.
-   [X] I have necessary comments in my code, particularly in hard-to-understand areas.
-   [X] I have run end-to-end tests and provided the validation results above.
-   [X] I have made or will make corresponding changes to the documentation if needed.