### PR TITLE
[GRPO] grpo_trainer's train_step arguments to match other trainers

### DIFF
--- a/src/MaxText/experimental/rl/grpo_trainer.py
+++ b/src/MaxText/experimental/rl/grpo_trainer.py
@@ -340,7 +340,7 @@ def grpo_loss_fn(model, config, data, dropout_rng, params, reference_params, is_
 # -----------------------------------------------------------------------------
 
 
-def train_step(model, config, state_mesh_shardings, state, data, dropout_rng):
+def train_step(model, config, state_mesh_shardings, params_shardings, state, data, dropout_rng):
   """Performs a single training step of the GRPO algorithm.
 
   This function computes the GRPO loss, calculates gradients, and updates the
@@ -351,6 +351,8 @@ def train_step(model, config, state_mesh_shardings, state, data, dropout_rng):
     model: The transformer model to be trained.
     config: The training configuration object.
     state_mesh_shardings: Pytree of sharding specifications for the training state.
+    params_shardings: Pytree of sharding specifications for the model parameters.
+                      This argument is not used and is kept to match the signature of other trainers.
     state: The current training state, including parameters and optimizer state.
     data: A batch of training data, including prompts and generated completions.
     dropout_rng: JAX PRNG key for dropout.


### PR DESCRIPTION
# Description

A recent change to train_step arguments in train.py broke grpo_trainer.py cause grpo_trainer depends on `train_utils.jit_train_and_eval_step` to jit its train_step. 


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

run locally

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
