### PR TITLE
add tranposed gmm tiling for wo

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -171,8 +171,8 @@ use_custom_sort_vjp: False # whether to use a custom sort vjp for sparse matmul 
 use_ring_of_experts: False # whether to use ring of experts for sparse matmul expert parallelism
 # Tunable tiling dimensions used for Megablox
 tile_batch_seq: 512
-tile_activation_dim: 1024
-tile_weight_dim: 1024
+tile_embed_dim: 1024
+tile_mlp_dim: 1024
 norm_topk_prob: False # Boolean to enable the top-k probability normalization. Qwen3-specific normalization of router weights.
 
 # How the expert axis is used to shard attention weights and activations

--- a/src/MaxText/layers/moe.py
+++ b/src/MaxText/layers/moe.py
@@ -782,12 +782,7 @@ class RoutedMoE(nnx.Module):
   ):
     """Perform sparse matrix multiplication of inputs and Experts."""
 
-    def gmm(inputs, kernel, group_sizes, expert_assignments):
-      tile_size = (
-          self.config.tile_batch_seq,
-          self.config.tile_activation_dim,
-          self.config.tile_weight_dim,
-      )
+    def gmm(inputs, kernel, tiling, group_sizes, expert_assignments):
       pad_length = self.config.tile_batch_seq
       hs_shape = inputs.shape
       # pad length is the 1st dimension of tiling size in gmm call
@@ -808,9 +803,9 @@ class RoutedMoE(nnx.Module):
         rhs_quantize_dtype = quant_dg.fwd.dg_quantizer.rhs.numerics.get_dtype()
       m, k, n = inputs.shape[0], inputs.shape[1], kernel.shape[2]
       tiling = (
-          min(tile_size[0], m),
-          min(tile_size[1], k),
-          min(tile_size[2], n),
+          min(tiling[0], m),
+          min(tiling[1], k),
+          min(tiling[2], n),
       )
       if self.config.megablox:
         output = mblx.gmm(
@@ -1031,14 +1026,24 @@ class RoutedMoE(nnx.Module):
           group_sizes=group_sizes,
           expert_assignments=selected_experts,
       )
-      layer_w0 = gmm_fn(x, w0)
+      wi_tile_size = (
+          self.config.tile_batch_seq,
+          self.config.tile_embed_dim,
+          self.config.tile_mlp_dim,
+      )
+      wo_tile_size = (
+          self.config.tile_batch_seq,
+          self.config.tile_mlp_dim,
+          self.config.tile_embed_dim,
+      )
+      layer_w0 = gmm_fn(x, w0, tiling=wi_tile_size)
       if self.get_tensor_transpose_parallelism_size() > 1:
         layer_w0 = jax.lax.psum(layer_w0, "tensor_transpose")
       if self.config.mlp_bias:
         layer_w0 = layer_w0 + w0_bias
       layer_w0 = adc.checkpoint_name(layer_w0, "mlpwi_0")
 
-      layer_w1 = gmm_fn(x, w1)
+      layer_w1 = gmm_fn(x, w1, tiling=wi_tile_size)
       if self.get_tensor_transpose_parallelism_size() > 1:
         layer_w1 = jax.lax.psum(layer_w1, "tensor_transpose")
       if self.config.mlp_bias:
@@ -1046,7 +1051,7 @@ class RoutedMoE(nnx.Module):
       layer_w1 = adc.checkpoint_name(layer_w1, "mlpwi_1")
       intermediate_layer = self.apply_ffn_activation(layer_w0, layer_w1)
 
-      intermediate_output = gmm_fn(intermediate_layer, wo)
+      intermediate_output = gmm_fn(intermediate_layer, wo, tiling=wo_tile_size)
       if self.get_tensor_parallelism_size() > 1:
         intermediate_output = jax.lax.psum_scatter(intermediate_output, "tensor", scatter_dimension=1, tiled=True)
       if self.config.mlp_bias:


### PR DESCRIPTION
# Description

Previous all gmms used same tiling configuration. 

This PR enabled same tilings for wi-0, wi-1, and transposed for wo.

This PR improved step time from [41.5s](http://xprof.corp.google.com/trace_viewer/qinwen-6480524894885440759) to [39.5s](http://xprof.corp.google.com/trace_viewer/qinwen-10024501887474315790).


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
