### PR TITLE
Support Instruct models for checkpoint conversion

### DIFF
--- a/MaxText/utils/ckpt_conversion/to_maxtext.py
+++ b/MaxText/utils/ckpt_conversion/to_maxtext.py
@@ -154,12 +154,23 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"  # Suppress TensorFlow logging
 
+  # Check if the user is using an Instruct version. If so, use the base model architecture
+  for i in range(len(argv)):
+    if argv[i].startswith("model_name="):
+      model_name_arg = argv[i].split("=")[1]
+      model_name_original = model_name_arg
+      if "-Instruct" in model_name_arg:
+        max_logging.log(f"Warning: You want an Instruct version, so we are using the base model architecture instead.")
+        model_name_arg = model_name_arg.replace("-Instruct", "")
+        argv[i] = f"model_name={model_name_arg}"
+      break
+
   config = pyconfig.initialize(argv)
   # check the supported model ids
-  if config.model_name not in HF_IDS:
-    raise ValueError(f"Unsupported model name: {config.model_name}. Supported models are: {list(HF_IDS.keys())}")
+  if model_name_original not in HF_IDS:
+    raise ValueError(f"Unsupported model name: {model_name_original}. Supported models are: {list(HF_IDS.keys())}")
 
-  model_id = HF_IDS[config.model_name]
+  model_id = HF_IDS[model_name_original]
   max_utils.print_system_information()
   if not config.base_output_directory:
     output_directory = f"tmp/{config.run_name}"

--- a/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -446,6 +446,7 @@ HF_MODEL_CONFIGS = {
     "qwen3-14b": qwen3_14b_config,
     "qwen3-32b": qwen3_32b_config,
     "llama3.1-8b": llama31_8b_config,
+    "llama3.1-8b-Instruct": llama31_8b_config,
     "llama3.1-70b": llama31_70b_config,
     "llama3.1-405b": llama31_405b_config,
     "qwen3-30b-a3b": qwen3_30b_a3b_thinking_2507_config,

--- a/MaxText/utils/ckpt_conversion/utils/utils.py
+++ b/MaxText/utils/ckpt_conversion/utils/utils.py
@@ -63,6 +63,7 @@ HF_IDS = {
     "qwen3-14b": "Qwen/Qwen3-14B",
     "qwen3-32b": "Qwen/Qwen3-32B",
     "llama3.1-8b": "meta-llama/Llama-3.1-8B",
+    "llama3.1-8b-Instruct": "meta-llama/Llama-3.1-8B-Instruct",
     "llama3.1-70b": "meta-llama/Llama-3.1-70B",
     "llama3.1-405b": "meta-llama/Llama-3.1-405B",
     "qwen3-30b-a3b": "Qwen/Qwen3-30B-A3B-Thinking-2507",


### PR DESCRIPTION
# Description

Add support to convert Instruction tuned model checkpoints to MaxText from Huggingface, in particular adding Llama3.1-8b-Instruct model.

# Tests

Tested conversion of Llama3.1-8b-Instruct model
```
python -m MaxText.utils.ckpt_conversion.to_maxtext MaxText/configs/base.yml     model_name=llama3.1-8b-Instruct     base_output_directory=gs://yixuannwang-maxtext-logs/llama3.1-8b-Instruct/unscanned     scan_layers=False

python -m MaxText.tests.forward_pass_logit_checker MaxText/configs/base.yml model_name=llama3.1-8b tokenizer_path=assets/tokenizer_llama3.tiktoken tokenizer_type=tiktoken load_parameters_path=gs://yixuannwang-maxtext-logs/llama3.1-8b-Instruct/unscanned/0/items/ per_device_batch_size=1 run_name=ht_test max_prefill_predict_length=8 max_target_length=16 dataset_type=synthetic steps=10 async_checkpointing=false scan_layers=false --hf_model_path=meta-llama/Llama-3.1-8B-Instruct --max_kl_div=0.015 --run_hf_model=True
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
