### PR TITLE
Add `norm_ckpt_name` to `mlp_block`

### DIFF
--- a/MaxText/layers/gemma.py
+++ b/MaxText/layers/gemma.py
@@ -117,6 +117,7 @@ class GemmaDecoderLayer(nn.Module):
         config=cfg,
         quant=self.quant,
         use_pre_norm=True,
+        norm_ckpt_name="pre_ffw_norm",
     )(residual, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
 

--- a/MaxText/layers/gemma2.py
+++ b/MaxText/layers/gemma2.py
@@ -128,6 +128,7 @@ class Gemma2DecoderLayer(nn.Module):
         config=cfg,
         quant=self.quant,
         use_pre_norm=True,
+        norm_ckpt_name="pre_ffw_norm_local",
     )(attention_lnx, deterministic=deterministic)
 
     if cfg.use_post_ffw_norm:

--- a/MaxText/layers/gemma3.py
+++ b/MaxText/layers/gemma3.py
@@ -158,6 +158,7 @@ class Gemma3DecoderLayer(nn.Module):
         config=cfg,
         quant=self.quant,
         use_pre_norm=True,
+        norm_ckpt_name="pre_ffw_norm",
     )(attention_lnx, deterministic=deterministic)
 
     if cfg.use_post_ffw_norm:

--- a/MaxText/layers/llama2.py
+++ b/MaxText/layers/llama2.py
@@ -140,6 +140,7 @@ class LlamaDecoderLayer(nn.Module):
         quant=self.quant,
         model_mode=model_mode,
         use_pre_norm=True,
+        norm_ckpt_name="post_self_attention_layer_norm",
     )(intermediate_inputs, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, activation_axis_names)
 

--- a/MaxText/layers/llama4.py
+++ b/MaxText/layers/llama4.py
@@ -494,6 +494,7 @@ class Llama4DecoderLayer(nn.Module):
           config=cfg,
           quant=self.quant,
           use_pre_norm=True,
+          norm_ckpt_name="post_self_attention_layer_norm",
       )(intermediate_inputs, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
 

--- a/MaxText/layers/mistral.py
+++ b/MaxText/layers/mistral.py
@@ -129,6 +129,7 @@ class MistralDecoderLayer(nn.Module):
         config=cfg,
         quant=self.quant,
         use_pre_norm=True,
+        norm_ckpt_name="post_self_attention_layer_norm",
     )(intermediate_inputs, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
 

--- a/MaxText/layers/qwen3.py
+++ b/MaxText/layers/qwen3.py
@@ -125,6 +125,7 @@ class Qwen3DecoderLayer(nn.Module):
           config=cfg,
           quant=self.quant,
           use_pre_norm=True,
+          norm_ckpt_name="post_self_attention_layer_norm",
       )(residual_after_attention, deterministic=deterministic)
     else:  # Mixture of Experts MLP -- not supported / tested in MaxText
       # Post Attention LayerNorm (corresponds to Qwen3's `post_attention_layernorm`)


### PR DESCRIPTION
# Description

PR GH-2101 obmits the checkpointing name for normalization layers. This PR added the name back so that the `mlp_block` can checkpoint the normalization with the correct name.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
