### PR TITLE
Removed qwix since it will be installed with tunix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,5 @@ transformers
 tunix @ https://github.com/google/tunix/archive/d770659621eb16ef6588268e26fa687fa068df20.zip
 google-jetstream @ https://github.com/AI-Hypercomputer/JetStream/archive/daedc21c393f23449fb54ddc4f75fca34348ea9c.zip
 mlperf-logging @ https://github.com/mlcommons/logging/archive/38ab22670527888c8eb7825a4ece176fcc36a95d.zip
-qwix @ https://github.com/google/qwix/archive/f2fd7b9114ff8d09e5b0131a453351578502da8a.zip
 # datasets 0.4.0 is not compatible with fsspec==2025.7.0. It will be updated in the next datasets release.
 datasets @ https://github.com/huggingface/datasets/archive/6790e138c00b87a1ddc72184f89e7814cf784360.zip

--- a/requirements_with_jax_ai_image.txt
+++ b/requirements_with_jax_ai_image.txt
@@ -18,7 +18,6 @@ pyink
 pylint
 pytest
 pytype
-qwix@git+https://github.com/google/qwix.git
 sentencepiece==0.1.97
 tensorflow-datasets
 tensorflow-text>=2.17.0


### PR DESCRIPTION
# Description

Unit tests are broken due to a dependency resolution error with qwix being downloaded from requirements.txt file and as a dependency of tunix. We need to remove qwix as being a dep directly listed in requirements.txt as it will be installed as part of tunix

`ERROR: Cannot install -r /deps/requirements_with_jax_ai_image.txt (line 27) and qwix 0.0.0 (from git+https://github.com/google/qwix.git) because these package versions have conflicting dependencies.
#13 27.24 
#13 27.24 The conflict is caused by:
#13 27.24     The user requested qwix 0.0.0 (from git+https://github.com/google/qwix.git)
#13 27.24     tunix 0.0.0 depends on qwix 0.0.0 (from git+https://github.com/google/qwix)
#13 27.24 
#13 27.24 To fix this you could try to:
#13 27.24 1. loosen the range of package versions you've specified
#13 27.24 2. remove package versions to allow pip attempt to solve the dependency conflict`

# Tests

Using this pr unit test run as a test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
