### PR TITLE
[/MaxText/scratch_code/*.py] `pyink` + `pylint` + `codespell` + `typing`

### DIFF
--- a/MaxText/scratch_code/generate_grpo_golden_logits.py
+++ b/MaxText/scratch_code/generate_grpo_golden_logits.py
@@ -291,7 +291,10 @@ class GRPOTest(unittest.TestCase):
         "avg_advantage": aux.avg_advantage.tolist(),
     }
     model_output_path = os.path.join(
-        os.path.dirname(PKG_DIR), "MaxText", "test_assets", f"golden_data_grpo_{self.cfg_no_ckpt_loading.model_name}.jsonl"
+        os.path.dirname(PKG_DIR),
+        "MaxText",
+        "test_assets",
+        f"golden_data_grpo_{self.cfg_no_ckpt_loading.model_name}.jsonl",
     )
     with jsonlines.open(model_output_path, "w") as f:
       f.write(data_to_save)

--- a/MaxText/scratch_code/generate_sft_golden_data.py
+++ b/MaxText/scratch_code/generate_sft_golden_data.py
@@ -27,10 +27,13 @@ To check correctness for other models:
 """
 
 import argparse
-import jax
-import jsonlines
 import os
 import sys
+
+import jsonlines
+
+import jax
+
 import torch
 from transformers import TrainingArguments, AutoModelForCausalLM, AutoTokenizer
 from trl import SFTConfig, SFTTrainer
@@ -190,13 +193,18 @@ def test_with_trl_and_save_golden_data(config):
 if __name__ == "__main__":
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
-    os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
+    os.environ["LIBTPU_INIT_ARGS"] = (
+        os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
+    )
 
   parser = argparse.ArgumentParser()
   parser.add_argument("--model-name", type=str, required=False, default="llama2-7b")
   parser.add_argument("--tokenizer-path", type=str, required=False, default="meta-llama/Llama-2-7b-chat-hf")
   parser.add_argument(
-      "--model-ckpt-path", type=str, required=False, default="gs://maxtext-model-checkpoints/llama2-7b-chat/scanned/0/items"
+      "--model-ckpt-path",
+      type=str,
+      required=False,
+      default="gs://maxtext-model-checkpoints/llama2-7b-chat/scanned/0/items",
   )
 
   trl_config = parser.parse_args(sys.argv[1:])


### PR DESCRIPTION
# Description

This improves the overall quality of this codebase through application of automated code-quality tooling. You already have pre-commit hooks; this PR adds everything in your `code_style.sh` into it; so no longer will people be able to contribute code so low quality it doesn't pass the automated code-quality checking tooling.

NOTE: this is a subset of #1999 so should be merged before that PR.

# Tests

N/A

Hand-verified with:
```sh
$ d=<directory this PR is on>
$ pyink --pyink-indentation=2 --line-length=122 "$d"
$ pylint --disable=R0401,R0917,W0201,W0613 --ignore-patterns='.pytype,.*pyi$' "$d"'/'
$ pytype --jobs auto --keep-going "$d"'/'
$ codespell -w --skip="*.txt,pylintrc,.*,assets/*" -L ND,nd,sems,TE,ROUGE,rouge "$d"
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
