### PR TITLE
Add automated check for docs build

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,3 +31,4 @@ Before submitting this PR, please make sure (put X in square brackets):
 - [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
 - [ ] I have run end-to-end tests tests and provided workload links above if applicable.
 - [ ] I have made or will make corresponding changes to the doc if needed.
+- [ ] I have added any new documentation pages to [the relevant toctree](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

--- a/.github/workflows/check_docs_build.yml
+++ b/.github/workflows/check_docs_build.yml
@@ -1,0 +1,29 @@
+name: Check the Documentation Build
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip' # caching pip dependencies
+
+      - name: Install dependencies
+        run: pip install -r requirements_docs.txt
+
+      - name: Build documentation
+        run: |
+          sphinx-build -b html docs/ docs/_build/html


### PR DESCRIPTION
# Description

This PR adds a simple check to the CI workflows that verifies the documentation build. This will prevent accidental breakage of the docs. 

It also includes a new item in the PR template checklist to make sure new documentation pages are correctly added to the Table of Contents.

# Tests

I tested the workflow locally using [act](https://github.com/nektos/act).
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
