### PR TITLE
Fix direct uploading of HF checkpoints to GCS.

### DIFF
--- a/src/MaxText/utils/ckpt_conversion/utils/utils.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/utils.py
@@ -34,6 +34,7 @@ import numpy as np
 from google.cloud.storage import Client, transfer_manager
 
 from safetensors.numpy import save_file as numpy_save_file
+from safetensors.numpy import save as numpy_save
 from safetensors.flax import save as save_flax_to_bytes
 
 from huggingface_hub import HfApi, repo_exists
@@ -561,8 +562,8 @@ def upload_state_dict_to_gcs(state_dict: dict, gs_bucket_path: str):
   blob_name = "/".join(blob_path_parts)
 
   # 1. Serialize the state_dict to an in-memory byte buffer
-  buffer = io.BytesIO()
-  np.savez(buffer, **state_dict)
+  data = numpy_save(state_dict, metadata={"format": "pt"})
+  buffer = io.BytesIO(data)
   buffer.seek(0)  # Rewind the buffer to the beginning
 
   # 2. Upload the bytes to GCS


### PR DESCRIPTION
# Description

When running `MaxText.ckpt_conversion.to_huggingface` with the `base_output_directory` pointing directly to a GCS bucket, it is saved to an invalid safetensors format, giving a `Error while deserializing header: HeaderTooLarge` error. This PR addresses that by using `safetensors.numpy.save` to get back the bytes in the safetensors format and write those to the bucket.

# Tests

```
python3 -m MaxText.utils.ckpt_conversion.to_huggingface src/MaxText/configs/base.yml model_name=qwen3-32b load_parameters_path=path/to/maxtext/checkpoint/items/0 base_output_directory=path/to/hf/checkpoint scan_layers=true enable_single_controller=true
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
