### PR TITLE
Add minimal_flash back for backward compatible

### DIFF
--- a/MaxText/layers/decoders.py
+++ b/MaxText/layers/decoders.py
@@ -282,8 +282,10 @@ class Decoder(nn.Module):
     policy = None
     cfg = self.config
     if cfg.remat_policy != "none":
-      if cfg.remat_policy == "minimal_with_context":
+      if cfg.remat_policy in ("minimal_with_context", "minimal_flash"):
         # save all
+        if cfg.remat_policy == "minimal_flash":
+            max_logging.log("WARNING: 'minimal_flash' will be deprecated soon, please use 'minimal_with_context' instead.")
         policy = self.minimal_policy(with_context=True)
       elif cfg.remat_policy == "minimal":
         # save all except context

--- a/end_to_end/gpu/a3/test_llama2_7b.sh
+++ b/end_to_end/gpu/a3/test_llama2_7b.sh
@@ -59,7 +59,7 @@ export XLA_FLAGS="--xla_dump_to=$BASE_OUTPUT_PATH/$RUN_NAME/HLO_dumps/
  --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_enable_reduce_scatter_combine_by_dim=false
  --xla_disable_hlo_passes=rematerialization"
 
-python3 -m MaxText.train MaxText/configs/base.yml run_name=$RUN_NAME hardware=gpu steps=30 dcn_data_parallelism=1 ici_fsdp_parallelism=8 per_device_batch_size=4 max_target_length=4096 model_name=llama2-7b enable_checkpointing=true attention=cudnn_flash_te remat_policy=minimal_flash use_iota_embed=true scan_layers=false dataset_type=synthetic async_checkpointing=${ASYNC_CHECKPOINTING} base_output_directory=$BASE_OUTPUT_DIRECTORY
+python3 -m MaxText.train MaxText/configs/base.yml run_name=$RUN_NAME hardware=gpu steps=30 dcn_data_parallelism=1 ici_fsdp_parallelism=8 per_device_batch_size=4 max_target_length=4096 model_name=llama2-7b enable_checkpointing=true attention=cudnn_flash_te remat_policy=minimal_with_context use_iota_embed=true scan_layers=false dataset_type=synthetic async_checkpointing=${ASYNC_CHECKPOINTING} base_output_directory=$BASE_OUTPUT_DIRECTORY
 
 export XLA_PYTHON_CLIENT_MEM_FRACTION=0.65
 export TF_FORCE_GPU_ALLOW_GROWTH=true

--- a/end_to_end/gpu/test_collective_matmul_llama2_7b.sh
+++ b/end_to_end/gpu/test_collective_matmul_llama2_7b.sh
@@ -49,7 +49,7 @@ python3 -m MaxText.train \
     scan_layers=true \
     monitor_goodput=false \
     enable_goodput_recording=false \
-    remat_policy=minimal_flash \
+    remat_policy=minimal_with_context \
     attention=cudnn_flash_te \
     max_target_length=4096 \
     use_iota_embed=true \

--- a/end_to_end/gpu/test_fp8_gemm_llama2_7b.sh
+++ b/end_to_end/gpu/test_fp8_gemm_llama2_7b.sh
@@ -47,7 +47,7 @@ python3 -m MaxText.train \
     scan_layers=true \
     monitor_goodput=false \
     enable_goodput_recording=false \
-    remat_policy=minimal_flash \
+    remat_policy=minimal_with_context \
     attention=cudnn_flash_te \
     max_target_length=4096 \
     use_iota_embed=true \


### PR DESCRIPTION
# Description

Add minimal_flash config back for backward compatibl:
* please see more [context](https://chat.google.com/room/AAAAc3VtJGo/eJ0EkpleJ6c/eJ0EkpleJ6c?cls=10).
* also noticed 3 missed config.

# Tests

* Expect GitHub runner tests are passing.
* Have a local test to see warning log.

```
TFRT TPU v5
Built on Aug 29 2025 03:15:48 (1756462548) cl/800688264
Num_devices: 4, shape (1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1)
Setting up checkpoint logger...
Checkpointing disabled, not creating checkpoint manager.
WARNING: 'minimal_flash' will be deprecated soon, please use 'minimal_with_context' instead.
No existing checkpoints found, not restoring checkpoint.
```



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
