### PR TITLE
Interface with Tunix

### DIFF
--- a/MaxText/integration/tunix/tunix_adapter.py
+++ b/MaxText/integration/tunix/tunix_adapter.py
@@ -1,0 +1,66 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Optional, Tuple, Any
+
+from jax import Array
+from flax import nnx
+from MaxText.layers.models import Transformer
+from MaxText.integration.tunix.weight_mapping import VLLM_WEIGHT_MAPPING
+
+class TunixMaxTextAdapter(nnx.Module):
+  """Adapter exposing Tunix Trainer call signature over a Transformer model."""
+
+  def __init__(
+      self,
+      base_model: Transformer,
+  ):
+    super().__init__()
+    self.base = base_model
+
+  # ------------------------------------------------------------------ #
+  # Tunix call signature
+  # ------------------------------------------------------------------ #
+  def __call__(
+      self,
+      input_tokens: Array,  # [B, L]
+      positions: Array,  # [B, L]
+      cache: Optional[Any],  # Tunix currently passes None from Trainers
+      attention_mask: Optional[Array],  # [B, L, L] or None
+      output_hidden_states: bool = False,  # ignored
+  ) -> Tuple[Array, None]:
+    """Forward compatible with Tunix Trainers default loss.
+    Returns logits, None.
+    """
+    logits = self.base(
+        decoder_input_tokens=input_tokens,
+        decoder_positions=positions,
+        # TODO: @mazumdera - add support for packing
+        decoder_segment_ids=None,
+    )
+    return logits, None
+
+  def to_hf_mappings(self):
+    return VLLM_WEIGHT_MAPPING[self.base.config.model_name].to_hf_mapping()
+
+  def to_hf_transpose_keys(self):
+    return VLLM_WEIGHT_MAPPING[self.base.config.model_name].to_hf_transpose_keys()
+
+  def to_hf_hook_fns(self):
+    return VLLM_WEIGHT_MAPPING[self.base.config.model_name].to_hf_hook_fns()
+
+  def lora_to_hf_mappings(self):
+    return VLLM_WEIGHT_MAPPING[self.base.config.model_name].lora_to_hf_mappings()

--- a/MaxText/integration/tunix/weight_mapping/__init__.py
+++ b/MaxText/integration/tunix/weight_mapping/__init__.py
@@ -1,0 +1,33 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from MaxText.integration.tunix.weight_mapping.llama3 import LLAMA3_VLLM_MAPPING
+
+
+class VLLM_WEIGHT_MAPPING:
+  """Mapping MaxText model weights to vLLM's model weights"""
+
+  def __getattr__(self, name):
+    if name.startswith("llama3.1"):
+      return LLAMA3_VLLM_MAPPING
+    else:
+      raise ValueError("{} vLLM weight mapping not found.".format(name))
+
+  def __getitem__(self, key):
+    return getattr(self, key)
+
+  @classmethod
+  def __class_getitem__(cls, key):
+    instance = cls()
+    return instance[key]

--- a/MaxText/integration/tunix/weight_mapping/llama3.py
+++ b/MaxText/integration/tunix/weight_mapping/llama3.py
@@ -1,0 +1,111 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+import numpy as np
+import jax
+
+
+@dataclass
+class LLAMA3_VLLM_MAPPING:
+  """Mapping MaxText Llama 2 and Llama 3 weights to vLLM's Llama 2 and Llama 3 weights."""
+
+  def to_hf_hook_fns():
+
+    def reorder_rope(arr):
+      evens = arr[..., ::2]
+      odds = arr[..., 1::2]
+      return jax.numpy.concatenate((evens, odds), axis=arr.ndim - 1)
+
+    def transform_query_kernel(arr):
+      head_dim = arr.shape[-1]
+      depth_scale = np.dtype("float32").type(np.sqrt(head_dim))
+      arr = arr * depth_scale
+      return reorder_rope(arr)
+
+    hook_fns = {
+        "base.decoder.layers.self_attention.query.kernel": transform_query_kernel,
+        "base.decoder.layers.self_attention.key.kernel": reorder_rope,
+    }
+    return hook_fns
+
+  def to_hf_transpose_keys():
+    return {}
+
+  def lora_to_hf_mappings():
+    return None
+
+  def to_hf_mapping():
+    """
+    Mapping from MaxText model to HuggingFace vLLM model.
+    Currently the param mapping conforms to the Tunix API, which combines the param name and sharding in one dictionary.
+    This is subject to change in the future where we can decouple the two.
+    """
+    return {
+        # Token embeddings - shard vocab dimension
+        "base.token_embedder.embedding": (
+            "model.embed.embedding",
+            ("model", None),
+        ),
+        # Final layer norm - no sharding needed
+        "base.decoder.decoder_norm.scale": (
+            "model.norm.scale",
+            (None,),
+        ),
+        # LM head (logits projection) - shard vocab dimension
+        "base.decoder.logits_dense.kernel": (
+            "model.lm_head",
+            (None, "model"),
+        ),
+        # Layer-specific mappings (scanned -> unscanned)
+        # MLP components - shard hidden dimensions
+        "base.decoder.layers.mlp.wi_0.kernel": (
+            "model.layers.*.mlp.gate_proj.kernel",
+            (None, "layer", "model"),
+        ),
+        "base.decoder.layers.mlp.wi_1.kernel": (
+            "model.layers.*.mlp.up_proj.kernel",
+            (None, "layer", "model"),
+        ),
+        "base.decoder.layers.mlp.wo.kernel": (
+            "model.layers.*.mlp.down_proj.kernel",
+            ("model", "layer", None),
+        ),
+        # Layer norms - no sharding needed
+        "base.decoder.layers.pre_self_attention_layer_norm.scale": (
+            "model.layers.*.input_layernorm.scale",
+            (None, "layer"),
+        ),
+        "base.decoder.layers.post_self_attention_layer_norm.scale": (
+            "model.layers.*.post_attention_layernorm.scale",
+            (None, "layer"),
+        ),
+        # Attention components - shard head dimensions
+        "base.decoder.layers.self_attention.query.kernel": (
+            "model.layers.*.self_attn.q_proj.kernel",
+            (None, "layer", "model", None),
+        ),
+        "base.decoder.layers.self_attention.key.kernel": (
+            "model.layers.*.self_attn.k_proj.kernel",
+            (None, "layer", "model", None),
+        ),
+        "base.decoder.layers.self_attention.value.kernel": (
+            "model.layers.*.self_attn.v_proj.kernel",
+            (None, "layer", "model", None),
+        ),
+        "base.decoder.layers.self_attention.out.kernel": (
+            "model.layers.*.self_attn.o_proj.kernel",
+            ("model", "layer", None, None),
+        ),
+    }

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -24,6 +24,7 @@ import datetime
 
 import jax
 from jax.experimental.compilation_cache import compilation_cache
+from jax.tree_util import register_pytree_node_class
 
 import omegaconf
 
@@ -1177,7 +1178,7 @@ def using_fsdp_and_transpose_parallelism(raw_keys) -> bool:
       or int(raw_keys["dcn_fsdp_transpose_parallelism"]) > 1
   )
 
-
+@register_pytree_node_class
 class HyperParameters:
   """Wrapper class to expose the configuration in a read-only manner."""
 
@@ -1196,6 +1197,14 @@ class HyperParameters:
 
   def get_keys(self):
     return self._config.keys
+  
+
+  def tree_flatten(self):
+    return (), self
+
+  @classmethod
+  def tree_unflatten(cls, aux_data, children):
+    return aux_data
 
 
 def initialize(argv, **kwargs):


### PR DESCRIPTION
# Description

Add a wrapper around MaxText's Transformer (which is NNX module) class to be compatible with Tunix's call function. Also, register `HyperParameters` as `pytree_node_class`. This was needed during checkpoint loading such that Jax doesn't traverse inside the `HyperParameters` class

# Tests

Tested by running 

`python3 grpo_llama3_demo1.py`

on the GRPO script https://github.com/google/tunix/blob/anisha-tunix-grpo-kaggle/examples/grpo_llama3_demo1.py. And compared the outputs before and after the change.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
