### PR TITLE
init KVCache fix for grpo trainer

### DIFF
--- a/end_to_end/tpu/test_grpo.sh
+++ b/end_to_end/tpu/test_grpo.sh
@@ -23,10 +23,11 @@ JAX_BACKEND_TARGET=grpc://127.0.0.1:29000
 ENABLE_PATHWAYS_PERSISTENCE='1'
 HF_TOKEN=${HF_TOKEN}
 
-MAX_PREFILL_LENGTH=128
-MAX_TARGET_LENGTH=256
+MAX_PREFILL_LENGTH=${MAX_PREFILL_LENGTH:-128}
+MAX_TARGET_LENGTH=${MAX_TARGET_LENGTH:-256}
 NUM_GENERATIONS=2
 
+INFERENCE_PER_DEVICE_BS=$((${INFERENCE_PER_DEVICE_BATCH_SIZE} * ${NUM_GENERATIONS}))
 
 COMMON_ARGS="model_name=${MODEL} base_output_directory=${BASE_OUTPUT_DIRECTORY} \
 max_prefill_predict_length=${MAX_PREFILL_LENGTH} max_target_length=${MAX_TARGET_LENGTH} \
@@ -44,10 +45,10 @@ inference_rollouts=5 \
 per_device_batch_size=${TRAINING_PER_DEVICE_BATCH_SIZE} num_generations=${NUM_GENERATIONS} steps=${STEPS}"
 
 INFERENCE_ARGS="run_name=grpo scan_layers=false \
-per_device_batch_size=${INFERENCE_PER_DEVICE_BATCH_SIZE} \
+per_device_batch_size=${INFERENCE_PER_DEVICE_BS} num_generations=${NUM_GENERATIONS} \
 ici_data_parallelism=${NUM_SAMPLERS} ici_tensor_parallelism=${DEVICES_PER_SAMPLER}"
 
 JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE='1' \
-    python3 -m MaxText.experimental.rl.grpo_trainer "${MAXTEXT_PKG_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/MaxText}"/experimental/rl/grpo.yml  \
+    python3 src/MaxText/experimental/rl/grpo_trainer.py "${MAXTEXT_PKG_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/MaxText}"/experimental/rl/grpo.yml  \
     ${COMMON_ARGS} ${TRAINING_ARGS} ${MAXTEXT_PKG_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/MaxText}/experimental/rl/grpo_inference.yml \
     ${COMMON_ARGS} ${INFERENCE_ARGS}

--- a/src/MaxText/experimental/rl/grpo_trainer.py
+++ b/src/MaxText/experimental/rl/grpo_trainer.py
@@ -615,7 +615,7 @@ def generate_completions(
     thread_example_batch_trimmed = jax.tree_util.tree_map(
         lambda arr: arr[
             : int(
-                worker_config_inference.per_device_batch_size
+                (worker_config_inference.per_device_batch_size // worker_config_inference.num_generations)
                 * worker_config_train.inference_replicas
                 * worker_config_train.inference_devices_per_replica
             )
@@ -923,6 +923,7 @@ def main(argv: Sequence[str]) -> None:
         f"with {jax.device_count()} devices"
     )
   config_inference = pyconfig.initialize(configs_argv[1])
+
   if config.per_device_batch_size < 1.0 or config_inference.per_device_batch_size < 1.0:
     raise ValueError("GRPO does not support setting per_device_batch_size < 1.0")
   jax.config.update("jax_use_shardy_partitioner", config.shardy)

--- a/src/MaxText/experimental/rl/grpo_utils.py
+++ b/src/MaxText/experimental/rl/grpo_utils.py
@@ -127,7 +127,6 @@ def generate_offline_completions(config, tokenizer_model, inference_engine, data
     )
 
   results = inference_engine.batch_inference(input_data)
-
   prompt_completions_segmentation = []
   completion_segmentation = []
   prompt_completions = []

--- a/src/MaxText/layers/attention_op.py
+++ b/src/MaxText/layers/attention_op.py
@@ -527,7 +527,9 @@ class AttentionOp(nnx.Module):
     """Check attention inputs."""
 
     assert key.ndim == value.ndim, f"k (dim {key.ndim}), v (dim {value.ndim}) must have same rank."
-    assert query.shape[:-3] == key.shape[:-3] == value.shape[:-3], "q, k, v batch dims must match."
+    assert (
+        query.shape[:-3] == key.shape[:-3] == value.shape[:-3]
+    ), f"{query.shape[:-3]=}, {key.shape[:-3]=}, {value.shape[:-3]=} batch dims must match."
     assert key.shape[-2] == value.shape[-2], "k, v num_kv_heads must match."
     assert key.shape[-3] == value.shape[-3], "k, v lengths must match."
     assert query.shape[-1] == key.shape[-1], "q, k depths must match."

--- a/src/MaxText/layers/gemma.py
+++ b/src/MaxText/layers/gemma.py
@@ -57,7 +57,7 @@ class GemmaDecoderLayer(nnx.Module):
     self.quant = quant
     self.rngs = rngs
 
-    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, mesh, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
     self.pre_self_attention_norm = RMSNorm(

--- a/src/MaxText/layers/gemma2.py
+++ b/src/MaxText/layers/gemma2.py
@@ -58,7 +58,7 @@ class Gemma2DecoderLayer(nnx.Module):
     self.quant = quant
     self.rngs = rngs
 
-    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, mesh, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
     self.pre_self_attention_norm_local = RMSNorm(

--- a/src/MaxText/layers/llama2.py
+++ b/src/MaxText/layers/llama2.py
@@ -57,7 +57,7 @@ class LlamaDecoderLayer(nnx.Module):
     self.mesh = mesh
     self.quant = quant
 
-    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, mesh, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
     self.pre_self_attention_layer_norm = RMSNorm(

--- a/src/MaxText/layers/llama4.py
+++ b/src/MaxText/layers/llama4.py
@@ -385,7 +385,7 @@ class Llama4DecoderLayer(nnx.Module):
     self.is_nope_layer = is_nope_layer
     self.is_moe_layer = is_moe_layer
 
-    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, mesh, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
     self.pre_self_attention_layer_norm = RMSNorm(

--- a/src/MaxText/layers/mistral.py
+++ b/src/MaxText/layers/mistral.py
@@ -55,7 +55,7 @@ class MistralDecoderLayer(nnx.Module):
     self.quant = quant
     self.rngs = rngs
 
-    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, mesh, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
     self.pre_self_attention_layer_norm = RMSNorm(

--- a/src/MaxText/layers/mixtral.py
+++ b/src/MaxText/layers/mixtral.py
@@ -60,7 +60,7 @@ class MixtralDecoderLayer(nnx.Module):
     self.quant = quant
     self.rngs = rngs
 
-    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, mesh, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
 
     self.pre_self_attention_layer_norm = RMSNorm(

--- a/src/MaxText/layers/models.py
+++ b/src/MaxText/layers/models.py
@@ -298,7 +298,7 @@ class Transformer(nnx.Module):
     self.decoder = nnx_wrappers.ToNNX(decoder_linen, rngs=rngs)
     self.hidden_states = None
 
-    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config=cfg, model_mode=model_mode)
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config=cfg, mesh=mesh, model_mode=model_mode)
     dummy_decoder_input_tokens = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
     dummy_decoder_positions = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
 

--- a/src/MaxText/layers/qwen3.py
+++ b/src/MaxText/layers/qwen3.py
@@ -54,7 +54,7 @@ class AttentionWithNorm(nnx.Module):
     self.mesh = mesh
     self.quant = quant
 
-    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, mesh, model_mode)
     dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
     self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
 

--- a/src/MaxText/max_utils.py
+++ b/src/MaxText/max_utils.py
@@ -954,7 +954,7 @@ def rescan_train_state_params(params, source_shardings, scan_axis, layer_groups)
     decoder[layer_name] = scanned
 
 
-def get_batch_seq_len_for_mode(config, model_mode):
+def get_batch_seq_len_for_mode(config, mesh, model_mode):
   """
   Resolves the batch size and sequence length based on the model's operational mode.
 
@@ -973,12 +973,12 @@ def get_batch_seq_len_for_mode(config, model_mode):
 
   elif model_mode == MODEL_MODE_AUTOREGRESSIVE:
     # Autoregressive/decode mode: Generate one token at a time for a batch.
-    batch_size = config.micro_batch_size_to_train_on
+    batch_size = int(config.per_device_batch_size * mesh.size)
     seq_len = 1
 
   elif model_mode == MODEL_MODE_TRAIN:
     # Training mode: Process a full batch of full-length sequences.
-    batch_size = config.micro_batch_size_to_train_on
+    batch_size = int(config.per_device_batch_size * mesh.size)
     seq_len = config.max_target_length
 
   else:

--- a/src/MaxText/maxtext_utils.py
+++ b/src/MaxText/maxtext_utils.py
@@ -1060,7 +1060,7 @@ def get_prefill_kv_cache_annotations(model, config, rng, mesh, page_state: None 
 
   def init_kv_cache(model, config):
     input_shape = (
-        config.micro_batch_size_to_train_on,
+        int(config.per_device_batch_size * mesh.size),
         config.max_prefill_predict_length,
     )
     image_shape = multimodal_utils.get_dummy_image_shape_for_init(
@@ -1091,7 +1091,7 @@ def get_kv_cache_annotations(model, config, rng, mesh, page_state: None | PageSt
   """Get a shaped abstraction of the state (including optimizer)"""
 
   def init_kv_cache(model, config):
-    input_shape = (config.micro_batch_size_to_train_on, 1)
+    input_shape = (int(config.per_device_batch_size * mesh.size), 1)
     image_shape = multimodal_utils.get_dummy_image_shape_for_init(
         config.model_name, batch_size=config.micro_batch_size_to_train_on
     )

--- a/tests/inference/benchmark_offline_engine.py
+++ b/tests/inference/benchmark_offline_engine.py
@@ -1,0 +1,144 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Command: JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 python tests/inference/benchmark_offline_engine.py
+"""
+
+import pathwaysutils
+
+pathwaysutils.initialize()
+
+import sys
+import os.path
+import random
+import time
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from MaxText.globals import MAXTEXT_PKG_DIR
+from MaxText import max_logging
+from MaxText import pyconfig
+from MaxText.inference.offline_engine import OfflineEngine, InputData, CompletionOutput
+
+
+def get_metrics(results: list[CompletionOutput], start_time, end_time):
+  total_tokens = 0
+  for _, tokens in enumerate(results):
+    total_tokens += len(tokens.token_ids)
+  max_logging.log(f"Time taken: {end_time - start_time} seconds")
+  max_logging.log(f"Total tokens: {total_tokens}")
+  max_logging.log(f"Tokens per second: {total_tokens / (end_time - start_time)}")
+
+
+def init_pyconfig(**kwargs):
+  """Initialize pyconfig for benchmarking"""
+  init_kwargs = {
+      "run_name": "test",
+      # Parallelism
+      "per_device_batch_size": 1,
+      "ici_data_parallelism": 16,  # <=== set ici_data_parallelism to dp
+      "ici_tensor_parallelism": 4,  # <=== set ici_data_parallelism to tp / seq parallel
+      # Inference
+      "max_prefill_predict_length": 128,
+      "max_target_length": 256,
+      "return_log_prob": True,  # <=== set this to True
+      # Model
+      "model_name": "gemma2-2b",
+      "attention": "dot_product",
+      "allow_split_physical_axes": True,
+      "scan_layers": False,
+      # Checkpoints
+      "tokenizer_type": "huggingface",
+      "tokenizer_path": "google/gemma-2-2b-it",
+      "hf_path": "trl-lib/tldr",
+      # "load_parameters_path": "gs://inference-benchmarks/models/llama2-70b-chat/quant/int8_",
+      "enable_single_controller": True,  # for pathways
+  } | kwargs
+  _config = pyconfig.initialize(
+      [sys.argv[0], os.path.join(MAXTEXT_PKG_DIR, "experimental", "rl", "grpo_inference.yml")],
+      **init_kwargs,
+  )
+  return _config
+
+
+config = init_pyconfig()
+continous_batching = True
+max_logging.log("initialized pyconfig")
+random.seed(42)
+
+data = [np.arange(1, 129) for _ in range(config.global_batch_size_to_train_on)]
+true_lengths = [config.max_prefill_predict_length for _ in range(config.global_batch_size_to_train_on)]
+input_data = []
+for i, d in enumerate(data):
+  input_data.append(
+      InputData(
+          id=int(i),
+          tokens=np.array(d),
+          true_length=true_lengths[i],
+      )
+  )
+
+
+def run(
+    profile=False,
+    profile_path="",
+):
+  """Run offline engine"""
+  inference_engine = OfflineEngine(
+      config,
+      params=None,
+      enable_batch_prefill=False,
+      rng=jax.random.PRNGKey(0),
+      eos_ids=[1002],
+      debug=False,
+  )
+  max_logging.log("Starting Warmup")
+  _ = [inference_engine.batch_inference(input_data) for _ in range(4)]
+  max_logging.log("Warmup Ended")
+  start_time = time.time()
+  max_logging.log(f"First Round. Start time: {start_time}")
+  results = inference_engine.batch_inference(input_data)
+  results = jax.block_until_ready(results)
+  end_time = time.time()
+  max_logging.log(f"First Round. Time taken to run {len(input_data)} inference samples: {end_time - start_time} seconds")
+
+  if profile:
+    jax.profiler.start_trace(profile_path)
+    start_time = time.time()
+    max_logging.log(f"Second Round. Start time: {start_time}")
+    results = inference_engine.batch_inference(input_data)
+    results = jax.block_until_ready(results)
+    end_time = time.time()
+    jax.profiler.stop_trace()
+    max_logging.log(
+        f"Second Round. Time taken to run {len(input_data)} inference samples: {end_time - start_time} seconds"
+    )
+    if continous_batching:
+      tokens = 0
+      for result in results:
+        tokens += len(result.token_ids)
+    else:
+      tokens = 0
+      for result in results:
+        tokens += jnp.count_nonzero(result.token_ids)
+    max_logging.log(f"Tokens generated: {tokens}")
+    max_logging.log(f"Tokens per second: {tokens / (end_time - start_time)}")
+
+
+run(
+    profile=True,
+    profile_path=f"gs://runner-maxtext-logs/mohitkhatwani_offline_benchmark/app_2/0908/{time.strftime('%Y%m%d-%H%M%S')}/",
+)


### PR DESCRIPTION
# Description

originally kvcache was initialized using `config.global_batch_size_to_train_on` and model was initialized using `max_utils.get_batch_seq_len_for_mode`. These ways assumed that the whole mesh is going to be used for model initialization. 

In grpo_trainer with disaggregated setup, we initialize the training and inference model with a submesh. This PR uses mesh.size to calculate global batch size used for initializing the model. 


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
