### PR TITLE
Update pinned commit for Tunix

### DIFF
--- a/maxtext_jax_ai_image.Dockerfile
+++ b/maxtext_jax_ai_image.Dockerfile
@@ -49,7 +49,7 @@ RUN if [ "$DEVICE" = "tpu" ] && [ "$JAX_STABLE_STACK_BASEIMAGE" = "us-docker.pkg
 
 # Install tunix at a pinned commit for TPU devices, skip for GPU
 RUN if [ "$DEVICE" = "tpu" ]; then \
-        python3 -m pip install 'google-tunix @ https://github.com/google/tunix/archive/e03f154edd2abfddd6b9babb72a3d0d3c4d81bb2.zip'; \
+        python3 -m pip install 'google-tunix @ https://github.com/google/tunix/archive/6c2a613217ed6bb1c9d60088d6e3c67184821c69.zip'; \
   fi
 
 # Now copy the remaining code (source files that may change frequently)

--- a/setup.sh
+++ b/setup.sh
@@ -191,7 +191,7 @@ if [[ "$MODE" == "stable" || ! -v MODE ]]; then
 
         # TODO: Once tunix has support for GPUs, move it from here to requirements.txt
         echo "Installing tunix for stable TPU environment"
-        python3 -m uv pip install 'google-tunix @ https://github.com/google/tunix/archive/e03f154edd2abfddd6b9babb72a3d0d3c4d81bb2.zip'
+        python3 -m uv pip install 'google-tunix @ https://github.com/google/tunix/archive/6c2a613217ed6bb1c9d60088d6e3c67184821c69.zip'
 
         if [[ -n "$LIBTPU_GCS_PATH" ]]; then
             # Install custom libtpu


### PR DESCRIPTION
# Description
A customer reported issue when installing Tunix with their installation setup. They install flax by `pip install -e /opt/flax` which was getting overwritten by Tunix's dependency installation. PR in Tunix: https://github.com/google/tunix/pull/388 solves this problem. So, we are pointing the pinned commit in MaxText to use that particular commit in Tunix to fix the customer issue.

# Tests
N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
