### PR TITLE
A trial of apply @fused to optimzier state offloading

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -705,6 +705,8 @@ mu_dtype: "" # data type to store "mu" of AdamW tracking the first moment. Inher
 # Setting nu_dtype is not yet supported by optax, instead nu_dtype is always inherited from weights.
 # See b/399961932 for more.
 
+adamw_fused_memory_host_offload: False # Use fused AdamW with memory host offloading.
+
 # Stack trace parameters
 collect_stack_trace: False
 stack_trace_to_cloud: False  # Uploads to cloud logging if True, else to the console if False.

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -957,6 +957,10 @@ class AdamW(BaseModel):
       "",
       description="Data type for 'mu' (first moment) in AdamW. Inherits from weight_dtype if empty.",
   )
+  adamw_fused_memory_host_offload: bool = Field(
+      False,
+      description="Use fused AdamW with memory host offloading.",
+  )
 
 
 class PositionalEmbedding(BaseModel):

--- a/src/MaxText/maxtext_utils.py
+++ b/src/MaxText/maxtext_utils.py
@@ -916,7 +916,7 @@ def get_abstract_state(model, tx, config, rng, mesh, is_training=True):
             state_mesh_shardings.opt_state,
         )
     )
-  if is_training and config.optimizer_memory_host_offload:
+  if is_training and (config.optimizer_memory_host_offload or config.adamw_fused_memory_host_offload):
     opt_state = jax.tree_util.tree_map(lambda x: x.with_memory_kind(kind="pinned_host"), state_mesh_shardings.opt_state)
     state_mesh_shardings = state_mesh_shardings.replace(opt_state=opt_state)
   if is_training and config.parameter_memory_host_offload:


### PR DESCRIPTION
Apply @jax.fused to optimizer state and parameter update. This can avoid memory copies while offloading the optimizer states to the host memory. The device will read and write the host memory directly with fine grained memory control.