### PR TITLE
fix import statement for convert_deepseek_family_ckpt

### DIFF
--- a/src/MaxText/convert_deepseek_family_unscanned_ckpt.py
+++ b/src/MaxText/convert_deepseek_family_unscanned_ckpt.py
@@ -35,7 +35,7 @@ import torch
 import psutil
 from tqdm import tqdm
 
-from MaxText import convert_deepseek_family_family_ckpt as ds_ckpt
+from MaxText import convert_deepseek_family_ckpt as ds_ckpt
 from MaxText import llama_or_mistral_ckpt
 from MaxText import max_logging
 from MaxText.inference_utils import str2bool


### PR DESCRIPTION
# Description

Import path of convert_deepseek_family_ckpt was incorrectly renamed, fixing it from
convert_deepseek_family_family_ckpt -> convert_deepseek_family_ckpt

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
