### PR TITLE
Migrate multi_token_prediction to NNX

### DIFF
--- a/src/MaxText/layers/models.py
+++ b/src/MaxText/layers/models.py
@@ -92,16 +92,23 @@ class TransformerLinenPure(nn.Module):
       # For MTP, we use the DecoderLayer blueprint to ensure architectural consistency.
       # By convention, this is the last layer in the list.
       mtp_layer = layer_types[-1]
-      self.mtp_block = MultiTokenPredictionBlock(
-          config=self.config, mesh=self.mesh, name="mtp_block", transformer_layer_module=mtp_layer, decoder=self.decoder
+      mtp_block = nnx_wrappers.to_linen_class(
+        base_nnx_class=MultiTokenPredictionBlock,
+        base_metadata_fn=initializers.variable_to_logically_partitioned,
       )
+      self.mtp_block = mtp_block(
+        config=self.config,
+        mesh=self.mesh,
+        transformer_layer_module=mtp_layer,
+        decoder=self.decoder,
+      )
+
 
   def logits_from_hidden_states(self, hidden_states, deterministic, model_mode):
     """
     Compute logits from hidden states (wrapping decoder._apply_output_head).
     This function is only used for vocabulary tiling.
     """
-    # pylint: disable=protected-access
     logits = self.decoder._apply_output_head(
         shared_embedding=self.shared_embedding,
         y=hidden_states,
@@ -185,7 +192,7 @@ class TransformerLinenPure(nn.Module):
     # Its only effect is to "sow" these losses; it does not alter the primary logits output.
     if self.config.mtp_num_layers > 0:
       self.mtp_block(
-          shared_embedding=self.shared_embedding,
+          # shared_embedding=self.shared_embedding,
           main_hidden_state=hidden_state,
           input_ids=decoder_input_tokens,
           target_ids=decoder_target_tokens,
@@ -313,10 +320,13 @@ class Transformer(nnx.Module):
       # For MTP, we use the DecoderLayer blueprint to ensure architectural consistency.
       # By convention, this is the last layer in the list.
       mtp_layer = layer_types[-1]
-      mtp_block_linen = MultiTokenPredictionBlock(
-          config=self.config, mesh=self.mesh, name="mtp_block", transformer_layer_module=mtp_layer, decoder=self.decoder
+      self.mtp_block = MultiTokenPredictionBlock(
+        config=self.config,
+        mesh=self.mesh,
+        transformer_layer_module=mtp_layer,
+        decoder=self.decoder,
+        rngs=rngs,
       )
-      self.mtp_block = nnx_wrappers.ToNNX(mtp_block_linen, rngs=rngs)
 
       self.mtp_block.lazy_init(
           shared_embedding=self.token_embedder,

--- a/src/MaxText/layers/multi_token_prediction.py
+++ b/src/MaxText/layers/multi_token_prediction.py
@@ -20,12 +20,13 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 
-from flax import linen as nn
+from flax import nnx
 
 from MaxText.common_types import Config, MODEL_MODE_TRAIN
-from MaxText.layers.linears import dense_general
-from MaxText.layers.normalizations import rms_norm
+from MaxText.layers.linears import DenseGeneral
+from MaxText.layers.normalizations import RMSNorm
 from MaxText.layers.decoders import Decoder, DecoderLayer
+from MaxText.layers import nnx_wrappers
 from MaxText import max_utils
 from MaxText import maxtext_utils
 
@@ -53,7 +54,7 @@ def roll_and_mask(x: jnp.ndarray, shift: int = -1) -> jnp.ndarray:
   return jnp.roll(x, shift, axis=1).at[:, shift:, ...].set(0)
 
 
-class MultiTokenPredictionLayer(nn.Module):
+class MultiTokenPredictionLayer(nnx.Module):
   """
   Implements Multi-Token Prediction (MTP) step:
       1. Normalization of previous hidden state and target token embedding.
@@ -70,12 +71,53 @@ class MultiTokenPredictionLayer(nn.Module):
       processed hidden state from its internal transformer block.
   """
 
-  config: Config
-  mesh: Mesh
-  layer_number: int
-  transformer_layer_module: Type[DecoderLayer] = DecoderLayer
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      layer_number: int,
+      transformer_layer_module: Type[DecoderLayer],
+      *,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.layer_number = layer_number
+    self.transformer_layer_module = transformer_layer_module
+    self.rngs = rngs
+    k = layer_number
+    cfg = self.config
 
-  @nn.compact
+    self.embedding_norm = RMSNorm(
+        num_features=cfg.base_emb_dim,
+        epsilon=cfg.normalization_layer_epsilon,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        kernel_axes=("norm",),
+        rngs=rngs,
+    )
+    self.hidden_state_norm = RMSNorm(
+        num_features=cfg.base_emb_dim,
+        epsilon=cfg.normalization_layer_epsilon,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        kernel_axes=("norm",),
+        rngs=rngs,
+    )
+    self.projection_layer = DenseGeneral(
+        in_features_shape=2 * cfg.base_emb_dim,
+        out_features_shape=cfg.base_emb_dim,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        use_bias=False,
+        kernel_axes=("concat_embed", "embed"),
+        rngs=rngs,
+    )
+    mtp_transformer_layer = transformer_layer_module(
+        config=cfg, mesh=mesh, model_mode=MODEL_MODE_TRAIN, name=f"mtp_{k}_transformer_layer"
+    )
+    self.transformer_layer = nnx_wrappers.ToNNX(mtp_transformer_layer, rngs=rngs)
+
   def __call__(
       self,
       prev_hidden_state: jnp.ndarray,
@@ -107,54 +149,22 @@ class MultiTokenPredictionLayer(nn.Module):
         next_hidden_state: The hidden state produced by this MTP step's internal transformer.
                            Shape: [batch, seq_len, hidden_size]
     """
-    cfg = self.config
-    mesh = self.mesh
-    k = self.layer_number
-
     # --- 1. Normalize Hidden State and Embedding ---
-    embedding_norm_layer = rms_norm(
-        num_features=target_token_embedding.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name=f"mtp_{k}_embedding_norm",
-        epsilon=cfg.normalization_layer_epsilon,
-        kernel_axes=("norm",),
-    )
-    embedding_norm = embedding_norm_layer(target_token_embedding)
+    embedding_norm = self.embedding_norm(target_token_embedding)
 
-    hidden_state_norm_layer = rms_norm(
-        num_features=prev_hidden_state.shape[-1],
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        name=f"mtp_{k}_hidden_state_norm",
-        epsilon=cfg.normalization_layer_epsilon,
-        kernel_axes=("norm",),
-    )
-
-    hidden_state_norm = hidden_state_norm_layer(prev_hidden_state)
+    hidden_state_norm = self.hidden_state_norm(prev_hidden_state)
 
     # --- 2. Concatenate Normalized Representations ---
     # Shape: [B, S, 2*H]
     concatenated_features = jnp.concatenate([embedding_norm, hidden_state_norm], axis=-1)
 
     # --- 3. Project Concatenated Features ---
-    # Projects from 2*H back down to H
-    projection_layer = dense_general(
-        inputs_shape=concatenated_features.shape,
-        out_features_shape=cfg.base_emb_dim,
-        dtype=cfg.dtype,
-        weight_dtype=cfg.weight_dtype,
-        use_bias=False,
-        kernel_axes=("concat_embed", "embed"),
-        name=f"mtp_{k}_projection",
-    )
+    # Projects from 2*H back down to H    
     # Shape: [B, S, H]
-    projected_features = projection_layer(concatenated_features)
+    projected_features = self.projection_layer(concatenated_features)
 
     # --- 4. Pass through MTP Transformer Block ---
-    output = self.transformer_layer_module(
-        config=cfg, mesh=mesh, model_mode=model_mode, name=f"mtp_{k}_transformer_layer"
-    )(
+    output = self.transformer_layer(
         inputs=projected_features,
         decoder_segment_ids=decoder_segment_ids,
         decoder_positions=position_ids,
@@ -174,15 +184,34 @@ class MultiTokenPredictionLayer(nn.Module):
     return next_hidden_state
 
 
-class MultiTokenPredictionBlock(nn.Module):
+class MultiTokenPredictionBlock(nnx.Module):
   """Orchestrates the MTP process by running a sequence of MTP layers."""
 
-  config: Config
-  mesh: Mesh
-  transformer_layer_module: Type[DecoderLayer]
-  decoder: Decoder
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      transformer_layer_module: Type[DecoderLayer],
+      decoder: nnx.Module,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.transformer_layer_module = transformer_layer_module
+    self.decoder = decoder
+    self.rngs = rngs if rngs is not None else nnx.Rngs(0)
+    self.mtp_layers = nnx.List([])
+    for k in range(1, config.mtp_num_layers + 1):
+      layer = MultiTokenPredictionLayer(
+        config=config,
+        mesh=mesh,
+        layer_number=k,
+        transformer_layer_module=transformer_layer_module,
+        rngs=rngs,
+      )
+      setattr(self, f"mtp_layer_{k}", layer)
+      self.mtp_layers.append(layer)
 
-  @nn.compact
   def __call__(
       self,
       shared_embedding,
@@ -220,13 +249,7 @@ class MultiTokenPredictionBlock(nn.Module):
       )
 
       # Instantiate and apply the MTP layer for this step
-      mtp_layer = MultiTokenPredictionLayer(
-          config=cfg,
-          mesh=self.mesh,
-          layer_number=k,
-          name=f"mtp_layer_{k}",
-          transformer_layer_module=self.transformer_layer_module,
-      )
+      mtp_layer = self.mtp_layers[k - 1]
 
       next_mtp_hidden_state = mtp_layer(
           mtp_hidden_state,
@@ -246,20 +269,18 @@ class MultiTokenPredictionBlock(nn.Module):
       )
       mtp_xent_masked = mtp_xent * rolled_target_mask
 
-      # This logic doesn't run during model initialization to avoid unwated population of the mutable collections.
-      if not self.is_initializing():
-        # For evaluation, save the top prediction and a valid token mask.
-        # This is only active for the target layer during an eval run.
-        if cfg.mtp_eval_target_module == k and self.is_mutable_collection("mtp_acceptance"):
-          mtp_top_1_pred = jnp.argmax(mtp_logits, axis=-1)
-          self.sow("mtp_acceptance", "mtp_preds", mtp_top_1_pred)
-          self.sow("mtp_acceptance", "mtp_mask", rolled_target_mask)
+      # For evaluation, save the top prediction and a valid token mask.
+      # This is only active for the target layer during an eval run.
+      if cfg.mtp_eval_target_module == k:
+        mtp_top_1_pred = jnp.argmax(mtp_logits, axis=-1)
+        self.sow("mtp_acceptance", "mtp_preds", mtp_top_1_pred)
+        self.sow("mtp_acceptance", "mtp_mask", rolled_target_mask)
 
-        # For training, save the loss components for this MTP head.
-        # This is only active during a training run.
-        if self.is_mutable_collection("mtp_losses"):
-          self.sow("mtp_losses", "losses", jnp.sum(mtp_xent_masked))
-          self.sow("mtp_losses", "weights", jnp.sum(rolled_target_mask))
+      # For training, save the loss components for this MTP head.
+      # This is only active during a training run.
+      if model_mode == MODEL_MODE_TRAIN:
+        self.sow("mtp_losses", "losses", jnp.sum(mtp_xent_masked))
+        self.sow("mtp_losses", "weights", jnp.sum(rolled_target_mask))
 
       # The output of this layer is the input for the next, maintaining the causal chain.
       mtp_hidden_state = next_mtp_hidden_state


### PR DESCRIPTION
# Description

Migrate Multi_Token_Prediction (MTP) to use NNX module.

# Tests

We use [xpk](https://github.com/AI-Hypercomputer/xpk) to create tpu cluster and assign workload.

# Environment

Machine type : `v5litepod-8` TPU VM
Software machine : `tpu-ubuntu2204-base`
Python Version : `3.12.11`

# Test Command
Run train command to train qwen3-0.6b for 25 steps:
```
python3 -m MaxText.train MaxText/configs/base.yml run_name=mtp_linen_validation_run base_output_directory=gs://lance-maxtext/maxtext_output model_name=qwen3-0.6b dataset_type=synthetic steps=25 per_device_batch_size=1 metrics_file=metrics.txt mtp_num_layers=8 mtp_loss_scaling_factor=0.1 mtp_eval_target_module=1 async_checkpointing=false max_target_length=256 ici_pipeline_parallelism=4
```

Logs:
[Linen, before migration](https://paste.googleplex.com/6212477348085760)
[NNX, after migration](https://paste.googleplex.com/5365437051305984)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
