### PR TITLE
Review of "Running MaxText at Scale with XPK" guide

### DIFF
--- a/docs/run_maxtext/run_maxtext_via_xpk.md
+++ b/docs/run_maxtext/run_maxtext_via_xpk.md
@@ -164,7 +164,7 @@ This guide focuses on submitting workloads to an existing cluster. Cluster creat
 
 The examples below run on a single TPU slice (`--num-slices=1`) or a small number of GPU nodes (`--num-nodes=2`). To scale your job to a larger, multi-host configuration, you simply increase these values.
 
-For instance, to run a job across **four TPU slices**, you would change `--num-slices=1` to `--num-slices=4`. This tells XPK to allocate four `v5litepod-256` slices and orchestrate the training job across all of them as a single workload. Similarly, for GPUs, you would increase the `--num-nodes` value.
+For instance, to run a job across **four TPU slices**, you would change `--num-slices=1` to `--num-slices=4`. This tells XPK to allocate four slices and orchestrate the training job across all of them as a single workload. Because `--tpu-type` is set to `v5litepod-256`, it allocates a total of `256*4 = 1,024` chips. Similarly, for GPUs, you would increase the `--num-nodes` value.
 ```
 
 3. **Create the workload (run the job)**


### PR DESCRIPTION
# Description

Follow-up to https://github.com/AI-Hypercomputer/maxtext/pull/2238.

This PR mostly fixes some syntax and rendering issues for the "Running MaxText at Scale with XPK" guide. It includes 
- Replacing a text-based diagram with an SVG;
- Adding some admonition-style blocks for notes and important content in the guide;
- Enabling the "copybutton" Sphinx extension, which adds a nice element to each code-block allowing the reader to copy the code-block contents directly, for convenience;
- Addressing @kyle-meggs ' s suggestion from https://github.com/AI-Hypercomputer/maxtext/pull/2238#discussion_r2305780460;
- Some other quick fixes to prevent the Read The Docs build from failing (might be redundant with some of the work in #2266 )

# Tests

The documentation pages were successfully built locally.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
