### PR TITLE
Fix for megablox, treat quantize as a bool

### DIFF
--- a/MaxText/kernels/megablox/gmm.py
+++ b/MaxText/kernels/megablox/gmm.py
@@ -433,13 +433,13 @@ def gmm(
         def _init_out():
           out[...] = existing_out[...]
 
-    def mask_k_rem(x, *, dim, quantize):
+    def mask_k_rem(x: jax.Array, *, dim: int, quantize: bool):
       if k_rem == 0:
         return x
 
       orig_dtype = x.dtype
       iota = lax.broadcasted_iota(jnp.int32, x.shape, dim)
-      if quantize is None:
+      if not quantize:
         x = x.astype(jnp.float32)
       else:
         x = x.astype(jnp.int32)


### PR DESCRIPTION
This should avoid rounding the entire last tile in the non-quantized path.

# Description

When masking the last reduction-axis tile, correctly decide on non-quantized path based on the bool argument. Previously the argument passed was a bool, but a None/not-None was expected within the function.

FIXES: b/439845640
