### PR TITLE
Add muon optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See our guide on running MaxText in decoupled mode, without any GCP dependencies
 
 ## 🔥 Latest news 🔥
 
+* \[December 22, 2025\] [Muon optimizer](https://kellerjordan.github.io/posts/muon) is now supported.
 * \[December 10, 2025\] DeepSeek V3.1 is now supported. Use existing configs for [DeepSeek V3 671B](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/MaxText/configs/models/deepseek3-671b.yml) and load in V3.1 checkpoint to use model.
 * \[December 9, 2025\] [New RL and SFT Notebook tutorials](https://github.com/AI-Hypercomputer/maxtext/tree/main/src/MaxText/examples) are available.
 * \[December 4, 2025\] The [ReadTheDocs documentation site](https://maxtext.readthedocs.io/en/latest/index.html) has been reorganized.

--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -704,7 +704,7 @@ gradient_clipping_threshold: 1.0
 # batch by accumulating the gradient over a set of steps.
 gradient_accumulation_steps: 1
 
-opt_type: "adamw"  # one of "adamw", "adam_pax" or "sgd"
+opt_type: "adamw"  # one of "adamw", "adam_pax", "sgd", or "muon"
 
 # AdamW optimizer parameters
 # We use AdamW following Llama2's training details, see https://arxiv.org/pdf/2307.09288.pdf section 2.2
@@ -716,6 +716,14 @@ adam_weight_decay: 0.1 # AdamW Weight decay
 mu_dtype: "" # data type to store "mu" of AdamW tracking the first moment. Inherits from  weight_dtype if unset.
 # Setting nu_dtype is not yet supported by optax, instead nu_dtype is always inherited from weights.
 # See b/399961932 for more.
+
+# Muon optimizer parameters
+# https://github.com/google-deepmind/optax/blob/main/optax/contrib/_muon.py
+# "mu_dtype", "adam_eps" are shared by AdamW
+# "nesterov", "ns_coeffs", "ns_steps", "weight_decay_mask", "adaptive" use default
+muon_beta: 0.95 # Decay rate for the exponentially weighted average of grads.
+muon_weight_decay: 0 # Strength of the weight decay regularization. This is multiplied with the learning rate.
+muon_consistent_rms: None # If None, apply width scaling to updates. If float, apply consistent rms scaling (recommend 0.2).
 
 # Stack trace parameters
 collect_stack_trace: False

--- a/src/MaxText/maxtext_utils.py
+++ b/src/MaxText/maxtext_utils.py
@@ -752,18 +752,19 @@ def init_initial_state(model, tx, config, is_training, key):
 
 def get_abstract_param(model, config):
   """Get abstract model structure (name, shape) without materializing the weights to save memory"""
-  key = jax.random.PRNGKey(0)
-  input_shape = (config.micro_batch_size_to_train_on, config.max_target_length)
-  image_shape = multimodal_utils.get_dummy_image_shape_for_init(
-      config.model_name, batch_size=config.micro_batch_size_to_train_on
-  )
-  abstract_vars = jax.eval_shape(
-      model.init,
-      {"params": key, "dropout": key, "aqt": key},
-      jnp.ones(input_shape, dtype=jnp.int32),
-      jnp.ones(input_shape, dtype=jnp.int32),
-      encoder_images=np.ones(image_shape, dtype=jnp.int32) if config.use_multimodal else None,
-  )
+  with model.mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
+    key = jax.random.PRNGKey(0)
+    input_shape = (config.micro_batch_size_to_train_on, config.max_target_length)
+    image_shape = multimodal_utils.get_dummy_image_shape_for_init(
+        config.model_name, batch_size=config.micro_batch_size_to_train_on
+    )
+    abstract_vars = jax.eval_shape(
+        model.init,
+        {"params": key, "dropout": key, "aqt": key},
+        jnp.ones(input_shape, dtype=jnp.int32),
+        jnp.ones(input_shape, dtype=jnp.int32),
+        encoder_images=np.ones(image_shape, dtype=jnp.int32) if config.use_multimodal else None,
+    )
   return abstract_vars
 
 

--- a/src/MaxText/muon_utils.py
+++ b/src/MaxText/muon_utils.py
@@ -1,0 +1,174 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Utilities for Muon optimizer integration and dimension number generation.
+
+This module provides functions to automatically generate MuonDimensionNumbers
+for various MaxText models. These dimension numbers are crucial for the Muon
+optimizer to correctly apply its update rules.
+
+This module can also be run as a script to inspect the generated dimension
+numbers for a specific model. Example:
+  python3 -m MaxText.muon_utils qwen3-4b True
+"""
+
+
+import os
+import sys
+from typing import Optional, Tuple
+
+import flax.linen as nn
+import jax
+from optax.contrib._muon import MuonDimensionNumbers as mdn
+
+from MaxText import maxtext_utils, pyconfig
+from MaxText.globals import MAXTEXT_PKG_DIR
+from MaxText.layers import models, quantizations
+
+
+Transformer = models.transformer_as_linen
+
+
+def _is_path_contain_any(tuples, path):
+  return any(x in path for x in tuples)
+
+
+def transform_logic(path: Tuple[str, ...]) -> Optional[mdn]:
+  """
+  Determines Muon dimension numbers based on the parameter's hierarchical path.
+
+  This function defines the mapping from a parameter's logical path within the model
+  to its corresponding MuonDimensionNumbers (mdn). The strategy is applied in
+  a specific order to handle general cases and then more specific ones, allowing
+  for fall-through logic in nested structures.
+
+  Strategy:
+  1. Exclusions: Parameters not suitable for Muon (e.g., scalars, embeddings,
+     unembedding) are explicitly returned as `None`.
+  2. Special Weights:
+     2.1 MoE Block Specific Weights
+     2.2 Self-Attention Specific Weights
+  3. Standard Weights: Default mapping for most other 3D weight shapes.
+
+  Args:
+    path: A tuple of strings representing the hierarchical path of the parameter.
+
+  Returns:
+    An instance of `MuonDimensionNumbers` if a specific mapping is found,
+    `None` for excluded parameters, or a default `mdn` for standard weights.
+  """
+
+  # 1 Exclude parameters not suitable for Muon (scalar, embeddings, unembedding)
+  if _is_path_contain_any(("scale", "bias", "embedding", "logits_dense"), path):
+    return None
+
+  # 2 Special weights
+  # 2.1 Special weights: MoE, [0, L, -2, -1]
+  # L (optional) stands for layer when scan_layers=True
+  if "MoeBlock_0" in path:
+    # exclude gate
+    if _is_path_contain_any(("wi_0", "wi_1", "wo"), path):
+      return mdn((-2,), (-1,))
+
+  # 2.2 Special weights: Self attention
+  elif "self_attention" in path:
+    # Attention output projection: [0, L, -2, -1]
+    if "out" in path:
+      return mdn((0, -2), (-1,))
+    # Attention qkv projection: [0, L, -2, -1]
+    # MLA, exclude wq_a / wkv_a
+    elif _is_path_contain_any(("query", "key", "value", "wq_b", "wkv_b"), path):
+      return mdn((0,), (-2, -1))
+
+  # 3 Standard weights, [0, L, -1]
+  return mdn((0,), (-1,))
+
+
+def get_transform_tree(tree, path=()):
+  """Extraction utility via recursion."""
+  if isinstance(tree, dict):
+    return {k: get_transform_tree(v, path + (k,)) for k, v in tree.items()}
+  else:
+    return transform_logic(path)
+
+
+def get_muon_weight_dimension_numbers(model, config, verbose=False):
+  """Extract muon dimension number from model structure."""
+  # quickly get param structure without materialization
+  abstract_param = maxtext_utils.get_abstract_param(model, config)
+  # get muon dimension number from param
+  muon_weight_dimension_numbers = get_transform_tree(abstract_param)
+  if verbose:
+    _print_structure_debug(abstract_param, muon_weight_dimension_numbers)
+  return muon_weight_dimension_numbers
+
+
+def _print_structure_debug(abstract_param, muon_weight_dimension_numbers):
+  """Prints the model structure and the resulting Muon config."""
+  # Access the shape from the inner ShapeDtypeStruct and names from the wrapper
+  # Return a new tree with the same structure containing only shapes/names
+  info_tree = jax.tree_util.tree_map(
+      lambda leaf: {"shape": leaf.value.shape, "names": leaf.names},
+      abstract_param,
+      is_leaf=lambda x: isinstance(x, nn.LogicallyPartitioned),
+  )
+  print(f"\n=== Model Structure ===\n{info_tree}")
+  print(f"\n=== Muon Dimension Numbers ===\n{muon_weight_dimension_numbers}")
+  print("\nIs this reasonable?")
+
+
+def get_model_mdn(model_name, scan_layers=True, verbose=False):
+  """Initializes a model and retrieves its Muon dimension numbers.
+
+  This function sets up the configuration for a given model, initializes the
+  transformer model, and then extracts the Muon dimension numbers for the model's
+  weights. It can optionally print verbose debug information.
+
+  Args:
+    model_name: The name of the model to be initialized.
+    scan_layers: Whether to use layer scanning in the model configuration.
+    verbose: If True, prints detailed debugging information about the model
+      structure and Muon dimension numbers.
+
+  Returns:
+    A tree structure containing the Muon dimension numbers for the model's
+    parameters.
+  """
+  # Setup config
+  argv = [
+      None,
+      os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"),
+      f"model_name={model_name}",
+      f"scan_layers={scan_layers}",
+      "attention=dot_product",
+  ]
+  config = pyconfig.initialize(argv)
+  # Setup model
+  devices_array = maxtext_utils.create_device_mesh(config)
+  mesh = jax.sharding.Mesh(devices_array, config.mesh_axes)
+  quant = quantizations.configure_quantization(config)
+  model = Transformer(config, mesh=mesh, quant=quant)
+  # Get dimension number
+  muon_weight_dimension_numbers = get_muon_weight_dimension_numbers(model, config, verbose=verbose)
+  return muon_weight_dimension_numbers
+
+
+if __name__ == "__main__":
+  if len(sys.argv) != 3:
+    print("Usage: python3 -m MaxText.muon_utils <model_name> <scan_layers:True/False>")
+    sys.exit(1)
+  model_name_arg = sys.argv[1]
+  scan_layers_arg = sys.argv[2].lower() == "true"
+  get_model_mdn(model_name_arg, scan_layers_arg, verbose=True)

--- a/src/MaxText/optimizers.py
+++ b/src/MaxText/optimizers.py
@@ -19,9 +19,11 @@ import jax
 import jax.numpy as jnp
 
 import optax
+from optax.contrib._muon import muon
+from MaxText.muon_utils import get_muon_weight_dimension_numbers
 
 
-def get_optimizer(config, learning_rate_schedule):
+def get_optimizer(config, learning_rate_schedule, model=None):
   """Create optimizer."""
   if config.opt_type == "adamw":
     # Create AdamW Optimizer following Llama2's training details, see https://arxiv.org/pdf/2307.09288.pdf section 2.2
@@ -45,6 +47,29 @@ def get_optimizer(config, learning_rate_schedule):
     )
   elif config.opt_type == "sgd":
     return optax.sgd(learning_rate_schedule)
+  elif config.opt_type == "muon":
+    # extract muon dimension number from model structure
+    if model is not None:
+      muon_weight_dimension_numbers = get_muon_weight_dimension_numbers(model, config)
+    else:
+      raise ValueError("Please specify model to extract muon dimension number.")
+    muon_kwargs = {
+        # Shared parameters: "nesterov" uses default
+        "learning_rate": learning_rate_schedule,
+        "eps": config.adam_eps,
+        "mu_dtype": config.mu_dtype,
+        # Muon-specific parameters: "ns_coeffs", "ns_steps", "weight_decay_mask", "adaptive" uses default
+        "beta": config.muon_beta,
+        "weight_decay": config.muon_weight_decay,
+        "muon_weight_dimension_numbers": muon_weight_dimension_numbers,
+        "consistent_rms": config.muon_consistent_rms,
+        # AdamW-specific parameters
+        "adam_b1": config.adam_b1,
+        "adam_b2": config.adam_b2,
+        "adam_eps_root": config.adam_eps_root,
+        "adam_weight_decay": config.adam_weight_decay,
+    }
+    return muon(**muon_kwargs)
   else:
     raise ValueError(f"{config.opt_type=} is not a supported.")
 

--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -132,6 +132,16 @@ def _prepare_for_pydantic(raw_keys: dict[str, Any]) -> dict[str, Any]:
     if key == "run_name" and new_value is None:
       new_value = ""
 
+    # Preprocess muon_consistent_rms to be None or float
+    if key == "muon_consistent_rms":
+      if value in ["None", "none"]:
+        new_value = None
+      else:
+        try:
+          new_value = float(value)
+        except ValueError as e:
+          raise ValueError("muon_consistent_rms should be None or float") from e
+
     pydantic_kwargs[key] = new_value
 
   return pydantic_kwargs
@@ -293,13 +303,8 @@ def initialize_pydantic(argv: list[str], **kwargs) -> MaxTextConfig:
 
   pydantic_kwargs = _prepare_for_pydantic(raw_keys_dict)
 
-  if pydantic_kwargs.get("use_tokamax_splash") and pydantic_kwargs.get(
-      "use_jax_splash"
-  ):
-    raise ValueError(
-        "At most one of `use_tokamax_splash` and `use_jax_splash` can be set to"
-        " True."
-    )
+  if pydantic_kwargs.get("use_tokamax_splash") and pydantic_kwargs.get("use_jax_splash"):
+    raise ValueError("At most one of `use_tokamax_splash` and `use_jax_splash` can be set to True.")
 
   # Initialize JAX distributed system before device backend is initialized.
   if pydantic_kwargs.get("jax_debug_log_modules"):

--- a/src/MaxText/sft/sft_trainer.py
+++ b/src/MaxText/sft/sft_trainer.py
@@ -144,7 +144,8 @@ def setup_trainer_state(mt_config, goodput_recorder=None):
   with maybe_record_goodput(goodput_recorder, GoodputEvent.TPU_INIT):
     model, mesh = model_creation_utils.create_nnx_model(mt_config)
     learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(mt_config)
-    optimizer = optimizers.get_optimizer(mt_config, learning_rate_schedule)
+    # pass in model for muon
+    optimizer = optimizers.get_optimizer(mt_config, learning_rate_schedule, model)
 
   with maybe_record_goodput(goodput_recorder, GoodputEvent.TRAINING_PREPARATION):
     training_hooks = hooks.SFTTrainingHooks(mt_config, mesh, learning_rate_schedule, goodput_recorder)

--- a/src/MaxText/train_compile.py
+++ b/src/MaxText/train_compile.py
@@ -89,7 +89,8 @@ def get_shaped_inputs(topology_mesh, config):
   model = Transformer(config, topology_mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
   # The learning_rate_schedule is baked into the compiled object.
   learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(config)
-  tx = optimizers.get_optimizer(config, learning_rate_schedule)
+  # pass in model for muon
+  tx = optimizers.get_optimizer(config, learning_rate_schedule, model)
 
   # Shaped RNG keys
   _, example_rng = jax.random.split(jax.random.PRNGKey(0), 2)

--- a/src/MaxText/train_utils.py
+++ b/src/MaxText/train_utils.py
@@ -35,7 +35,8 @@ def create_training_tools(config, model, mesh):
   """Creates the init_rng, optimizer, learning rate schedule, and checkpoint manager."""
   init_rng = jax.random.PRNGKey(config.init_weights_seed)
   learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(config)
-  tx = optimizers.get_optimizer(config, learning_rate_schedule)
+  # pass in model for muon
+  tx = optimizers.get_optimizer(config, learning_rate_schedule, model)
   logger = checkpointing.setup_checkpoint_logger(config)
   if config.enable_multi_tier_checkpointing:
     checkpoint_manager = checkpointing.create_orbax_emergency_replicator_checkpoint_manager(

--- a/src/MaxText/utils/ckpt_conversion/to_maxtext.py
+++ b/src/MaxText/utils/ckpt_conversion/to_maxtext.py
@@ -66,7 +66,6 @@ import jax
 import psutil
 from flax.training import train_state
 import flax.linen as nn
-from flax.linen import partitioning as nn_partitioning
 from transformers import AutoConfig, AutoModelForCausalLM
 from tqdm import tqdm
 from huggingface_hub import hf_hub_download, list_repo_files
@@ -466,8 +465,7 @@ def main(args: Sequence[str], test_args: Sequence[str]) -> None:
   maxtext_model_flax = models.transformer_as_linen(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
 
   # Get abstract model structure (name, shape) without materializing the weights to save memory
-  with maxtext_model_flax.mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
-    abstract_params_tree = maxtext_utils.get_abstract_param(maxtext_model_flax, config)["params"]
+  abstract_params_tree = maxtext_utils.get_abstract_param(maxtext_model_flax, config)["params"]
 
   abstract_params_flat, _ = jax.tree_util.tree_flatten_with_path(abstract_params_tree)
   # Standardize abstract tree for later unflattening

--- a/tests/muon_test.py
+++ b/tests/muon_test.py
@@ -1,0 +1,240 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Unit tests for Muon dimension number generation.
+
+This suite verifies that the automatically generated Muon dimension numbers
+for various models match their hardcoded reference values.
+  python3 -m pytest -v --pyargs tests.muon_test -rP -s
+"""
+
+import unittest
+from absl.testing import parameterized
+from optax.contrib import MuonDimensionNumbers as mdn
+from MaxText.muon_utils import get_model_mdn
+import pytest
+
+# deepseek2, specific: q_lora_rank=0
+# applicable: deepseek2-16, but not deepseek2-236b (q_lora_rank=1536)
+_DEEPSEEK2_ATTENTION = {
+    "self_attention": {
+        "kv_norm": {"scale": None},
+        "wkv_a": {"kernel": mdn((0,), (-1,))},
+        "wkv_b": {"kernel": mdn((0,), (-2, -1))},
+        "out": {"kernel": mdn((0, -2), (-1,))},
+        "query": {"kernel": mdn((0,), (-2, -1))},  # ds2
+    },
+    "post_self_attention_layer_norm": {"scale": None},
+    "pre_self_attention_layer_norm": {"scale": None},
+}
+
+DEEPSEEK2_DIMENSION_NUMBER = {
+    "params": {
+        "decoder": {
+            "dense_layers": {
+                "mlp": {
+                    "wi_0": {"kernel": mdn((0,), (-1,))},
+                    "wi_1": {"kernel": mdn((0,), (-1,))},
+                    "wo": {"kernel": mdn((0,), (-1,))},
+                },
+                **_DEEPSEEK2_ATTENTION,
+            },
+            "moe_layers": {
+                "DeepSeekMoeBlock_0": {
+                    "MoeBlock_0": {
+                        "wi_0": mdn((-2,), (-1,)),
+                        "wi_1": mdn((-2,), (-1,)),
+                        "wo": mdn((-2,), (-1,)),
+                        "gate": {"kernel": mdn((0,), (-1,))},  # ds2
+                    },
+                    "shared_experts": {
+                        "wi_0": {"kernel": mdn((0,), (-1,))},
+                        "wi_1": {"kernel": mdn((0,), (-1,))},
+                        "wo": {"kernel": mdn((0,), (-1,))},
+                    },
+                },
+                **_DEEPSEEK2_ATTENTION,
+            },
+            "decoder_norm": {"scale": None},
+            "logits_dense": {"kernel": None},
+        },
+        "token_embedder": {"embedding": None},
+    }
+}
+
+
+# deepseek3
+_DEEPSEEK3_ATTENTION = {
+    "self_attention": {
+        "kv_norm": {"scale": None},
+        "wkv_a": {"kernel": mdn((0,), (-1,))},
+        "wkv_b": {"kernel": mdn((0,), (-2, -1))},
+        "out": {"kernel": mdn((0, -2), (-1,))},
+        "q_norm": {"scale": None},  # ds3
+        "wq_a": {"kernel": mdn((0,), (-1,))},  # ds3
+        "wq_b": {"kernel": mdn((0,), (-2, -1))},  # ds3
+    },
+    "post_self_attention_layer_norm": {"scale": None},
+    "pre_self_attention_layer_norm": {"scale": None},
+}
+
+DEEPSEEK3_DIMENSION_NUMBER = {
+    "params": {
+        "decoder": {
+            "dense_layers": {
+                "mlp": {
+                    "wi_0": {"kernel": mdn((0,), (-1,))},
+                    "wi_1": {"kernel": mdn((0,), (-1,))},
+                    "wo": {"kernel": mdn((0,), (-1,))},
+                },
+                **_DEEPSEEK3_ATTENTION,
+            },
+            "moe_layers": {
+                "DeepSeekMoeBlock_0": {
+                    "MoeBlock_0": {
+                        "wi_0": mdn((-2,), (-1,)),
+                        "wi_1": mdn((-2,), (-1,)),
+                        "wo": mdn((-2,), (-1,)),
+                        "gate": {"kernel": mdn((0,), (-1,)), "bias": None},  # ds3
+                    },
+                    "shared_experts": {
+                        "wi_0": {"kernel": mdn((0,), (-1,))},
+                        "wi_1": {"kernel": mdn((0,), (-1,))},
+                        "wo": {"kernel": mdn((0,), (-1,))},
+                    },
+                },
+                **_DEEPSEEK3_ATTENTION,
+            },
+            "decoder_norm": {"scale": None},
+            "logits_dense": {"kernel": None},
+        },
+        "token_embedder": {"embedding": None},
+    }
+}
+
+# gemma3
+_GEMMA3_LAYER = {
+    "mlp": {
+        "wi_0": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+        "wi_1": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+        "wo": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+    },
+    "post_ffw_norm": {"scale": None},
+    "pre_ffw_norm": {"scale": None},
+    "self_attention": {
+        "query": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+        "key": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+        "value": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+        "out": {"kernel": mdn(reduction_axis=(0, -2), output_axis=(-1,))},
+        "key_norm": {"scale": None},
+        "query_norm": {"scale": None},
+    },
+    "post_self_attention_norm": {"scale": None},
+    "pre_self_attention_norm": {"scale": None},
+}
+
+GEMMA3_DIMENSION_NUMBER = {
+    "params": {
+        "decoder": {
+            "decoder_norm": {"scale": None},
+            "layers": {f"layers_{i}": _GEMMA3_LAYER for i in range(6)},
+            "layers_remainder": {f"layers_{i}": _GEMMA3_LAYER for i in range(4)},
+        },
+        "token_embedder": {"embedding": None},
+    }
+}
+
+
+# llama2 (also llama3)
+LLAMA2_DIMENSION_NUMBER = {
+    "params": {
+        "decoder": {
+            "decoder_norm": {"scale": None},
+            "layers": {
+                "mlp": {
+                    "wi_0": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+                    "wi_1": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+                    "wo": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+                },
+                "self_attention": {
+                    "query": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "key": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "value": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "out": {"kernel": mdn(reduction_axis=(0, -2), output_axis=(-1,))},
+                },
+                "post_self_attention_layer_norm": {"scale": None},
+                "pre_self_attention_layer_norm": {"scale": None},
+            },
+            "logits_dense": {"kernel": None},
+        },
+        "token_embedder": {"embedding": None},
+    }
+}
+
+
+# qwen3, specific: logits_via_embedding=True
+# applicable: qwen3-0.6b, qwen3-4b, but not: qwen3-8b, qwen3-14b (logits_via_embedding=False)
+QWEN3_DIMENSION_NUMBER = {
+    "params": {
+        "decoder": {
+            "decoder_norm": {"scale": None},
+            "layers": {
+                "mlp": {
+                    "wi_0": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+                    "wi_1": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+                    "wo": {"kernel": mdn(reduction_axis=(0,), output_axis=(-1,))},
+                },
+                "self_attention": {
+                    "query": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "key": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "value": {"kernel": mdn(reduction_axis=(0,), output_axis=(-2, -1))},
+                    "out": {"kernel": mdn(reduction_axis=(0, -2), output_axis=(-1,))},
+                    "key_norm": {"scale": None},
+                    "query_norm": {"scale": None},
+                },
+                "post_self_attention_layer_norm": {"scale": None},
+                "pre_self_attention_layer_norm": {"scale": None},
+            },
+        },
+        "token_embedder": {"embedding": None},
+    }
+}
+
+
+class MuonDimensionTest(parameterized.TestCase):
+
+  @parameterized.named_parameters(
+      ("deepseek2-16b", "deepseek2-16b", DEEPSEEK2_DIMENSION_NUMBER),
+      ("deepseek3-671b", "deepseek3-671b", DEEPSEEK3_DIMENSION_NUMBER),
+      ("kimi-k2-1t", "kimi-k2-1t", DEEPSEEK3_DIMENSION_NUMBER),
+      ("llama2-7b", "llama2-7b", LLAMA2_DIMENSION_NUMBER),
+      ("llama3-8b", "llama3-8b", LLAMA2_DIMENSION_NUMBER),
+      ("llama3.1-8b", "llama3.1-8b", LLAMA2_DIMENSION_NUMBER),
+      ("llama3.3-70b", "llama3.3-70b", LLAMA2_DIMENSION_NUMBER),
+      ("gemma3-4b", "gemma3-4b", GEMMA3_DIMENSION_NUMBER),
+      ("qwen3-0.6b", "qwen3-0.6b", QWEN3_DIMENSION_NUMBER),
+  )
+  @pytest.mark.tpu_only
+  def test_model_integration(self, model_name, expected_output):
+    """
+    Initializes the specified MaxText model and asserts that the generated
+    Muon dimension numbers match the hardcoded reference.
+    """
+    actual_output = get_model_mdn(model_name, scan_layers=True)
+    self.assertEqual(actual_output, expected_output)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

This PR integrates [Muon optimizer](https://kellerjordan.github.io/posts/muon/) to MaxText training. We use implementation from [Optax](https://github.com/google-deepmind/optax/blob/main/optax/contrib/_muon.py) with reshaping interface. 

Special note for Muon optimizer: (1) Muon is used together with AdamW. (2) Muon only applies for 2D parameter, and we need reshape 3D/4D to 2D when applicable.

Fix: b/437908829


## 0 Prerequisite

The changes will need optax >=0.2.7. ~~As of 2025-12-18, we only have [optax release](https://github.com/google-deepmind/optax/releases) 0.2.6 from 2025-09. For now, we need manual install from head.~~ [Optax 0.2.7 is released on 2026-02-05](https://github.com/google-deepmind/optax/releases).

Need latest changes in [optax.contrib.muon](https://github.com/google-deepmind/optax/blob/main/optax/contrib/_muon.py). Importantly, we recently modified it to have 
  - reshape interface: https://github.com/google-deepmind/optax/pull/1407 (2025-08-25)
  - consistent rms match: https://github.com/google-deepmind/optax/pull/1435 (2025-10-23)

```
# Install the specific commit
pip install git+https://github.com/google-deepmind/optax@9858013795e22958fc2b318fb59f254bf700b10e
```
or 
```
# uninstall the old version first
pip uninstall optax
# Install the latest 'main' branch 
pip install git+https://github.com/google-deepmind/optax
```

## 1 Code change

Basic integration:
- `src/MaxText/configs/base.yml`: add muon config, while reusing adamw config
-  `src/MaxText/optimizers.py`: use optax.contrib.muon

Reshape interface (see Sec 3)
- `src/MaxText/muon_utils.py`: 
  - we use `maxtext.get_abstract_param` to get abstract structure without materializing the weight. This does not have memory or FLOP overhead.
  - from the structure, we use `get_transform_tree` to get the muon dimension number.
  - To review the muon dimension number of a model: e.g., `python3 -m MaxText.muon_utils qwen3-4b True`. This is helpful for integrating Muon with more models (see Sec 3.3)
- pass in model for `optimizers.get_optimizer` (`train_utils.py`, `train_compile.py`, `sft_trainer.py`)
- `muon_test.py`: unit test to ensure generated Muon dimension numbers match the hardcoded reference


## 2 User guide

**Model Specific Support: Reshape**
- **deepseek2, deepseek3, kimi-k2, qwen3, gemma3, llama2 / llama3** (i.e., `DecoderBlockTypeDEEPSEEK, DecoderBlockType.QWEN3, DecoderBlockType.GEMMA3, DecoderBlockType.LLAMA2`). 
- The reshaping for these is tested in unit test against hardcoded reference. 
- For other models, raise an error.
- For integrating Muon with more models, see Sec 3.3

**Sharding**: Works with different sharding (e.g., tested FSDP, DP, TP)

**Configs**: `opt_type=muon`, optionally `muon_beta=0.95`, `muon_weight_decay=0.1`, `muon_consistent_rms=0.2`

**Pretrain command**
```
BASE_OUTPUT_PATH=gs://runner-maxtext-logs
RUN_NAME=muon-$(date +%Y-%m-%d-%H-%M-%S)
python3 -m MaxText.train MaxText/configs/base.yml \
base_output_directory=$BASE_OUTPUT_PATH run_name=$RUN_NAME \
model_name=gemma3-4b \
tokenizer_type=sentencepiece tokenizer_path=src/MaxText/assets/tokenizer.gemma3 \
dataset_type=tfds dataset_path='gs://mlperf-llm-public2' dataset_name='c4/en:3.0.4' train_split='train2' \
enable_checkpointing=false dtype=bfloat16 weight_dtype=bfloat16 \
opt_type=muon learning_rate=5e-4 adam_weight_decay=0.1 muon_weight_decay=0.1 muon_consistent_rms=0.2 \
per_device_batch_size=16 max_target_length=2048 steps=20 \
ici_fsdp_parallelism=4 ici_data_parallelism=1 ici_tensor_parallelism=1 \
cosine_learning_rate_final_fraction=0.1 warmup_steps_fraction=0.1 learning_rate_schedule_steps=-1 \
override_model_config=true enable_dropout=false \
profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3
```

**Train compile command**
```
BASE_OUTPUT_PATH=gs://runner-maxtext-logs
RUN_NAME=muon-$(date +%Y-%m-%d-%H-%M-%S)
python3 -m MaxText.train_compile MaxText/configs/base.yml \
base_output_directory=$BASE_OUTPUT_PATH run_name=$RUN_NAME \
model_name=gemma3-4b \
tokenizer_type=sentencepiece tokenizer_path=src/MaxText/assets/tokenizer.gemma3 \
dataset_type=tfds dataset_path='gs://mlperf-llm-public2' dataset_name='c4/en:3.0.4' train_split='train2' \
enable_checkpointing=false dtype=bfloat16 weight_dtype=bfloat16 \
opt_type=muon learning_rate=5e-4 adam_weight_decay=0.1 muon_weight_decay=0.1 muon_consistent_rms=0.2 \
per_device_batch_size=16 max_target_length=2048 steps=20 \
ici_fsdp_parallelism=2 ici_data_parallelism=1 ici_tensor_parallelism=2 \
cosine_learning_rate_final_fraction=0.1 warmup_steps_fraction=0.1 learning_rate_schedule_steps=-1 \
override_model_config=true enable_dropout=false \
compile_topology=v5p-8 compile_topology_num_slices=1
```

##  3 Reshape Interface

### 3.1 Why we need this?

3D and 4D parameters are logically 2D. Use the **MuonDimensionNumber (mdn)** for reshaping specification.
- Note: `reduction_dim` - in feature, `output_dim` - out feature, the rest dims are batch over. dims can be negative number, e.g., 0 is 0th dim, -1 is the last dim, -2 is second to last. dims grouped together are flatten.
- e.g., `decoder.moe_layers.DeepSeekMoeBlock_0.MoeBlock_0.wo`,  (num_experts,  num_layer, **base_moe_mlp_dim**, **base_emb_dim**), reduction_dim = (-2,), output_dim = (-1,)
- e.g, `decoder.moe_layers.self_attention.out.kernel`, (**base_num_query_heads**, num_layer, **v_head_dim**, **base_emb_dim**), reduction = (0, -2), outputdim = (-1,)
- As muon is designed for 2D we do not apply muon to scalar (norm, bias). Additionally, we do not apply it for embedding and unembedding, as previous work suggests this is empirically better

On the Optax side, this is achieved via https://github.com/google-deepmind/optax/pull/1407.


### 3.2 How we integrate it into MaxText?


#### Determine mdn for parameter

To determine a mdn for a parameter: we can investigate the weight shape. For example
- check code: `self.query = DenseGeneral(in_features_shape=self.config.emb_dim, out_features_shape=(self.num_query_heads, self.qk_head_dim)`
- check parameter: `decoder.moe_layers.self_attention.query.kernel`. The shape is `(base_emb_dim, L, base_num_query_heads, qk_head_dim)`, where qk_head_dim=(qk_nope_head_dim + qk_rope_head_dim).
- determine the muon dimension. in_features is axis 0, out_features is axis -2 and -1. Thus, mdn(reduction_axes=(0,), output_axes=(-2, -1)).  (Remark: why not set output_axes=(2, 3), because axis 1 is optional only for scan)

Note many parameters are shared across model, so we only need to go through this process when there is new component.

#### Assemble mdn for model

One way is to hardcode the dimension number for each model. Example: `tests.muon_test`.

To generalize the reshaping, we choose another way
- Given the abstract model param, we extract a static tree of mdn, using name-based rules.
- (Alternatively, we can pass a callable mdn to muon. However, this can introduce more overhead for update.)

### 3.3 How to accommodate more models

Step 1: check hard-coded reference in `tests/muon_test.py` to get a sense

Step 2: print model structure and automatically dimension number, feed output to Gemini. Example:
```
# example: model_name=qwen3-4b, scan_layers=True
python3 -m MaxText.muon_utils qwen3-4b True
```
```
=== Model Structure ===
{'params': {'decoder': {'decoder_norm': {'scale': {'shape': (2560,), 'names': ('norm',)}}, 'layers': {'mlp': {'wi_0': {'kernel': {'shape': (2560, 36, 9728), 'names': ('embed', 'layers', 'mlp')}}, 'wi_1': {'kernel': {'shape': (2560, 36, 9728), 'names': ('embed', 'layers', 'mlp')}}, 'wo': {'kernel': {'shape': (9728, 36, 2560), 'names': ('mlp', 'layers', 'embed')}}}, 'post_self_attention_layer_norm': {'scale': {'shape': (2560, 36), 'names': ('norm', 'layers')}}, 'pre_self_attention_layer_norm': {'scale': {'shape': (2560, 36), 'names': ('norm', 'layers')}}, 'self_attention': {'key': {'kernel': {'shape': (2560, 36, 8, 128), 'names': ('embed', 'layers', 'kv_heads', 'kv_head_dim')}}, 'key_norm': {'scale': {'shape': (128, 36), 'names': ('norm', 'layers')}}, 'out': {'kernel': {'shape': (32, 36, 128, 2560), 'names': ('heads', 'layers', 'kv', 'embed')}}, 'query': {'kernel': {'shape': (2560, 36, 32, 128), 'names': ('embed', 'layers', 'q_heads', 'kv')}}, 'query_norm': {'scale': {'shape': (128, 36), 'names': ('norm', 'layers')}}, 'value': {'kernel': {'shape': (2560, 36, 8, 128), 'names': ('embed', 'layers', 'kv_heads', 'kv_head_dim')}}}}}, 'token_embedder': {'embedding': {'shape': (151936, 2560), 'names': ('vocab', 'embed')}}}}

=== Muon Dimension Numbers ===
{'params': {'decoder': {'decoder_norm': {'scale': None}, 'layers': {'mlp': {'wi_0': {'kernel': MuonDimensionNumbers(reduction_axis=(0,), output_axis=(-1,))}, 'wi_1': {'kernel': MuonDimensionNumbers(reduction_axis=(0,), output_axis=(-1,))}, 'wo': {'kernel': MuonDimensionNumbers(reduction_axis=(0,), output_axis=(-1,))}}, 'post_self_attention_layer_norm': {'scale': None}, 'pre_self_attention_layer_norm': {'scale': None}, 'self_attention': {'key': {'kernel': MuonDimensionNumbers(reduction_axis=(0,), output_axis=(-2, -1))}, 'key_norm': {'scale': None}, 'out': {'kernel': MuonDimensionNumbers(reduction_axis=(0, -2), output_axis=(-1,))}, 'query': {'kernel': MuonDimensionNumbers(reduction_axis=(0,), output_axis=(-2, -1))}, 'query_norm': {'scale': None}, 'value': {'kernel': MuonDimensionNumbers(reduction_axis=(0,), output_axis=(-2, -1))}}}}, 'token_embedder': {'embedding': None}}}

Is this reasonable?
```

Step 3: If Gemini says not reasonable, copy paste `MaxText.muon_utils.transform_logic` function and ask it to revise.

```
# gemini answer for this example
Yes, this configuration looks highly reasonable and correct for a scanned (layer-stacked) Transformer implementation using the Muon optimizer.

The configuration correctly identifies the fan-in (reduction axis) and fan-out (output axis) for the weight matrices, while correctly excluding vector parameters (Norms) and the Embedding table.

Here is the detailed verification of why this works: ...
```

Step 4: Double check of the final muon number, add it to the test.  (e.g., compare it with similar model from Step 1, or double check component as in 3.2)


# Tests

unit test for reshape: `python3 -m pytest -v --pyargs tests.muon_test -rP -s`
- This test can be run on CPU
- deepseek2, deepseek3, kimi-k2, gemma3, llama2 / llama3, qwen3

end-to-end test
- gemma3-4b: b/437908829#comment21


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
