### PR TITLE
Fix TP sharding issue

### DIFF
--- a/src/MaxText/layers/attention_op.py
+++ b/src/MaxText/layers/attention_op.py
@@ -902,6 +902,7 @@ class AttentionOp(nnx.Module):
     value = jnp.transpose(value, axes=(0, 2, 1, 3))
     segment_axis_names_q = None
     segment_axis_names_kv = None
+    sink_axis_names = nn.logical_to_mesh_axes((HEAD,))
     if decoder_segment_ids is not None:
       if self.config.expert_shard_attention_option == EP_AS_CONTEXT:
         segment_axis_names_q = nn.logical_to_mesh_axes((BATCH_NO_EXP, Q_LENGTH))
@@ -1042,7 +1043,7 @@ class AttentionOp(nnx.Module):
             segment_axis_names_splash_kernel,
             None,  # no sharding for cp_size
             None,  # no sharding for load_balanced_context_parallel
-            None,  # no sharding for sinks
+            sink_axis_names,  # sharding align with query heads
         ),
         out_specs=axis_names_q,
         check_rep=False,


### PR DESCRIPTION
# Description

Fix sharding shape misalignment issue for TP & TP transpose.

# Tests

Before the change:

1) flash attention meets ` assert sinks.shape == (num_q_heads,)` issue
2) MLP met `intermediate_output = intermediate_output + wo_bias` misalignement issue
3) Shape imcompatible issue during decoding due to padding (variable overwritten) 

After the change:
* flash attention: [link](https://paste.googleplex.com/5469053783244800)
* MLP: [link](https://paste.googleplex.com/6526021544968192)
* Decoding without any shape compatible issue: [link](https://paste.googleplex.com/6278671895363584)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
