### PR TITLE
Migrate Qwen3 to NNX

### DIFF
--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -393,9 +393,9 @@ class Decoder(nn.Module):
       case DecoderBlockType.GPT_OSS:
         return [gpt_oss.GptOssScannableBlock] if self.config.scan_layers else [gpt_oss.GptOssDecoderLayer]
       case DecoderBlockType.QWEN3:
-        return [qwen3.Qwen3DecoderLayer]
+        return [qwen3.Qwen3DecoderLayerToLinen]
       case DecoderBlockType.QWEN3_MOE:
-        return [qwen3.Qwen3MoeDecoderLayer]
+        return [qwen3.Qwen3MoeDecoderLayerToLinen]
       case DecoderBlockType.SIMPLE:
         return [simple_layer.SimpleDecoderLayer]
       case DecoderBlockType.SIMPLE_MLP:


### PR DESCRIPTION
# Description

1. migrate Qwen3DecoderLayer (dense) and Qwen3MoeDecoderLayer (moe) from Linen to NNX. 
- shared component: RMSNorm + Attention + RMSNorm
- the dense model is close to llama2 (MlpBlock), https://github.com/AI-Hypercomputer/maxtext/pull/2370
- the moe model is close to mixtral (RoutedMOE), https://github.com/AI-Hypercomputer/maxtext/pull/2166
2. change variable name to be consistent with other decoder [layers](https://github.com/AI-Hypercomputer/maxtext/tree/main/src/MaxText/layers) (e.g., llama2, mixtral, deepseek)
3. axis: activation_length -> activation_norm_length. 
- activation_norm_length is used in other decoder layers, and is the correct way. Fix: b/441547754


# Tests

Details in b/448171914

## [dense: qwen3-4b]

train: v5p-8
- cmd: https://paste.googleplex.com/6224473325961216 
- https://diff.googleplex.com/#key=S714ns5bS1fi
- memory same, loss / tflop similar

decode: v6e-8
- cmd: https://paste.googleplex.com/5372041654042624
- https://diff.googleplex.com/#key=DgewTDqTEv37
- Memstats same, RAMstats slight diff (24.04 vs. 23.98), output same

jetstream: v6e-8
- log1: 
  - cmd: https://paste.googleplex.com/6306253127155712
  - https://diff.googleplex.com/#key=BSHtWmusqNyQ
  - memstats same, RAMstats slight diff (23.29 vs. 23.69)
- log2: 
  - cmd: https://paste.googleplex.com/6028629595258880
  - https://diff.googleplex.com/#key=e02j0rUAX2QD
  - acc same 0.6942
- profile 
  - cmd: https://paste.googleplex.com/4892507330707456
  - before (6s): https://xprof.corp.google.com/memory_profile/shuningjin-13138045314128610787
  - after (6s): https://xprof.corp.google.com/memory_profile/shuningjin-5512421363322943186
  - similar peak mem ~3.89GiB, id match

## [moe: qwen3-30b-a3b]

train: v5p-8
- cmd: https://paste.googleplex.com/4815163307982848
- https://diff.googleplex.com/#key=IfEi6RXU05u9
- memory same, loss / tflop similar

decode: v6e-8
- cmd: https://paste.googleplex.com/4808862590959616
- https://diff.googleplex.com/#key=wlOtFS9GpTMD
- Memstats same, RAMstats slight diff (56.31 vs. 56.82), output same

jetstream: v6e-8
- log1: 
  - cmd: https://paste.googleplex.com/6027123068370944
  - https://diff.googleplex.com/#key=bTprvexIVOLd
  - same memstats, RAMstats slight diff (60.57 vs. 60.93)
- log2: 
  - cmd: https://paste.googleplex.com/6320961863417856
  - https://diff.googleplex.com/#key=UzGxEatlvgLW
  - same acc=0.792
- profile (ignore this, new profile with 6s in comment)
  - cmd: https://paste.googleplex.com/4850704028139520
  - before (1s): https://xprof.corp.google.com/memory_profile/shuningjin-10823727747969299875
  - after (1s): https://xprof.corp.google.com/memory_profile/shuningjin-15805069810789941347
  - similar peak mem ~11.40GiB, id match

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
