### PR TITLE
feat(train): Enable z_loss regularization and logging via `z_loss_weight` flag

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -146,6 +146,7 @@ logits_dot_in_fp32: False  # whether to use fp32 in logits_dense or shared_embed
 cast_logits_to_fp32: True # whether to cast the logits to fp32. The higher precision is generally beneficial, but it can vary slightly.
 float32_qk_product: False # in dot_product attention, whether to cast to fp32 the inputs to qk product
 float32_logits: False # in dot_product attention, whether to cast to fp32 the inputs to softmax
+z_loss_weight: 0.0 # z-loss regularization weight, 0.0 to disable
 
 # Multi-Token Prediction Configs
 # The number of auxiliary prediction layers to use for MTP.


### PR DESCRIPTION
This PR enables the `z_loss` (logit regularization) feature in the main training loop.

Previously, `train.py` hardcoded the `z_loss` factor to `0.0`, disabling this feature. This change introduces a new config flag, `z_loss_weight`, allowing users to control the regularization strength. It also adds the `z_loss` component to the training and evaluation metrics.

### Why is this change being made?

The `z_loss` term (`weight * log(z)^2`) is a useful regularization technique for penalizing large logits, which can improve model stability and prevent logit drift. The core function `max_utils.cross_entropy_with_logits` already supported this, but it was inaccessible from the training script.

This PR "re-enables" this dormant feature, providing a valuable hyperparameter for tuning.

This solution is:
* **Flexible:** Users can now enable and tune `z_loss` strength via config.
* **Backward-compatible:** The new `z_loss_weight` flag defaults to `0.0`, ensuring existing configurations are unaffected.
* **Correct:** It correctly integrates the `z_loss` value into the metrics logging pipeline, handling both standard and gradient-accumulated (GA) steps.

### Changes in this PR

* **`base.yml`:**
    * Adds a new hyperparameter, `z_loss_weight: 0.0`, near other regularization flags like `dropout_rate`.

* **`loss_fn` (`train.py`):**
    * Calls `max_utils.cross_entropy_with_logits` with `config.z_loss_weight` instead of `0.0`.
    * Captures the `z_loss` component, applies the `targets_segmentation` mask, and computes its `jnp.sum()`.
    * Returns `z_loss` in the `aux` dict, handling GA and non-GA cases consistently:
        * **If GA > 1:** Returns the **sum** of `z_loss` (to be accumulated).
        * **If GA == 1:** Returns the **average** of `z_loss` (to be logged directly).

* **`train_step` (`train.py`):**
    * **GA Branch:**
        * The `z_loss` sum is now correctly accumulated in `accumulate_gradient`.
        * The final `learning/z_loss` metric is calculated as an **average per token** (total `z_loss` sum / `total_weights`) to ensure consistent logging.
    * **Non-GA Branch:**
        * The `z_loss` average from `loss_fn` is retrieved and logged directly as `learning/z_loss`.

* **`eval_step` (`train.py`):**
    * Captures the average `z_loss` from `loss_fn` and logs it as `evaluation/z_loss`.

Fixes: #2352 

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.