### PR TITLE
Migrate jax.experimental.shardmap to jax.shardmap

### DIFF
--- a/pedagogical_examples/shmap_collective_matmul.py
+++ b/pedagogical_examples/shmap_collective_matmul.py
@@ -29,7 +29,6 @@ import jax.numpy as jnp
 from jax.experimental.pjit import pjit
 from jax.sharding import PartitionSpec as P
 from jax.sharding import Mesh
-from jax.experimental.shard_map import shard_map
 
 MESH_DATA_AXIS = "dp"
 MESH_FSDP_AXIS = "fsdp"
@@ -103,14 +102,14 @@ jit_matmul = pjit(matmul, out_shardings=P(MESH_FSDP_AXIS, None, MESH_TENSOR_AXIS
 
 
 @partial(
-    shard_map,
+    jax.shard_map,
     mesh=global_mesh,
     in_specs=(
         P(MESH_FSDP_AXIS, MESH_TENSOR_AXIS, None),
         P(MESH_FSDP_AXIS, MESH_TENSOR_AXIS, None),
     ),
     out_specs=P(MESH_FSDP_AXIS, None, MESH_TENSOR_AXIS, None),
-    check_rep=False,
+    check_vma=False,
 )
 def collective_matmul(activations, weights):  # pylint: disable=redefined-outer-name
   """Collective matrix multiply"""

--- a/src/MaxText/inference/paged_attention.py
+++ b/src/MaxText/inference/paged_attention.py
@@ -21,7 +21,6 @@ import functools
 
 import jax
 import jax.numpy as jnp
-from jax.experimental.shard_map import shard_map
 from jax.experimental.pallas.ops.tpu.paged_attention import paged_attention_kernel
 from jax.sharding import PartitionSpec as P
 from jax.sharding import Mesh
@@ -327,7 +326,7 @@ class PagedAttentionOp(nnx.Module):
     q_pspec = nn.logical_to_mesh_axes((None, None, "paged_kv_heads", None))
 
     @functools.partial(
-        shard_map,
+        jax.shard_map,
         mesh=self.mesh,
         in_specs=(
             q_pspec,
@@ -338,7 +337,7 @@ class PagedAttentionOp(nnx.Module):
             None,
         ),
         out_specs=q_pspec,
-        check_rep=False,
+        check_vma=False,
     )
     def wrap_paged_attention(q, k_pages, v_pages, lengths, page_indices, pages_per_compute_block):
       q = jnp.squeeze(q, axis=1)

--- a/src/MaxText/layers/moe.py
+++ b/src/MaxText/layers/moe.py
@@ -25,7 +25,6 @@ import flax.linen as nn
 from flax import nnx
 import jax
 from jax import ad_checkpoint as adc
-from jax.experimental import shard_map
 from jax.experimental import xla_metadata
 import jax.numpy as jnp
 import numpy as np
@@ -908,7 +907,7 @@ class RoutedMoE(nnx.Module):
       wo_pspec = aqt.partition_spec(wo_pspec, (1,), wo_kernel.dtype, use_bias=False)
 
     @functools.partial(
-        shard_map.shard_map,
+        jax.shard_map,
         mesh=self.mesh,
         in_specs=(
             input_partition_pspec,
@@ -923,7 +922,7 @@ class RoutedMoE(nnx.Module):
             None,
         ),
         out_specs=(nn.logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", "activation_embed"))),
-        check_rep=False,
+        check_vma=False,
     )
     def wrapper(x, logits, pre_bias_logits, w0, w1, wo, w0_bias, w1_bias, wo_bias, rngs):
       batch_size, sequence_length, _ = x.shape


### PR DESCRIPTION
# Description

`jax.experimental.shardmap.shardmap` is deprecated in jax==0.8.0, see [link](https://source.corp.google.com/piper///depot/google3/third_party/py/jax/experimental/shard_map.py;rcl=818706343;cl=820475662;l=20). Migrate all shardmap to `jax.shardmap` and update `check_rep` to `check_vma` due to shardmap changes.

# Tests

Standard MaxText tests.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
