### PR TITLE
fix tokamax default config

### DIFF
--- a/src/MaxText/layers/attention_op.py
+++ b/src/MaxText/layers/attention_op.py
@@ -1098,9 +1098,9 @@ class AttentionOp(nnx.Module):
             block_q_dkv=min(global_block_q_dkv, query.shape[2]),
             block_kv_dkv=min(global_block_kv_dkv, key.shape[2]),
             block_kv_dkv_compute=min(global_block_kv_dkv_compute, query.shape[2]),
-            block_q_dq=None, # tokamax only supports fused bwd kernel
-            block_kv_dq=None, # tokamax only supports fused bwd kernel
-            use_fused_bwd_kernel=True, # tokamax only supports fused bwd kernel
+            block_q_dq=None,  # tokamax only supports fused bwd kernel
+            block_kv_dq=None,  # tokamax only supports fused bwd kernel
+            use_fused_bwd_kernel=True,  # tokamax only supports fused bwd kernel
             q_layout=splash_attention_kernel.QKVLayout[global_q_layout],
             k_layout=splash_attention_kernel.QKVLayout[global_k_layout],
             v_layout=splash_attention_kernel.QKVLayout[global_v_layout],


### PR DESCRIPTION
# Description
1. fix tokamax default config to pass none for `block_dq`

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
