### PR TITLE
Qwen3-Next Gated FullAttention Implementation

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -905,6 +905,8 @@ gdn_num_value_heads: 32
 gdn_chunk_size: 64
 # Whether to apply L2 normalization to query and key tensors inside the Gated Delta Rule kernel.
 use_qk_norm_in_gdn: True
+# The ratio of dimension to apply ROPE on
+partial_rotary_factor: 1.0
 
 # Use tokamax library for gmm kernel implementation
 use_tokamax_gmm: false

--- a/src/MaxText/configs/models/qwen3-next-80b-a3b.yml
+++ b/src/MaxText/configs/models/qwen3-next-80b-a3b.yml
@@ -45,3 +45,4 @@ gdn_chunk_size: 64
 
 # RoPE Settings
 rope_max_timescale: 10000000
+partial_rotary_factor: 0.25

--- a/src/MaxText/layers/normalizations.py
+++ b/src/MaxText/layers/normalizations.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from flax import linen as nn
 from flax import nnx
+from flax.linen import initializers as linen_initializers
 from jax import lax
 import jax
 import jax.numpy as jnp
@@ -26,7 +27,7 @@ from MaxText import max_logging
 from MaxText import max_utils
 from MaxText.layers import nnx_wrappers
 from MaxText.layers.initializers import Initializer, variable_to_logically_partitioned
-from MaxText.common_types import Array, ShardMode
+from MaxText.common_types import Array, DType, ShardMode
 
 
 class RMSNorm(nnx.Module):
@@ -42,6 +43,7 @@ class RMSNorm(nnx.Module):
       kernel_axes: tuple[None | str, ...] = (),
       scale_init: Initializer = nn.initializers.ones,
       parameter_memory_host_offload: bool = False,
+      scale_offset: float = 0.0,
       *,
       rngs: nnx.Rngs,
   ):
@@ -53,6 +55,7 @@ class RMSNorm(nnx.Module):
     self.kernel_axes = kernel_axes
     self.scale_init = scale_init
     self.parameter_memory_host_offload = parameter_memory_host_offload
+    self.scale_offset = scale_offset
     self.scale = nnx.Param(
         scale_init(rngs.params(), (num_features,), weight_dtype),
         sharding=kernel_axes,
@@ -73,8 +76,83 @@ class RMSNorm(nnx.Module):
       out_sharding = None
 
     scale = jnp.asarray(scale, self.dtype)
+    effective_scale = scale + self.scale_offset  # Apply offset
     # broadcast 2nd input then element-wise mul
-    return jnp.einsum("i...k,...k->i...k", y, scale, out_sharding=out_sharding)
+    return jnp.einsum("i...k,...k->i...k", y, effective_scale, out_sharding=out_sharding)
+
+
+def Qwen3NextRMSNorm(num_features: int, eps: float, dtype: DType, weight_dtype: DType, *, rngs: nnx.Rngs):
+  """
+  Used for input and post attention layernorms
+  in Qwen3NextDecoderLayer.
+
+  This normalization layer is specific to Qwen3-Next. Key characteristics:
+  1.  The learnable scale parameter `scale` is initialized to ZEROS.
+  2.  The scale is applied as `(1.0 + self.scale)`, making the initial scale effectively 1.0.
+      This matches the PyTorch implementation of Qwen3NextRMSNorm.
+  """
+  return nnx.data(
+      RMSNorm(
+          num_features=num_features,
+          epsilon=eps,
+          dtype=dtype,
+          weight_dtype=weight_dtype,
+          scale_init=linen_initializers.zeros,
+          scale_offset=1.0,
+          rngs=rngs,
+      )
+  )
+
+
+class Qwen3NextRMSNormGated(nnx.Module):
+  """
+  This applies RMS Normalization and then a gated activation function (SiLU).
+  This is used within the Qwen3NextGatedDeltaNet.
+
+  The normalization is performed by an internal `RMSNorm` instance (`self.rms_norm`),
+  which has its own learnable `scale` parameter, initialized to ONES.
+
+  Attributes:
+    num_features: The number of features in the input.
+    eps: A small epsilon value to prevent division by zero in RMSNorm.
+    dtype: The datatype of the computation.
+    weight_dtype: The datatype of the internal RMSNorm scale.
+  """
+
+  def __init__(self, num_features: int, eps: float, dtype: DType, weight_dtype: DType, *, rngs: nnx.Rngs):
+    self.num_features = num_features
+    self.eps = eps
+    self.dtype = dtype
+    self.weight_dtype = weight_dtype
+    self.rms_norm = nnx.data(
+        RMSNorm(
+            num_features=num_features,
+            epsilon=eps,
+            dtype=dtype,
+            weight_dtype=weight_dtype,
+            scale_init=nnx.initializers.ones,
+            rngs=rngs,
+        )
+    )
+
+  def __call__(self, hidden_states: Array, gate: Array) -> Array:
+    """
+    Applies RMSNorm and then a SiLU gate.
+
+    Args:
+      hidden_states: The input array to be normalized (o). Shape: (..., F)
+      gate: The gating array for the activation (z). Shape: (..., F)
+            where F is num_features.
+
+    Returns:
+      The normalized and gated output array. Shape: (..., F)
+    """
+    normalized_states = self.rms_norm(hidden_states)
+
+    # Gated Activation using SiLU (Sigmoid-weighted Linear Unit)
+    gated_states = normalized_states * jax.nn.silu(gate.astype(jnp.float32))
+
+    return gated_states.astype(self.dtype)
 
 
 def rms_norm(


### PR DESCRIPTION
# Description

This pr adds the Qwen3-Next Gated Full Attention implementation to the existing Qwen3-Next code in qwen3.py. 

Current implementation in maxtext uses normal Attention, but qwen3 next requires attention with 2 slight tweaks: an output gate and partial ROPE applied to 25% of head_dim. This pr adds this functionality by building a custom attention class for Qwen3-Next on top of AttentionOp for the core attention calculation.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/448407748

# Tests

I have added a testcase that compares the pytorch ref to the jax ref and compares the output tensors after the gated fullattention layer. 

This tests is passing after running this command: `pytest -vvs tests/check_qwen3_next_vs_reference.py::TestQwen3Next::test_full_attention_jax_vs_pytorch`: https://paste.googleplex.com/5626786360721408

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
