### PR TITLE
Update workflow trigger rule

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -35,13 +35,14 @@ jobs:
           env | grep '^DEBUG_'
 
   review:
-    # code review: PR is not from a fork (a critical security precaution) & label added as gemini-review
+    # code review: PR is not from a fork (a critical security precaution) & label containing 'gemini-review' is added
+    # (use contains instead of == to relax the constraints with multiple labels condition)
     if: |- 
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.fork == false &&
         github.event.action == 'labeled' &&
-        github.event.label.name == 'gemini-review'
+        contains(github.event.label.name, 'gemini-review')
       )
     runs-on: 'ubuntu-latest'
     timeout-minutes: 10


### PR DESCRIPTION
# Description

Relax the constraint with multiple labels in the PR:
* If we have multiple labels in PR, then adding `gemini-review` will not post back the comments ([example](https://screenshot.googleplex.com/AsvK9TJLwHXFsQ7))
* Update the rule from `github.event.label.name == 'gemini-review'` to `contains(github.event.label.name, 'gemini-review')` will workaround the issue (tested in this PR)

Side note: In debug mode, **I see the requests are being throttled using free tier**

```
failed with status 429. Retrying with backoff... ApiError: {"error":{"message":"{\n  \"error\": {\n    \"code\": 429,\n    \"message\": \"You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: [https://ai.google.dev/gemini-api/docs/rate-limits.\\n*](https://ai.google.dev/gemini-api/docs/rate-limits.//n*) Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 2\\nPlease retry in 37.38241118s.\",\n    \"status\": \"RESOURCE_EXHAUSTED\",\n    \"details\": [\n      {\n        \"@type\": \"type.googleapis.com/google.rpc.QuotaFailure\",\n        \"violations\": [\n          {\n            \"quotaMetric\": \"generativelanguage.googleapis.com/generate_content_free_tier_requests\",\n            \"quotaId\": \"GenerateRequestsPerMinutePerProjectPerModel-FreeTier\",\n            \"quotaDimensions\": {\n              \"model\": \"gemini-2.5-pro\",\n              \"location\": \"global\"\n            },\n            \"quotaValue\": \"2\"\n          }\n        ]\n      },\n      {\n        \"@type\": \"type.googleapis.com/google.rpc.Help\",\n        \"links\": [\n          {\n            \"description\": \"Learn more about Gemini API quotas\",\n            \"url\": \"[https://ai.google.dev/gemini-api/docs/rate-limits\](https://ai.google.dev/gemini-api/docs/rate-limits/)"\n          }\n        ]\n      },\n      {\n        \"@type\": \"type.googleapis.com/google.rpc.RetryInfo\",\n        \"retryDelay\": \"37s\"\n      }\n    ]\n  }\n}\n","code":429,"status":"Too Many Requests"}}
```

# Tests

Manual tests on debug mode

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
