### PR TITLE
Decouple MLA Projection Initialization from Base Attention Class to fix double initialization issue

### DIFF
--- a/src/MaxText/layers/attentions.py
+++ b/src/MaxText/layers/attentions.py
@@ -468,14 +468,7 @@ class Attention(nnx.Module):
           rngs=self.rngs,
       )
 
-    if self.config.fused_qkv:
-      self.qkv_proj = self.init_qkv_w(inputs_shape=inputs_q_shape)
-    else:
-      self.query = self.init_query_w(inputs_q_shape=inputs_q_shape)
-      self.key = self.init_kv_w(inputs_kv_shape=inputs_kv_shape)
-      self.value = self.init_kv_w(inputs_kv_shape=inputs_kv_shape)
-
-    self.out = self.init_out_w(output_dim=inputs_q_shape[-1])
+    self._init_projections(inputs_q_shape, inputs_kv_shape)
 
     if self.config.attention_sink:
       self.sinks = nnx.Param(
@@ -506,6 +499,16 @@ class Attention(nnx.Module):
     else:
       self.query_norm = None
       self.key_norm = None
+
+  def _init_projections(self, inputs_q_shape: Tuple, inputs_kv_shape: Tuple) -> None:
+    """Initializes the query, key, value, and output projections."""
+    if self.config.fused_qkv:
+      self.qkv_proj = self.init_qkv_w(inputs_shape=inputs_q_shape)
+    else:
+      self.query = self.init_query_w(inputs_q_shape=inputs_q_shape)
+      self.key = self.init_kv_w(inputs_kv_shape=inputs_kv_shape)
+      self.value = self.init_kv_w(inputs_kv_shape=inputs_kv_shape)
+    self.out = self.init_out_w(output_dim=inputs_q_shape[-1])
 
   def init_query_w(self, inputs_q_shape: Tuple) -> nnx.Module:
     """Query projection initialization."""

--- a/src/MaxText/layers/deepseek.py
+++ b/src/MaxText/layers/deepseek.py
@@ -77,6 +77,7 @@ def self_attention_with_norm(
       max_target_length=cfg.max_target_length,
       max_prefill_predict_length=cfg.max_prefill_predict_length,
       attention_kernel=cfg.attention,
+      attention_type=cfg.attention_type,
       inputs_q_shape=lnx.shape,
       inputs_kv_shape=lnx.shape,
       mesh=mesh,

--- a/tests/attention_test.py
+++ b/tests/attention_test.py
@@ -732,9 +732,7 @@ class AttentionTest(parameterized.TestCase):
       attention_w_layout_full_this_idx = attention_w_layout_full[:, idx : idx + 1, :]
       self.assertTrue(attention_w_layout_full_this_idx.shape == attention_w_layout_idx.shape)
       self.assertTrue(
-          jax.numpy.allclose(
-              attention_w_layout_full_this_idx, attention_w_layout_idx, rtol=rtol, atol=atol, equal_nan=False
-          )
+          jax.numpy.allclose(attention_w_layout_full_this_idx, attention_w_layout_idx, rtol=rtol, atol=atol, equal_nan=False)
       )
 
   @pytest.mark.tpu_only
@@ -851,9 +849,7 @@ class AttentionTest(parameterized.TestCase):
         model_mode=MODEL_MODE_PREFILL,
     )
     self.assertTrue(
-        jax.numpy.allclose(
-            attention_w_reshape_q_full[:, :prefill_length, :], attention_w_reshape_q_prefill, equal_nan=False
-        )
+        jax.numpy.allclose(attention_w_reshape_q_full[:, :prefill_length, :], attention_w_reshape_q_prefill, equal_nan=False)
     )
 
     self.assertTrue(jax.numpy.allclose(attention_wo_reshape_q_prefill, attention_w_reshape_q_prefill, equal_nan=False))
@@ -1047,8 +1043,16 @@ class MLATest(parameterized.TestCase):
 
   def setUp(self):
     """Initializes the configuration for each test"""
+    super().setUp()
+    config = pyconfig.initialize(
+        [sys.argv[0], os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")],
+        **self.config_arguments,
+    )
+    self.cfg = config
     self.rng = jax.random.PRNGKey(0)
     self.nnx_rng = nnx.Rngs(params=0, dropout=jax.random.PRNGKey(42))
+    devices_array = maxtext_utils.create_device_mesh(self.cfg)
+    self.mesh = Mesh(devices_array, self.cfg.mesh_axes)
 
   def init_mla(self, config_arguments, rope_type):
     """Helper function to initialize MLA with different model names."""
@@ -1178,6 +1182,61 @@ class MLATest(parameterized.TestCase):
       self.assertEqual(mla_full_this_idx.shape, mla_idx.shape)
       # TODO (b/394626702) uncomment last check when decode and kv_cache are implemented for MLA
       # self.assertTrue(jax.numpy.allclose(mla_full_this_idx, mla_idx, rtol=1e-02, atol=1e-02, equal_nan=False))
+
+  def test_projection_initialization(self):
+    """Tests that MLA and Attention layers initialize the correct projection weights."""
+    # 1. Initialize a standard Attention layer for comparison
+    # Create a copy of the arguments and override the attention_type for the base model
+    attention_config_args = self.config_arguments.copy()
+    attention_config_args["attention_type"] = AttentionType.GLOBAL.value
+    attention_cfg = pyconfig.initialize(
+        [sys.argv[0], os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")],
+        **attention_config_args,
+    )
+    dummy_inputs_q = jnp.ones(
+        (attention_cfg.global_batch_size_to_train_on, attention_cfg.max_target_length, attention_cfg.base_emb_dim)
+    )
+    dummy_inputs_kv = jnp.ones(
+        (attention_cfg.global_batch_size_to_train_on, attention_cfg.max_target_length, attention_cfg.base_emb_dim)
+    )
+
+    base_attention = Attention(
+        config=attention_cfg,
+        num_query_heads=attention_cfg.num_query_heads,
+        num_kv_heads=attention_cfg.num_kv_heads,
+        head_dim=attention_cfg.head_dim,
+        max_target_length=attention_cfg.max_target_length,
+        max_prefill_predict_length=attention_cfg.max_prefill_predict_length,
+        inputs_q_shape=dummy_inputs_q.shape,
+        inputs_kv_shape=dummy_inputs_kv.shape,
+        mesh=self.mesh,
+        attention_kernel="dot_product",
+        dtype=attention_cfg.dtype,
+        rngs=self.nnx_rng,
+    )
+
+    # 2. Assert that the base Attention layer HAS all its standard projections
+    self.assertTrue(hasattr(base_attention, "query"), "Base Attention should have 'query' projection.")
+    self.assertTrue(hasattr(base_attention, "key"), "Base Attention should have 'key' projection.")
+    self.assertTrue(hasattr(base_attention, "value"), "Base Attention should have 'value' projection.")
+    self.assertTrue(hasattr(base_attention, "out"), "Base Attention should have 'out' projection.")
+
+    # 3. Initialize the MLA layer
+    mla_cfg, mla_layer = self.init_mla(self.config_arguments, rope_type="default")
+
+    # 4. Assert that the MLA layer DOES NOT HAVE the base projections
+    self.assertFalse(hasattr(mla_layer, "query"), "MLA should not have 'query' projection.")
+    self.assertFalse(hasattr(mla_layer, "key"), "MLA should not have 'key' projection.")
+    self.assertFalse(hasattr(mla_layer, "value"), "MLA should not have 'value' projection.")
+
+    # 5. Assert that the MLA layer HAS all of its own specific projections AND the common 'out' projection
+    self.assertTrue(hasattr(mla_layer, "wq_a"), "MLA should have 'wq_a' projection.")
+    self.assertTrue(hasattr(mla_layer, "wq_b"), "MLA should have 'wq_b' projection.")
+    self.assertTrue(hasattr(mla_layer, "wkv_a"), "MLA should have 'wkv_a' projection.")
+    self.assertTrue(hasattr(mla_layer, "wkv_b"), "MLA should have 'wkv_b' projection.")
+    self.assertTrue(hasattr(mla_layer, "q_norm"), "MLA should have 'q_norm' projection.")
+    self.assertTrue(hasattr(mla_layer, "kv_norm"), "MLA should have 'kv_norm' projection.")
+    self.assertTrue(hasattr(mla_layer, "out"), "MLA should have 'out' projection.")
 
   @parameterized.named_parameters(
       {

--- a/tests/maxtext_utils_test.py
+++ b/tests/maxtext_utils_test.py
@@ -423,6 +423,7 @@ class TestPromptLogprobsFromPrefill(unittest.TestCase):
   """
   Test suite for the inference utility function 'prompt_logprobs_from_prefill'.
   """
+
   def test_shift_and_masking(self):
     # B=1, S=5, V=4
     B, S, V = 1, 5, 4
@@ -465,6 +466,7 @@ class TestPromptLogprobsFromPackedPrefill(unittest.TestCase):
   """
   Test suite for the inference utility function 'prompt_logprobs_from_packed_prefill'.
   """
+
   def test_respects_segments_and_masking(self):
     # Build a packed sequence of two prompts.
     # Global S=8, V=5
@@ -638,6 +640,42 @@ class TestSamplingFunctions(unittest.TestCase):
     self.assertEqual(tokens.shape, (batch_size,))
     for token in tokens:
         self.assertIn(token.item(), top_k_indices)
+
+
+class TestCalculateBytesFromPytree(unittest.TestCase):
+  """Test suite for the byte calculation utility function."""
+
+  def test_bytes_from_pytree_arrays(self):
+    """Tests byte calculation with standard JAX and NumPy arrays."""
+    params = {
+        "a": jnp.zeros((2, 3), jnp.float32), # 2 * 3 * 4 = 24 bytes
+        "b": np.zeros((5,), np.int32)        # 5 * 4 = 20 bytes
+    }
+    expected_total_bytes = 44
+    self.assertEqual(max_utils.calculate_bytes_from_pytree(params), expected_total_bytes)
+
+  def test_bytes_from_pytree_shape_dtype_struct(self):
+    """Tests byte calculation with a ShapeDtypeStruct."""
+    s = jax.ShapeDtypeStruct(shape=(7, 11), dtype=jnp.bfloat16)
+    params = {"s": s}
+    # 7 * 11 * 2 (bfloat16 size) = 154 bytes
+    expected_total_bytes = 154
+    self.assertEqual(max_utils.calculate_bytes_from_pytree(params), expected_total_bytes)
+
+  def test_bytes_from_pytree_mixed_and_none(self):
+    """Tests a heterogeneous pytree with mixed types including None and scalars."""
+    params = {
+        "a": None,                               # 0 bytes
+        "b": 3,                                  # 8 bytes (int64)
+        "c": 1.0,                                # 8 bytes (float64)
+        "d": jax.ShapeDtypeStruct((4,), jnp.int8) # 4 * 1 = 4 bytes
+    }
+    expected_total_bytes = 20
+    self.assertEqual(max_utils.calculate_bytes_from_pytree(params), expected_total_bytes)
+
+  def test_bytes_from_pytree_empty_dict(self):
+    """Tests that an empty pytree correctly returns 0 bytes."""
+    self.assertEqual(max_utils.calculate_bytes_from_pytree({}), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Fix DeepSeek checkpoint loading issue of ShapeDtypeStruct not being Materialized.

### Problem

The `MLA` (Multi-Head Latent Attention) class inherits from the base `Attention` class. Previously, this caused `MLA` to unnecessarily initialize the `query`, `key`, and `value` projection weights from the parent class, even though `MLA` uses its own unique projection mechanism and never uses these base projections. This was causing a crash when loading from DeepSeek checkpoint.

### Solution

This PR refactors the initialization logic to decouple the subclass from the parent's specific implementation details.

1.  A new private method, `_init_projections`, has been introduced in the base `Attention` class. This method now encapsulates the initialization of all standard projection layers (`query`, `key`, `value`, and `out`).
2.  The `MLA` subclass now overrides `_init_projections` to initialize only its own required projections (e.g., `wq_a`, `wkv_b`, `out`, etc.).

By overriding this method, `MLA` no longer executes the base class's projection initialization, preventing the creation of unused parameters.


# Tests

Unit tests and DeepSeek v3 e2e test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
