### PR TITLE
Migrate LlamaDecoderLayer to NNX

### DIFF
--- a/src/MaxText/inference/kvcache.py
+++ b/src/MaxText/inference/kvcache.py
@@ -310,8 +310,9 @@ class KVCache(nnx.Module):
     self.model_mode = model_mode
     self.use_chunked_prefill = use_chunked_prefill
 
-    self._initialize_prefill_caches(model_mode)
-    self._initialize_ar_cache_vars(model_mode)
+    if model_mode in (MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE):
+      self._initialize_prefill_caches(model_mode)
+      self._initialize_ar_cache_vars(model_mode)
 
   @property
   def prefill_key_vars(self):
@@ -510,7 +511,7 @@ class KVCache(nnx.Module):
 
     assert not self.kv_quant, "Not support kv_quant now."
     if decoder_segment_ids is not None:
-      self.batch, segment_id_seq_len = decoder_segment_ids.shape
+      _, segment_id_seq_len = decoder_segment_ids.shape
       assert self.key_seq_len == segment_id_seq_len, f"{self.key_seq_len=}, {segment_id_seq_len=} should match."
 
     assert key.dtype == value.dtype, "Key and Value Dtypes should match."
@@ -694,6 +695,12 @@ class KVCache(nnx.Module):
 
     else:
       one_hot_indices = one_hot_indices.astype(int)
+
+      # Align batch size for cache with new token in decoding
+      if cached_key.value.shape[2] != one_token_key_shaped_for_cache.shape[2]:
+        cached_key.value = jnp.repeat(cached_key.value, one_token_key_shaped_for_cache.shape[2], axis=2)
+        cached_value.value = jnp.repeat(cached_value.value, one_token_value_shaped_for_cache.shape[2], axis=2)
+
       cached_key.value = jax.lax.dynamic_update_index_in_dim(
           cached_key.value, one_token_key_shaped_for_cache, ar_cache_update_idx, ar_cache_update_axis
       )
@@ -773,6 +780,11 @@ class KVCache(nnx.Module):
         use_ragged_attention,
     )
     active_indicator = jnp.zeros((self.batch, 1), dtype=jnp.int32) + DECODING_ACTIVE_SEQUENCE_INDICATOR
+    
+    # Align batch size for cached segment IDs with indicator in decoding
+    if cached_ar_segment_id_var.value.shape[0] != active_indicator.shape[0]:
+      cached_ar_segment_id_var.value = jnp.repeat(cached_ar_segment_id_var.value, active_indicator.shape[0], axis=0)
+
     cached_ar_segment_id_var.value = jax.lax.dynamic_update_index_in_dim(
         cached_ar_segment_id_var.value, active_indicator, jnp.squeeze(cache_ar_index_var.value), 1
     )

--- a/src/MaxText/layers/llama2.py
+++ b/src/MaxText/layers/llama2.py
@@ -19,17 +19,20 @@
 import jax.numpy as jnp
 from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
-# from jax.experimental.pallas.ops.tpu import flash_attention
 
 from flax import linen as nn
+from flax import nnx
 
 from MaxText.inference import page_manager
 from MaxText.common_types import Config
-from MaxText.layers.linears import mlp_block
+from MaxText import max_utils
+from MaxText.layers.linears import Dropout, MlpBlock
+from MaxText.layers import initializers
+from MaxText.layers import nnx_wrappers
 from MaxText.layers import quantizations
-from MaxText.layers.attentions import attention_as_linen
+from MaxText.layers.attentions import Attention
 from MaxText.layers.quantizations import AqtQuantization as Quant
-from MaxText.layers.normalizations import rms_norm
+from MaxText.layers.normalizations import RMSNorm
 from MaxText.common_types import MODEL_MODE_PREFILL
 
 
@@ -38,15 +41,92 @@ from MaxText.common_types import MODEL_MODE_PREFILL
 # -----------------------------------------
 
 
-class LlamaDecoderLayer(nn.Module):
+class LlamaDecoderLayer(nnx.Module):
   """Transformer decoder layer that attends to the encoder."""
 
-  config: Config
-  mesh: Mesh
-  model_mode: str
-  quant: None | Quant = None
+  def __init__(
+      self,
+      config: Config,
+      model_mode: str,
+      mesh: Mesh,
+      rngs: nnx.Rngs,
+      quant: None | Quant = None,
+  ):
 
-  @nn.compact
+    self.config = config
+    self.mesh = mesh
+    self.quant = quant
+
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
+
+    self.pre_self_attention_layer_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=rngs,
+    )
+
+    self.self_attention = Attention(
+        config=config,
+        num_query_heads=config.num_query_heads,
+        num_kv_heads=config.num_kv_heads,
+        head_dim=config.head_dim,
+        max_target_length=config.max_target_length,
+        max_prefill_predict_length=config.max_prefill_predict_length,
+        attention_kernel=config.attention,
+        inputs_q_shape=dummy_inputs_shape,
+        inputs_kv_shape=dummy_inputs_shape,
+        mesh=mesh,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        dropout_rate=config.dropout_rate,
+        float32_qk_product=config.float32_qk_product,
+        float32_logits=config.float32_logits,
+        quant=self.quant,
+        kv_quant=quantizations.configure_kv_quant(config),
+        prefill_cache_axis_order=tuple(map(int, config.prefill_cache_axis_order.split(","))),
+        ar_cache_axis_order=tuple(map(int, config.ar_cache_axis_order.split(","))),
+        compute_axis_order=tuple(map(int, config.compute_axis_order.split(","))),
+        reshape_q=config.reshape_q,
+        use_ragged_attention=config.use_ragged_attention,
+        ragged_block_size=config.ragged_block_size,
+        model_mode=model_mode,
+        rngs=rngs,
+    )
+
+    self.post_self_attention_layer_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=rngs,
+    )
+
+    self.mlp = MlpBlock(
+        in_features=config.emb_dim,
+        intermediate_dim=config.mlp_dim,
+        activations=config.mlp_activations,
+        intermediate_dropout_rate=config.dropout_rate,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        config=config,
+        quant=self.quant,
+        model_mode=model_mode,
+        rngs=rngs,
+    )
+
+    self.dropout = Dropout(rate=config.dropout_rate, broadcast_dims=(-2,), rngs=rngs)
+
+    if model_mode == MODEL_MODE_PREFILL:
+      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
+    else:
+      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+
   def __call__(
       self,
       inputs,
@@ -59,57 +139,15 @@ class LlamaDecoderLayer(nn.Module):
       previous_chunk=None,
   ):
     cfg = self.config
-    mesh = self.mesh
 
-    if model_mode == MODEL_MODE_PREFILL:
-      activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
-    else:
-      activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
-
-    inputs = nn.with_logical_constraint(inputs, activation_axis_names)
+    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
-    lnx_rms = rms_norm(
-        num_features=inputs.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="pre_self_attention_layer_norm",
-        kernel_axes=("norm",),
-        epsilon=cfg.normalization_layer_epsilon,
-    )
-    lnx = lnx_rms(inputs)
+    lnx = self.pre_self_attention_layer_norm(inputs)
 
-    lnx = nn.with_logical_constraint(lnx, activation_axis_names)
+    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
 
     # Self-attention block
-    attention_layer = attention_as_linen(
-        config=cfg,
-        num_query_heads=cfg.num_query_heads,
-        num_kv_heads=cfg.num_kv_heads,
-        head_dim=cfg.head_dim,
-        max_target_length=cfg.max_target_length,
-        max_prefill_predict_length=cfg.max_prefill_predict_length,
-        attention_kernel=cfg.attention,
-        inputs_q_shape=lnx.shape,
-        inputs_kv_shape=lnx.shape,
-        mesh=mesh,
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        dropout_rate=cfg.dropout_rate,
-        name="self_attention",
-        float32_qk_product=cfg.float32_qk_product,
-        float32_logits=cfg.float32_logits,
-        quant=self.quant,
-        kv_quant=quantizations.configure_kv_quant(cfg),
-        prefill_cache_axis_order=tuple(map(int, cfg.prefill_cache_axis_order.split(","))),
-        ar_cache_axis_order=tuple(map(int, cfg.ar_cache_axis_order.split(","))),
-        compute_axis_order=tuple(map(int, cfg.compute_axis_order.split(","))),
-        reshape_q=cfg.reshape_q,
-        use_ragged_attention=cfg.use_ragged_attention,
-        ragged_block_size=cfg.ragged_block_size,
-        model_mode=model_mode,
-    )
-
-    attention_lnx = attention_layer(
+    attention_lnx = self.self_attention(
         lnx,
         lnx,
         decoder_positions,
@@ -121,40 +159,20 @@ class LlamaDecoderLayer(nn.Module):
         previous_chunk=previous_chunk,
     )
 
-    attention_lnx = nn.with_logical_constraint(attention_lnx, activation_axis_names)
+    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
     intermediate_inputs = inputs + attention_lnx
 
     # Fully Connected
-    hidden_states = rms_norm(
-        num_features=intermediate_inputs.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="post_self_attention_layer_norm",
-        kernel_axes=("norm",),
-        epsilon=cfg.normalization_layer_epsilon,
-    )(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, activation_axis_names)
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
 
     # MLP block.
-    mlp_lnx = mlp_block(
-        in_features=hidden_states.shape[-1],
-        intermediate_dim=cfg.mlp_dim,
-        activations=cfg.mlp_activations,
-        intermediate_dropout_rate=cfg.dropout_rate,
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="mlp",
-        config=cfg,
-        quant=self.quant,
-        model_mode=model_mode,
-    )(hidden_states, deterministic=deterministic)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, activation_axis_names)
+    mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
+    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs
-
-    layer_output = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(layer_output, deterministic=deterministic)
-
-    layer_output = nn.with_logical_constraint(layer_output, activation_axis_names)
+    layer_output = self.dropout(layer_output, deterministic=deterministic)
+    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
 
     if cfg.record_internal_nn_metrics:
       self.sow("intermediates", "activation_mean", jnp.mean(layer_output))
@@ -169,3 +187,9 @@ class LlamaDecoderLayer(nn.Module):
       return layer_output, None
     else:
       return layer_output
+
+
+LlamaDecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    LlamaDecoderLayer,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)

--- a/src/MaxText/layers/multi_token_prediction.py
+++ b/src/MaxText/layers/multi_token_prediction.py
@@ -192,6 +192,7 @@ class MultiTokenPredictionBlock(nn.Module):
       target_mask,
       position_ids,
       decoder_segment_ids,
+      model_mode,
       deterministic,
   ):
     cfg = self.config
@@ -237,7 +238,7 @@ class MultiTokenPredictionBlock(nn.Module):
       )
 
       # Project to logits using the shared embedding transpose
-      mtp_logits = self.decoder._apply_output_head(shared_embedding, next_mtp_hidden_state, deterministic)
+      mtp_logits = self.decoder._apply_output_head(shared_embedding, next_mtp_hidden_state, deterministic, model_mode)
 
       # Calculate cross-entropy loss for this specific layer's prediction
       mtp_xent, _ = max_utils.cross_entropy_with_logits(

--- a/src/MaxText/layers/nnx_wrappers.py
+++ b/src/MaxText/layers/nnx_wrappers.py
@@ -555,69 +555,70 @@ def to_linen_class(
     base_skip_rng: bool = False,
     **partial_kwargs: tp.Any,
 ) -> type[ToLinen]:
-  """Dynamically wraps an NNX module class into a Flax Linen module class."""
+  """A dynamically created Linen Module that wraps a specific NNX Module.
+
+  This class is not meant to be used directly. Instead, it is created and
+  returned by the `to_linen_class` function. It acts as a "partially applied"
+  version of the `ToLinen` wrapper, where the NNX module to be wrapped and
+  its default arguments are pre-configured.
+
+  When you instantiate this class, it behaves like a standard Linen module.
+  The arguments you provide during instantiation can override the defaults
+  that were set when this class was created by `to_linen_class`.
+
+  For example:
+    >>> from flax import linen as nn, nnx
+    >>> from MaxText.layers import linears
+    >>> # Create a specialized Linen wrapper for linears.DenseGeneral
+    >>> LinenDenseGeneral = to_linen_class(linears.DenseGeneral)
+    >>> # Now, LinenDenseGeneral can be used like a regular Linen module
+    >>> class MyModel(nn.Module):
+    ...   def setup(self):
+    ...     # Instantiate the wrapped linears.DenseGeneral with its arguments
+    ...     self.dense = LinenDenseGeneral(
+    ...         in_features_shape=10, out_features_shape=5
+    ...     )
+    ...   def __call__(self, x):
+    ...     return self.dense(x)
+
+  Attributes:
+    (The attributes are dynamically set by the `ToLinen` parent class based
+      on the arguments provided during instantiation.)
+  """
+
+  def __init__(
+      self,
+      args=None,
+      kwargs=None,
+      nnx_class=None,
+      skip_rng=None,
+      metadata_fn=None,
+      name=_MISSING,
+      parent=_MISSING,
+      **other_kwargs,
+  ):
+    linen_kwargs = {}
+    if not isinstance(parent, _Missing):
+      linen_kwargs["parent"] = parent
+    if not isinstance(name, _Missing):
+      linen_kwargs["name"] = name
+    ToLinen.__init__(
+      self,
+      nnx_class=nnx_class or base_nnx_class,
+      args=args or (),
+      metadata_fn=metadata_fn or base_metadata_fn,
+      skip_rng=skip_rng or base_skip_rng,
+      kwargs=FrozenDict({**partial_kwargs, **(kwargs or {}), **other_kwargs}),
+      **linen_kwargs,
+    )
 
   class ToLinenPartial(ToLinen):
-    """A dynamically created Linen Module that wraps a specific NNX Module.
-
-    This class is not meant to be used directly. Instead, it is created and
-    returned by the `to_linen_class` function. It acts as a "partially applied"
-    version of the `ToLinen` wrapper, where the NNX module to be wrapped and
-    its default arguments are pre-configured.
-
-    When you instantiate this class, it behaves like a standard Linen module.
-    The arguments you provide during instantiation can override the defaults
-    that were set when this class was created by `to_linen_class`.
-
-    For example:
-      >>> from flax import linen as nn, nnx
-      >>> from MaxText.layers import linears
-      >>> # Create a specialized Linen wrapper for linears.DenseGeneral
-      >>> LinenDenseGeneral = to_linen_class(linears.DenseGeneral)
-      >>> # Now, LinenDenseGeneral can be used like a regular Linen module
-      >>> class MyModel(nn.Module):
-      ...   def setup(self):
-      ...     # Instantiate the wrapped linears.DenseGeneral with its arguments
-      ...     self.dense = LinenDenseGeneral(
-      ...         in_features_shape=10, out_features_shape=5
-      ...     )
-      ...   def __call__(self, x):
-      ...     return self.dense(x)
-
-    Attributes:
-      (The attributes are dynamically set by the `ToLinen` parent class based
-       on the arguments provided during instantiation.)
-    """
+    """A dynamically created Linen Module that wraps a specific NNX Module."""
 
     def __init_subclass__(cls, **kwargs):
       super().__init_subclass__(**kwargs)
-
-      def __init__(
-          self,
-          args=None,
-          kwargs=None,
-          nnx_class=None,
-          skip_rng=None,
-          metadata_fn=None,
-          name=_MISSING,
-          parent=_MISSING,
-          **other_kwargs,
-      ):
-        linen_kwargs = {}
-        if not isinstance(parent, _Missing):
-          linen_kwargs["parent"] = parent
-        if not isinstance(name, _Missing):
-          linen_kwargs["name"] = name
-        ToLinen.__init__(
-            self,
-            nnx_class=nnx_class or base_nnx_class,
-            args=args or (),
-            metadata_fn=metadata_fn or base_metadata_fn,
-            skip_rng=skip_rng or base_skip_rng,
-            kwargs=FrozenDict({**partial_kwargs, **(kwargs or {}), **other_kwargs}),
-            **linen_kwargs,
-        )
-
       cls.__init__ = __init__
+
+  ToLinenPartial.__init__ = __init__
 
   return ToLinenPartial

--- a/src/MaxText/max_utils.py
+++ b/src/MaxText/max_utils.py
@@ -36,6 +36,7 @@ import orbax.checkpoint as ocp
 from orbax.checkpoint.experimental.emergency.multi_tier_checkpointing import initialization
 import psutil
 from tensorboardX import writer
+from MaxText.common_types import MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN
 
 initialize_multi_tier_checkpointing = initialization.initialize_multi_tier_checkpointing
 HYBRID_RING_64X4 = "hybrid_ring_64x4"
@@ -952,3 +953,37 @@ def rescan_train_state_params(params, source_shardings, scan_axis, layer_groups)
 
     # Store result and clear temporary memory
     decoder[layer_name] = scanned
+
+
+def get_batch_seq_len_for_mode(config, model_mode):
+  """
+  Resolves the batch size and sequence length based on the model's operational mode.
+
+  Args:
+    config: A configuration object with model parameters.
+    model_mode: The current operational mode 
+                (e.g., PREFILL, AUTOREGRESSIVE, TRAIN).
+
+  Returns:
+    A tuple of (batch_size, seq_len).
+  """
+  if model_mode == MODEL_MODE_PREFILL:
+    # Prefill mode: Process one full-length prompt.
+    batch_size = 1
+    seq_len = config.max_prefill_predict_length
+    
+  elif model_mode == MODEL_MODE_AUTOREGRESSIVE:
+    # Autoregressive/decode mode: Generate one token at a time for a batch.
+    batch_size = config.micro_batch_size_to_train_on
+    seq_len = 1
+    
+  elif model_mode == MODEL_MODE_TRAIN:
+    # Training mode: Process a full batch of full-length sequences.
+    batch_size = config.micro_batch_size_to_train_on
+    seq_len = config.max_target_length
+    
+  else:
+    # Explicitly handle unknown modes instead of falling back to a default.
+    raise ValueError(f"Unknown model_mode: {model_mode}")
+  
+  return batch_size, seq_len

--- a/tests/decode_tests.py
+++ b/tests/decode_tests.py
@@ -40,7 +40,7 @@ class DecodeTests(unittest.TestCase):
           "ici_tensor_parallelism=4",
           "max_target_length=128",
           "per_device_batch_size=1",
-          rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizer.llama2')}",
+          rf"tokenizer_path={os.path.join('src', MAXTEXT_ASSETS_ROOT, 'tokenizer.llama2')}",
       ],
       "int8": [  # tests decode with int8 quantization
           None,
@@ -55,7 +55,7 @@ class DecodeTests(unittest.TestCase):
           "per_device_batch_size=1",
           "quantization=int8",
           "quantize_kvcache=True",
-          rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizer.llama2')}",
+          rf"tokenizer_path={os.path.join('src', MAXTEXT_ASSETS_ROOT, 'tokenizer.llama2')}",
       ],
       "pdb_lt_1": [  # tests decode with per_device_batch_size < 1
           None,
@@ -68,7 +68,7 @@ class DecodeTests(unittest.TestCase):
           "ici_tensor_parallelism=4",
           "max_target_length=128",
           "per_device_batch_size=.25",
-          rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizer.llama2')}",
+          rf"tokenizer_path={os.path.join('src', MAXTEXT_ASSETS_ROOT, 'tokenizer.llama2')}",
       ],
   }
 

--- a/tests/integration_tests/inference_microbenchmark_smoke_test.py
+++ b/tests/integration_tests/inference_microbenchmark_smoke_test.py
@@ -35,7 +35,7 @@ class Inference_Microbenchmark(unittest.TestCase):
         [
             None,
             os.path.join(MAXTEXT_PKG_DIR, "configs", "tpu_smoke_test.yml"),
-            rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizer.llama2')}",
+            rf"tokenizer_path={os.path.join('src', MAXTEXT_ASSETS_ROOT, 'tokenizer.llama2')}",
             "ici_autoregressive_parallelism=-1",
             "ici_fsdp_parallelism=1",
             "max_prefill_predict_length=1024",

--- a/tests/maxtext_utils_test.py
+++ b/tests/maxtext_utils_test.py
@@ -165,7 +165,7 @@ class ModelWithMultipleCollections(nn.Module):
   def setup(self):
     self.kernel = self.variable("special_variables", "my_first_kernel", lambda: jnp.ones((4, 5)))
 
-  def __call__(self, x, y, encoder_images=None, nnx_method=None):
+  def __call__(self, x, y, encoder_images=None, nnx_method=None, model_mode=None):
     x = self.dense(x)
     x = x @ self.kernel.value
     return x

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -134,7 +134,8 @@ class TestModel(unittest.TestCase):
         {"params": self.rng, "aqt": self.rng},
         ids,
         decoder_positions,
-        decoder_segment_ids,
+        model_mode=MODEL_MODE_TRAIN,
+        decoder_segment_ids=decoder_segment_ids,
         enable_dropout=False,
     )
 
@@ -142,7 +143,8 @@ class TestModel(unittest.TestCase):
         {"params": self.rng, "aqt": self.rng},
         ids,
         decoder_positions,
-        decoder_segment_ids,
+        model_mode=MODEL_MODE_PREFILL,
+        decoder_segment_ids=decoder_segment_ids,
         enable_dropout=False,
     )
 
@@ -150,9 +152,9 @@ class TestModel(unittest.TestCase):
         train_transformer_vars,
         ids,
         decoder_positions,
-        decoder_segment_ids,
-        enable_dropout=False,
         model_mode=MODEL_MODE_TRAIN,
+        decoder_segment_ids=decoder_segment_ids,
+        enable_dropout=False,
         rngs={"aqt": self.rng},
     )
 
@@ -160,9 +162,9 @@ class TestModel(unittest.TestCase):
         prefill_transformer_vars,
         ids[:, :PREFILL_RANGE],
         decoder_positions[:, :PREFILL_RANGE],
+        model_mode=MODEL_MODE_PREFILL,
         decoder_segment_ids=decoder_segment_ids[:, :PREFILL_RANGE],
         enable_dropout=False,
-        model_mode=MODEL_MODE_PREFILL,
         rngs={"aqt": self.rng},
         mutable=["cache"],
     )
@@ -179,8 +181,8 @@ class TestModel(unittest.TestCase):
           prefill_transformer_vars,
           ids_idx,
           decoder_positions_idx,
-          enable_dropout=False,
           model_mode=MODEL_MODE_AUTOREGRESSIVE,
+          enable_dropout=False,
           rngs={"aqt": self.rng},
           mutable=["cache"],
       )

--- a/tests/multi_token_prediction_test.py
+++ b/tests/multi_token_prediction_test.py
@@ -28,6 +28,8 @@ from MaxText.globals import MAXTEXT_PKG_DIR
 from MaxText.layers.decoders import Decoder, DecoderLayer
 from MaxText.layers import multi_token_prediction  # The class under test
 from MaxText.layers import embeddings
+from MaxText.common_types import MODEL_MODE_TRAIN
+
 
 TEST_LAYER_NUM = 1
 
@@ -146,7 +148,7 @@ class MTPBlockTestModel(nn.Module):
     )
 
   def __call__(
-      self, main_hidden_state, input_ids, target_ids, target_mask, position_ids, decoder_segment_ids, deterministic
+      self, main_hidden_state, input_ids, target_ids, target_mask, position_ids, decoder_segment_ids, model_mode, deterministic
   ):
     return self.mtp_block(
         self.shared_embedding,
@@ -156,6 +158,7 @@ class MTPBlockTestModel(nn.Module):
         target_mask,
         position_ids,
         decoder_segment_ids,
+        model_mode,
         deterministic,
     )
 
@@ -194,6 +197,7 @@ class MultiTokenPredictionBlockTest(unittest.TestCase):
         self.target_mask,
         self.position_ids,
         self.decoder_segment_ids,
+        model_mode=MODEL_MODE_TRAIN,
         deterministic=True,
     )
 
@@ -208,6 +212,7 @@ class MultiTokenPredictionBlockTest(unittest.TestCase):
         self.position_ids,
         self.decoder_segment_ids,
         deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
         mutable=["mtp_losses"],
     )
     self.assertIn("mtp_losses", captured_vars)
@@ -237,6 +242,7 @@ class MultiTokenPredictionBlockTest(unittest.TestCase):
         self.decoder_segment_ids,
         deterministic=False,
         mutable=["mtp_losses"],
+        model_mode=MODEL_MODE_TRAIN,
         rngs={"dropout": self.rng},
     )
 


### PR DESCRIPTION
# Description

This is co-work with @bvandermoon and @shuningjin 

Example to migrate llama2 to NNX. This change is based on @bvandermoon's [branch](https://github.com/AI-Hypercomputer/maxtext/compare/bvandermoon-nnx-single-kvcache-memory-issue) and keep it untouched for sanity check. This PR squashes all commits into one.

FIX: b/445953113, b/439070153

# Tests

Details in b/445953113#comment13

1. decode cmd: https://paste.googleplex.com/4995561203826688
- decode diff: https://diff.googleplex.com/#key=8kLLbM6jhJky, same as main (memstat after init, output)
2. train cmd: https://paste.googleplex.com/5801717128101888
- train diff: https://diff.googleplex.com/#key=9wKB5thwoIP9, same as main (TFLOP for last steps)
3. jetstream cmd, PDB=6: https://paste.googleplex.com/4992195518136320 (b/445953113#comment7)
- jetstream diff: https://diff.googleplex.com/#key=fqj8G4bz5Bom, same as main (acc, similar speed)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
