### PR TITLE
Fix AttributeError raised when restoring from a checkpoint with EmergencyCheckpointManager

### DIFF
--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -353,21 +353,21 @@ def load_state_if_possible(
       checkpoint_args = ocp.args.PyTreeRestore(item=abstract_unboxed_pre_state, restore_args=restore_args)
 
       match (checkpoint_manager, dataset_type, data_iterator):
-        # Case 1: Matches if 'checkpoint_manager' is an instance of either EmergencyCheckpointManager
-        # or EmergencyReplicatorCheckpointManager. The '_' indicates that 'dataset_type' and
-        # 'data_iterator' can be any value and aren't used in this pattern.
-        case (checkpoint_manager, _, _) if isinstance(
-            checkpoint_manager, (EmergencyCheckpointManager, EmergencyReplicatorCheckpointManager)
-        ):
+        # Case 1: Matches if 'checkpoint_manager' is an instance of EmergencyCheckpointManager. The '_' 
+        # indicates that 'dataset_type' and 'data_iterator' can be any value and aren't used in this pattern.
+        case (checkpoint_manager, _, _) if isinstance(checkpoint_manager, EmergencyCheckpointManager):
+          return (checkpoint_manager.restore(step, args=Composite(state=checkpoint_args)), None)
+        # Case 2: Matches if 'checkpoint_manager' is an instance of EmergencyReplicatorCheckpointManager.
+        case (checkpoint_manager, _, _) if isinstance(checkpoint_manager, EmergencyReplicatorCheckpointManager):
           return (checkpoint_manager.restore(step, args=Composite(state=checkpoint_args)).state, None)
-        # Case 2: Matches if dataset type is "grain" and a specific checkpoint file exits for the iterator
+        # Case 3: Matches if dataset type is "grain" and a specific checkpoint file exits for the iterator
         # exists within the checkpoint manager's directory for the given step.
         case (checkpoint_manager, dataset_type, data_iterator) if dataset_type == "grain" and data_iterator and (
             checkpoint_manager.directory / str(step) / "iter"
         ).exists():
           grain_iter = grain.PyGrainCheckpointRestore(data_iterator.local_iterator)
           return (checkpoint_manager.restore(step, args=Composite(items=checkpoint_args, iter=grain_iter)), None)
-        # Case 3: Default/Fallback case.
+        # Case 4: Default/Fallback case.
         # This case acts as a wildcard ('_') and matches if none of the preceding cases were met.
         case _:
           return (checkpoint_manager.restore(step, args=Composite(items=checkpoint_args)), None)


### PR DESCRIPTION
# Description

In the current implementation, when restoring from a checkpoint with an `EmergencyCheckpointManager`, `load_state_if_possible` extracts the `TrainState` by accessing the `.state` attribute of the output of `checkpoint_manager.restore(...)`. However, `EmergencyCheckpointManager` already extracts the state, causing an `AttributeError` to be raised when `load_state_if_possible` tries to do so again.

This PR fixes the `AttributeError` by modifying the code to directly return the output of `checkpoint_manager.restore(...)` when using an EmergencyCheckpointManager.

# Tests

This change was tested using this script: https://gist.github.com/rao-ashish/7350b5b31380be150413ed3db4b1423b.

The script launches processes running a MaxText training job for a few iterations. To test the PR, (1) the script was launched to save checkpoints over a few iterations, (2) one of the rank's local checkpoints are deleted, and (3) the script is rerun, with the expected behavior being that the train state is restored by broadcasting it from a rank that still has a local checkpoint saved. The attribute error is raised at step (3) when using the current implementation, and is not raised when using the patched version.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
