### PR TITLE
Integrate TE/JAX GroupedGEMM for MoE.

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -164,6 +164,7 @@ num_experts: 1
 num_experts_per_tok: 1
 megablox: True
 sparse_matmul: True
+te_grouped_gemm: False
 capacity_factor: -1.0 # a factor to decide expert capacity for token dropping, and no dropping by default
 load_balance_loss_weight: 0.01 # weight for the load balance loss
 use_random_routing: False # whether to use random routing for debug/test purpose

--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -1,4 +1,5 @@
 # Copyright 2023–2025 Google LLC
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/MaxText/layers/moe.py
+++ b/src/MaxText/layers/moe.py
@@ -1,4 +1,5 @@
 # Copyright 2023–2025 Google LLC
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description
[NVIDIA - GPU]
Integrate Transformer Engine/JAX's grouped gemm for a better performance on MoE related training.
For standalone GEMMs performance, TE/JAX grouped-gemm could reach 1.2x faster than the alternative batch-gemm.

# Tests

Tested on DeepSeek V3 671B models training.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
