### PR TITLE
Fix mismatched quote in `end_to_end/tpu/test_convergence_1b_params.sh`

### DIFF
--- a/end_to_end/tpu/test_convergence_1b_params.sh
+++ b/end_to_end/tpu/test_convergence_1b_params.sh
@@ -55,7 +55,7 @@ then
         "hf_eval_files=$DATASET_PATH/hf/c4/c4-validation-*.parquet "
 fi
 
-TRAIN_CMD="python3 -m MaxText.train ${MAXTEXT_PKG_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/MaxText}/configs/base.yml" \
+TRAIN_CMD="python3 -m MaxText.train ${MAXTEXT_PKG_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/MaxText}/configs/base.yml \
         steps=$STEPS eval_steps=$EVAL_STEPS eval_interval=$EVAL_INTERVAL \
         per_device_batch_size=$PER_DEVICE_BATCH_SIZE learning_rate=3e-4 enable_checkpointing=false \
         max_target_length=2048 global_parameter_scale=1 \


### PR DESCRIPTION

# Description

This change fixes a mismatched quote introduced in #2304 in  `end_to_end/tpu/test_convergence_1b_params.sh`.  
The error (`unexpected EOF while looking for matching '"'`) occurred  whenever the script was invoked (e.g., via an Airflow DAG `maxtext_convergence`).
4 tasks failed in DAGs [maxtext_convergence](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_convergence/grid?search=maxtext_convergence&dag_run_id=scheduled__2025-10-02T06%3A00%3A00%2B00%3A00&task_id=maxtext-convergence-int8-v6e-256.run_model.wait_for_workload_completion&tab=logs) with following error:
```
{xpk.py:319} INFO - end_to_end/tpu/test_convergence_1b_params.sh: line 68: unexpected EOF while looking for matching `"'
```

FIXES: b/448770568

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
