### PR TITLE
Add missing page_state for Mixtral call

### DIFF
--- a/src/MaxText/layers/mixtral.py
+++ b/src/MaxText/layers/mixtral.py
@@ -135,6 +135,8 @@ class MixtralDecoderLayer(nnx.Module):
       deterministic,
       model_mode,
       previous_chunk=None,
+      page_state=None,
+      slot=None,
   ):
 
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)


### PR DESCRIPTION
# Description

The previous missing page_state for Mixtral __call__ leads to broken XLML test. This PR adds back the missing page_sate and slot.

FIXS: b/453745922

# Tests

Standard MaxText tests.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
