### PR TITLE
Add more codeowners for model bringup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,13 @@
-* @gobbleturk @khatwanimohit @bvandermoon @vipannalla @RissyRan @richjames0 @gagika @shralex @yangyuwei @SurbhiJainUSC @hengtaoguo @A9isha @aireenmei @NuojCheng @jiangjy1982
+* @gobbleturk @khatwanimohit @bvandermoon @vipannalla @RissyRan @richjames0 @gagika @shralex @SurbhiJainUSC @hengtaoguo @A9isha @aireenmei @NuojCheng @jiangjy1982 @suexu1025
+
+# Model bring-up
+src/MaxText/assets @parambole @shuningjin @RissyRan @suexu1025 @jiangjy1982 @gobbleturk @bvandermoon @gagika @shralex @richjames0
+src/MaxText/configs/models @parambole @shuningjin @RissyRan @suexu1025 @jiangjy1982 @gobbleturk @bvandermoon @gagika @shralex @richjames0
+src/MaxText/utils/ckpt_conversion @parambole @shuningjin @RissyRan @suexu1025 @jiangjy1982 @gobbleturk @bvandermoon @hengtaoguo @gagika @shralex @richjames0
+src/MaxText/layers @parambole @shuningjin @RissyRan @suexu1025 @jiangjy1982 @gobbleturk @bvandermoon @gagika @shralex @richjames0
 
 # Features
-src/MaxText/experimental/rl @A9isha @khatwanimohit @gagika @richjames0
+src/MaxText/experimental/rl @A9isha @khatwanimohit @xuefgu @gagika @richjames0
 src/MaxText/input_pipeline @aireenmei @SurbhiJainUSC @richjames0
 src/MaxText/kernels/megablox @RissyRan @michelle-yooh @gagika @richjames0
 src/MaxText/kernels/ragged_attention.py @patemotter @vipannalla @richjames0
@@ -17,8 +23,8 @@ src/MaxText/inference @vipannalla @mitalisi @gpolovets1 @mailvijayasingh @jrplat
 src/MaxText/inference_mlperf @vipannalla @mitalisi @gpolovets1 @mailvijayasingh @jrplatin @patemotter @lumosis @richjames0
 
 # Dockerfiles and dependencies
-*.Dockerfile @bvandermoon @yangyuwei @parambole @richjames0
-*.txt @bvandermoon @yangyuwei @parambole @richjames0
+*.Dockerfile @bvandermoon @parambole @richjames0
+*.txt @bvandermoon @parambole @richjames0
 
 # Workflow files
 .github/workflows @gobbleturk @khatwanimohit @shralex @parambole @richjames0


### PR DESCRIPTION
# Description

Add more codeowners from the JAX model and performance team for model bringup.

Follow up:
* need refactor for those checkpoint [scripts](https://screenshot.googleplex.com/79abgrir32f9KFP) into `src/MaxText/utils/ckpt_conversion` folder.

# Tests

Manual check: [link](https://screenshot.googleplex.com/3iY9gPcKJapH6oE)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
