### PR TITLE
Fixes bash syntax Issue #2332

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -156,7 +156,7 @@ if [ -e "$libtpu_path" ]; then
     rm "$libtpu_path"
 fi
 
-elif [[ "$MODE" == "stable" || ! -v MODE ]]; then
+if [[ "$MODE" == "stable" || ! -v MODE ]]; then
 # Stable mode
     if [[ $DEVICE == "tpu" ]]; then
         echo "Installing stable jax, jaxlib for tpu"


### PR DESCRIPTION
# Description

This simply changes an `elif` to `if` that was causing a bash syntax error since there was no top-level `if` (removed in PR #2314)

This will fix a small typo error when checking `$MODE` in `setup.sh`.

FIXES: #2332

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Running the following completes (instead of an error):

```
git clone https://github.com/google/maxtext.git
cd maxtext
bash setup.sh
```

Testing this as part of container image (uses MaxText), runs as epxected


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
