### PR TITLE
Remove batch truncation for fractional batch sizes.

### DIFF
--- a/src/MaxText/train.py
+++ b/src/MaxText/train.py
@@ -94,13 +94,6 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
     loss: average loss
     aux: a dictionary including intermediate_outputs, total_loss, and total_weights
   """
-  # decimate proportion of data when per_device_batch_size<1
-  if is_train:
-    for k, v in data.items():
-      data[k] = v[: config.micro_batch_size_to_train_on, :]
-  else:
-    for k, v in data.items():
-      data[k] = v[: config.micro_batch_size_to_eval_on, :]
   mutable_collections = ["intermediates"]
   if config.mtp_num_layers > 0 and is_train:
     # The single model.apply call now triggers the entire chain if MTP is enabled:


### PR DESCRIPTION
# Description

When running with a `per_device_batch_size < 1`, rather than splitting larger batches from the data loader into the smaller batch sizes for training, the larger batch is truncated. This PR changes it so that instead the larger batch is split into smaller batches which are looped over instead, so that no data is discarded.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
