### PR TITLE
Fix: Create the gcs folder when creating Orbax EMC checkpointer

### DIFF
--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -154,15 +154,17 @@ def create_orbax_emergency_checkpoint_manager(
   flags.FLAGS.experimental_orbax_use_distributed_process_id = True
   max_logging.log("Creating emergency checkpoint manager...")
 
-  # Only create directories if running on GPUs as the previous
+  # Create the persistent checkpoint directory if it does not exist
+  persistent_p = epath.Path(persistent_checkpoint_dir)
+  persistent_p.mkdir(exist_ok=True, parents=True)
+
+  # Only create local directories if running on GPUs as the previous
   # directory structure might be assumed by TPUs
   if global_mesh.devices.flatten()[0].platform == "gpu":
     # pylint: disable=protected-access
     local_checkpoint_dir = f"{local_checkpoint_dir}/{jax._src.distributed.global_state.process_id}"
     local_p = epath.Path(local_checkpoint_dir)
-    persistent_p = epath.Path(persistent_checkpoint_dir)
     local_p.mkdir(exist_ok=True, parents=True)
-    persistent_p.mkdir(exist_ok=True, parents=True)
 
   manager = EmergencyCheckpointManager(
       local_checkpoint_dir,


### PR DESCRIPTION
# Description

The Orbax EMC checkpointer in its current state does not automatically create necessary subdirectories within a GCS bucket, leading to a file not found error when a training job attempts to save the 0 checkpoint. This fix ensures that the checkpointer can create the required subfolders on GCS before attempting to write a checkpoint.

FIXES: b/437830796

# Tests

This fix has been validated with a dedicated test case that reproduces the original bug. Details and results can be found in the [Buganizer ticket](https://buganizer.corp.google.com/issues/437830796#comment1) and the [Original Buganizer ticket](436674299)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
