### PR TITLE
Fix train step counter in on_train_step_end() hook for SFT

### DIFF
--- a/tests/sft_hooks_test.py
+++ b/tests/sft_hooks_test.py
@@ -87,7 +87,7 @@ class SFTHooksTest(unittest.TestCase):
     self.mock_train_ctx.train_steps = 1
     self.training_hooks.on_train_step_start(self.mock_train_ctx)
     self.training_hooks.on_train_step_end(
-        self.mock_train_ctx, train_step=0, train_loss=5.0, step_time=0.004
+        self.mock_train_ctx, train_step=1, train_loss=5.0, step_time=0.004
     )
 
     expected_metrics = {
@@ -100,7 +100,7 @@ class SFTHooksTest(unittest.TestCase):
     }
     self.training_hooks.metric_logger.record_train_metrics.assert_called()
     self.training_hooks.metric_logger.write_metrics.assert_called_with(
-        expected_metrics, 0
+        expected_metrics, 1
     )
     self.assertEqual(len(self.training_hooks.train_metadata), 1)
 


### PR DESCRIPTION
# Description

[This commit](https://github.com/google/tunix/commit/ef0b4e582e048d4316a24fc5e16bee16c402c9ce) in Tunix changed the training loop, causing the `train_step` to be incremented before logging metrics. As a result, Tunix logs the metrics at x+1 for step=x. This created an issue with MaxText, which expects the `on_train_step_end()` hook to be called with train_step=x, when logging metrics for step x. As a result, the SFTTrainingHooks.on_train_step_end() hook failed with an AssertionError. 
```
AssertionError: SFTTrainingHooks.on_train_step_start() must be called before SFTTrainingHooks.on_train_step_end()
```

This PR resolves the problem by adjusting the on_train_step_end() hook to account for this change in the step increment timing.



# Tests

`bash end_to_end/tpu/llama3.1/8b/run_sft.sh`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
