### PR TITLE
Integrate Workload Hang Monitoring and Rolling Window Goodput

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -45,7 +45,7 @@ load_full_state_path: ""
 # problems with the checkpointer we recommend trying the synchronous one.
 enable_checkpointing: True
 async_checkpointing: True
-checkpoint_period: 10_000
+checkpoint_period: 20
 # enables one replica to read the ckpt then broadcast to the rest
 enable_single_replica_ckpt_restoring: False
 
@@ -574,14 +574,17 @@ eval_steps: -1  # run this number of steps for eval, recommend setting this to p
 target_eval_loss: 0.  # early stop once reaching target eval_loss
 
 # Goodput parameters
-enable_goodput_recording: False
-monitor_goodput: False
+enable_goodput_recording: True
+enable_goodput_monitoring: True
 goodput_upload_interval_seconds: 30
 enable_pathways_goodput: False
 monitor_step_time_deviation: True
 step_deviation_interval_seconds: 30
 enable_gcp_goodput_metrics: True
 enable_gcp_step_deviation_metrics: True
+# Rolling Window Goodput parameters
+enable_rolling_window_goodput_monitoring: True
+rolling_window_size: [86400, 259200, 432000] # 1d, 3d, 5d
 
 # GCP workload monitoring
 report_heartbeat_metric_for_gcp_monitoring: False

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -73,6 +73,7 @@ from MaxText.utils.goodput_utils import (
     GoodputEvent,
     create_goodput_recorder,
     maybe_monitor_goodput,
+    maybe_monitor_rolling_window_goodput,
     maybe_record_goodput,
 )
 from MaxText.vertex_tensorboard import VertexTensorboardManager
@@ -989,8 +990,7 @@ def main(argv: Sequence[str]) -> None:
   if config.use_vertex_tensorboard or os.environ.get("UPLOAD_DATA_TO_TENSORBOARD"):
     vertex_tensorboard_manager.configure_vertex_tensorboard(config)
 
-  # Goodput configurations
-  maybe_monitor_goodput(config)
+  # Create the Goodput recorder
   recorder = create_goodput_recorder(config)
 
   # Stack traces configurations
@@ -1003,9 +1003,12 @@ def main(argv: Sequence[str]) -> None:
   )
   diagnostic_config = diagnostic_configuration.DiagnosticConfig(debug_config)
 
-  with diagnostic.diagnose(diagnostic_config):
-    with maybe_record_goodput(recorder, GoodputEvent.JOB):
-      train_loop(config, recorder)
+  # maybe_monitor_goodput(config),
+  # with maybe_monitor_goodput(config), maybe_monitor_rolling_window_goodput(config):
+  with maybe_monitor_goodput(config), maybe_monitor_rolling_window_goodput(config):
+    with diagnostic.diagnose(diagnostic_config):
+      with maybe_record_goodput(recorder, GoodputEvent.JOB):
+        train_loop(config, recorder)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR integrates enhancements to our Goodput measurement system, focusing on improved monitoring capabilities such as Workload Hang Monitoring & Rolling Window Goodput Monitoring and increases robustness for long-running training jobs.

Specifically, it adds:
1.  **Workload Hang Monitoring Support:** Detects and flags instances where the training workload might be stuck or unresponsive.
2.  **Rolling Window Goodput Monitoring Support:** Provides insights into goodput over dynamic, recent timeframes, complementing cumulative goodput metrics.
3.  **Final Upload & Safe Exit:** Ensures that all outstanding metrics are flushed and monitoring processes gracefully terminate upon job completion or shutdown.
4.  **More Disruption, Checkpointing & GCS Badput Breakdown:** More Badput Buckets

### Testing

- Rolling Window Goodput [1d, 3d, 5d]: 
![image](https://github.com/user-attachments/assets/84ab50a2-b521-4451-975d-0501d4eeb0c6)
- Workload Hang Monitoring: 
![image](https://github.com/user-attachments/assets/6763cd95-ee2e-4bd2-bb61-255baae33b40)
- Cumulative Goodput: 
![image](https://github.com/user-attachments/assets/9f96c01e-0e6d-4cdd-88b8-316418efab39)
- Cumulative Badput: 
![image](https://github.com/user-attachments/assets/59b7fff0-4450-420c-846c-216396229ec7)

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
