### PR TITLE
Add zero-1 pyconfig rule

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -466,6 +466,9 @@ ici_autoregressive_parallelism: 1
 ici_pipeline_parallelism: 1
 ici_expert_parallelism: 1
 
+# Enable ZeRO-1 optimizer sharding over data axis
+shard_optimizer_over_data: False
+
 # The number of TPU slices is automatically determined, you should not set this explicitly. For ahead of time compilation,
 # you should set compile_toplogy_num_slices, which will in turn set this value. For non-TPU environments this is set to 1.
 num_slices: -1
@@ -859,7 +862,6 @@ subslice_shape: ""
 
 # NNX
 enable_nnx: false
-shard_optimizer_over_data: False
 
 ################################## Qwen3-Next Specific Configs ##################################
 # Kernel size for the 1D convolution in the Gated Delta Net

--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -261,6 +261,9 @@ def validate_keys(keys):
           "For Qwen3-Next, sparse_matmul must be False for now. The dense path has been verified against reference."
       )
 
+  if keys["shard_optimizer_over_data"]:
+    validate_optimizer_sharding_over_data(keys)
+
 
 def validate_tokenizer(keys):
   assert keys[
@@ -1117,6 +1120,15 @@ def validate_ragged_dot(raw_keys):
       jax.config.update(config_flag, True)
     except AttributeError:
       max_logging.log(f"JAX config {config_flag} not found, possibly due to old JAX version.")
+
+
+def validate_optimizer_sharding_over_data(raw_keys):
+  zero1_supported_opt_types = ("adamw", "adam_pax")
+  if raw_keys["opt_type"] not in zero1_supported_opt_types:
+    raise ValueError(
+        f"Optimizer type {raw_keys["opt_type"]} is not supported for optimizer sharding.\n"
+        f"Please use an optimizer from this list: {zero1_supported_opt_types}."
+    )
 
 
 def create_new_logical_axis_rules(old_logical_axis_rules, new_logical_axis_rules):


### PR DESCRIPTION
# Description

Raise value error if opt_type is non-adam when zero-1 is enabled.

# Tests

Standard MaxText tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
