### PR TITLE
use Pytree as base type in nnx_wrappers

### DIFF
--- a/src/MaxText/layers/nnx_wrappers.py
+++ b/src/MaxText/layers/nnx_wrappers.py
@@ -28,7 +28,7 @@ from flax.nnx import graph
 from flax.nnx import variablelib
 from flax.nnx.bridge import module as bdg_module
 from flax.nnx.module import Module
-from flax.nnx import Object
+from flax.nnx import Pytree
 from flax.nnx.rnglib import Rngs
 import jax
 from jax import tree_util as jtu
@@ -135,7 +135,7 @@ def nnx_attrs_to_linen_vars(nnx_attrs: dict) -> dict:
 
 def _set_initializing(module: Module, initializing: bool):
   for _, value in graph.iter_graph(module):
-    if isinstance(value, Object):
+    if isinstance(value, Pytree):
       value._object__state._initializing = initializing  # pylint: disable=protected-access
 
 


### PR DESCRIPTION
# Description
Uses Pytree instead of Object as the base type to check for in `nnx_wrappers` as `Object` is no longer an alias for `Pytree` but a subclass.

# Tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.