### PR TITLE
Fix JAX version bugs for nightly image

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -51,7 +51,7 @@ jobs:
       device_name: v4-8
       cloud_runner: linux-x86-n2-16-buildkit
       build_mode: jax_ai_image
-      base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:jax0.7.0_rev1
+      base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:latest
 
   gpu_image:
     needs: prelim

--- a/maxtext_jax_ai_image.Dockerfile
+++ b/maxtext_jax_ai_image.Dockerfile
@@ -50,13 +50,15 @@ RUN if [ "$DEVICE" = "tpu" ] && [ "$JAX_STABLE_STACK_BASEIMAGE" = "us-docker.pkg
 # Install google-tunix for TPU devices, skip for GPU
 RUN if [ "$DEVICE" = "tpu" ]; then \
         python3 -m pip install 'google-tunix>=0.1.2'; \
-        echo "tunix installed, MODE is $MODE"; \
-        echo $MODE; \
         echo $JAX_AI_IMAGE_BASEIMAGE; \
         # TODO: Once tunix stopped pinning jax 0.7.1, we should remove our 0.7.0 version pin (b/450286600)
-        if [ "$MODE" = "stable_stack" ]; then \
-          python3 -m pip install 'jax==0.7.0' 'jaxlib==0.7.0' 'libtpu==0.0.19'; \
-        fi; \
+        if [[ "$JAX_AI_IMAGE_BASEIMAGE" == *"nightly"* ]]; then \
+            echo "Nightly image detected"; \
+            python3 -m pip install --upgrade jax jaxlib; \
+        else \
+            echo "Non-nightly image"; \
+            python3 -m pip install 'jax==0.7.0' 'jaxlib==0.7.0' 'libtpu==0.0.19'; \
+        fi
   fi
 
 # Now copy the remaining code (source files that may change frequently)


### PR DESCRIPTION
# Description

Skip the JAX 0.7.0 installation for the nightly images. Only do so for the stable_stack used in GitHub CI.

[b/451429959](https://b.corp.google.com/issues/451429959)

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
