### PR TITLE
Plumb per_device_batch_size as argument to test_convergence_1b_params 

### DIFF
--- a/end_to_end/tpu/test_convergence_1b_params.sh
+++ b/end_to_end/tpu/test_convergence_1b_params.sh
@@ -17,8 +17,10 @@ echo "Running test_convergence_1b_params.sh"
 export LOSS_THRESHOLD=100.0 # Set to large value so test is guaranteed to pass.
 export STEPS=20400 # Run for 20B tokens for a 1B sized mode for "chinchilla" scaling https://arxiv.org/abs/2203.15556
 export EVAL_STEPS=160
+export EVAL_INTERVAL=100
 export DATASET_TYPE=tfds
 export MTP_NUM_LAYERS=0 # Disable MTP by default
+export PER_DEVICE_BATCH_SIZE=8.0 # With the default learning rate (3e-4) this should have global batch of 512, with 2k sequence length (1M global batch in tokens)
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -54,8 +56,8 @@ then
 fi
 
 TRAIN_CMD="python3 -m MaxText.train MaxText/configs/base.yml \
-        steps=$STEPS eval_steps=$EVAL_STEPS eval_interval=2 \
-        per_device_batch_size=8.0 learning_rate=3e-4 enable_checkpointing=false \
+        steps=$STEPS eval_steps=$EVAL_STEPS eval_interval=$EVAL_INTERVAL \
+        per_device_batch_size=$PER_DEVICE_BATCH_SIZE learning_rate=3e-4 enable_checkpointing=false \
         max_target_length=2048 global_parameter_scale=1 \
         metrics_file=metrics.txt base_output_directory=$OUTPUT_PATH \
         dataset_path=$DATASET_PATH dataset_type=$DATASET_TYPE log_period=150 \


### PR DESCRIPTION
# Description

Add option to plumb in per_device_batch_size as argument to test_convergence_1b_params. This allows users to run this test on a different number of chips (e.g. v6e-256), and scale the per_device_batch_size so the global batch size remains constant (512)

Corresponding Airflow: https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/821/files

# Tests

Ran test manually with pdb=2 on v6e-256, saw the same ~2.5 loss [gcloud log links](https://cloudlogging.app.goo.gl/YNPX9Vw62NZnkkDq5)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
