### PR TITLE
Update patch to ensure maxtext images are downgraded to 0.7.0

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -51,7 +51,7 @@ jobs:
       device_name: v4-8
       cloud_runner: linux-x86-n2-16-buildkit
       build_mode: jax_ai_image
-      base_image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:latest
+      base_image: us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.7.0-rev1
 
   gpu_image:
     needs: prelim


### PR DESCRIPTION
# Description

Maxtext unit tests are having a mismatch between jax version and libtpu version. They initially pull the 0.7.2 JAII, then downgrade only the jax and jaxlib versions to 0.7.2, but not the corresponding libtpu version. This is causing pallas libtpu error for unit tests using pathways backend. 

Notice 1: The downgrade to jax 0.7.0 is because google-tunix has a requirement to be <= 0.7.1 jax. Once tunix removes the jax version pin, we will revert these changes to the normal flow.

# Tests

Building a maxtext image and will verify the pip freeze: https://paste.googleplex.com/6454746957348864

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
