### PR TITLE
Add an option to save a checkpoint on completion

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -44,6 +44,7 @@ load_full_state_path: ""
 # async_checkpointing is true, else a synchronous one is used. If you have
 # problems with the checkpointer we recommend trying the synchronous one.
 enable_checkpointing: True
+save_checkpoint_on_completion: True
 async_checkpointing: True
 checkpoint_period: 10_000
 # enables one replica to read the ckpt then broadcast to the rest

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -698,8 +698,9 @@ def train_loop(config, recorder, state=None):
 
       metric_logger.buffer_and_write_train_metrics(metrics, step, step_time_delta)
 
-    state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]
-    checkpointing.maybe_save_checkpoint(checkpoint_manager, state_to_save, config, data_iterator)
+    if config.save_checkpoint_on_completion:
+      state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]
+      checkpointing.maybe_save_checkpoint(checkpoint_manager, state_to_save, config, data_iterator)
   except exceptions.StopTraining as e:
     max_logging.log(f"Training stopped: {str(e)}")
   finally:


### PR DESCRIPTION
# Description

Add an option to save a checkpoint on completion. The option doesn't change the default behavior but allows skipping the last checkpoint-saving for various purposes (e.g. faster testing).

# Tests

Tested with the new flag being True and False and it works as intended.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
