### PR TITLE
Fix vocab sharding constraints

### DIFF
--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -612,7 +612,7 @@ class Decoder(nn.Module):
       logits = nn.with_logical_constraint(logits, (None, None, "activation_vocab"))
     else:
       logits = nn.with_logical_constraint(
-          logits, ("activation_embed_and_logits_batch", "activation_length", "activation_vocab")
+          logits, ("activation_embed_and_logits_batch", "activation_length_no_exp", "activation_vocab")
       )
 
     if self.config.cast_logits_to_fp32:

--- a/src/MaxText/layers/embeddings.py
+++ b/src/MaxText/layers/embeddings.py
@@ -152,7 +152,7 @@ class Embed(nnx.Module):
       output = jnp.asarray(embedding, self.dtype)[inputs]
 
     output_prefill_axis_names = ("activation_embed_and_logits_batch", "prefill_activation_length", "activation_embed")
-    output_default_axis_names = ("activation_embed_and_logits_batch", "activation_length", "activation_embed")
+    output_default_axis_names = ("activation_embed_and_logits_batch", "activation_length_no_exp", "activation_embed")
 
     if model_mode == MODEL_MODE_PREFILL:
       output = nn.with_logical_constraint(output, output_prefill_axis_names)


### PR DESCRIPTION
# Description

Some logical axis rule collisions were introduced with https://github.com/AI-Hypercomputer/maxtext/pull/2023, this PR removes some of these collisions.

In particular now the vocab activations [batch, sequence, vocab] will be sharded by sequence parallelism or context parallelism correctly (previously the sequence dimension would be incorrectly replicated due to a logical axis collision). This allows for much higher batch sizes and performance, e.g. 

Before:
pdb=1/16, seq=128k: (2000 tokens/s)

After:
pdb=1, seq=128k: (2500 tokens/s)

See this [bug](https://b.corp.google.com/issues/433561718#comment19) for more, in particular comments 19-22

Related bug: b/433561718


# Tests

Several benchmarks run with this fix discussed in b/433561718 with tracking sheet [here](https://docs.google.com/spreadsheets/d/1BVMbWkShfKw-Z5lhQSdst4FKmziMTBXdvwv2mIQs26Y/edit?resourcekey=0-A9HlNvtDU4Fi-WskqIpzKQ&gid=0#gid=0)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
