### PR TITLE
Change attention mask type to uint8 for cudnn_flash_te

### DIFF
--- a/src/MaxText/layers/attention_op.py
+++ b/src/MaxText/layers/attention_op.py
@@ -1140,6 +1140,7 @@ class AttentionOp(nnx.Module):
       # generate attn_mask
       mask_type = "padding_causal"  # only padding_causal mask type can take a created mask
       attn_mask = self.generate_attention_mask(query, key, decoder_segment_ids, model_mode)
+      attn_mask = attn_mask.astype(jnp.uint8)  # TE requires uint8/boolean mask
 
     dpa_layer = DotProductAttention(
         head_dim=head_dim,


### PR DESCRIPTION
# Description

This forces the dtype of the attention mask for TransfromerEngine to be uint8. This allows DeepSeekV3 and other models to run through TransformerEngine (using the nightly jax:maxtext container from 09-04-2025).

This is needed to pass assert added in TransformerEngine https://github.com/NVIDIA/TransformerEngine/blob/c47f329b2084406093124851a3aeecb935183def/transformer_engine/jax/cpp_extensions/softmax.py#L484 . This enables the MLA from DeepSeekV3 to not through an assert in TransformerEngine.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

I ran it locally on H200s and verified the assert is no longer an issue when using cudnn_attn_te as the attention implementation.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
