### PR TITLE
change field_validator to cls

### DIFF
--- a/benchmarks/api_server/server_models.py
+++ b/benchmarks/api_server/server_models.py
@@ -69,7 +69,7 @@ class CompletionRequest(SamplingParams):
   logprobs: Optional[int] = None
 
   @field_validator("logprobs")
-  def validate_logprobs(self, v):
+  def validate_logprobs(cls, v):
     if v is not None and v < 0:
       raise ValueError("logprobs must be a non-negative integer if provided.")
     return v


### PR DESCRIPTION
Update the field_validator in ```server_models``` as pedantic v2.x is using cls instead of self in pydantic v1.x


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
