### PR TITLE
Simple change fixing moe e2e error

### DIFF
--- a/tests/forward_pass_logit_checker.py
+++ b/tests/forward_pass_logit_checker.py
@@ -279,7 +279,7 @@ def main(config, test_args):  # pylint: disable=W0621
           rngs={"aqt": init_rng},
       )
 
-      full_train_logits = jax.experimental.multihost_utils.process_allgather(full_train_logits)
+      full_train_logits = jax.experimental.multihost_utils.process_allgather(full_train_logits, tiled=True)
       # if full_train_logits shape is [num_hosts, batch_size, seq_len, vocab_size]
       if full_train_logits.ndim == 4:
         full_train_logits = jnp.reshape(full_train_logits, (-1, config.max_target_length, config.vocab_size))


### PR DESCRIPTION
# Description

Due to Jax upgrading from 0.7.0 to 0.8.0 in MaxText, `jax.experimental.multihost_utils._handle_array_process_allgather()` adds checker on `tiled` input: https://github.com/jax-ml/jax/blob/403977d2e252539d2df33cf26d9aeb9dd587e8bf/jax/experimental/multihost_utils.py#L98-L101. We need to add `tiled=True` to bypass the error.

FIXES: b/456514096

# Tests

Test results: https://paste.googleplex.com/4783288120115200

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
