### PR TITLE
Refactor models to use `mlp_block` +  `use_pre_norm`

### DIFF
--- a/MaxText/layers/gemma2.py
+++ b/MaxText/layers/gemma2.py
@@ -115,17 +115,9 @@ class Gemma2DecoderLayer(nn.Module):
     attention_lnx += inputs
     residual = attention_lnx
 
-    attn_output = rms_norm(
-        num_features=attention_lnx.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="pre_ffw_norm_local",
-        kernel_axes=("norm",),
-    )(attention_lnx)
-
-    # MLP block.
+    # MLP block with pre-norm.
     mlp_lnx = mlp_block(
-        in_features=attn_output.shape[-1],
+        in_features=attention_lnx.shape[-1],
         intermediate_dim=cfg.mlp_dim,
         activations=cfg.mlp_activations,
         intermediate_dropout_rate=cfg.dropout_rate,
@@ -135,7 +127,8 @@ class Gemma2DecoderLayer(nn.Module):
         model_mode=model_mode,
         config=cfg,
         quant=self.quant,
-    )(attn_output, deterministic=deterministic)
+        use_pre_norm=True,
+    )(attention_lnx, deterministic=deterministic)
 
     if cfg.use_post_ffw_norm:
       mlp_lnx = rms_norm(

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -314,7 +314,7 @@ class MlpBlock(nnx.Module):
       rngs: nnx.Rngs,
   ) -> None:
     """A MlpBlock module.
-    
+
     Args:
       config: Config object containing model parameters.
       in_features: Number of input features.
@@ -422,8 +422,19 @@ class MlpBlock(nnx.Module):
     """Applies Transformer MlpBlock module."""
     cfg = self.config
 
+
     if self.mlp_layer_norm is not None:
       inputs = self.mlp_layer_norm(inputs)
+      if self.model_mode == MODEL_MODE_PREFILL:
+        inputs = nn.with_logical_constraint(inputs, ("activation_batch",
+                                                     "prefill_activation_norm_length",
+                                                     "activation_embed")
+                                            )
+      else:
+        inputs = nn.with_logical_constraint(inputs, ("activation_batch",
+                                                     "activation_norm_length",
+                                                     "activation_embed")
+                                            )
 
     # Iterate over specified MLP input activation functions.
     # e.g. ('relu',) or ('gelu', 'linear') for gated-gelu.

--- a/MaxText/layers/llama2.py
+++ b/MaxText/layers/llama2.py
@@ -127,20 +127,9 @@ class LlamaDecoderLayer(nn.Module):
     attention_lnx = nn.with_logical_constraint(attention_lnx, activation_axis_names)
     intermediate_inputs = inputs + attention_lnx
 
-    # Fully Connected
-    hidden_states = rms_norm(
-        num_features=intermediate_inputs.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="post_self_attention_layer_norm",
-        kernel_axes=("norm",),
-        epsilon=cfg.normalization_layer_epsilon,
-    )(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, activation_axis_names)
-
-    # MLP block.
+    # MLP block with pre-norm.
     mlp_lnx = mlp_block(
-        in_features=hidden_states.shape[-1],
+        in_features=intermediate_inputs.shape[-1],
         intermediate_dim=cfg.mlp_dim,
         activations=cfg.mlp_activations,
         intermediate_dropout_rate=cfg.dropout_rate,
@@ -150,7 +139,8 @@ class LlamaDecoderLayer(nn.Module):
         config=cfg,
         quant=self.quant,
         model_mode=model_mode,
-    )(hidden_states, deterministic=deterministic)
+        use_pre_norm=True,
+    )(intermediate_inputs, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs

--- a/MaxText/layers/llama4.py
+++ b/MaxText/layers/llama4.py
@@ -454,21 +454,20 @@ class Llama4DecoderLayer(nn.Module):
     )
     intermediate_inputs = inputs + attention_lnx
 
-    # Fully Connected
-    hidden_states = rms_norm(
+    load_balance_loss = None
+    if self.is_moe_layer:
+      # Fully Connected
+      hidden_states = rms_norm(
         num_features=intermediate_inputs.shape[-1],
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
         name="post_self_attention_layer_norm",
         kernel_axes=("norm",),
         epsilon=cfg.normalization_layer_epsilon,
-    )(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(
-        hidden_states, ("activation_batch", "activation_norm_length", "activation_embed")
-    )
-
-    load_balance_loss = None
-    if self.is_moe_layer:
+      )(intermediate_inputs)
+      hidden_states = nn.with_logical_constraint(
+          hidden_states, ("activation_batch", "activation_norm_length", "activation_embed")
+      )
       # NOTE: the naming mismatch here is to ensure reverse compatibility with existing checkpoints.
       # The `name` represents the weight name in JAX/checkpoints and so the class name
       # is just for readability.
@@ -483,8 +482,9 @@ class Llama4DecoderLayer(nn.Module):
           quant=self.quant,
       )(hidden_states)
     else:
+      # MLP block with pre-norm.
       mlp_lnx = mlp_block(
-          in_features=hidden_states.shape[-1],
+          in_features=intermediate_inputs.shape[-1],
           intermediate_dim=cfg.mlp_dim,
           activations=cfg.mlp_activations,
           intermediate_dropout_rate=cfg.dropout_rate,
@@ -493,7 +493,8 @@ class Llama4DecoderLayer(nn.Module):
           name="mlp",
           config=cfg,
           quant=self.quant,
-      )(hidden_states, deterministic=deterministic)
+          use_pre_norm=True,
+      )(intermediate_inputs, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
 
     layer_output = mlp_lnx + intermediate_inputs

--- a/MaxText/layers/mistral.py
+++ b/MaxText/layers/mistral.py
@@ -117,21 +117,9 @@ class MistralDecoderLayer(nn.Module):
     )
     intermediate_inputs = inputs + attention_lnx
 
-    # Fully Connected
-    hidden_states = rms_norm(
-        num_features=intermediate_inputs.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="post_self_attention_layer_norm",
-        kernel_axes=("norm",),
-        epsilon=cfg.normalization_layer_epsilon,
-    )(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(
-        hidden_states, ("activation_batch", "activation_norm_length", "activation_embed")
-    )
-
+    # MLP block with pre-norm.
     mlp_lnx = mlp_block(
-        in_features=hidden_states.shape[-1],
+        in_features=intermediate_inputs.shape[-1],
         intermediate_dim=cfg.mlp_dim,
         activations=cfg.mlp_activations,
         intermediate_dropout_rate=cfg.dropout_rate,
@@ -140,7 +128,8 @@ class MistralDecoderLayer(nn.Module):
         name="mlp",
         config=cfg,
         quant=self.quant,
-    )(hidden_states, deterministic=deterministic)
+        use_pre_norm=True,
+    )(intermediate_inputs, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
 
     layer_output = mlp_lnx + intermediate_inputs

--- a/MaxText/layers/qwen3.py
+++ b/MaxText/layers/qwen3.py
@@ -111,21 +111,11 @@ class Qwen3DecoderLayer(nn.Module):
     # Residual connection after attention
     residual_after_attention = inputs_checkpoint + attention_output
 
-    # Post Attention LayerNorm (corresponds to Qwen3's `post_attention_layernorm`)
-    mlp_input = rms_norm(
-        num_features=residual_after_attention.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="post_self_attention_layer_norm",  # Standard MaxText naming
-        epsilon=cfg.normalization_layer_epsilon,
-        kernel_axes=("norm",),
-    )(residual_after_attention)
-    mlp_input = nn.with_logical_constraint(mlp_input, ("activation_batch", "activation_length", "activation_embed"))
 
     # MLP block
     if cfg.num_experts is None or cfg.num_experts <= 1:  # Dense MLP
       mlp_output = linears.mlp_block(
-          in_features=mlp_input.shape[-1],
+          in_features=residual_after_attention.shape[-1],
           intermediate_dim=cfg.mlp_dim,
           activations=cfg.mlp_activations,
           intermediate_dropout_rate=cfg.dropout_rate,
@@ -134,8 +124,20 @@ class Qwen3DecoderLayer(nn.Module):
           name="mlp",
           config=cfg,
           quant=self.quant,
-      )(mlp_input, deterministic=deterministic)
+          use_pre_norm=True,
+      )(residual_after_attention, deterministic=deterministic)
     else:  # Mixture of Experts MLP -- not supported / tested in MaxText
+      # Post Attention LayerNorm (corresponds to Qwen3's `post_attention_layernorm`)
+      mlp_input = rms_norm(
+          num_features=residual_after_attention.shape[-1],
+          dtype=cfg.dtype,
+          weight_dtype=cfg.weight_dtype,
+          name="post_self_attention_layer_norm",  # Standard MaxText naming
+          epsilon=cfg.normalization_layer_epsilon,
+          kernel_axes=("norm",),
+      )(residual_after_attention)
+      mlp_input = nn.with_logical_constraint(mlp_input, ("activation_batch", "activation_length", "activation_embed"))
+
       mlp_output, _ = moe.RoutedMoE(
           config=cfg,
           num_experts=cfg.num_experts,


### PR DESCRIPTION
# Description

This PR refactors some of the models to use the existing `use_pre_norm` in the `mlp_block` instead of calling a separate norm before the MLP block. 
It should not affect the performance or functionality of MaxText, but rather be code cleanup. 
Besides, this PR also paved the way for us to integrate the TransformerEngine LayerNormMLP block into MaxText for our E2E testing.

# Tests

No changes in testing

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
