### PR TITLE
Add tokamax megablox kernel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ tensorflow-datasets
 tensorflow-text
 tensorflow
 tiktoken
+tokamax>=0.0.3
 transformers
 google-jetstream @ https://github.com/AI-Hypercomputer/JetStream/archive/29329e8e73820993f77cfc8efe34eb2a73f5de98.zip
 mlperf-logging @ https://github.com/mlcommons/logging/archive/38ab22670527888c8eb7825a4ece176fcc36a95d.zip

--- a/requirements_with_jax_ai_image.txt
+++ b/requirements_with_jax_ai_image.txt
@@ -23,4 +23,5 @@ sentencepiece>=0.2.0
 tensorflow-datasets
 tensorflow-text>=2.17.0
 tiktoken
+tokamax>=0.0.3
 transformers

--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -876,3 +876,6 @@ gdn_num_value_heads: 32
 gdn_chunk_size: 64
 # Whether to apply L2 normalization to query and key tensors inside the Gated Delta Rule kernel.
 use_qk_norm_in_gdn: True
+
+# Use tokamax library for gmm kernel implementation
+use_tokamax_gmm: false

--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -287,6 +287,12 @@ def validate_quantization_methods(keys):
       raise ValueError(f"Invalid quantization method {keys['quantization']}. Valid options are {valid_quant_methods}")
 
 
+def validate_tokamax_usage(keys):
+  """Validate tokamax usage for gmm kernel"""
+  if keys["use_tokamax_gmm"] and keys["hardware"] != "tpu":
+    raise ValueError(f"Invalid tokamax's megablox kernel usage for hardware {keys['hardware']}. Only TPU is supported.")
+
+
 def validate_data_input(keys):
   """validate provided parameters for data input"""
   if not keys["hf_access_token"]:
@@ -734,6 +740,7 @@ class _HyperParameters:
     validate_data_input(raw_keys)
     validate_constant_bound(raw_keys)
     validate_quantization_methods(raw_keys)
+    validate_tokamax_usage(raw_keys)
 
     raw_keys["decoder_block"] = DecoderBlockType(raw_keys["decoder_block"])
 


### PR DESCRIPTION
# Description

- adds tokamax as a deps in requirements*.txt files. 
- use ragged_dot api from tokamax hidding behind a flag `use_tokamax_gmm` 

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/436335556

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Perf and convergence runs done by @suexu1025 in b/436335556#comment11. 
Latest perf run  in https://b.corp.google.com/issues/436335556#comment15

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
