### PR TITLE
add a check in setup.sh if /etc/needrestart/needrestart.conf exists

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -32,11 +32,10 @@ export NEEDRESTART_SUSPEND=1
 export NEEDRESTART_MODE=l
 
 # Enable automatic restart of services without the need for prompting 
-if command -v sudo &> /dev/null
-then
-   sudo sed -i "s/#\$nrconf{restart} = 'i';/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
+if command -v sudo &> /dev/null && [ -f /etc/needrestart/needrestart.conf ]; then
+    sudo sed -i "s/#\$nrconf{restart} = 'i';/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
 else
-   echo "Unable to find sudo. Skipping editing needrestart.conf" 
+   echo "Skipping editing needrestart.conf"
 fi
 
 echo "Checking Python version..."


### PR DESCRIPTION
# Description

#2216 broke running setup.sh on cloudtop and our partner teams running setup.sh inside a docker image. With this change I'm checking if that file exists first. 

Error: 
```
+ /bin/bash ./setup.sh MODE=stable
sed: can't read /etc/needrestart/needrestart.conf: No such file or directory
```


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

n/a

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
