### PR TITLE
Support Grain per_worker_buffer_size

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -572,12 +572,14 @@ hf_access_token: ''
 # For multiple patterns, use semicolon (;) to separate and colon (:) to specify weights.
 # Example: "path/to/data1.array_record*:0.3;path/to/data2.array_record*:0.7"
 # Note: When using multiple files (separated by ';'), only ArrayRecord format is supported.
-# For more details, see https://github.com/google/maxtext/blob/main/getting_started/Data_Input_Pipeline.md#grain-input-pipeline
+# For more details, see https://github.com/AI-Hypercomputer/maxtext/blob/main/docs/guides/data_input_pipeline/data_input_grain.md
 grain_train_files: ''
 grain_eval_files: ''
 grain_file_type: 'arrayrecord' # arrayrecord or parquet
 grain_worker_count: 1
+grain_per_worker_buffer_size: 1
 grain_worker_count_eval: 1
+grain_per_worker_buffer_size_eval: 1
 # for using pathways
 colocated_python_data_input: False  # experimental feature, under testing
 

--- a/tests/grain_data_processing_test.py
+++ b/tests/grain_data_processing_test.py
@@ -165,6 +165,7 @@ class GrainParquetProcessingTest(unittest.TestCase):
         grain_file_type="parquet",
         grain_train_files=os.path.join(temp_dir, "gcsfuse", "hf", "c4", "c4-train-00000-of-01637.parquet"),
         grain_worker_count=1,
+        grain_per_worker_buffer_size=1,
         tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizer"),
         enable_checkpointing=False,
     )


### PR DESCRIPTION
# Description

Support `per_worker_buffer_size` configuration in the Grain data pipeline, which otherwise would be [default to 1](https://google-grain.readthedocs.io/en/latest/_autosummary/grain.multiprocessing.MultiprocessingOptions.html#grain.multiprocessing.MultiprocessingOptions.__init__).

This PR adds the configurations for `per_worker_buffer_size` for both the training and evaluation pipelines with PyGrain.


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Since this is a relatively straightforward change, I relied on the E2E tests pipelines with this PR to verify compatiability.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
