### PR TITLE
Fix weight_name for Qwix in the NNX bridge

### DIFF
--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -615,18 +615,15 @@ def configure_kv_quant(config):
 def get_basic_config(config, dtype):
   """Basic Qwix config that only quantizes forward passes."""
   rules = [
-      # Dot-product attention is not quantized for now.
       qwix.QtRule(
-        module_path='decoder/.*layers.*/self_attention/attention_op',
-        weight_qtype=None,
-        act_qtype=None,
+          # This rule applies to all projections in attention and mlp layers,
+          # but not the dot-product attention or logits_dense.
+          module_path="decoder/.*layers.*",
+          op_names=("dot_general",),
+          weight_qtype=dtype,
+          act_qtype=dtype,
+          bwd_weight_grad_tile_size=1 / config.quantization_local_shard_count,
       ),
-      qwix.QtRule(
-        module_path='decoder/.*layers.*',  # Apply to all modules
-        weight_qtype=dtype,
-        act_qtype=dtype,
-        bwd_weight_grad_tile_size = 1 / config.quantization_local_shard_count
-      )
     ]
   return rules
 
@@ -635,23 +632,20 @@ def get_fp8_config(config):
   """ fp8 config rules with per-tensor calibration.
   """
   rules = [
-      # Dot-product attention is not quantized for now.
       qwix.QtRule(
-        module_path='decoder/.*layers.*/self_attention/attention_op',
-        weight_qtype=None,
-        act_qtype=None,
+          # This rule applies to all projections in attention and mlp layers,
+          # but not the dot-product attention or logits_dense.
+          module_path="decoder/.*layers.*",
+          op_names=("dot_general",),
+          weight_qtype=jnp.float8_e4m3fn,
+          act_qtype=jnp.float8_e4m3fn,
+          bwd_qtype=jnp.float8_e5m2,
+          bwd_use_original_residuals=True,
+          disable_channelwise_axes=True,  # per_tensor calibration
+          weight_calibration_method=config.quantization_calibration_method,
+          act_calibration_method=config.quantization_calibration_method,
+          bwd_calibration_method=config.quantization_calibration_method,
       ),
-      qwix.QtRule(
-        module_path='decoder/.*layers.*',  # Apply to all modules
-        weight_qtype=jnp.float8_e4m3fn,
-        act_qtype=jnp.float8_e4m3fn,
-        bwd_qtype=jnp.float8_e5m2,
-        bwd_use_original_residuals=True,
-        disable_channelwise_axes=True, # per_tensor calibration
-        weight_calibration_method = config.quantization_calibration_method,
-        act_calibration_method = config.quantization_calibration_method,
-        bwd_calibration_method = config.quantization_calibration_method,
-      )
     ]
   return rules
 


### PR DESCRIPTION
Without this patch, Qwix always uses the act_qtype for both activations and weights.

_enable_linen_module_paths is renamed to _fix_for_qwix_quantization to be more explicit about why we need this function.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
