### PR TITLE
Removing the unused constant `MODEL_MODE_INSERT`.

### DIFF
--- a/MaxText/common_types.py
+++ b/MaxText/common_types.py
@@ -62,7 +62,6 @@ CACHE_SCALE_KV = "cache_scale_kv"
 MODEL_MODE_AUTOREGRESSIVE = "autoregressive"
 MODEL_MODE_PREFILL = "prefill"
 MODEL_MODE_TRAIN = "train"
-MODEL_MODE_INSERT = "insert"
 
 # expert_shard_attention_option
 EP_AS_CONTEXT = "context"


### PR DESCRIPTION
[From Jules]

# Description

This PR removes the unused constant MODEL_MODE_INSERT from the MaxText/common_types.py file.

This change is being made to improve code quality by removing dead code. The MODEL_MODE_INSERT constant was not referenced anywhere in the repository, making it unnecessary. This solution is good because it simplifies the codebase without affecting any functionality.

Tests
I verified that the constant was unused by searching the entire codebase for any references to MODEL_MODE_INSERT. My search confirmed that the constant was only present in its definition in MaxText/common_types.py, with no other usages found.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
