### PR TITLE
Add option to save (checkpoint) TPU flash attention

### DIFF
--- a/src/MaxText/layers/attention_op.py
+++ b/src/MaxText/layers/attention_op.py
@@ -1012,6 +1012,7 @@ class AttentionOp(nnx.Module):
           q_seq_shards=cp_size,  # axis for sequence sharding
           block_sizes=block_sizes,
           attn_logits_soft_cap=attn_logits_soft_cap,
+          residual_checkpoint_name="context",
       )
       return splash_kernel
 

--- a/tests/train_compile_test.py
+++ b/tests/train_compile_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Tests for the common Max Utils """
 
 import unittest
 import os.path
@@ -83,6 +82,22 @@ class TrainCompile(unittest.TestCase):
             "remat_policy=minimal_offloaded",
             "use_iota_embed=true",
             "global_parameter_scale=128",
+        )
+    )
+
+  @pytest.mark.cpu_only
+  def test_save_flash(self):
+    compiled_trainstep_file = "/tmp/test_save_flash"
+    train_compile_main(
+        (
+            "",
+            os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "compile_topology_num_slices=1",
+            "per_device_batch_size=1",
+            "remat_policy=custom",
+            "context=device" # Context is our name for the splash attention output for both TPU and GPU kernels.      
         )
     )
 


### PR DESCRIPTION
# Description

This PR adds an option to checkpoint (either to HBM or host) the output of flash attention so that it doesn't have to be recomputed in the backward pass. This brings flash attention to parity with all of the other activations - every activation can individually choose between three choices (remat, save to HBM, save to host).

This change is especially important for long context where the extra splash attention computation time in the backward pass is expensive. For instance this feature improves performance by 20% relatively for llama8-B with 128k context length (see b/433561718 for more.)

The memory usage is the output of attention - of shape [batch, sequence, query_heads, head_dim] x num_layers. This is generally the same total size as the decoder layers, and may need to be offloaded for large problem sizes.

We choose to use the same name "context" as for GPU attention kernel for consistency. Saving GPU "context" or TPU "context" is exactly the same behavior just using device specific kernels.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/400547121



# Tests

Ran many benchmarks with this feature (see b/433561718), and including a (rather ineffective) unit test. Ideally we would read / regex the LLO to assert there is no backward computation, but we can also have integration performance benchmarks on long context to prevent regressions.

* v6e run with remat=custom context=offload [xprof](https://xprof.corp.google.com/trace_viewer/mattdavidow-2967131576332927901?hosts=t1v-n-70a81276-w-0&host_index=0&trace_filter_config={}&view_start=-632.043&view_end=4852.360)
* v6e run with default remat policy [xprof](https://xprof.corp.google.com/trace_viewer/mattdavidow-15094684290972147247?hosts=t1v-n-70a81276-w-0&host_index=0&trace_filter_config={}&view_start=2160.528&view_end=2340.826)
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
