### PR TITLE
[Qwix] More configurable dtypes for backward pass in fp8 config

### DIFF
--- a/MaxText/kernels/megablox/ops.py
+++ b/MaxText/kernels/megablox/ops.py
@@ -17,11 +17,14 @@
 # pylint: disable=too-many-positional-arguments
 
 from typing import Literal
-
+import dataclasses
 import jax
 import jax.numpy as jnp
 
 from aqt.jax.v2 import aqt_tensor
+
+import qwix
+import qwix.pallas as qpl
 
 from MaxText.kernels.megablox import gmm as backend
 
@@ -30,6 +33,11 @@ gmm = jax.custom_vjp(
     nondiff_argnums=(3, 4, 7, 8, 9, 10, 11),
 )
 
+def _get_current_rule(op_name: str):
+  rule = qpl.get_current_rule(op_name)
+  if rule is not None and not isinstance(rule, qwix.QtRule):
+    rule = qwix.QtRule(**dataclasses.asdict(rule))
+  return rule
 
 def _gmm_fwd(
     lhs: jnp.ndarray,
@@ -55,6 +63,12 @@ def _gmm_fwd(
     ],
 ]:
   """Forward function for GMM VJP."""
+  if use_qwix_quantization:
+    lhs_quantize_dtype, rhs_quantize_dtype = None, None
+    rule = _get_current_rule("dot_general")
+    if rule is not None:
+      lhs_quantize_dtype = rule.act_qtype
+      rhs_quantize_dtype = rule.weight_qtype
   out = backend.gmm(
       lhs,
       rhs,
@@ -90,6 +104,16 @@ def _gmm_bwd(
     grad: jnp.ndarray,
 ) -> tuple[jnp.ndarray, jnp.ndarray, None, None, jnp.ndarray]:
   """Backward function for throughput GMM VJP."""
+  if use_qwix_quantization:
+    lhs_quantize_dtype, rhs_quantize_dtype = None, None
+    rule = _get_current_rule("dot_general")
+    if rule is not None:
+      if rule.additional_qt_config is not None:
+        lhs_quantize_dtype = rule.additional_qt_config["dlhs_lhs_qtype"]
+        rhs_quantize_dtype = rule.additional_qt_config["dlhs_rhs_qtype"]
+      else:
+        lhs_quantize_dtype = rule.act_qtype
+        rhs_quantize_dtype = rule.bwd_qtype
   del preferred_element_type
   lhs, rhs, group_sizes, group_offset, num_actual_groups = residual
   grad_lhs = backend.gmm(
@@ -105,6 +129,16 @@ def _gmm_bwd(
       rhs_quantize_dtype=rhs_quantize_dtype,
       use_qwix_quantization=use_qwix_quantization,
   )
+  if use_qwix_quantization:
+    lhs_quantize_dtype, rhs_quantize_dtype = None, None
+    rule = _get_current_rule("dot_general")
+    if rule is not None:
+      if rule.additional_qt_config is not None:
+        lhs_quantize_dtype = rule.additional_qt_config["drhs_lhs_qtype"]
+        rhs_quantize_dtype = rule.additional_qt_config["drhs_rhs_qtype"]
+      else:
+        lhs_quantize_dtype = rule.bwd_qtype
+        rhs_quantize_dtype = rule.act_qtype
   grad_rhs = backend.tgmm(
       lhs.swapaxes(0, 1),
       grad,

--- a/MaxText/layers/moe.py
+++ b/MaxText/layers/moe.py
@@ -717,6 +717,7 @@ class RoutedMoE(nnx.Module):
             tiling=tiling,
             lhs_quantize_dtype=lhs_quantize_dtype,
             rhs_quantize_dtype=rhs_quantize_dtype,
+            use_qwix_quantization=self.config.use_qwix_quantization,
         )
       else:
         rhs_inputs = kernel

--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -666,11 +666,17 @@ def get_quantization_rule(config: Config):
           act_qtype=jnp.float8_e4m3fn,
           bwd_qtype=jnp.float8_e5m2,
           bwd_use_original_residuals=True,
-          disable_channelwise_axes=True,  # per_tensor calibration
+          disable_channelwise_axes=True, # per_tensor calibration
           weight_calibration_method=config.quantization_calibration_method,
           act_calibration_method=config.quantization_calibration_method,
           bwd_calibration_method=config.quantization_calibration_method,
           op_names=("dot_general",),
+          additional_qt_config={
+            "dlhs_lhs_qtype": jnp.float8_e5m2,
+            "dlhs_rhs_qtype": jnp.float8_e4m3fn,
+            "drhs_lhs_qtype": jnp.float8_e4m3fn,
+            "drhs_rhs_qtype": jnp.float8_e5m2,
+          },
       )
     case "fp8_gpu":
       return qwix.QtRule(


### PR DESCRIPTION
# Description

This PR adds more configuration for dtypes in backward pass of gmm megablox kernel. 
Example usage is added in fp8_full quantization config.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/437361619

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

unit tests and test run on deepseekv2-16b

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
