### PR TITLE
Raise  value error when using chunk attention with load balanced CP

### DIFF
--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -169,6 +169,10 @@ def validate_keys(keys):
   validate_prefill_and_target_lengths(keys["max_prefill_predict_length"], keys["max_target_length"])
   validate_rope_type(keys["rope_type"])
 
+  # TODO remove after b/435512699 resolved
+  if keys["context_parallel_size"] > 1 and keys["context_parallel_load_balance"] and keys["attention_type"] == "chunk":
+    raise ValueError("Currently load-balanced context parallelism is not supported for chunk attention.")
+
   if keys["mtp_eval_target_module"] < 0:
     raise ValueError("mtp_eval_target_module cannot be negative. Set to 0 to disable evaluation.")
 


### PR DESCRIPTION
# Description

Raise  value error when `context_parallel_size > 1` and `context_parallel_load_balance==True` and `attention_type=='chunk'` as currently the logic is not compatible, as reported in b/435512699

Once the problem is fixed, the value can be removed.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
