### PR TITLE
Add assertion to MoE MLP dim

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -178,7 +178,7 @@ norm_topk_prob: False # Boolean to enable the top-k probability normalization. Q
 expert_shard_attention_option: "fsdp"
 
 # deepseek moe
-base_moe_mlp_dim: 7168 # intermediate dimension at MoE layer (use base_mlp_dim if not DeepSeek style)
+base_moe_mlp_dim: 7168 # intermediate dimension at MoE layer. For a fully MoE model, base_mlp_dim must be equal to base_moe_mlp_dim.
 first_num_dense_layers: 0 # number of initial dense layers in the model
 shared_experts: 1
 routed_scaling_factor: 1.0 # scaling factor for routing scores

--- a/MaxText/configs/models/llama4-17b-16e.yml
+++ b/MaxText/configs/models/llama4-17b-16e.yml
@@ -23,7 +23,7 @@ base_emb_dim: 5120
 base_num_decoder_layers: 48
 base_num_query_heads: 40
 base_num_kv_heads: 8
-base_mlp_dim: 16384
+base_mlp_dim: 8192
 base_moe_mlp_dim: 8192
 vocab_size: 202048
 normalization_layer_epsilon: 1e-05

--- a/MaxText/configs/models/mixtral-8x22b.yml
+++ b/MaxText/configs/models/mixtral-8x22b.yml
@@ -19,6 +19,7 @@ base_emb_dim: 6144
 base_num_query_heads: 48
 base_num_kv_heads: 8
 base_mlp_dim: 16384
+base_moe_mlp_dim: 16384
 base_num_decoder_layers: 56
 head_dim: 128
 mlp_activations: ["silu","linear"]

--- a/MaxText/configs/models/mixtral-8x7b.yml
+++ b/MaxText/configs/models/mixtral-8x7b.yml
@@ -19,6 +19,7 @@ base_emb_dim: 4096
 base_num_query_heads: 32
 base_num_kv_heads: 8
 base_mlp_dim: 14336
+base_moe_mlp_dim: 14336
 base_num_decoder_layers: 32
 head_dim: 128
 mlp_activations: ["silu","linear"]

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -207,6 +207,7 @@ def validate_keys(keys):
 
   validate_multiple_slices(keys)
   if keys["num_experts"] > 1:
+    validate_mlp_dim(keys)
     validate_sparse_matmul_parallelism(keys)
     validate_ragged_dot(keys)
     validate_deepseek_moe(keys)
@@ -971,6 +972,14 @@ def validate_deepseek_moe(raw_keys):
       raise ValueError(
           f'config num_experts: {raw_keys["num_experts"]} must be divisible by n_routing_groups: {raw_keys["n_routing_groups"]}'
       )
+
+def validate_mlp_dim(raw_keys):
+  """Validates that MLP dimensions are consistent for fully MoE models."""
+  is_fully_moe_model = (raw_keys["interleave_moe_layer_step"] == 1 and raw_keys["first_num_dense_layers"] == 0)
+  base_mlp_dim = raw_keys["base_mlp_dim"]
+  base_moe_mlp_dim = raw_keys["base_moe_mlp_dim"]
+  if is_fully_moe_model and (base_mlp_dim != base_moe_mlp_dim):
+      raise ValueError(f'For a fully MoE model, base_mlp_dim must be equal to base_moe_mlp_dim. Received base_mlp_dim={base_mlp_dim} and base_moe_mlp_dim={base_moe_mlp_dim}.')
 
 
 def validate_sparse_matmul_parallelism(raw_keys):


### PR DESCRIPTION
# Description

For pure MoE architecture, add assertion to avoid conflicts from base_mlp_dim and base_moe_mlp_dim configs. Fix b/440352365. 

# Tests

**Expect no tflops changes for those MoE models.**

with `per_device_batch_size=12, max_target_length=2048`:

```
llama2-7b (dense as baseline)
before: Total TFLOPs per device per step: 1013.835620155392
after: Total TFLOPs per device per step: 1013.835620155392

mixtral-8x7b
before: Total TFLOPs per device per step: 1919.438064451584
after: Total TFLOPs per device per step: 1919.438064451584

mixtral-8x22b
before: Total TFLOPs per device per step: 5848.708222550015
after: Total TFLOPs per device per step: 5848.708222550015

deepseek2-16b
before: Total TFLOPs per device per step: 382.33369372262405
after: Total TFLOPs per device per step: 382.33369372262405

deepseek3-671b
before: Total TFLOPs per device per step: 5777.786501332992
after: Total TFLOPs per device per step: 5777.786501332992

llama4-17b-16e
before: Total TFLOPs per device per step: 2453.8490339328
after: Total TFLOPs per device per step: 2453.8490339328

llama4-17b-128e
before: Total TFLOPs per device per step: 2455.58849568768
after: Total TFLOPs per device per step: 2455.58849568768

qwen3-235b-a22b
before: Total TFLOPs per device per step: 3412.8239630745597
after: Total TFLOPs per device per step: 3412.8239630745597

qwen3-480b-a35b
before: Total TFLOPs per device per step: 5323.274808459264
after: Total TFLOPs per device per step: 5323.274808459264
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
