### PR TITLE
Create a CI workflow that build maxtext package and run tests against it

### DIFF
--- a/.github/workflows/build_and_test_maxtext.yml
+++ b/.github/workflows/build_and_test_maxtext.yml
@@ -1,0 +1,113 @@
+# Copyright 2025 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow will build maxtext python package and run tests.
+
+name: MaxText Package Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Run the job every 4 hours
+    - cron:  '0 */4 * * *'
+
+concurrency:
+  # Dedup pull requests (canceling previous runs of the same workflow for same PR), and scheduled runs but nothing else
+  group: >
+    ${{
+      github.event_name == 'pull_request' && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) ||
+      github.event_name == 'schedule' && format('{0}-schedule', github.workflow) ||
+      github.run_id
+    }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+jobs:
+  build_and_upload_maxtext_package:
+    name: Build and upload maxtext package
+    uses: ./.github/workflows/build_package.yml
+    with:
+      device_type: tpu
+      device_name: v4-8
+      cloud_runner: linux-x86-n2-16-buildkit
+
+  maxtext_cpu_unit_tests:
+    needs: build_and_upload_maxtext_package
+    uses: ./.github/workflows/run_tests_against_package.yml
+    strategy:
+        fail-fast: false # don't cancel all jobs on failure
+        matrix:
+          image_type: ["py312"]
+    with:
+      device_type: cpu
+      device_name: X64
+      cloud_runner: linux-x86-n2-16
+      image_type: ${{ matrix.image_type }}
+      pytest_marker: 'cpu_only'
+      xla_python_client_mem_fraction: 0.75
+      tf_force_gpu_allow_growth: false
+      container_resource_option: "--privileged"
+      is_scheduled_run: ${{ github.event_name == 'schedule' }}
+
+  maxtext_tpu_unit_tests:
+    needs: build_and_upload_maxtext_package
+    uses: ./.github/workflows/run_tests_against_package.yml
+    strategy:
+        fail-fast: false
+        matrix:
+          image_type: ["py312"]
+    with:
+      device_type: tpu
+      device_name: v4-8
+      image_type: ${{ matrix.image_type }}
+      cloud_runner: linux-x86-ct4p-240-4tpu
+      pytest_marker: 'not cpu_only and not gpu_only and not integration_test'
+      xla_python_client_mem_fraction: 0.75
+      tf_force_gpu_allow_growth: false
+      container_resource_option: "--privileged"
+      is_scheduled_run: ${{ github.event_name == 'schedule' }}
+
+  maxtext_tpu_integration_tests:
+    needs: build_and_upload_maxtext_package
+    uses: ./.github/workflows/run_tests_against_package.yml
+    strategy:
+        fail-fast: false
+        matrix:
+          image_type: ["py312"]
+    with:
+      device_type: tpu
+      device_name: v4-8
+      image_type: ${{ matrix.image_type }}
+      cloud_runner: linux-x86-ct4p-240-4tpu
+      pytest_marker: 'not cpu_only and not gpu_only and integration_test'
+      xla_python_client_mem_fraction: 0.75
+      tf_force_gpu_allow_growth: false
+      container_resource_option: "--privileged"
+      is_scheduled_run: ${{ github.event_name == 'schedule' }}
+
+  notify_failure:
+    name: Notify failed build # creates an issue or modifies last open existing issue for failed build
+    needs: [maxtext_cpu_unit_tests, maxtext_tpu_unit_tests, maxtext_tpu_integration_tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - name: Check whether one of the jobs failed
+      if: ${{ contains(needs.*.result, 'failure') && github.event.pull_request == null && github.event_name != 'workflow_dispatch' }}
+      uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -1,0 +1,52 @@
+# Copyright 2025 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file defines a module for building and uploading a maxtext pacakge
+# based on the pyproject.toml at the current github workspace.
+
+name: Build and Upload MaxText Package
+
+on:
+  workflow_call:
+    inputs:
+      device_type:
+        required: true
+        type: string
+      device_name:
+        required: true
+        type: string
+      cloud_runner:
+        required: false
+        type: string
+
+permissions:
+  contents: read
+jobs:
+  build_and_upload:
+    name: Build and upload maxtext package (${{ inputs.device_name }})
+    runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
+    container: python:3.12.3-slim-bullseye
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip build uv
+      - name: Build maxtext wheel
+        run: |
+          uv build --wheel
+      - name: Upload the built maxtext wheel
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: maxtext-wheel
+          path: dist/*

--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -1,0 +1,90 @@
+# Copyright 2025 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file defines a module for running tests against the built maxtext package.
+
+name: Run Tests Against MaxText Package
+
+on:
+  workflow_call:
+    inputs:
+      device_type:
+        required: true
+        type: string
+      device_name:
+        required: true
+        type: string
+      image_type:
+        required: false
+        type: string
+      pytest_marker:
+        required: true
+        type: string
+      is_scheduled_run:
+        required: true
+        type: string
+      xla_python_client_mem_fraction:
+        required: true
+        type: string
+      tf_force_gpu_allow_growth:
+        required: true
+        type: string
+      container_resource_option:
+        required: true
+        type: string
+      cloud_runner:
+        required: false
+        type: string
+
+permissions:
+  contents: read
+jobs:
+  run:
+    runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
+    container:
+      image: gcr.io/tpu-prod-env-multipod/maxtext-unit-test-${{ inputs.device_type == 'cpu' && 'tpu' || inputs.device_type }}:${{ inputs.image_type != '' && inputs.image_type }}
+      env:
+        XLA_PYTHON_CLIENT_MEM_FRACTION: ${{ inputs.xla_python_client_mem_fraction }}
+        TF_FORCE_GPU_ALLOW_GROWTH: ${{ inputs.tf_force_gpu_allow_growth }}
+        TPU_SKIP_MDS_QUERY: ${{ inputs.device_type == 'cpu' && '1' || '' }}
+      options: ${{ inputs.container_resource_option }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Download the maxtext wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: maxtext-wheel
+      - name: Install the maxtext wheel
+        run: |
+          python3 -m uv pip install maxtext-*-py3-none-any.whl --resolution=lowest --system
+          python3 --version
+          python3 -m pip freeze
+      - name: Copy test assets files
+        run : gcloud storage cp gs://maxtext-test-assets/* src/MaxText/test_assets
+      - name: Display contents of workspace # TODO: Remove
+        run: ls -R
+      - name: Run Tests
+        run: |
+          if [ "${{ inputs.is_scheduled_run }}" == "true" ]; then
+            FINAL_PYTEST_MARKER="${{ inputs.pytest_marker }}"
+          else
+            FINAL_PYTEST_MARKER="${{ inputs.pytest_marker }} and not scheduled_only"
+          fi
+          # TODO: Use package data for testing and remove the env vars
+          export MAXTEXT_REPO_ROOT=$(pwd)
+          export MAXTEXT_ASSETS_ROOT=$(pwd)/src/MaxText/assets
+          export MAXTEXT_TEST_ASSETS_ROOT=$(pwd)/src/MaxText/test_assets
+          export MAXTEXT_PKG_DIR=$(pwd)/src/MaxText
+          # TODO: Fix the skipped tests and remove the deselect flags
+          python3 -m pytest -v -m "${FINAL_PYTEST_MARKER}" --durations=0 --deselect "tests/aot_hlo_identical_test.py::AotHloIdenticalTest::test_default_hlo_match" --deselect "tests/tokenizer_test.py::TokenizerTest::test_detokenize"

--- a/clean_py_env.Dockerfile
+++ b/clean_py_env.Dockerfile
@@ -1,0 +1,63 @@
+# This Dockerfile is used to build a Docker image containing all the
+# system-level dependencies required for maxtext. Since the maxtext
+# package itself includes all the necessary Python dependencies, this
+# image is designed to have a clean Python environment with just pip
+# and uv installed.
+#
+# Build a docker image by running:
+# `docker build --build-arg DEVICE=tpu -t <docker_image_name>:<tag> -f clean_py_env.Dockerfile .`
+# Or
+# `docker build --build-arg PYTHON_VERSION=3.11 --build-arg DEVICE=tpu -t <docker_image_name>:<tag> -f clean_py_env.Dockerfile .`
+#
+# How to upload the image to Google Container Registry (GCR):
+# e.g., DEVICE=tpu and PYTHON_VERSION=3.12
+#.  gcloud init
+#   gcloud auth configure-docker
+#   docker tag <docker_image_name>:<tag> gcr.io/tpu-prod-env-multipod/maxtext-unit-test-tpu:py312
+#   docker push gcr.io/tpu-prod-env-multipod/maxtext-unit-test-tpu:py312
+
+# Default to Python 3.12. This ARG must be declared before FROM.
+ARG PYTHON_VERSION=3.12
+
+# Use the PYTHON_VERSION ARG to specify the base image tag
+FROM python:${PYTHON_VERSION}-slim-bullseye
+
+# Set the working directory in the container
+WORKDIR /maxtext
+
+# Arguments
+ARG DEVICE
+
+# Enviroment variables
+ENV DEVICE=$DEVICE
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+ENV PIP_NO_CACHE_DIR=1
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV CLOUD_SDK_VERSION=latest
+# Ensure apt package installations run without manual intervention
+ENV DEBIAN_FRONTEND=noninteractive
+# See all env variables
+RUN env
+
+# System level dependencies
+RUN apt-get update && apt-get install -y apt-utils git curl gnupg procps iproute2 ethtool cmake pkg-config build-essential dnsutils && rm -rf /var/lib/apt/lists/*
+# Add the Google Cloud SDK package repository
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list
+# Install the Google Cloud SDK
+RUN apt-get update && apt-get install -y google-cloud-sdk && rm -rf /var/lib/apt/lists/*
+# Install gcsfuse
+RUN export GCSFUSE_REPO=gcsfuse-bullseye && \
+    echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    apt update -y && apt -y install gcsfuse && \
+    rm -rf /var/lib/apt/lists/*
+# See all installed system level packages
+RUN apt list --installed
+
+# Upgrade pip to the latest version
+RUN python -m pip install --upgrade pip uv
+RUN rm -rf /root/.cache/pip
+
+# Clean python env
+RUN python -m uv pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 path = "src/MaxText/__init__.py"
 
 [project]
-name = "MaxText"
+name = "maxtext"
 description = "MaxText is a simple, performant and scalable Jax LLM!"
 dynamic = ["version"]
 requires-python = ">=3.12"

--- a/src/MaxText/__init__.py
+++ b/src/MaxText/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 __author__ = "Google LLC"
-__version__ = "2025.09.11"
+__version__ = "0.1.0"
 __description__ = (
     "MaxText is a high performance, highly scalable, open-source LLM written in pure Python/Jax and "
     "targeting Google Cloud TPUs and GPUs for training and **inference."


### PR DESCRIPTION
Create MaxText Package Tests workflow, which builds maxtext package and run cpu/tpu unit/integration tests. 

Save the built maxtext distributions as action artifacts. Artifacts are retained within the workflow run for 90 days.

Create a docker image, which has all the system level deps for maxtext and no python libraries pre-installed except `pip` and `uv`, for the package testing in a clean python environment.

Test with local configs/assets/test_assets files for now.

# Tests

The MaxText Package Tests presubmit passed. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
