### PR TITLE
[GRPO] create a new resharding API which uses split_my_mesh_axis from pathwaysutils

### DIFF
--- a/end_to_end/tpu/test_grpo.sh
+++ b/end_to_end/tpu/test_grpo.sh
@@ -5,10 +5,14 @@
 # External users can update pre-trained model checkpoint GCS path (gs://) to your accessible locations.
 # Usage:
   HF_TOKEN=<huggingface access token> \
-  MODEL=llama3.3-70b TOKENIZER=meta-llama/Llama-3.3-70B \
-  NUM_SAMPLERS=4 DEVICES_PER_SAMPLER=8 \
+  MODEL=llama3.1-8b TOKENIZER=meta-llama/Llama-3.1-8B-Instruct \
+  NUM_SAMPLERS=2 DEVICES_PER_SAMPLER=8 \
   TRAINING_PER_DEVICE_BATCH_SIZE=1 \
-  INFERENCE_PER_DEVICE_BATCH_SIZE=4 \
+  INFERENCE_PER_DEVICE_BATCH_SIZE=1 \
+  TRAINING_SUBSLICE=2,8 \
+  INFERENCE_SUBSLICE=2,8 \
+  MAX_PREFILL_LENGTH=128 \
+  MAX_TARGET_LENGTH=256 \
   STEPS=20 \
   bash end_to_end/tpu/test_grpo.sh
 '
@@ -23,10 +27,11 @@ JAX_BACKEND_TARGET=grpc://127.0.0.1:29000
 ENABLE_PATHWAYS_PERSISTENCE='1'
 HF_TOKEN=${HF_TOKEN}
 
-MAX_PREFILL_LENGTH=128
-MAX_TARGET_LENGTH=256
+MAX_PREFILL_LENGTH=${MAX_PREFILL_LENGTH:-128}
+MAX_TARGET_LENGTH=${MAX_TARGET_LENGTH:-256}
 NUM_GENERATIONS=2
 
+INFERENCE_PER_DEVICE_BS=$((${INFERENCE_PER_DEVICE_BATCH_SIZE} * ${NUM_GENERATIONS}))
 
 COMMON_ARGS="model_name=${MODEL} base_output_directory=${BASE_OUTPUT_DIRECTORY} \
 max_prefill_predict_length=${MAX_PREFILL_LENGTH} max_target_length=${MAX_TARGET_LENGTH} \
@@ -35,19 +40,22 @@ tokenizer_type=huggingface tokenizer_path=${TOKENIZER} \
 dataset_type=hf hf_path='trl-lib/tldr' \
 enable_single_controller=true \
 dtype=bfloat16 weight_dtype=bfloat16 \
-allow_split_physical_axes=true enable_goodput_recording=false monitor_goodput=false \
-profiler=xplane skip_first_n_steps_for_profiler=10 profiler_steps=5"
+allow_split_physical_axes=true enable_goodput_recording=false monitor_goodput=false"
 
 TRAINING_ARGS="run_name=${RUN_NAME} scan_layers=true \
-inference_replicas=${NUM_SAMPLERS} inference_devices_per_replica=${DEVICES_PER_SAMPLER} \
-inference_rollouts=5 \
-per_device_batch_size=${TRAINING_PER_DEVICE_BATCH_SIZE} num_generations=${NUM_GENERATIONS} steps=${STEPS}"
+inference_replicas=${NUM_SAMPLERS} inference_devices_per_replica=${DEVICES_PER_SAMPLER} subslice_shape=${TRAINING_SUBSLICE} \
+inference_rollouts=1 \
+per_device_batch_size=${TRAINING_PER_DEVICE_BATCH_SIZE} num_generations=${NUM_GENERATIONS} steps=${STEPS} \
+profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3"
 
+# Make sure profiles on inference TPUs are not captured while profiling trainers TPUs
+# Set a small number for profiler_steps during inference as the profiles turn out large in size
 INFERENCE_ARGS="run_name=grpo scan_layers=false \
-per_device_batch_size=${INFERENCE_PER_DEVICE_BATCH_SIZE} \
-ici_data_parallelism=${NUM_SAMPLERS} ici_tensor_parallelism=${DEVICES_PER_SAMPLER}"
+per_device_batch_size=${INFERENCE_PER_DEVICE_BS} num_generations=${NUM_GENERATIONS} \
+ici_data_parallelism=${NUM_SAMPLERS} ici_tensor_parallelism=${DEVICES_PER_SAMPLER} subslice_shape=${INFERENCE_SUBSLICE} \
+profiler=xplane skip_first_n_steps_for_profiler=10 profiler_steps=2"
 
 JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE='1' \
-    python3 -m MaxText.experimental.rl.grpo_trainer "${MAXTEXT_PKG_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/MaxText}"/experimental/rl/grpo.yml  \
-    ${COMMON_ARGS} ${TRAINING_ARGS} ${MAXTEXT_PKG_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/MaxText}/experimental/rl/grpo_inference.yml \
+    python3 src/MaxText/experimental/rl/grpo_trainer.py src/MaxText/experimental/rl/grpo.yml  \
+    ${COMMON_ARGS} ${TRAINING_ARGS} src/MaxText/experimental/rl/grpo_inference.yml \
     ${COMMON_ARGS} ${INFERENCE_ARGS}

--- a/src/MaxText/experimental/rl/grpo_trainer.py
+++ b/src/MaxText/experimental/rl/grpo_trainer.py
@@ -33,6 +33,8 @@ entire training loop, including checkpointing and metric logging.
 """
 
 
+import pathwaysutils
+
 import datetime
 import time
 import os
@@ -586,8 +588,6 @@ def generate_completions(
     worker_tokenizer_model,
     worker_config_inference,
     worker_config_train,
-    worker_data_buffer,
-    worker_data_buffer_lock,
     worker_input_data_shardings,
     engine_lock,
 ):
@@ -604,8 +604,6 @@ def generate_completions(
     worker_tokenizer_model: The tokenizer model.
     worker_config_inference: The configuration for the inference process.
     worker_config_train: The main training configuration.
-    worker_data_buffer: A list acting as a shared buffer to store generated data.
-    worker_data_buffer_lock: A lock to ensure thread-safe access to the buffer.
     worker_input_data_shardings: Sharding specifications for the data.
     engine_lock: A lock to ensure thread-safe use of the inference engine.
   """
@@ -615,7 +613,7 @@ def generate_completions(
     thread_example_batch_trimmed = jax.tree_util.tree_map(
         lambda arr: arr[
             : int(
-                worker_config_inference.per_device_batch_size
+                (worker_config_inference.per_device_batch_size // worker_config_inference.num_generations)
                 * worker_config_train.inference_replicas
                 * worker_config_train.inference_devices_per_replica
             )
@@ -626,13 +624,7 @@ def generate_completions(
         worker_config_inference, worker_tokenizer_model, worker_inference_engine, thread_example_batch_trimmed
     )
     processed_batch = jax.device_put(processed_batch, worker_input_data_shardings)
-  with worker_data_buffer_lock:
-    if not worker_data_buffer:
-      worker_data_buffer.append(processed_batch)
-    else:
-      worker_data_buffer[0] = jax.tree_util.tree_map(
-          lambda a, b: np.concatenate([a, b], axis=0), worker_data_buffer[0], processed_batch
-      )
+  return processed_batch
 
 
 def train_loop(config, config_inference, recorder, state=None):
@@ -705,6 +697,7 @@ def train_loop(config, config_inference, recorder, state=None):
 
   start_step = get_first_step(state)  # this is the start_step for training
   prof = profiler.Profiler(config, offset_step=start_step)
+  inference_prof = profiler.Profiler(config_inference, offset_step=start_step)
   data_loader = DataLoader(config_inference, inference_mesh, data_iterator, recorder)
   metric_logger = MetricLogger(config=config, learning_rate_schedule=learning_rate_schedule)
 
@@ -721,6 +714,7 @@ def train_loop(config, config_inference, recorder, state=None):
       worker_input_data_shardings,
       engine_lock,
       stop_event,
+      profiler_object,
   ):
     """The target function for the data generation worker thread.
 
@@ -738,21 +732,40 @@ def train_loop(config, config_inference, recorder, state=None):
       worker_input_data_shardings: Sharding specs for the generated data.
       engine_lock: A lock for thread-safe inference engine access.
       stop_event: A threading.Event to signal when the worker should stop.
+      profiling_event: a threading.Event to signal when to profile.
     """
+    worker_step = 0
+    is_profiling = False
     while not stop_event.is_set():
       try:
-        with jax.profiler.StepTraceAnnotation("inference"):
-          generate_completions(
+        if worker_step == profiler_object.start_initial_profile_step and not is_profiling:
+          profiler_object.activate()
+          is_profiling = True
+        elif worker_step == profiler_object.finished_initial_profile_step and is_profiling:
+          profiler_object.deactivate()
+          is_profiling = False
+        with jax.profiler.StepTraceAnnotation("inference", step_num=worker_step):
+          processed_batch = generate_completions(
               data_loader,
               worker_inference_engine,
               worker_tokenizer_model,
               worker_config_inference,
               worker_config_train,
-              worker_data_buffer,
-              worker_data_buffer_lock,
               worker_input_data_shardings,
               engine_lock,
           )
+          jax.block_until_ready(processed_batch)
+
+        with worker_data_buffer_lock:
+          if not worker_data_buffer:
+            worker_data_buffer.append(processed_batch)
+          else:
+            worker_data_buffer[0] = jax.tree_util.tree_map(
+                lambda a, b: np.concatenate([a, b], axis=0),
+                worker_data_buffer[0],
+                processed_batch,
+            )
+        worker_step += 1
       except StopIteration:
         max_logging.log("Data iterator exhausted in generation worker. Stopping.")
         break
@@ -763,19 +776,6 @@ def train_loop(config, config_inference, recorder, state=None):
 
   stop_event = threading.Event()
   inference_engine_lock = threading.Lock()
-
-  max_logging.log("Inference Rollout")
-  generate_completions(
-      data_loader,
-      inference_engine,
-      tokenizer_model,
-      config_inference,
-      config,
-      data_buffer,
-      data_buffer_lock,
-      data_sharding,
-      inference_engine_lock,
-  )
 
   required_batch_size = int(config.per_device_batch_size * config.num_generations * mesh.size)
   generation_thread = threading.Thread(
@@ -790,6 +790,7 @@ def train_loop(config, config_inference, recorder, state=None):
           data_sharding,  # Sharding for the data put into the buffer
           inference_engine_lock,
           stop_event,
+          inference_prof,  # profiler object
       ),
       daemon=True,  # So it exits when the main thread exits
   )
@@ -830,8 +831,10 @@ def train_loop(config, config_inference, recorder, state=None):
               {"params": state.params["params"]},
               {"params": state_mesh_shardings.params["params"]},
               mesh,
-              inference_state_mesh_shardings,
+              {"params": inference_state_mesh_shardings.params["params"]},
           )
+          with data_buffer_lock:
+            data_buffer.clear()
 
       step_time_delta = datetime.datetime.now() - last_step_completion
       last_step_completion = datetime.datetime.now()
@@ -895,6 +898,7 @@ def main(argv: Sequence[str]) -> None:
   training and inference, sets up system environment variables, and launches
   the `train_loop`.
   """
+  pathwaysutils.initialize()
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   # TF allocates extraneous GPU memory when using TFDS data
   # this leads to CUDA OOMs. WAR for now is to hide GPUs from TF
@@ -923,6 +927,7 @@ def main(argv: Sequence[str]) -> None:
         f"with {jax.device_count()} devices"
     )
   config_inference = pyconfig.initialize(configs_argv[1])
+
   if config.per_device_batch_size < 1.0 or config_inference.per_device_batch_size < 1.0:
     raise ValueError("GRPO does not support setting per_device_batch_size < 1.0")
   jax.config.update("jax_use_shardy_partitioner", config.shardy)

--- a/src/MaxText/experimental/rl/grpo_utils.py
+++ b/src/MaxText/experimental/rl/grpo_utils.py
@@ -14,13 +14,28 @@
 
 """Utility functions for GRPO (Generative Rejection-based Policy Optimization)."""
 
+import math
+import numpy as np
 import jax
 import jax.numpy as jnp
-import numpy as np
+import jaxtyping
+from typing import Any, Callable
+
 from MaxText import max_logging
 from MaxText import max_utils
 from MaxText.common_types import DecoderBlockType
 from MaxText.inference.offline_engine import InputData
+
+from pathwaysutils.experimental import reshard as experimental_reshard
+from pathwaysutils.experimental import split_by_mesh_axis
+
+
+def _identity(x):
+  return x
+
+
+INTERMEDIATE_SPLIT_SUFFIX = "_intermediate_split"
+INTERMEDIATE_REPLICA_SUFFIX = "_intermediate_replica"
 
 
 def compute_log_probs(
@@ -127,7 +142,6 @@ def generate_offline_completions(config, tokenizer_model, inference_engine, data
     )
 
   results = inference_engine.batch_inference(input_data)
-
   prompt_completions_segmentation = []
   completion_segmentation = []
   prompt_completions = []
@@ -185,18 +199,23 @@ def pathways_reshard(config, inference_engine, params, source_shardings, source_
   else:
     layer_groups = [("layers", config.base_num_decoder_layers)]
   if not config.scan_layers:
+    params_to_reshard = jax.tree_util.tree_map(lambda x: x, params)
     max_utils.unscan_train_state_params(
-        params, source_shardings, source_mesh, scan_axis=config.param_scan_axis, layer_groups=layer_groups
+        params_to_reshard,
+        source_shardings,
+        source_mesh,
+        scan_axis=config.param_scan_axis,
+        layer_groups=layer_groups,
     )
+  else:
+    params_to_reshard = params
 
-  inference_engine.update_params(
-      params, jax.tree_util.tree_map(lambda x: x.spec, destination_shardings.params), is_pw_reshard=True
-  )
-
-  if not config.scan_layers:
-    max_utils.rescan_train_state_params(
-        params, source_shardings, scan_axis=config.param_scan_axis, layer_groups=layer_groups
-    )
+  with (
+      jax.transfer_guard_device_to_host("disallow_explicit"),
+      jax.transfer_guard_host_to_device("disallow_explicit"),
+  ):
+    resharded_params = reshard_pytree(params_to_reshard, destination_shardings)
+  inference_engine.update_params(resharded_params)
 
 
 def dummy_reward_len(valid_seq_mask):
@@ -349,3 +368,241 @@ def filter_and_split(config, example_batch, num_groups, global_batch_size_per_gr
     list_of_output_batches.append(current_group_dict)
 
   return list_of_output_batches
+
+
+def _maybe_find_intermediate_sharding(source_sharding, target_sharding):
+  """Maybe finds an intermediate sharding to reshard to before target sharding."""
+  if not isinstance(source_sharding, jax.sharding.NamedSharding) or not isinstance(
+      target_sharding, jax.sharding.NamedSharding
+  ):
+    max_logging.log(
+        "None-NamedSharding does not need intermediate sharding." f" {source_sharding=}, {target_sharding=}",
+    )
+    return None
+  src_mesh = source_sharding.mesh
+  dst_mesh = target_sharding.mesh
+
+  def _get_sharding_dims(sharding, mesh):
+    sharding_dims = {}
+    used_mesh_axis_names = set()
+    for i, axis_name in enumerate(sharding.spec):
+      if axis_name is None:
+        sharding_dims[(i, None)] = 1
+      else:
+        if isinstance(axis_name, tuple):
+          used_mesh_axis_names |= set(axis_name)
+          shard_size = math.prod([mesh.shape[name] for name in axis_name])
+          first_axis_name = axis_name[0]
+          sharding_dims[(i, mesh.axis_names.index(first_axis_name))] = shard_size
+        else:
+          assert isinstance(axis_name, str), "axis_name expected to be a string or a tuple of strings."
+          used_mesh_axis_names.add(axis_name)
+          sharding_dims[(i, mesh.axis_names.index(axis_name))] = mesh.shape[axis_name]
+    largest_shards = max(sharding_dims.values()) if len(sharding_dims) else 1
+    if len(sharding_dims) < len(mesh.shape):
+      for mi, mesh_axis in enumerate(mesh.axis_names):
+        if mesh_axis not in used_mesh_axis_names:
+          sharding_dims[(None, mi)] = 1
+    return sharding_dims, largest_shards
+
+  src_sharding_dims, src_largest_shards = _get_sharding_dims(source_sharding, src_mesh)
+  dst_sharding_dims, dst_largest_shards = _get_sharding_dims(target_sharding, dst_mesh)
+  # Not able to handle resharding with undividable shardings.
+  if src_largest_shards % dst_largest_shards != 0:
+    return None
+
+  total_source_sharding_dims = math.prod(list(src_sharding_dims.values()))
+  total_dst_sharding_dims = math.prod(list(dst_sharding_dims.values()))
+
+  if total_source_sharding_dims <= total_dst_sharding_dims or total_source_sharding_dims % total_dst_sharding_dims != 0:
+    return None
+
+  new_split_dim_shards = None
+  new_split_axis = None
+  replicas = src_largest_shards // dst_largest_shards
+
+  # Find gcd(src_dim_shards, dst_dim_shards),
+  # If all of them are 1s, an all-gather is needed as the single replica of
+  # the source cannot be presented by any sharded form on the target devices.
+  gcd_shards = []
+  for (sharding_mesh_axis_idx, src_dim_shards), (_, dst_dim_shards) in zip(
+      src_sharding_dims.items(), dst_sharding_dims.items()
+  ):
+    gcd_dim_shards = math.gcd(src_dim_shards, dst_dim_shards)
+    if gcd_dim_shards == 1:
+      if src_dim_shards > dst_dim_shards and src_dim_shards == src_largest_shards:
+        new_split_axis = sharding_mesh_axis_idx
+        new_split_dim_shards = (src_dim_shards // replicas, replicas)
+    gcd_shards.append(gcd_dim_shards)
+  if math.prod(gcd_shards) != 1 or new_split_axis is None:
+    return None
+
+  # Generate the intermediate sharding.
+  new_split_mesh_axis_name = src_mesh.axis_names[new_split_axis[1]] + INTERMEDIATE_SPLIT_SUFFIX
+  new_split_mesh_replica_axis_name = src_mesh.axis_names[new_split_axis[1]] + INTERMEDIATE_REPLICA_SUFFIX
+  intermediate_mesh = jax.sharding.Mesh(
+      src_mesh.devices.reshape(
+          tuple(
+              list(src_mesh.devices.shape[: new_split_axis[1]])
+              + [new_split_dim_shards[0], new_split_dim_shards[1]]
+              + list(src_mesh.devices.shape[new_split_axis[1] + 1 :])
+          )
+      ),
+      axis_names=tuple(
+          list(src_mesh.axis_names[: new_split_axis[1]])
+          + [new_split_mesh_axis_name, new_split_mesh_replica_axis_name]
+          + list(src_mesh.axis_names[new_split_axis[1] + 1 :])
+      ),
+  )
+
+  intermediate_spec = tuple(
+      list(source_sharding.spec[: new_split_axis[0]])
+      + [new_split_mesh_axis_name]
+      + list(source_sharding.spec[new_split_axis[0] + 1 :])
+  )
+  intermediate_sharding = jax.sharding.NamedSharding(
+      intermediate_mesh,
+      jax.sharding.PartitionSpec(*intermediate_spec),
+      memory_kind=source_sharding.memory_kind,
+  )
+
+  return intermediate_sharding
+
+
+def _experimental_pre_reshard(splitfn, src_pytree, target_shardings):
+  """Simple heuristic to determine if resharding with replicated all-gather is needed."""
+  src_shardings = jax.tree_util.tree_map(
+      lambda x: x.sharding,
+      src_pytree,
+  )
+  intermediate_shardings = jax.tree_util.tree_map(
+      _maybe_find_intermediate_sharding,
+      src_shardings,
+      target_shardings,
+  )
+
+  src_leaves_with_path, src_treedef = jax.tree_util.tree_flatten_with_path(src_pytree)
+  intermediate_sharding_leaves_with_path, _ = jax.tree_util.tree_flatten_with_path(intermediate_shardings)
+  intermediate_sharding_leaves_with_path = dict(intermediate_sharding_leaves_with_path)
+
+  to_split_src_pytree_leaves = []
+  to_split_src_pytree_leaves_indexes = []
+  to_split_intermediate_sharding_leaves = []
+
+  intermediate_mesh = None
+  to_update_src_pytree_leaves = []
+
+  for i, (path, src) in enumerate(src_leaves_with_path):
+    to_update_src_pytree_leaves.append(src)
+    if intermediate_sharding := intermediate_sharding_leaves_with_path.get(path, None):
+      if intermediate_mesh is None:
+        intermediate_mesh = intermediate_sharding.mesh
+      to_split_src_pytree_leaves.append(src)
+      to_split_src_pytree_leaves_indexes.append(i)
+      to_split_intermediate_sharding_leaves.append(intermediate_sharding)
+
+  if intermediate_mesh is None:
+    return src_pytree
+
+  to_split_axis = None
+  for axis_name in intermediate_mesh.axis_names:
+    if axis_name.endswith(INTERMEDIATE_REPLICA_SUFFIX):
+      to_split_axis = axis_name
+      break
+  assert to_split_axis is not None, f"No replica axis found in the intermediate mesh {intermediate_mesh}."
+
+  temp_source = jax.jit(
+      _identity,
+      out_shardings=to_split_intermediate_sharding_leaves,
+  )(to_split_src_pytree_leaves)
+
+  to_split_src_pytree_leaves, *_ = splitfn(temp_source, to_split_axis)
+
+  for i, src_pytree_leaf in enumerate(to_split_src_pytree_leaves):
+    to_update_src_pytree_leaves[to_split_src_pytree_leaves_indexes[i]] = src_pytree_leaf
+  updated_src_pytree = jax.tree_util.tree_unflatten(src_treedef, to_update_src_pytree_leaves)
+  return updated_src_pytree
+
+
+def _get_reshard_fn_pathwaysutils(
+    *,
+    cache_resharding_plans: bool,
+    donate: bool,
+    use_experimental_pre_reshard: bool,
+):
+  """Returns a reshard function using pathwaysutils."""
+
+  def reshard_fn(
+      x: Any,
+      sharding: jax.sharding.Sharding | Any,
+  ):
+    if use_experimental_pre_reshard:
+      x = _experimental_pre_reshard(split_by_mesh_axis.split_by_mesh_axis, x, sharding)
+
+    return experimental_reshard.reshard(
+        x,
+        sharding,
+        donate=donate,
+        cache_resharding_plans=cache_resharding_plans,
+    )
+
+  return reshard_fn
+
+
+def _get_reshard_fn(
+    cache_resharding_plans: bool,
+    donate: bool,
+    use_experimental_pre_reshard: bool,
+    get_reshard_fns: list[Callable[..., Any]],
+):
+  """Returns a reshard function."""
+  for get_reshard_fn in get_reshard_fns:
+    try:
+      reshard_fn = get_reshard_fn(
+          cache_resharding_plans=cache_resharding_plans,
+          donate=donate,
+          use_experimental_pre_reshard=use_experimental_pre_reshard,
+      )
+    except (ImportError, EnvironmentError):
+      max_logging.log(f"Could not support {get_reshard_fn=}.")
+    else:
+      return reshard_fn
+
+  raise ValueError(f"Could not find a reshard function from {get_reshard_fns=}.")
+
+
+def reshard_pytree(
+    source: jaxtyping.PyTree,
+    target: jaxtyping.PyTree,
+    cache_plan: bool = True,
+    donate_input: bool = False,
+    use_experimental_pre_reshard: bool = True,
+) -> jaxtyping.PyTree:
+  """Reshard input pytree from source sharding and mesh to target sharding and mesh."""
+
+  def _get_dst_sharding(x):
+    if isinstance(x, jax.sharding.NamedSharding | jax.sharding.SingleDeviceSharding):
+      return x
+    else:
+      return jax.sharding.NamedSharding(
+          x.sharding.mesh,
+          x.sharding.spec,
+          memory_kind=x.sharding.memory_kind,
+      )
+
+  dst_shardings = jax.tree_util.tree_map(
+      _get_dst_sharding,
+      target,
+  )
+  reshard_fn = _get_reshard_fn(
+      cache_resharding_plans=cache_plan,
+      donate=donate_input,
+      use_experimental_pre_reshard=use_experimental_pre_reshard,
+      get_reshard_fns=[
+          _get_reshard_fn_pathwaysutils,
+      ],
+  )
+
+  resharded_array = reshard_fn(source, dst_shardings)
+  resharded_array = jax.block_until_ready(resharded_array)
+  return resharded_array

--- a/src/MaxText/layers/attention_op.py
+++ b/src/MaxText/layers/attention_op.py
@@ -527,7 +527,9 @@ class AttentionOp(nnx.Module):
     """Check attention inputs."""
 
     assert key.ndim == value.ndim, f"k (dim {key.ndim}), v (dim {value.ndim}) must have same rank."
-    assert query.shape[:-3] == key.shape[:-3] == value.shape[:-3], "q, k, v batch dims must match."
+    assert (
+        query.shape[:-3] == key.shape[:-3] == value.shape[:-3]
+    ), f"{query.shape[:-3]=}, {key.shape[:-3]=}, {value.shape[:-3]=} batch dims must match."
     assert key.shape[-2] == value.shape[-2], "k, v num_kv_heads must match."
     assert key.shape[-3] == value.shape[-3], "k, v lengths must match."
     assert query.shape[-1] == key.shape[-1], "q, k depths must match."

--- a/src/MaxText/max_utils.py
+++ b/src/MaxText/max_utils.py
@@ -29,6 +29,7 @@ from etils import epath
 import flax
 import jax
 from jax.experimental import mesh_utils
+from jax.sharding import PartitionSpec as P
 import jax.numpy as jnp
 import numpy as np
 import orbax.checkpoint as ocp
@@ -894,29 +895,41 @@ def unscan_train_state_params(params, sharding, mesh, scan_axis, layer_groups):
     layer_groups: list of tuples like:
       [("dense_layers", 4), ("moe_layers", 12)]
   """
-  decoder = params["params"]["decoder"]
-  sharding = sharding["params"]["decoder"]
+  params_copy = params.unfreeze() if hasattr(params, "unfreeze") else params
+  decoder = params_copy["params"]["decoder"]
+  sharding_decoder = sharding["params"]["decoder"]
+
+  # Helper function to remove the scan axis from a PartitionSpec
+  def strip_scan_axis(pspec: P) -> P:
+    """Removes the element at `scan_axis` from a PartitionSpec tuple."""
+    spec_tuple = tuple(pspec)
+    return P(*(spec_tuple[:scan_axis] + spec_tuple[scan_axis + 1 :]))
 
   for layer_name, num_layers in layer_groups:
     scanned_layers = decoder[layer_name]
+    scanned_sharding = sharding_decoder[layer_name]
 
-    def strip_axis(pspec):
-      return jax.sharding.PartitionSpec(*(pspec[:scan_axis] + pspec[scan_axis + 1 :]))
+    # 1. Compute the target sharding for a single, unscanned layer.
+    # This is done once per layer group, with no expensive compilation.
+    unscanned_sharding_spec = jax.tree_util.tree_map(
+        strip_scan_axis, jax.tree_util.tree_map(lambda x: x.spec, scanned_sharding)
+    )
+    unscanned_sharding = jax.tree_util.tree_map(lambda ps: jax.sharding.NamedSharding(mesh, ps), unscanned_sharding_spec)
 
-    old_spec = jax.tree_util.tree_map(lambda x: x.spec, sharding[layer_name])
-    new_spec = jax.tree_util.tree_map(strip_axis, old_spec)
-    new_sharding = jax.tree_util.tree_map(lambda ps: jax.sharding.NamedSharding(mesh, ps), new_spec)
+    # 2. Create a list of PyTrees, one for each layer, by slicing the original.
+    # This is more direct than repeatedly calling a JIT'd function.
+    layer_pytrees = [
+        jax.tree_util.tree_map(functools.partial(jnp.take, indices=i, axis=scan_axis), scanned_layers)
+        for i in range(num_layers)
+    ]
 
-    def slice_layer(arr, i):
-      return jax.tree_util.tree_map(lambda x: jnp.take(x, i, axis=scan_axis), arr)
+    # 3. Reshard each layer's PyTree and assign it to the new key.
+    for i, layer_params in enumerate(layer_pytrees):
+      resharded_params = jax.device_put(layer_params, unscanned_sharding)
+      decoder[f"{layer_name}_{i}"] = resharded_params
 
-    p_slice_layer = jax.jit(slice_layer, out_shardings=new_sharding)
-
-    for i in range(num_layers):
-      per_layer = p_slice_layer(scanned_layers, i)
-      decoder[f"{layer_name}_{i}"] = per_layer
-
-    del decoder[layer_name]  # Free memory
+    # 4. Clean up the original scanned parameter to free up memory.
+    del decoder[layer_name]
 
 
 def rescan_train_state_params(params, source_shardings, scan_axis, layer_groups):

--- a/src/MaxText/maxengine.py
+++ b/src/MaxText/maxengine.py
@@ -1512,7 +1512,8 @@ class MaxEngine(engine_api.Engine):
         if tokenizer_model.tokenizer.unk_token_id is not None:
           tokenizer_model.tokenizer.pad_token_id = tokenizer_model.tokenizer.unk_token_id
         else:
-          tokenizer_model.tokenizer.pad_token_id = -1
+          print(f"Warning: setting pad_token_id to eos_token_id:{tokenizer_model.tokenizer.eos_token_id}")
+          tokenizer_model.tokenizer.pad_token_id = tokenizer_model.tokenizer.eos_token_id
       return tokenizer_model
     else:
       raise ValueError(f"Unsupported tokenizer type: {metadata.tokenizer_type}")

--- a/src/MaxText/maxtext_utils.py
+++ b/src/MaxText/maxtext_utils.py
@@ -53,7 +53,9 @@ def get_input_data_sharding(config, mesh):
   return nn.logical_to_mesh_sharding(P(*config.input_data_sharding_logical_axes), mesh, config.logical_axis_rules)
 
 
-def get_functional_train_with_signature(train_step, data_sharding, state_mesh_shardings, model, config, params_shardings=None):
+def get_functional_train_with_signature(
+    train_step, data_sharding, state_mesh_shardings, model, config, params_shardings=None
+):
   """Get the shardings (both state and data) for `train_step`."""
   functional_train = functools.partial(train_step, model, config, state_mesh_shardings, params_shardings)
   functional_train.__name__ = "train_step"
@@ -97,14 +99,14 @@ def get_shaped_batch(config):
 
 def should_prevent_cse_in_remat(config):
   """Determines whether to prevent common subexpression elimination (CSE) in remat.
-  
+
   CSE should not be prevented when:
   1. Layers are being scanned (scan_layers=True), OR
   2. Gradient accumulation is enabled (gradient_accumulation_steps > 1) on GPU hardware
-  
+
   Args:
     config: Configuration object with scan_layers, gradient_accumulation_steps, and hardware
-  
+
   Returns:
     bool: True if CSE should be prevented, False otherwise
   """
@@ -961,6 +963,7 @@ def setup_training_state(model, data_iterator, tx, config, rng, mesh, checkpoint
       is_training,
   )
 
+
 def unbox_logicallypartioned(boxed_pytree):
   """Unboxes the flax.LogicallyPartitioned pieces
   Args:
@@ -975,23 +978,24 @@ def unbox_logicallypartioned(boxed_pytree):
       is_leaf=lambda k: isinstance(k, nn.spmd.LogicallyPartitioned),
   )
 
+
 def add_data_to_sharding(mesh, path, aval, sharding):
   """Adds 'data' dimension to sharding spec if compatible and not already present.
-  
+
   This function attempts to add data parallelism to a sharding specification by finding
   a dimension that is divisible by the 'data' mesh axis size and doesn't conflict with
   existing partitioning (e.g., tensor parallelism).
   This function is mainly used to add data parallelism to the optimizer state for Zero-1 style sharding.
-  
+
   Args:
     mesh: The device mesh
     path: JAX tree path to the value being sharded
     aval: Abstract value with shape information
     sharding: Current NamedSharding to potentially augment
-  
+
   Returns:
     NamedSharding: Updated sharding with 'data' dimension added, or original if unchanged
-  
+
   Raises:
     AssertionError: If sharding is not NamedSharding or shape cannot be sharded
   """
@@ -1000,10 +1004,12 @@ def add_data_to_sharding(mesh, path, aval, sharding):
   try:
     sharded_shape = sharding.shard_shape(aval.shape)
   except Exception as e:
-    raise AssertionError(f"Could not shard value {jax.tree_util.keystr(path)} of shape={aval.shape} with {sharding=}") from e
+    raise AssertionError(
+        f"Could not shard value {jax.tree_util.keystr(path)} of shape={aval.shape} with {sharding=}"
+    ) from e
   pspec = sharding.spec
 
-  if 'data' in jax.tree.leaves(pspec):
+  if "data" in jax.tree.leaves(pspec):
     return sharding
 
   for idx, (size, partition) in enumerate(zip(sharded_shape, pspec)):
@@ -1013,25 +1019,26 @@ def add_data_to_sharding(mesh, path, aval, sharding):
     if isinstance(partition, str):
       partition = (partition,)
 
-    if size % mesh.shape['data'] == 0 and (partition is None or 'tensor' not in partition):
-      added_component = ('data',) + partition
-      new_pspec = jax.sharding.PartitionSpec(*(pspec[:idx] + (added_component,) + pspec[idx+1:]))
+    if size % mesh.shape["data"] == 0 and (partition is None or "tensor" not in partition):
+      added_component = ("data",) + partition
+      new_pspec = jax.sharding.PartitionSpec(*(pspec[:idx] + (added_component,) + pspec[idx + 1 :]))
       new_sharding = jax.sharding.NamedSharding(sharding.mesh, new_pspec)
       return new_sharding
   return sharding
 
+
 def maybe_update_params_sharding_with_opt(config, state_mesh_shardings):
   """Updates parameter sharding configuration when optimizer state sharding is enabled.
-  
+
   When shard_optimizer_over_data is enabled (Zero-1 style sharding), this function
   extracts the optimizer state shardings from the Adam optimizer's first moment (mu)
   and merges them with the parameter shardings. This ensures parameter sharding is
   consistent with how the optimizer state is distributed across the compute mesh.
-  
+
   Args:
     config: Configuration object with shard_optimizer_over_data flag
     state_mesh_shardings: Train state mesh shardings containing params and opt_state
-  
+
   Returns:
     A tuple of (prev_params_shardings, updated_state_mesh_shardings):
       - prev_params_shardings: Original parameter shardings before the update
@@ -1042,16 +1049,21 @@ def maybe_update_params_sharding_with_opt(config, state_mesh_shardings):
   if config.shard_optimizer_over_data:
     if isinstance(state_mesh_shardings.opt_state, optax.ScaleByAdamState):
       sharded_fp32_params = state_mesh_shardings.opt_state.mu
-    elif isinstance(state_mesh_shardings.opt_state, tuple) and isinstance(state_mesh_shardings.opt_state[0], optax.ScaleByAdamState):
+    elif isinstance(state_mesh_shardings.opt_state, tuple) and isinstance(
+        state_mesh_shardings.opt_state[0], optax.ScaleByAdamState
+    ):
       sharded_fp32_params = state_mesh_shardings.opt_state[0].mu
     else:
-      raise NotImplementedError(f"Could not find optimizer state shardings from optimizer of type {type(state_mesh_shardings.opt_state)}")
+      raise NotImplementedError(
+          f"Could not find optimizer state shardings from optimizer of type {type(state_mesh_shardings.opt_state)}"
+      )
     if "params" not in sharded_fp32_params.keys():
       # When quantization=fp8 is enabled the sharded_fp32_params
       # are not wrapped in `params`. Here we wrap them back.
       sharded_fp32_params = {"params": sharded_fp32_params}
     state_mesh_shardings = state_mesh_shardings.replace(params=dict(prev_params_shardings, **sharded_fp32_params))
   return prev_params_shardings, state_mesh_shardings
+
 
 def setup_initial_state(
     model,
@@ -1145,7 +1157,11 @@ def get_abstract_state(model, tx, config, rng, mesh, is_training=True):
   if is_training and config.shard_optimizer_over_data:
     # Add data to sharding for optimizer state
     state_mesh_shardings = state_mesh_shardings.replace(
-      opt_state=jax.tree.map_with_path(functools.partial(add_data_to_sharding, mesh), unbox_logicallypartioned(abstract_state).opt_state, state_mesh_shardings.opt_state)
+        opt_state=jax.tree.map_with_path(
+            functools.partial(add_data_to_sharding, mesh),
+            unbox_logicallypartioned(abstract_state).opt_state,
+            state_mesh_shardings.opt_state,
+        )
     )
   if is_training and config.optimizer_memory_host_offload:
     opt_state = jax.tree_util.tree_map(lambda x: x.with_memory_kind(kind="pinned_host"), state_mesh_shardings.opt_state)

--- a/src/MaxText/train_utils.py
+++ b/src/MaxText/train_utils.py
@@ -76,9 +76,7 @@ def create_training_tools(config, model, mesh):
   return init_rng, checkpoint_manager, learning_rate_schedule, tx
 
 
-def jit_train_step(
-    config, model, state, state_mesh_shardings, data_sharding, train_step, params_shardings
-):
+def jit_train_step(config, model, state, state_mesh_shardings, data_sharding, train_step, params_shardings):
   """Returns a JIT-compiled train step function, which is loaded from a file if specified in the config."""
   (
       functional_train,
@@ -144,9 +142,7 @@ def jit_train_and_eval_step(
 ):
   """Returns a JIT-compiled train and eval step function."""
   data_sharding = maxtext_utils.get_input_data_sharding(config, mesh)
-  p_train_step = jit_train_step(
-      config, model, state, state_mesh_shardings, data_sharding, train_step, params_shardings
-  )
+  p_train_step = jit_train_step(config, model, state, state_mesh_shardings, data_sharding, train_step, params_shardings)
   p_eval_step = None
   if eval_data_iterator:
     p_eval_step = jit_eval_step(config, model, state_mesh_shardings, data_sharding, eval_step)

--- a/tests/inference/benchmark_offline_engine.py
+++ b/tests/inference/benchmark_offline_engine.py
@@ -1,0 +1,144 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Command: JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 python tests/inference/benchmark_offline_engine.py
+"""
+
+import pathwaysutils
+
+pathwaysutils.initialize()
+
+import sys
+import os.path
+import random
+import time
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from MaxText.globals import MAXTEXT_PKG_DIR
+from MaxText import max_logging
+from MaxText import pyconfig
+from MaxText.inference.offline_engine import OfflineEngine, InputData, CompletionOutput
+
+
+def get_metrics(results: list[CompletionOutput], start_time, end_time):
+  total_tokens = 0
+  for _, tokens in enumerate(results):
+    total_tokens += len(tokens.token_ids)
+  max_logging.log(f"Time taken: {end_time - start_time} seconds")
+  max_logging.log(f"Total tokens: {total_tokens}")
+  max_logging.log(f"Tokens per second: {total_tokens / (end_time - start_time)}")
+
+
+def init_pyconfig(**kwargs):
+  """Initialize pyconfig for benchmarking"""
+  init_kwargs = {
+      "run_name": "test",
+      # Parallelism
+      "per_device_batch_size": 1,
+      "ici_data_parallelism": 16,  # <=== set ici_data_parallelism to dp
+      "ici_tensor_parallelism": 4,  # <=== set ici_data_parallelism to tp / seq parallel
+      # Inference
+      "max_prefill_predict_length": 128,
+      "max_target_length": 256,
+      "return_log_prob": True,  # <=== set this to True
+      # Model
+      "model_name": "gemma2-2b",
+      "attention": "dot_product",
+      "allow_split_physical_axes": True,
+      "scan_layers": False,
+      # Checkpoints
+      "tokenizer_type": "huggingface",
+      "tokenizer_path": "google/gemma-2-2b-it",
+      "hf_path": "trl-lib/tldr",
+      # "load_parameters_path": "gs://inference-benchmarks/models/llama2-70b-chat/quant/int8_",
+      "enable_single_controller": True,  # for pathways
+  } | kwargs
+  _config = pyconfig.initialize(
+      [sys.argv[0], os.path.join(MAXTEXT_PKG_DIR, "experimental", "rl", "grpo_inference.yml")],
+      **init_kwargs,
+  )
+  return _config
+
+
+config = init_pyconfig()
+continous_batching = True
+max_logging.log("initialized pyconfig")
+random.seed(42)
+
+data = [np.arange(1, 129) for _ in range(config.global_batch_size_to_train_on)]
+true_lengths = [config.max_prefill_predict_length for _ in range(config.global_batch_size_to_train_on)]
+input_data = []
+for i, d in enumerate(data):
+  input_data.append(
+      InputData(
+          id=int(i),
+          tokens=np.array(d),
+          true_length=true_lengths[i],
+      )
+  )
+
+
+def run(
+    profile=False,
+    profile_path="",
+):
+  """Run offline engine"""
+  inference_engine = OfflineEngine(
+      config,
+      params=None,
+      enable_batch_prefill=False,
+      rng=jax.random.PRNGKey(0),
+      eos_ids=[1002],
+      debug=False,
+  )
+  max_logging.log("Starting Warmup")
+  _ = [inference_engine.batch_inference(input_data) for _ in range(4)]
+  max_logging.log("Warmup Ended")
+  start_time = time.time()
+  max_logging.log(f"First Round. Start time: {start_time}")
+  results = inference_engine.batch_inference(input_data)
+  results = jax.block_until_ready(results)
+  end_time = time.time()
+  max_logging.log(f"First Round. Time taken to run {len(input_data)} inference samples: {end_time - start_time} seconds")
+
+  if profile:
+    jax.profiler.start_trace(profile_path)
+    start_time = time.time()
+    max_logging.log(f"Second Round. Start time: {start_time}")
+    results = inference_engine.batch_inference(input_data)
+    results = jax.block_until_ready(results)
+    end_time = time.time()
+    jax.profiler.stop_trace()
+    max_logging.log(
+        f"Second Round. Time taken to run {len(input_data)} inference samples: {end_time - start_time} seconds"
+    )
+    if continous_batching:
+      tokens = 0
+      for result in results:
+        tokens += len(result.token_ids)
+    else:
+      tokens = 0
+      for result in results:
+        tokens += jnp.count_nonzero(result.token_ids)
+    max_logging.log(f"Tokens generated: {tokens}")
+    max_logging.log(f"Tokens per second: {tokens / (end_time - start_time)}")
+
+
+run(
+    profile=True,
+    profile_path=f"gs://runner-maxtext-logs/mohitkhatwani_offline_benchmark/app_2/0908/{time.strftime('%Y%m%d-%H%M%S')}/",
+)


### PR DESCRIPTION
# Description

This PR introduces an API for resharding which uses split_by_mesh_axis from pathwaysutils. It includes a function to find intermediate shardings for split_by_mesh_axis when possible. 

Logs for llama3.1-8b on v5p-64:
https://cloudlogging.app.goo.gl/cu9xgZtatFSUyfyh6

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/449217704

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

A test which runs on v5p-64 with pathways as backend

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
