### PR TITLE
NNX Migration for Mixtral models

### DIFF
--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -381,7 +381,7 @@ class Decoder(nn.Module):
         # TODO(ranran): update to Mistral with sliding window attention
         return [mistral.MistralDecoderLayerToLinen]
       case DecoderBlockType.MIXTRAL:
-        return [mixtral.MixtralDecoderLayer]
+        return [mixtral.MixtralDecoderLayerToLinen]
       case DecoderBlockType.DEEPSEEK:
         if self.config.use_batch_split_schedule:
           return [deepseek_batchsplit.DeepSeekDenseLayer, deepseek_batchsplit.DeepSeekMoELayer]

--- a/src/MaxText/layers/mixtral.py
+++ b/src/MaxText/layers/mixtral.py
@@ -22,14 +22,18 @@ from jax.sharding import Mesh
 import jax.numpy as jnp
 
 from flax import linen as nn
+from flax import nnx
 
-from MaxText.layers import initializers
-from MaxText.layers import models
+from MaxText import max_utils
+from MaxText.common_types import Config
+
+from MaxText.layers import nnx_wrappers, initializers
 from MaxText.layers import moe
 from MaxText.layers import quantizations
-from MaxText.layers.attentions import attention_as_linen
+from MaxText.layers.linears import Dropout
+from MaxText.layers.attentions import Attention
 from MaxText.layers.quantizations import AqtQuantization as Quant
-from MaxText.layers.normalizations import rms_norm
+from MaxText.layers.normalizations import RMSNorm
 
 
 # -----------------------------------------
@@ -37,15 +41,92 @@ from MaxText.layers.normalizations import rms_norm
 # -----------------------------------------
 
 
-class MixtralDecoderLayer(nn.Module):
+class MixtralDecoderLayer(nnx.Module):
   """Transformer decoder layer that attends to the encoder."""
 
-  config: models.Config
-  mesh: Mesh
-  model_mode: str
-  quant: None | Quant = None
-
   @nn.compact
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      quant: None | Quant = None,
+      *,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.quant = quant
+    self.rngs = rngs
+
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
+
+    self.pre_self_attention_layer_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=self.rngs,
+    )
+
+    self.self_attention = Attention(
+        config=config,
+        num_query_heads=config.num_query_heads,
+        num_kv_heads=config.num_kv_heads,
+        head_dim=config.head_dim,
+        max_target_length=config.max_target_length,
+        max_prefill_predict_length=config.max_prefill_predict_length,
+        attention_kernel=config.attention,
+        inputs_q_shape=dummy_inputs_shape,
+        inputs_kv_shape=dummy_inputs_shape,
+        mesh=mesh,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        dropout_rate=config.dropout_rate,
+        float32_qk_product=config.float32_qk_product,
+        float32_logits=config.float32_logits,
+        quant=self.quant,
+        kv_quant=quantizations.configure_kv_quant(config),
+        prefill_cache_axis_order=tuple(map(int, config.prefill_cache_axis_order.split(","))),
+        ar_cache_axis_order=tuple(map(int, config.ar_cache_axis_order.split(","))),
+        compute_axis_order=tuple(map(int, config.compute_axis_order.split(","))),
+        reshape_q=config.reshape_q,
+        use_ragged_attention=config.use_ragged_attention,
+        ragged_block_size=config.ragged_block_size,
+        model_mode=model_mode,
+        rngs=self.rngs,
+    )
+
+    self.post_self_attention_layer_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=self.rngs,
+    )
+
+    self.MoeBlock_0 = moe.RoutedMoE(
+        config=config,
+        num_experts=config.num_experts,
+        num_experts_per_tok=config.num_experts_per_tok,
+        mesh=mesh,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed", None),
+        intermediate_dim=config.mlp_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        quant=self.quant,
+        rngs=self.rngs,
+    )
+
+    self.dropout = Dropout(rate=config.dropout_rate, broadcast_dims=(-2,), rngs=rngs)
+
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
   def __call__(
       self,
       inputs,
@@ -54,53 +135,15 @@ class MixtralDecoderLayer(nn.Module):
       deterministic,
       model_mode,
       previous_chunk=None,
-      page_state=None,
-      slot=None,
   ):
-    cfg = self.config
-    mesh = self.mesh
 
-    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
-    lnx_rms = rms_norm(
-        num_features=inputs.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="pre_self_attention_layer_norm",
-        kernel_axes=("norm",),
-        epsilon=cfg.normalization_layer_epsilon,
-    )
-    lnx = lnx_rms(inputs)
 
-    lnx = nn.with_logical_constraint(lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+    lnx = self.pre_self_attention_layer_norm(inputs)
+    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
 
-    # Self-attention block
-    attention_layer = attention_as_linen(
-        config=cfg,
-        num_query_heads=cfg.num_query_heads,
-        num_kv_heads=cfg.num_kv_heads,
-        head_dim=cfg.head_dim,
-        max_target_length=cfg.max_target_length,
-        max_prefill_predict_length=cfg.max_prefill_predict_length,
-        attention_kernel=cfg.attention,
-        inputs_q_shape=lnx.shape,
-        inputs_kv_shape=lnx.shape,
-        mesh=mesh,
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        dropout_rate=cfg.dropout_rate,
-        name="self_attention",
-        float32_qk_product=cfg.float32_qk_product,
-        float32_logits=cfg.float32_logits,
-        quant=self.quant,
-        kv_quant=quantizations.configure_kv_quant(cfg),
-        prefill_cache_axis_order=tuple(map(int, cfg.prefill_cache_axis_order.split(","))),
-        ar_cache_axis_order=tuple(map(int, cfg.ar_cache_axis_order.split(","))),
-        compute_axis_order=tuple(map(int, cfg.compute_axis_order.split(","))),
-        model_mode=model_mode,
-    )
-
-    attention_lnx = attention_layer(
+    attention_lnx = self.self_attention(
         lnx,
         lnx,
         decoder_positions,
@@ -110,55 +153,28 @@ class MixtralDecoderLayer(nn.Module):
         previous_chunk=previous_chunk,
     )
 
-    attention_lnx = nn.with_logical_constraint(
-        attention_lnx, ("activation_batch", "activation_norm_length", "activation_embed")
-    )
+    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
     intermediate_inputs = inputs + attention_lnx
 
     # Fully Connected
-    hidden_states = rms_norm(
-        num_features=intermediate_inputs.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="post_self_attention_layer_norm",
-        kernel_axes=("norm",),
-        epsilon=cfg.normalization_layer_epsilon,
-    )(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(
-        hidden_states, ("activation_batch", "activation_norm_length", "activation_embed")
-    )
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
 
     load_balance_loss = None
     # NOTE: the naming mismatch here is to ensure reverse compatibility with existing checkpoints.
     # The `name` represents the weight name in JAX/checkpoints and so the class name
     # is just for readability.
-    mlp_lnx, load_balance_loss = moe.get_routed_moe(
-        name="MoeBlock_0",
-        config=cfg,
-        num_experts=cfg.num_experts,
-        num_experts_per_tok=cfg.num_experts_per_tok,
-        mesh=mesh,
-        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
-        kernel_axes=("embed", None),
-        intermediate_dim=cfg.mlp_dim,
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        quant=self.quant,
-    )(hidden_states)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+    mlp_lnx, load_balance_loss = self.MoeBlock_0(hidden_states)
+    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs
-    layer_output = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(layer_output, deterministic=deterministic)
-
-    layer_output = nn.with_logical_constraint(
-        layer_output,
-        ("activation_batch", "activation_norm_length", "activation_embed"),
-    )
+    layer_output = self.dropout(layer_output, deterministic=deterministic)
+    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
 
     if load_balance_loss is not None:
       self.sow("intermediates", "moe_lb_loss", load_balance_loss)
 
-    if cfg.record_internal_nn_metrics:
+    if self.config.record_internal_nn_metrics:
       self.sow("intermediates", "activation_mean", jnp.mean(layer_output))
       self.sow("intermediates", "activation_stdev", jnp.std(layer_output))
       self.sow(
@@ -167,7 +183,13 @@ class MixtralDecoderLayer(nn.Module):
           jnp.sum(layer_output == 0) / jnp.size(layer_output),
       )
 
-    if cfg.scan_layers:
+    if self.config.scan_layers:
       return layer_output, None
     else:
       return layer_output
+
+
+MixtralDecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    MixtralDecoderLayer,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)


### PR DESCRIPTION
# Description

Migrate Mixtral model to NNX. Comparing f4f286ca3f757911936fe1118fb0342719fd2ea4 (before mixtral migration) and e1bd50a60ad27252abaea42254b116c41013d4cd (after mixtral migration).

# Tests

## Training tests

### Command
```
xpk workload create \
--cluster ${CLUSTER_NAME} \
--project ${PROJECT} \
--zone ${ZONE} \
--docker-image gcr.io/tpu-prod-env-multipod/chengnuojin-mixtral-before \ # Or after
--workload chengnuojin-mixtral-test-$RANDOM \
--tpu-type=${DEVICE_TYPE} \
--num-slices=1  \
--command="python -m MaxText.train MaxText/configs/base.yml   run_name=nc_test_mixtral_$RANDOM   steps=10   base_output_directory=gs://chengnuojin-maxtext-logs   dataset_path=gs://chengnuojin-maxtext-dataset   model_name=mixtral-8x7b   enable_checkpointing=True  load_parameters_path=gs://ml-auto-solutions/output/sparsity_diffusion_devx/maxtext/chained_tests_mixtral-8x7b_stable-2025-08-15-01-00-23/8x7b/scanned_ckpt/0/items/   per_device_batch_size=1   max_target_length=1024 profiler=xplane"
```

### Before Mixtral Migration

[log](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22chengnuojin-v5p-32%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22chengnuojin-mixtral-test-7616-slice-job-0-0-%22%20severity%3E%3DDEFAULT;storageScope=project;cursorTimestamp=2025-10-02T20:05:07.408210748Z;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)

```
Total memory size: 55.3 GB, Output size: 32.6 GB, Temp size: 22.7 GB, Argument size: 32.6 GB, Host temp size: 0.0 GB.
```

### After Mixtral Migration
[log](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22chengnuojin-v5p-32%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22chengnuojin-mixtral-test-32731-slice-job-0-0-%22%20severity%3E%3DDEFAULT;storageScope=project;cursorTimestamp=2025-10-02T19:47:19.013432923Z;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)

```
Total memory size: 55.3 GB, Output size: 32.6 GB, Temp size: 22.7 GB, Argument size: 32.6 GB, Host temp size: 0.0 GB.
```


## Jetstream Inference test

### Command

Step 1: https://paste.googleplex.com/6704482813607936

Step 2: https://paste.googleplex.com/5493528058789888

Step 3: https://paste.googleplex.com/4872008944975872

### Before Mixtral Migration

[xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-5167139554249442966)
```
Memstats: After load_params:
        Using (GB) 21.75 / 95.74 (22.717777%) on TPU_0(process=0,(0,0,0,0))
        Using (GB) 21.75 / 95.74 (22.717777%) on TPU_1(process=0,(1,0,0,0))
        Using (GB) 21.75 / 95.74 (22.717777%) on TPU_2(process=0,(0,1,0,0))
        Using (GB) 21.75 / 95.74 (22.717777%) on TPU_3(process=0,(1,1,0,0))

RAMstats: After load_params:
        Using (GB) 48.66 / 440.83 (11.038269%) -->  Available:389.28
```
### After Mixtral Migration

[xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-608291853873681355)
```
Memstats: After load_params:
        Using (GB) 21.75 / 95.74 (22.717777%) on TPU_0(process=0,(0,0,0,0))
        Using (GB) 21.75 / 95.74 (22.717777%) on TPU_1(process=0,(1,0,0,0))
        Using (GB) 21.75 / 95.74 (22.717777%) on TPU_2(process=0,(0,1,0,0))
        Using (GB) 21.75 / 95.74 (22.717777%) on TPU_3(process=0,(1,1,0,0))

RAMstats: After load_params:
        Using (GB) 58.39 / 440.83 (13.245469%) -->  Available:379.54
```
### Web diff
https://diff.googleplex.com/#key=BznGYDr4RWma


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
