### PR TITLE
Add decoder block types in linears.py

### DIFF
--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -406,6 +406,9 @@ class MlpBlock(nnx.Module):
         DecoderBlockType.MISTRAL,
         DecoderBlockType.MIXTRAL,
         DecoderBlockType.GEMMA,
+        DecoderBlockType.GEMMA2,
+        DecoderBlockType.GEMMA3,
+        DecoderBlockType.QWEN3,
         DecoderBlockType.DEEPSEEK,
         DecoderBlockType.LLAMA4,
     ):


### PR DESCRIPTION
# Description

This PR fixes issue arised in [this message](https://chat.google.com/room/AAAAc3VtJGo/zeBQipLkvYQ/vpcx9AK2HP0?cls=10) stemming from #2101. Adding more supported decoder blocks to avoid errors.

# Tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
