### PR TITLE
Temporarily disable tokamax splash due to mask errors

### DIFF
--- a/src/MaxText/layers/attention_op.py
+++ b/src/MaxText/layers/attention_op.py
@@ -35,7 +35,7 @@ from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_ke
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask
 
 from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_kernel as tokamax_splash_kernel
-from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_mask as tokamax_splash_mask
+# from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_mask as tokamax_splash_mask
 
 
 from flax import linen as nn
@@ -145,7 +145,7 @@ def validate_flash_attention_with_sinks_on_gpu(sinks: Array | None) -> None:
 
 
 # TODO(agagik): change tokamax_splash_mask._ComputableMask to be non protected
-class ChunkedCausalMask(tokamax_splash_mask._ComputableMask):  # pylint: disable=protected-access
+class ChunkedCausalMask(splash_attention_mask._ComputableMask):  # pylint: disable=protected-access
   """Lazy chunked causal mask.
 
   Attention is causal within each chunk (0, K), (K, 2K), (2K, 3K), ... tokens attend to each other but not across chunks.
@@ -1775,7 +1775,7 @@ class AttentionOp(nnx.Module):
 
 
 # pylint: disable=protected-access
-class LoadBalancedCausalMask(tokamax_splash_mask._ComputableMask):
+class LoadBalancedCausalMask(splash_attention_mask._ComputableMask):
   """Lazy causal mask, prevents the model from attending to future tokens.
   Attributes:
     offset: Offset of q start wrt kv. A positive offset shifts the bottom

--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -294,6 +294,9 @@ def validate_tokamax_usage(keys):
   """Validate tokamax usage for gmm kernel"""
   if keys["use_tokamax_gmm"] and keys["hardware"] != "tpu":
     raise ValueError(f"Invalid tokamax's megablox kernel usage for hardware {keys['hardware']}. Only TPU is supported.")
+  if keys["use_tokamax_splash"]:
+    # Disable tokamax splash until b/455970812 fixed
+    raise ValueError("Tokamax splash temporarily blocked due to MaxText testing error. Please follow b/455970812.")
 
 
 def validate_data_input(keys):

--- a/tests/attention_test.py
+++ b/tests/attention_test.py
@@ -576,7 +576,6 @@ class AttentionTest(parameterized.TestCase):
       },
   )
   # TODO (b/454764135.) : This tests fails with new tokamax kernel
-  @pytest.mark.skip(reason="Issue w/ tokamax kernel CP->EP sharding correctness. ")
   @pytest.mark.tpu_only
   def test_tpu_flash_attention_context_parallel(
       self, ici_context_parallelism, context_parallel_load_balance, ici_expert_parallelism, expert_shard_attention_option

--- a/tests/integration_tests/train_tests.py
+++ b/tests/integration_tests/train_tests.py
@@ -144,6 +144,7 @@ class TrainTests(unittest.TestCase):
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only
+  @pytest.mark.skip("Temporarily disable tokamax splash, see b/455970812.")
   def test_tpu_tokamax(self):
     train_main(TrainTests.CONFIGS["base"] + ["use_tokamax_splash=true"])
 


### PR DESCRIPTION
# Description

Temporarily disable tokamax splash until we find way to pass all maxtext tests, follow b/455970812.

# Tests



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
