### PR TITLE
Pinning JAX=0.7.0 to allow google-tunix=0.1.1

### DIFF
--- a/maxtext_jax_ai_image.Dockerfile
+++ b/maxtext_jax_ai_image.Dockerfile
@@ -50,6 +50,8 @@ RUN if [ "$DEVICE" = "tpu" ] && [ "$JAX_STABLE_STACK_BASEIMAGE" = "us-docker.pkg
 # Install google-tunix for TPU devices, skip for GPU
 RUN if [ "$DEVICE" = "tpu" ]; then \
         python3 -m pip install 'google-tunix>=0.1.0'; \
+        # TODO: Once tunix stopped pinning jax 0.7.1, we should remove our 0.7.0 version pin (b/450286600)
+        python3 -m pip install 'jax==0.7.0' 'jaxlib==0.7.0'; \
   fi
 
 # Now copy the remaining code (source files that may change frequently)


### PR DESCRIPTION
# Description

Current `cpu_unit_tests` are [failing](https://github.com/AI-Hypercomputer/maxtext/actions/runs/18350713027/job/52270253358). The reason is that google-tunix 0.1.1 is downgrading to [JAX 0.7.1](https://screenshot.googleplex.com/5wusABhmVmhaHfr), which is known to have pallas mosaic errors. This PR re-installs `jax==0.7.0` after tunix installation, so that we have can keep `google-tunix==0.1.1` for new features. We should recover when tunix stopped pinning JAX 0.7.1.

[b/450286600](https://b.corp.google.com/issues/450286600)

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
