### PR TITLE
Alphabetize ReadTheDocs guides

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -19,20 +19,20 @@
 ```{toctree}
 :maxdepth: 1
 
-guides/run_maxtext.md
-guides/custom_model.md
-guides/data_input_pipeline.md
-guides/knowledge_distillation.md
-guides/gcp_workload_observability.md
-guides/monitor_goodput.md
-guides/use_vertex_ai_tensorboard.md
-guides/features_and_diagnostics.md
-guides/pallas_kernels_performance.md
-guides/understand_logs_and_metrics.md
-guides/xprof_user_guide.md
 guides/checkpointing_solutions.md
+guides/custom_model.md
+guides/gcp_workload_observability.md
+guides/features_and_diagnostics.md
+guides/install_maxtext.md
+guides/knowledge_distillation.md
+guides/data_input_pipeline.md
+guides/monitor_goodput.md
 guides/megascale_hang_playbook.md
 guides/multimodal.md
+guides/pallas_kernels_performance.md
+guides/run_maxtext.md
+guides/understand_logs_and_metrics.md
 guides/update_dependencies.md
-guides/install_maxtext.md
+guides/use_vertex_ai_tensorboard.md
+guides/xprof_user_guide.md
 ```

--- a/docs/guides/custom_model.md
+++ b/docs/guides/custom_model.md
@@ -14,7 +14,7 @@
  limitations under the License.
  -->
 
-# How to customize your model configs on TPU
+# Customize your model configs on TPU
 
 ## Introduction
 

--- a/docs/guides/install_maxtext.md
+++ b/docs/guides/install_maxtext.md
@@ -14,7 +14,7 @@
  limitations under the License.
  -->
 
-# Installing MaxText
+# Install MaxText
 
 This document discusses how to install MaxText. We recommend installing MaxText inside a Python virtual environment.
 

--- a/docs/guides/run_maxtext.md
+++ b/docs/guides/run_maxtext.md
@@ -1,4 +1,4 @@
-# Running MaxText on different environments
+# Run MaxText on different environments
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/guides/update_dependencies.md
+++ b/docs/guides/update_dependencies.md
@@ -14,7 +14,7 @@
  limitations under the License.
  -->
 
-# How to update MaxText dependencies using seed-env
+# Update MaxText dependencies
 
 ## Introduction
 


### PR DESCRIPTION
# Description

* Alphabetize ReadTheDocs user guides. The actual doc titles are alphabetical, not the file names, since RTS shows the doc title in the sidebar
* Minor doc title updates for brevity + consistency

# Tests

N/A. Small doc changes only

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
