### PR TITLE
Add @jacoguzo as code owner for markdown files and *

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @gobbleturk @khatwanimohit @bvandermoon @vipannalla @RissyRan @richjames0 @gagika @shralex @SurbhiJainUSC @hengtaoguo @A9isha @aireenmei @NuojCheng @jiangjy1982 @suexu1025
+* @gobbleturk @khatwanimohit @bvandermoon @vipannalla @RissyRan @richjames0 @gagika @shralex @SurbhiJainUSC @hengtaoguo @A9isha @aireenmei @NuojCheng @jiangjy1982 @suexu1025 @jacoguzo
 
 # Model bring-up
 src/MaxText/assets @parambole @shuningjin @RissyRan @suexu1025 @jiangjy1982 @gobbleturk @bvandermoon @gagika @shralex @richjames0
@@ -25,6 +25,9 @@ src/MaxText/inference_mlperf @vipannalla @mitalisi @gpolovets1 @mailvijayasingh 
 # Dockerfiles and dependencies
 *.Dockerfile @bvandermoon @parambole @richjames0
 *.txt @bvandermoon @parambole @richjames0
+
+# Docs 
+*.md @jacoguzo @RissyRan @shralex @bvandermoon @parambole @richjames0
 
 # Workflow files
 .github/workflows @gobbleturk @khatwanimohit @shralex @parambole @richjames0


### PR DESCRIPTION
# Description

Added @jacoguzo to CODEOWNERS for .md files and * to help speedup review of documentation efforts.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

No tests necessary

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
