### PR TITLE
Migrate Gemma3VisionEncoderLayer and VisionEmbedder to NNX

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -790,6 +790,7 @@ remat_policy_for_vit: "minimal"  # Remat policy for multimodal model's vision en
 image_size_for_vit: 896 # Default for Gemma3, and should be overwritten by model's config
 image_path: "" # Local image path used for decoding
 image_placeholder: "<|image|>"
+posemb_type_for_vit: "learn"
 
 ### llama4 multi modal configs
 hidden_size_for_vit: 1408
@@ -798,6 +799,7 @@ num_attention_heads_for_vit: 16
 num_channels_for_vit: 3
 tile_size_for_vit: 336
 patch_size_for_vit: 14
+conv_stride_for_vit: 14
 num_hidden_layers_for_vit: 34
 projector_input_dim_for_vit: 4096
 projector_output_dim_for_vit: 4096

--- a/src/MaxText/configs/models/gemma3-12b.yml
+++ b/src/MaxText/configs/models/gemma3-12b.yml
@@ -31,3 +31,14 @@ use_post_ffw_norm: true
 local_rope_max_timescale: 10_000
 rope_max_timescale: 1_000_000
 rope_linear_scaling_factor: 8.0
+
+# Multimodal flags (need to set use_multimodal=true)
+image_size_for_vit: 896
+num_channels_for_vit: 3
+patch_size_for_vit: 14
+conv_stride_for_vit: 14
+hidden_size_for_vit: 1152
+intermediate_size_for_vit: 4304
+num_hidden_layers_for_vit: 27
+num_attention_heads_for_vit: 16
+image_placeholder: <start_of_image>

--- a/src/MaxText/configs/models/gemma3-27b.yml
+++ b/src/MaxText/configs/models/gemma3-27b.yml
@@ -31,3 +31,14 @@ use_post_ffw_norm: true
 local_rope_max_timescale: 10_000
 rope_max_timescale: 1_000_000
 rope_linear_scaling_factor: 8.0
+
+# Multimodal flags (need to set use_multimodal=true)
+image_size_for_vit: 896
+num_channels_for_vit: 3
+patch_size_for_vit: 14
+conv_stride_for_vit: 14
+hidden_size_for_vit: 1152
+intermediate_size_for_vit: 4304
+num_hidden_layers_for_vit: 27
+num_attention_heads_for_vit: 16
+image_placeholder: <start_of_image>

--- a/src/MaxText/configs/models/gemma3-4b.yml
+++ b/src/MaxText/configs/models/gemma3-4b.yml
@@ -31,3 +31,14 @@ use_post_ffw_norm: true
 local_rope_max_timescale: 10_000
 rope_max_timescale: 1_000_000
 rope_linear_scaling_factor: 8.0
+
+# Multimodal flags (need to set use_multimodal=true)
+image_size_for_vit: 896
+num_channels_for_vit: 3
+patch_size_for_vit: 14
+conv_stride_for_vit: 14
+hidden_size_for_vit: 1152
+intermediate_size_for_vit: 4304
+num_hidden_layers_for_vit: 27
+num_attention_heads_for_vit: 16
+image_placeholder: <start_of_image>

--- a/src/MaxText/layers/attention_op.py
+++ b/src/MaxText/layers/attention_op.py
@@ -1369,18 +1369,19 @@ class AttentionOp(nnx.Module):
     b, t, n, d = query.shape
     n_kv = key.shape[-2]
     assert n_kv == self.num_kv_heads
+    precision_kwargs = {"precision": self.config.matmul_precision} if einsum is jnp.einsum else {}
     if model_mode == MODEL_MODE_TRAIN or self.compute_axis_order == (0, 1, 2, 3):
       query = jnp.reshape(query, (b, t, n_kv, n // n_kv, d))
       if self.reshape_q and q_seq_len == 1:
         query = jnp.broadcast_to(query, (b, 2, n_kv, n // n_kv, d))
-      result = einsum("btkgd,bskd->bkgts", query, key)
+      result = einsum("btkgd,bskd->bkgts", query, key, **precision_kwargs)
     elif self.compute_axis_order == (0, 2, 1, 3):
       query = jnp.transpose(query, axes=self.compute_axis_order)
       key = jax.tree.map(lambda x: jnp.transpose(x, axes=self.compute_axis_order), key)
       query = jnp.reshape(query, (b, n_kv, n // n_kv, t, d))
       if self.reshape_q and q_seq_len == 1:
         query = jnp.broadcast_to(query, (b, n_kv, n // n_kv, 2, d))
-      result = einsum("bkgtd,bksd->bkgts", query, key)
+      result = einsum("bkgtd,bksd->bkgts", query, key, **precision_kwargs)
     else:
       raise NotImplementedError(self.compute_axis_order)
     return result
@@ -1407,17 +1408,18 @@ class AttentionOp(nnx.Module):
       n // n_kv: number of group for query, sometimes annotated with g
     """
 
+    precision_kwargs = {"precision": self.config.matmul_precision} if einsum is jnp.einsum else {}
     if self.kv_quant:
       # manually cast to bf16 to avoid the fp32 XLA ops for speedup
       if isinstance(value, KVTensor) and self.kv_quant.dtype == jnp.float8_e4m3fn:
         value.qvalue = value.qvalue.astype(jnp.bfloat16)
     if model_mode == MODEL_MODE_TRAIN or self.compute_axis_order == (0, 1, 2, 3):
-      out = einsum("bkgts,bskd->btkgd", attn_weights, value)
+      out = einsum("bkgts,bskd->btkgd", attn_weights, value, **precision_kwargs)
       b, t, n_kv, g, d = out.shape
       result = jnp.reshape(out, (b, t, n_kv * g, d))
     elif self.compute_axis_order == (0, 2, 1, 3):
       value = jax.tree.map(lambda x: jnp.transpose(x, axes=self.compute_axis_order), value)
-      out = einsum("bkgts,bksd->bkgtd", attn_weights, value)
+      out = einsum("bkgts,bksd->bkgtd", attn_weights, value, **precision_kwargs)
       b, n_kv, g, t, d = out.shape
       result = jnp.reshape(out, (b, n_kv * g, t, d))
       result = self.reverse_transepose(result, self.compute_axis_order)

--- a/src/MaxText/layers/encoders.py
+++ b/src/MaxText/layers/encoders.py
@@ -39,7 +39,7 @@ class VisionEncoder(nn.Module):
     if self.config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
       from MaxText.layers import gemma3  # pylint: disable=import-outside-toplevel
 
-      return [gemma3.Gemma3VisionEncoderLayer, gemma3.VisionEmbedder]
+      return [gemma3.gemma3visionencoder_as_linen, gemma3.visionembedder_as_linen]
     elif self.config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
       from MaxText.layers import llama4  # pylint: disable=import-outside-toplevel
 

--- a/src/MaxText/layers/gemma3.py
+++ b/src/MaxText/layers/gemma3.py
@@ -20,13 +20,16 @@ from jax.sharding import Mesh
 import jax.numpy as jnp
 
 from flax import linen as nn
+from flax import nnx
 
 from MaxText.common_types import Config, AttentionType
 from MaxText.layers import quantizations
-from MaxText.layers.attentions import attention_as_linen
-from MaxText.layers.linears import mlp_block
-from MaxText.layers.normalizations import rms_norm
+from MaxText.layers import nnx_wrappers
+from MaxText.layers.attentions import attention_as_linen, Attention
+from MaxText.layers.linears import mlp_block, DenseGeneral
+from MaxText.layers.normalizations import rms_norm, RMSNorm
 from MaxText.layers.quantizations import AqtQuantization as Quant
+from MaxText.layers.initializers import variable_to_logically_partitioned
 
 
 GEMMA3_ATTENTION_PATTERN = (
@@ -276,6 +279,7 @@ def _posemb_sincos_2d(
     *,
     width: int,
     temperature: float = 10_000.0,
+    precision: str = "default",
     dtype: jnp.dtype = jnp.float32,
 ):
   """Follows the MoCo v3 logic."""
@@ -284,165 +288,205 @@ def _posemb_sincos_2d(
   assert width % 4 == 0, "Width must be mult of 4 for sincos posemb"
   omega = jnp.arange(width // 4) / (width // 4 - 1)
   omega = 1.0 / (temperature**omega)
-  y = jnp.einsum("m,d->md", y.flatten(), omega)
-  x = jnp.einsum("m,d->md", x.flatten(), omega)
+  y = jnp.einsum("m,d->md", y.flatten(), omega, precision=precision)
+  x = jnp.einsum("m,d->md", x.flatten(), omega, precision=precision)
   pe = jnp.concatenate([jnp.sin(x), jnp.cos(x), jnp.sin(y), jnp.cos(y)], axis=1)
   return jnp.asarray(pe, dtype)[None, :, :]
 
 
-class MlpBlockViT(nn.Module):
-  """Transformer MLP / feed-forward block."""
+class MlpBlockViT(nnx.Module):
+  """NNX version of Transformer MLP / feed-forward block."""
 
-  block_id: int
-  dtype_mm: str
-  mlp_dim: int | None = None  # Defaults to 4x input dim
-  dropout: float = 0.0
+  def __init__(
+      self,
+      config: Config,
+      block_id: int,
+      *,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.block_id = block_id
+    self.rngs = rngs
 
-  @nn.compact
+    self.Dense_0 = DenseGeneral(
+        in_features_shape=self.config.hidden_size_for_vit,
+        out_features_shape=self.config.intermediate_size_for_vit,
+        dtype=self.config.dtype_mm,
+        use_bias=True,
+        matmul_precision=self.config.matmul_precision,
+        rngs=self.rngs,
+    )
+    self.Dropout_0 = nnx.Dropout(rate=self.config.dropout_rate)
+    self.Dense_1 = DenseGeneral(
+        in_features_shape=self.config.intermediate_size_for_vit,
+        out_features_shape=self.config.hidden_size_for_vit,
+        dtype=self.config.dtype_mm,
+        use_bias=True,
+        matmul_precision=self.config.matmul_precision,
+        rngs=self.rngs,
+    )
+
   def __call__(self, x: jax.Array, deterministic: bool = True) -> jax.Array:
-    """Applies Transformer MlpBlock module."""
-    inits = {"kernel_init": nn.initializers.xavier_uniform(), "bias_init": nn.initializers.normal(stddev=1e-6)}
-
-    d = x.shape[-1]
-    x = nn.Dense(features=self.mlp_dim or 4 * d, dtype=self.dtype_mm, **inits)(x)
-    x = nn.gelu(x)
-    x = nn.Dropout(rate=self.dropout)(x, deterministic)
-    x = nn.Dense(
-        features=d,
-        dtype=self.dtype_mm,
-        **inits,
-    )(x)
+    """Applies the Transformer MlpBlock module."""
+    x = self.Dense_0(x)
+    x = nnx.gelu(x)
+    x = self.Dropout_0(x, deterministic=deterministic)
+    x = self.Dense_1(x)
     return x
 
 
-class Encoder1DBlock(nn.Module):
+class Encoder1DBlock(nnx.Module):
   """Single transformer encoder block (MHSA + MLP)."""
 
-  block_id: int
-  dtype_mm: str
-  mlp_dim: int | None = None  # Defaults to 4x input dim
-  num_heads: int = 12
-  dropout: float = 0.0
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      block_id: int,
+      *,
+      rngs: nnx.Rngs,
+  ):
+    self.block_id = block_id
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
+    self.seq_len = (self.config.image_size_for_vit // self.config.patch_size_for_vit) ** 2
 
-  @nn.compact
-  def __call__(self, x: jax.Array, deterministic: bool = True) -> jax.Array:
-    y = nn.LayerNorm()(x)
+    self.LayerNorm_0 = nnx.LayerNorm(num_features=self.config.hidden_size_for_vit, rngs=self.rngs)
+    self.MultiHeadDotProductAttention_0 = Attention(
+        config=self.config,
+        num_query_heads=self.config.num_attention_heads_for_vit,
+        num_kv_heads=self.config.num_attention_heads_for_vit,
+        head_dim=self.config.hidden_size_for_vit // self.config.num_attention_heads_for_vit,
+        max_target_length=self.seq_len,
+        mesh=self.mesh,
+        attention_kernel="dot_product",
+        inputs_q_shape=(self.config.per_device_batch_size, self.seq_len, self.config.hidden_size_for_vit),
+        inputs_kv_shape=(self.config.per_device_batch_size, self.seq_len, self.config.hidden_size_for_vit),
+        dropout_rate=0,
+        is_nope_layer=True,
+        use_bias_in_projections=True,
+        attention_type=AttentionType.FULL,
+        use_qk_norm=False,
+        query_pre_attn_scalar=1 / (self.config.hidden_size_for_vit // self.config.num_attention_heads_for_vit) ** 0.5,
+        model_mode="train",
+        is_vision=True,
+        rngs=self.rngs,
+    )
+    self.LayerNorm_1 = nnx.LayerNorm(num_features=self.config.hidden_size_for_vit, rngs=self.rngs)
+    self.MlpBlockViT_0 = MlpBlockViT(
+        block_id=self.block_id,
+        config=self.config,
+        rngs=self.rngs,
+    )
+    self.Dropout_0 = nnx.Dropout(self.config.dropout_rate, rngs=self.rngs)
 
-    y = nn.MultiHeadDotProductAttention(
-        num_heads=self.num_heads,
-        kernel_init=nn.initializers.xavier_uniform(),
-        deterministic=deterministic,
-        dtype=self.dtype_mm,
-    )(y, y)
-    y = nn.Dropout(rate=self.dropout)(y, deterministic)
+  def __call__(self, x: jax.Array, deterministic: bool = False) -> jax.Array:
+    y = self.LayerNorm_0(x)
+
+    y = self.MultiHeadDotProductAttention_0(inputs_q=y, inputs_kv=y, deterministic=deterministic)
+    y = self.Dropout_0(y, deterministic=deterministic)
     x = x + y
 
-    y = nn.LayerNorm()(x)
-    y = MlpBlockViT(
-        block_id=self.block_id,
-        mlp_dim=self.mlp_dim,
-        dropout=self.dropout,
-        dtype_mm=self.dtype_mm,
-    )(y, deterministic)
-    y = nn.Dropout(rate=self.dropout)(y, deterministic)
+    y = self.LayerNorm_1(x)
+    y = self.MlpBlockViT_0(y, deterministic=deterministic)
+    y = self.Dropout_0(y, deterministic=deterministic)
     x = x + y
     return x
 
 
-class Encoder(nn.Module):
+class Encoder(nnx.Module):
   """Transformer Model Encoder for sequence to sequence translation."""
 
-  depth: int
-  dtype_mm: str
-  remat_policy: str
-  mlp_dim: int | None = None  # Defaults to 4x input dim
-  num_heads: int = 12
-  dropout: float = 0.0
-  scan: bool = False
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      *,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
 
-  @nn.compact
+    for lyr in range(self.config.num_hidden_layers_for_vit):
+      layer_name = f"encoderblock_{lyr}"
+      layer = Encoder1DBlock(
+          block_id=lyr,
+          config=self.config,
+          mesh=self.mesh,
+          rngs=self.rngs,
+      )
+      setattr(self, layer_name, layer)
+    self.encoder_norm = nnx.LayerNorm(num_features=self.config.hidden_size_for_vit, rngs=self.rngs)
+
   def __call__(self, x: jax.Array, deterministic: bool = True) -> jax.Array:
-    if self.scan:
-      # TODO(aireenmei, hengtaoguo): fix this branch to enable scan support for vision encoder
-      block = nn.remat(
-          Encoder1DBlock,
-          prevent_cse=False,
-          static_argnums=(2,),  # 0=self, 2=deterministic
-          policy=getattr(jax.checkpoint_policies, self.remat_policy, None),
-      )
-      x = nn.scan(
-          block,
-          variable_axes={"params": 0},
-          split_rngs={"params": True, "dropout": True},
-          in_axes=nn.broadcast,
-          length=self.depth,
-      )(
-          block_id=0,
-          name="encoderblock",
-          dtype_mm=self.dtype_mm,
-          mlp_dim=self.mlp_dim,
-          num_heads=self.num_heads,
-          dropout=self.dropout,
-      )(
-          x, deterministic
-      )
-    else:
-      # Input Encoder
-      for lyr in range(self.depth):
-        block_cur = Encoder1DBlock(
-            block_id=lyr,
-            name=f"encoderblock_{lyr}",
-            dtype_mm=self.dtype_mm,
-            mlp_dim=self.mlp_dim,
-            num_heads=self.num_heads,
-            dropout=self.dropout,
-        )
-        x = block_cur(x, deterministic)
-    x: jax.Array = nn.LayerNorm(name="encoder_norm")(x)
+    # TODO(aireenmei, hengtaoguo): add if-scan branch to enable scan support for vision encoder
+    for lyr in range(self.config.num_hidden_layers_for_vit):
+      x = getattr(self, f"encoderblock_{lyr}")(x, deterministic=deterministic)
+    x = self.encoder_norm(x)
     return x
 
 
-class Einsum(nn.Module):
+class Einsum(nnx.Module):
   """Einsum is a convenience module for parameterized tensor multiplication."""
 
-  shape: tuple[int, ...]
-  weight_name: str = "w"
-  initializer: nn.initializers.Initializer = nn.initializers.normal()
-  dtype: jnp.dtype | None = None
+  def __init__(
+      self,
+      shape: tuple[int, ...],
+      initializer: nnx.initializers.Initializer = nnx.initializers.normal(),
+      dtype: jnp.dtype | None = None,
+      precision: str = "default",
+      *,
+      rngs: nnx.Rngs,
+  ):
+    self.precision = precision
+    self.w = nnx.Param(initializer(rngs.params(), shape, dtype))
 
-  @nn.compact
   def __call__(self, eqn: str, x: jax.Array) -> jax.Array:
-    w = self.param(
-        self.weight_name,
-        self.initializer,
-        self.shape,
-        self.dtype if self.dtype is not None else None,
-    )
-    return jnp.einsum(eqn, x, w)
+    return jnp.einsum(eqn, x, self.w, precision=self.precision)
 
 
-class VisionEmbedder(nn.Module):
+class VisionEmbedder(nnx.Module):
   """Projects image embeddings to the embedding space of the text encoder."""
 
-  config: Config
-  mesh: Mesh
-  vision_proj_dim: int = 1152
+  def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
 
-  def setup(self):
-    if self.vision_proj_dim:
-      self.mm_soft_embedding_norm = rms_norm(self.vision_proj_dim)
-      self.mm_input_projection = Einsum((self.vision_proj_dim, self.config.emb_dim))
+    self.mm_soft_embedding_norm = RMSNorm(
+        num_features=self.config.hidden_size_for_vit,
+        dtype=self.config.dtype_mm,
+        weight_dtype=self.config.weight_dtype,
+        epsilon=self.config.normalization_layer_epsilon,
+        kernel_axes=("norm",),
+        rngs=self.rngs,
+    )
+    self.mm_input_projection = Einsum(shape=(self.config.hidden_size_for_vit, self.config.emb_dim), precision=self.config.matmul_precision, rngs=self.rngs)
 
-  def encode_vision(self, x: jax.Array) -> jax.Array:
+  def __call__(self, x: jax.Array, eqn: str = "...tm,md->...td") -> jax.Array:
     x = self.mm_soft_embedding_norm(x)
-    x = self.mm_input_projection("...tm,md->...td", x)
+    x = self.mm_input_projection(eqn, x)
     return x
 
-  def __call__(self, x: jax.Array) -> jax.Array:
-    return self.encode_vision(x)
+
+def visionembedder_as_linen(
+    config: Config,
+    mesh: Mesh,
+):
+  """Creates a VisionEmbedder module."""
+  return nnx_wrappers.to_linen(
+      VisionEmbedder,
+      config,
+      mesh=mesh,
+      name="VisionEmbedder_0",
+      abstract_init=False,
+      metadata_fn=variable_to_logically_partitioned,
+  )
 
 
-class VisionExit(nn.Module):
+class VisionExit(nnx.Module):
   """The vision exit layer.
 
   Possibly downsample the soft tokens to a required output length.
@@ -451,7 +495,9 @@ class VisionExit(nn.Module):
     output_length: The embed will be spatially avg-pooled to this output length.
   """
 
-  output_length: int = 256
+  def __init__(self, output_length: int = 256, *, rngs: nnx.Rngs):
+    self.output_length = output_length
+    self.rngs = rngs
 
   def __call__(self, x):
     cur_length = x.shape[1]
@@ -467,24 +513,55 @@ class VisionExit(nn.Module):
     assert not cur_width % output_width, f"{cur_width=} {output_width=}"
     window = cur_width // output_width
     window_shape = (window, window)
-    x = nn.avg_pool(x, window_shape=window_shape, strides=window_shape)
+    x = nnx.avg_pool(x, window_shape=window_shape, strides=window_shape)
     batch_size, height, width, embed_dim = x.shape
     return jnp.reshape(x, (batch_size, height * width, embed_dim))
 
 
-class Gemma3VisionEncoderLayer(nn.Module):
+def vision_exit_as_linen(x: jax.Array, output_length: int) -> jax.Array:
+  """A wrapper to use VisionExit as a function."""
+  return nnx.bridge.to_linen(VisionExit, output_length=output_length)(x)
+
+
+class Gemma3VisionEncoderLayer(nnx.Module):
   """gemma 3 vision encoder layer"""
 
-  config: Config
-  mesh: Mesh
-  patch_size: tuple[int, int] = (14, 14)
-  width: int = 1152
-  mlp_dim: int | None = 4304  # Defaults to 4x input dim
-  depth: int = 27
-  num_heads: int = 16
-  posemb: str = "learn"  # Can also be "sincos2d"
-  dropout: float = 0.0
-  # or "dots_with_no_batch_dims_saveable" for more speed (memory costly)
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      *,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
+
+    self.embedding = nnx.Conv(
+        in_features=self.config.num_channels_for_vit,
+        out_features=self.config.hidden_size_for_vit,
+        kernel_size=(self.config.patch_size_for_vit, self.config.patch_size_for_vit),
+        strides=self.config.conv_stride_for_vit,
+        padding="VALID",
+        precision=self.config.matmul_precision,
+        rngs=self.rngs,
+    )
+    self.pos_embedding = self._get_posemb(
+        self.config.posemb_type_for_vit,
+        seqshape=(
+            self.config.image_size_for_vit // self.config.patch_size_for_vit,
+            self.config.image_size_for_vit // self.config.patch_size_for_vit,
+        ),
+        width=self.config.hidden_size_for_vit,
+        dtype=self.config.dtype_mm,
+    )
+    self.Dropout_0 = nnx.Dropout(self.config.dropout_rate, rngs=self.rngs)
+    self.Transformer = Encoder(
+        config=self.config,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.VisionExit = VisionExit(output_length=256, rngs=self.rngs)
 
   def _get_posemb(
       self,
@@ -492,67 +569,59 @@ class Gemma3VisionEncoderLayer(nn.Module):
       *,
       seqshape: tuple[int, int],
       width: int,
-      name: str,
       dtype: jnp.dtype = jnp.float32,
   ):
     """Returns the position embedding."""
     if typ == "learn":
-      shape_product = seqshape[0] * seqshape[1]
-      return self.param(
-          name,
-          nn.initializers.normal(stddev=1 / (width**0.5)),
-          (1, shape_product, width),
-          dtype,
-      )
+      shape = (1, seqshape[0] * seqshape[1], width)
+      initializer = nnx.initializers.normal(stddev=1 / (width**0.5))
+      return nnx.Param(initializer(self.rngs.params(), shape, dtype))
     elif typ == "sincos2d":
-      return _posemb_sincos_2d(*seqshape, width=width, dtype=dtype)
+      return _posemb_sincos_2d(*seqshape, width=width, dtype=dtype, precision=self.config.matmul_precision)
     else:
       raise ValueError(f"Unknown posemb type: {typ}")
 
-  @nn.compact
   def __call__(self, inputs, deterministic, train=False):
     """ViT model that transforms image inputs to image embeddings.
     Args:
       inputs: jnp.array shaped [B, N, H, W, C], e.g. [4, 1, 896, 896, 3]
     Returns:
-      jnp.array for image embeddings, shaped [B, N, P, D], e.g. [4, 1, 256, 2560]
+      jnp.array for image embeddings, shaped [B, N, P, D], e.g. [4, 1, 256, 1152]
     """
-    cfg = self.config
     # currently only supports N=1, the inputs shape is [B, H, W, C]
     if len(inputs.shape) == 4:
       inputs = inputs[:, None, :]
     b, n, h, w, c = inputs.shape
     x = jnp.reshape(inputs, [b * n, h, w, c])
     # Gemma3 uses conv2d with stride 14 and kernel size 14 to extract patches.
-    x = nn.Conv(features=1152, kernel_size=(14, 14), strides=14, padding="VALID", name="embedding")(x)
+    x = self.embedding(x)
     bn, h, w, c = x.shape
     x = jnp.reshape(x, [bn, h * w, c])
 
-    # Add posemb before adding extra token.
-    x = x + self._get_posemb(
-        self.posemb,
-        seqshape=(h, w),
-        width=c,
-        name="pos_embedding",
-        dtype=x.dtype,
-    )
-
-    x = nn.Dropout(rate=self.dropout)(x, not train)
+    x = self.pos_embedding + x
+    x = self.Dropout_0(x)
 
     # Transformer encoder to extract image features.
-    x = Encoder(
-        depth=self.depth,
-        mlp_dim=self.mlp_dim,
-        num_heads=self.num_heads,
-        dropout=self.dropout,
-        scan=False,  # TODO(aireenmei, hengtaoguo): support scan in vision encoder
-        remat_policy=cfg.remat_policy_for_vit,
-        dtype_mm=cfg.dtype_mm,
-        name="Transformer",
-    )(x, deterministic=deterministic)
+    x = self.Transformer(x, deterministic=deterministic)
 
     # Gemma3 use a vision exit layer to downsample the soft tokens to a required output length.
-    x = VisionExit(output_length=256)(x)
+    x = self.VisionExit(x)
     bn, l, c = x.shape
     x = jnp.reshape(x, [b, n, l, c])
     return x
+
+
+def gemma3visionencoder_as_linen(
+    config: Config,
+    mesh: Mesh,
+):
+  """Creates a Gemma3VisionEncoder module."""
+  module = nnx_wrappers.to_linen(
+      Gemma3VisionEncoderLayer,
+      config=config,
+      mesh=mesh,
+      name="Gemma3VisionEncoderLayer_0",
+      abstract_init=False,
+      metadata_fn=variable_to_logically_partitioned,
+  )
+  return module


### PR DESCRIPTION
# Description

This PR migrates the `Gemma3VisionEncoderLayer` and `VisionEmbedder` class to use NNX.
- All submodules migrated to NNX. Of note, we also migrated from `nnx.Dense/nnx.MultiHeadAttention` to MaxText `DenseGeneral/Attention`: MaxText format migration complete. 
- Preserve the checkpoint's current parameter names and hierarchy.
- The `nnx_wrappers.to_linen` bridge is used within `encoders.py`.
- Refactored hard-coded Gemma3 multimodal configuration to `base.yml` for clarity.
- Including @aireenmei's fix on the `precision=self.config.matmul_precision` across nnx.Conv/DenseGeneral layers. Adding precision flags to `attention_op.py` for einsum, and this change drastically reduces KL divergence from ~8.7 to ~0.03.

# Tests

Tested with multimodal decode command:
```
python -m MaxText.decode MaxText/configs/base.yml model_name=gemma3-4b tokenizer_path=assets/tokenizer.gemma3 load_parameters_path=gs://maxtext-gemma/unified/gemma3/4b/unscanned/2025-08-09-01-17/0/items per_device_batch_size=1 run_name=ht_test max_prefill_predict_length=272 max_target_length=300 steps=1 async_checkpointing=false scan_layers=false use_multimodal=true prompt=\'Describe\ image\ \<start_of_image\>\' image_path=\'MaxText/test_assets/test_image.jpg\' attention=\'dot_product\'
```
Results:
```
Input `<start_of_turn>user
Describe image <start_of_image><end_of_turn>
<start_of_turn>model
` -> `Here's a description of the image:

**Overall Impression:** The image is a bright, expansive cityscape view of Seattle, Washington, with`
```

Tested with sft_trainer with [command](https://paste.googleplex.com/5858533295521792) and [workload](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22v5p-8-bodaborg-europe-west4-b%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22hengtaoguo-2025-09-04-17-14-36-slice-job-0-0-%22%20severity%3E%3DDEFAULT%0Atimestamp%20%3E%3D%20%222025-09-04T17:16:17.719938761Z%22%20AND%20timestamp%20%3C%3D%20%222025-09-04T17:24:42.873411327Z%22;storageScope=project;cursorTimestamp=2025-09-04T17:16:40.092655322Z;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)

KL divergence check [command](https://paste.googleplex.com/6201259405213696):
```
max KL divergence = 0.030590716749429703
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
