### PR TITLE
Add support for Qwen3-Next Model Architecture

### DIFF
--- a/src/MaxText/common_types.py
+++ b/src/MaxText/common_types.py
@@ -86,6 +86,7 @@ class DecoderBlockType(enum.Enum):
   GEMMA3 = "gemma3"
   QWEN3 = "qwen3"
   QWEN3_MOE = "qwen3_moe"
+  QWEN3_NEXT = "qwen3_next"
   GPT3 = "gpt3"
   GPT_OSS = "gpt_oss"
   SIMPLE = "simple"

--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -860,3 +860,19 @@ subslice_shape: ""
 # NNX
 enable_nnx: false
 shard_optimizer_over_data: False
+
+################################## Qwen3-Next Specific Configs ##################################
+# Kernel size for the 1D convolution in the Gated Delta Net
+gdn_conv_kernel_dim: 4
+# Head dimension for the key/query in the Gated Delta Net
+gdn_key_head_dim: 128
+# Head dimension for the value in the Gated Delta Net
+gdn_value_head_dim: 128
+# Number of key/query heads in the Gated Delta Net
+gdn_num_key_heads: 16
+# Number of value heads in the Gated Delta Net
+gdn_num_value_heads: 32
+# Chunk size for the parallel scan algorithm in the Gated Delta Net.
+gdn_chunk_size: 64
+# Whether to apply L2 normalization to query and key tensors inside the Gated Delta Rule kernel.
+use_qk_norm_in_gdn: True

--- a/src/MaxText/configs/models/qwen3-next-80b-a3b.yml
+++ b/src/MaxText/configs/models/qwen3-next-80b-a3b.yml
@@ -1,0 +1,47 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# MaxText/configs/models/qwen3-next-80b-a3b.yml
+
+# Set the decoder block to our new implementation
+decoder_block: "qwen3_next"
+
+# Core Architectural Parameters
+base_emb_dim: 2048
+base_num_decoder_layers: 48
+base_num_query_heads: 16
+base_num_kv_heads: 2
+head_dim: 256
+vocab_size: 151936
+normalization_layer_epsilon: 1.0e-6
+
+# MoE Specific Parameters
+# Set base_mlp_dim to match base_moe_mlp_dim to pass validation for fully MoE models.
+base_mlp_dim: 512
+base_moe_mlp_dim: 512
+num_experts: 512
+num_experts_per_tok: 10
+norm_topk_prob: True
+
+# Qwen3-Next Specific Parameters for Linear Attention (Gated Delta Net)
+inhomogeneous_layer_cycle_interval: 4
+gdn_conv_kernel_dim: 4
+gdn_key_head_dim: 128
+gdn_value_head_dim: 128
+gdn_num_key_heads: 16
+gdn_num_value_heads: 32
+gdn_chunk_size: 64
+
+# RoPE Settings
+rope_max_timescale: 10000000

--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -401,6 +401,8 @@ class Decoder(nn.Module):
         return [qwen3.Qwen3DecoderLayerToLinen]
       case DecoderBlockType.QWEN3_MOE:
         return [qwen3.Qwen3MoeDecoderLayerToLinen]
+      case DecoderBlockType.QWEN3_NEXT:
+        return [qwen3.Qwen3NextScannableBlockToLinen] if self.config.scan_layers else [qwen3.Qwen3NextDecoderLayerToLinen]
       case DecoderBlockType.SIMPLE:
         return [simple_layer.SimpleDecoderLayerToLinen]
       case DecoderBlockType.SIMPLE_MLP:
@@ -452,6 +454,7 @@ class Decoder(nn.Module):
         DecoderBlockType.GEMMA3,
         DecoderBlockType.QWEN3,
         DecoderBlockType.QWEN3_MOE,
+        DecoderBlockType.QWEN3_NEXT,
         DecoderBlockType.GPT_OSS,
         DecoderBlockType.SIMPLE,
         DecoderBlockType.SIMPLE_MLP,
@@ -824,6 +827,8 @@ class Decoder(nn.Module):
                   "is_nope_layer": llama4.determine_is_nope_layer(lyr, self.config.nope_layer_interval),
                   "is_moe_layer": llama4.determine_is_moe_layer(lyr, self.config.interleave_moe_layer_step),
               }
+            if cfg.decoder_block == DecoderBlockType.QWEN3_NEXT:
+              layer_kwargs = {"layer_idx": lyr}
             if cfg.decoder_block == DecoderBlockType.GPT_OSS:
               layer_kwargs = {"attention_type": gpt_oss.get_attention_type(layer_id=lyr)}
             layer = RemattedBlockLayer(

--- a/src/MaxText/layers/normalizations.py
+++ b/src/MaxText/layers/normalizations.py
@@ -25,6 +25,7 @@ from MaxText import max_logging
 from MaxText import max_utils
 from MaxText.layers import nnx_wrappers
 from MaxText.layers.initializers import Initializer, variable_to_logically_partitioned
+from MaxText.common_types import Array
 
 
 class RMSNorm(nnx.Module):
@@ -93,3 +94,19 @@ def rms_norm(
       metadata_fn=variable_to_logically_partitioned,
   )
   return module
+
+
+def l2norm(x: Array, dim: int = -1, eps: float = 1e-6) -> Array:
+  """L2 normalization function. Normalizes a vector to have a length of 1.
+
+  Args:
+    x: Input array.
+    dim: The axis or axes along which to normalize. Defaults to the last axis.
+    eps: Small epsilon to prevent division by zero.
+
+  Returns:
+    L2 normalized array with the same shape as x.
+  """
+
+  inv_norm = jax.lax.rsqrt((x * x).sum(axis=dim, keepdims=True) + jnp.array(eps, dtype=x.dtype))
+  return x * inv_norm

--- a/src/MaxText/layers/qwen3.py
+++ b/src/MaxText/layers/qwen3.py
@@ -16,24 +16,905 @@
 # pylint: disable=arguments-differ
 # pylint: disable=no-name-in-module
 
+from typing import cast
+
+import jax
+import jax.nn
 from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
 import jax.numpy as jnp
 
 from flax import linen as nn
 from flax import nnx
+from flax.linen import initializers as linen_initializers
 
 from MaxText import max_utils
-from MaxText.common_types import Config
-from MaxText.layers import initializers
+from MaxText.common_types import Config, DType, Array
+from MaxText.layers import attentions
+from MaxText.layers import initializers as max_initializers
+from MaxText.layers import linears
+from MaxText.layers import moe
 from MaxText.layers import nnx_wrappers
 from MaxText.layers import quantizations
+from MaxText.layers.normalizations import RMSNorm, l2norm
+from MaxText.layers.quantizations import AqtQuantization as Quant
+from MaxText.inference import page_manager
 from MaxText.layers.attentions import Attention
 from MaxText.layers.linears import MlpBlock
 from MaxText.layers.moe import RoutedMoE
-from MaxText.layers.normalizations import RMSNorm
-from MaxText.layers.quantizations import AqtQuantization as Quant
-from MaxText.inference import page_manager
+
+
+# -----------------------------------------
+# Qwen3-Next Layer Implementations
+# -----------------------------------------
+
+
+def jax_chunk_gated_delta_rule(
+    query: Array,
+    key: Array,
+    value: Array,
+    g: Array,
+    beta: Array,
+    chunk_size: int = 64,
+    initial_state: None | Array = None,
+    use_qk_norm_in_gdn: bool = False,
+) -> tuple[Array, None | Array]:
+  """
+  A JAX implementation of the chunked Gated Delta Rule, a parallel scan algorithm.
+  This function implements the core recurrent logic of the Gated Delta Network in
+  a hardware-efficient way by splitting the sequence into chunks and using
+  jax.lax.scan for the recurrent part.
+
+  Tensor Shape Abbreviations:
+    B: batch_size, S: sequence_length, H: num_heads,
+    D_k: key/query_head_dim, D_v: value_head_dim,
+    N: num_chunks, C: chunk_size
+
+  Args:
+    query: Query tensor. Shape (B, S, H, D_k)
+    key: Key tensor. Shape (B, S, H, D_k)
+    value: Value tensor. Shape (B, S, H, D_v)
+    g: Log decay tensor. Shape (B, S, H)
+    beta: Gate tensor. Shape (B, S, H)
+    chunk_size: The size of each chunk for processing.
+    initial_state: Optional initial state for the recurrence. Shape (B, H, D_k, D_v)
+    use_qk_norm_in_gdn: Whether to apply L2 normalization to query and key.
+
+  Returns:
+    Output tensor. Shape (B, S, H, D_v)
+    Final recurrent state. Shape (B, H, D_k, D_v) or None
+  """
+
+  # =========================================================================
+  # STAGE 1: PREPARATION & PADDING
+  # =========================================================================
+  initial_dtype = query.dtype
+  if use_qk_norm_in_gdn:
+    query = l2norm(query, dim=-1, eps=1e-6)
+    key = l2norm(key, dim=-1, eps=1e-6)
+
+  # Transpose (B, S, H, D) -> (B, H, S, D)
+  query = jnp.transpose(query, (0, 2, 1, 3)).astype(jnp.float32)
+  key = jnp.transpose(key, (0, 2, 1, 3)).astype(jnp.float32)
+  value = jnp.transpose(value, (0, 2, 1, 3)).astype(jnp.float32)
+  # Transpose (B, S, H) -> (B, H, S)
+  beta = jnp.transpose(beta, (0, 2, 1)).astype(jnp.float32)
+  g = jnp.transpose(g, (0, 2, 1)).astype(jnp.float32)
+
+  batch_size, num_heads, sequence_length, k_head_dim = key.shape
+  v_head_dim = value.shape[-1]
+  pad_size = (chunk_size - sequence_length % chunk_size) % chunk_size
+
+  # Padding to make sequence_length divisible by chunk_size
+  if pad_size > 0:
+    query = jnp.pad(query, ((0, 0), (0, 0), (0, pad_size), (0, 0)))  # (B, H, S_padded, D_k)
+    key = jnp.pad(key, ((0, 0), (0, 0), (0, pad_size), (0, 0)))  # (B, H, S_padded, D_k)
+    value = jnp.pad(value, ((0, 0), (0, 0), (0, pad_size), (0, 0)))  # (B, H, S_padded, D_v)
+    beta = jnp.pad(beta, ((0, 0), (0, 0), (0, pad_size)))  # (B, H, S_padded)
+    g = jnp.pad(g, ((0, 0), (0, 0), (0, pad_size)))  # (B, H, S_padded)
+
+  total_sequence_length = sequence_length + pad_size
+  # query shape: (B, H, S_padded, D_k)
+  scale = jax.lax.rsqrt(jnp.array(query.shape[-1]).astype(jnp.float32))
+  query = query * scale
+
+  v_beta = value * jnp.expand_dims(beta, -1)  # (B, H, S_padded, D_v)
+  k_beta = key * jnp.expand_dims(beta, -1)  # (B, H, S_padded, D_k)
+
+  # Reshape to chunks
+  num_chunks = total_sequence_length // chunk_size
+  # query_c shape: (B, H, N, C, D_k)
+  query_c = query.reshape(batch_size, num_heads, num_chunks, chunk_size, k_head_dim)
+  key_c = key.reshape(batch_size, num_heads, num_chunks, chunk_size, k_head_dim)
+  k_beta_c = k_beta.reshape(batch_size, num_heads, num_chunks, chunk_size, k_head_dim)
+  v_beta_c = v_beta.reshape(batch_size, num_heads, num_chunks, chunk_size, v_head_dim)
+  g_c = g.reshape(batch_size, num_heads, num_chunks, chunk_size)  # (B, H, N, C)
+
+  mask = jnp.triu(jnp.ones((chunk_size, chunk_size), dtype=bool), k=0)  # (C, C)
+
+  # =========================================================================
+  # STAGE 2: INTRA-CHUNK CALCULATION (PARALLEL)
+  # =========================================================================
+  # g_cumsum shape: (B, H, N, C)
+  g_cumsum = jnp.cumsum(g_c, axis=-1)
+  # g_diff shape: (B, H, N, C, C)
+  g_diff = jnp.expand_dims(g_cumsum, -1) - jnp.expand_dims(g_cumsum, -2)
+
+  # Apply tril to zero out the upper triangle of g_diff. This is crucial because
+  # the upper triangle contains large positive values that would cause exp() to overflow.
+  g_diff_tril = jnp.tril(g_diff)
+
+  # Exponentiate the lower triangular g_diff. Since these values are non-positive,
+  # exp() will not overflow and will produce values between 0 and 1.
+  g_diff_exp = jnp.exp(g_diff_tril).astype(jnp.float32)
+
+  # The result g_diff_exp is already lower triangular and serves as the decay_mask.
+  # decay_mask shape: (B, H, N, C, C)
+  decay_mask = g_diff_exp
+
+  # --- Precompute within-chunk attention ---
+  # NOTE: Precision set to HIGHEST for numerical accuracy.
+  prec = jax.lax.Precision.HIGHEST
+  # attn shape: (B, H, N, C, C)
+  attn = -jnp.matmul(k_beta_c, jnp.swapaxes(key_c, -1, -2), precision=prec) * decay_mask
+  attn = jnp.where(mask, 0.0, attn)
+
+  # Iterative refinement of the intra-chunk attention.
+  # This loop is equivalent to inverting (I - A) where A is the lower triangular part of attn.
+  def inner_attn_body(i, attn_val):
+    # indices: (C,)
+    indices = jnp.arange(chunk_size)
+    # col_mask: (C,)
+    col_mask = indices < i
+    # row: (B, H, N, C)
+    row = attn_val[..., i, :] * col_mask
+    # sub_mask: (C, C)
+    sub_mask = jnp.expand_dims(indices < i, -1) & (indices < i)
+    # sub: (B, H, N, C, C)
+    sub = attn_val * sub_mask
+    # row_exp: (B, H, N, C, 1)
+    row_exp = jnp.expand_dims(row, -1)
+    # term: (B, H, N, C, C)
+    term = row_exp * sub
+    # summed: (B, H, N, C)
+    summed = jnp.sum(term, axis=-2)
+    # update_val: (B, H, N, C)
+    update_val = row + summed
+    # original_row: (B, H, N, C)
+    original_row = attn_val[..., i, :]
+    # new_row: (B, H, N, C)
+    new_row = jnp.where(col_mask, update_val, original_row)
+    return attn_val.at[..., i, :].set(new_row)
+
+  attn = jax.lax.fori_loop(1, chunk_size, inner_attn_body, attn)
+
+  attn = attn + jnp.eye(chunk_size, dtype=attn.dtype)  # (B, H, N, C, C)
+  # value_intra shape: (B, H, N, C, D_v)
+  value_intra = jnp.matmul(attn, v_beta_c, precision=prec)
+  # k_cumdecay shape: (B, H, N, C, D_k)
+  k_cumdecay = jnp.matmul(attn, (k_beta_c * jnp.expand_dims(jnp.exp(g_cumsum), -1)), precision=prec)
+  # --- End Precompute ---
+
+  output_final_state = initial_state is not None
+  if initial_state is None:
+    # last_recurrent_state shape: (B, H, D_k, D_v)
+    last_recurrent_state = jnp.zeros((batch_size, num_heads, k_head_dim, v_head_dim), dtype=value_intra.dtype)
+  else:
+    last_recurrent_state = initial_state.astype(value_intra.dtype)
+
+  # mask_inter shape: (C, C)
+  mask_inter = jnp.triu(jnp.ones((chunk_size, chunk_size), dtype=bool), k=1)
+
+  # Transpose for scan: (B, H, N, C, D) -> (N, B, H, C, D)
+  query_scan = jnp.transpose(query_c, (2, 0, 1, 3, 4))
+  key_scan = jnp.transpose(key_c, (2, 0, 1, 3, 4))
+  value_scan = jnp.transpose(value_intra, (2, 0, 1, 3, 4))
+  k_cumdecay_scan = jnp.transpose(k_cumdecay, (2, 0, 1, 3, 4))
+  # Transpose for scan: (B, H, N, C) -> (N, B, H, C)
+  g_scan = jnp.transpose(g_cumsum, (2, 0, 1, 3))
+  decay_mask_scan = jnp.transpose(decay_mask, (2, 0, 1, 3, 4))
+
+  xs = (query_scan, key_scan, value_scan, k_cumdecay_scan, g_scan, decay_mask_scan)
+
+  # =========================================================================
+  # STAGE 3: INTER-CHUNK RECURRENCE (SEQUENTIAL VIA SCAN)
+  # =========================================================================
+  def scan_body(prev_state, x):
+    q_i, k_i, v_i, k_cumdecay_i, g_i, decay_mask_i = x
+    # prev_state shape: (B, H, D_k, D_v)
+    last_recurrent_state = prev_state
+    prec = jax.lax.Precision.HIGHEST
+
+    # Intra-chunk attention for the current chunk
+    # attn_i shape: (B, H, C, C)
+    attn_i = jnp.matmul(q_i, jnp.swapaxes(k_i, -1, -2), precision=prec) * decay_mask_i
+    attn_i = jnp.where(mask_inter, 0.0, attn_i)
+
+    # Interaction with the recurrent state
+    # v_prime shape: (B, H, C, D_v)
+    v_prime = jnp.matmul(k_cumdecay_i, last_recurrent_state, precision=prec)
+    # v_new shape: (B, H, C, D_v)
+    v_new = v_i - v_prime
+
+    # g_i is cumulative sum, so exp(g_i) is the decay factor
+    g_i_exp = jnp.exp(g_i)
+    # attn_inter shape: (B, H, C, D_v)
+    attn_inter = jnp.matmul(q_i * jnp.expand_dims(g_i_exp, -1), last_recurrent_state, precision=prec)
+
+    # core_attn_out_i shape: (B, H, C, D_v)
+    core_attn_out_i = attn_inter + jnp.matmul(attn_i, v_new, precision=prec)
+
+    # Update the recurrent state
+    # g_i_last_exp shape: (B, H, 1, 1)
+    g_i_last_exp = jnp.exp(g_i[..., -1, None, None])
+    # new_last_recurrent_state shape: (B, H, D_k, D_v)
+    new_last_recurrent_state = last_recurrent_state * g_i_last_exp
+
+    # g_diff_exp shape: (B, H, C, 1)
+    g_diff_exp = jnp.expand_dims(jnp.exp(jnp.expand_dims(g_i[..., -1], -1) - g_i), -1)
+    # k_i_g_diff shape: (B, H, C, D_k)
+    k_i_g_diff = k_i * g_diff_exp
+
+    # Update term shape: (B, H, D_k, D_v)
+    update_term = jnp.matmul(jnp.swapaxes(k_i_g_diff, -1, -2), v_new, precision=prec)
+    new_last_recurrent_state = new_last_recurrent_state + update_term
+
+    return new_last_recurrent_state, core_attn_out_i
+
+  # final_state shape: (B, H, D_k, D_v)
+  # core_attn_out_stacked shape: (N, B, H, C, D_v)
+  final_state, core_attn_out_stacked = jax.lax.scan(scan_body, last_recurrent_state, xs)
+
+  # =========================================================================
+  # STAGE 4: FINALIZATION
+  # =========================================================================
+  # core_attn_out shape: (B, H, N, C, D_v)
+  core_attn_out = jnp.transpose(core_attn_out_stacked, (1, 2, 0, 3, 4))
+
+  # core_attn_out shape: (B, H, S_padded, D_v)
+  core_attn_out = core_attn_out.reshape(batch_size, num_heads, -1, v_head_dim)
+  # Trim padding: (B, H, S, D_v)
+  core_attn_out = core_attn_out[:, :, :sequence_length, :]
+
+  # Transpose back to (B, S, H, D_v)
+  core_attn_out = jnp.transpose(core_attn_out, (0, 2, 1, 3)).astype(initial_dtype)
+
+  return core_attn_out, final_state if output_final_state else None
+
+
+class Qwen3NextRMSNorm(nnx.Module):
+  """
+  Used for input and post attention layernorms
+  in Qwen3NextDecoderLayer.
+
+  This normalization layer is specific to Qwen3-Next. Key characteristics:
+  1.  The learnable scale parameter `weight` is initialized to ZEROS.
+  2.  The scale is applied as `(1.0 + self.weight)`, making the initial scale effectively 1.0.
+      This matches the PyTorch implementation of Qwen3NextRMSNorm.
+  3.  It is NOT a zero-centered normalization (as in the blog); it still uses the root mean square of the inputs.
+      The standard `MaxText.layers.normalizations.RMSNorm` also does not center the data.
+  4.  This differs from the standard MaxText `RMSNorm`
+      (MaxText.layers.normalizations.RMSNorm) which initializes its scale to ONES
+      and applies it multiplicatively (`y * scale`).
+  """
+
+  def __init__(self, num_features: int, eps: float, dtype: DType, weight_dtype: DType, *, rngs: nnx.Rngs):
+    self.num_features = num_features
+    self.eps = eps
+    self.dtype = dtype
+    self.weight_dtype = weight_dtype
+
+    self.weight = nnx.Param(linen_initializers.zeros(rngs.params(), (self.num_features,), self.weight_dtype))
+
+  def __call__(self, x: Array) -> Array:
+    """Applies RMSNorm to the input tensor."""
+    weight = self.weight.value
+    x_dtype = x.dtype
+    x = x.astype(jnp.float32)
+    variance = jnp.mean(jnp.square(x), axis=-1, keepdims=True)
+    x = x * jax.lax.rsqrt(variance + self.eps)
+    # Add 1.0 to the learnable weight
+    x = x * (1.0 + weight.astype(jnp.float32))
+    return x.astype(x_dtype)
+
+
+class Qwen3NextRMSNormGated(nnx.Module):
+  """
+  This applies RMS Normalization and then a gated activation function (SiLU).
+  This is used within the Qwen3NextGatedDeltaNet.
+
+  Attributes:
+    num_features: The number of features in the input.
+    eps: A small epsilon value to prevent division by zero in RMSNorm.
+    dtype: The datatype of the computation.
+    weight_dtype: The datatype of the weights.
+  """
+
+  def __init__(self, num_features: int, eps: float, dtype: DType, weight_dtype: DType, *, rngs: nnx.Rngs):
+    self.num_features = num_features
+    self.eps = eps
+    self.dtype = dtype
+    self.weight_dtype = weight_dtype
+
+    self.weight = nnx.Param(nnx.initializers.ones(rngs.params(), (self.num_features,), self.weight_dtype))
+
+  def __call__(self, hidden_states: Array, gate: Array) -> Array:
+    """
+    Applies RMSNorm and then a SiLU gate.
+
+    Args:
+      hidden_states: The input array to be normalized (o). Shape: (..., F)
+      gate: The gating array for the activation (z). Shape: (..., F)
+            where F is num_features.
+
+    Returns:
+      The normalized and gated output array. Shape: (..., F)
+    """
+    weight = self.weight.value
+
+    # RMS Normalization logic
+    hidden_states_f32 = hidden_states.astype(jnp.float32)
+    variance = jnp.mean(jnp.square(hidden_states_f32), axis=-1, keepdims=True)
+    normalized_states = hidden_states_f32 * jax.lax.rsqrt(variance + self.eps)
+    normalized_states = normalized_states * weight.astype(jnp.float32)
+
+    # Gated Activation using SiLU (Sigmoid-weighted Linear Unit)
+    gated_states = normalized_states * jax.nn.silu(gate.astype(jnp.float32))
+
+    return gated_states.astype(self.dtype)
+
+
+class Qwen3NextGatedDeltaNet(nnx.Module):
+  """
+  This module implements the full end-to-end logic of a Gated Delta Network layer.
+
+  End-to-End Equations Implemented:
+  Let `x` be the input `hidden_states`.
+
+  Step A: Input Projections
+  1. (q_raw, k_raw, v_raw, z) = Linear_qkvz(x)
+  2. (b, a) = Linear_ba(x)
+
+  Step B: 1D Convolution
+  1. qkv_conv = silu(Conv1D(concatenate(q_raw, k_raw, v_raw)))
+  2. (q, k, v) = split(qkv_conv)
+
+  Step C: Gated Delta Rule (Recurrent Core)
+  1. Gates: β=sigmoid(b), g = -exp(A_log) * softplus(a + dt_bias)
+  2. Core Calculation: core_attn_out = jax_chunk_gated_delta_rule(q, k, v, g, β)
+
+  Step D: Final Output Stage
+  1. y = RMSNorm(core_attn_out) * silu(z)
+  2. output = Linear_out(y)
+
+  Attributes:
+    config: MaxText configuration object.
+    dtype: The datatype of the computation.
+  """
+
+  def __init__(self, config: Config, dtype: DType = jnp.float32, *, rngs: nnx.Rngs):
+    self.config = config
+    self.dtype = dtype
+    cfg = self.config
+
+    in_features = cfg.emb_dim
+    self.num_v_heads = cfg.gdn_num_value_heads
+    self.num_k_heads = cfg.gdn_num_key_heads
+    self.head_k_dim = cfg.gdn_key_head_dim
+    self.head_v_dim = cfg.gdn_value_head_dim
+    self.key_dim = self.head_k_dim * self.num_k_heads
+    self.value_dim = self.head_v_dim * self.num_v_heads
+    conv_dim = self.key_dim * 2 + self.value_dim
+    conv_kernel_size = cfg.gdn_conv_kernel_dim
+
+    # Submodule instantiations
+    self.in_proj_qkvz = linears.DenseGeneral(
+        in_features_shape=in_features,
+        out_features_shape=(self.key_dim * 2 + self.value_dim * 2),
+        dtype=cfg.dtype,
+        kernel_axes=("embed", "mlp"),
+        matmul_precision=cfg.matmul_precision,
+        rngs=rngs,
+    )
+    self.in_proj_ba = linears.DenseGeneral(
+        in_features_shape=in_features,
+        out_features_shape=(self.num_v_heads * 2),
+        dtype=cfg.dtype,
+        kernel_axes=("embed", "mlp"),
+        matmul_precision=cfg.matmul_precision,
+        rngs=rngs,
+    )
+
+    self.conv1d = nnx.Conv(
+        in_features=conv_dim,
+        out_features=conv_dim,
+        kernel_size=(conv_kernel_size,),
+        feature_group_count=conv_dim,  # Depthwise
+        padding="CAUSAL",
+        use_bias=False,
+        dtype=cfg.dtype,
+        precision=cfg.matmul_precision,
+        rngs=rngs,
+    )
+
+    # Initialize A_log to match torch.log(torch.uniform(0, 16))
+    def a_log_init(key, shape, dtype=jnp.float32):
+      # Sample from Uniform(epsilon, 16) to avoid log(0)
+      a_vals = jax.random.uniform(key, shape=shape, dtype=dtype, minval=1e-9, maxval=16.0)
+      return jnp.log(a_vals)
+
+    self.A_log = nnx.Param(a_log_init(rngs.params(), (self.num_v_heads,)))
+    self.dt_bias = nnx.Param(nnx.initializers.ones(rngs.params(), (self.num_v_heads,)))
+
+    self.norm = Qwen3NextRMSNormGated(
+        num_features=self.head_v_dim,  # Normalize over the head dimension (D_v)
+        eps=cfg.normalization_layer_epsilon,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        rngs=rngs,
+    )
+    self.out_proj = linears.DenseGeneral(
+        in_features_shape=self.value_dim,
+        out_features_shape=(in_features,),
+        dtype=cfg.dtype,
+        kernel_axes=("mlp", "embed"),
+        matmul_precision=cfg.matmul_precision,
+        rngs=rngs,
+    )
+
+  def __call__(self, hidden_states: Array) -> Array:
+    cfg = self.config
+
+    # =========================================================================
+    # STEP A: Input Projections
+    # =========================================================================
+    # hidden_states shape: (B, S, E)
+    # qkvz shape: (B, S, 2*key_dim + 2*value_dim)
+    qkvz = self.in_proj_qkvz(hidden_states)
+    # ba shape: (B, S, 2*H_v)
+    ba = self.in_proj_ba(hidden_states)
+
+    # q shape: (B, S, key_dim), k shape: (B, S, key_dim), v shape: (B, S, value_dim), z shape: (B, S, value_dim)
+    q, k, v, z = jnp.split(qkvz, [self.key_dim, 2 * self.key_dim, 2 * self.key_dim + self.value_dim], axis=-1)
+    # b shape: (B, S, H_v), a shape: (B, S, H_v)
+    b, a = jnp.split(ba, [self.num_v_heads], axis=-1)
+
+    # =========================================================================
+    # STEP B: 1D Convolution
+    # =========================================================================
+    # qkv shape: (B, S, conv_dim)
+    qkv = jnp.concatenate([q, k, v], axis=-1)
+
+    # TODO(parambole): Implement caching logic for conv_state and recurrent_state
+
+    # Input to conv_layer should be (B, S, C)
+    # qkv_conv shape: (B, S, conv_dim)
+    qkv_conv = jax.nn.silu(self.conv1d(qkv).astype(jnp.float32)).astype(cfg.dtype)
+    # q_conv shape: (B, S, key_dim), k_conv shape: (B, S, key_dim), v_conv shape: (B, S, value_dim)
+    q_conv, k_conv, v_conv = jnp.split(qkv_conv, [self.key_dim, 2 * self.key_dim], axis=-1)
+
+    # Reshape for multi-head processing
+    batch, seq_len, _ = hidden_states.shape
+    # query shape: (B, S, H_k, D_k)
+    query = q_conv.reshape(batch, seq_len, self.num_k_heads, self.head_k_dim)
+    # key shape: (B, S, H_k, D_k)
+    key = k_conv.reshape(batch, seq_len, self.num_k_heads, self.head_k_dim)
+    # value shape: (B, S, H_v, D_v)
+    value = v_conv.reshape(batch, seq_len, self.num_v_heads, self.head_v_dim)
+
+    # =========================================================================
+    # STEP C: Gated Delta Rule Recurrence
+    # =========================================================================
+    A_log = self.A_log.value
+    dt_bias = self.dt_bias.value
+    # beta shape: (B, S, H_v)
+    beta = jax.nn.sigmoid(b)
+    # g shape: (B, S, H_v)
+    g = -jnp.exp(A_log.astype(jnp.float32)) * jax.nn.softplus(a.astype(jnp.float32) + dt_bias.astype(jnp.float32))
+    g = g.astype(cfg.dtype)
+
+    if self.num_v_heads > self.num_k_heads and self.num_v_heads % self.num_k_heads == 0:
+      repeats = self.num_v_heads // self.num_k_heads
+      # query shape after repeat: (B, S, H_v, D_k)
+      query = jnp.repeat(query, repeats, axis=2)
+      # key shape after repeat: (B, S, H_v, D_k)
+      key = jnp.repeat(key, repeats, axis=2)
+    elif self.num_k_heads > self.num_v_heads and self.num_k_heads % self.num_v_heads == 0:
+      # This case might occur if key/query heads are more than value heads.
+      pass  # No repeating needed for query/key in this case
+
+    # TODO(parambole): Pass and update cache state for jax_chunk_gated_delta_rule
+    # core_attn_out shape: (B, S, H_v, D_v)
+    core_attn_out, _ = jax_chunk_gated_delta_rule(
+        query, key, value, g, beta, chunk_size=cfg.gdn_chunk_size, use_qk_norm_in_gdn=cfg.use_qk_norm_in_gdn
+    )
+
+    # =========================================================================
+    # STEP D: Final Output Stage
+    # =========================================================================
+    # The normalization and gating is applied per-head on the value dimension.
+    # We first reshape the `z` tensor to match the multi-head structure of `core_attn_out`.
+    # z shape from (B, S, value_dim) -> (B, S, H_v, D_v)
+    z_reshaped = z.reshape(batch, seq_len, self.num_v_heads, self.head_v_dim)
+
+    # Apply the norm and gate. Output shape: (B, S, H_v, D_v)
+    gated_output_reshaped = self.norm(core_attn_out, z_reshaped)
+
+    # Reshape back to a single feature dimension for the final projection.
+    # Shape from (B, S, H_v, D_v) -> (B, S, value_dim)
+    gated_output = gated_output_reshaped.reshape(batch, seq_len, -1)
+
+    # Final output shape: (B, S, E)
+    output = self.out_proj(gated_output)
+
+    return output
+
+
+class Qwen3NextFullAttention(nnx.Module):
+  """Placeholder for Qwen3-Next full attention."""
+
+  def __init__(
+      self, config: Config, mesh: Mesh, model_mode: str, layer_idx: int, quant: None | Quant = None, *, rngs: nnx.Rngs
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.layer_idx = layer_idx
+    self.quant = quant
+    cfg = self.config
+
+    # TODO(rbierneni): Implement the actual Qwen3NextAttention logic.
+    # This is a placeholder. The actual Qwen3NextAttention in the PyTorch code has:
+    # 1.  q_proj projection: hidden_size -> num_attention_heads * head_dim * 2.
+    #     This output is chunked to get query_states and a 'gate'.
+    # 2.  Qwen3NextRMSNorm (self.q_norm and self.k_norm) is applied to query_states
+    #     and key_states *before* RoPE. These norms are on the head_dim.
+    # 3.  The final attention output is gated: attn_output = attn_output * torch.sigmoid(gate).
+    # 4.  k_proj and v_proj are standard Linear layers to num_key_value_heads * head_dim.
+    # 5.  RoPE is applied to the normed query and key.
+    # 6.  The o_proj maps from num_attention_heads * head_dim back to hidden_size.
+
+    # Placeholder call to standard MaxText attention
+    # NOTE: This will NOT match the Qwen3Next behavior or weights.
+
+    # Get mode-specific batch size and sequence length for shape
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(cfg, model_mode)
+    inputs_shape = (batch_size, seq_len, cfg.emb_dim)
+
+    self.attention_layer = attentions.Attention(
+        config=cfg,
+        num_query_heads=cfg.num_query_heads,
+        num_kv_heads=cfg.num_kv_heads,
+        head_dim=cfg.head_dim,
+        max_target_length=cfg.max_target_length,
+        max_prefill_predict_length=cfg.max_prefill_predict_length,
+        attention_kernel=cfg.attention,
+        inputs_q_shape=inputs_shape,
+        inputs_kv_shape=inputs_shape,
+        mesh=self.mesh,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        dropout_rate=cfg.dropout_rate,
+        name="self_attention",
+        quant=self.quant,
+        kv_quant=quantizations.configure_kv_quant(cfg),
+        use_qk_norm=False,
+        model_mode=model_mode,
+        rngs=rngs,
+    )
+
+  def __call__(
+      self,
+      inputs: jnp.ndarray,
+      decoder_segment_ids: None | jnp.ndarray,
+      decoder_positions: None | jnp.ndarray,
+      deterministic: bool,
+      model_mode: str,
+      # TODO(parambole): Add cache arguments
+  ):
+
+    # TODO(parambole): Add caching in/out
+    attention_output = self.attention_layer(
+        inputs,
+        inputs,
+        decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        deterministic=deterministic,
+        model_mode=model_mode,
+    )
+    return attention_output
+
+
+class Qwen3NextSparseMoeBlock(nnx.Module):
+  """
+  This module encapsulates the unique MoE structure of Qwen3-Next, which includes:
+  1. A set of routed experts, where each token is sent to a subset of experts.
+  2. A single shared expert, which all tokens pass through.
+  3. A learnable gate that determines the contribution of the shared expert.
+
+  Attributes:
+    config: The model configuration object.
+    mesh: The device mesh for sharding.
+    quant: Optional quantization configuration.
+  """
+
+  def __init__(self, config: Config, mesh: Mesh, quant: None | Quant = None, *, rngs: nnx.Rngs):
+    self.config = config
+    self.mesh = mesh
+    self.quant = quant
+    cfg = self.config
+
+    # 1. Instantiate and apply the routed experts block.
+    self.routed_experts = moe.RoutedMoE(
+        config=cfg,
+        num_experts=cfg.num_experts,
+        num_experts_per_tok=cfg.num_experts_per_tok,
+        mesh=self.mesh,
+        kernel_init=max_initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed", None),
+        intermediate_dim=cfg.moe_mlp_dim,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        quant=self.quant,
+        rngs=rngs,
+    )
+
+    # 2. Instantiate and apply the shared expert.
+    self.shared_expert = linears.MlpBlock(
+        config=cfg,
+        in_features=cfg.emb_dim,
+        intermediate_dim=cfg.moe_mlp_dim,
+        activations=cfg.mlp_activations,
+        intermediate_dropout_rate=cfg.dropout_rate,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        quant=self.quant,
+        model_mode=config.model_call_mode,
+        rngs=rngs,
+    )
+
+    # 3. Instantiate and apply the gate for the shared expert.
+    self.shared_expert_gate = linears.DenseGeneral(
+        in_features_shape=cfg.emb_dim,
+        out_features_shape=1,
+        use_bias=False,  # Qwen3-Next shared_expert_gate does not have a bias
+        dtype=cfg.dtype,
+        kernel_init=max_initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed", "vocab"),
+        rngs=rngs,
+    )
+
+  def __call__(self, hidden_states: Array, deterministic: bool) -> tuple[Array, Array | None]:
+    """
+    Applies the sparse MoE block to the input hidden states.
+
+    Args:
+      hidden_states: The input array from the previous layer. Shape: (batch, seq, embed_dim)
+      deterministic: If True, disables dropout.
+
+    Returns:
+      A tuple containing:
+        - The output array of the MoE block.
+        - The load balancing loss from the routed experts, if applicable during training.
+    """
+    # 1. Apply the routed experts block.
+    routed_output, load_balance_loss = self.routed_experts(hidden_states)
+
+    # 2. Apply the shared expert.
+    shared_expert_output = self.shared_expert(hidden_states, deterministic=deterministic)
+
+    # 3. Apply the gate for the shared expert.
+    shared_gate_output = self.shared_expert_gate(hidden_states)
+
+    # 4. Combine the outputs.
+    final_output = routed_output + jax.nn.sigmoid(shared_gate_output) * shared_expert_output
+
+    return final_output, load_balance_loss
+
+
+class Qwen3NextScannableBlock(nnx.Module):
+  """A scannable block of Qwen3-Next decoder layers.
+
+  This module contains a fixed number of heterogeneous decoder layers that form
+  a repeating pattern, as defined by `config.inhomogeneous_layer_cycle_interval`. It is
+  intended to be the body of an `nn.scan` transformation to construct the full
+  decoder stack efficiently.
+
+  Attributes:
+    config: The model configuration object.
+    mesh: The device mesh for sharding.
+    model_mode: The operational mode (e.g., 'train', 'prefill').
+    quant: Optional quantization configuration.
+  """
+
+  def __init__(self, config: Config, mesh: Mesh, model_mode: str, quant: None | Quant = None, *, rngs: nnx.Rngs):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.quant = quant
+    self.rngs = rngs
+    cfg = self.config
+
+    # Instantiate each layer within the block in __init__
+    for i in range(cfg.inhomogeneous_layer_cycle_interval):
+      layer_rngs = self.rngs.fork()  # Fork RNGs for each layer
+      layer_name = f"layer_{i}"
+      layer = Qwen3NextDecoderLayer(
+          config=self.config,
+          mesh=self.mesh,
+          quant=self.quant,
+          model_mode=self.model_mode,
+          layer_idx=i,
+          rngs=layer_rngs,
+      )
+      setattr(self, layer_name, layer)
+
+  def __call__(
+      self,
+      carry: jnp.ndarray,
+      decoder_segment_ids: None | jnp.ndarray,
+      decoder_positions: None | jnp.ndarray,
+      deterministic: bool,
+      model_mode: str,
+      previous_chunk=None,
+      page_state: None | page_manager.PageState = None,
+      slot: None | int = None,
+  ) -> tuple[Array, None]:
+    """Applies the block of decoder layers to the input carry.
+
+    Args:
+      carry: The input tensor from the previous scan iteration.
+      # ... other arguments are broadcasted to each iteration.
+
+    Returns:
+      A tuple containing the output of the block (the new carry) and an empty
+      value for the scan's `y` collection.
+    """
+    cfg = self.config
+    x = carry
+
+    # Loop over the number of sub-layers that make up one repeating pattern.
+    for i in range(cfg.inhomogeneous_layer_cycle_interval):
+      layer = getattr(self, f"layer_{i}")
+      x = layer(
+          x,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          previous_chunk,
+          page_state,
+          slot,
+      )
+
+    # The output of the block is the carry for the next scan iteration.
+    return x, None
+
+
+class Qwen3NextDecoderLayer(nnx.Module):
+  """
+  This layer is a hybrid, capable of functioning as either:
+  1. A standard attention + MoE layer.
+  2. A linear attention + MoE layer.
+
+  NOTE: This implementation assumes every layer contains a MoE block, which is true for
+  models like Qwen3-Next-80B-A3B where `decoder_sparse_step=1`. For models that
+  interleave dense and sparse MLP layers, conditional logic would be needed here.
+
+  Attributes:
+    config: The model configuration object.
+    mesh: The device mesh for sharding.
+    model_mode: The operational mode (e.g., 'train', 'prefill').
+    layer_idx: The index of the current layer in the transformer stack.
+    quant: Optional quantization configuration.
+  """
+
+  def __init__(
+      self, config: Config, mesh: Mesh, model_mode: str, layer_idx: int, quant: None | Quant = None, *, rngs: nnx.Rngs
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.layer_idx = layer_idx
+    self.quant = quant
+    cfg = self.config
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+    # First LayerNorm, applied before the attention block.
+    self.input_layernorm = Qwen3NextRMSNorm(
+        num_features=cfg.emb_dim,
+        eps=cfg.normalization_layer_epsilon,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        rngs=rngs,
+    )
+
+    # Determine the type of attention mechanism for the current layer.
+    is_full_attention_layer = (self.layer_idx + 1) % cfg.inhomogeneous_layer_cycle_interval == 0
+
+    # Conditionally instantiate either the Linear Attention or Full Attention block.
+    if is_full_attention_layer:
+      self.attention = Qwen3NextFullAttention(
+          config=cfg,
+          mesh=self.mesh,
+          quant=self.quant,
+          model_mode=model_mode,
+          layer_idx=self.layer_idx,
+          rngs=rngs,
+      )
+    else:
+      self.attention = Qwen3NextGatedDeltaNet(config=cfg, dtype=cfg.dtype, rngs=rngs)
+
+    # Second LayerNorm, applied before the MoE block.
+    self.post_attention_layernorm = Qwen3NextRMSNorm(
+        num_features=cfg.emb_dim,
+        eps=cfg.normalization_layer_epsilon,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        rngs=rngs,
+    )
+
+    # Instantiate our `Qwen3NextSparseMoeBlock`.
+    self.mlp = Qwen3NextSparseMoeBlock(config=cfg, mesh=self.mesh, quant=self.quant, rngs=rngs)
+
+  def __call__(
+      self,
+      inputs: jnp.ndarray,
+      decoder_segment_ids: None | jnp.ndarray,
+      decoder_positions: None | jnp.ndarray,
+      deterministic: bool,
+      model_mode: str,
+      previous_chunk=None,
+      page_state: None | page_manager.PageState = None,
+      slot: None | int = None,
+  ):
+    residual = inputs
+
+    # First LayerNorm, applied before the attention block.
+    hidden_states = self.input_layernorm(inputs)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+
+    # Conditionally apply either the Linear Attention or Full Attention block.
+    if isinstance(self.attention, Qwen3NextFullAttention):
+      attention_output = cast(Qwen3NextFullAttention, self.attention)(
+          hidden_states,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+      )
+    elif isinstance(self.attention, Qwen3NextGatedDeltaNet):
+      attention_output = cast(Qwen3NextGatedDeltaNet, self.attention)(hidden_states)
+    else:
+      raise TypeError(f"Unexpected type for self.attention: {type(self.attention)}")
+
+    # First residual connection after attention
+    hidden_states = residual + attention_output
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+
+    # Prepare for the MoE block by capturing the new residual
+    residual = hidden_states
+
+    # Second LayerNorm, applied before the MoE block.
+    hidden_states = self.post_attention_layernorm(hidden_states)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+
+    # Instantiate and call our `Qwen3NextSparseMoeBlock`.
+    mlp_output, load_balance_loss = self.mlp(hidden_states, deterministic=deterministic)
+
+    # We sow the load balancing loss so it can be collected and added to the total loss
+    # during training.
+    if load_balance_loss is not None:
+      self.sow("intermediates", "moe_lb_loss", load_balance_loss)
+
+    # Final residual connection (after the MoE block)
+    layer_output = residual + mlp_output
+    layer_output = nn.with_logical_constraint(
+        layer_output,
+        self.activation_axis_names,
+    )
+
+    return layer_output
 
 
 # -----------------------------------------
@@ -213,7 +1094,7 @@ class Qwen3MoeDecoderLayer(AttentionWithNorm):
         num_experts=config.num_experts,
         num_experts_per_tok=config.num_experts_per_tok,
         mesh=mesh,
-        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_init=max_initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
         kernel_axes=("embed", None),
         intermediate_dim=config.moe_mlp_dim,  # same as config.mlp_dim
         dtype=config.dtype,
@@ -253,10 +1134,20 @@ class Qwen3MoeDecoderLayer(AttentionWithNorm):
 
 Qwen3DecoderLayerToLinen = nnx_wrappers.to_linen_class(
     Qwen3DecoderLayer,
-    base_metadata_fn=initializers.variable_to_logically_partitioned,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
 )
 
 Qwen3MoeDecoderLayerToLinen = nnx_wrappers.to_linen_class(
     Qwen3MoeDecoderLayer,
-    base_metadata_fn=initializers.variable_to_logically_partitioned,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3NextDecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Qwen3NextDecoderLayer,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3NextScannableBlockToLinen = nnx_wrappers.to_linen_class(
+    Qwen3NextScannableBlock,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
 )

--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -255,6 +255,12 @@ def validate_keys(keys):
   if keys["decoder_block"] == "llama4":
     validate_llama4_config(keys)
 
+  if keys["decoder_block"] == "qwen3_next":
+    if keys["sparse_matmul"]:
+      raise ValueError(
+          "For Qwen3-Next, sparse_matmul must be False for now. The dense path has been verified against reference."
+      )
+
 
 def validate_tokenizer(keys):
   assert keys[
@@ -391,6 +397,7 @@ def validate_model_name(s: str) -> bool:
       "qwen3-235b-a22b",
       "qwen3-30b-a3b",
       "qwen3-480b-a35b",
+      "qwen3-next-80b-a3b",
       "gpt3-175b",
       "gpt3-22b",
       "gpt3-6b",

--- a/tests/check_qwen3_next_vs_reference.py
+++ b/tests/check_qwen3_next_vs_reference.py
@@ -1,0 +1,853 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for GatedDeltaRule in Qwen3-Next against its PyTorch reference.
+"""
+import unittest
+import os
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh
+from flax import nnx
+
+from MaxText import pyconfig
+from MaxText.layers import qwen3, normalizations
+from MaxText.globals import MAXTEXT_PKG_DIR
+
+
+# ----------------------------------------------------------------------
+# START: Copied PyTorch functions
+# Source: Hugging Face Transformers library
+# https://github.com/huggingface/transformers/blob/a9731a725eb1d7b3b7e11f0ad35a819fa4ee8b20/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+# Note: Some function/class names might be slightly adapted (e.g., _PT suffix) to avoid collisions.
+# ----------------------------------------------------------------------
+def l2norm_torch(x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):
+  """This function is intended to align with the l2norm implementation in the FLA library."""
+  inv_norm = torch.rsqrt((x * x).sum(dim=dim, keepdim=True) + eps)
+  return x * inv_norm
+
+
+def torch_chunk_gated_delta_rule(
+    query,
+    key,
+    value,
+    g,
+    beta,
+    chunk_size=64,
+    initial_state=None,
+    output_final_state=False,
+    # Keep original HF name in PT func signature for clarity
+    use_qk_l2norm_in_kernel=False,
+):
+  """
+  PyTorch implementation of the chunked Gated Delta Rule attention mechanism.
+
+  Based on the Hugging Face Transformers implementation for Qwen3-Next.
+
+  Args:
+    query: Query tensor (B, S, H, K).
+    key: Key tensor (B, S, H, K).
+    value: Value tensor (B, S, H, V).
+    g: Decay tensor (B, S, H).
+    beta: Sigmoid gate tensor (B, S, H).
+    chunk_size: The size of chunks for processing.
+    initial_state: Optional initial hidden state for recurrent processing.
+    output_final_state: Whether to return the final hidden state.
+    use_qk_l2norm_in_kernel: Whether to apply L2 normalization to query and key.
+
+  Returns:
+    A tuple containing the attention output tensor and the final hidden state (if requested).
+  """
+  initial_dtype = query.dtype
+  if use_qk_l2norm_in_kernel:
+    query = l2norm_torch(query, dim=-1, eps=1e-6)
+    key = l2norm_torch(key, dim=-1, eps=1e-6)
+
+  # Transpose (B, S, H, K) -> (B, H, S, K)
+  query, key, value = [x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value)]
+  beta, g = [x.transpose(1, 2).contiguous().to(torch.float32) for x in (beta, g)]
+
+  batch_size, num_heads, sequence_length, k_head_dim = key.shape
+  v_head_dim = value.shape[-1]
+  pad_size = (chunk_size - sequence_length % chunk_size) % chunk_size
+  if pad_size > 0:
+    query = F.pad(query, (0, 0, 0, pad_size))
+    key = F.pad(key, (0, 0, 0, pad_size))
+    value = F.pad(value, (0, 0, 0, pad_size))
+    beta = F.pad(beta, (0, pad_size))
+    g = F.pad(g, (0, pad_size))
+
+  total_sequence_length = sequence_length + pad_size
+  scale = 1 / (query.shape[-1] ** 0.5)
+  query = query * scale
+
+  v_beta = value * beta.unsqueeze(-1)
+  k_beta = key * beta.unsqueeze(-1)
+  # reshape to chunks
+  query, key, value, k_beta, v_beta = [
+      x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1]) for x in (query, key, value, k_beta, v_beta)
+  ]
+  g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
+  mask = torch.triu(
+      torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device),
+      diagonal=0,
+  )
+
+  # chunk decay
+  g = g.cumsum(dim=-1)
+  decay_mask = ((g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float()).tril()
+  attn = -((k_beta @ key.transpose(-1, -2)) * decay_mask).masked_fill(mask, 0)
+  for i in range(1, chunk_size):
+    row = attn[..., i, :i].clone()
+    sub = attn[..., :i, :i].clone()
+    attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
+  attn = attn + torch.eye(chunk_size, dtype=attn.dtype, device=attn.device)
+  value = attn @ v_beta
+  k_cumdecay = attn @ (k_beta * g.exp().unsqueeze(-1))
+  last_recurrent_state = (
+      torch.zeros(batch_size, num_heads, k_head_dim, v_head_dim).to(value)
+      if initial_state is None
+      else initial_state.to(value)
+  )
+  core_attn_out = torch.zeros_like(value)
+  mask = torch.triu(
+      torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device),
+      diagonal=1,
+  )
+
+  # for each chunk
+  for i in range(0, total_sequence_length // chunk_size):
+    q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
+    attn = (q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]).masked_fill_(mask, 0)
+    v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state
+    v_new = v_i - v_prime
+    attn_inter = (q_i * g[:, :, i, :, None].exp()) @ last_recurrent_state
+    core_attn_out[:, :, i] = attn_inter + attn @ v_new
+    last_recurrent_state = (
+        last_recurrent_state * g[:, :, i, -1, None, None].exp()
+        + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(-1, -2) @ v_new
+    )
+
+  if not output_final_state:
+    last_recurrent_state = None
+  core_attn_out = core_attn_out.reshape(core_attn_out.shape[0], core_attn_out.shape[1], -1, core_attn_out.shape[-1])
+  core_attn_out = core_attn_out[:, :, :sequence_length]
+  core_attn_out = core_attn_out.transpose(1, 2).contiguous().to(initial_dtype)
+  return core_attn_out, last_recurrent_state
+
+
+class Qwen3NextRMSNorm_PT(nn.Module):
+  """
+  PyTorch implementation of the custom RMSNorm used in Qwen3-Next.
+
+  This version applies a (1.0 + weight) scaling factor after normalization.
+  """
+
+  def __init__(self, dim: int, eps: float = 1e-6):
+    """Initializes the Qwen3NextRMSNorm_PT layer."""
+    super().__init__()
+    self.eps = eps
+    # The weight is initialized to zeros, matching the real model.
+    self.weight = torch.nn.Parameter(torch.zeros(dim))
+
+  def _norm(self, x):
+    """Applies the RMS normalization."""
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+  def forward(self, x):
+    """Forward pass for Qwen3NextRMSNorm_PT."""
+    output = self._norm(x.float())
+    # The core Qwen3-Next logic: scaling by (1.0 + weight)
+    output = output * (1.0 + self.weight.float())
+    return output.type_as(x)
+
+
+class Qwen3NextMLP_PT(nn.Module):
+  """
+  PyTorch implementation of the MLP block for Qwen3-Next models.
+
+  Uses SiLU activation (SwiGLU).
+  """
+
+  def __init__(self, config, intermediate_size=None):
+    """Initializes the Qwen3NextMLP_PT layer."""
+    super().__init__()
+    self.config = config
+    self.hidden_size = config.hidden_size
+    self.intermediate_size = config.intermediate_size if intermediate_size is None else intermediate_size
+    self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+    self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+    self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+    self.act_fn = F.silu
+
+  def forward(self, x):
+    """Forward pass for the MLP block."""
+    down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+    return down_proj
+
+
+class Qwen3NextExperts_PT(nn.ModuleList):
+  """
+  PyTorch ModuleList containing the expert MLP layers for the MoE block.
+  """
+
+  def __init__(self, config):
+    """Initializes the list of expert MLP layers."""
+    super().__init__()
+    self.num_experts = config.num_experts
+    for _ in range(config.num_experts):
+      self.append(Qwen3NextMLP_PT(config, intermediate_size=config.moe_intermediate_size))
+
+  def forward(
+      self,
+      hidden_states: torch.Tensor,
+      top_k_index: torch.Tensor,
+      top_k_weights: torch.Tensor,
+  ) -> torch.Tensor:
+    """Forward pass for the expert layers."""
+    final_hidden_states = torch.zeros_like(hidden_states)
+    expert_mask = torch.nn.functional.one_hot(top_k_index, num_classes=self.num_experts).permute(2, 1, 0)
+    expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+    for expert_idx in expert_hit:
+      idx, top_x = torch.where(expert_mask[expert_idx].squeeze(0))
+      current_state = hidden_states[None, top_x].reshape(-1, hidden_states.shape[-1])
+      current_hidden_states = self[expert_idx](current_state) * top_k_weights[top_x, idx, None]
+      final_hidden_states.index_add_(0, top_x, current_hidden_states.to(hidden_states.dtype))
+    return final_hidden_states
+
+
+class Qwen3NextSparseMoeBlock_PT(nn.Module):
+  """
+  PyTorch implementation of the Sparse Mixture-of-Experts (MoE) block for Qwen3-Next.
+
+  Includes token routing, expert layers, and a shared expert component.
+  """
+
+  def __init__(self, config):
+    """Initializes the MoE block components."""
+    super().__init__()
+    self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
+    self.experts = Qwen3NextExperts_PT(config)
+    self.num_experts_per_tok = config.num_experts_per_tok
+    self.norm_topk_prob = config.norm_topk_prob
+    self.shared_expert = Qwen3NextMLP_PT(config, intermediate_size=config.shared_expert_intermediate_size)
+    self.shared_expert_gate = torch.nn.Linear(config.hidden_size, 1, bias=False)
+
+  def route_tokens_to_experts(self, hidden_states, router_logits):
+    """
+    Computes routing weights and selects top-k experts for each token.
+
+    Args:
+      hidden_states: Input tensor to determine the dtype for routing weights.
+      router_logits: Logits output by the gating network.
+
+    Returns:
+      A tuple containing the indices of the selected experts and their corresponding routing weights.
+    """
+    routing_weights = F.softmax(router_logits, dim=-1, dtype=torch.float)
+    routing_weights, selected_experts = torch.topk(routing_weights, self.num_experts_per_tok, dim=-1)
+    if self.norm_topk_prob:
+      routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+    routing_weights = routing_weights.to(hidden_states.dtype)
+    return selected_experts, routing_weights
+
+  def forward(self, hidden_states: torch.Tensor):
+    """Forward pass for the Sparse MoE block."""
+    batch_size, sequence_length, hidden_dim = hidden_states.shape
+    hidden_states_reshaped = hidden_states.view(-1, hidden_dim)
+    shared_expert_output = self.shared_expert(hidden_states_reshaped)
+    router_logits = self.gate(hidden_states_reshaped)
+    selected_experts, routing_weights = self.route_tokens_to_experts(hidden_states_reshaped, router_logits)
+    expert_output = self.experts(hidden_states_reshaped, selected_experts, routing_weights)
+    shared_expert_output = F.sigmoid(self.shared_expert_gate(hidden_states_reshaped)) * shared_expert_output
+    expert_output += shared_expert_output
+    expert_output = expert_output.reshape(batch_size, sequence_length, hidden_dim)
+    return expert_output, router_logits
+
+
+class Qwen3NextRMSNormGated_PT(nn.Module):
+  """
+  PyTorch implementation of RMS Normalization with optional gating.
+
+  If a gate tensor is provided, the normalized output is element-wise multiplied by SiLU(gate).
+  """
+
+  def __init__(self, hidden_size, eps=1e-6):
+    """Initializes the RMSNormGated layer."""
+    super().__init__()
+    self.weight = torch.nn.Parameter(torch.ones(hidden_size))
+    self.variance_epsilon = eps
+
+  def forward(self, hidden_states, gate=None):
+    """Forward pass for RMSNormGated."""
+    input_dtype = hidden_states.dtype
+    hidden_states = hidden_states.to(torch.float32)
+    variance = hidden_states.pow(2).mean(-1, keepdim=True)
+    hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+    hidden_states = self.weight * hidden_states
+    if gate is not None:
+      hidden_states = hidden_states * F.silu(gate.to(torch.float32))
+    return hidden_states.to(input_dtype)
+
+
+class Qwen3NextGatedDeltaNet_PT(nn.Module):
+  """
+  PyTorch implementation of the Gated Delta Net (GDN) used in Qwen3-Next.
+
+  This module implements a form of linear attention with gating and convolutional components.
+  """
+
+  def __init__(self, config):
+    """Initializes the Gated Delta Net layers and parameters."""
+    super().__init__()
+    self.hidden_size = config.hidden_size
+    # Use gdn_* names from MaxText config perspective for consistency in PT model setup
+    self.num_v_heads = config.gdn_num_value_heads
+    self.num_k_heads = config.gdn_num_key_heads
+    self.head_k_dim = config.gdn_key_head_dim
+    self.head_v_dim = config.gdn_value_head_dim
+    self.key_dim = self.head_k_dim * self.num_k_heads
+    self.value_dim = self.head_v_dim * self.num_v_heads
+    self.conv_kernel_size = config.gdn_conv_kernel_dim
+    self.activation = config.hidden_act
+    self.layer_norm_epsilon = config.normalization_layer_epsilon
+
+    self.conv_dim = self.key_dim * 2 + self.value_dim
+    self.conv1d = nn.Conv1d(
+        in_channels=self.conv_dim,
+        out_channels=self.conv_dim,
+        bias=False,
+        kernel_size=self.conv_kernel_size,
+        groups=self.conv_dim,
+        padding=self.conv_kernel_size - 1,
+    )
+
+    projection_size_qkvz = self.key_dim * 2 + self.value_dim * 2
+    projection_size_ba = self.num_v_heads * 2
+    self.in_proj_qkvz = nn.Linear(self.hidden_size, projection_size_qkvz, bias=False)
+    self.in_proj_ba = nn.Linear(self.hidden_size, projection_size_ba, bias=False)
+
+    self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads))
+    A = torch.empty(self.num_v_heads).uniform_(0, 16)
+    self.A_log = nn.Parameter(torch.log(A))
+    self.norm = Qwen3NextRMSNormGated_PT(self.head_v_dim, eps=self.layer_norm_epsilon)
+    self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
+
+  def forward(self, hidden_states):
+    """Forward pass for the Gated Delta Net."""
+    batch_size, seq_len, _ = hidden_states.shape
+    projected_states_qkvz = self.in_proj_qkvz(hidden_states)
+    projected_states_ba = self.in_proj_ba(hidden_states)
+
+    # Simplified split for test where num_v_heads == num_k_heads
+    q, k, v, z = torch.split(
+        projected_states_qkvz,
+        [self.key_dim, self.key_dim, self.value_dim, self.value_dim],
+        dim=-1,
+    )
+    b, a = torch.split(projected_states_ba, [self.num_v_heads, self.num_v_heads], dim=-1)
+
+    mixed_qkv = torch.cat((q, k, v), dim=-1).transpose(1, 2)
+    qkv_conv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len]).transpose(1, 2)
+    q_conv, k_conv, v_conv = torch.split(qkv_conv, [self.key_dim, self.key_dim, self.value_dim], dim=-1)
+
+    query = q_conv.reshape(batch_size, seq_len, self.num_k_heads, self.head_k_dim)
+    key = k_conv.reshape(batch_size, seq_len, self.num_k_heads, self.head_k_dim)
+    value = v_conv.reshape(batch_size, seq_len, self.num_v_heads, self.head_v_dim)
+
+    beta = b.sigmoid()
+    g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias.float())
+
+    # Use the renamed config flag when calling the reference function internally
+    core_attn_out, _ = torch_chunk_gated_delta_rule(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        chunk_size=self.config.gdn_chunk_size,  # Use renamed config
+        use_qk_l2norm_in_kernel=self.config.use_qk_norm_in_gdn,  # Use renamed config
+    )
+
+    z_reshaped = z.reshape(batch_size, seq_len, self.num_v_heads, self.head_v_dim)
+    gated_output = self.norm(core_attn_out, z_reshaped)
+    gated_output = gated_output.reshape(batch_size, seq_len, -1)
+    output = self.out_proj(gated_output)
+    return output
+
+
+# ----------------------------------------------------------------------
+# END: Copied PyTorch functions
+# ----------------------------------------------------------------------
+
+
+class TestQwen3Next(unittest.TestCase):
+  """Main test class for Qwen3-Next layers."""
+
+  def setUp(self):
+    """Set up a complete configuration and test environment for all Qwen3-Next tests."""
+    super().setUp()
+    # This setup now includes all necessary parameters for both linear attention and MoE tests.
+    self.cfg = pyconfig.initialize(
+        [
+            None,
+            os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"),
+            # Base settings for the test
+            "run_name=qwen3_next_test",
+            "dtype=float32",
+            "weight_dtype=float32",
+            "matmul_precision=highest",
+            "decoder_block=qwen3_next",
+            # Model dimensions
+            "base_emb_dim=128",
+            "base_num_query_heads=4",
+            "base_num_kv_heads=4",
+            "head_dim=32",
+            # Gated Delta Net Dims (Using renamed parameters)
+            "gdn_num_value_heads=4",
+            "gdn_num_key_heads=4",
+            "gdn_key_head_dim=32",
+            "gdn_value_head_dim=32",
+            "gdn_conv_kernel_dim=4",
+            "gdn_chunk_size=64",
+            "use_qk_norm_in_gdn=True",  # Use renamed parameter
+            "normalization_layer_epsilon=1e-5",
+            # MoE Test Configs (with a small number of experts)
+            "base_mlp_dim=256",
+            "num_experts=8",
+            "num_experts_per_tok=2",
+            "base_moe_mlp_dim=256",  # moe_mlp_dim will be calculated from this
+            "norm_topk_prob=True",
+            "fsdp_shard_on_exp=False",
+            "mlp_activations=['silu', 'linear']",
+            "dropout_rate=0.0",
+            # Force the test to use the 'dense_matmul' path in the MoE layer,
+            # as the 'sparse_matmul' path was found to be numerically incorrect compared to the reference.
+            "sparse_matmul=False",
+        ]
+    )
+    # Update the SimpleNamespace config used by PT models too
+    self.pt_internal_cfg = SimpleNamespace(
+        hidden_size=self.cfg.emb_dim,
+        gdn_num_value_heads=self.cfg.gdn_num_value_heads,
+        gdn_num_key_heads=self.cfg.gdn_num_key_heads,
+        gdn_key_head_dim=self.cfg.gdn_key_head_dim,
+        gdn_value_head_dim=self.cfg.gdn_value_head_dim,
+        gdn_conv_kernel_dim=self.cfg.gdn_conv_kernel_dim,
+        hidden_act="silu",
+        normalization_layer_epsilon=self.cfg.normalization_layer_epsilon,
+        gdn_chunk_size=self.cfg.gdn_chunk_size,
+        use_qk_norm_in_gdn=self.cfg.use_qk_norm_in_gdn,
+        # MoE related for PT models
+        moe_intermediate_size=self.cfg.moe_mlp_dim,
+        shared_expert_intermediate_size=self.cfg.moe_mlp_dim,
+        num_experts=self.cfg.num_experts,
+        num_experts_per_tok=self.cfg.num_experts_per_tok,
+        norm_topk_prob=self.cfg.norm_topk_prob,
+    )
+
+    self.batch_size = 2
+    self.seq_len = 128
+    # Use the emb_dim calculated by pyconfig from base_emb_dim
+    self.hidden_size = self.cfg.emb_dim
+    devices = np.array(jax.devices())
+    num_devices = len(devices)
+
+    # Create a mesh shape where the 'data' axis gets all available devices,
+    # and all other axes defined in the config have a size of 1.
+    mesh_shape = [1] * len(self.cfg.mesh_axes)
+    mesh_shape[self.cfg.mesh_axes.index("data")] = num_devices
+
+    # Create the Mesh object with the full list of axis names from the config.
+    self.mesh = Mesh(devices.reshape(mesh_shape), self.cfg.mesh_axes)
+    torch.manual_seed(0)
+    np.random.seed(0)
+    self.rng = jax.random.PRNGKey(0)
+    self.nnx_rngs = nnx.Rngs(self.rng)
+    print("setUp complete!")
+
+  def test_rms_norm_gated(self):
+    """Tests the Qwen3NextRMSNormGated layer."""
+    print("Running test_rms_norm_gated...")
+    hidden_states_pt = torch.randn(self.batch_size, self.seq_len, self.hidden_size)
+    gate_pt = torch.randn(self.batch_size, self.seq_len, self.hidden_size)
+    weight_pt = torch.rand(self.hidden_size)
+
+    # PyTorch reference
+    pt_model = Qwen3NextRMSNormGated_PT(self.hidden_size, eps=self.cfg.normalization_layer_epsilon)
+    pt_model.weight.data = weight_pt
+    pt_model.eval()
+    with torch.no_grad():
+      expected_output = pt_model(hidden_states_pt, gate_pt)
+
+    # JAX implementation
+    jax_model = qwen3.Qwen3NextRMSNormGated(
+        num_features=self.hidden_size,
+        eps=self.cfg.normalization_layer_epsilon,
+        dtype=self.cfg.dtype,
+        weight_dtype=self.cfg.weight_dtype,
+        rngs=self.nnx_rngs,
+    )
+    params = {"weight": nnx.Param(jnp.array(weight_pt.numpy()))}
+    nnx.update(jax_model, params)
+    hidden_states_jax = jnp.array(hidden_states_pt.numpy())
+    gate_jax = jnp.array(gate_pt.numpy())
+
+    @jax.jit
+    def run_jax(hidden_states, gate):
+      """Runs the JAX RMSNormGated model."""
+      return jax_model(hidden_states, gate)
+
+    actual_output = run_jax(hidden_states_jax, gate_jax)
+
+    np.testing.assert_allclose(
+        expected_output.numpy(),
+        actual_output,
+        rtol=1e-5,
+        atol=1e-6,  # Tight tolerance for this layer
+        err_msg="Qwen3NextRMSNormGated does not match PyTorch reference!",
+    )
+    print("test_rms_norm_gated passed!")
+
+  def test_l2norm(self):
+    """Tests the l2norm function."""
+    print("Running test_l2norm...")
+    # Use renamed config parameters
+    x_pt = torch.randn(
+        self.batch_size,
+        self.seq_len,
+        self.cfg.gdn_num_value_heads,
+        self.cfg.gdn_key_head_dim,
+    )
+    expected_output = l2norm_torch(x_pt)
+    # Call l2norm from normalizations module now
+    actual_output = normalizations.l2norm(jnp.array(x_pt.numpy()))
+    np.testing.assert_allclose(
+        expected_output.numpy(),
+        actual_output,
+        rtol=1e-5,
+        atol=1e-6,
+        err_msg="l2norm does not match PyTorch reference!",
+    )
+    print("test_l2norm passed!")
+
+  def test_chunk_gated_delta_rule_logic(self):
+    """
+    Directly tests the `jax_chunk_gated_delta_rule` against the original PyTorch reference.
+    """
+    print("Running test_chunk_gated_delta_rule_logic...")
+    # Use renamed config parameters
+    num_heads = self.cfg.gdn_num_value_heads
+    k_head_dim = self.cfg.gdn_key_head_dim
+    v_head_dim = self.cfg.gdn_value_head_dim
+    chunk_size = self.cfg.gdn_chunk_size
+
+    key = jax.random.PRNGKey(42)
+    key_q, key_k, key_v, key_g, key_beta = jax.random.split(key, 5)
+
+    # Shapes are (B, S, H, D)
+    q_jax = (
+        jax.random.normal(
+            key_q,
+            (self.batch_size, self.seq_len, num_heads, k_head_dim),
+            dtype=jnp.float32,
+        )
+        * 0.1
+    )
+    k_jax = (
+        jax.random.normal(
+            key_k,
+            (self.batch_size, self.seq_len, num_heads, k_head_dim),
+            dtype=jnp.float32,
+        )
+        * 0.1
+    )
+    v_jax = (
+        jax.random.normal(
+            key_v,
+            (self.batch_size, self.seq_len, num_heads, v_head_dim),
+            dtype=jnp.float32,
+        )
+        * 0.1
+    )
+    g_jax = jax.random.normal(key_g, (self.batch_size, self.seq_len, num_heads), dtype=jnp.float32) * 0.1
+    beta_jax = jax.random.uniform(key_beta, (self.batch_size, self.seq_len, num_heads), dtype=jnp.float32)
+
+    q_torch = torch.from_numpy(np.asarray(q_jax).copy())
+    k_torch = torch.from_numpy(np.asarray(k_jax).copy())
+    v_torch = torch.from_numpy(np.asarray(v_jax).copy())
+    g_torch = torch.from_numpy(np.asarray(g_jax).copy())
+    beta_torch = torch.from_numpy(np.asarray(beta_jax).copy())
+
+    target_atol = 1e-6
+    target_rtol = 1e-6
+
+    # Test without L2Norm (pass False using the original PT arg name)
+    torch_output, _ = torch_chunk_gated_delta_rule(
+        q_torch.clone(),
+        k_torch.clone(),
+        v_torch.clone(),
+        g_torch.clone(),
+        beta_torch.clone(),
+        chunk_size=chunk_size,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=False,
+    )
+    # Pass False using the new JAX arg name
+    jax_output, _ = qwen3.jax_chunk_gated_delta_rule(
+        q_jax,
+        k_jax,
+        v_jax,
+        g_jax,
+        beta_jax,
+        chunk_size=chunk_size,
+        initial_state=None,
+        use_qk_norm_in_gdn=False,
+    )
+    np.testing.assert_allclose(
+        torch_output.detach().numpy(),
+        np.asarray(jax_output),
+        atol=target_atol,
+        rtol=target_rtol,
+        err_msg=f"JAX and PyTorch outputs are NOT close without L2Norm within atol={target_atol}, rtol={target_rtol}!",
+    )
+    print(f"JAX and PyTorch outputs are close without L2Norm within atol={target_atol}, rtol={target_rtol}!")
+
+    # Test with L2Norm (pass True using the original PT arg name)
+    torch_output_norm, _ = torch_chunk_gated_delta_rule(
+        q_torch.clone(),
+        k_torch.clone(),
+        v_torch.clone(),
+        g_torch.clone(),
+        beta_torch.clone(),
+        chunk_size=chunk_size,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+    # Pass True using the new JAX arg name
+    jax_output_norm, _ = qwen3.jax_chunk_gated_delta_rule(
+        q_jax,
+        k_jax,
+        v_jax,
+        g_jax,
+        beta_jax,
+        chunk_size=chunk_size,
+        initial_state=None,
+        use_qk_norm_in_gdn=True,
+    )
+    np.testing.assert_allclose(
+        torch_output_norm.detach().numpy(),
+        np.asarray(jax_output_norm),
+        atol=target_atol,
+        rtol=target_rtol,
+        err_msg=f"JAX and PyTorch outputs are NOT close with L2Norm within atol={target_atol}, rtol={target_rtol}!",
+    )
+    print(f"JAX and PyTorch outputs are close with L2Norm within atol={target_atol}, rtol={target_rtol}!")
+    print("test_chunk_gated_delta_rule_logic passed!")
+
+  def test_gated_delta_net_structure(self):
+    """Tests the structure and output shape of Qwen3NextGatedDeltaNet."""
+    print("Running test_gated_delta_net_structure...")
+    hidden_states_jax = jnp.ones((self.batch_size, self.seq_len, self.hidden_size), dtype=self.cfg.dtype)
+
+    jax_model = qwen3.Qwen3NextGatedDeltaNet(config=self.cfg, rngs=self.nnx_rngs)
+
+    @jax.jit
+    def run_jax(hidden_states):
+      """Runs the JAX GatedDeltaNet model."""
+      return jax_model(hidden_states, deterministic=True)
+
+    output_jax = run_jax(hidden_states_jax)
+
+    self.assertEqual(output_jax.shape, (self.batch_size, self.seq_len, self.hidden_size))
+
+    print("test_gated_delta_net_structure passed!")
+
+  def test_qwen3_next_rms_norm(self):
+    """Tests the custom Qwen3NextRMSNorm layer against its PyTorch reference."""
+    print("Running test_qwen3_next_rms_norm...")
+    # 1. Set up the PyTorch reference model and inputs.
+    hidden_states_pt = torch.randn(self.batch_size, self.seq_len, self.hidden_size)
+    weight_pt = torch.rand(self.hidden_size)
+
+    pt_model = Qwen3NextRMSNorm_PT(self.hidden_size, eps=self.cfg.normalization_layer_epsilon)
+    pt_model.weight.data = weight_pt
+    pt_model.eval()
+
+    with torch.no_grad():
+      expected_output = pt_model(hidden_states_pt)
+
+    # 2. Set up the JAX implementation.
+    jax_model = qwen3.Qwen3NextRMSNorm(
+        num_features=self.hidden_size,
+        eps=self.cfg.normalization_layer_epsilon,
+        dtype=jnp.float32,
+        weight_dtype=jnp.float32,
+        rngs=self.nnx_rngs,
+    )
+
+    params = {"weight": nnx.Param(jnp.array(weight_pt.numpy()))}
+    nnx.update(jax_model, params)
+    hidden_states_jax = jnp.array(hidden_states_pt.numpy())
+
+    @jax.jit
+    def run_jax(x):
+      """Runs the JAX Qwen3NextRMSNorm model."""
+      return jax_model(x)
+
+    actual_output = run_jax(hidden_states_jax)
+
+    # 3. Compare the outputs.
+    np.testing.assert_allclose(
+        expected_output.numpy(),
+        actual_output,
+        rtol=1e-6,
+        atol=1e-6,
+        err_msg="Qwen3NextRMSNorm does not match PyTorch reference!",
+    )
+    print("test_qwen3_next_rms_norm passed!")
+
+  def test_qwen3_next_sparse_moe_block(self):
+    """
+    Tests the full Qwen3NextSparseMoeBlock against its PyTorch reference.
+
+    This test passes by setting `sparse_matmul=False` in the config, which forces the
+    underlying `RoutedMoE` module to use its `dense_matmul` implementation.
+    """
+    print("Running test_qwen3_next_sparse_moe_block...")
+    # 1. Use the SimpleNamespace config created in setUp for PT model
+    pt_config = self.pt_internal_cfg
+
+    # 2. Set up the PyTorch reference model and get the expected output
+    pt_model = Qwen3NextSparseMoeBlock_PT(pt_config)
+    pt_model.eval()
+    hidden_states_pt = torch.randn(self.batch_size, self.seq_len, self.cfg.emb_dim)
+    with torch.no_grad():
+      expected_output, _ = pt_model(hidden_states_pt)
+
+    # 3. Construct the JAX params tree, ensuring weights are correctly transposed
+    pt_experts = pt_model.experts
+    stacked_gate_proj = torch.stack([expert.gate_proj.weight.T for expert in pt_experts])
+    stacked_up_proj = torch.stack([expert.up_proj.weight.T for expert in pt_experts])
+    stacked_down_proj = torch.stack([expert.down_proj.weight.T for expert in pt_experts])
+
+    # Map PyTorch weights to JAX NNX module attributes
+    jax_params = {
+        "routed_experts": {
+            "gate": {"kernel": nnx.Param(jnp.array(pt_model.gate.weight.T.detach().numpy()))},
+            "wi_0": nnx.Param(jnp.array(stacked_gate_proj.detach().numpy())),
+            "wi_1": nnx.Param(jnp.array(stacked_up_proj.detach().numpy())),
+            "wo": nnx.Param(jnp.array(stacked_down_proj.detach().numpy())),
+        },
+        "shared_expert": {
+            "wi": {  # Assuming fused_mlp=True in config for shared_expert
+                "0": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.gate_proj.weight.T.detach().numpy()))},
+                "1": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.up_proj.weight.T.detach().numpy()))},
+            },
+            "wo": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.down_proj.weight.T.detach().numpy()))},
+        },
+        "shared_expert_gate": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert_gate.weight.T.detach().numpy()))},
+    }
+    # Adjust shared_expert structure if not fused
+    if not self.cfg.fused_mlp:
+      jax_params["shared_expert"] = {
+          "wi_0": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.gate_proj.weight.T.detach().numpy()))},
+          "wi_1": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.up_proj.weight.T.detach().numpy()))},
+          "wo": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.down_proj.weight.T.detach().numpy()))},
+      }
+
+    # 4. Set up and run the full JAX Qwen3NextSparseMoeBlock
+    jax_model = qwen3.Qwen3NextSparseMoeBlock(config=self.cfg, mesh=self.mesh, quant=None, rngs=self.nnx_rngs)
+    nnx.update(jax_model, jax_params)
+    hidden_states_jax = jnp.array(hidden_states_pt.numpy())
+
+    @jax.jit
+    def run_jax(x):
+      """Runs the JAX SparseMoeBlock model."""
+      output, _ = jax_model(x, deterministic=True)
+      return output
+
+    actual_output = run_jax(hidden_states_jax)
+
+    # 5. Compare the outputs
+    np.testing.assert_allclose(
+        expected_output.detach().numpy(),
+        actual_output,
+        rtol=1e-5,
+        atol=1e-5,
+        err_msg="Qwen3NextSparseMoeBlock does not match PyTorch reference!",
+    )
+    print("test_qwen3_next_sparse_moe_block passed!")
+
+  def test_gated_delta_net_full(self):
+    """Tests the full Qwen3NextGatedDeltaNet layer for numerical correctness."""
+    print("Running test_gated_delta_net_full...")
+    # 1. Use the SimpleNamespace config created in setUp for PT model
+    pt_config = self.pt_internal_cfg
+
+    pt_model = Qwen3NextGatedDeltaNet_PT(pt_config).eval()
+    # Add MaxText config ref to PT model instance for internal use
+    pt_model.config = self.cfg
+
+    hidden_states_pt = torch.randn(self.batch_size, self.seq_len, self.cfg.emb_dim)
+    with torch.no_grad():
+      expected_output = pt_model(hidden_states_pt)
+
+    # 2. Setup JAX model and map weights
+    jax_model = qwen3.Qwen3NextGatedDeltaNet(config=self.cfg, dtype=jnp.float32, rngs=self.nnx_rngs)
+
+    conv1d_weight_pt = pt_model.conv1d.weight.detach().numpy()
+    # Transpose PT (out, in/groups, kw) -> JAX (kw, in/groups, out)
+    # For depthwise, out=in=groups, so PT=(C, 1, kw) -> JAX=(kw, 1, C)
+    conv1d_weight_jax = np.transpose(conv1d_weight_pt, (2, 1, 0))
+
+    params = {
+        "in_proj_qkvz": {"kernel": nnx.Param(jnp.array(pt_model.in_proj_qkvz.weight.T.detach().numpy()))},
+        "in_proj_ba": {"kernel": nnx.Param(jnp.array(pt_model.in_proj_ba.weight.T.detach().numpy()))},
+        "conv1d": {"kernel": nnx.Param(jnp.array(conv1d_weight_jax))},
+        "A_log": nnx.Param(jnp.array(pt_model.A_log.detach().numpy())),
+        "dt_bias": nnx.Param(jnp.array(pt_model.dt_bias.detach().numpy())),
+        "norm": {"weight": nnx.Param(jnp.array(pt_model.norm.weight.detach().numpy()))},
+        "out_proj": {"kernel": nnx.Param(jnp.array(pt_model.out_proj.weight.T.detach().numpy()))},
+    }
+    nnx.update(jax_model, params)
+    hidden_states_jax = jnp.array(hidden_states_pt.numpy())
+
+    @jax.jit
+    def run_jax(x):
+      """Runs the JAX GatedDeltaNet model."""
+      return jax_model(x, deterministic=True)
+
+    actual_output = run_jax(hidden_states_jax)
+
+    # 3. Compare outputs
+    np.testing.assert_allclose(
+        expected_output.numpy(),
+        actual_output,
+        rtol=1e-4,
+        atol=1e-4,  # Relaxed tolerance slightly for end-to-end layer
+        err_msg="Qwen3NextGatedDeltaNet does not match PyTorch reference!",
+    )
+    print("test_gated_delta_net_full passed!")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
### TL;DR

-   **What**: This PR integrates the **Qwen3-Next** architecture into MaxText. Key features include a hybrid attention mechanism combining a **Gated Delta Net** (a form of linear attention) with standard attention, and an ultra-sparse MoE block that includes a **shared expert**.

-   **How**: By implementing several new, highly-optimized JAX layers (`Qwen3NextGatedDeltaNet`, `Qwen3NextSparseMoeBlock`, `Qwen3NextRMSNorm`), creating a hybrid `Qwen3NextDecoderLayer` that alternates between attention types based on the `full_attention_interval`, and validating each new component against a PyTorch reference in a robust new test suite.

* * * * *

### Detailed Description

This pull request introduces an implementation of the Qwen3-Next architecture, as described in the [official Qwen3-Next blog post](https://qwen.ai/blog?id=4074cca80393150c248e508aa62983f9cb7d27cd&from=research.latest-advancements-list).

#### **Architectural Implementation (`src/MaxText/layers/qwen3.py`)**

-   **Hybrid Attention**: The core of this architecture is its hybrid attention system. This PR implements:

    -   **`Qwen3NextGatedDeltaNet`**: A full JAX implementation of the Gated Delta Net for efficient linear attention. The core recurrence is handled by the pure JAX `jax_chunk_gated_delta_rule`, a parallel scan algorithm.

    -   **`Qwen3NextFullAttention`**: A **placeholder** for the model's standard attention layers.

-   **Custom Normalization**: A custom **`Qwen3NextRMSNorm`** layer is included where the learnable weight is initialized to zeros and applied as `(1.0 + weight)`, matching the reference implementation's specific behavior.

* * * * *

#### **Decoder and Model Integration**

-   **`Qwen3NextDecoderLayer`**: This new decoder layer acts as the hybrid controller. Based on its `layer_idx` and the `full_attention_interval` config parameter, it conditionally invokes either the `Qwen3NextGatedDeltaNet` or the `Qwen3NextFullAttention` layer before passing the result to the `Qwen3NextSparseMoeBlock`.

-   **Scanned Layers**: The implementation also introduces a **`Qwen3NextScannableBlock`**.

-   **Configuration**: A new model config `qwen3-next-80b-a3b.yml` is added, along with the necessary parameters in `base.yml` to control the new architectural features.

* * * * *

#### **Testing and Validation**

This PR includes a new test file, `tests/check_qwen3_next_vs_reference.py`.

-   It directly copies the reference PyTorch implementations for each new component.

-   It provides granular unit tests that validate the numerical output of each JAX module (`Qwen3NextGatedDeltaNet`, `Qwen3NextSparseMoeBlock`, etc.) against its corresponding PyTorch reference.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed.
