### PR TITLE
Support multiple images per example in Gemma3

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -798,9 +798,13 @@ freeze_vision_encoder_params: True
 dtype_mm: "float32"  # Data type for multimodal model's vision encoder
 remat_policy_for_vit: "minimal"  # Remat policy for multimodal model's vision encoder. Check `remat_policy` for options.
 image_size_for_vit: 896 # Default for Gemma3, and should be overwritten by model's config
-image_path: "" # Local image path used for decoding
+image_path: "" # Local image path used for decoding, can be multiple paths separated by comma, exp "/path/image1.jpg,/path/image2.jpg"
 image_placeholder: "<|image|>"
 posemb_type_for_vit: "learn"
+# max_num_images_per_example only applies for training when your image column is a list of images.
+# -1 means no limit, and will pad to the max possible number of images determined by sequence length.
+# Set it to avoid unnecessary padding if you know the maximum number of images per example.
+max_num_images_per_example: -1
 
 ### llama4 multi modal configs
 hidden_size_for_vit: 1408

--- a/src/MaxText/decode.py
+++ b/src/MaxText/decode.py
@@ -16,7 +16,7 @@
 
 import os
 from typing import Sequence
-
+import numpy as np
 import jax
 import jax.numpy as jnp
 
@@ -101,13 +101,14 @@ def main(argv: Sequence[str]) -> None:
   prefill_length = config.max_prefill_predict_length
   processor_output = multimodal_utils.PreprocessorOutput()
   if config.use_multimodal:
-    text = multimodal_utils.reformat_prompt(
-        text, image_placeholder=config.image_placeholder, model_name=config.model_name
+    image_path = config.image_path.split(",")
+    images = [multimodal_utils.load_image_from_path(p) for p in image_path]
+    processor_outputs = [multimodal_utils.pre_process_image(img, model_name=config.model_name) for img in images]
+    image_offsets = sum(
+        [multimodal_utils.get_image_offsets(config.model_name, processor_output=po) for po in processor_outputs]
     )
-    # TODO(hengtaoguo): Support multiple images as input.
-    images = multimodal_utils.load_image_from_path(config.image_path)
-    processor_output = multimodal_utils.pre_process_image(images, model_name=config.model_name)
-    prefill_length -= multimodal_utils.get_image_offsets(config.model_name, processor_output=processor_output)
+    prefill_length -= image_offsets
+    text = multimodal_utils.reformat_prompt(text, image_placeholder=config.image_placeholder, model_name=config.model_name, num_images=len(images))
 
   metadata = engine.get_tokenizer()
   tokenizer_model = engine.build_tokenizer(metadata)
@@ -119,9 +120,9 @@ def main(argv: Sequence[str]) -> None:
   tokens, true_length = tokenizer_model.encode(text, is_bos=not has_chat_template, prefill_lengths=[prefill_length])
   if config.use_multimodal:
     tokens = multimodal_utils.prepare_text_for_image_fusion(
-        tokens, model_name=config.model_name, processor_output=processor_output
+        tokens, model_name=config.model_name, processor_output=processor_outputs
     )
-    true_length += multimodal_utils.get_image_offsets(config.model_name, processor_output=processor_output)
+    true_length += image_offsets
 
   assert (
       true_length <= config.max_prefill_predict_length
@@ -147,7 +148,7 @@ def main(argv: Sequence[str]) -> None:
       prefill_result, first_token = engine.prefill(
           params=params,
           padded_tokens=tokens,
-          images=processor_output.pixel_values,
+          images=np.stack([po.pixel_values for po in processor_outputs]) if config.use_multimodal else None,
           true_length=true_length,
           rng=rng_prefill,
           slot=i,

--- a/src/MaxText/experimental/rl/grpo_input_pipeline.py
+++ b/src/MaxText/experimental/rl/grpo_input_pipeline.py
@@ -169,7 +169,7 @@ def preprocessing_pipeline(
 
   operations = [
       grain.MapOperation(lists2array),
-      _input_pipeline_utils.PadOrTrimToMaxLength(max_target_length),
+      _input_pipeline_utils.PadOrTrimToMaxLength(max_target_length, add_true_length=True),
       grain.Batch(batch_size=global_batch_size // jax.process_count(), drop_remainder=drop_remainder),
   ]
 

--- a/src/MaxText/input_pipeline/_grain_data_processing.py
+++ b/src/MaxText/input_pipeline/_grain_data_processing.py
@@ -133,7 +133,7 @@ def pretrain_preprocessing_pipeline(dataset, config, data_columns, tokenize, gra
     }
     dataset = dataset.map(_input_pipeline_utils.Rekey(rekey_dict))
   else:
-    dataset = dataset.map(_input_pipeline_utils.PadToMaxLength(config.max_target_length, pad_id))
+    dataset = dataset.map(_input_pipeline_utils.PadOrTrimToMaxLength(config.max_target_length, pad_id))
   batch_fn = functools.partial(grain.experimental.batch_and_pad, batch_size=batch_size, pad_value=pad_id)
   dataset = dataset.batch(batch_size, batch_fn=batch_fn)
 
@@ -175,7 +175,7 @@ def dpo_preprocessing_pipeline(dataset, config, data_columns, tokenize, grain_wo
         )
     )
 
-  dataset = dataset.map(_input_pipeline_utils.PadToMaxLength(config.max_target_length, pad_id))
+  dataset = dataset.map(_input_pipeline_utils.PadOrTrimToMaxLength(config.max_target_length, pad_id))
   batch_size = config.global_batch_size_to_load // jax.process_count()
   batch_fn = functools.partial(grain.experimental.batch_and_pad, batch_size=batch_size, pad_value=pad_id)
   dataset = dataset.batch(batch_size, batch_fn=batch_fn)

--- a/tests/multimodal_utils_test.py
+++ b/tests/multimodal_utils_test.py
@@ -27,6 +27,14 @@ class TestTextImageFusionGemma3(unittest.TestCase):
     self.BEGIN_IMAGE_TOKEN = 255999
     self.mm_tokens = [self.BEGIN_IMAGE_TOKEN, -2, -2]
 
+  def test_add_zero_image(self):
+    tokens = np.asarray([1, 2, 3, 4, 5, 6])
+    num_images = 0
+    new_tokens = multimodal_utils.insert_sequence(
+        at=self.BEGIN_IMAGE_TOKEN, sequence=self.mm_tokens, tokens=tokens, max_num_images=num_images
+    )
+    np.testing.assert_array_equal(new_tokens, tokens)
+  
   def test_add_single_image(self):
     tokens = np.asarray([1, 2, 3, self.BEGIN_IMAGE_TOKEN, 5, 6])
     num_images = 1


### PR DESCRIPTION
# Description

The Gemma3 model was pre-trained with a mix of text + image of long seq_len (128k for 4B model), and there is no limit in the number of images per example. Our initial support only allows one image per example. This PR expands the support.
* User can provide multiple images to run decode.py
* When using sft, the "image" column in the dataset can be a single image, or a list of images of different lengths

Feature request: b/435464855

# Tests
* [decode script](https://paste.googleplex.com/5911819562647552); [decode output](https://paste.googleplex.com/6257301044461568)
* For SFT, the testing dataset ChartQA only contains a single image. For testing purpose, I added a transformation function to make the "image" column a list of images of varied length:
```
def ensure_images_is_list(example):
   if not isinstance(example["images"], list):
      example["images"] = [example["images"]] * np.random.randint(0, 3)
   print(f"{len(example['images'])=}")
   return example
dataset = dataset.map(ensure_images_is_list)
```
* [sft script](https://paste.googleplex.com/5742407480115200); [sft output](https://paste.googleplex.com/6030701925367808)
* the original dataset with single image per example is also tested to confirm it's still supported.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
