### PR TITLE
Migrate Llama4DecoderLayer and Llama4ScannableBlock to NNX

### DIFF
--- a/end_to_end/tpu/llama4/Run_Llama4.md
+++ b/end_to_end/tpu/llama4/Run_Llama4.md
@@ -71,4 +71,5 @@ python3 -m MaxText.decode src/MaxText/configs/base.yml scan_layers=false base_ou
 ## Supported MoE strategy
 * Dropless
   * General dense matmul implementation with flag `sparse_matmul=False capacity_factor=-1`.
-  * Support for `megablox` and `ragged_dot` is coming soon!
+  * [MegaBlocks](https://arxiv.org/abs/2211.15841) implementation with flag `sparse_matmul=True megablox=True`.
+  * [JAX ragged_dot](https://github.com/jax-ml/jax/blob/a8fb0e01f8d083fff337d3c26375bb1b77344a99/jax/_src/lax/lax.py#L2415) implementation with flag `sparse_matmul=True megablox=False`.

--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -401,7 +401,7 @@ class Decoder(nn.Module):
       case DecoderBlockType.SIMPLE_MLP:
         return [simple_layer.SimpleMlpDecoderLayer]
       case DecoderBlockType.LLAMA4:
-        return [llama4.Llama4ScannableBlock] if self.config.scan_layers else [llama4.Llama4DecoderLayer]
+        return [llama4.Llama4ScannableBlockToLinen] if self.config.scan_layers else [llama4.Llama4DecoderLayerToLinen]
       case _:
         # Default case to handle any unknown decoder block types.
         raise ValueError(f"Incorrect decoder_block name {self.config.decoder_block.value=}")

--- a/src/MaxText/layers/llama4.py
+++ b/src/MaxText/layers/llama4.py
@@ -23,17 +23,23 @@ from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
 
 from flax import linen as nn
+from flax import nnx
 
 from MaxText.common_types import Config, Array, MODEL_MODE_TRAIN, AttentionType
+from MaxText import max_utils
 from MaxText.inference import page_manager
 from MaxText.layers import initializers
-from MaxText.layers.linears import mlp_block
+from MaxText.layers import nnx_wrappers
 from MaxText.layers import linears
-from MaxText.layers import moe
 from MaxText.layers import quantizations
 from MaxText.layers import attentions
 from MaxText.layers.quantizations import AqtQuantization as Quant
-from MaxText.layers.normalizations import rms_norm
+from MaxText.layers.normalizations import RMSNorm
+from MaxText.layers.attentions import Attention
+from MaxText.layers.linears import MlpBlock
+from MaxText.layers.linears import Dropout
+from MaxText.layers.moe import RoutedAndSharedMoE
+from MaxText.common_types import MODEL_MODE_PREFILL
 
 
 #### Multi modal model implementation
@@ -343,25 +349,135 @@ def determine_is_moe_layer(layer_id: int, interleave_moe_layer_step: int) -> boo
 # -----------------------------------------
 
 
-class Llama4DecoderLayer(nn.Module):
-  """Transformer decoder layer for Llama4.
+class Llama4DecoderLayer(nnx.Module):
+  """Transformer decoder layer for Llama4."""
 
-  Attributes:
-    config: Config, MaxText model config
-    mesh: Mesh, JAX device mesh (used for sharding)
-    quant: None | Quant, quantization config
-    is_nope_layer: bool, whether to use RoPE or not on this layer
-    is_moe_layer: bool, whether this layer operates as a MoE layer
-  """
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      rngs: nnx.Rngs,
+      quant: None | Quant = None,
+      is_nope_layer: bool = False,
+      is_moe_layer: bool = False,
+  ):
+    """Initializes the Llama4 decoder layer.
 
-  config: Config
-  mesh: Mesh
-  model_mode: str
-  quant: None | Quant = None
-  is_nope_layer: bool = False
-  is_moe_layer: bool = False
+    Args:
+      config: The main model configuration object.
+      mesh: The device mesh used for sharding parameters and activations.
+      model_mode: One of MODEL_MODE_TRAIN, MODEL_MODE_PREFILL, or MODEL_MODE_AUTOREGRESSIVE.
+      rngs: An `nnx.Rngs` object to provide random numbers.
+      quant: An optional configuration for quantization. Defaults to None.
+      is_nope_layer: If True, this layer will be configured as No Position Embeddings layer. Defaults to False.
+      is_moe_layer: If True, this layer will use a MoE block. Defaults to False as Dense.
+    """
 
-  @nn.compact
+    self.config = config
+    self.mesh = mesh
+    self.quant = quant
+    self.rngs = rngs
+    self.is_nope_layer = is_nope_layer
+    self.is_moe_layer = is_moe_layer
+
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
+
+    self.pre_self_attention_layer_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=rngs,
+    )
+
+    # Instead of scaling the query values in the checkpoint conversion (`llama_or_mistral_ckpt`)
+    # we'll do it dynamically in the forward pass of Attention
+    query_pre_attn_scalar = config.head_dim**-0.5
+    self.self_attention = Attention(
+        config=config,
+        num_query_heads=config.num_query_heads,
+        num_kv_heads=config.num_kv_heads,
+        head_dim=config.head_dim,
+        max_target_length=config.max_target_length,
+        max_prefill_predict_length=config.max_prefill_predict_length,
+        attention_kernel=config.attention,
+        inputs_q_shape=dummy_inputs_shape,
+        inputs_kv_shape=dummy_inputs_shape,
+        mesh=mesh,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        dropout_rate=config.dropout_rate,
+        float32_qk_product=config.float32_qk_product,
+        float32_logits=config.float32_logits,
+        quant=self.quant,
+        kv_quant=quantizations.configure_kv_quant(config),
+        prefill_cache_axis_order=tuple(map(int, config.prefill_cache_axis_order.split(","))),
+        ar_cache_axis_order=tuple(map(int, config.ar_cache_axis_order.split(","))),
+        compute_axis_order=tuple(map(int, config.compute_axis_order.split(","))),
+        reshape_q=config.reshape_q,
+        use_ragged_attention=config.use_ragged_attention,
+        ragged_block_size=config.ragged_block_size,
+        is_nope_layer=self.is_nope_layer,
+        use_qk_norm=config.use_qk_norm,
+        query_pre_attn_scalar=query_pre_attn_scalar,
+        temperature_tuning=config.temperature_tuning,
+        temperature_tuning_scale=0.1,
+        temperature_tuning_floor_scale=8192.0,
+        # note: chunk_attn_window_size is set in the config
+        attention_type=AttentionType.GLOBAL if self.is_nope_layer else AttentionType.CHUNK,
+        model_mode=model_mode,
+        rngs=rngs,
+    )
+
+    self.post_self_attention_layer_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=self.rngs,
+    )
+
+    if self.is_moe_layer:
+      # NOTE: the name Llama4MoEBlock_0 is to ensure reverse compatibility with
+      # existing checkpoints for MoE block.
+      self.Llama4MoEBlock_0 = RoutedAndSharedMoE(
+          config=config,
+          mesh=self.mesh,
+          kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+          kernel_axes=("embed", None),
+          dtype=config.dtype,
+          weight_dtype=config.weight_dtype,
+          quant=self.quant,
+          rngs=self.rngs,
+      )
+    else:
+      self.mlp = MlpBlock(
+          in_features=config.emb_dim,
+          intermediate_dim=config.mlp_dim,
+          activations=config.mlp_activations,
+          intermediate_dropout_rate=config.dropout_rate,
+          dtype=config.dtype,
+          weight_dtype=config.weight_dtype,
+          config=config,
+          quant=self.quant,
+          model_mode=model_mode,
+          rngs=self.rngs,
+      )
+
+    self.dropout = Dropout(rate=config.dropout_rate, broadcast_dims=(-2,), rngs=self.rngs)
+    if model_mode == MODEL_MODE_PREFILL:
+      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
+    else:
+      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+  @property
+  def moe_block(self):
+    return self.Llama4MoEBlock_0
+
   def __call__(
       self,
       inputs,
@@ -375,65 +491,16 @@ class Llama4DecoderLayer(nn.Module):
       previous_chunk=None,
   ):
     cfg = self.config
-    mesh = self.mesh
-
     assert cfg.num_experts >= 1, "Expected the Llama4 config to have `num_experts > 1`."
 
-    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
-    lnx_rms = rms_norm(
-        num_features=inputs.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="pre_self_attention_layer_norm",
-        kernel_axes=("norm",),
-        epsilon=cfg.normalization_layer_epsilon,
-    )
-    lnx = lnx_rms(inputs)
 
-    lnx = nn.with_logical_constraint(lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
-    # Instead of scaling the query values in the checkpoint conversion (`llama_or_mistral_ckpt`)
-    # we'll do it dynamically in the forward pass of Attention
-    query_pre_attn_scalar = cfg.head_dim**-0.5
+    lnx = self.pre_self_attention_layer_norm(inputs)
+    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
 
     # Self-attention block
-    attention_layer = attentions.attention_as_linen(
-        config=cfg,
-        num_query_heads=cfg.num_query_heads,
-        num_kv_heads=cfg.num_kv_heads,
-        head_dim=cfg.head_dim,
-        max_target_length=cfg.max_target_length,
-        max_prefill_predict_length=cfg.max_prefill_predict_length,
-        attention_kernel=cfg.attention,
-        inputs_q_shape=lnx.shape,
-        inputs_kv_shape=lnx.shape,
-        mesh=mesh,
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        dropout_rate=cfg.dropout_rate,
-        name="self_attention",
-        float32_qk_product=cfg.float32_qk_product,
-        float32_logits=cfg.float32_logits,
-        quant=self.quant,
-        kv_quant=quantizations.configure_kv_quant(cfg),
-        prefill_cache_axis_order=tuple(map(int, cfg.prefill_cache_axis_order.split(","))),
-        ar_cache_axis_order=tuple(map(int, cfg.ar_cache_axis_order.split(","))),
-        compute_axis_order=tuple(map(int, cfg.compute_axis_order.split(","))),
-        reshape_q=cfg.reshape_q,
-        use_ragged_attention=cfg.use_ragged_attention,
-        ragged_block_size=cfg.ragged_block_size,
-        is_nope_layer=self.is_nope_layer,
-        use_qk_norm=cfg.use_qk_norm,
-        query_pre_attn_scalar=query_pre_attn_scalar,
-        temperature_tuning=cfg.temperature_tuning,
-        temperature_tuning_scale=0.1,
-        temperature_tuning_floor_scale=8192.0,
-        # note: chunk_attn_window_size is set in the config
-        attention_type=AttentionType.GLOBAL if self.is_nope_layer else AttentionType.CHUNK,
-        model_mode=model_mode,
-    )
-
-    attention_lnx = attention_layer(
+    attention_lnx = self.self_attention(
         lnx,
         lnx,
         decoder_positions,
@@ -445,66 +512,22 @@ class Llama4DecoderLayer(nn.Module):
         previous_chunk=previous_chunk,
         bidirectional_mask=bidirectional_mask,
     )
-
-    attention_lnx = nn.with_logical_constraint(
-        attention_lnx, ("activation_batch", "activation_norm_length", "activation_embed")
-    )
+    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
     intermediate_inputs = inputs + attention_lnx
 
     # Fully Connected
-    hidden_states = rms_norm(
-        num_features=intermediate_inputs.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name="post_self_attention_layer_norm",
-        kernel_axes=("norm",),
-        epsilon=cfg.normalization_layer_epsilon,
-    )(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(
-        hidden_states, ("activation_batch", "activation_norm_length", "activation_embed")
-    )
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
 
-    load_balance_loss = None
     if self.is_moe_layer:
-      # NOTE: the naming mismatch here is to ensure reverse compatibility with existing checkpoints.
-      # The `name` represents the weight name in JAX/checkpoints and so the class name
-      # is just for readability.
-      mlp_lnx = moe.get_routed_and_shared_moe(
-          name="Llama4MoEBlock_0",
-          config=cfg,
-          mesh=self.mesh,
-          kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
-          kernel_axes=("embed", None),
-          dtype=cfg.dtype,
-          weight_dtype=cfg.weight_dtype,
-          quant=self.quant,
-      )(hidden_states)
+      mlp_lnx = self.moe_block(hidden_states)
     else:
-      mlp_lnx = mlp_block(
-          in_features=hidden_states.shape[-1],
-          intermediate_dim=cfg.mlp_dim,
-          activations=cfg.mlp_activations,
-          intermediate_dropout_rate=cfg.dropout_rate,
-          dtype=cfg.dtype,
-          weight_dtype=cfg.weight_dtype,
-          name="mlp",
-          config=cfg,
-          quant=self.quant,
-      )(hidden_states, deterministic=deterministic)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+      mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
+    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs
-
-    layer_output = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(layer_output, deterministic=deterministic)
-
-    layer_output = nn.with_logical_constraint(
-        layer_output,
-        ("activation_batch", "activation_norm_length", "activation_embed"),
-    )
-
-    # NOTE: this is only needed for dropping MoE
-    if load_balance_loss is not None:
-      self.sow("intermediates", "moe_lb_loss", load_balance_loss)
+    layer_output = self.dropout(layer_output, deterministic=deterministic)
+    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
 
     if cfg.record_internal_nn_metrics:
       self.sow("intermediates", "activation_mean", jnp.mean(layer_output))
@@ -521,27 +544,59 @@ class Llama4DecoderLayer(nn.Module):
       return layer_output
 
 
-class Llama4ScannableBlock(nn.Module):
-  '''
-  A repeatable block given nope_layer_interval and interleave_moe_layer_step
+Llama4DecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Llama4DecoderLayer,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)
 
-  Attributes:
-    config: Config, MaxText model config
-    mesh: Mesh, JAX device mesh (used for sharding)
-    quant: None | Quant, quantization config
-    nope_layer_interval: int, the interval at which layers should use NoPE.
-    interleave_moe_layer_step: int, the interval or stride for placing MoE layers.
-  """
-  '''
 
-  config: Config
-  mesh: Mesh
-  model_mode: str
-  quant: None | Quant = None
-  nope_layer_interval: int = 1
-  interleave_moe_layer_step: int = 1
+class Llama4ScannableBlock(nnx.Module):
+  """A repeatable block given nope_layer_interval and interleave_moe_layer_step."""
 
-  @nn.compact
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      rngs: nnx.Rngs,
+      quant: None | Quant = None,
+      nope_layer_interval: int = 1,
+      interleave_moe_layer_step: int = 1,
+  ):
+    """Initializes the scannable block.
+
+    Args:
+      config: The main model configuration object.
+      mesh: The device mesh used for sharding parameters and activations.
+      model_mode: One of MODEL_MODE_TRAIN, MODEL_MODE_PREFILL, or MODEL_MODE_AUTOREGRESSIVE.
+      rngs: An `nnx.Rngs` object to provide random numbers for initialization.
+      quant: An optional configuration for quantization. Defaults to None.
+      nope_layer_interval: Specifies the interval for inserting a NoPE layer.
+      interleave_moe_layer_step: Specifies the interval for inserting a MoE layer.
+    """
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.quant = quant
+    self.rngs = rngs
+    self.nope_layer_interval = nope_layer_interval
+    self.interleave_moe_layer_step = interleave_moe_layer_step
+
+    for layer_id in range(self.config.inhomogeneous_layer_cycle_interval):
+      nope_layer = determine_is_nope_layer(layer_id, self.nope_layer_interval)
+      moe_layer = determine_is_moe_layer(layer_id, self.interleave_moe_layer_step)
+      layer_name = f"layers_{layer_id}"
+      layer = Llama4DecoderLayer(
+          config=self.config,
+          mesh=self.mesh,
+          model_mode=self.model_mode,
+          rngs=self.rngs,
+          quant=self.quant,
+          is_nope_layer=nope_layer,
+          is_moe_layer=moe_layer,
+      )
+      setattr(self, layer_name, layer)
+
   def __call__(
       self,
       inputs,
@@ -556,24 +611,12 @@ class Llama4ScannableBlock(nn.Module):
   ):
 
     cfg = self.config
-    mesh = self.mesh
 
     inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     y = inputs
     for layer_id in range(cfg.inhomogeneous_layer_cycle_interval):
-      nope_layer = determine_is_nope_layer(layer_id, self.nope_layer_interval)
-      moe_layer = determine_is_moe_layer(layer_id, self.interleave_moe_layer_step)
-      layer = Llama4DecoderLayer(
-          config=cfg,
-          mesh=mesh,
-          name=f"layers_{layer_id}",
-          quant=self.quant,
-          model_mode=model_mode,
-          is_nope_layer=nope_layer,
-          is_moe_layer=moe_layer,
-      )
-      y = layer(
+      y = getattr(self, f"layers_{layer_id}")(
           y,
           decoder_segment_ids,
           decoder_positions,
@@ -590,6 +633,12 @@ class Llama4ScannableBlock(nn.Module):
       return y, None
     else:
       return y
+
+
+Llama4ScannableBlockToLinen = nnx_wrappers.to_linen_class(
+    Llama4ScannableBlock,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)
 
 
 class Llama4VisionEncoderLayer(nn.Module):


### PR DESCRIPTION
# Description

* Migrate Llama4 text layers to NNX
* Remove unused `load_balance_loss`, which is currently enabled for dropping only, and llama4 only supports dropless ([here](https://github.com/AI-Hypercomputer/maxtext/blob/0f12f3da34607759aba4532dacf102c47c220215/src/MaxText/pyconfig.py#L338)).
* Updated the supported methods (thanks @shuningjin for the reminder)

# Tests

## Training

* Before the change - [logs](https://cloudlogging.app.goo.gl/ne95eXtTbTPivzbf8)
* After the change - [logs](https://cloudlogging.app.goo.gl/cv9BnJ6JCzfBgRS39)

```
# Before
Total memory size: 111.9 GB, Output size: 37.6 GB, Temp size: 74.3 GB, Argument size: 37.6 GB, Host temp size: 0.0 GB.
Using (GB) 38.15 / 95.74 (39.847504%) on TPU_8(process=0,(0,0,0,0))

completed step: 6, seconds: 13.701, TFLOP/s/device: 123.013, Tokens/s/device: 1195.841, total_weights: 262144, loss: 12.405

# After
Total memory size: 111.9 GB, Output size: 37.6 GB, Temp size: 74.3 GB, Argument size: 37.6 GB, Host temp size: 0.0 GB.
Using (GB) 38.15 / 95.74 (39.847504%) on TPU_0(process=0,(0,0,0,0))

completed step: 6, seconds: 13.686, TFLOP/s/device: 123.146, Tokens/s/device: 1197.138, total_weights: 262144, loss: 12.403
```

## Decoding

Noticed extra 1.2GB memory usage in `RAMstats: After load_params` 

* Before the change - [logs](https://cloudlogging.app.goo.gl/5Va7XG2GPCvU6TFV7)
* After the change - [logs](https://cloudlogging.app.goo.gl/PRhDenK7vbcqtvRc6)

```
Before

INFO 2025-10-01T23:23:05.733151482Z [resource.labels.containerName: jax-tpu] {}
INFO 2025-10-01T23:23:05.733193390Z [resource.labels.containerName: jax-tpu] Memstats: After load_params:
INFO 2025-10-01T23:23:05.733197370Z [resource.labels.containerName: jax-tpu] Using (GB) 50.2 / 95.74 (52.433675%) on TPU_4(process=1,(0,0,1,0))
INFO 2025-10-01T23:23:05.733199798Z [resource.labels.containerName: jax-tpu] Using (GB) 50.2 / 95.74 (52.433675%) on TPU_5(process=1,(1,0,1,0))
INFO 2025-10-01T23:23:05.733209563Z [resource.labels.containerName: jax-tpu] Using (GB) 50.2 / 95.74 (52.433675%) on TPU_6(process=1,(0,1,1,0))
INFO 2025-10-01T23:23:05.733213353Z [resource.labels.containerName: jax-tpu] Using (GB) 50.2 / 95.74 (52.433675%) on TPU_7(process=1,(1,1,1,0))

INFO 2025-10-01T23:23:05.733220215Z [resource.labels.containerName: jax-tpu] RAMstats: After load_params:
INFO 2025-10-01T23:23:05.733377282Z [resource.labels.containerName: jax-tpu] Using (GB) 15.63 / 440.84 (3.545504%) --> Available:422.44
INFO 2025-10-01T23:24:04.226796401Z [resource.labels.containerName: jax-tpu] Input `I love to` -> ` use the word “soul” in my writing. It’s a word that has a lot of meaning and can be used in a lot of different ways. I think it’s a word that can be used to describe a lot of different things, and I think it’s a word that can be used to describe a lot of different people.


After

INFO 2025-10-01T23:21:57.777933154Z [resource.labels.containerName: jax-tpu] Memstats: After load_params:
INFO 2025-10-01T23:21:57.777936309Z [resource.labels.containerName: jax-tpu] Using (GB) 50.2 / 95.74 (52.433675%) on TPU_4(process=1,(0,0,1,0))
INFO 2025-10-01T23:21:57.777943718Z [resource.labels.containerName: jax-tpu] Using (GB) 50.2 / 95.74 (52.433675%) on TPU_5(process=1,(1,0,1,0))
INFO 2025-10-01T23:21:57.777945827Z [resource.labels.containerName: jax-tpu] Using (GB) 50.2 / 95.74 (52.433675%) on TPU_6(process=1,(0,1,1,0))
INFO 2025-10-01T23:21:57.777947795Z [resource.labels.containerName: jax-tpu] Using (GB) 50.2 / 95.74 (52.433675%) on TPU_7(process=1,(1,1,1,0))

INFO 2025-10-01T23:21:57.777952490Z [resource.labels.containerName: jax-tpu] RAMstats: After load_params:
INFO 2025-10-01T23:21:57.778108970Z [resource.labels.containerName: jax-tpu] Using (GB) 16.82 / 440.84 (3.815443%) --> Available:421.26
INFO 2025-10-01T23:22:55.166921501Z [resource.labels.containerName: jax-tpu] Input `I love to` -> ` use the word “soul” in my writing. It’s a word that has a lot of meaning and can be used in a lot of different ways. I think it’s a word that can be used to describe a lot of different things, and I think it’s a word that can be used to describe a lot of different people.

```

## JetStream

Noticed 50GB less memory usage in RAMstats (from code this indicates the CPU memory usage)

* logs in diff - [link](https://diff.googleplex.com/#key=HTXNT73BVLpa) (no obvious diff)
* Profile matching - [link](https://screenshot.googleplex.com/5RsqazkUc5DNQGi)
* Profile before the change: [link](https://xprof.corp.google.com/memory_viewer/ranran-10261707462630720157) 
* Profile after the change: [link](https://xprof.corp.google.com/memory_profile/ranran-14079089929521082001)

```
# Before

Memstats: After load_params:
	Using (GB) 50.19 / 95.74 (52.423230%) on TPU_0(process=0,(0,0,0,0))
	Using (GB) 50.19 / 95.74 (52.423230%) on TPU_1(process=0,(1,0,0,0))
	Using (GB) 50.19 / 95.74 (52.423230%) on TPU_2(process=0,(0,1,0,0))
	Using (GB) 50.19 / 95.74 (52.423230%) on TPU_3(process=0,(1,1,0,0))

RAMstats: After load_params:
	Using (GB) 300.04 / 440.83 (68.062518%) -->  Available:138.08

# After

Memstats: After load_params:
	Using (GB) 50.19 / 95.74 (52.423230%) on TPU_0(process=0,(0,0,0,0))
	Using (GB) 50.19 / 95.74 (52.423230%) on TPU_1(process=0,(1,0,0,0))
	Using (GB) 50.19 / 95.74 (52.423230%) on TPU_2(process=0,(0,1,0,0))
	Using (GB) 50.19 / 95.74 (52.423230%) on TPU_3(process=0,(1,1,0,0))

RAMstats: After load_params:
	Using (GB) 247.21 / 440.83 (56.078307%) -->  Available:190.91
```


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
