### PR TITLE
fix grpo name

### DIFF
--- a/MaxText/experimental/rl/README.md
+++ b/MaxText/experimental/rl/README.md
@@ -1,10 +1,10 @@
-# Generalized Reinforcement Policy Optimization (GRPO) in MaxText
+# Group Relative Policy Optimization (GRPO) in MaxText
 
 This directory contains code and documentation for **GRPO**, a reinforcement learning algorithm designed to optimize language model policies within the MaxText framework. GRPO enables training language models to perform specific tasks by optimizing for a reward signal, going beyond standard language modeling objectives. This implementation leverages techniques such as **Fully Sharded Data Parallelism (FSDP)** for training and **Data Parallelism (DP) + Tensor Parallelism (TP)** for inference.
 
 ## Key Concepts
 
-*   **GRPO (Generalized Reinforcement Policy Optimization):** A policy optimization algorithm that uses reinforcement learning principles to improve the quality of a language model's responses based on a provided reward signal.
+*   **GRPO (Group Relative Policy Optimization):** A policy optimization algorithm that uses reinforcement learning principles to improve the quality of a language model's responses based on a provided reward signal.
 *   **FSDP (Fully Sharded Data Parallelism):** A technique for distributing model parameters across multiple devices during training, allowing for efficient training of large models.
 *   **DP (Data Parallelism):** A technique for distributing data across multiple devices during inference, allowing for efficient inference of large models.
 *   **Sharding:** For more information on sharding, refer to [getting_started/Sharding.md](https://github.com/AI-Hypercomputer/maxtext/blob/main/getting_started/Sharding.md)


### PR DESCRIPTION
# Description

Fix incorrect expansion of the acronym GRPO in the `MaxText/experimental/rl/README.md`.
Changed from Generalized Reinforcement Policy Optimization → Group Relative Policy Optimization.

This is a minor documentation fix; no code changes are involved.

# Tests

No tests needed since this is a doc-only change.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X]  Self-reviewed the change.
- [X] Confirmed the correct name is now consistently used.
