### PR TITLE
[WIP] LLama3.1 ckpt conversion support

### DIFF
--- a/MaxText/tests/forward_pass_logit_checker.py
+++ b/MaxText/tests/forward_pass_logit_checker.py
@@ -291,6 +291,8 @@ def main(config, test_args):  # pylint: disable=W0621
       raise ValueError
     hf_model = AutoModelForCausalLM.from_pretrained(test_args.hf_model_path, torch_dtype=torch.bfloat16)
     tokenizer = AutoTokenizer.from_pretrained(test_args.hf_model_path)
+    if 'Llama-3.1' in test_args.hf_model_path:
+      tokenizer.pad_token = tokenizer.eos_token
 
     init_rng = jax.random.PRNGKey(config.init_weights_seed)
     init_rng, rng1 = jax.random.split(init_rng)

--- a/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -290,6 +290,76 @@ qwen3_32b_config = transformers.Qwen3Config(
     torch_dtype="bfloat16",
 )
 
+
+llama31_8b_config = transformers.LlamaConfig(
+    vocab_size=128256,
+    hidden_size=4096,
+    intermediate_size=14336,
+    num_hidden_layers=32,
+    num_attention_heads=32,
+    num_key_value_heads=8,
+    max_position_embeddings=131072,
+    head_dim=128,
+    rms_norm_eps=1e-5,
+    bos_token_id=128000,
+    eos_token_id=128001,
+    attention_bias=False,
+    attention_dropout=0.0,
+    hidden_act="silu",
+    initializer_range=0.02,
+    mlp_bias=False,
+    model_type="llama",
+    pretraining_tp=1,
+    rope_scaling={
+        "factor": 8.0,
+        "low_freq_factor": 1.0,
+        "high_freq_factor": 4.0,
+        "original_max_position_embeddings": 8192,
+        "rope_type": "llama3"
+    },
+    rope_theta=500000.0,
+    tie_word_embeddings=False,
+    use_cache=True,
+)
+
+llama31_70b_config = transformers.LlamaConfig(
+    vocab_size=128256,
+    hidden_size=8192,
+    intermediate_size=28672,
+    num_hidden_layers=80,
+    num_attention_heads=64,
+    head_dim=128,
+    num_key_value_heads=8,
+    max_position_embeddings=131072,
+    rms_norm_eps=1e-05,
+    bos_token_id=128000,
+    eos_token_id=[128001, 128008, 128009],
+    rope_scaling={
+        "factor": 8.0,
+        "high_freq_factor": 4.0,
+        "low_freq_factor": 1.0,
+        "original_max_position_embeddings": 8192,
+        "rope_type": "llama3",
+    },
+    rope_theta=500000.0,
+    tie_word_embeddings=False,
+)
+
+llama31_405b_config = transformers.LlamaConfig(
+    vocab_size=128256,
+    hidden_size=16384,
+    intermediate_size=53248,
+    num_hidden_layers=126,
+    num_attention_heads=128,
+    num_key_value_heads=8,
+    head_dim=128,
+    max_position_embeddings=131072,
+    rms_norm_eps=1e-05,
+    bos_token_id=128000,
+    eos_token_id=128001,
+)
+
+
 HF_MODEL_CONFIGS = {
     "gemma2-2b": gemma2_2b_config,
     "gemma2-9b": gemma2_9b_config,
@@ -302,4 +372,7 @@ HF_MODEL_CONFIGS = {
     "qwen3-8b": qwen3_8b_config,
     "qwen3-14b": qwen3_14b_config,
     "qwen3-32b": qwen3_32b_config,
+    "llama3.1-8b": llama31_8b_config,
+    "llama3.1-70b": llama31_70b_config,
+    "llama3.1-405b": llama31_405b_config,
 }

--- a/MaxText/utils/ckpt_conversion/utils/hf_shape.py
+++ b/MaxText/utils/ckpt_conversion/utils/hf_shape.py
@@ -305,6 +305,61 @@ def QWEN3_HF_WEIGHTS_TO_SHAPE(config):
     mapping.update(layer_mapping)
   return mapping
 
+def LLAMA31_HF_WEIGHTS_TO_SHAPE(config):
+    """Returns mapping between HuggingFace weights path and weights shape.
+
+    Args:
+        config (dict): Model configuration dictionary, defined in `model_configs.py`
+
+    Returns:
+        dict: A mapping where:
+            - Keys are HuggingFace model parameter paths
+            - Values are parameter shape as a List
+    """
+
+    mapping = {
+        "model.embed_tokens.weight": [config["vocab_size"], config["hidden_size"]],
+        "model.norm.weight": [config["hidden_size"]],
+        "lm_head.weight": [config["vocab_size"], config["hidden_size"]]
+    }
+    for layer_idx in range(config["num_hidden_layers"]):
+        layer_mapping = {
+            f"model.layers.{layer_idx}.input_layernorm.weight": [config["hidden_size"]],
+            f"model.layers.{layer_idx}.mlp.down_proj.weight": [
+                config["hidden_size"],
+                config["intermediate_size"],
+            ],
+            f"model.layers.{layer_idx}.mlp.up_proj.weight": [
+                config["intermediate_size"],
+                config["hidden_size"],
+            ],
+            f"model.layers.{layer_idx}.mlp.gate_proj.weight": [
+                config["intermediate_size"],
+                config["hidden_size"],
+            ],
+            f"model.layers.{layer_idx}.post_attention_layernorm.weight": [
+                config["hidden_size"]
+            ],
+            f"model.layers.{layer_idx}.self_attn.k_proj.weight": [
+                config["num_key_value_heads"] * config["head_dim"],
+                config["hidden_size"],
+            ],
+            f"model.layers.{layer_idx}.self_attn.o_proj.weight": [
+                config["hidden_size"],
+                config["num_attention_heads"] * config["head_dim"],
+            ],
+            f"model.layers.{layer_idx}.self_attn.q_proj.weight": [
+                config["num_attention_heads"] * config["head_dim"],
+                config["hidden_size"],
+            ],
+            f"model.layers.{layer_idx}.self_attn.v_proj.weight": [
+                config["num_key_value_heads"] * config["head_dim"],
+                config["hidden_size"],
+            ],
+        }
+        mapping = {**mapping, **layer_mapping}
+    return mapping
+
 
 HF_SHAPE = {
     "gemma2-2b": GEMMA2_HF_WEIGHTS_TO_SHAPE,
@@ -318,4 +373,7 @@ HF_SHAPE = {
     "qwen3-8b": QWEN3_HF_WEIGHTS_TO_SHAPE,
     "qwen3-14b": QWEN3_HF_WEIGHTS_TO_SHAPE,
     "qwen3-32b": QWEN3_HF_WEIGHTS_TO_SHAPE,
+    "llama3.1-8b": LLAMA31_HF_WEIGHTS_TO_SHAPE,
+    "llama3.1-70b": LLAMA31_HF_WEIGHTS_TO_SHAPE,
+    "llama3.1-405b": LLAMA31_HF_WEIGHTS_TO_SHAPE,
 }

--- a/MaxText/utils/ckpt_conversion/utils/param_mapping.py
+++ b/MaxText/utils/ckpt_conversion/utils/param_mapping.py
@@ -830,6 +830,211 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=Fa
   return mapping
 
 
+def LLAMA31_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
+    """
+    Returns a dictionary mapping from MaxText parameter names to
+    HuggingFace LLaMA3.1 parameter names.
+
+    Args:
+        config (dict): Model configuration dictionary containing:
+            - num_hidden_layers (int): The number of decoder layers.
+        scan_layers (bool, optional): If True, MaxText layers are 'stacked'
+            into a single param. Defaults to False.
+
+    Returns:
+        dict: A mapping from MaxText parameter names to HF parameter names (str)
+              or lists of names (if scan_layers=True).
+    """
+    n_layers = config["num_hidden_layers"]
+
+    mapping = {
+        "params-token_embedder-embedding": "model.embed_tokens.weight",
+        "params-decoder-logits_dense-kernel": "lm_head.weight",
+        "params-decoder-decoder_norm-scale": "model.norm.weight",
+    }
+
+    if scan_layers:
+        mapping[
+            "params-decoder-layers-self_attention-query-kernel"
+        ] = [
+            f"model.layers.{layer_idx}.self_attn.q_proj.weight"
+            for layer_idx in range(n_layers)
+        ]
+        mapping[
+            "params-decoder-layers-self_attention-key-kernel"
+        ] = [
+            f"model.layers.{layer_idx}.self_attn.k_proj.weight"
+            for layer_idx in range(n_layers)
+        ]
+        mapping[
+            "params-decoder-layers-self_attention-value-kernel"
+        ] = [
+            f"model.layers.{layer_idx}.self_attn.v_proj.weight"
+            for layer_idx in range(n_layers)
+        ]
+        mapping[
+            "params-decoder-layers-self_attention-out-kernel"
+        ] = [
+            f"model.layers.{layer_idx}.self_attn.o_proj.weight"
+            for layer_idx in range(n_layers)
+        ]
+        mapping[
+            "params-decoder-layers-mlp-wi_0-kernel"
+        ] = [
+            f"model.layers.{layer_idx}.mlp.gate_proj.weight"
+            for layer_idx in range(n_layers)
+        ]
+        mapping[
+            "params-decoder-layers-mlp-wi_1-kernel"
+        ] = [
+            f"model.layers.{layer_idx}.mlp.up_proj.weight"
+            for layer_idx in range(n_layers)
+        ]
+        mapping[
+            "params-decoder-layers-mlp-wo-kernel"
+        ] = [
+            f"model.layers.{layer_idx}.mlp.down_proj.weight"
+            for layer_idx in range(n_layers)
+        ]
+        mapping[
+            "params-decoder-layers-pre_self_attention_layer_norm-scale"
+        ] = [
+            f"model.layers.{layer_idx}.input_layernorm.weight"
+            for layer_idx in range(n_layers)
+        ]
+        mapping[
+            "params-decoder-layers-post_self_attention_layer_norm-scale"
+        ] = [
+            f"model.layers.{layer_idx}.post_attention_layernorm.weight"
+            for layer_idx in range(n_layers)
+        ]
+    else:
+        for layer_idx in range(n_layers):
+            mapping[
+                f"params-decoder-layers_{layer_idx}-self_attention-query-kernel"
+            ] = f"model.layers.{layer_idx}.self_attn.q_proj.weight"
+            mapping[
+                f"params-decoder-layers_{layer_idx}-self_attention-key-kernel"
+            ] = f"model.layers.{layer_idx}.self_attn.k_proj.weight"
+            mapping[
+                f"params-decoder-layers_{layer_idx}-self_attention-value-kernel"
+            ] = f"model.layers.{layer_idx}.self_attn.v_proj.weight"
+            mapping[
+                f"params-decoder-layers_{layer_idx}-self_attention-out-kernel"
+            ] = f"model.layers.{layer_idx}.self_attn.o_proj.weight"
+            mapping[
+                f"params-decoder-layers_{layer_idx}-mlp-wi_0-kernel"
+            ] = f"model.layers.{layer_idx}.mlp.gate_proj.weight"
+            mapping[
+                f"params-decoder-layers_{layer_idx}-mlp-wi_1-kernel"
+            ] = f"model.layers.{layer_idx}.mlp.up_proj.weight"
+            mapping[
+                f"params-decoder-layers_{layer_idx}-mlp-wo-kernel"
+            ] = f"model.layers.{layer_idx}.mlp.down_proj.weight"
+            mapping[
+                f"params-decoder-layers_{layer_idx}-pre_self_attention_layer_norm-scale"
+            ] = f"model.layers.{layer_idx}.input_layernorm.weight"
+            mapping[
+                f"params-decoder-layers_{layer_idx}-post_self_attention_layer_norm-scale"
+            ] = f"model.layers.{layer_idx}.post_attention_layernorm.weight"
+
+    return mapping
+
+def LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=False):
+    """Creates parameter transformation functions for converting between MaxText and
+    HuggingFace formats.
+
+    This function generates a mapping of transformation functions that handle the necessary
+    conversions between MaxText and HuggingFace parameter formats, including operations like
+    reshaping.
+    """
+    nlayers = config["num_hidden_layers"]
+
+    def scale_query_layer(input_tensor, target_shape):
+      def to_hf():
+          depth_scale = np.dtype("float32").type(np.sqrt(config["head_dim"]))
+          
+          original_dtype = input_tensor.dtype
+          output_tensor = input_tensor.astype(np.float32) * depth_scale
+          return output_tensor.astype(original_dtype)
+
+      def from_hf():
+          depth_scale = np.dtype("float32").type(1 / np.sqrt(config["head_dim"]))
+
+          original_dtype = input_tensor.dtype
+          output_tensor = input_tensor.astype(np.float32) * depth_scale
+          return output_tensor.astype(original_dtype)
+      if saving_to_hf:
+          return to_hf()
+      else:
+          return from_hf()
+
+    def adjust_rope(input_tensor, target_shape):
+      def from_hf(arr):
+          """Convert from HF's concatenated layout to MaxText's interleaved layout"""
+          half_dim = arr.shape[-1] // 2
+          first_half = arr[..., :half_dim]
+          second_half = arr[..., half_dim:]
+          return jax.numpy.stack([first_half, second_half], axis=-1).reshape(arr.shape)
+
+      def to_hf(arr):
+          """Convert from MaxText's interleaved layout to HF's concatenated layout"""
+          evens = arr[..., ::2]
+          odds = arr[..., 1::2]
+          return jax.numpy.concatenate((evens, odds), axis=arr.ndim - 1)
+
+      if saving_to_hf:
+          return to_hf(input_tensor)
+      else:
+          return from_hf(input_tensor)
+
+        
+    def reshape_kernel(input_tensor, target_shape):
+      def to_hf():
+          flipped_target_shape = np.flip(np.array(target_shape))
+          return input_tensor.reshape(flipped_target_shape).transpose()
+
+      def from_hf():
+          return input_tensor.transpose().reshape(target_shape)
+
+      if saving_to_hf:
+          return to_hf()
+      else:
+          return from_hf()
+    
+    query_hooks = [reshape_kernel, adjust_rope, scale_query_layer]
+    key_hooks = [reshape_kernel, adjust_rope]
+    
+    if not saving_to_hf:
+        query_hooks.reverse()
+        key_hooks.reverse()
+
+    hook_fns = {}
+
+    hook_fns["params-decoder-logits_dense-kernel"] = reshape_kernel
+
+    if scan_layers:
+        hook_fns = {
+            **hook_fns,
+            f"params-decoder-layers-self_attention-query-kernel": query_hooks,
+            f"params-decoder-layers-self_attention-key-kernel": key_hooks,
+            f"params-decoder-layers-self_attention-value-kernel": reshape_kernel,
+            f"params-decoder-layers-self_attention-out-kernel": reshape_kernel,
+            f"params-decoder-layers-mlp-wi_0-kernel": reshape_kernel,
+            f"params-decoder-layers-mlp-wi_1-kernel": reshape_kernel,
+            f"params-decoder-layers-mlp-wo-kernel": reshape_kernel,
+        }
+    else:
+        for layer_idx in range(nlayers):
+            hook_fns[f"params-decoder-layers_{layer_idx}-self_attention-query-kernel"] = query_hooks
+            hook_fns[f"params-decoder-layers_{layer_idx}-self_attention-key-kernel"] = key_hooks
+            hook_fns[f"params-decoder-layers_{layer_idx}-self_attention-value-kernel"] = reshape_kernel
+            hook_fns[f"params-decoder-layers_{layer_idx}-self_attention-out-kernel"] = reshape_kernel
+            hook_fns[f"params-decoder-layers_{layer_idx}-mlp-wi_0-kernel"] = reshape_kernel 
+            hook_fns[f"params-decoder-layers_{layer_idx}-mlp-wi_1-kernel"] = reshape_kernel 
+            hook_fns[f"params-decoder-layers_{layer_idx}-mlp-wo-kernel"] = reshape_kernel 
+    return hook_fns
+
 PARAM_MAPPING = {
     "gemma2-2b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma2-9b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
@@ -842,6 +1047,9 @@ PARAM_MAPPING = {
     "qwen3-8b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen3-14b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen3-32b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "llama3.1-8b": LLAMA31_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "llama3.1-70b": LLAMA31_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "llama3.1-405b": LLAMA31_MAXTEXT_TO_HF_PARAM_MAPPING,
 }
 
 HOOK_FNS = {
@@ -856,4 +1064,7 @@ HOOK_FNS = {
     "qwen3-8b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen3-14b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen3-32b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "llama3.1-8b": LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "llama3.1-70b": LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "llama3.1-405b": LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN,
 }

--- a/MaxText/utils/ckpt_conversion/utils/utils.py
+++ b/MaxText/utils/ckpt_conversion/utils/utils.py
@@ -60,6 +60,9 @@ HF_IDS = {
     "qwen3-8b": "Qwen/Qwen3-8B",
     "qwen3-14b": "Qwen/Qwen3-14B",
     "qwen3-32b": "Qwen/Qwen3-32B",
+    "llama3.1-8b": "meta-llama/Llama-3.1-8B",
+    "llama3.1-70b": "meta-llama/Llama-3.1-70B",
+    "llama3.1-405b": "meta-llama/Llama-3.1-405B",
 }
 
 


### PR DESCRIPTION
# Description

Add checkpoint conversion support for llama3.1 families. 


- Model specific mappings added
- Fix of forward_pass_logit_checker.py to test on Llama3.1 models


# Tests

Llama3.1-8b is tested.
We used the `forward_pass_logit_checker.py` to validate the converted ckpt:
```
python -m MaxText.tests.forward_pass_logit_checker MaxText/configs/base.yml model_name=llama3.1-8b tokenizer_path=assets/tokenizer_llama3.tiktoken tokenizer_type=tiktoken load_parameters_path=gs://yixuannwang-maxtext-logs/llama3.1-8b/unscanned/0/items/ per_device_batch_size=1 run_name=ht_test max_prefill_predict_length=8 max_target_length=16 dataset_type=synthetic steps=10 async_checkpointing=false scan_layers=false --hf_model_path=meta-llama/Llama-3.1-8B \
--max_kl_div=0.015 \
--run_hf_model=True
```

Part of the test output:
```
--- Prompt: What is the ---

--- MaxText model top 10 tokens ---
| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 6864       | capital              | 12.7500    |
| 836        | name                 | 11.5625    |
| 6811       | difference           | 10.8750    |
| 2592       | source               | 10.6250    |
| 1888       | best                 | 10.5625    |
| 19463      | probability          | 10.5000    |
| 3148       | mass                 | 10.2500    |
| 3685       | expected             | 10.1875    |
| 8286       | volume               | 10.1875    |
| 7438       | meaning              | 9.6875     |


--- HF model top 10 tokens ---
| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 6864       | capital              | 12.6875    |
| 836        | name                 | 11.5625    |
| 6811       | difference           | 10.8750    |
| 2592       | source               | 10.6875    |
| 1888       | best                 | 10.5625    |
| 19463      | probability          | 10.5000    |
| 3148       | mass                 | 10.2500    |
| 3685       | expected             | 10.1875    |
| 8286       | volume               | 10.0625    |
| 7438       | meaning              | 9.6875     |


--- Similarity Metrics of Top Tokens ---
| Metric                         | Value                |
|--------------------------------|----------------------|
| overlap_count                  | 10/10                |
| jaccard_similarity             | 1.0                  |
| rank_agreement_percentage      | 100.0                |


Average KL divergence per token (D_KL(P_golden || Q_model)): 0.000140

Max KL divergence for a single token in the set: 0.001938
```


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
