### PR TITLE
Add rule to load quantization ckpt

### DIFF
--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -215,6 +215,7 @@ def validate_keys(keys):
 
   validate_multiple_slices(keys)
   if keys["num_experts"] > 1:
+    validate_quantization_checkpoint(keys)
     validate_mlp_dim(keys)
     validate_sparse_matmul_parallelism(keys)
     validate_ragged_dot(keys)
@@ -991,6 +992,13 @@ def validate_deepseek_moe(raw_keys):
       raise ValueError(
           f'config num_experts: {raw_keys["num_experts"]} must be divisible by n_routing_groups: {raw_keys["n_routing_groups"]}'
       )
+
+
+def validate_quantization_checkpoint(raw_keys):
+  """Validates quantization settings when loading a checkpoint."""
+  if raw_keys["quantization"] and raw_keys["load_parameters_path"] and not raw_keys["use_qwix_quantization"]:
+    raise ValueError("Please set `use_qwix_quantization=True` to load checkpoint using Qwix instead of AQT.")
+
 
 def validate_mlp_dim(raw_keys):
   """Validates that MLP dimensions are consistent for fully MoE models."""


### PR DESCRIPTION
# Description

This is only affects loading AQT quantized ckpt for MoE models, and we suggest users to use [Qwix](https://github.com/google/qwix) instead. 

Context:
* We met issues to load AQT quantization ckpt for decoding after NNX migration, b/442608470
* The fix is doable (like attention does with some [dummy values & workaround](https://github.com/AI-Hypercomputer/maxtext/blob/01c7137d4e13878e38baae44dc99e588eaa50a70/src/MaxText/layers/attention_op.py#L477-L525)).
* Confirmed with team that Qwix is working end-to-end, so we'd like to add an assertion to the pyconfig to indicate this is an known issue, and we will do the clean up of AQT once convergence of Qwix is fully verified.


# Tests

Test locally:
* Functional end-to-end without `load_parameters_path` for both AQT & Qwix
* Assertion when using AQT + `load_parameters_path`: [link](https://paste.googleplex.com/5113077431402496)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
