### PR TITLE
Fix docs build for RTD

### DIFF
--- a/docs/guides/data_input_tfds.md
+++ b/docs/guides/data_input_tfds.md
@@ -5,7 +5,7 @@
 bash download_dataset.sh {GCS_PROJECT} {GCS_BUCKET_NAME}
 ```
 2. In `src/MaxText/configs/base.yml` or through command line, set the following parameters:
-```yml
+```yaml
 dataset_type: tfds
 dataset_name: 'c4/en:3.0.1'
 # set eval_interval > 0 to use the specified eval dataset. Otherwise, only metrics on the train set will be calculated.


### PR DESCRIPTION
# Description

Addresses failure in ReadTheDocs build due to a typo in the selected lexer for a code block.

# Tests

Docs build successfully locally.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
