### PR TITLE
Fix: Correct path to `extra_deps_from_github.txt`

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -172,7 +172,7 @@ else
       exit 2
     else
       python3 -m uv pip install --resolution=lowest -r "$tpu_requirements_txt" \
-                                                    -r "${MAXTEXT_REPO_ROOT?}"'/extra_deps_from_github.txt'
+                                                    -r "${MAXTEXT_REPO_ROOT?}"'/src/install_maxtext_extra_deps/extra_deps_from_github.txt'
     fi
 fi
 


### PR DESCRIPTION
# Description
**What does this PR do?**
This PR fixes a bug in `setup.sh` that causes the script to fail with a "File not found" error when trying to install `extra_deps_from_github.txt`.

**Why is this change necessary?**
The path used in the uv pip install command (${MAXTEXT_REPO_ROOT}/extra_deps_from_github.txt) is incorrect. After the major repository refactor that moved project code into the src/ directory, the correct location for this file is now `${MAXTEXT_REPO_ROOT}/src/install_maxtext_extra_deps/extra_deps_from_github.txt`.

**How does this PR fix the issue?**
This PR updates the uv pip install command in setup.sh to point to the correct file path.

**Before:**
```
... -r "${MAXTEXT_REPO_ROOT?}"'/extra_deps_from_github.txt'
```
**After:**
```
... -r "${MAXTEXT_REPO_ROOT?}"'/src/install_maxtext_extra_deps/extra_deps_from_github.txt'
```


FIXES: [b/454233010](https://buganizer.corp.google.com/issues/454233010)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
