### PR TITLE
[setup.sh] Fix Python version check to correctly lexicographically compare

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -49,7 +49,7 @@ fi
 PY_VERSION=${PY_VERSION##* }
 PY_VERSION=${PY_VERSION%.*}
 # shellcheck disable=SC2072
-if [ "$PYTHON_VERSION" \< '3.12' ]; then
+if [[ '3.12' > "$PY_VERSION" ]]; then
     echo -e "\n\e[31mERROR: Outdated Python Version! You are currently using ${PY_VERSION}.*, but MaxText requires Python version 3.12 or higher.\e[0m"
     # Ask the user if they want to create a virtual environment with uv
     read -p "Would you like to create a Python 3.12 virtual environment using uv? (y/n) " -n 1 -r


### PR DESCRIPTION
# Description

[setup.sh] Fix Python version check to correctly lexicographically compare

# Tests

```sh
$ python3 --version
Python 3.12.8
$ PY_VERSION=$(python3 --version 2>&1)
$ PY_VERSION=${PY_VERSION##* }
$ PY_VERSION=${PY_VERSION%.*}
$ printf '%s\n' "$PY_VERSION"
3.12
$ if [[ ! "$PY_VERSION" > '3.11' ]]; then echo less than ; else echo gte ; fi
gte
$ PY_VERSION='3.13'
$ if [[ ! "$PY_VERSION" > '3.11' ]]; then echo less than ; else echo gte ; fi
gte
$ PY_VERSION='3.11'
$ if [[ ! "$PY_VERSION" > '3.11' ]]; then echo less than ; else echo gte ; fi
less than
$ PY_VERSION='3.12'
$ if [[ ! "$PY_VERSION" > '3.11' ]]; then echo less than ; else echo gte ; fi
gte
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).