### PR TITLE
Onboarding explicit sharding to MaxText

### DIFF
--- a/src/MaxText/common_types.py
+++ b/src/MaxText/common_types.py
@@ -100,3 +100,8 @@ class AttentionType(enum.Enum):
   CHUNK = "chunk"
   MLA = "mla"
   FULL = "full"
+
+
+class ShardMode(enum.Enum):
+  AUTO = "auto"  # default
+  EXPLICIT = "explicit"

--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -353,6 +353,7 @@ jax_cache_dir: "~/jax_cache"
 hardware: 'tpu' # Supported hardware types are 'tpu', 'gpu', 'gpu_multiprocess' and 'cpu'
 
 # Parallelism
+shard_mode: "auto" # can be either auto or explicit
 mesh_axes: ['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'context', 'context_autoregressive', 'tensor', 'tensor_transpose', 'tensor_sequence', 'expert', 'autoregressive']
 logical_axis_rules: [
                       ['activation_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],

--- a/src/MaxText/data_loader.py
+++ b/src/MaxText/data_loader.py
@@ -48,7 +48,11 @@ class DataLoader:
         else:
           example_batch = next(self.data_iterator)
         # Reshard data from loaded sharding to performant activation sharding
-        self.last_batch = jax.lax.with_sharding_constraint(example_batch, self.input_data_shardings)
+        self.last_batch = maxtext_utils.maybe_shard_with_name(
+            example_batch,
+            self.input_data_shardings,
+            self.config.shard_mode,
+        )
         self.check_example_batch()
       except Exception as e:  # pylint: disable=broad-except
         if isinstance(e, StopIteration):

--- a/src/MaxText/gradient_accumulation.py
+++ b/src/MaxText/gradient_accumulation.py
@@ -16,6 +16,10 @@
 
 import jax
 import jax.numpy as jnp
+from jax.sharding import NamedSharding
+
+from MaxText.common_types import ShardMode
+from MaxText.maxtext_utils import maybe_shard_with_name
 
 
 def gradient_accumulation_loss_and_grad(
@@ -58,6 +62,17 @@ def gradient_accumulation_loss_and_grad(
       - final_aux (PyTree): Auxiliary outputs, summed across microbatches.
       - raw_grads (PyTree): The accumulated and averaged gradients.
   """
+
+  def _maybe_shard_with_name(inputs, sharding_names):
+    """Wrapper of maybe_shard_with_name with fixed shard_mode"""
+    return maybe_shard_with_name(inputs, sharding_names, config.shard_mode)
+
+  # For more efficient DP/ZeRO-1 + GA
+  if config.shard_mode == ShardMode.EXPLICIT and config.ici_data_parallelism > 1:
+    ga_params_shardings = jax.tree.map(update_sharding_for_reduced, params_shardings)
+    grad_shardings = jax.tree.map(update_sharding_for_unreduced, params_shardings)
+  else:
+    ga_params_shardings = grad_shardings = params_shardings
   # When using Zero-1 optimizer sharding, cast params to lower precision and apply sharding constraints
   # so that all-gather is done once in the lower precision before the gradient accumulation loop
   if config.shard_optimizer_over_data:
@@ -68,15 +83,14 @@ def gradient_accumulation_loss_and_grad(
       return param
 
     ga_params = jax.tree_util.tree_map(convert_to_bf16, params)
-    ga_params = jax.tree.map(jax.lax.with_sharding_constraint, ga_params, params_shardings)
   else:
     ga_params = params
 
+  ga_params = jax.tree.map(_maybe_shard_with_name, ga_params, ga_params_shardings)
   grad_func = jax.value_and_grad(_loss_fn, argnums=4, has_aux=True)
 
   def accumulate_gradient(acc_grad_and_loss, data):
     ga_params = acc_grad_and_loss["ga_params"]
-
     (_, aux), cur_batch_gradient = grad_func(model, config, data, dropout_rng, ga_params, *extra_dpo_args, is_train=True)
     acc_grad_and_loss["loss"] += aux["total_loss"]
     acc_grad_and_loss["moe_lb_loss"] += aux["moe_lb_loss"]
@@ -94,7 +108,7 @@ def gradient_accumulation_loss_and_grad(
 
   data = jax.tree_util.tree_map(reshape_to_microbatch_accumulations, data)
   init_grad = jax.tree_util.tree_map(jnp.zeros_like, ga_params)
-  init_grad = jax.tree.map(jax.lax.with_sharding_constraint, init_grad, params_shardings)
+  init_grad = jax.tree.map(_maybe_shard_with_name, init_grad, grad_shardings)
   init_grad_and_loss = {
       "loss": 0.0,
       "grad": init_grad,
@@ -113,9 +127,23 @@ def gradient_accumulation_loss_and_grad(
       + grad_and_loss["mtp_loss"] / config.gradient_accumulation_steps
   )
   raw_grads = grad_and_loss["grad"]
-  if config.shard_optimizer_over_data:
-    raw_grads = jax.tree.map(jax.lax.with_sharding_constraint, raw_grads, params_shardings)
+  raw_grads = jax.tree.map(_maybe_shard_with_name, raw_grads, params_shardings)
   raw_grads = jax.tree_util.tree_map(lambda arr: arr / grad_and_loss["total_weights"], raw_grads)
   aux = jax.tree.map(lambda x: jnp.sum(x, axis=0), aux)  # pytype: disable=module-attr
 
   return loss, aux, raw_grads
+
+
+# GA helper functions
+def update_sharding_for_reduced(sharding: NamedSharding) -> NamedSharding:
+  """
+  Add reduced on data axis of given NamedSharding
+  """
+  return sharding.update(spec=sharding.spec.update(reduced={"data"}))
+
+
+def update_sharding_for_unreduced(sharding: NamedSharding) -> NamedSharding:
+  """
+  Add unreduced on data axis of given NamedSharding
+  """
+  return sharding.update(spec=sharding.spec.update(unreduced={"data"}))

--- a/src/MaxText/layers/attention_mla.py
+++ b/src/MaxText/layers/attention_mla.py
@@ -18,7 +18,7 @@ import math
 from typing import Any, Optional, Tuple
 
 from jax.ad_checkpoint import checkpoint_name
-from jax.sharding import Mesh
+from jax.sharding import Mesh, NamedSharding
 import jax.numpy as jnp
 
 from flax import linen as nn
@@ -663,6 +663,7 @@ class MLA(Attention):
       inputs_kv: Array,
       inputs_positions: Array | None = None,
       decoder_segment_ids: Array | None = None,
+      out_sharding: NamedSharding | None = None,
       *,
       model_mode: str = MODEL_MODE_TRAIN,
       deterministic: bool = False,

--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -22,13 +22,13 @@ import functools
 import jax
 import jax.numpy as jnp
 from jax.ad_checkpoint import checkpoint_name
-from jax.sharding import Mesh
+from jax.sharding import Mesh, NamedSharding
 
 from flax import linen as nn
 from flax import nnx
 from flax.linen.partitioning import ScanIn
 
-from MaxText.common_types import DecoderBlockType, Config, EP_AS_CONTEXT
+from MaxText.common_types import DecoderBlockType, ShardMode, Config, EP_AS_CONTEXT
 from MaxText.common_types import MODEL_MODE_TRAIN, MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
 from MaxText import max_logging
 from MaxText import max_utils
@@ -89,14 +89,23 @@ class DecoderLayer(nn.Module):
   ):
     cfg = self.config
     mesh = self.mesh
+    _maybe_shard_with_logical = functools.partial(
+        maxtext_utils.maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=cfg.shard_mode,
+    )
 
     if self.model_mode == MODEL_MODE_PREFILL:
-      logical_axis_names = ("activation_batch", "prefill_activation_length", "activation_mlp")
-    elif cfg.expert_shard_attention_option == EP_AS_CONTEXT and self.model_mode == MODEL_MODE_TRAIN:
-      logical_axis_names = ("activation_batch_no_exp", "activation_length", "activation_mlp")
+      logical_axis_names = ("activation_batch", "prefill_activation_length", "activation_embed")
+    elif self.config.expert_shard_attention_option == EP_AS_CONTEXT and self.model_mode == MODEL_MODE_TRAIN:
+      logical_axis_names = ("activation_batch_no_exp", "activation_length", "activation_embed")
     else:
-      logical_axis_names = ("activation_batch", "activation_length_no_exp", "activation_mlp")
-    inputs = nn.with_logical_constraint(inputs, logical_axis_names)
+      logical_axis_names = ("activation_batch", "activation_length_no_exp", "activation_embed")
+
+    if model_mode == MODEL_MODE_PREFILL:
+      inputs = _maybe_shard_with_logical(inputs, logical_axis_names)
+    else:
+      inputs = _maybe_shard_with_logical(inputs, logical_axis_names)
 
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     # inputs: embedded inputs to the decoder with shape [batch, length, emb_dim]
@@ -109,9 +118,9 @@ class DecoderLayer(nn.Module):
         kernel_axes=("norm",),
     )(inputs)
     if model_mode == MODEL_MODE_PREFILL:
-      lnx = nn.with_logical_constraint(lnx, logical_axis_names)
+      lnx = _maybe_shard_with_logical(lnx, logical_axis_names)
     else:
-      lnx = nn.with_logical_constraint(lnx, logical_axis_names)
+      lnx = _maybe_shard_with_logical(lnx, logical_axis_names)
 
     attention_layer = attention_as_linen(
         config=self.config,
@@ -149,9 +158,9 @@ class DecoderLayer(nn.Module):
     )
 
     if model_mode == MODEL_MODE_PREFILL:
-      attention_lnx = nn.with_logical_constraint(attention_lnx, logical_axis_names)
+      attention_lnx = _maybe_shard_with_logical(attention_lnx, logical_axis_names)
     else:
-      attention_lnx = nn.with_logical_constraint(attention_lnx, logical_axis_names)
+      attention_lnx = _maybe_shard_with_logical(attention_lnx, logical_axis_names)
 
     # MLP block.
     mlp_lnx = linears.mlp_block(
@@ -165,11 +174,12 @@ class DecoderLayer(nn.Module):
         model_mode=model_mode,
         config=cfg,
         quant=self.quant,
+        mesh=self.mesh,
     )(lnx, deterministic=deterministic)
     if model_mode == MODEL_MODE_PREFILL:
-      mlp_lnx = nn.with_logical_constraint(mlp_lnx, logical_axis_names)
+      mlp_lnx = _maybe_shard_with_logical(mlp_lnx, logical_axis_names)
     else:
-      mlp_lnx = nn.with_logical_constraint(mlp_lnx, logical_axis_names)
+      mlp_lnx = _maybe_shard_with_logical(mlp_lnx, logical_axis_names)
 
     next_layer_addition = mlp_lnx + attention_lnx
 
@@ -179,12 +189,12 @@ class DecoderLayer(nn.Module):
 
     layer_output = next_layer_addition_dropped_out + inputs
     if model_mode == MODEL_MODE_PREFILL:
-      layer_output = nn.with_logical_constraint(
+      layer_output = _maybe_shard_with_logical(
           layer_output,
           logical_axis_names,
       )
     else:
-      layer_output = nn.with_logical_constraint(
+      layer_output = _maybe_shard_with_logical(
           layer_output,
           logical_axis_names,
       )
@@ -460,7 +470,7 @@ class Decoder(nn.Module):
         DecoderBlockType.SIMPLE_MLP,
         DecoderBlockType.LLAMA4,
     ):
-      return functools.partial(rms_norm, num_features=num_features)
+      return functools.partial(rms_norm, num_features=num_features, shard_mode=self.config.shard_mode)
     elif self.config.decoder_block == DecoderBlockType.GPT3:
       return functools.partial(gpt3.gpt3_layer_norm, num_features=num_features, reductions_in_fp32=False, use_bias=True)
     else:
@@ -572,6 +582,7 @@ class Decoder(nn.Module):
           embedding_init=nn.initializers.normal(stddev=1.0),
           name="position_embedder",
           config=cfg,
+          mesh=self.mesh,
       )(decoder_positions, model_mode=model_mode)
     return y
 
@@ -580,6 +591,20 @@ class Decoder(nn.Module):
     """Applies final normalization and projects hidden states to logits."""
 
     cfg = self.config
+    if cfg.shard_mode == ShardMode.EXPLICIT:
+      norm_out_sharding = NamedSharding(
+          self.mesh,
+          nn.logical_to_mesh_axes(
+              (
+                  "activation_batch",
+                  "activation_length_no_exp",
+                  "activation_embed",
+              )
+          ),
+      )
+    else:
+      norm_out_sharding = None
+
     y = self.get_norm_layer(num_features=y.shape[-1])(
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
@@ -587,8 +612,22 @@ class Decoder(nn.Module):
         epsilon=cfg.normalization_layer_epsilon,
         kernel_axes=("norm",),
         parameter_memory_host_offload=cfg.parameter_memory_host_offload,
-    )(y)
+    )(y, out_sharding=norm_out_sharding)
     y = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(y, deterministic=deterministic)
+
+    if model_mode in (MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE):
+      out_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes((None, None, "activation_vocab")))
+    else:
+      out_sharding = NamedSharding(
+          self.mesh,
+          nn.logical_to_mesh_axes(
+              (
+                  "activation_embed_and_logits_batch",
+                  "activation_length_no_exp",
+                  "activation_vocab",
+              )
+          ),
+      )
 
     # [batch, length, emb_dim] -> [batch, length, vocab_size]
     if cfg.logits_via_embedding:
@@ -600,7 +639,7 @@ class Decoder(nn.Module):
       if isinstance(embedding_table, nn.spmd.LogicallyPartitioned):
         embedding_table = embedding_table.unbox()
       attend_dtype = jnp.float32 if cfg.logits_dot_in_fp32 else cfg.dtype
-      logits = attend_on_embedding(y, embedding_table, attend_dtype, self.config)
+      logits = attend_on_embedding(y, embedding_table, attend_dtype, self.config, out_sharding)
 
       if self.config.normalize_embedding_logits:
         # Correctly normalize pre-softmax logits for this shared case.
@@ -615,18 +654,14 @@ class Decoder(nn.Module):
           weight_dtype=cfg.weight_dtype,
           dtype=jnp.float32 if cfg.logits_dot_in_fp32 else cfg.dtype,  # for logit training stability
           kernel_axes=("embed", "vocab"),
+          shard_mode=cfg.shard_mode,
           name="logits_dense",
           matmul_precision=self.config.matmul_precision,
           parameter_memory_host_offload=cfg.parameter_memory_host_offload,
       )(
-          y
+          y,
+          out_sharding=out_sharding,
       )  # We do not quantize the logits matmul.
-    if model_mode in (MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE):
-      logits = nn.with_logical_constraint(logits, (None, None, "activation_vocab"))
-    elif cfg.num_vocab_tiling == 1:
-      logits = nn.with_logical_constraint(
-          logits, ("activation_embed_and_logits_batch", "activation_length_no_exp", "activation_vocab")
-      )
 
     if self.config.cast_logits_to_fp32:
       logits = logits.astype(jnp.float32)

--- a/src/MaxText/layers/deepseek.py
+++ b/src/MaxText/layers/deepseek.py
@@ -194,6 +194,7 @@ class DeepSeekDenseLayer(nn.Module):
         weight_dtype=cfg.weight_dtype,
         name="mlp",
         config=cfg,
+        mesh=self.mesh,
         quant=self.quant,
     )(hidden_states, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, logical_axis_names)

--- a/src/MaxText/layers/deepseek_batchsplit.py
+++ b/src/MaxText/layers/deepseek_batchsplit.py
@@ -225,6 +225,7 @@ class DeepSeekDenseLayer(DeepSeekGenericLayer):
         name="mlp",
         config=self.config,
         quant=self.quant,
+        mesh=self.mesh,
     )
 
   def mlp(self, x, deterministic):

--- a/src/MaxText/layers/gemma.py
+++ b/src/MaxText/layers/gemma.py
@@ -102,6 +102,7 @@ class GemmaDecoderLayer(nnx.Module):
 
     self.mlp = MlpBlock(
         config=config,
+        mesh=self.mesh,
         in_features=config.emb_dim,
         intermediate_dim=config.mlp_dim,
         activations=config.mlp_activations,

--- a/src/MaxText/layers/gemma2.py
+++ b/src/MaxText/layers/gemma2.py
@@ -113,6 +113,7 @@ class Gemma2DecoderLayer(nnx.Module):
 
     self.mlp_local = MlpBlock(
         config=config,
+        mesh=self.mesh,
         in_features=config.emb_dim,
         intermediate_dim=config.mlp_dim,
         activations=config.mlp_activations,
@@ -186,6 +187,7 @@ class Gemma2DecoderLayer(nnx.Module):
 
     self.mlp_global = MlpBlock(
         config=config,
+        mesh=self.mesh,
         in_features=config.emb_dim,
         intermediate_dim=config.mlp_dim,
         activations=config.mlp_activations,

--- a/src/MaxText/layers/gemma3.py
+++ b/src/MaxText/layers/gemma3.py
@@ -157,6 +157,7 @@ class Gemma3DecoderLayer(nnx.Module):
         config=config,
         quant=self.quant,
         model_mode=model_mode,
+        mesh=mesh,
         rngs=self.rngs,
     )
 

--- a/src/MaxText/layers/gpt3.py
+++ b/src/MaxText/layers/gpt3.py
@@ -22,7 +22,7 @@ import jax
 from jax import lax
 import jax.numpy as jnp
 from jax.ad_checkpoint import checkpoint_name
-from jax.sharding import Mesh
+from jax.sharding import Mesh, NamedSharding
 
 from flax import linen as nn
 from flax import nnx
@@ -81,7 +81,7 @@ class Gpt3LayerNorm(nnx.Module):
     else:
       self.bias = None
 
-  def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+  def __call__(self, x: jnp.ndarray, out_sharding: NamedSharding | None = None) -> jnp.ndarray:
     """Applies layer normalization on the input."""
     if self.reductions_in_fp32:
       x = jnp.asarray(x, jnp.float32)
@@ -98,7 +98,13 @@ class Gpt3LayerNorm(nnx.Module):
       scale = jax.device_put(scale, max_utils.device_space())
 
     scale = jnp.asarray(scale, self.dtype)
-    output = normed_inputs * (scale + 1)
+    # broadcast second inputs and element-wise mul
+    output = jnp.einsum(
+        "i...k,...k->i...k",
+        normed_inputs,
+        scale + 1,
+        out_sharding=out_sharding,
+    )
 
     if self.bias is not None:
       bias = self.bias.value
@@ -397,6 +403,7 @@ class Gpt3DecoderLayer(nn.Module):
         use_pre_norm=True,
         config=cfg,
         quant=self.quant,
+        mesh=self.mesh,
     )(attention_lnx, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
 

--- a/src/MaxText/layers/linears.py
+++ b/src/MaxText/layers/linears.py
@@ -23,6 +23,7 @@ import jax
 import jax.numpy as jnp
 
 from jax import lax
+from jax.sharding import NamedSharding, Mesh
 from jax.ad_checkpoint import checkpoint_name
 
 from flax import nnx
@@ -30,7 +31,8 @@ import flax.linen as nn
 
 from MaxText import max_logging
 from MaxText import max_utils
-from MaxText.common_types import DecoderBlockType, DType, Array, Config
+from MaxText.maxtext_utils import maybe_shard_with_logical
+from MaxText.common_types import DecoderBlockType, ShardMode, DType, Array, Config
 from MaxText.common_types import MODEL_MODE_TRAIN, MODEL_MODE_PREFILL, EP_AS_CONTEXT
 from MaxText.layers import nnx_wrappers, quantizations
 from MaxText.layers import normalizations
@@ -77,7 +79,14 @@ def _compute_dot_general(inputs, kernel, kernel_axes, axis, contract_ind, matmul
 
 
 def _compute_dot_general_nnx(
-    inputs, kernel, axis, contract_ind, matmul_precision, quant_dot_general: nnx_wrappers.ToNNX | None, initializing: bool
+    inputs,
+    kernel,
+    axis,
+    contract_ind,
+    matmul_precision,
+    quant_dot_general: nnx_wrappers.ToNNX | None,
+    initializing: bool,
+    out_sharding: NamedSharding | None = None,
 ):
   """Computes a dot_general operation that may be quantized."""
   dot_general = lax.dot_general
@@ -86,7 +95,10 @@ def _compute_dot_general_nnx(
     if initializing:
       quant_dot_general.lazy_init(inputs, kernel, ((axis, contract_ind), ((), ())), precision=None)
     return quant_dot_general(inputs, kernel, ((axis, contract_ind), ((), ())), precision=None, mutable=["aqt"])
-  return dot_general(inputs, kernel, ((axis, contract_ind), ((), ())), precision=matmul_precision)
+
+  return dot_general(
+      inputs, kernel, ((axis, contract_ind), ((), ())), precision=matmul_precision, out_sharding=out_sharding
+  )
 
 
 class DenseGeneral(nnx.Module):
@@ -103,6 +115,7 @@ class DenseGeneral(nnx.Module):
       kernel_axes: tuple[None | str, ...] = (),
       quant: None | Quant = None,
       use_bias: bool = False,
+      shard_mode: ShardMode = ShardMode.AUTO,
       matmul_precision: str = "default",
       parameter_memory_host_offload: bool = False,
       *,  # Following arguments are keyword-only
@@ -121,6 +134,7 @@ class DenseGeneral(nnx.Module):
       kernel_axes: logical axes for partitioning the kernel.
       quant: quantization config, defaults to None implying no quantization.
       use_bias: whether to add bias in linear transformation.
+      shard_mode: auto or explicit shard mode.
       matmul_precision: Precision for matrix multiplication.
       parameter_memory_host_offload: Determines whether to offload params to host
       rngs: RNG state for initialization in nnx.
@@ -134,6 +148,7 @@ class DenseGeneral(nnx.Module):
     self.kernel_axes = kernel_axes
     self.quant = quant
     self.use_bias = use_bias
+    self.shard_mode = shard_mode
     self.matmul_precision = matmul_precision
     self.parameter_memory_host_offload = parameter_memory_host_offload
 
@@ -181,7 +196,7 @@ class DenseGeneral(nnx.Module):
       return None
     return getattr(self, self._quant_dot_general_name)
 
-  def __call__(self, inputs: Array, _initializing: bool = False) -> Array:
+  def __call__(self, inputs: Array, _initializing: bool = False, out_sharding: NamedSharding | None = None) -> Array:
     """Applies a linear transformation to the inputs along multiple dimensions.
 
     Args:
@@ -211,6 +226,10 @@ class DenseGeneral(nnx.Module):
         kernel = jax.device_put(kernel, max_utils.device_space())
       kernel = jnp.asarray(kernel, self.dtype)
 
+    # out_sharding should be None for auto mesh axis
+    if self.shard_mode != ShardMode.EXPLICIT:
+      out_sharding = None
+
     contract_ind = tuple(range(0, len(self.axis)))
     output = _compute_dot_general_nnx(
         inputs,
@@ -220,6 +239,7 @@ class DenseGeneral(nnx.Module):
         self.matmul_precision,
         self.quant_dot_general,
         _initializing,
+        out_sharding,
     )
 
     if self.bias is not None:
@@ -240,6 +260,7 @@ def dense_general(
     kernel_axes: tuple[None | str, ...] = (),
     quant: None | Quant = None,
     use_bias: bool = False,
+    shard_mode: ShardMode = ShardMode.AUTO,
     matmul_precision: str = "default",
     parameter_memory_host_offload: bool = False,
     name: None | str = None,
@@ -258,6 +279,7 @@ def dense_general(
     kernel_axes: logical axes for partitioning the kernel.
     quant: quantization config, defaults to None implying no quantization.
     use_bias: whether to add bias in linear transformation.
+    shard_mode: indicating the shard mode
     matmul_precision: Precision for matrix multiplication.
     parameter_memory_host_offload: Determines whether to offload params to host
     name: name passed to the ToLinen Module
@@ -281,6 +303,7 @@ def dense_general(
       kernel_axes=kernel_axes,
       quant=quant,
       use_bias=use_bias,
+      shard_mode=shard_mode,
       matmul_precision=matmul_precision,
       parameter_memory_host_offload=parameter_memory_host_offload,
       name=name,
@@ -319,6 +342,7 @@ class MlpBlock(nnx.Module):
   def __init__(
       self,
       config: Config,
+      mesh: Mesh,
       in_features: int,
       intermediate_dim: int = 2048,
       activations: Sequence[str | Callable[..., Any]] = ("relu",),
@@ -337,6 +361,7 @@ class MlpBlock(nnx.Module):
 
     Args:
       config: Config object containing model parameters.
+      mesh: Mesh object of device and physical axes information
       in_features: Number of input features.
       intermediate_dim: Shared dimension of hidden layers.
       activations: Type of activations for each layer.  Each element is either
@@ -349,8 +374,10 @@ class MlpBlock(nnx.Module):
       use_bias: whether to add bias in all feedforward layers.
       use_pre_norm: whether to add pre layer norm in mlp layers.
       quant: Optional quantization config, no quantization if None.
+      out_sharding: Named sharding of outputs
     """
     self.config = config
+    self.mesh = mesh
     self.in_features = in_features
     self.intermediate_dim = intermediate_dim
     self.activations = activations
@@ -374,6 +401,13 @@ class MlpBlock(nnx.Module):
     else:
       self.mlp_layer_norm = None
 
+    if self.model_mode == MODEL_MODE_PREFILL:
+      self.intermediate_logical = ("activation_batch", "prefill_activation_length", "activation_mlp")
+    elif config.expert_shard_attention_option == EP_AS_CONTEXT and self.model_mode == MODEL_MODE_TRAIN:
+      self.intermediate_logical = ("activation_batch_no_exp", "activation_length", "activation_mlp")
+    else:
+      self.intermediate_logical = ("activation_batch", "activation_length_no_exp", "activation_mlp")
+
     if config.fused_mlp:
       self.wi = DenseGeneral(
           in_features_shape=in_features,
@@ -384,6 +418,7 @@ class MlpBlock(nnx.Module):
           kernel_axes=("embed", "num_activations", "mlp"),
           quant=self.quant,
           use_bias=self.use_bias,
+          shard_mode=self.config.shard_mode,
           matmul_precision=self.config.matmul_precision,
           rngs=rngs,
       )
@@ -399,6 +434,7 @@ class MlpBlock(nnx.Module):
             kernel_axes=("embed", "mlp"),
             quant=self.quant,
             use_bias=self.use_bias,
+            shard_mode=self.config.shard_mode,
             matmul_precision=self.config.matmul_precision,
             rngs=rngs,
         )
@@ -413,8 +449,15 @@ class MlpBlock(nnx.Module):
         kernel_axes=("mlp", "embed"),
         quant=self.quant,
         use_bias=self.use_bias,
+        shard_mode=self.config.shard_mode,
         matmul_precision=self.config.matmul_precision,
         rngs=rngs,
+    )
+
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=config.shard_mode,
     )
 
   def get_norm_layer(self, num_features: int):
@@ -441,7 +484,14 @@ class MlpBlock(nnx.Module):
     else:
       raise ValueError(f"Incorrect decoder_block name {self.config.decoder_block.value=}")
 
-  def __call__(self, inputs, decode: bool = False, deterministic: bool = False):
+  def __call__(
+      self,
+      inputs,
+      decode: bool = False,
+      deterministic: bool = False,
+      intermediate_sharding: NamedSharding | None = None,
+      out_sharding: NamedSharding | None = None,
+  ):
     """Applies Transformer MlpBlock module."""
     cfg = self.config
 
@@ -452,7 +502,7 @@ class MlpBlock(nnx.Module):
     # e.g. ('relu',) or ('gelu', 'linear') for gated-gelu.
     activations = []
     if cfg.fused_mlp:
-      x = self.wi(inputs)
+      x = self.wi(inputs, out_sharding=intermediate_sharding)
       x = checkpoint_name(x, "mlpwi")
       for idx, act_fn in enumerate(self.activations):
         y = _convert_to_activation_function(act_fn)(x[:, :, idx, ...])
@@ -461,7 +511,7 @@ class MlpBlock(nnx.Module):
       for idx, act_fn in enumerate(self.activations):
         dense_name = "wi" if len(self.activations) == 1 else f"wi_{idx}"
         module = getattr(self, dense_name)
-        x = module(inputs)
+        x = module(inputs, out_sharding=intermediate_sharding)
         x = checkpoint_name(x, "mlp" + dense_name)
         if cfg.activations_in_float32:
           x = x.astype(jnp.float32)
@@ -472,14 +522,8 @@ class MlpBlock(nnx.Module):
     x = functools.reduce(operator.mul, activations).astype(self.dtype)
     # Apply dropout and final dense output projection.
     x = self.dropout(x, deterministic=deterministic)  # Broadcast along length.
-    if self.model_mode == MODEL_MODE_PREFILL:
-      x = nn.with_logical_constraint(x, ("activation_batch", "prefill_activation_length", "activation_mlp"))
-    elif cfg.expert_shard_attention_option == EP_AS_CONTEXT and self.model_mode == MODEL_MODE_TRAIN:
-      x = nn.with_logical_constraint(x, ("activation_batch_no_exp", "activation_length", "activation_mlp"))
-    else:
-      x = nn.with_logical_constraint(x, ("activation_batch", "activation_length_no_exp", "activation_mlp"))
-
-    output = self.wo(x)
+    x = self._maybe_shard_with_logical(x, self.intermediate_logical)
+    output = self.wo(x, out_sharding=out_sharding)
 
     output = checkpoint_name(output, "mlpwo")
     return output
@@ -488,6 +532,7 @@ class MlpBlock(nnx.Module):
 def mlp_block(
     *,
     config: Config,
+    mesh: Mesh,
     in_features: int,
     intermediate_dim: int = 2048,
     activations: Sequence[str | Callable[..., Any]] = ("relu",),
@@ -505,6 +550,7 @@ def mlp_block(
   module = nnx_wrappers.to_linen(
       MlpBlock,
       config=config,
+      mesh=mesh,
       in_features=in_features,
       intermediate_dim=intermediate_dim,
       activations=activations,

--- a/src/MaxText/layers/llama2.py
+++ b/src/MaxText/layers/llama2.py
@@ -16,9 +16,10 @@
 # pylint: disable=arguments-differ
 # pylint: disable=no-name-in-module
 
+import functools
 import jax.numpy as jnp
 from jax.ad_checkpoint import checkpoint_name
-from jax.sharding import Mesh
+from jax.sharding import Mesh, NamedSharding
 
 from flax import linen as nn
 from flax import nnx
@@ -26,6 +27,7 @@ from flax import nnx
 from MaxText.inference import page_manager
 from MaxText.common_types import Config
 from MaxText import max_utils
+from MaxText.maxtext_utils import maybe_shard_with_logical
 from MaxText.layers.linears import Dropout, MlpBlock
 from MaxText.layers import initializers
 from MaxText.layers import nnx_wrappers
@@ -57,6 +59,11 @@ class LlamaDecoderLayer(nnx.Module):
     self.mesh = mesh
     self.quant = quant
 
+    if model_mode == MODEL_MODE_PREFILL:
+      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
+    else:
+      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
@@ -64,6 +71,7 @@ class LlamaDecoderLayer(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=rngs,
@@ -101,6 +109,7 @@ class LlamaDecoderLayer(nnx.Module):
         num_features=config.emb_dim,
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
+        shard_mode=config.shard_mode,
         kernel_axes=("norm",),
         epsilon=config.normalization_layer_epsilon,
         rngs=rngs,
@@ -114,6 +123,7 @@ class LlamaDecoderLayer(nnx.Module):
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
         config=config,
+        mesh=mesh,
         quant=self.quant,
         model_mode=model_mode,
         rngs=rngs,
@@ -121,10 +131,11 @@ class LlamaDecoderLayer(nnx.Module):
 
     self.dropout = Dropout(rate=config.dropout_rate, broadcast_dims=(-2,), rngs=rngs)
 
-    if model_mode == MODEL_MODE_PREFILL:
-      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
-    else:
-      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    self._maybe_shard_with_logical = functools.partial(
+        maybe_shard_with_logical,
+        mesh=self.mesh,
+        shard_mode=config.shard_mode,
+    )
 
   def __call__(
       self,
@@ -139,11 +150,11 @@ class LlamaDecoderLayer(nnx.Module):
   ):
     cfg = self.config
 
-    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
-    lnx = self.pre_self_attention_layer_norm(inputs)
-
-    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    lnx_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(self.activation_axis_names))
+    lnx = self.pre_self_attention_layer_norm(inputs, out_sharding=lnx_sharding)
+    lnx = self._maybe_shard_with_logical(lnx, self.activation_axis_names)
 
     # Self-attention block
     attention_lnx = self.self_attention(
@@ -156,22 +167,32 @@ class LlamaDecoderLayer(nnx.Module):
         slot=slot,
         page_state=page_state,
         previous_chunk=previous_chunk,
+        out_sharding=lnx_sharding,
     )
 
-    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+    attention_lnx = self._maybe_shard_with_logical(attention_lnx, self.activation_axis_names)
     intermediate_inputs = inputs + attention_lnx
 
     # Fully Connected
-    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
-    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs, out_sharding=lnx_sharding)
+    hidden_states = self._maybe_shard_with_logical(hidden_states, self.activation_axis_names)
 
     # MLP block.
-    mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
-    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+    mlp_intermediate_sharding = NamedSharding(
+        self.mesh,
+        nn.logical_to_mesh_axes(("activation_batch", "activation_length_no_exp", "activation_mlp")),
+    )
+    mlp_lnx = self.mlp(
+        hidden_states,
+        deterministic=deterministic,
+        intermediate_sharding=mlp_intermediate_sharding,
+        out_sharding=lnx_sharding,
+    )
+    mlp_lnx = self._maybe_shard_with_logical(mlp_lnx, self.activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs
     layer_output = self.dropout(layer_output, deterministic=deterministic)
-    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+    layer_output = self._maybe_shard_with_logical(layer_output, self.activation_axis_names)
 
     if cfg.record_internal_nn_metrics:
       self.sow("intermediates", "activation_mean", jnp.mean(layer_output))

--- a/src/MaxText/layers/llama4.py
+++ b/src/MaxText/layers/llama4.py
@@ -415,6 +415,7 @@ class Llama4DecoderLayer(nnx.Module):
       )
     else:
       self.mlp = MlpBlock(
+          mesh=self.mesh,
           in_features=config.emb_dim,
           intermediate_dim=config.mlp_dim,
           activations=config.mlp_activations,

--- a/src/MaxText/layers/mistral.py
+++ b/src/MaxText/layers/mistral.py
@@ -105,6 +105,7 @@ class MistralDecoderLayer(nnx.Module):
     )
 
     self.mlp = MlpBlock(
+        mesh=self.mesh,
         in_features=config.emb_dim,
         intermediate_dim=config.mlp_dim,
         activations=config.mlp_activations,

--- a/src/MaxText/layers/models.py
+++ b/src/MaxText/layers/models.py
@@ -82,6 +82,7 @@ class TransformerLinenPure(nn.Module):
         embedding_init=nn.initializers.normal(stddev=1.0),
         name="token_embedder",
         config=cfg,
+        mesh=self.mesh,
     )
     self.vision_encoder = VisionEncoder(config=cfg, mesh=mesh) if cfg.use_multimodal else None
     self.decoder = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
@@ -284,6 +285,7 @@ class Transformer(nnx.Module):
     cfg = self.config
     mesh = self.mesh
     self.token_embedder = Embed(
+        mesh=self.mesh,
         num_embeddings=cfg.vocab_size,
         num_features=cfg.emb_dim,
         dtype=cfg.dtype,

--- a/src/MaxText/layers/moe.py
+++ b/src/MaxText/layers/moe.py
@@ -1811,6 +1811,7 @@ class RoutedAndSharedMoE(nnx.Module):
         rngs=self.rngs,
     )
     self.shared_experts = linears.MlpBlock(
+        mesh=self.mesh,
         in_features=self.config.emb_dim,
         intermediate_dim=self.config.shared_experts * self.config.moe_mlp_dim,
         activations=self.config.mlp_activations,

--- a/src/MaxText/layers/qwen3.py
+++ b/src/MaxText/layers/qwen3.py
@@ -662,6 +662,7 @@ class Qwen3NextSparseMoeBlock(nnx.Module):
     # 2. Instantiate and apply the shared expert.
     self.shared_expert = linears.MlpBlock(
         config=cfg,
+        mesh=mesh,
         in_features=cfg.emb_dim,
         intermediate_dim=cfg.moe_mlp_dim,
         activations=cfg.mlp_activations,
@@ -1042,6 +1043,7 @@ class Qwen3DecoderLayer(AttentionWithNorm):
         dtype=config.dtype,
         weight_dtype=config.weight_dtype,
         config=config,
+        mesh=mesh,
         quant=quant,
         model_mode=model_mode,
         rngs=rngs,

--- a/src/MaxText/max_utils.py
+++ b/src/MaxText/max_utils.py
@@ -805,21 +805,6 @@ def reorder_causal_load_balanced(batch, cp_size):
   }
 
 
-def shard_reorder_causal_load_balanced(batch, cp_size):
-  """Shard the output of the reordered sequence."""
-  reordered = reorder_causal_load_balanced(batch, cp_size)
-  for _, v in batch.items():
-    if isinstance(v, jax.Array):
-      reordered = jax.lax.with_sharding_constraint(reordered, v.sharding)
-      break
-  return reordered
-
-
-def get_reorder_callable(cp_size):
-  """Creates a callable that can be used with map() to reorder batches."""
-  return functools.partial(shard_reorder_causal_load_balanced, cp_size=cp_size)
-
-
 @staticmethod
 def reorder_mask_load_balancing(tensor, cp_size: int, seq_dim: int):
   """

--- a/src/MaxText/train_utils.py
+++ b/src/MaxText/train_utils.py
@@ -19,7 +19,6 @@ import os
 import jax
 from MaxText import checkpointing
 from MaxText import max_logging
-from MaxText import max_utils
 from MaxText import maxtext_utils
 from MaxText import optimizers
 from MaxText.dpo_utils import _merge_dpo_state
@@ -190,10 +189,10 @@ def setup_train_loop(config, recorder, devices=None):
     # Apply reordering wrapper to data iterators if context parallelism is enabled
     with mesh:
       if context_parallel_size > 1 and config.context_parallel_load_balance:
-        data_iterator = map(max_utils.get_reorder_callable(context_parallel_size), data_iterator)
+        data_iterator = map(maxtext_utils.get_reorder_callable(context_parallel_size, config.shard_mode), data_iterator)
         if eval_data_iterator:
           eval_data_iterator = map(
-              max_utils.get_reorder_callable(context_parallel_size),
+              maxtext_utils.get_reorder_callable(context_parallel_size, config.shard_mode),
               eval_data_iterator,
           )
 

--- a/tests/attention_test.py
+++ b/tests/attention_test.py
@@ -26,7 +26,7 @@ from absl.testing import parameterized
 
 import numpy as np
 
-from jax.sharding import Mesh, NamedSharding
+from jax.sharding import Mesh, NamedSharding, AxisType
 import jax
 import jax.numpy as jnp
 
@@ -36,7 +36,14 @@ from flax.linen import partitioning as nn_partitioning
 from MaxText import maxtext_utils
 from MaxText import max_utils
 from MaxText import pyconfig
-from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, AttentionType
+from MaxText.common_types import (
+    DECODING_ACTIVE_SEQUENCE_INDICATOR,
+    MODEL_MODE_AUTOREGRESSIVE,
+    MODEL_MODE_PREFILL,
+    MODEL_MODE_TRAIN,
+    AttentionType,
+    ShardMode,
+)
 from MaxText.globals import MAXTEXT_PKG_DIR
 from MaxText.layers.attentions import Attention
 from MaxText.layers.attention_op import ChunkedCausalMask, _make_bidirectional_block_mask, _generate_chunk_attention_mask
@@ -285,6 +292,7 @@ class AttentionTest(parameterized.TestCase):
   def setUp(self):
     """Initializes the configuration for each test"""
     super().setUp()
+    jax.config.update("jax_remove_size_one_mesh_axis_from_type", True)
     config = pyconfig.initialize(
         [sys.argv[0], os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")],
         **self.config_arguments,
@@ -578,7 +586,11 @@ class AttentionTest(parameterized.TestCase):
   # TODO (b/454764135.) : This tests fails with new tokamax kernel
   @pytest.mark.tpu_only
   def test_tpu_flash_attention_context_parallel(
-      self, ici_context_parallelism, context_parallel_load_balance, ici_expert_parallelism, expert_shard_attention_option
+      self,
+      ici_context_parallelism,
+      context_parallel_load_balance,
+      ici_expert_parallelism,
+      expert_shard_attention_option,
   ):
     """Test equivalence between dot_product and flash attention + context/expert parallelism"""
     num_kv_heads = self.num_kv_heads
@@ -604,7 +616,8 @@ class AttentionTest(parameterized.TestCase):
         expert_shard_attention_option=expert_shard_attention_option,
     )
     devices_array_cp = maxtext_utils.create_device_mesh(cfg_cp)
-    mesh_cp = Mesh(devices_array_cp, cfg_cp.mesh_axes)
+    axis_names = [AxisType.Auto for _ in cfg_cp.mesh_axes]
+    mesh_cp = Mesh(devices_array_cp, cfg_cp.mesh_axes, axis_types=tuple(axis_names))
     attention_as_mha_flash_cp = Attention(
         config=cfg_cp,
         num_query_heads=cfg_cp.num_query_heads,
@@ -626,6 +639,10 @@ class AttentionTest(parameterized.TestCase):
     mha_generic_flash_cp_output = _forward_with_context_expert_parallelism(
         cfg_cp, mesh_cp, attention_as_mha_flash_cp, lnx, decoder_segment_ids, decoder_positions
     )
+
+    # This removes all sharding information and makes them standard NumPy arrays.
+    mha_generic_output = jax.device_get(mha_generic_output)
+    mha_generic_flash_cp_output = jax.device_get(mha_generic_flash_cp_output)
 
     self.assertTrue(
         jax.numpy.allclose(mha_generic_output, mha_generic_flash_cp_output, rtol=1e-01, atol=1e-01, equal_nan=False),
@@ -1049,6 +1066,7 @@ class MLATest(parameterized.TestCase):
   def setUp(self):
     """Initializes the configuration for each test"""
     super().setUp()
+    jax.config.update("jax_remove_size_one_mesh_axis_from_type", True)
     config = pyconfig.initialize(
         [sys.argv[0], os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")],
         **self.config_arguments,
@@ -1290,7 +1308,11 @@ class MLATest(parameterized.TestCase):
   # TODO (b/454764135.) : This tests fails with new tokamax kernel
   @pytest.mark.tpu_only
   def test_tpu_flash_attention_context_parallel(
-      self, ici_context_parallelism, context_parallel_load_balance, ici_expert_parallelism, expert_shard_attention_option
+      self,
+      ici_context_parallelism,
+      context_parallel_load_balance,
+      ici_expert_parallelism,
+      expert_shard_attention_option,
   ):
     """Test equivalence between dot_product and flash attention + context/expert parallelism"""
 
@@ -1383,7 +1405,7 @@ def _forward_with_context_expert_parallelism(cfg_cp, mesh_cp, attention_cp, lnx,
   if context_parallel_size > 1 and cfg_cp.context_parallel_load_balance:
     batch = {"inputs": lnx, "inputs_segmentation": decoder_segment_ids, "inputs_position": decoder_positions}
     with mesh_cp:
-      reordered_batch = max_utils.get_reorder_callable(context_parallel_size)(batch)
+      reordered_batch = maxtext_utils.get_reorder_callable(context_parallel_size, ShardMode.AUTO)(batch)
     lnx = reordered_batch["inputs"]
     decoder_segment_ids = reordered_batch["inputs_segmentation"]
     decoder_positions = reordered_batch["inputs_position"]

--- a/tests/moe_test.py
+++ b/tests/moe_test.py
@@ -179,7 +179,9 @@ class MlpBlockTest(unittest.TestCase):
     )
     self.rng = jax.random.PRNGKey(42)
     quant = Fp8Quantization()
+    devices_array = maxtext_utils.create_device_mesh(self.config)
     self.model = linears.mlp_block(
+        mesh=Mesh(devices_array, self.config.mesh_axes),
         config=self.config,
         in_features=2,
         intermediate_dim=2,
@@ -193,7 +195,7 @@ class MlpBlockTest(unittest.TestCase):
     )
 
   def test_init(self):
-    x = jnp.array([1.0, 2.0])
+    x = jnp.array([1.0, 2.0]).reshape((1, 1, 2))  # TODO(bug): need reshape due to error
     self.model.init({"params": self.rng, "dropout": self.rng}, x)
 
 
@@ -273,6 +275,7 @@ class MoeLoopBlock(nnx.Module):
   def __init__(
       self,
       config: Config,
+      mesh: Mesh,
       inputs_shape: tuple[int, ...],
       num_experts: int,
       num_experts_per_tok: int,
@@ -283,6 +286,7 @@ class MoeLoopBlock(nnx.Module):
       dtype: DType = jnp.bfloat16,
   ):
     self.config = config
+    self.mesh = mesh
     self.inputs_shape = inputs_shape
     self.num_experts = num_experts
     self.num_experts_per_tok = num_experts_per_tok
@@ -302,6 +306,7 @@ class MoeLoopBlock(nnx.Module):
     for k in range(self.num_experts):
       expert_module = linears.MlpBlock(
           config=self.config,
+          mesh=self.mesh,
           in_features=self.inputs_shape[-1],
           intermediate_dim=self.config.mlp_dim,
           activations=["silu", "linear"],
@@ -334,6 +339,7 @@ class MoeLoopBlock(nnx.Module):
 
 def get_moe_loop(
     config: Config,
+    mesh: Mesh,
     inputs_shape: tuple[int, ...],
     num_experts: int,
     num_experts_per_tok: int,
@@ -346,6 +352,7 @@ def get_moe_loop(
   module = nnx_wrappers.to_linen(
       MoeLoopBlock,
       config=config,
+      mesh=mesh,
       inputs_shape=inputs_shape,
       num_experts=num_experts,
       num_experts_per_tok=num_experts_per_tok,
@@ -361,10 +368,11 @@ def get_moe_loop(
 class RoutedMoeTest(unittest.TestCase):
   """Routed Mixture of Experts test."""
 
-  def get_expected_output(self, rng, hidden_states, cfg):
+  def get_expected_output(self, rng, hidden_states, cfg, mesh):
     """Retrieve expected output from Routed Mixture of Experts."""
     model = get_moe_loop(
         config=cfg,
+        mesh=mesh,
         inputs_shape=hidden_states.shape,
         num_experts=cfg.num_experts,
         num_experts_per_tok=cfg.num_experts_per_tok,
@@ -448,7 +456,7 @@ class RoutedMoeTest(unittest.TestCase):
 
     devices_array = maxtext_utils.create_device_mesh(cfg)
     mesh = Mesh(devices_array, cfg.mesh_axes)
-    variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg)
+    variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
     actual_output, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
     self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
 
@@ -476,7 +484,7 @@ class RoutedMoeTest(unittest.TestCase):
 
     devices_array = maxtext_utils.create_device_mesh(cfg)
     mesh = Mesh(devices_array, cfg.mesh_axes)
-    variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg)
+    variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
     actual_output, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
     self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
 
@@ -504,7 +512,7 @@ class RoutedMoeTest(unittest.TestCase):
 
     devices_array = maxtext_utils.create_device_mesh(cfg)
     mesh = Mesh(devices_array, cfg.mesh_axes)
-    variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg)
+    variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
     actual_output, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
     self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-05, atol=1e-05, equal_nan=False))
 
@@ -518,7 +526,7 @@ class RoutedMoeTest(unittest.TestCase):
         dtype="bfloat16",
         megablox=True,
         sparse_matmul=True,
-        per_device_batch_size=1,
+        per_device_batch_size=4,  # TODO(b/450900273): sharding error if pdbs=1
         ici_expert_parallelism=4,
     )
 
@@ -534,7 +542,7 @@ class RoutedMoeTest(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(cfg)
     mesh = Mesh(devices_array, cfg.mesh_axes)
     with nn_partitioning.axis_rules(cfg.logical_axis_rules):
-      variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg)
+      variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
       actual_output, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
       self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
 
@@ -548,7 +556,7 @@ class RoutedMoeTest(unittest.TestCase):
         dtype="bfloat16",
         megablox=True,
         sparse_matmul=True,
-        per_device_batch_size=1,
+        per_device_batch_size=4,  # TODO(b/450900273): sharding error if pdbs=1
         ici_fsdp_parallelism=2,
         ici_fsdp_transpose_parallelism=2,
         moe_fsdp_use_two_stage_all_gather=True,
@@ -566,7 +574,7 @@ class RoutedMoeTest(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(cfg)
     mesh = Mesh(devices_array, cfg.mesh_axes)
     with nn_partitioning.axis_rules(cfg.logical_axis_rules):
-      variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg)
+      variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
       actual_output, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
       self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
 
@@ -610,7 +618,7 @@ class RoutedMoeTest(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(cfg)
     mesh = Mesh(devices_array, cfg.mesh_axes)
     with nn_partitioning.axis_rules(cfg.logical_axis_rules):
-      variables, _ = self.get_expected_output(rng_model, hidden_states, cfg)
+      variables, _ = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
       tp_transpose_output, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
       tp_output, _ = self.get_moe_output(variables, hidden_states, cfg2, mesh)
       self.assertTrue(jax.numpy.allclose(tp_output, tp_transpose_output, rtol=1e-05, atol=1e-05, equal_nan=False))
@@ -641,7 +649,7 @@ class RoutedMoeTest(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(cfg)
     mesh = Mesh(devices_array, cfg.mesh_axes)
     with nn_partitioning.axis_rules(cfg.logical_axis_rules):
-      variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg)
+      variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
       actual_output, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
       self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
 

--- a/tests/multi_token_prediction_test.py
+++ b/tests/multi_token_prediction_test.py
@@ -131,6 +131,7 @@ class MTPBlockTestModel(nn.Module):
   def setup(self):
     """Initializes the MTP block and its dependencies for the test."""
     self.shared_embedding = embeddings.embed_as_linen(
+        mesh=self.mesh,
         num_embeddings=self.config.vocab_size,
         num_features=self.config.base_emb_dim,
         config=self.config,

--- a/tests/train_smoke_test.py
+++ b/tests/train_smoke_test.py
@@ -53,6 +53,35 @@ class Train(unittest.TestCase):
         ]
     )
 
+  def test_tiny_config_explicit_shardmode(self):
+    test_tmpdir = os.environ.get("TEST_TMPDIR")  # pylint: disable=unused-variable
+    train_main(
+        [
+            None,
+            os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"),
+            # pylint: disable=f-string-without-interpolation
+            f"base_output_directory=gs://runner-maxtext-logs",
+            "run_name=runner_test",
+            r"dataset_path=gs://maxtext-dataset",
+            "base_emb_dim=8",
+            "base_num_query_heads=4",
+            "base_num_kv_heads=4",
+            "base_mlp_dim=32",
+            "base_num_decoder_layers=8",
+            "head_dim=128",
+            "per_device_batch_size=2",
+            "max_target_length=1024",
+            "dataset_type=synthetic",
+            "steps=10",
+            "shard_mode=explicit",
+            "enable_checkpointing=False",
+            rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizer.llama2')}",
+            "enable_goodput_recording=False",
+            "enable_checkpoint_cloud_logger=False",
+            "monitor_goodput=False",
+        ]
+    )
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
# Description

This pull request integrates support for JAX [explicit sharding](https://docs.jax.dev/en/latest/notebooks/explicit-sharding.html) (a.k.a "shard-in-types") into MaxText.

Explicit sharding is a JAX feature that provides more fine-grained control over array sharding, making sharding strategies easier to reason about and debug. This change will facilitate the development of new sharding schemes and aid in diagnosing sharding-related issues within MaxText.

We made following changes:

*   Introduces a `shard_mode` configuration parameter in `config.py`.
    *   `auto` (default): Maintains the existing behavior using automatic sharding.
    *   `explicit`: Enables the new explicit sharding mode.

*   Adds `maxtext_utils.maybe_shard_with_name()` and `maxtext_utils.maybe_shard_with_logical()`. These functions act as a wrappers of:
    *   In `auto` mode, it wraps `jax.lax.with_sharding_constraint()` or `nn.with_logical_constraint()`.
    *   In `explicit` mode, it wraps `jax.sharding.reshard()` to enforce the specified sharding.

*  Adds an optional `out_sharding` argument to `__call__()` of most MaxText modules involving `jnp.dot()` or `jnp.mul()`. This allows specifying the desired output sharding for an operation when in `explicit` mode. When `shard_mode='auto'`, `out_sharding` must be `None`, which is reflected in the code.

*  Adds the `mesh: Mesh` argument to the initialization of certain Modules. This is necessary even if not previously required, as the `Mesh` object is needed to create `NamedSharding` objects for explicit sharding.

* Adds a smoke test for `shard_mode=explicit`.

In this PR explicit sharding only supports `decoder_block=simple/simple_mlp/llama2`. It does not support quantization feature, which has a different `dot_general` structure. This PR is the first PR introducing explicit sharding and supports on more models/structures will be introduced as followups.

==================Nov 7, 2025 Updated==================

In response to [the comment](https://github.com/AI-Hypercomputer/maxtext/pull/2470#issuecomment-3503367400) (thank you for pointing it out!), this PR did add a reduce/unreduce feature from explicit sharding to improve the gradient accumulation performance. In llama2-7b experiment with pdb=1, ga=4 using ZeRO-1 sharding, the MFU gets improved about ~60%, mostly contributed by removing redundant all-reduces.

- auto shard mode [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-10448453490320307301)
- explicit shard mode [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-11665678167708868122)

==================End of Nov 7, 2025 Updated==================

# Tests

Conclusion: This PR does not impact performance of llama2-7b under auto mode. The performance difference between auto and explicit shard mode is very minor.

## Llama2-7b FSDP
* 0c5af959387621b85606349db44329bfc922d479: [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-3144200311081834343)
* `shard_mode=auto`: [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-810181959157897536)
* `shard_mode=explicit`: [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-9792599363066673052)

## Llama2-7b FSDP+TP
* 0c5af959387621b85606349db44329bfc922d479: [xprof]( http://xprof.corp.google.com/trace_viewer/chengnuojin-11253716425491499365)
* `shard_mode=auto`: [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-7590291178569740463)
* `shard_mode=explicit`: [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-8981931700864424183)

## Llama2-7b FSDP+CP
* 0c5af959387621b85606349db44329bfc922d479: [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-47596118493536047)
* `shard_mode=auto`: [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-14805973730010680181)
* `shard_mode=explicit`: [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-5050779611709569279)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
