### PR TITLE
Add vocabulary tiling to reduce redundant memory

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -341,6 +341,7 @@ logical_axis_rules: [
                       ['activation_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_batch_no_exp', ['data', 'fsdp', 'fsdp_transpose']],
                       ['activation_embed_and_logits_batch', ['data', 'stage', 'fsdp', 'fsdp_transpose', 'expert']],
+                      ['activation_embed_and_logits_batch_sequence', ['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'context', 'expert']],
                       ['activation_heads', ['tensor', 'tensor_transpose', 'sequence','tensor_sequence','autoregressive']],
                       ['activation_kv_heads', ['tensor', 'tensor_transpose', 'sequence','tensor_sequence']],
                       ['activation_length', ['sequence', 'context', 'expert']],
@@ -451,6 +452,13 @@ ici_expert_parallelism: 1
 # The number of TPU slices is automatically determined, you should not set this explicitly. For ahead of time compilation,
 # you should set compile_toplogy_num_slices, which will in turn set this value. For non-TPU environments this is set to 1.
 num_slices: -1
+
+# Vocab Tiling Configs
+# Enables a memory-saving optimization by computing the cross-entropy loss in chunks.
+# The logits are tiled into `num_vocab_tiling` parts along the batch-sequence axis,
+# reducing peak memory usage. This is highly recommended for models with large
+# vocabularies (e.g., Gemma). Set to a value greater than 1 to enable.
+num_vocab_tiling: 1
 
 # Tokenizer
 vocab_size: 32_000 # powers of 2 for sharding

--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -610,7 +610,7 @@ class Decoder(nn.Module):
       )  # We do not quantize the logits matmul.
     if self.model_mode in (MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE):
       logits = nn.with_logical_constraint(logits, (None, None, "activation_vocab"))
-    else:
+    elif cfg.num_vocab_tiling == 1:
       logits = nn.with_logical_constraint(
           logits, ("activation_embed_and_logits_batch", "activation_length_no_exp", "activation_vocab")
       )
@@ -825,7 +825,13 @@ class Decoder(nn.Module):
     # After the final transformer layer, `y` holds the raw, un-normalized hidden state.
     hidden_state = y
 
-    logits = self._apply_output_head(shared_embedding, hidden_state, deterministic)
+    # When vocab tiling is enabled in training mode, full logits won't generate to reduce memory
+    # Instead, we keep track on the hidden states, which has smaller size compared to full logits
+    if cfg.num_vocab_tiling > 1 and self.model_mode == MODEL_MODE_TRAIN:
+      logits = None
+      self.sow('intermediates', 'hidden_states', hidden_state)
+    else:
+      logits = self._apply_output_head(shared_embedding, hidden_state, deterministic)
 
     # The API of the Decoder is now a tuple, providing both the main output
     # and the raw hidden state needed for auxiliary tasks.

--- a/src/MaxText/layers/models.py
+++ b/src/MaxText/layers/models.py
@@ -94,6 +94,18 @@ class TransformerLinenPure(nn.Module):
           config=self.config, mesh=self.mesh, name="mtp_block", transformer_layer_module=mtp_layer, decoder=self.decoder
       )
 
+  def logits_from_hidden_states(self, hidden_states, deterministic):
+    """
+    Compute logits from hidden states (wrapping decoder._apply_output_head).
+    This function is only used for vocabulary tiling.
+    """
+    logits = self.decoder._apply_output_head(
+        shared_embedding=self.shared_embedding,
+        y=hidden_states,
+        deterministic=deterministic,
+    )
+    return logits
+
   def __call__(
       self,
       decoder_input_tokens: jnp.ndarray,
@@ -249,7 +261,7 @@ class Transformer(nnx.Module):
 
     decoder_linen = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
     self.decoder = nnx_wrappers.ToNNX(decoder_linen, rngs=rngs)
-
+    self.hidden_states = None
     if self.model_mode == MODEL_MODE_PREFILL:
       seq_len = cfg.max_prefill_predict_length
     elif self.model_mode == MODEL_MODE_AUTOREGRESSIVE:
@@ -348,6 +360,10 @@ class Transformer(nnx.Module):
         bidirectional_mask=bidirectional_mask,
         image_embeddings=image_embeddings,
     )
+
+    # Materialize hidden state when vocab tiling is enabled
+    if self.config.num_vocab_tiling > 1:
+      self.hidden_states = hidden_state
 
     # If we are initializing the model AND MTP is enabled, we must create
     # dummy target tensors. This allows Flax to trace the MTPBlock and create

--- a/src/MaxText/maxtext_utils.py
+++ b/src/MaxText/maxtext_utils.py
@@ -1415,3 +1415,182 @@ def all_gather_over_fsdp(variables, sharding_info, mesh, logical_axis_rules):
   # Apply the constraint to the model's current variables. This tells JAX to
   # gather the weights into this layout.
   return jax.lax.with_sharding_constraint(variables, physical_constraint_no_fsdp)
+
+
+# Vocab Tiling Helper Functions
+def compute_loss_nnx(intermediate_outputs, logits, data, config, model, params, is_train):
+  one_hot_targets = jax.nn.one_hot(data["targets"], config.vocab_size)
+  xent, _ = max_utils.cross_entropy_with_logits(logits, one_hot_targets, 0.0)
+  xent = nn.with_logical_constraint(xent, ("activation_embed_and_logits_batch", "activation_length"))
+  # Mask out paddings at the end of each example.
+  xent = xent * (data["targets_segmentation"] != 0)
+  total_loss = jnp.sum(xent)
+  return total_loss
+
+
+def compute_loss_linen(intermediate_outputs, logits, data, config, model, params, is_train):
+  if config.num_vocab_tiling > 1:
+    hidden_state_key = ("intermediates", "decoder", "hidden_states")
+    hidden_states = get_nested_value(intermediate_outputs, hidden_state_key)[0]
+    total_loss = get_vocab_tiling_loss_linen(hidden_states, data, config, model, params, is_train)
+  else:
+    one_hot_targets = jax.nn.one_hot(data["targets"], config.vocab_size)
+    xent, _ = max_utils.cross_entropy_with_logits(logits, one_hot_targets, 0.0)
+    xent = nn.with_logical_constraint(xent, ("activation_embed_and_logits_batch", "activation_length"))
+    # Mask out paddings at the end of each example.
+    xent = xent * (data["targets_segmentation"] != 0)
+    total_loss = jnp.sum(xent)
+  return total_loss
+
+
+def get_vocab_tiling_loss_linen(
+    hidden_states,
+    data,
+    config,
+    model,
+    params,
+    is_train,
+):
+  labels = data["targets"]
+  segmentation = data["targets_segmentation"]
+  deterministic = not config.enable_dropout if is_train else True
+
+  param_spec= nn.get_partition_spec(params)
+  hidden_spec = jax.sharding.NamedSharding(model.mesh, nn.logical_to_mesh_axes(("activation_embed_and_logits_batch", "activation_length_no_exp", "activation_embed")))
+  label_spec = jax.sharding.NamedSharding(model.mesh, nn.logical_to_mesh_axes(("activation_embed_and_logits_batch", "activation_length_no_exp")))
+  reshaped_hidden_spec = jax.sharding.NamedSharding(model.mesh, nn.logical_to_mesh_axes(("num_tile", 'activation_embed_and_logits_batch_sequence', "activation_embed")))
+  reshaped_data_spec = jax.sharding.NamedSharding(model.mesh, nn.logical_to_mesh_axes(("num_tile", 'activation_embed_and_logits_batch_sequence')))
+  chunked_hidden_spec = jax.sharding.NamedSharding(model.mesh, nn.logical_to_mesh_axes(('activation_embed_and_logits_batch_sequence', "activation_embed")))
+  chunked_data_spec = jax.sharding.NamedSharding(model.mesh, nn.logical_to_mesh_axes(('activation_embed_and_logits_batch_sequence',)))
+  chunked_logits_spec = jax.sharding.NamedSharding(model.mesh, nn.logical_to_mesh_axes(('activation_embed_and_logits_batch_sequence', "activation_vocab")))
+  
+  hidden_states = jax.lax.with_sharding_constraint(hidden_states, hidden_spec)
+  labels = jax.lax.with_sharding_constraint(labels, label_spec)
+  segmentation = jax.lax.with_sharding_constraint(segmentation, label_spec)
+  #TODO (chengnuojin) all gather only embedding table instead of all params after NNX module is enabled
+  gathered_params = all_gather_over_fsdp(params, param_spec, model.mesh, config.logical_axis_rules)
+
+  # Customized forward and backward maps for the embedding tiling
+  @jax.custom_vjp
+  def chunked_cross_entropy_loss(gathered_params, hidden_states, labels, segmentation):
+      """
+      Calculates the total cross-entropy loss using vocab tiling.
+      """
+      total_loss, _ = _chunked_cross_entropy_loss_fwd(gathered_params, hidden_states, labels, segmentation)
+      return total_loss
+
+
+  def _chunked_cross_entropy_loss_fwd(gathered_params, hidden_states, labels, segmentation):
+      batch_size, seq_len, emb_dim = hidden_states.shape
+      vocab_tile_size = (batch_size * seq_len) // config.num_vocab_tiling
+
+      reshaped_hidden_states = hidden_states.reshape((config.num_vocab_tiling, vocab_tile_size, emb_dim))
+      reshaped_hidden_states = jax.lax.with_sharding_constraint(reshaped_hidden_states, reshaped_hidden_spec)
+      reshaped_labels = labels.reshape((config.num_vocab_tiling, vocab_tile_size))
+      reshaped_labels = jax.lax.with_sharding_constraint(reshaped_labels, reshaped_data_spec)
+      reshaped_segmentation = segmentation.reshape((config.num_vocab_tiling, vocab_tile_size))
+      reshaped_segmentation = jax.lax.with_sharding_constraint(reshaped_segmentation, reshaped_data_spec)
+      
+      # Scan body accumulates loss from each tile given chunked hidden states and labels
+      def _fwd_scan_body(loss_accumulator, chunk_data):
+          hidden_chunk, label_chunk, segmentation_chunk = chunk_data
+          hidden_chunk = jax.lax.with_sharding_constraint(hidden_chunk, chunked_hidden_spec)
+          label_chunk = jax.lax.with_sharding_constraint(label_chunk, chunked_data_spec)
+          segmentation_chunk = jax.lax.with_sharding_constraint(segmentation_chunk, chunked_data_spec)
+
+          # Calculate logits for the current chunk
+          chunk_logits = model.apply(
+              {'params': gathered_params['params']},
+              hidden_chunk,
+              deterministic=deterministic,
+              method='logits_from_hidden_states'
+          )
+          chunk_logits = jax.lax.with_sharding_constraint(chunk_logits, chunked_logits_spec)
+          one_hot_label_chunk = jax.nn.one_hot(label_chunk, config.vocab_size)
+          chunk_xent, _ = max_utils.cross_entropy_with_logits(chunk_logits, one_hot_label_chunk, 0.0)
+          masked_xent = jnp.sum(chunk_xent * (segmentation_chunk != 0))
+          loss_accumulator += masked_xent
+          return loss_accumulator, None
+
+      initial_loss = 0.0
+      total_loss, _ = jax.lax.scan(
+          _fwd_scan_body,
+          initial_loss,
+          (reshaped_hidden_states, reshaped_labels, reshaped_segmentation)
+      )
+      residuals = (gathered_params, reshaped_hidden_states, reshaped_labels, reshaped_segmentation, batch_size, seq_len, emb_dim)
+
+      return total_loss, residuals
+
+  def _chunked_cross_entropy_loss_bwd(residuals, loss_cotangent):
+    gathered_params, reshaped_hidden_states, reshaped_labels, reshaped_segmentation, batch_size, seq_len, emb_dim = residuals
+    
+    def _single_chunk_loss_fn(input_params, input_hidden_chunk, input_label_chunk, input_segmentation_chunk):
+      chunk_logits = model.apply(
+          {'params': input_params['params']},
+          input_hidden_chunk,
+          deterministic=deterministic,
+          method='logits_from_hidden_states'
+      )
+      chunk_logits = jax.lax.with_sharding_constraint(chunk_logits, chunked_logits_spec)
+      one_hot_label_chunk = jax.nn.one_hot(input_label_chunk, config.vocab_size)
+      xent, _ = max_utils.cross_entropy_with_logits(chunk_logits, one_hot_label_chunk, 0.0)
+      return jnp.sum(xent * (input_segmentation_chunk != 0))
+
+    def _bwd_scan_body(grad_params_acc, chunk_data):
+      hidden_chunk, label_chunk, segmentation_chunk = chunk_data
+        
+      # Apply sharding constraints to the chunk data
+      hidden_chunk = jax.lax.with_sharding_constraint(hidden_chunk, chunked_hidden_spec)
+      label_chunk = jax.lax.with_sharding_constraint(label_chunk, chunked_data_spec)
+      segmentation_chunk = jax.lax.with_sharding_constraint(segmentation_chunk, chunked_data_spec)
+
+      # Create a loss function closure that captures the current chunk's labels and segmentation.
+      # This gives `jax.vjp` a function with the required signature: `loss(params, hidden_states)`.
+      loss_fn_for_vjp = lambda p, h: _single_chunk_loss_fn(p, h, label_chunk, segmentation_chunk)
+      
+      # Get the vector-Jacobian product function wrt both params and hidden states
+      _, vjp_fn = jax.vjp(loss_fn_for_vjp, gathered_params, hidden_chunk)
+      
+      # 1.0 since total_loss is sum of all individual chunked loss
+      (grad_params_update, grad_hidden_chunk) = vjp_fn(1.0)
+      grad_hidden_chunk = jax.lax.with_sharding_constraint(grad_hidden_chunk, chunked_hidden_spec)
+      
+      grad_params_acc = jax.tree_util.tree_map(
+          lambda acc, update: acc + update, grad_params_acc, grad_params_update,
+      )
+      return grad_params_acc, grad_hidden_chunk
+
+    initial_grad_params_acc = jax.tree_util.tree_map(jnp.zeros_like, gathered_params)
+
+    # The scan now returns the total gradients for the params in the final carry
+    grad_params, grad_reshaped_hidden_states = jax.lax.scan(
+        _bwd_scan_body,
+        initial_grad_params_acc,
+        (reshaped_hidden_states, reshaped_labels, reshaped_segmentation)
+    )
+    grad_reshaped_hidden_states = jax.lax.with_sharding_constraint(grad_reshaped_hidden_states, reshaped_hidden_spec)
+    # TODO (chengnuojin): we may want to convert grad_params to bf16 to save memory
+    # grad_params = jax.tree_util.tree_map(lambda x, y: y.astype(x.dtype), gathered_params, grad_params)
+    # Chain-rule to accumulate gradients
+    grad_params = jax.tree_util.tree_map(lambda g: g * loss_cotangent, grad_params)
+    # Give back sharding constraint
+    grad_reshaped_hidden_states = grad_reshaped_hidden_states.reshape((batch_size, seq_len, emb_dim))
+    grad_reshaped_hidden_states = jax.lax.with_sharding_constraint(grad_reshaped_hidden_states, hidden_spec)
+    return (
+      grad_params, # grad for params
+      grad_reshaped_hidden_states.astype(reshaped_hidden_states.dtype),
+      None, # grad for reshaped_labels
+      None, # grad for reshaped_segmentation
+    )
+
+  chunked_cross_entropy_loss.defvjp(_chunked_cross_entropy_loss_fwd, _chunked_cross_entropy_loss_bwd)
+
+  total_loss = chunked_cross_entropy_loss(
+    gathered_params,
+    hidden_states,
+    labels,
+    segmentation,
+  )
+
+  return total_loss

--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -155,6 +155,17 @@ def validate_expert_shard_attention_option(expert_shard_attention_option: str) -
     raise ValueError(
         f"Invalid expert_shard_attention_option was passed. Got: {expert_shard_attention_option}. Valid options: {valid_expert_shard_attention_option}"
     )
+    
+    
+def validate_vocab_tiling(num_vocab_tiling: int, per_device_batch_size: int, max_target_length: int, enable_nnx: bool):
+  if (per_device_batch_size * max_target_length) % num_vocab_tiling != 0:
+    raise ValueError(
+      "Per device batch size times sequence length should be divisible by the number of vocab tiles."
+    )
+  if num_vocab_tiling > 1 and enable_nnx: #TODO (chengnuojin) enable vocab tiling on NNX after NNX migration
+    raise ValueError(
+      "We currently don't support vocab tiling on NNX module."
+    )
 
 
 def validate_keys(keys):
@@ -170,6 +181,7 @@ def validate_keys(keys):
   validate_model_call_mode(keys["model_call_mode"])
   validate_prefill_and_target_lengths(keys["max_prefill_predict_length"], keys["max_target_length"])
   validate_rope_type(keys["rope_type"])
+  validate_vocab_tiling(keys["num_vocab_tiling"], keys["per_device_batch_size"], keys["max_target_length"], keys["enable_nnx"])
 
   # TODO remove after b/435512699 resolved
   if keys["context_parallel_size"] > 1 and keys["context_parallel_load_balance"] and keys["attention_type"] == "chunk":

--- a/tests/vocab_tiling_test.py
+++ b/tests/vocab_tiling_test.py
@@ -1,0 +1,412 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Tests for verifying losses and gradients match using/without using vocab tiling."""
+
+import unittest
+import pytest
+import os
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh
+from flax.core import freeze
+
+from MaxText import maxtext_utils
+from MaxText.maxtext_utils import compute_loss_linen
+from MaxText.common_types import Config
+from MaxText.globals import MAXTEXT_PKG_DIR
+from MaxText import pyconfig
+from MaxText.common_types import MODEL_MODE_TRAIN
+from MaxText.layers import models
+from MaxText.layers import quantizations
+
+
+class LossAndGradientCorrectnessTest(unittest.TestCase):
+  """
+  Unit tests for verifying loss and gradient correctness of vocabulary tiling.
+  """
+
+  def setUp(self):
+    """
+    Set up common configurations and dummy data for the tests.
+    """
+    self.base_config = [None, os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")]
+    self.rng = jax.random.PRNGKey(1234)
+    self.batch_size = 1
+    self.seq_len = 64
+    self.dummy_inputs = jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32)
+    self.rtol = 1e-2
+
+  def get_grads(self, cfg: Config, params, data):
+    """
+    Computes and returns the gradients for a given configuration and set of parameters.
+    """
+    quant = quantizations.configure_quantization(cfg)
+    devices_array = maxtext_utils.create_device_mesh(cfg)
+    mesh = Mesh(devices_array, cfg.mesh_axes)
+    model = models.transformer_as_linen(cfg, mesh=mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
+
+    @jax.jit
+    def grad_fn(p, d):
+      def loss_fn(train_params):
+        logits, intermediate_outputs = model.apply(
+            train_params,
+            decoder_input_tokens=self.dummy_inputs,
+            decoder_positions=self.dummy_inputs,
+            mutable=['intermediates']
+        )
+        return compute_loss_linen(
+            intermediate_outputs, logits, d, cfg, model, train_params, is_train=True
+        )
+      return jax.value_and_grad(loss_fn)(p)
+
+    return grad_fn(params, data)
+
+  @pytest.mark.tpu_only
+  def test_tiling_gradient_non_tied_embedding(self):
+    """
+    Tests loss and gradient correctness for a model with non-tied embeddings (FSDP).
+    """
+    cfg_non_tiling = pyconfig.initialize(
+        self.base_config,
+        run_name="grad_test_non_tied_no_tiling",
+        enable_checkpointing=False,
+        enable_dropout=False,
+        max_target_length=self.seq_len,
+        per_device_batch_size=self.batch_size,
+        logits_via_embedding=False,
+        base_num_decoder_layers=0,
+        dtype='float32',
+        matmul_precision='high',
+        num_vocab_tiling=1,
+    )
+    quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
+    devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
+    mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)
+    model_non_tiling = models.transformer_as_linen(cfg_non_tiling, mesh=mesh_non_tiling, quant=quant_non_tiling, model_mode=MODEL_MODE_TRAIN)
+    
+    rng_model, rng_targets = jax.random.split(self.rng)
+
+    params = model_non_tiling.init(
+        {"params": rng_model, "dropout": rng_model},
+        self.dummy_inputs,
+        self.dummy_inputs,
+    )
+
+    data = {
+        "targets": jax.random.randint(rng_targets, (self.batch_size, self.seq_len), 0, cfg_non_tiling.vocab_size),
+        "targets_segmentation": jnp.ones((self.batch_size, self.seq_len)),
+    }
+
+    loss_non_tiling, grads_non_tiling = self.get_grads(cfg_non_tiling, params, data)
+
+    cfg_tiling = pyconfig.initialize(
+        self.base_config,
+        run_name="value_and_grad_test_non_tied_with_tiling",
+        enable_checkpointing=False,
+        enable_dropout=False,
+        max_target_length=self.seq_len,
+        per_device_batch_size=self.batch_size,
+        logits_via_embedding=False,
+        base_num_decoder_layers=0,
+        dtype='float32',
+        matmul_precision='high',
+        num_vocab_tiling=4,
+    )
+    loss_tiling, grads_tiling = self.get_grads(cfg_tiling, params, data)
+    # Loss correctness test
+    assert jnp.allclose(
+      loss_non_tiling,
+      loss_tiling,
+      rtol=self.rtol
+    ), "Losses do not match for non-tied embeddings."
+
+    # Gradient correctness test
+    assert jnp.allclose(
+        grads_non_tiling['params']['decoder']['logits_dense']['kernel'].unbox(),
+        grads_tiling['params']['decoder']['logits_dense']['kernel'].unbox(),
+        rtol=self.rtol
+    ), "Gradients of embedding table do not match for non-tied embeddings."
+
+  @pytest.mark.tpu_only
+  def test_tiling_gradient_tied_embedding(self):
+    """
+    Tests loss and gradient correctness for a model with tied embeddings (FSDP).
+    """
+    cfg_non_tiling = pyconfig.initialize(
+        self.base_config,
+        run_name="value_and_grad_test_tied_no_tiling",
+        enable_checkpointing=False,
+        max_target_length=self.seq_len,
+        per_device_batch_size=self.batch_size,
+        logits_via_embedding=True,
+        base_num_decoder_layers=0,
+        dtype='float32',
+        matmul_precision='high',
+        num_vocab_tiling=1,
+    )
+
+    quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
+    devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
+    mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)
+    model_non_tiling = models.transformer_as_linen(cfg_non_tiling, mesh=mesh_non_tiling, quant=quant_non_tiling, model_mode=MODEL_MODE_TRAIN)
+
+    rng_model, rng_targets = jax.random.split(self.rng)
+
+    params = model_non_tiling.init(
+        {"params": rng_model, "dropout": rng_model},
+        self.dummy_inputs,
+        self.dummy_inputs,
+    )
+
+    data = {
+        "targets": jax.random.randint(rng_targets, (self.batch_size, self.seq_len), 0, cfg_non_tiling.vocab_size),
+        "targets_segmentation": jnp.ones((self.batch_size, self.seq_len)),
+    }
+
+    loss_non_tiling, grads_non_tiling = self.get_grads(cfg_non_tiling, params, data)
+
+    cfg_tiling = pyconfig.initialize(
+        self.base_config,
+        run_name="grad_test_tied_with_tiling",
+        enable_checkpointing=False,
+        max_target_length=self.seq_len,
+        per_device_batch_size=self.batch_size,
+        logits_via_embedding=True,
+        base_num_decoder_layers=0,
+        dtype='float32',
+        matmul_precision='high',
+        num_vocab_tiling=4,
+    )
+    loss_tiling, grads_tiling = self.get_grads(cfg_tiling, params, data)
+
+    assert jnp.allclose(
+      loss_non_tiling,
+      loss_tiling,
+      rtol=self.rtol
+    ), "Losses do not match for tied embeddings."
+
+    assert jnp.allclose(
+        grads_non_tiling['params']['token_embedder']['embedding'].unbox(),
+        grads_tiling['params']['token_embedder']['embedding'].unbox(),
+        rtol=self.rtol
+    ), "Gradients of embedding table do not match for tied embeddings."
+
+
+  @pytest.mark.tpu_only
+  def test_tiling_gradient_data_parallelism(self):
+    """
+    Tests loss and gradient correctness for data parallelism sharding.
+    """
+    cfg_non_tiling = pyconfig.initialize(
+        self.base_config,
+        run_name="value_and_grad_test_dp_non_tiling",
+        enable_checkpointing=False,
+        enable_dropout=False,
+        max_target_length=self.seq_len,
+        per_device_batch_size=self.batch_size,
+        ici_data_parallelism=4,
+        base_num_decoder_layers=0,
+        dtype='float32',
+        matmul_precision='high',
+        num_vocab_tiling=1,
+    )
+    quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
+    devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
+    mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)
+    model_non_tiling = models.transformer_as_linen(cfg_non_tiling, mesh=mesh_non_tiling, quant=quant_non_tiling, model_mode=MODEL_MODE_TRAIN)
+    
+    rng_model, rng_targets = jax.random.split(self.rng)
+
+    params = model_non_tiling.init(
+        {"params": rng_model, "dropout": rng_model},
+        self.dummy_inputs,
+        self.dummy_inputs,
+    )
+
+    data = {
+        "targets": jax.random.randint(rng_targets, (self.batch_size, self.seq_len), 0, cfg_non_tiling.vocab_size),
+        "targets_segmentation": jnp.ones((self.batch_size, self.seq_len)),
+    }
+
+    loss_non_tiling, grads_non_tiling = self.get_grads(cfg_non_tiling, params, data)
+
+    cfg_tiling = pyconfig.initialize(
+        self.base_config,
+        run_name="value_and_grad_test_dp_tiling",
+        enable_checkpointing=False,
+        enable_dropout=False,
+        max_target_length=self.seq_len,
+        per_device_batch_size=self.batch_size,
+        logits_via_embedding=False,
+        base_num_decoder_layers=0,
+        dtype='float32',
+        matmul_precision='high',
+        ici_data_parallelism=4,
+        num_vocab_tiling=4,
+    )
+    loss_tiling, grads_tiling = self.get_grads(cfg_tiling, params, data)
+    # Loss correctness test
+    assert jnp.allclose(
+      loss_non_tiling,
+      loss_tiling,
+      rtol=self.rtol
+    ), "Losses do not match for data parallelism."
+
+    # Gradient correctness test
+    assert jnp.allclose(
+        grads_non_tiling['params']['decoder']['logits_dense']['kernel'].unbox(),
+        grads_tiling['params']['decoder']['logits_dense']['kernel'].unbox(),
+        rtol=self.rtol
+    ), "Gradients of embedding table do not match for data parallelism."
+
+
+  @pytest.mark.tpu_only
+  def test_tiling_gradient_tensor_parallelism(self):
+    """
+    Tests loss and gradient correctness for tensor parallelism sharding.
+    """
+    cfg_non_tiling = pyconfig.initialize(
+        self.base_config,
+        run_name="value_and_grad_test_tp_non_tiling",
+        enable_checkpointing=False,
+        enable_dropout=False,
+        max_target_length=self.seq_len,
+        per_device_batch_size=self.batch_size,
+        ici_tensor_parallelism=4,
+        base_num_decoder_layers=0,
+        dtype='float32',
+        matmul_precision='high',
+        num_vocab_tiling=1,
+    )
+    quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
+    devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
+    mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)
+    model_non_tiling = models.transformer_as_linen(cfg_non_tiling, mesh=mesh_non_tiling, quant=quant_non_tiling, model_mode=MODEL_MODE_TRAIN)
+    
+    rng_model, rng_targets = jax.random.split(self.rng)
+
+    params = model_non_tiling.init(
+        {"params": rng_model, "dropout": rng_model},
+        self.dummy_inputs,
+        self.dummy_inputs,
+    )
+
+    data = {
+        "targets": jax.random.randint(rng_targets, (self.batch_size, self.seq_len), 0, cfg_non_tiling.vocab_size),
+        "targets_segmentation": jnp.ones((self.batch_size, self.seq_len)),
+    }
+
+    loss_non_tiling, grads_non_tiling = self.get_grads(cfg_non_tiling, params, data)
+
+    cfg_tiling = pyconfig.initialize(
+        self.base_config,
+        run_name="value_and_grad_test_tp_tiling",
+        enable_checkpointing=False,
+        enable_dropout=False,
+        max_target_length=self.seq_len,
+        per_device_batch_size=self.batch_size,
+        logits_via_embedding=False,
+        base_num_decoder_layers=0,
+        dtype='float32',
+        matmul_precision='high',
+        ici_tensor_parallelism=4,
+        num_vocab_tiling=4,
+    )
+    loss_tiling, grads_tiling = self.get_grads(cfg_tiling, params, data)
+    # Loss correctness test
+    assert jnp.allclose(
+      loss_non_tiling,
+      loss_tiling,
+      rtol=self.rtol
+    ), "Losses do not match for tensor parallelism."
+
+    # Gradient correctness test
+    assert jnp.allclose(
+        grads_non_tiling['params']['decoder']['logits_dense']['kernel'].unbox(),
+        grads_tiling['params']['decoder']['logits_dense']['kernel'].unbox(),
+        rtol=self.rtol
+    ), "Gradients of embedding table do not match for tensor parallelism."
+
+  @pytest.mark.tpu_only
+  def test_tiling_gradient_context_parallelism(self):
+    """
+    Tests loss and gradient correctness for context parallelism sharding.
+    """
+    cfg_non_tiling = pyconfig.initialize(
+        self.base_config,
+        run_name="value_and_grad_test_cp_non_tiling",
+        enable_checkpointing=False,
+        enable_dropout=False,
+        max_target_length=self.seq_len,
+        per_device_batch_size=self.batch_size,
+        ici_context_parallelism=4,
+        base_num_decoder_layers=0,
+        dataset_type='synthetic',
+        packing=False,
+        dtype='float32',
+        matmul_precision='high',
+        num_vocab_tiling=1,
+    )
+    quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
+    devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
+    mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)
+    model_non_tiling = models.transformer_as_linen(cfg_non_tiling, mesh=mesh_non_tiling, quant=quant_non_tiling, model_mode=MODEL_MODE_TRAIN)
+    
+    rng_model, rng_targets = jax.random.split(self.rng)
+
+    params = model_non_tiling.init(
+        {"params": rng_model, "dropout": rng_model},
+        self.dummy_inputs,
+        self.dummy_inputs,
+    )
+
+    data = {
+        "targets": jax.random.randint(rng_targets, (self.batch_size, self.seq_len), 0, cfg_non_tiling.vocab_size),
+        "targets_segmentation": jnp.ones((self.batch_size, self.seq_len)),
+    }
+
+    loss_non_tiling, grads_non_tiling = self.get_grads(cfg_non_tiling, params, data)
+
+    cfg_tiling = pyconfig.initialize(
+        self.base_config,
+        run_name="value_and_grad_test_cp_tiling",
+        enable_checkpointing=False,
+        enable_dropout=False,
+        max_target_length=self.seq_len,
+        per_device_batch_size=self.batch_size,
+        logits_via_embedding=False,
+        base_num_decoder_layers=0,
+        ici_context_parallelism=4,
+        dataset_type='synthetic',
+        packing=False,
+        dtype='float32',
+        matmul_precision='high',
+        num_vocab_tiling=4,
+    )
+    loss_tiling, grads_tiling = self.get_grads(cfg_tiling, params, data)
+
+    # Loss correctness test
+    assert jnp.allclose(
+      loss_non_tiling,
+      loss_tiling,
+      rtol=self.rtol
+    ), "Losses do not match for context parallelism."
+
+    # Gradient correctness test
+    assert jnp.allclose(
+        grads_non_tiling['params']['decoder']['logits_dense']['kernel'].unbox(),
+        grads_tiling['params']['decoder']['logits_dense']['kernel'].unbox(),
+        rtol=self.rtol
+    ), "Gradients of embedding table do not match for context parallelism."


### PR DESCRIPTION
# Description

This PR introduces **vocabulary tiling**, a new feature for MaxText designed to significantly reduce peak memory consumption during training.

This optimization is particularly beneficial for two key scenarios:

1.  **Training large-vocabulary models on limited devices:** It makes it possible to train models like Gemma 2B and Gemma-2 2B, which have large vocabulary sizes, on hardware with limited memory.
2.  **Training with long sequence lengths:** It makes training on long context lengths more feasible by avoiding the need to store the entire, large logits tensor in memory for the final loss computation.

The core idea of vocabulary tiling is to avoid explicitly materializing the full final logits tensor. Instead, the logits activation is chunked (or "tiled") along the batch-sequence dimension.

As illustrated in the diagram below, the forward and backward passes are repeated `num_vocab_tiling` times. In each iteration, a small slice of the logits is computed, used to calculate the loss, and the Vector-Jacobian product is immediately backpropagated. This iterative process avoids holding the complete, memory-intensive logits tensor.


![Illustration of the vocabulary tiling process, showing chunked logits with repeated forward and backward passes.](https://github.com/user-attachments/assets/f8f7beda-488e-4dda-99ad-f540f2c79a0f)
*Figure 1: The vocabulary tiling process. The forward and backward passes are repeated for each tile, preventing the full logits tensor from being stored in memory.*

For a more in-depth technical explanation, please see the design document.

Doc: go/maxtext-vocab-tiling
FIXES: b/429255841

# Tests

## Correctness Tests

Test losses and embedding table gradient differences in `MaxText/tests/vocab_tiling_test.py` with 1\% relative error tolerance in following cases:
- Default non-tied embedding (`logits_via_embedding=False`).
- Tied embedding and default sharding (FSDP).
- Data parallelism.
- Tensor parallelism.
- Context parallelism.

## Performance Tests

See [doc](https://docs.google.com/document/d/1OdjQb-kVO2sVNbNyEwYmVmEFP9Tz_JdEria_aARnNe0/edit?resourcekey=0-xu47ZgKDZMCBxCGEgidnGA&tab=t.0#bookmark=id.3u2uxaamsc6x).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
