### PR TITLE
Add script to run evaluation before and after SFT training

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -488,6 +488,7 @@ tokenizer_path: "src/MaxText/assets/tokenizer.llama2"
 # hf pipeline only supports huggingface type, and will ignore tokenizer_type flag
 tokenizer_type: "sentencepiece" # Currently supporting: "tiktoken", "sentencepiece", "huggingface"
 use_chat_template: False
+chat_template_path: "" # path to chat template json file
 tokenize_train_data: True  # False if the dataset is pre-tokenized
 tokenize_eval_data: True  # False if the dataset is pre-tokenized
 add_bos: True

--- a/src/MaxText/examples/chat_templates/math_qa.json
+++ b/src/MaxText/examples/chat_templates/math_qa.json
@@ -1,0 +1,5 @@
+{
+  "PROMPT_TEMPLATE": "You are given a mathematical problem. You must solve the problem and provide your reasoning. Place your entire thought process and steps between <reasoning> and </reasoning>. After your reasoning, provide only the final numerical answer, extracted from your reasoning steps, between <answer> and </answer>. The user's problem is:\n{question}",
+  "COMPLETION_TEMPLATE": "<reasoning>\n{reasoning}\n</reasoning>\n<answer>{answer}</answer>",
+  "REASONING_ANSWER_SEPARATOR": "####"
+}

--- a/src/MaxText/examples/sft_qwen3_demo.ipynb
+++ b/src/MaxText/examples/sft_qwen3_demo.ipynb
@@ -2,7 +2,9 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "1nb_Ppf2ZUQL"
+      },
       "source": [
         "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/AI-Hypercomputer/maxtext/blob/main/src/MaxText/examples/sft_qwen3_demo.ipynb)\n",
         "\n",
@@ -11,45 +13,26 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "FGbe4_YQZUQL"
+      },
       "source": [
         "## Overview\n",
         "\n",
-        "This notebook can run on the **public TPU v5e-1**\n",
+        "This notebook performs SFT training and evaluation workflow on [OpenAI's GSM8K dataset](https://huggingface.co/datasets/openai/gsm8k).\n",
+        "The primary goal is to demonstrate the end-to-end process of:\n",
+        "1. Pre-SFT Evaluation: Calcuating baseline accuracy for the model before training.\n",
+        "2. SFT Training: Fine-tune the model using MaxText & Tunix SFT trainer.\n",
+        "3. Post-SFT Evaluation: Re-running the evaluation loop after training to measure the performance gain achieved by SFT.\n",
         "\n",
-        "This notebook demonstrates how to perform Supervised Fine-Tuning (SFT) on Qwen3-0.6B using the Hugging Face ultrachat_200k dataset with Tunix integration for efficient training.\n",
-        "\n",
-        "## Dataset Overview\n",
-        "\n",
-        "**Dataset Link:** https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k\n",
-        "\n",
-        "### Dataset Information:\n",
-        "- **Name:** HuggingFaceH4/ultrachat_200k\n",
-        "- **Type:** Supervised Fine-Tuning dataset\n",
-        "- **Size:** ~200k conversations\n",
-        "- **Format:** Chat conversations with human-AI pairs\n",
-        "- **Splits:** train_sft, test_sft\n",
-        "- **Data columns:** ['messages']\n",
-        "\n",
-        "### Dataset Structure:\n",
-        "Each example contains a 'messages' field with:\n",
-        "- **role:** 'user' or 'assistant'\n",
-        "- **content:** The actual message text\n",
-        "\n",
-        "### Example data format:\n",
-        "```json\n",
-        "{\n",
-        "  \"messages\": [\n",
-        "    {\"role\": \"user\", \"content\": \"What is the capital of France?\"},\n",
-        "    {\"role\": \"assistant\", \"content\": \"The capital of France is Paris.\"}\n",
-        "  ]\n",
-        "}\n",
-        "```\n"
+        "This notebook can run on the **public TPU v5e-1**."
       ]
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "zolxPWhQZUQL"
+      },
       "source": [
         "## Prerequisites\n",
         "\n",
@@ -65,7 +48,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "Rk_QpVVuZUQL"
+      },
       "source": [
         "### Get Your Hugging Face Token\n",
         "\n",
@@ -96,25 +81,56 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
+      "cell_type": "markdown",
       "metadata": {
-        "id": "5KPyOE8e9WbO"
+        "id": "D9ms-jTSZUQL"
       },
-      "outputs": [],
       "source": [
-        "#Install maxtext and dependencies\n",
-        "# 1. Install uv, a fast Python package installer\n",
-        "!pip install uv\n",
-        "\n",
-        "# 2. Install MaxText and its dependencies\n",
-        "!uv pip install maxtext --resolution=lowest\n",
-        "!install_maxtext_github_deps"
+        "## Installation: MaxText & Other Dependencies"
       ]
     },
     {
+      "cell_type": "code",
+      "source": [
+        "!git clone https://github.com/AI-Hypercomputer/maxtext.git\n",
+        "%cd /content/maxtext\n",
+        "\n",
+        "# Install uv, a fast Python package installer\n",
+        "!pip install uv\n",
+        "\n",
+        "# Install MaxText and its dependencies\n",
+        "!uv pip install -e .[tpu] --resolution=lowest\n",
+        "\n",
+        "# Install vLLM\n",
+        "!VLLM_TARGET_DEVICE=\"tpu\" pip install --no-cache-dir --pre \\\n",
+        "    --index-url https://us-python.pkg.dev/cloud-tpu-images/maxtext-rl/simple/ \\\n",
+        "    --extra-index-url https://pypi.org/simple/ \\\n",
+        "    --extra-index-url https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ \\\n",
+        "    --extra-index-url https://download.pytorch.org/whl/nightly/cpu \\\n",
+        "    --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html \\\n",
+        "    --find-links https://storage.googleapis.com/libtpu-wheels/index.html \\\n",
+        "    --find-links https://storage.googleapis.com/libtpu-releases/index.html \\\n",
+        "    --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \\\n",
+        "    --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html \\\n",
+        "    vllm==0.11.1rc1.dev292+g1b86bd8e1.tpu\n",
+        "!pip install --no-cache-dir --pre \\\n",
+        "    --index-url https://us-python.pkg.dev/cloud-tpu-images/maxtext-rl/simple/ \\\n",
+        "    --extra-index-url https://pypi.org/simple/ \\\n",
+        "    --extra-index-url https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ \\\n",
+        "    --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html \\\n",
+        "    tpu-commons==0.1.2"
+      ],
+      "metadata": {
+        "id": "OSPRVbi7n6tB"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "ywtealAxZUQM"
+      },
       "source": [
         "### Restart Session\n",
         "To apply certain changes, you need to restart the session.\n",
@@ -129,34 +145,39 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "Clexf-j7ZUQM"
+      },
       "source": [
-        "## Set up the maxtext environment"
+        "## Imports"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "PkBI9A3JZUQM"
+      },
       "outputs": [],
       "source": [
-        "# MaxText \n",
-        "try:\n",
-        "    import MaxText\n",
-        "    from MaxText import pyconfig\n",
-        "    from MaxText.sft.sft_trainer import train as sft_train\n",
-        "    import os\n",
-        "    MAXTEXT_AVAILABLE = True\n",
-        "    print(\"✓ MaxText imports successful\")\n",
-        "except ImportError as e:\n",
-        "    print(f\"⚠️ MaxText not available: {e}\")\n",
-        "    MAXTEXT_AVAILABLE = False\n",
+        "import os\n",
+        "import transformers\n",
         "\n",
-        "# Hugging Face Authentication Setup\n",
+        "import MaxText\n",
+        "from MaxText import pyconfig\n",
+        "from MaxText.examples.sft_train_and_evaluate import evaluate_model, get_test_dataset\n",
+        "from MaxText.integration.tunix.tunix_adapter import TunixMaxTextAdapter\n",
+        "from MaxText.sft import sft_trainer\n",
+        "\n",
+        "from tunix.rl.rollout.vllm_rollout import VllmRollout\n",
+        "\n",
+        "from datetime import datetime\n",
+        "from flax import nnx\n",
         "from huggingface_hub import login\n",
-        "# use google colab userdata to get the HF token\n",
-        "from google.colab import userdata\n",
-        "\n",
+        "try:\n",
+        "    from google.colab import userdata\n",
+        "except Exception:\n",
+        "    pass\n",
         "\n",
         "MAXTEXT_REPO_ROOT=os.path.dirname(MaxText.__file__)\n",
         "print(f\"MaxText installation path: {MAXTEXT_REPO_ROOT}\")"
@@ -165,70 +186,127 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "JBbPN-uVZUQM"
+      },
       "outputs": [],
       "source": [
-        "## Set the model, checkpoint path and output directory\n",
-        "MODEL_NAME = \"qwen3-0.6b\"\n",
-        "# If you do not have the checkpoint this colab will download the checkpoint from HF and store at `\"{MAXTEXT_REPO_ROOT}/qwen_checkpoint\\\"`\n",
-        "MODEL_CHECKPOINT_PATH = f\"{MAXTEXT_REPO_ROOT}/qwen_checkpoint\"\n",
-        "\n",
-        "# This is the directory where the fine-tuned model will be saved\n",
-        "# You can change it to any path you want \n",
-        "BASE_OUTPUT_DIRECTORY = \"/tmp/out/maxtext_qwen06\"\n",
-        "\n",
-        "# Set your Hugging Face token as a secret in the Google Colab   \n",
-        "HF_TOKEN = userdata.get(\"HF_TOKEN\")\n",
-        "# HF_TOKEN = \"your_actual_token_here\" - use this for a private jupyter lab\n",
-        "login(token=HF_TOKEN)"
+        "try:\n",
+        "    HF_TOKEN = userdata.get(\"HF_TOKEN\")\n",
+        "except Exception:\n",
+        "    HF_TOKEN=os.environ.get(\"HF_TOKEN\")\n",
+        "if HF_TOKEN:\n",
+        "    login(token=HF_TOKEN)\n",
+        "    print(\"Authenticated with Hugging Face successfully!\")\n",
+        "else:\n",
+        "    print(\"Authentication failed: HF_TOKEN is not set.\")"
       ]
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "aENuzm9iZUQM"
+      },
       "source": [
-        "## Get model checkpoint"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# This is the command to convert the HF model to the MaxText format \n",
-        "if not os.path.exists(MODEL_CHECKPOINT_PATH):\n",
-        "    !python3 -m MaxText.utils.ckpt_conversion.to_maxtext \\\n",
-        "        $MAXTEXT_REPO_ROOT/configs/base.yml \\\n",
-        "        model_name=$MODEL_NAME \\\n",
-        "        base_output_directory=$MODEL_CHECKPOINT_PATH \\\n",
-        "        hf_access_token=$HF_TOKEN \\\n",
-        "        use_multimodal=false \\\n",
-        "        scan_layers=false"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Initialize jax and set model config"
+        "## Model Configurations"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "CxzKMBQd_U5-"
+        "id": "RjPYYl3zZUQM"
       },
       "outputs": [],
       "source": [
-        "# this is the code to initialize jax if it's not initialized in the cell above\n",
-        "import jax\n",
+        "MODEL_NAME = \"qwen3-0.6b\"\n",
+        "TOKENIZER_PATH = \"Qwen/Qwen3-0.6B\"\n",
+        "tokenizer = transformers.AutoTokenizer.from_pretrained(\n",
+        "  TOKENIZER_PATH,\n",
+        "  token=HF_TOKEN,\n",
+        ")\n",
         "\n",
-        "if not jax.distributed.is_initialized():\n",
-        "    jax.distributed.initialize()\n",
-        "print(f\"JAX version: {jax.__version__}\")\n",
-        "print(f\"JAX devices: {jax.devices()}\")"
+        "# This colab will download the checkpoint from HF and store at `MODEL_CHECKPOINT_PATH`\n",
+        "MODEL_CHECKPOINT_PATH = f\"{MAXTEXT_REPO_ROOT}/qwen_checkpoint\"\n",
+        "\n",
+        "RUN_NAME = datetime.now().strftime(\"%Y-%m-%d-%H-%m-%S\")\n",
+        "\n",
+        "# This is the directory where the fine-tuned model checkpoint will be saved\n",
+        "BASE_OUTPUT_DIRECTORY = f\"/tmp/maxtext_qwen06\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4L37Ij4NZUQM"
+      },
+      "source": [
+        "## Download Qwen3-0.6B Model Checkpoint from Hugging Face"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "kJanDAc0ZUQM"
+      },
+      "outputs": [],
+      "source": [
+        "%%capture\n",
+        "!python3 -m MaxText.utils.ckpt_conversion.to_maxtext \\\n",
+        "    $MAXTEXT_REPO_ROOT/configs/base.yml \\\n",
+        "    model_name=$MODEL_NAME \\\n",
+        "    base_output_directory=$MODEL_CHECKPOINT_PATH \\\n",
+        "    hf_access_token=$HF_TOKEN \\\n",
+        "    use_multimodal=false \\\n",
+        "    scan_layers=true"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "1T0bm82lZUQM"
+      },
+      "outputs": [],
+      "source": [
+        "print(f\"Model checkpoint can be found at: {MODEL_CHECKPOINT_PATH}/0/items\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PC-hILG0ZUQM"
+      },
+      "source": [
+        "## Dataset Configurations"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "O3MLdr9kZUQM"
+      },
+      "outputs": [],
+      "source": [
+        "DATASET_NAME = \"openai/gsm8k\"\n",
+        "TRAIN_DATA_SPLIT = \"train\"\n",
+        "TEST_DATA_SPLIT = \"test\"\n",
+        "HF_DATA_DIR = \"main\"\n",
+        "TRAIN_DATA_COLUMNS = [\"question\", \"answer\"]\n",
+        "CHAT_TEMPLATE_PATH = f\"{MAXTEXT_REPO_ROOT}/examples/chat_templates/math_qa.json\"\n",
+        "NUM_TEST_SAMPLES = 20 # Total number of samples to test\n",
+        "BATCH_SIZE = 1 # Number of test samples to process in a batch"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yeAHmxSYZUQM"
+      },
+      "source": [
+        "## MaxText Configurations"
       ]
     },
     {
@@ -239,40 +317,146 @@
       },
       "outputs": [],
       "source": [
-        "# Fixed configuration setup for Qwen-0.6B on small TPU\n",
-        "if MAXTEXT_AVAILABLE:\n",
-        "    config_argv = [\n",
-        "        \"\",\n",
-        "        f\"{MAXTEXT_REPO_ROOT}/configs/sft.yml\",   # base SFT config\n",
-        "        f\"load_parameters_path={MODEL_CHECKPOINT_PATH}/0/items/\",  # Load pre-trained weights!, replace with your checkpoint path\n",
-        "        f\"model_name={MODEL_NAME}\",\n",
-        "        \"steps=20\",                                     # very short run for testing\n",
-        "        \"per_device_batch_size=1\",                      # minimal to avoid OOM\n",
-        "        \"max_target_length=1024\",                        \n",
-        "        \"learning_rate=2.0e-5\",                         # safe small LR\n",
-        "        \"eval_steps=5\",\n",
-        "        \"weight_dtype=bfloat16\",\n",
-        "        \"dtype=bfloat16\",\n",
-        "        \"hf_path=HuggingFaceH4/ultrachat_200k\",                       # HuggingFace dataset/model if needed\n",
-        "        f\"hf_access_token={HF_TOKEN}\",\n",
-        "        f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
-        "        \"run_name=sft_qwen0.6b_test\",\n",
-        "        \"tokenizer_path=Qwen/Qwen3-0.6B\",                # Qwen tokenizer\n",
-        "        \"eval_interval=10\",\n",
-        "        \"profiler=xplane\",\n",
-        "    ]\n",
-        "\n",
-        "    # Initialize configuration using MaxText's pyconfig\n",
-        "    config = pyconfig.initialize(config_argv)\n",
-        "\n",
-        "    print(\"✓ Fixed configuration loaded:\")\n",
-        "    print(f\"  - Model: {config.model_name}\")\n",
-        "    print(f\"  - Dataset: {config.hf_path}\")\n",
-        "    print(f\"  - Steps: {config.steps}\")\n",
-        "    print(f\"  - Use SFT: {config.use_sft}\")\n",
-        "    print(f\"  - Learning Rate: {config.learning_rate}\")\n",
-        "else:\n",
-        "    print(\"MaxText not available - cannot load configuration\")"
+        "%%capture\n",
+        "config = pyconfig.initialize([\n",
+        "    \"\",\n",
+        "    f\"{MAXTEXT_REPO_ROOT}/configs/sft.yml\",\n",
+        "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}/0/items\",\n",
+        "    f\"model_name={MODEL_NAME}\",\n",
+        "    f\"hf_access_token={HF_TOKEN}\",\n",
+        "    f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
+        "    f\"run_name={RUN_NAME}\",\n",
+        "    f\"tokenizer_path={TOKENIZER_PATH}\",\n",
+        "    f\"hf_path={DATASET_NAME}\",\n",
+        "    f\"train_split={TRAIN_DATA_SPLIT}\",\n",
+        "    f\"hf_data_dir={HF_DATA_DIR}\",\n",
+        "    f\"train_data_columns={TRAIN_DATA_COLUMNS}\",\n",
+        "    \"steps=500\",\n",
+        "    \"per_device_batch_size=1\",\n",
+        "    \"max_target_length=1024\",\n",
+        "    \"learning_rate=3e-6\",\n",
+        "    \"weight_dtype=bfloat16\",\n",
+        "    \"dtype=bfloat16\",\n",
+        "    f\"chat_template_path={CHAT_TEMPLATE_PATH}\",\n",
+        "])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "O9b0GWo-ZUQM"
+      },
+      "source": [
+        "## Initial Setup & Data Preparation"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TDqFmvUCZUQM"
+      },
+      "source": [
+        "### Create Test Dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "wscWYxrtZUQM"
+      },
+      "outputs": [],
+      "source": [
+        "test_dataset = get_test_dataset(config, tokenizer)\n",
+        "test_dataset = test_dataset[:NUM_TEST_SAMPLES]\n",
+        "test_dataset = test_dataset.to_iter_dataset().batch(BATCH_SIZE, drop_remainder=True)\n",
+        "TOTAL_BATCHES = NUM_TEST_SAMPLES // BATCH_SIZE\n",
+        "print(f\"Processing {NUM_TEST_SAMPLES} examples with a batch size of {BATCH_SIZE}. This will result in {TOTAL_BATCHES} total batches for the test run.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bLSvOOEUZUQM"
+      },
+      "source": [
+        "### Create SFT Trainer State"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2IHsC0m6ZUQM"
+      },
+      "outputs": [],
+      "source": [
+        "trainer, mesh = sft_trainer.setup_trainer_state(config)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PpKtEqzFZUQM"
+      },
+      "source": [
+        "### Create vLLM Rollout"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3-pf_rbqZUQM"
+      },
+      "outputs": [],
+      "source": [
+        "tunix_model = TunixMaxTextAdapter(trainer.model)\n",
+        "vllm_rollout = VllmRollout(\n",
+        "    model=tunix_model,\n",
+        "    tokenizer=tokenizer,\n",
+        "    cache_config_or_size=1280,\n",
+        "    mesh=mesh,\n",
+        "    model_version=TOKENIZER_PATH,\n",
+        "    hbm_utilization=0.8,\n",
+        "    init_with_random_weights=True,\n",
+        "    tpu_backend_type=\"jax\",\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "567gTxsEZUQM"
+      },
+      "source": [
+        "## Evaluation before SFT Training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "OnACa3zCZUQM"
+      },
+      "outputs": [],
+      "source": [
+        "print(\"Running Pre-SFT Evaluation...\")\n",
+        "score = evaluate_model(test_dataset, vllm_rollout, debug=False)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "u5-M4iYkZUQN"
+      },
+      "outputs": [],
+      "source": [
+        "print(\"========================= Score for PRE-SFT Evaluation =========================\")\n",
+        "print(f\"Percentage of test samples where the model produced the correct numerical answer: {score['correct']}%\")\n",
+        "print(f\"Percentage of test samples where the model produced the numerical answer within 10%: {score['partially_correct']}%\")\n",
+        "print(f\"Percentage of test samples where the model's output adheres to the expected structure: {score['correct_format']}%\")"
       ]
     },
     {
@@ -281,27 +465,62 @@
         "id": "EJE1ookSAzz-"
       },
       "source": [
-        "## Train the model, save the tuned model "
+        "## SFT Training"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "mgwpNgQYCJEd"
+        "editable": true,
+        "id": "mgwpNgQYCJEd",
+        "tags": []
       },
       "outputs": [],
       "source": [
-        "#  Execute the training using MaxText SFT trainer's train() function\n",
-        "if MAXTEXT_AVAILABLE:\n",
-        "    print(\"=\"*60)\n",
-        "    print(\"EXECUTING ACTUAL TRAINING\")\n",
-        "    print(\"=\"*60)\n",
-        "\n",
-        "    sft_train(config)\n",
-        "\n",
-        "print(\"Training complete!\")\n",
-        "print(\"Model saved at: \", BASE_OUTPUT_DIRECTORY)"
+        "print(\"Starting SFT Training...\")\n",
+        "trainer = sft_trainer.train_model(config, trainer, mesh)\n",
+        "print(\"SFT Training Complete!\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WEdNYRhwZUQN"
+      },
+      "source": [
+        "## Evaluation after SFT Training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "XcsZacZdZUQN"
+      },
+      "outputs": [],
+      "source": [
+        "print(\"Running Post-SFT Evaluation...\")\n",
+        "model = TunixMaxTextAdapter(trainer.model)\n",
+        "state = nnx.state(model)\n",
+        "vllm_rollout.update_params(state)\n",
+        "score = evaluate_model(test_dataset, vllm_rollout, debug=False)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "editable": true,
+        "tags": [],
+        "id": "-JtYTPvJZUQN"
+      },
+      "outputs": [],
+      "source": [
+        "print(\"========================= Score for POST-SFT Evaluation =========================\")\n",
+        "print(f\"Percentage of test samples where the model produced the correct numerical answer: {score['correct']}%\")\n",
+        "print(f\"Percentage of test samples where the model produced the numerical answer within 10%: {score['partially_correct']}%\")\n",
+        "print(f\"Percentage of test samples where the model's output adheres to the expected structure: {score['correct_format']}%\")"
       ]
     }
   ],
@@ -312,7 +531,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "base",
+      "display_name": "Python 3 (ipykernel)",
       "language": "python",
       "name": "python3"
     },
@@ -326,7 +545,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.12.2"
+      "version": "3.12.11"
     }
   },
   "nbformat": 4,

--- a/src/MaxText/examples/sft_train_and_evaluate.py
+++ b/src/MaxText/examples/sft_train_and_evaluate.py
@@ -1,0 +1,314 @@
+#  Copyright 2025 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+This script performs SFT training and evaluation workflow on OpenAI's GSM8K dataset.
+The primary goal is to demonstrate the end-to-end process of:
+1. Pre-SFT Evaluation: Calcuating baseline accuracy for the model before training.
+2. SFT Training: Fine-tune the model using MaxText & Tunix SFT trainer.
+3. Post-SFT Evaluation: Re-running the evaluation loop after training to measure the performance gain achieved by SFT.
+
+## Example command to run on single-host TPU:
+```
+# Install dependencies in virtual environment
+bash setup.sh && bash src/MaxText/examples/install_tunix_vllm_requirement.sh
+
+# Environment configurations
+export RUN_NAME=$(date +%Y-%m-%d-%H-%M-%S)
+export OUTPUT_PATH=<GCS Bucket Path for output/logs>
+export MODEL_NAME=llama3.1-8b
+export TOKENIZER_PATH=meta-llama/Llama-3.1-8B-Instruct
+export MODEL_CHECKPOINT_PATH=<GCS path to model checkpoint>
+export HF_ACCESS_TOKEN=<Hugging Face access token>
+
+python3 -m MaxText.examples.sft_train_and_evaluate MaxText/configs/sft.yml \
+  run_name=$RUN_NAME base_output_directory=$OUTPUT_PATH \
+  model_name=$MODEL_NAME load_parameters_path=$MODEL_CHECKPOINT_PATH \
+  hf_access_token=$HF_ACCESS_TOKEN tokenizer_path=$TOKENIZER_PATH
+```
+
+## Example command to run on multi-host TPUs using McJAX:
+```
+# Build & upload docker image
+export DOCKER_IMAGE_NAME=${USER}_runner
+bash docker_build_dependency_image.sh MODE=post-training && bash docker_upload_runner.sh CLOUD_IMAGE_NAME=$DOCKER_IMAGE_NAME
+
+# Environment configurations
+export PROJECT=<Google Cloud Project ID>
+export CLUSTER_NAME=<Mame of GKE cluster>
+export ZONE=<CGKE cluster zone>
+export TPU_TYPE=<TPU type>
+export DOCKER_IMAGE="gcr.io/${PROJECT}/${DOCKER_IMAGE_NAME}
+export RUN_NAME=$(date +%Y-%m-%d-%H-%M-%S)
+export OUTPUT_PATH=<GCS Bucket Path for output/logs>
+export MODEL_NAME=llama3.1-8b
+export TOKENIZER_PATH=meta-llama/Llama-3.1-8B-Instruct
+export MODEL_CHECKPOINT_PATH=<GCS path to model checkpoint>
+export HF_ACCESS_TOKEN=<Hugging Face access token>
+
+# Run workload via XPK
+xpk workload create \
+--cluster ${CLUSTER_NAME} \
+--docker-image ${DOCKER_IMAGE} \
+--workload=sft-${RUN_NAME} \
+--tpu-type ${TPU_TYPE} --num-slices=1 --zone=${ZONE} \
+--project=${PROJECT} \
+--command "HF_TOKEN=$HF_ACCESS_TOKEN python3 -m MaxText.examples.sft_train_and_evaluate MaxText/configs/sft.yml \
+  run_name=$RUN_NAME base_output_directory=$OUTPUT_PATH \
+    model_name=$MODEL_NAME load_parameters_path=$MODEL_CHECKPOINT_PATH \
+      hf_access_token=$HF_ACCESS_TOKEN tokenizer_path=$TOKENIZER_PATH"
+```
+"""
+
+from absl import app
+from tqdm.auto import tqdm
+from typing import Sequence
+
+import datasets
+import grain
+import os
+import re
+import transformers
+
+from flax import nnx
+
+from MaxText import globals
+from MaxText import max_logging
+from MaxText import max_utils
+from MaxText import pyconfig
+from MaxText.input_pipeline import instruction_data_processing
+from MaxText.integration.tunix.tunix_adapter import TunixMaxTextAdapter
+from MaxText.sft import sft_trainer
+
+# Suppress vLLM logging with a severity level below ERROR
+os.environ["VLLM_LOGGING_LEVEL"] = "ERROR"
+from tunix.rl.rollout import base_rollout
+from tunix.rl.rollout.vllm_rollout import VllmRollout
+
+# Skip JAX precompilation to make vLLM startup faster
+os.environ["SKIP_JAX_PRECOMPILE"] = "1"
+
+DATASET_NAME = "openai/gsm8k"
+DATASET_DATA_DIR = "main"
+DATASET_TRAIN_SPLIT = "train"
+DATASET_TEST_SPLIT = "test"
+DATASET_DATA_COLUMN = ["question", "answer"]
+TRAIN_STEPS = 10000
+SEED = 42
+BATCH_SIZE = 4
+NUM_TEST_SAMPLES = 1320
+MAX_TOKENS_TO_GENERATE = 768
+MAX_PROMPT_LENGTH = 256
+EVALUATION_CONFIG = {"temperature": 1e-4, "top_k": 1, "top_p": 1.0}
+REASONING_START = "<reasoning>"
+REASONING_END = "</reasoning>"
+ANSWER_START = "<answer>"
+ANSWER_END = "</answer>"
+# Regex to check the full format (reasoning + answer markers)
+MATCH_FORMAT = re.compile(
+    rf"^.*?" rf"{REASONING_START}.+?{REASONING_END}.*?" rf"{ANSWER_START}(.+?){ANSWER_END}" rf"[\s]{{0,}}$",
+    flags=re.MULTILINE | re.DOTALL,
+)
+# Regex to extract the final numerical answer
+MATCH_ANSWER = re.compile(rf"{ANSWER_START}.*?([\d\.\,\$]{{1,}})", flags=re.MULTILINE | re.DOTALL)
+CHAT_TEMPLATE_PATH = f"{globals.MAXTEXT_REPO_ROOT}/src/MaxText/examples/chat_templates/math_qa.json"
+
+
+def get_test_dataset(config, tokenizer):
+  template_config = instruction_data_processing.load_template_from_file(CHAT_TEMPLATE_PATH)
+  dataset = datasets.load_dataset(
+      DATASET_NAME,
+      data_dir=DATASET_DATA_DIR,
+      split=DATASET_TEST_SPLIT,
+      token=config.hf_access_token,
+  )
+
+  return (
+      grain.MapDataset.source(dataset)
+      .shuffle(seed=SEED)
+      .map(
+          lambda x: {
+              "question": x["question"],
+              "prompt": tokenizer.apply_chat_template(
+                  [
+                      {
+                          "role": "user",
+                          "content": template_config["PROMPT_TEMPLATE"].format(question=x["question"].strip()),
+                      }
+                  ],
+                  tokenize=False,
+                  add_generation_prompt=True,
+              ),
+              "target_answer": instruction_data_processing.extract_reasoning_and_answer(
+                  x["answer"], template_config["REASONING_ANSWER_SEPARATOR"]
+              )[1],
+          }
+      )
+  )
+
+
+def evaluate_model(dataset, vllm_rollout, debug=True):
+  """Runs evaluation on the model using vLLM."""
+  rollout_config = base_rollout.RolloutConfig(
+      max_tokens_to_generate=MAX_TOKENS_TO_GENERATE,
+      max_prompt_length=MAX_PROMPT_LENGTH,
+      temperature=EVALUATION_CONFIG["temperature"],
+      top_p=EVALUATION_CONFIG["top_p"],
+      top_k=EVALUATION_CONFIG["top_k"],
+      data_type="bfloat16",
+  )
+
+  total, total_correct, total_partially_correct, total_correct_format = 0, 0, 0, 0
+  for batch in tqdm(dataset):
+    batch_response = vllm_rollout.generate(batch["prompt"], rollout_config)
+    for i, question in enumerate(batch["question"]):
+      if debug:
+        print("========================================")
+        print(f"Question: {question}")
+        print("----------------------------------------")
+        print(f"Model Generated Response: {batch_response.text[i]}")
+        print("----------------------------------------")
+        print(f"Target Response: {batch["target_answer"][i]}")
+        print("========================================")
+
+      is_correct, is_partially_correct, has_correct_format = score_response(
+          target=batch["target_answer"][i], prediction=batch_response.text[i], debug=debug
+      )
+      if is_correct:
+        total_correct += 1
+      if is_partially_correct:
+        total_partially_correct += 1
+      if has_correct_format:
+        total_correct_format += 1
+      total += 1
+
+  return {
+      "correct": (total_correct / total) * 100,
+      "partially_correct": (total_partially_correct / total) * 100,
+      "correct_format": (total_correct_format / total) * 100,
+  }
+
+
+def safe_string_to_float(text):
+  text = text.replace(",", "").replace(" ", "")  # converts "2,125" to "2125"
+  text = text.replace("$", "")  # converts "$50" to "50"
+  return text
+
+
+def score_response(target, prediction, debug=True):
+  is_correct, is_partially_correct, has_correct_format = False, False, False
+  extracted_response = guess.group(1) if (guess := MATCH_ANSWER.search(prediction)) is not None else ""
+  extracted_response = safe_string_to_float(extracted_response)
+  target = safe_string_to_float(target)
+  try:
+    # Check exact correctness
+    if float(extracted_response.strip()) == float(target.strip()):
+      is_correct = True
+
+    # Check partial correctness (within 10%)
+    ratio = float(extracted_response.strip()) / float(target.strip())
+    if 0.9 <= ratio <= 1.1:
+      is_partially_correct = True
+
+    if MATCH_FORMAT.search(prediction) is not None:
+      has_correct_format = True
+  except (ValueError, TypeError, ZeroDivisionError) as e:
+    if debug:
+      print("Evaluation exception: ", e)
+
+  return is_correct, is_partially_correct, has_correct_format
+
+
+def create_vllm_rollout(config, model, mesh, tokenizer):
+  tunix_model = TunixMaxTextAdapter(model)
+  return VllmRollout(
+      model=tunix_model,
+      tokenizer=tokenizer,
+      cache_config_or_size=MAX_PROMPT_LENGTH + MAX_TOKENS_TO_GENERATE + 256,
+      mesh=mesh,
+      model_version=config.tokenizer_path,
+      hbm_utilization=0.2,
+      init_with_random_weights=True,
+      tpu_backend_type="jax",
+  )
+
+
+def get_tokenizer(config):
+  tokenizer = transformers.AutoTokenizer.from_pretrained(
+      config.tokenizer_path,
+      token=config.hf_access_token,
+  )
+  return tokenizer
+
+
+def train_and_evaluate(config):
+  tokenizer = get_tokenizer(config)
+  test_dataset = get_test_dataset(config, tokenizer)
+  test_dataset = test_dataset[:NUM_TEST_SAMPLES]
+  test_dataset = test_dataset.to_iter_dataset().batch(BATCH_SIZE, drop_remainder=True)
+  trainer, mesh = sft_trainer.setup_trainer_state(config)
+  vllm_rollout = create_vllm_rollout(config, trainer.model, mesh, tokenizer)
+
+  # 1. Pre-SFT Evaluation
+  max_logging.log(f"Running Pre-SFT evaluation...")
+  score = evaluate_model(test_dataset, vllm_rollout)
+  print("Score for PRE-SFT EVALUATION: ", score)
+
+  # 2. SFT Training
+  max_logging.log(f"Starting SFT training...")
+  trainer = sft_trainer.train_model(config, trainer, mesh)
+
+  # 3. Post-SFT Evaluation
+  max_logging.log(f"Running Post-SFT evaluation...")
+  tunix_model = TunixMaxTextAdapter(trainer.model)
+  state = nnx.state(tunix_model)
+  vllm_rollout.update_params(state)
+  score = evaluate_model(test_dataset, vllm_rollout)
+  print("Score for POST-SFT EVALUATION: ", score)
+
+
+def main(argv: Sequence[str]) -> None:
+  """Main function to run SFT training and evaluation.
+
+  Args:
+    argv: Command-line arguments.
+  """
+
+  common_argv_dict = {
+      "hf_path": DATASET_NAME,
+      "train_split": DATASET_TRAIN_SPLIT,
+      "hf_data_dir": DATASET_DATA_DIR,
+      "train_data_columns": DATASET_DATA_COLUMN,
+      "per_device_batch_size": 1,
+      "steps": TRAIN_STEPS,
+      "dtype": "bfloat16",
+      "weight_dtype": "bfloat16",
+      "learning_rate": 3e-6,
+      "chat_template_path": CHAT_TEMPLATE_PATH,
+  }
+  for arg in argv:
+    if arg.startswith("model_name="):
+      model_name = arg.split("=")[1]
+      if not model_name.lower().startswith("qwen"):
+        common_argv_dict["tokenizer_type"] = "huggingface"
+  for key, value in common_argv_dict.items():
+    argv.append(f"{key}={value}")
+
+  config = pyconfig.initialize(argv)
+  max_utils.print_system_information()
+  train_and_evaluate(config)
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/src/MaxText/input_pipeline/_hf_data_processing.py
+++ b/src/MaxText/input_pipeline/_hf_data_processing.py
@@ -27,6 +27,7 @@ import grain.python as grain
 import numpy as np
 
 from MaxText.input_pipeline import _input_pipeline_utils
+from MaxText.input_pipeline import instruction_data_processing
 from MaxText import multihost_dataloading
 
 
@@ -178,6 +179,7 @@ def preprocessing_pipeline(
     max_target_length,
     shuffle,
     data_shuffle_seed,
+    chat_template_path="",
     add_bos=True,
     add_eos=True,
     packing=True,
@@ -208,10 +210,16 @@ def preprocessing_pipeline(
   if use_sft:
     dataset = dataset.select_columns(data_column_names)
 
-    supported_columns = [["prompt", "completion"], ["messages"]]
+    supported_columns = [["prompt", "completion"], ["messages"], ["question", "answer"]]
     assert any(
         set(data_column_names) == set(supported) for supported in supported_columns
     ), f"Dataset column names mismatch. Expected columns to match one of {supported_columns}, but got {data_column_names}"
+
+    # convert instruction dataset to conversational format
+    dataset, data_column_names = instruction_data_processing.convert_to_conversational_format(
+        dataset=dataset, data_columns=data_column_names, chat_template_path=chat_template_path
+    )
+
     assert _input_pipeline_utils.is_conversational(
         dataset.features, data_column_names
     ), "Dataset is not in conversational format."
@@ -376,6 +384,7 @@ def make_hf_train_iterator(
         use_dpo=config.use_dpo,
         use_sft=config.use_sft,
         sft_train_on_completion_only=config.sft_train_on_completion_only,
+        chat_template_path=config.chat_template_path,
     )
   return train_iter
 
@@ -426,5 +435,6 @@ def make_hf_eval_iterator(
         use_dpo=config.use_dpo,
         use_sft=config.use_sft,
         sft_train_on_completion_only=config.sft_train_on_completion_only,
+        chat_template_path=config.chat_template_path,
     )
   return eval_iter

--- a/src/MaxText/input_pipeline/instruction_data_processing.py
+++ b/src/MaxText/input_pipeline/instruction_data_processing.py
@@ -1,0 +1,128 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Preprocessing for instruction dataset."""
+
+import datasets
+import json
+import os
+import re
+
+from MaxText import max_logging
+
+
+def load_template_from_file(template_path):
+  """Loads a template from a file."""
+  template_config = None
+  if os.path.isfile(template_path) and template_path.endswith(".json"):
+    with open(template_path, encoding="utf-8") as f:
+      template_config = json.load(f)
+  return template_config
+
+
+def get_template_placeholders(template):
+  """Dynamically extracts the format keys (placeholders) from a template string."""
+  # Finds all names inside {...}
+  return set(re.findall(r"(?<!{){([a-zA-Z0-9_]+)}(?!})", template))
+
+
+def extract_reasoning_and_answer(text, separator):
+  if separator not in text:
+    return None, None
+  [reasoning, answer] = text.split(separator)
+  return reasoning, answer
+
+
+def map_qa_data_to_conversation(example, template_config):
+  """Maps question-answer pairs to conversational format."""
+
+  # Initialize prompt and completion with fallback templates
+  prompt = {"role": "user", "content": example["question"]}
+  completion = {"role": "assistant", "content": example["answer"]}
+
+  # Apply templates to prompt and completion, if provided
+  if template_config:
+    # Apply PROMPT_TEMPLATE to prompt, if provided
+    if "PROMPT_TEMPLATE" in template_config:
+      placeholders = get_template_placeholders(template_config["PROMPT_TEMPLATE"])
+      if "question" not in placeholders:
+        max_logging.log("PROMPT_TEMPLATE has no 'question' placeholder. No template will be applied to prompt.")
+      else:
+        prompt = {
+            "role": "user",
+            "content": template_config["PROMPT_TEMPLATE"].format(question=example["question"].strip()),
+        }
+    else:
+      max_logging.log("PROMPT_TEMPLATE is empty. No template will be applied to prompt.")
+
+    # Apply COMPLETION_TEMPLATE to completion, if provided
+    if "COMPLETION_TEMPLATE" in template_config:
+      placeholders = get_template_placeholders(template_config["COMPLETION_TEMPLATE"])
+      if "REASONING_ANSWER_SEPARATOR" in template_config:
+        reasoning, answer = extract_reasoning_and_answer(example["answer"], template_config["REASONING_ANSWER_SEPARATOR"])
+        if "reasoning" not in placeholders or "answer" not in placeholders:
+          max_logging.log(
+              "COMPLETION_TEMPLATE is missing 'reasoning' or 'answer' placeholder."
+              " No template will be applied to completion."
+              " Remove REASONING_ANSWER_SEPARATOR from template or update COMPLETION_TEMPLATE."
+          )
+        else:
+          completion = {
+              "role": "assistant",
+              "content": template_config["COMPLETION_TEMPLATE"].format(
+                  reasoning=reasoning.strip(), answer=answer.strip()
+              ),
+          }
+      else:
+        max_logging.log(
+            "REASONING_ANSWER_SEPARATOR not found in chat template."
+            " Using only 'answer' placeholder for COMPLETION_TEMPLATE."
+        )
+        if "answer" not in placeholders:
+          max_logging.log(
+              "COMPLETION_TEMPLATE is missing 'answer' placeholder. No template will be applied to completion."
+          )
+        else:
+          completion = {
+              "role": "assistant",
+              "content": template_config["COMPLETION_TEMPLATE"].format(answer=example["answer"].strip()),
+          }
+    else:
+      max_logging.log("COMPLETION_TEMPLATE is empty. No template will be applied to completion.")
+
+  example["messages"] = [prompt, completion]
+  return example
+
+
+def convert_to_conversational_format(
+    dataset,
+    data_columns,
+    chat_template_path,
+):
+  """Converts instruction dataset to conversational format."""
+  template_config = None
+  if chat_template_path:
+    template_config = load_template_from_file(chat_template_path)
+  if "question" in data_columns and "answer" in data_columns:
+    dataset_features = datasets.Features(
+        {"messages": [{"content": datasets.Value(dtype="string"), "role": datasets.Value(dtype="string")}]}
+    )
+    dataset = dataset.map(
+        map_qa_data_to_conversation,
+        fn_kwargs={"template_config": template_config},
+        remove_columns=data_columns,
+        features=dataset_features,
+    )
+    data_columns = ["messages"]
+  return dataset, data_columns

--- a/src/MaxText/sft/sft_trainer.py
+++ b/src/MaxText/sft/sft_trainer.py
@@ -136,13 +136,8 @@ def use_maxtext_loss_function(trainer, mt_config):
   return trainer
 
 
-def train(mt_config, goodput_recorder=None):
-  """Runs the SFT training loop.
-
-  Args:
-    mt_config: MaxText config.
-    goodput_recorder: An optional GoodputRecorder to record performance metrics.
-  """
+def setup_trainer_state(mt_config, goodput_recorder=None):
+  """Set up prerequisites for training loop."""
   tunix_config = get_tunix_config(mt_config)
 
   with maybe_record_goodput(goodput_recorder, GoodputEvent.TPU_INIT):
@@ -159,9 +154,25 @@ def train(mt_config, goodput_recorder=None):
     trainer.with_data_hooks(data_hooks)
     trainer = use_maxtext_loss_function(trainer, mt_config)
 
-  with mesh, nn_partitioning.axis_rules(mt_config.logical_axis_rules):
-    trainer.train(data_hooks.train_data_iterator, data_hooks.eval_data_iterator)
+  return trainer, mesh
 
+
+def train_model(mt_config, trainer, mesh):
+  """Runs the SFT training loop in Tunix."""
+  with mesh, nn_partitioning.axis_rules(mt_config.logical_axis_rules):
+    trainer.train(trainer.data_hooks.train_data_iterator, trainer.data_hooks.eval_data_iterator)
+  return trainer
+
+
+def train(mt_config, goodput_recorder=None):
+  """Main method for SFT training.
+
+  Args:
+    mt_config: MaxText config.
+    goodput_recorder: An optional GoodputRecorder to record performance metrics.
+  """
+  trainer, mesh = setup_trainer_state(mt_config, goodput_recorder)
+  trainer = train_model(mt_config, trainer, mesh)
   return trainer, mesh
 
 

--- a/tests/instruction_data_processing_test.py
+++ b/tests/instruction_data_processing_test.py
@@ -1,0 +1,128 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Instruction data processing test."""
+
+import unittest
+
+from MaxText.input_pipeline import instruction_data_processing
+
+
+class InstructionDataProcessingTest(unittest.TestCase):
+
+  def test_map_qa_data_to_conversation_with_prompt_completion_template(self):
+    template_config = {
+        "PROMPT_TEMPLATE": "This is a question: {question}",
+        "COMPLETION_TEMPLATE": "<reasoning>\n{reasoning}\n</reasoning>\n<answer>\n{answer}\n</answer>",
+        "REASONING_ANSWER_SEPARATOR": "##",
+    }
+    example = {
+        "question": "What is 2 + 2?",
+        "answer": "Because 2 and 2 make 4.\n ## 4",
+    }
+    example = instruction_data_processing.map_qa_data_to_conversation(example, template_config)
+    self.assertTrue("messages" in example)
+    for data in example["messages"]:
+      if data["role"] == "user":
+        self.assertEqual(data["content"], "This is a question: What is 2 + 2?")
+      if data["role"] == "assistant":
+        self.assertEqual(data["content"], "<reasoning>\nBecause 2 and 2 make 4.\n</reasoning>\n<answer>\n4\n</answer>")
+
+  def test_map_qa_data_to_conversation_with_no_reasoning_template(self):
+    template_config = {
+        "PROMPT_TEMPLATE": "This is a question: {question}",
+        "COMPLETION_TEMPLATE": "The answer is: {answer}",
+    }
+    example = {
+        "question": "What is the capital of France?",
+        "answer": "The capital of France is Paris.",
+    }
+    example = instruction_data_processing.map_qa_data_to_conversation(example, template_config)
+    self.assertTrue("messages" in example)
+    for data in example["messages"]:
+      if data["role"] == "user":
+        self.assertEqual(data["content"], "This is a question: What is the capital of France?")
+      if data["role"] == "assistant":
+        self.assertEqual(data["content"], "The answer is: The capital of France is Paris.")
+
+  def test_map_qa_data_to_conversation_with_missing_reasoning_placeholder(self):
+    template_config = {
+        "PROMPT_TEMPLATE": "This is a question: {question}",
+        "COMPLETION_TEMPLATE": "The answer is: {answer}",
+        "REASONING_ANSWER_SEPARATOR": "##",
+    }
+    example = {
+        "question": "What is 2 + 2?",
+        "answer": "Because 2 and 2 make 4.\n ## The answer is: 4",
+    }
+    example = instruction_data_processing.map_qa_data_to_conversation(example, template_config)
+    self.assertTrue("messages" in example)
+    for data in example["messages"]:
+      if data["role"] == "user":
+        self.assertEqual(data["content"], "This is a question: What is 2 + 2?")
+      if data["role"] == "assistant":
+        self.assertEqual(data["content"], "Because 2 and 2 make 4.\n ## The answer is: 4")
+
+  def test_map_qa_data_to_conversation_with_missing_answer_placeholder(self):
+    template_config = {
+        "PROMPT_TEMPLATE": "This is a question: {question}",
+        "COMPLETION_TEMPLATE": "The answer is: {reply}",
+        "REASONING_ANSWER_SEPARATOR": "##",
+    }
+    example = {
+        "question": "What is 2 + 2?",
+        "answer": "Because 2 and 2 make 4.\n ## The answer is: 4",
+    }
+    example = instruction_data_processing.map_qa_data_to_conversation(example, template_config)
+    self.assertTrue("messages" in example)
+    for data in example["messages"]:
+      if data["role"] == "user":
+        self.assertEqual(data["content"], "This is a question: What is 2 + 2?")
+      if data["role"] == "assistant":
+        self.assertEqual(data["content"], "Because 2 and 2 make 4.\n ## The answer is: 4")
+
+  def test_map_qa_data_to_conversation_with_missing_question_placeholder(self):
+    template_config = {
+        "PROMPT_TEMPLATE": "This is a question: {user_question}",
+        "COMPLETION_TEMPLATE": "The answer is: {answer}",
+    }
+    example = {
+        "question": "What is 2 + 2?",
+        "answer": "Because 2 and 2 make 4.\n ## The answer is: 4",
+    }
+    example = instruction_data_processing.map_qa_data_to_conversation(example, template_config)
+    self.assertTrue("messages" in example)
+    for data in example["messages"]:
+      if data["role"] == "user":
+        self.assertEqual(data["content"], "What is 2 + 2?")
+      if data["role"] == "assistant":
+        self.assertEqual(data["content"], "The answer is: Because 2 and 2 make 4.\n ## The answer is: 4")
+
+  def test_map_qa_data_to_conversation_with_no_templates(self):
+    template_config = {}
+    example = {
+        "question": "What is the capital of Germany?",
+        "answer": "The capital of Germany is Berlin.",
+    }
+    example = instruction_data_processing.map_qa_data_to_conversation(example, template_config)
+    self.assertTrue("messages" in example)
+    for data in example["messages"]:
+      if data["role"] == "user":
+        self.assertEqual(data["content"], "What is the capital of Germany?")
+      if data["role"] == "assistant":
+        self.assertEqual(data["content"], "The capital of Germany is Berlin.")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

* Adds a script `sft_train_and_evaluate.py` to run evaluation before and after SFT for any model.
* Update `sft_qwen3_demo.ipynb` to add evaluation before and after SFT training on a Math dataset.

# Tests
### `sft_qwen3_demo` colab results:

<img width="1180" height="232" alt="image" src="https://github.com/user-attachments/assets/05b6040d-f749-452e-9bb3-f23a4eea552a" />

<img width="1128" height="218" alt="image" src="https://github.com/user-attachments/assets/0539b3fb-2f84-46ef-bdd0-583673e3339e" />

### `sft_train_and_evaluate.py` results on Qwen3-0.6B model:
<img width="1352" height="222" alt="image" src="https://github.com/user-attachments/assets/5bc81d15-79b7-41ab-86fc-9bf31017726b" />





# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
