### PR TITLE
Continue pinning Tunix dependency for nightly builds

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -146,7 +146,7 @@ if [[ "$MODE" == "nightly" ]]; then
     # Remove/update this section based on the pinned github repo commit in requirements.txt
     sed -i -E \
       -e 's|^mlperf-logging @ https?://github.com/mlcommons/logging/archive/.*\.zip$|mlperf-logging@git+https://github.com/mlperf/logging.git|' \
-      -e 's|^([^ ]*) @ https?://github.com/([^/]*\/[^/]*)/archive/.*\.zip$|\1@git+https://github.com/\2.git|' \
+      -e '/^tunix/!s|^([^ ]*) @ https?://github.com/([^/]*\/[^/]*)/archive/.*\.zip$|\1@git+https://github.com/\2.git|' \
       requirements.txt.nightly-temp
 
     echo "--- Installing modified nightly requirements: ---"


### PR DESCRIPTION
# Description

Keep tunix pinned for nightly builds. 

Tunix renamed their package from `tunix` to `google-tunix`. We pin Tunix to a specific commit, so it works fine since this commit still has the old name. But for nightly builds, we strip Github commit pins and build everything at HEAD. This PR keeps the Tunix pin.

This is not ideal since we want to build these dependencies at HEAD for nightlies, but it will work to unblock others until we can have a better long-term fix. Currently, there are PR testing issues with using the latest google-tunix commits, and Tunix is recommending to not use the PyPI package for now. So we can go with this temporarily to unblock

FIXES: b/446299605

# Tests

I can build the nightly image locally now with `bash docker_build_dependency_image.sh MODE=nightly`. This was failing on main with:

```
17.10   × Failed to download and build `tunix @
17.10   │ git+https://github.com/google/tunix.git`
17.10   ╰─▶ Package metadata name `google-tunix` does not match given name `tunix`
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
