### PR TITLE
Refactor tflops calculation to include gpt-oss

### DIFF
--- a/MaxText/configs/models/gpt-oss-120b.yml
+++ b/MaxText/configs/models/gpt-oss-120b.yml
@@ -46,7 +46,7 @@ num_experts: 128
 num_experts_per_tok: 4
 
 # General
-base_num_decoder_layers: 6 #36
+base_num_decoder_layers: 36
 vocab_size: 201088
 normalization_layer_epsilon: 1.0e-5
 enable_dropout: False


### PR DESCRIPTION
# Description

Refactor tflops calculation to include gpt-oss:
* combine llama and mixtral attention adjustment as one helper function
* add gpt attention adjustment for gpt_oss model with mixed attention parterns

# Tests

* local test & [unit test](https://paste.googleplex.com/4843687485636608)
```
pbs=12, max_target_length=2048

gemma3-4b
* before: 584.149911994368
* after: 584.149911994368

gemma3-12b
* before: 1769.4578064752639
* after: 1769.4578064752639

gpt-oss-20b:
* theory (active, 3.6B): 6BP rule = 6*12*2048*3.6*10^9/10^12 = 530.8416
* report from maxtext: 547.665909645312

gpt-oss-120b:
* theory (active, 5.1B): 6BP rule = 6*12*2048*5.1*10^9/10^12 = 752.0256
* report from maxtext: 780.268185059328
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
