### PR TITLE
Fix the setup.sh script to not block on service restart screen

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,14 @@ export DEBIAN_FRONTEND=noninteractive
 export NEEDRESTART_SUSPEND=1
 export NEEDRESTART_MODE=l
 
+# Enable automatic restart of services without the need for prompting 
+if command -v sudo &> /dev/null
+then
+   sudo sed -i "s/#\$nrconf{restart} = 'i';/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
+else
+   echo "Unable to find sudo. Skipping editing needrestart.conf" 
+fi
+
 apt-get update && apt-get install -y sudo
 (sudo bash || bash) <<'EOF'
 apt update && \


### PR DESCRIPTION
# Description

Bringing back Diwakar's change which was lost

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

n/a

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
