### PR TITLE
Pass model_mode to decoder layer __init__ functions

### DIFF
--- a/MaxText/convert_gpt3_ckpt_from_paxml.py
+++ b/MaxText/convert_gpt3_ckpt_from_paxml.py
@@ -54,6 +54,7 @@ from MaxText import maxtext_utils
 from MaxText import max_utils
 from MaxText import optimizers
 from MaxText import pyconfig
+from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.globals import PKG_DIR
 from MaxText.layers import quantizations
 from MaxText.layers.models import Transformer
@@ -89,7 +90,7 @@ def convert(paxml_ckpt_path, maxtext_model_name, base_output_directory, run_name
   mesh = Mesh(devices_array, cfg.mesh_axes)
 
   quant = quantizations.configure_quantization(cfg)
-  model = Transformer(cfg, mesh, quant=quant)
+  model = Transformer(cfg, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
   learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(cfg)
   tx = optimizers.get_optimizer(cfg, learning_rate_schedule)
 

--- a/MaxText/generate_param_only_checkpoint.py
+++ b/MaxText/generate_param_only_checkpoint.py
@@ -40,7 +40,7 @@ from MaxText import max_utils
 from MaxText import maxtext_utils
 from MaxText import optimizers
 from MaxText import pyconfig
-from MaxText.common_types import DecoderBlockType
+from MaxText.common_types import DecoderBlockType, MODEL_MODE_TRAIN
 from MaxText.layers import models, quantizations
 from MaxText.utils import gcs_utils
 from MaxText.utils import lora_utils
@@ -96,7 +96,7 @@ def _read_train_checkpoint(config, checkpoint_manager, mesh):
   """Read training checkpoint at path defined by load_full_state_path."""
   # Model and Optimizer definition
   quant = quantizations.configure_quantization(config)
-  model = Transformer(config, mesh, quant)
+  model = Transformer(config, mesh, quant, MODEL_MODE_TRAIN)
   rng = random.PRNGKey(0)
   learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(config)
   tx = optimizers.get_optimizer(config, learning_rate_schedule)
@@ -112,7 +112,7 @@ def _generate_lora_decode_checkpoints(config, mesh):
   """Read lora checkpoints checkpoint at path defined by load_full_state_path."""
   # Model and Optimizer definition
   quant = quantizations.configure_quantization(config)
-  model = Transformer(config, mesh, quant)
+  model = Transformer(config, mesh, quant, MODEL_MODE_TRAIN)
   rng = random.PRNGKey(0)
   learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(config)
   tx = optimizers.get_optimizer(config, learning_rate_schedule)

--- a/MaxText/layers/decoders.py
+++ b/MaxText/layers/decoders.py
@@ -68,6 +68,7 @@ class DecoderLayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
 
   @nn.compact
@@ -205,6 +206,7 @@ class SequentialBlockDecoderLayers(nn.Module):
   config: Config
   mesh: Mesh
   quant: Quant
+  model_mode: str
 
   @nn.compact
   def __call__(
@@ -218,7 +220,9 @@ class SequentialBlockDecoderLayers(nn.Module):
       page_state: Optional[page_manager.PageState] = None,
   ) -> jnp.ndarray:
     for lyr in range(self.num_decoder_layers):
-      inputs = self.decoder_layer(config=self.config, mesh=self.mesh, name=f"layers_{lyr}", quant=self.quant)(
+      inputs = self.decoder_layer(
+          config=self.config, mesh=self.mesh, name=f"layers_{lyr}", quant=self.quant, model_mode=model_mode
+      )(
           inputs,
           decoder_segment_ids,
           decoder_positions,
@@ -242,6 +246,7 @@ class Decoder(nn.Module):
   shared_embedding: nn.Module
   mesh: Mesh
   quant: Optional[Quant] = None
+  model_mode: str = MODEL_MODE_TRAIN
 
   def setup(self):
     """Initialize decoder layer."""
@@ -416,7 +421,7 @@ class Decoder(nn.Module):
     else:
       raise ValueError(f"Incorrect decoder_block name {self.config.decoder_block.value=}")
 
-  def scan_decoder_layers(self, cfg, decoder_layer, length, metadata_axis_name, mesh, in_axes_tuple, **kwargs):
+  def scan_decoder_layers(self, cfg, decoder_layer, length, metadata_axis_name, mesh, in_axes_tuple, model_mode, **kwargs):
     """scan decoder layers, calls `flax.linen.transforms.scan`"""
     initializing = self.is_mutable_collection("params")
     params_spec = cfg.param_scan_axis if initializing else ScanIn(cfg.param_scan_axis)
@@ -438,7 +443,14 @@ class Decoder(nn.Module):
         length=length,
         metadata_params={nn.PARTITION_NAME: metadata_axis_name},
     )
-    return scan_fn(config=cfg, mesh=mesh, name=metadata_axis_name, quant=self.quant, **kwargs)
+    return scan_fn(
+        config=cfg,
+        mesh=mesh,
+        name=metadata_axis_name,
+        quant=self.quant,
+        model_mode=model_mode,
+        **kwargs
+    )
 
   def get_pipeline_stage_module(self, decoder_blocks):
     """get pipeline stage module"""
@@ -455,7 +467,7 @@ class Decoder(nn.Module):
       policy = self.get_remat_policy()
       base_stage = self.set_remat_policy([base_stage], policy)[0]
     if cfg.num_layers_per_pipeline_stage == 1:
-      stage_module = base_stage(config=cfg, mesh=self.mesh, quant=self.quant)
+      stage_module = base_stage(config=cfg, mesh=self.mesh, quant=self.quant, model_mode=self.model_mode)
     elif cfg.scan_layers_per_stage:
       stage_module = self.scan_decoder_layers(
           cfg,
@@ -464,6 +476,7 @@ class Decoder(nn.Module):
           "layers_per_stage",
           self.mesh,
           in_axes_tuple=(nn.broadcast,) * 4,
+          model_mode=self.model_mode,
       )
     else:
       stage_module = SequentialBlockDecoderLayers(
@@ -472,6 +485,7 @@ class Decoder(nn.Module):
           config=cfg,
           mesh=self.mesh,
           quant=self.quant,
+          model_mode=self.model_mode,
       )
     return stage_module
 
@@ -629,6 +643,7 @@ class Decoder(nn.Module):
               "dense_layers",
               mesh,
               in_axes_tuple=(nn.broadcast,) * len(broadcast_args),
+              model_mode=model_mode,
           )(y, *broadcast_args)
           if num_moe_layers_outside_pp > 0:
             y, _ = self.scan_decoder_layers(
@@ -638,6 +653,7 @@ class Decoder(nn.Module):
                 "moe_layers",
                 mesh,
                 in_axes_tuple=(nn.broadcast,) * len(broadcast_args),
+                model_mode=model_mode,
             )(y, *broadcast_args)
         y = self.pipeline_module(y, *broadcast_args, partition_spec=partition_spec)
       else:  # Not DeepSeek
@@ -653,6 +669,7 @@ class Decoder(nn.Module):
                 "layers_outside_pipeline",
                 mesh,
                 in_axes_tuple=(nn.broadcast,) * len(broadcast_args),
+                model_mode=model_mode,
             )(y, *broadcast_args)
     else:
       if cfg.scan_layers:
@@ -672,12 +689,19 @@ class Decoder(nn.Module):
               "dense_layers",
               mesh,
               in_axes_tuple=(nn.broadcast,) * len(broadcast_args),
+              model_mode=model_mode,
           )(y, *broadcast_args)
           moe_layer = RemattedBlockLayers[1]
           moe_layer.__call__ = functools.partial(moe_layer.__call__, **layer_call_kwargs)
           num_moe_layers = cfg.num_decoder_layers - cfg.first_num_dense_layers
           y, _ = self.scan_decoder_layers(
-              cfg, moe_layer, num_moe_layers, "moe_layers", mesh, in_axes_tuple=(nn.broadcast,) * len(broadcast_args)
+              cfg,
+              moe_layer,
+              num_moe_layers,
+              "moe_layers",
+              mesh,
+              in_axes_tuple=(nn.broadcast,) * len(broadcast_args),
+              model_mode=model_mode,
           )(y, *broadcast_args)
         elif cfg.decoder_block == DecoderBlockType.GEMMA3:
           y = self._apply_gemma3_scanned_blocks(
@@ -708,6 +732,7 @@ class Decoder(nn.Module):
               "layers",
               mesh,
               in_axes_tuple=(nn.broadcast,) * len(broadcast_args),
+              model_mode=model_mode,
               **layer_kwargs,
           )(y, *broadcast_args)
       else:
@@ -723,7 +748,7 @@ class Decoder(nn.Module):
           # Iterate over the two layer groups (dense and MoE) and apply layer transformation
           for layer, num_layers, layer_prefix in zip(layers, num_layers_list, layer_prefixes):
             for index in range(num_layers):
-              y = layer(config=cfg, mesh=mesh, name=f"{layer_prefix}_{index}", quant=self.quant)(
+              y = layer(config=cfg, mesh=mesh, name=f"{layer_prefix}_{index}", quant=self.quant, model_mode=self.model_mode)(
                   y,
                   decoder_segment_ids,
                   decoder_positions,
@@ -748,7 +773,9 @@ class Decoder(nn.Module):
                   "is_moe_layer": llama4.determine_is_moe_layer(lyr, self.config.interleave_moe_layer_step),
               }
               layer_call_kwargs = {"bidirectional_mask": bidirectional_mask}
-            layer = RemattedBlockLayer(config=cfg, mesh=mesh, name=f"layers_{lyr}", quant=self.quant, **layer_kwargs)
+            layer = RemattedBlockLayer(
+                config=cfg, mesh=mesh, name=f"layers_{lyr}", quant=self.quant, model_mode=self.model_mode, **layer_kwargs
+            )
             y = layer(
                 y,
                 decoder_segment_ids,
@@ -814,6 +841,7 @@ class Decoder(nn.Module):
           "layers",
           mesh,
           in_axes_tuple=(nn.broadcast,) * len(broadcast_args),
+          model_mode=model_mode,
           **layer_kwargs,
       )(y, *broadcast_args, **layer_call_kwargs)
 
@@ -822,7 +850,9 @@ class Decoder(nn.Module):
     if num_remaining_layers > 0:
       # We name the remainder block with a 'remainder' suffix to avoid parameter name collisions
       rem_layer_kwargs = {"num_of_layers": num_remaining_layers}
-      layer = RemattedGemma3Block(config=cfg, mesh=mesh, quant=self.quant, name="layers_remainder", **rem_layer_kwargs)
+      layer = RemattedGemma3Block(
+          config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode, name="layers_remainder", **rem_layer_kwargs
+      )
       y, _ = layer(
           y,
           decoder_segment_ids,

--- a/MaxText/layers/deepseek.py
+++ b/MaxText/layers/deepseek.py
@@ -153,6 +153,7 @@ class DeepSeekDenseLayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
 
   @nn.compact
@@ -218,6 +219,7 @@ class DeepSeekMoELayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
 
   @nn.compact

--- a/MaxText/layers/gemma.py
+++ b/MaxText/layers/gemma.py
@@ -36,6 +36,7 @@ class GemmaDecoderLayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
 
   @nn.compact

--- a/MaxText/layers/gemma2.py
+++ b/MaxText/layers/gemma2.py
@@ -37,6 +37,7 @@ class Gemma2DecoderLayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
 
   @nn.compact

--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -63,6 +63,7 @@ class Gemma3DecoderLayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
   attention_type: AttentionType = AttentionType.LOCAL_SLIDING
 
@@ -219,6 +220,7 @@ class Gemma3ScannableBlock(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
   num_of_layers: int = 1
 
@@ -247,6 +249,7 @@ class Gemma3ScannableBlock(nn.Module):
       layer = Gemma3DecoderLayer(
           config=cfg,
           mesh=mesh,
+          model_mode=model_mode,
           name=f"layers_{layer_id}",
           quant=self.quant,
           attention_type=attention_type,

--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -321,6 +321,7 @@ class Gpt3DecoderLayer(nn.Module):
 
   config: models.Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
 
   @nn.compact

--- a/MaxText/layers/llama2.py
+++ b/MaxText/layers/llama2.py
@@ -47,6 +47,7 @@ class LlamaDecoderLayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
 
   @nn.compact

--- a/MaxText/layers/llama4.py
+++ b/MaxText/layers/llama4.py
@@ -360,6 +360,7 @@ class Llama4DecoderLayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
   is_nope_layer: bool = False
   is_moe_layer: bool = False
@@ -539,6 +540,7 @@ class Llama4ScannableBlock(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
   nope_layer_interval: int = 1
   interleave_moe_layer_step: int = 1
@@ -571,6 +573,7 @@ class Llama4ScannableBlock(nn.Module):
           mesh=mesh,
           name=f"layers_{layer_id}",
           quant=self.quant,
+          model_mode=model_mode,
           is_nope_layer=nope_layer,
           is_moe_layer=moe_layer,
       )

--- a/MaxText/layers/mistral.py
+++ b/MaxText/layers/mistral.py
@@ -45,6 +45,7 @@ class MistralDecoderLayer(nn.Module):
 
   config: models.Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
 
   @nn.compact

--- a/MaxText/layers/mixtral.py
+++ b/MaxText/layers/mixtral.py
@@ -46,6 +46,7 @@ class MixtralDecoderLayer(nn.Module):
 
   config: models.Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
 
   @nn.compact

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -41,12 +41,18 @@ from MaxText.maxtext_utils import all_gather_over_fsdp
 class Transformer(nn.Module):
   """An autoregressive transformer model."""
 
-  # Make new attributes required, so that all Transformer dependencies (train, decode, compile, etc) will error instead
-  #   of silently use defaults.
+  # Make new attributes required, so that all Transformer dependencies (train, decode,
+  # compile, etc) will error instead of silently use defaults.
   # pylint: disable=attribute-defined-outside-init
   config: Config
   mesh: Mesh
   quant: Quant
+  # Possible model_mode values can be found in MaxText.common_types.
+  # We generally use MaxText.common_types.MODEL_MODE_TRAIN or
+  # MaxText.common_types.MODEL_MODE_PREFILL for initializations here.
+  model_mode: str # May be different than the model_mode passed to __call__
+  # pylint: enable=attribute-defined-outside-init
+
 
   def setup(self):
     """Initialize shared_embedding & decoder layers."""
@@ -63,7 +69,9 @@ class Transformer(nn.Module):
         config=cfg,
     )
     self.vision_encoder = VisionEncoder(config=cfg, mesh=mesh) if cfg.use_multimodal else None
-    self.decoder = Decoder(config=cfg, shared_embedding=self.shared_embedding, mesh=mesh, quant=self.quant)
+    self.decoder = Decoder(
+        config=cfg, shared_embedding=self.shared_embedding, mesh=mesh, quant=self.quant, model_mode=self.model_mode
+    )
     # If MTP is enabled via config, set up the MTP block.
     if self.config.mtp_num_layers > 0:
       # Get the list of layer blueprints for the current model.
@@ -180,9 +188,13 @@ class ZeroOneTransformer(nn.Module):
   config: Config
   mesh: Mesh
   quant: Quant
+  # Possible model_mode values can be found in MaxText.common_types.
+  # We generally use MaxText.common_types.MODEL_MODE_TRAIN or
+  # MaxText.common_types.MODEL_MODE_PREFILL for initializations here.
+  model_mode: str # May be different than the model_mode passed to __call__
 
   def setup(self):
-    self.model = Transformer(self.config, self.mesh, self.quant)
+    self.model = Transformer(self.config, self.mesh, self.quant, self.model_mode)
 
   def __call__(
       self,

--- a/MaxText/layers/multi_token_prediction.py
+++ b/MaxText/layers/multi_token_prediction.py
@@ -154,7 +154,7 @@ class MultiTokenPredictionLayer(nn.Module):
     projected_features = projection_layer(concatenated_features)
 
     # --- 4. Pass through MTP Transformer Block ---
-    output = self.transformer_layer_module(config=cfg, mesh=mesh, name=f"mtp_{k}_transformer_layer")(
+    output = self.transformer_layer_module(config=cfg, mesh=mesh, model_mode=model_mode, name=f"mtp_{k}_transformer_layer")(
         inputs=projected_features,
         decoder_segment_ids=decoder_segment_ids,
         decoder_positions=position_ids,

--- a/MaxText/layers/qwen3.py
+++ b/MaxText/layers/qwen3.py
@@ -42,6 +42,7 @@ class Qwen3DecoderLayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[Quant] = None
 
   @nn.compact

--- a/MaxText/layers/simple_layer.py
+++ b/MaxText/layers/simple_layer.py
@@ -31,6 +31,7 @@ class SimpleDecoderLayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[quantizations.AqtQuantization] = None
 
   def setup(self):
@@ -54,6 +55,7 @@ class SimpleMlpDecoderLayer(nn.Module):
 
   config: Config
   mesh: Mesh
+  model_mode: str
   quant: Optional[quantizations.AqtQuantization] = None
 
   def setup(self):

--- a/MaxText/layerwise_quantization.py
+++ b/MaxText/layerwise_quantization.py
@@ -74,7 +74,7 @@ class LayerwiseQuantization:
 
     # Model and quantization config
     self.quant = quantizations.configure_quantization(config)
-    model = models.Transformer(config, mesh=self._mesh, quant=self.quant)
+    model = models.Transformer(config, mesh=self._mesh, quant=self.quant, model_mode=common_types.MODEL_MODE_TRAIN)
     rng = jax.random.PRNGKey(1234)
     self.unboxed_abstract_state, _, _ = maxtext_utils.get_abstract_state(model, None, self.config, rng, self._mesh, False)
 

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -113,7 +113,7 @@ class MaxEngine(engine_api.Engine):
 
     # Model and Optimizer definition
     quant = quantizations.configure_quantization(config)
-    self.model = models.Transformer(config, mesh=self._mesh, quant=quant)
+    self.model = models.Transformer(config, mesh=self._mesh, quant=quant, model_mode=MODEL_MODE_PREFILL)
     self.replicated_sharding = jax.sharding.NamedSharding(self._mesh, P(None))
 
     self.abstract_params = None

--- a/MaxText/scratch_code/generate_grpo_golden_logits.py
+++ b/MaxText/scratch_code/generate_grpo_golden_logits.py
@@ -51,7 +51,7 @@ from MaxText.experimental.rl.grpo_utils import compute_log_probs
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
 from MaxText.tests.grpo_trainer_correctness_test import prepare_maxtext_inputs
-from MaxText.common_types import Array
+from MaxText.common_types import Array, MODEL_MODE_TRAIN
 
 
 class GRPOTest(unittest.TestCase):
@@ -81,12 +81,14 @@ class GRPOTest(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(self.cfg)
     mesh = Mesh(devices_array, self.cfg.mesh_axes)
     # With checkpoint
-    self.model = models.Transformer(config=self.cfg, mesh=mesh, quant=None)
+    self.model = models.Transformer(config=self.cfg, mesh=mesh, quant=None, model_mode=MODEL_MODE_TRAIN)
     self.state, state_mesh_annotations = maxtext_utils.setup_decode_state(self.model, self.cfg, self.rng, mesh, None)
     self.state_mesh_shardings = nn.logical_to_mesh_sharding(state_mesh_annotations, mesh, self.cfg.logical_axis_rules)
     self.data_sharding = jax.NamedSharding(mesh, jax.sharding.PartitionSpec(None))
     # Without checkpoint
-    self.model_no_ckpt_loading = models.Transformer(config=self.cfg_no_ckpt_loading, mesh=mesh, quant=None)
+    self.model_no_ckpt_loading = models.Transformer(
+        config=self.cfg_no_ckpt_loading, mesh=mesh, quant=None, model_mode=MODEL_MODE_TRAIN
+    )
     self.state_no_ckpt_loading, _ = maxtext_utils.setup_decode_state(
         self.model_no_ckpt_loading, self.cfg_no_ckpt_loading, self.rng, mesh, None
     )

--- a/MaxText/tests/forward_pass_logit_checker.py
+++ b/MaxText/tests/forward_pass_logit_checker.py
@@ -52,7 +52,7 @@ from MaxText.utils.ckpt_conversion.utils.hf_utils import (
 from MaxText import max_logging
 from MaxText import maxtext_utils
 from MaxText import pyconfig
-from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR
+from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_TRAIN
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
 from MaxText.layers import quantizations
@@ -219,7 +219,7 @@ def main(config, test_args):  # pylint: disable=W0621
       devices_array = maxtext_utils.create_device_mesh(config)
       mesh = jax.sharding.Mesh(devices_array, config.mesh_axes)
       quant = quantizations.configure_quantization(config)
-      model = models.Transformer(config, mesh=mesh, quant=quant)
+      model = models.Transformer(config, mesh=mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
       state, _ = maxtext_utils.setup_decode_state(model, config, rng1, mesh, None)
 
     if test_args.golden_logits_path == "":
@@ -297,7 +297,7 @@ def main(config, test_args):  # pylint: disable=W0621
     devices_array = maxtext_utils.create_device_mesh(config)
     mesh = jax.sharding.Mesh(devices_array, config.mesh_axes)
     quant = quantizations.configure_quantization(config)
-    maxtext_model = models.Transformer(config, mesh, quant=quant)
+    maxtext_model = models.Transformer(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
     maxtext_state, _ = maxtext_utils.setup_decode_state(maxtext_model, config, rng1, mesh, None)
 
     prompts = ["I love to", "Today is a", "What is the"]

--- a/MaxText/tests/gpt3_test.py
+++ b/MaxText/tests/gpt3_test.py
@@ -29,6 +29,7 @@ import jax
 from MaxText import maxtext_utils
 from MaxText import pyconfig
 from MaxText.globals import PKG_DIR
+from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.layers import models
 from MaxText.layers import quantizations
 
@@ -71,7 +72,7 @@ class GPT3(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(self.cfg)
     mesh = Mesh(devices_array, self.cfg.mesh_axes)
     quant = quantizations.configure_quantization(self.cfg)
-    self.model = models.Transformer(config=self.cfg, mesh=mesh, quant=quant)
+    self.model = models.Transformer(config=self.cfg, mesh=mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
     self.example_batch = {
         "inputs": jnp.array([[11, 12, 13, 14, 15]], dtype=jnp.int32),
         "inputs_position": jnp.array([[0, 1, 2, 3, 4]], dtype=jnp.int32),

--- a/MaxText/tests/grpo_trainer_correctness_test.py
+++ b/MaxText/tests/grpo_trainer_correctness_test.py
@@ -47,6 +47,7 @@ from MaxText import maxengine
 from MaxText import maxtext_utils
 from MaxText import pyconfig
 import MaxText as mt
+from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.experimental.rl.grpo_trainer import grpo_loss_fn, _merge_grpo_state
 from MaxText.experimental.rl.grpo_utils import compute_log_probs
 from MaxText.inference import offline_engine
@@ -69,7 +70,7 @@ def setup_maxtext_model(config, mesh):
   init_rng = jax.random.PRNGKey(config.init_weights_seed)
   quant = quantizations.configure_quantization(config)
 
-  maxtext_model = models.Transformer(config=config, mesh=mesh, quant=quant)
+  maxtext_model = models.Transformer(config=config, mesh=mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
   state, state_mesh_annotations = maxtext_utils.setup_decode_state(maxtext_model, config, init_rng, mesh, None)
   state_mesh_shardings = nn.logical_to_mesh_sharding(state_mesh_annotations, mesh, config.logical_axis_rules)
   data_sharding = jax.NamedSharding(mesh, jax.sharding.PartitionSpec(None))

--- a/MaxText/tests/integration_tests/grpo_correctness.py
+++ b/MaxText/tests/integration_tests/grpo_correctness.py
@@ -37,6 +37,7 @@ from MaxText import maxtext_utils
 from MaxText import pyconfig
 from MaxText.experimental.rl.grpo_trainer import grpo_loss_fn, _merge_grpo_state
 from MaxText.experimental.rl.grpo_utils import compute_log_probs
+from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
 
@@ -63,7 +64,7 @@ class GRPOTest(unittest.TestCase):
     self.rng = jax.random.PRNGKey(42)
     devices_array = maxtext_utils.create_device_mesh(self.cfg)
     mesh = Mesh(devices_array, self.cfg.mesh_axes)
-    self.model = models.Transformer(config=self.cfg, mesh=mesh, quant=None)
+    self.model = models.Transformer(config=self.cfg, mesh=mesh, quant=None, model_mode=MODEL_MODE_TRAIN)
     self.state, _ = maxtext_utils.setup_decode_state(self.model, self.cfg, self.rng, mesh, None)
     self.tokenizer_model = transformers.AutoTokenizer.from_pretrained(
         "meta-llama/Llama-3.1-8B",

--- a/MaxText/tests/integration_tests/sft_trainer_correctness_test.py
+++ b/MaxText/tests/integration_tests/sft_trainer_correctness_test.py
@@ -40,6 +40,7 @@ from transformers import AutoTokenizer
 
 from MaxText import maxtext_utils
 from MaxText import pyconfig
+from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.globals import PKG_DIR
 from MaxText.input_pipeline import _input_pipeline_utils
 from MaxText.layers import models
@@ -114,7 +115,7 @@ def setup_maxtext_model(config):
   quant = quantizations.configure_quantization(config)
   devices_array = maxtext_utils.create_device_mesh(config)
   mesh = Mesh(devices_array, config.mesh_axes)
-  maxtext_model = models.Transformer(config=config, mesh=mesh, quant=quant)
+  maxtext_model = models.Transformer(config=config, mesh=mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
   state, _ = maxtext_utils.setup_decode_state(maxtext_model, config, init_rng, mesh, None)
   return maxtext_model, state, init_rng
 

--- a/MaxText/tests/maxengine_test.py
+++ b/MaxText/tests/maxengine_test.py
@@ -30,7 +30,7 @@ from jax.sharding import Mesh
 
 from MaxText import maxtext_utils
 from MaxText import pyconfig, maxengine
-from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR
+from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_PREFILL
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
 from MaxText.layers import quantizations
@@ -112,7 +112,7 @@ class MaxEngineTest(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(self.cfg)
     mesh = Mesh(devices_array, self.cfg.mesh_axes)
     quant = quantizations.configure_quantization(self.cfg)
-    model = models.Transformer(config=self.cfg, mesh=mesh, quant=quant)
+    model = models.Transformer(config=self.cfg, mesh=mesh, quant=quant, model_mode=MODEL_MODE_PREFILL)
     ids, decoder_segment_ids, decoder_positions = self.get_data()
 
     transformer_vars = model.init(
@@ -136,7 +136,7 @@ class MaxEngineTest(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(self.cfg)
     mesh = Mesh(devices_array, self.cfg.mesh_axes)
     quant = quantizations.configure_quantization(self.cfg)
-    model = models.Transformer(config=self.cfg, mesh=mesh, quant=quant)
+    model = models.Transformer(config=self.cfg, mesh=mesh, quant=quant, model_mode=MODEL_MODE_PREFILL)
     ids, decoder_segment_ids, decoder_positions = self.get_data()
 
     transformer_vars = model.init(

--- a/MaxText/tests/maxtext_utils_test.py
+++ b/MaxText/tests/maxtext_utils_test.py
@@ -38,6 +38,7 @@ import optax
 from MaxText import max_utils
 from MaxText import maxtext_utils
 from MaxText import pyconfig
+from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.globals import PKG_DIR
 from MaxText.layers import models
 from MaxText.layers import quantizations
@@ -216,7 +217,7 @@ class MaxUtilsInitTransformerState(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(self.config)
     self.mesh = Mesh(devices_array, self.config.mesh_axes)
     quant = quantizations.configure_quantization(self.config)
-    self.model = Transformer(self.config, mesh=self.mesh, quant=quant)
+    self.model = Transformer(self.config, mesh=self.mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
 
   def test_setup_decode_state(self):
     rng = random.PRNGKey(0)

--- a/MaxText/tests/model_test.py
+++ b/MaxText/tests/model_test.py
@@ -82,7 +82,7 @@ class TestModel(unittest.TestCase):
     new_config = self.init_pyconfig(cast_logits_to_fp32=cast_logits_to_fp32, logits_dot_in_fp32=False)
     devices_array = maxtext_utils.create_device_mesh(new_config)
     mesh = Mesh(devices_array, new_config.mesh_axes)
-    model = models.Transformer(config=new_config, mesh=mesh, quant=None)
+    model = models.Transformer(config=new_config, mesh=mesh, quant=None, model_mode=MODEL_MODE_TRAIN)
 
     ids, decoder_segment_ids, decoder_positions = self.get_data()
 
@@ -120,16 +120,21 @@ class TestModel(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(self.cfg)
     mesh = Mesh(devices_array, self.cfg.mesh_axes)
     quant = quantizations.configure_quantization(self.cfg)
-    model = models.Transformer(config=self.cfg, mesh=mesh, quant=quant)
+    train_model = models.Transformer(config=self.cfg, mesh=mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
+    prefill_model = models.Transformer(config=self.cfg, mesh=mesh, quant=quant, model_mode=MODEL_MODE_PREFILL)
 
     ids, decoder_segment_ids, decoder_positions = self.get_data()
 
-    transformer_vars = model.init(
+    train_transformer_vars = train_model.init(
         {"params": self.rng, "aqt": self.rng}, ids, decoder_positions, decoder_segment_ids, enable_dropout=False
     )
 
-    full_train_logits = model.apply(
-        transformer_vars,
+    prefill_transformer_vars = prefill_model.init(
+        {"params": self.rng, "aqt": self.rng}, ids, decoder_positions, decoder_segment_ids, enable_dropout=False
+    )
+
+    full_train_logits = train_model.apply(
+        train_transformer_vars,
         ids,
         decoder_positions,
         decoder_segment_ids,
@@ -138,8 +143,8 @@ class TestModel(unittest.TestCase):
         rngs={"aqt": self.rng},
     )
 
-    partial_prefill_logits, partial_cache = model.apply(
-        transformer_vars,
+    partial_prefill_logits, partial_cache = prefill_model.apply(
+        prefill_transformer_vars,
         ids[:, :PREFILL_RANGE],
         decoder_positions[:, :PREFILL_RANGE],
         decoder_segment_ids=decoder_segment_ids[:, :PREFILL_RANGE],
@@ -158,9 +163,9 @@ class TestModel(unittest.TestCase):
     for idx in range(PREFILL_RANGE, self.cfg.max_target_length):
       ids_idx = ids[:, idx : idx + 1]
       decoder_positions_idx = decoder_positions[:, idx : idx + 1]
-      transformer_vars.update(partial_cache)
-      ar_logits, partial_cache = model.apply(
-          transformer_vars,
+      prefill_transformer_vars.update(partial_cache)
+      ar_logits, partial_cache = prefill_model.apply(
+          prefill_transformer_vars,
           ids_idx,
           decoder_positions_idx,
           enable_dropout=False,

--- a/MaxText/tests/pipeline_parallelism_test.py
+++ b/MaxText/tests/pipeline_parallelism_test.py
@@ -58,10 +58,11 @@ class PipelineParallelismTest(unittest.TestCase):
     """check that the output and gradient are the same"""
     devices_array = maxtext_utils.create_device_mesh(config)
     mesh = Mesh(devices_array, config.mesh_axes)
+    model_mode = MODEL_MODE_TRAIN
     if single_pipeline_stage_class is None:
-      single_pipeline_stage = simple_layer.SimpleDecoderLayer(config=config, mesh=mesh)
+      single_pipeline_stage = simple_layer.SimpleDecoderLayer(config=config, mesh=mesh, model_mode=model_mode)
     else:
-      single_pipeline_stage = single_pipeline_stage_class(config=config, mesh=mesh)
+      single_pipeline_stage = single_pipeline_stage_class(config=config, mesh=mesh, model_mode=model_mode)
 
     def get_inputs(batch_size, sequence, features):
       """Get random inputs, and random dummy targets
@@ -85,9 +86,8 @@ class PipelineParallelismTest(unittest.TestCase):
         config.global_batch_size_to_train_on, config.max_target_length, config.emb_dim
     )
     deterministic = True
-    model_mode = MODEL_MODE_TRAIN
     # We use a simpler single matmul decoder layer for fast compilation in these tests.
-    single_pipeline_stage = simple_layer.SimpleDecoderLayer(config=config, mesh=mesh)
+    single_pipeline_stage = simple_layer.SimpleDecoderLayer(config=config, mesh=mesh, model_mode=model_mode)
     my_pipeline = pipeline.Pipeline(config=config, layers=single_pipeline_stage, mesh=mesh)
     init_pipeline_params = my_pipeline.init(
         jax.random.PRNGKey(0), inputs, inputs_position, inputs_segmentation, deterministic, model_mode

--- a/MaxText/tests/state_dtypes_test.py
+++ b/MaxText/tests/state_dtypes_test.py
@@ -24,6 +24,7 @@ import jax.numpy as jnp
 
 from MaxText import pyconfig
 from MaxText import optimizers
+from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.layers import models
 from MaxText.layers import quantizations
 from MaxText import maxtext_utils
@@ -43,7 +44,7 @@ class StateDtypes(unittest.TestCase):
     quant = quantizations.configure_quantization(config)
     devices_array = maxtext_utils.create_device_mesh(config)
     mesh = Mesh(devices_array, config.mesh_axes)
-    model = Transformer(config, mesh, quant=quant)
+    model = Transformer(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
     learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(config)
     tx = optimizers.get_optimizer(config, learning_rate_schedule)
     _, example_rng = jax.random.split(jax.random.PRNGKey(0), 2)

--- a/MaxText/train_compile.py
+++ b/MaxText/train_compile.py
@@ -42,6 +42,7 @@ from MaxText import maxtext_utils
 from MaxText import optimizers
 from MaxText import max_utils
 from MaxText import pyconfig
+from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.layers import models
 from MaxText.layers import quantizations
 from MaxText.utils import gcs_utils
@@ -86,7 +87,7 @@ def get_shaped_inputs(topology_mesh, config):
   """Get shaped abstractions of inputs to train_step: state, batch and rng"""
   # Construct the model and optimizer to get shaped versions of the state
   quant = quantizations.configure_quantization(config)
-  model = Transformer(config, topology_mesh, quant=quant)
+  model = Transformer(config, topology_mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
   # The learning_rate_schedule is baked into the compiled object.
   learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(config)
   tx = optimizers.get_optimizer(config, learning_rate_schedule)

--- a/MaxText/train_utils.py
+++ b/MaxText/train_utils.py
@@ -18,6 +18,7 @@ limitations under the License.
 """ Utils that are only interesting for training in MaxText. """
 
 import jax
+from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.layers import quantizations
 from MaxText.layers import models
 from MaxText import optimizers
@@ -27,9 +28,9 @@ from MaxText import maxtext_utils
 
 def get_transformer_model(config, mesh, quant):
   if config.model_fsdp_ag_once:
-    return models.ZeroOneTransformer(config, mesh, quant=quant)
+    return models.ZeroOneTransformer(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
   else:
-    return models.Transformer(config, mesh, quant=quant)
+    return models.Transformer(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
 
 
 def create_model(config, mesh):

--- a/MaxText/utils/ckpt_conversion/to_maxtext.py
+++ b/MaxText/utils/ckpt_conversion/to_maxtext.py
@@ -58,6 +58,7 @@ from MaxText import max_utils
 from MaxText import maxtext_utils
 from MaxText import pyconfig
 from MaxText import optimizers
+from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.layers import models, quantizations
 from MaxText.checkpointing import save_checkpoint
 from MaxText.utils.ckpt_conversion.utils.param_mapping import HOOK_FNS, PARAM_MAPPING
@@ -100,7 +101,8 @@ def main(argv: Sequence[str]) -> None:
   # Initialize MaxText model, optimizer, and abstract state
   rng = jax.random.PRNGKey(config.init_weights_seed)
   quant = quantizations.configure_quantization(config)
-  maxtext_model_flax = models.Transformer(config, mesh, quant=quant)
+  maxtext_model_flax = models.Transformer(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
+  maxtext_model_flax.init(rng)
   learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(config)
   tx = optimizers.get_optimizer(config, learning_rate_schedule)
 


### PR DESCRIPTION
# Description

Pass `model_mode` into `__init__` functions for the decoder layers. NNX modules are generally initializated in the `__init__` function of other modules instead of the `__call__` function like in Linen. We need `model_mode` in the decoder layer initializations to pass to child modules that use it.

Example: we use `model_mode` to determine whether to create the KVCache in Attention. Since we are moving Attention initialization to the `__init__` of the decoder layers, we need to access `model_mode` in `__init__` of the decoder layers.

# Tests

MaxText base model trains and Llama3.1-8B runs decode successfully on v6e-8 devbox:
```
python3 -m MaxText.train MaxText/configs/base.yml \
    run_name=<run_name> \
    base_output_directory=gs://<gcs_bucket> \
    dataset_type=synthetic \
    steps=10
```
```
python3 -m MaxText.decode MaxText/configs/base.yml \
    model_name=llama3.1-8b \
    tokenizer_path=assets/tokenizer_llama3.tiktoken \
    tokenizer_type=tiktoken \
    scan_layers=false \
    per_device_batch_size=1 \
    ici_fsdp_parallelism=1 \
    ici_autoregressive_parallelism=-1 \
    max_prefill_predict_length=128 \
    max_target_length=256 \
    prompt="I love to" \
    attention=dot_product
```
I got `MODEL_MODE_TRAIN` in the train command and `MODEL_MODE_PREFILL` in the decode command

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
