### PR TITLE
Add dense_matmul implementation for gpt-oss

### DIFF
--- a/src/MaxText/layers/moe.py
+++ b/src/MaxText/layers/moe.py
@@ -314,6 +314,11 @@ class RoutedMoE(nnx.Module):
         rngs=rngs,
     )
 
+    # pylint: disable=protected-access
+    self.activation_fn = linears._convert_to_activation_function(
+        self.config.mlp_activations[0]
+    )
+
     kernel_in_axis = np.arange(1)
     kernel_out_axis = np.arange(1, 2)
 
@@ -489,6 +494,20 @@ class RoutedMoE(nnx.Module):
     top_k_weights = jnp.take_along_axis(pre_bias_logits, top_k_indices, axis=-1)
     return top_k_weights, top_k_indices
 
+  def apply_ffn_activation(self, layer_w0, layer_w1):
+    """Applies FFN activation function."""
+    with jax.named_scope("ffn_act"):
+      if self.config.decoder_block == ctypes.DecoderBlockType.GPT_OSS:
+        layer_w0 = jnp.clip(layer_w0, a_min=None, a_max=self.config.mlp_activations_limit)
+        layer_w1 = jnp.clip(layer_w1, a_min=-self.config.mlp_activations_limit, a_max=self.config.mlp_activations_limit)
+        layer_act = self.activation_fn(layer_w0 * 1.702)
+        glu = jnp.multiply(layer_w0, layer_act)
+        intermediate_layer = jnp.multiply(glu, (layer_w1 + 1))
+      else:
+        layer_act = self.activation_fn(layer_w0)
+        intermediate_layer = jnp.multiply(layer_act, layer_w1)
+      return intermediate_layer.astype(self.dtype)
+  
   def permute(self, inputs, gate_logits, pre_bias_logits, use_custom_sort_vjp=True):
     """Permute tokens to group by expert to fit gmm call."""
     # reshape inputs (batch, sequence, emb) to (batch * sequence, emb)
@@ -796,7 +815,7 @@ class RoutedMoE(nnx.Module):
             lhs=inputs,
             rhs=kernel,
             group_sizes=group_sizes,
-            preferred_element_type=jnp.bfloat16,
+            preferred_element_type=self.dtype,
             tiling=tiling,
             lhs_quantize_dtype=lhs_quantize_dtype,
             rhs_quantize_dtype=rhs_quantize_dtype,
@@ -813,7 +832,7 @@ class RoutedMoE(nnx.Module):
               lhs=inputs,
               rhs=rhs_inputs,
               group_sizes=group_sizes,
-              preferred_element_type=jnp.bfloat16,
+              preferred_element_type=self.dtype,
           )
         if isinstance(kernel, aqt.QTensor):
           # Multiply outputs by the kernely scale
@@ -1018,17 +1037,7 @@ class RoutedMoE(nnx.Module):
       if self.config.mlp_bias:
         layer_w1 = layer_w1 + w1_bias
       layer_w1 = adc.checkpoint_name(layer_w1, "mlpwi_1")
-      # pylint: disable=protected-access
-
-      if self.config.decoder_block == ctypes.DecoderBlockType.GPT_OSS:
-        layer_w0 = jnp.clip(layer_w0, a_min=None, a_max=self.config.mlp_activations_limit)
-        layer_w1 = jnp.clip(layer_w1, a_min=-self.config.mlp_activations_limit, a_max=self.config.mlp_activations_limit)
-        layer_act = linears._convert_to_activation_function(self.config.mlp_activations[0])(layer_w0 * 1.702)
-        glu = jnp.multiply(layer_w0, layer_act)
-        intermediate_layer = jnp.multiply(glu, (layer_w1 + 1))
-      else:
-        layer_act = linears._convert_to_activation_function(self.config.mlp_activations[0])(layer_w0)
-        intermediate_layer = jnp.multiply(layer_act, layer_w1)
+      intermediate_layer = self.apply_ffn_activation(layer_w0, layer_w1)
 
       intermediate_output = gmm_fn(intermediate_layer, wo)
       if self.get_tensor_parallelism_size() > 1:
@@ -1408,7 +1417,7 @@ class RoutedMoE(nnx.Module):
     top_k_weights, top_k_indices = self.get_topk(gate_logits, pre_bias_logits)
     is_llama4_decoder_layer = self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4
     if is_llama4_decoder_layer:
-      router_scores = jax.nn.sigmoid(top_k_weights.astype(jnp.float32)).astype(jnp.bfloat16)
+      router_scores = jax.nn.sigmoid(top_k_weights.astype(jnp.float32)).astype(self.dtype)
       inputs = inputs * router_scores
     else:
       weights = self.reshape_and_update_weights(top_k_weights, top_k_indices)
@@ -1573,9 +1582,7 @@ class RoutedMoE(nnx.Module):
             mlp_axis,
         )
         layer_w1 = adc.checkpoint_name(layer_w1, "mlpwi_1")
-      # pylint: disable=protected-access
-      layer_w0_act = linears._convert_to_activation_function(self.config.mlp_activations[0])(layer_w0)
-      layer_multiply = jnp.multiply(layer_w0_act, layer_w1).astype(self.dtype)
+      layer_multiply = self.apply_ffn_activation(layer_w0, layer_w1)
       with jax.named_scope("wo"):
         wo_kernel_axes = ("exp", "mlp", None)
         wo_kernel = self.maybe_all_gather_kernel_weight_in_expert_parallelism(wo_kernel, wo_kernel_axes)
@@ -1626,7 +1633,7 @@ class RoutedMoE(nnx.Module):
             "BSM,EMH -> BSEH", inputs, w0_kernel, precision=matmul_precision
         )
         if self.config.mlp_bias:
-          layer_w0 = layer_w0 + w0_bias
+          layer_w0 = layer_w0 + w0_bias[None, None, :, :]
         if self.config.activations_in_float32:
           layer_w0 = layer_w0.astype(jnp.float32)
         layer_w0 = adc.checkpoint_name(layer_w0, "mlpwi_0")
@@ -1635,13 +1642,12 @@ class RoutedMoE(nnx.Module):
             "BSM,EMH -> BSEH", inputs, w1_kernel, precision=matmul_precision
         )
         if self.config.mlp_bias:
-          layer_w1 = layer_w1 + w1_bias
+          layer_w1 = layer_w1 + w1_bias[None, None, :, :]
         if self.config.activations_in_float32:
           layer_w1 = layer_w1.astype(jnp.float32)
         layer_w1 = adc.checkpoint_name(layer_w1, "mlpwi_1")
-      # pylint: disable=protected-access
-      layer_w0_act = linears._convert_to_activation_function(self.config.mlp_activations[0])(layer_w0)
-      layer_multiply = jnp.multiply(layer_w0_act, layer_w1).astype(self.dtype)
+      layer_multiply = self.apply_ffn_activation(layer_w0, layer_w1)
+
       with jax.named_scope("wo"):
         intermediate_layer = self.get_einsum(rhs_mesh_axes=self.wo_kernel_axes)(
             "BSEH,EHM -> BSEM",
@@ -1650,17 +1656,19 @@ class RoutedMoE(nnx.Module):
             precision=matmul_precision,
         )
         if self.config.mlp_bias:
-          intermediate_layer = intermediate_layer + wo_bias
+          intermediate_layer = intermediate_layer + wo_bias[None, None, :, :]
         if self.config.activations_in_float32:
           intermediate_layer = intermediate_layer.astype(jnp.float32)
         intermediate_layer = adc.checkpoint_name(intermediate_layer, "mlpwo")
       with jax.named_scope("w_sum"):
         if is_llama4_decoder_layer:
           weights = self.reshape_and_update_weights(jnp.ones_like(top_k_weights), top_k_indices)
+        # cast to f32 for sum up in einsum op
         output = jnp.einsum(
             "BSEM,BSE -> BSM",
-            intermediate_layer,
-            weights,  # pylint: disable=undefined-variable,possibly-used-before-assignment
+            intermediate_layer.astype(jnp.float32),
+            weights.astype(jnp.float32),  # pylint: disable=undefined-variable,possibly-used-before-assignment
+            precision=matmul_precision,
         ).astype(self.dtype)
       return output, None
 

--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -220,7 +220,6 @@ def validate_keys(keys):
     validate_ring_of_experts_parallelism(keys)
     validate_ragged_dot(keys)
     validate_deepseek_moe(keys)
-    validate_gpt_oss_moe(keys)
     validate_expert_shard_attention_option(keys["expert_shard_attention_option"])
 
   if keys["use_multimodal"]:
@@ -1000,11 +999,6 @@ def validate_mlp_dim(raw_keys):
   base_moe_mlp_dim = raw_keys["base_moe_mlp_dim"]
   if is_fully_moe_model and (base_mlp_dim != base_moe_mlp_dim):
       raise ValueError(f'For a fully MoE model, base_mlp_dim must be equal to base_moe_mlp_dim. Received base_mlp_dim={base_mlp_dim} and base_moe_mlp_dim={base_moe_mlp_dim}.')
-
-
-def validate_gpt_oss_moe(raw_keys):
-  if raw_keys["decoder_block"] == "gpt_oss" and not raw_keys["sparse_matmul"]:
-    raise ValueError(f"GPT OSS model only supports sparse matmul. Please set sparse_matmul=True.")
 
 
 def validate_sparse_matmul_parallelism(raw_keys):

--- a/tests/train_compile_test.py
+++ b/tests/train_compile_test.py
@@ -638,6 +638,50 @@ class TrainCompile(unittest.TestCase):
     )
 
   @pytest.mark.cpu_only
+  def test_moe_gpt_oss_20b_sparse_matmul(self):
+    compiled_trainstep_file = "/tmp/test_moe_gpt_oss_20b_sparse_matmul.pickle"
+    train_compile_main(
+        (
+            "",
+            os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-64",
+            "compile_topology_num_slices=1",
+            "model_name=gpt-oss-20b",
+            "per_device_batch_size=1",
+            "max_target_length=1024",
+            "dtype=bfloat16",
+            "weight_dtype=bfloat16",
+            "scan_layers=True",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=dot_product", # flash attention: need JAX version >= 0.7.2.dev20250824
+        )
+    )
+
+  @pytest.mark.cpu_only
+  def test_moe_gpt_oss_20b_dense_matmul(self):
+    compiled_trainstep_file = "/tmp/test_moe_gpt_oss_20b_dense_matmul.pickle"
+    train_compile_main(
+        (
+            "",
+            os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-64",
+            "compile_topology_num_slices=1",
+            "model_name=gpt-oss-20b",
+            "per_device_batch_size=1",
+            "max_target_length=1024",
+            "dtype=bfloat16",
+            "weight_dtype=bfloat16",
+            "scan_layers=True",
+            "sparse_matmul=False",
+            "capacity_factor=-1",
+            "attention=dot_product", # flash attention: need JAX version >= 0.7.2.dev20250824
+        )
+    )
+
+  @pytest.mark.cpu_only
   def test_gpt3_6b(self):
     compiled_trainstep_file = "/tmp/test_gpt3_6b"
     train_compile_main(


### PR DESCRIPTION
# Description

Appreciate great work from @shuningjin for verification!

* Add dense_matmul implementation
* Remove the assertion from pyconfig.py
* Add compile tests for functionality

# Tests

Test locally for logits verification:

```
gpt-oss-20b, max_target_length=max_prefill_predict_length=200

1 Dense + CPU
Max Numerical Difference 2.8133392333984375e-05
max KL divergence = 1.0624022195315774e-07

2 Dense + TPU
Max Numerical Difference 0.0010275840759277344
max KL divergence = 1.9383925575766625e-07
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
