### PR TITLE
Qwen3omni audio encoder

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -887,6 +887,33 @@ rope_theta_for_vit: 10000
 vision_output_dim_for_vit: 4096
 pixel_shuffle_ratio_for_vit: 0.5
 projector_dropout_for_vit: 0.0
+# Qwen3-OmniMoe vision encoder specific configs
+spatial_merge_size_for_vit: 2
+out_hidden_size_for_vit: 512
+hidden_act_for_vit: "gelu"
+temporal_patch_size_for_vit: 2
+num_position_embeddings_for_vit: 1024
+deepstack_visual_indexes_for_vit: []
+
+### Audio encoder configs (Qwen3-OmniMoe)
+d_model_for_audio: 256
+encoder_attention_heads_for_audio: 4
+encoder_ffn_dim_for_audio: 512
+encoder_layers_for_audio: 2
+attention_dropout_for_audio: 0.0
+activation_dropout_for_audio: 0.0
+activation_function_for_audio: "gelu"
+num_mel_bins_for_audio: 128
+max_source_positions_for_audio: 1500
+scale_embedding_for_audio: True
+n_window_for_audio: 50
+n_window_infer_for_audio: 800
+conv_chunksize_for_audio: 500
+downsample_hidden_size_for_audio: 256
+output_dim_for_audio: 512
+num_conv_layers_for_audio: 3
+max_timescale_for_audio: 10000.0
+max_sample_len_for_audio: 10000
 
 # Subslice shape in the form of "x,y,z" when using pathways (single controller). 
 # Example: "8,8" to use a 8x8 subgrid (64 chips) of a full pod (16x16) of trillium.

--- a/src/MaxText/configs/models/qwen3-omni-30b-a3b.yml
+++ b/src/MaxText/configs/models/qwen3-omni-30b-a3b.yml
@@ -38,3 +38,35 @@ rope_max_timescale: 10_000_000
 
 # General Model Settings
 enable_dropout: False
+
+# Audio Encoder Configuration (need to set use_audio=true to enable)
+# Based on https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
+d_model_for_audio: 1280
+encoder_layers_for_audio: 32
+encoder_attention_heads_for_audio: 20
+encoder_ffn_dim_for_audio: 5120
+max_source_positions_for_audio: 1500
+num_mel_bins_for_audio: 128
+downsample_hidden_size_for_audio: 480
+output_dim_for_audio: 2048
+attention_dropout_for_audio: 0.0
+n_window_for_audio: 50
+n_window_infer_for_audio: 400
+conv_chunksize_for_audio: 500
+num_conv_layers_for_audio: 3
+max_timescale_for_audio: 10000.0
+max_sample_len_for_audio: 10000
+
+# Vision Encoder Configuration (need to set use_images=true to enable)
+# Based on https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
+hidden_size_for_vit: 1152
+intermediate_size_for_vit: 4304
+num_attention_heads_for_vit: 16
+num_hidden_layers_for_vit: 27
+num_channels_for_vit: 3
+patch_size_for_vit: 16
+temporal_patch_size_for_vit: 2
+spatial_merge_size_for_vit: 2
+out_hidden_size_for_vit: 2048
+num_position_embeddings_for_vit: 2304
+deepstack_visual_indexes_for_vit: [8, 16, 24]

--- a/src/MaxText/layers/embeddings.py
+++ b/src/MaxText/layers/embeddings.py
@@ -858,6 +858,37 @@ def positional_embedding_as_linen(*, embedding_dims: int, max_wavelength: int = 
   )
 
 
+def sinusoids_position_embedding_as_linen(
+    *,
+    length: int,
+    channels: int,
+    max_timescale: float = _MAX_WAVELENGTH,
+    cast_as_fprop_dtype: bool = True,
+    fprop_dtype: DType = jnp.bfloat16,
+    name: str | None = None,
+):
+  """Initializes the SinusoidsPositionEmbedding module and returns it as a Linen module.
+
+  Args:
+    length: Maximum sequence length.
+    channels: Number of embedding channels (must be even).
+    max_timescale: Maximum timescale for sinusoidal frequencies.
+    cast_as_fprop_dtype: Whether to cast the output to the fprop dtype.
+    fprop_dtype: The dtype of the output.
+    name: Name of the Linen module.
+  """
+  return nnx_wrappers.to_linen(
+      SinusoidsPositionEmbedding,
+      length=length,
+      channels=channels,
+      max_timescale=max_timescale,
+      cast_as_fprop_dtype=cast_as_fprop_dtype,
+      fprop_dtype=fprop_dtype,
+      metadata_fn=variable_to_logically_partitioned,
+      name=name,
+  )
+
+
 @dataclasses.dataclass(repr=False)
 class PositionalEmbedding(nnx.Module):
   """A layer that adds sinusoidal positional embeddings to the input.
@@ -1035,3 +1066,59 @@ class LlamaVisionRotaryEmbedding(nnx.Module):
       output = output.astype(self.fprop_dtype)
 
     return output
+
+
+@dataclasses.dataclass(repr=False)
+class SinusoidsPositionEmbedding(nnx.Module):
+    """Sinusoidal position embeddings with precomputed table for efficient lookup."""
+
+    def __init__(
+        self,
+        length: int,
+        channels: int,
+        max_timescale: float = _MAX_WAVELENGTH,
+        cast_as_fprop_dtype: bool = True,
+        fprop_dtype: DType = jnp.bfloat16,
+        *,
+        rngs: nnx.Rngs = None,
+    ):
+        """Precompute sinusoidal position embeddings for all positions."""
+        if channels % 2 != 0:
+            raise ValueError("SinusoidsPositionEmbedding needs even channels input")
+
+        self.length = length
+        self.channels = channels
+        self.max_timescale = max_timescale
+        self.cast_as_fprop_dtype = cast_as_fprop_dtype
+        self.fprop_dtype = fprop_dtype
+
+        log_timescale_increment = jnp.log(max_timescale) / (channels // 2 - 1)
+        inv_timescales = jnp.exp(
+            -log_timescale_increment * jnp.arange(channels // 2, dtype=jnp.float32)
+        )
+        scaled_time = (
+            jnp.arange(length, dtype=jnp.float32)[:, None] * inv_timescales[None, :]
+        )
+        positional_embedding = jnp.concatenate(
+            [jnp.sin(scaled_time), jnp.cos(scaled_time)], axis=1
+        )
+
+        self.positional_embedding = nnx.Variable(positional_embedding)
+
+    def __call__(self, seqlen: int) -> Array:
+        """Return positional embeddings for given sequence length.
+
+        Args:
+            seqlen: Sequence length to retrieve embeddings for (must be <= self.length)
+
+        Returns:
+            Positional embeddings of shape (seqlen, channels)
+        """
+        output = jax.lax.dynamic_slice(
+            self.positional_embedding.value,
+            start_indices=(0, 0),
+            slice_sizes=(seqlen, self.channels),
+        )
+        if self.cast_as_fprop_dtype:
+            output = output.astype(self.fprop_dtype)
+        return output

--- a/src/MaxText/layers/qwen3.py
+++ b/src/MaxText/layers/qwen3.py
@@ -16,10 +16,13 @@
 # pylint: disable=arguments-differ
 # pylint: disable=no-name-in-module
 
-from typing import cast
+from typing import cast, Optional, Tuple
+import dataclasses
+import math
 
 import jax
 import jax.nn
+from jax import lax
 from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
 import jax.numpy as jnp
@@ -28,7 +31,7 @@ from flax import linen as nn
 from flax import nnx
 
 from MaxText import max_utils
-from MaxText.common_types import Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED
+from MaxText.common_types import Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED, AttentionType, MODEL_MODE_TRAIN
 from MaxText.layers import attentions
 from MaxText.layers import initializers as max_initializers
 from MaxText.layers import linears
@@ -39,10 +42,10 @@ from MaxText.layers.normalizations import RMSNorm, l2norm, Qwen3NextRMSNorm, Qwe
 from MaxText.layers.quantizations import AqtQuantization as Quant
 from MaxText.inference import page_manager
 from MaxText.layers.attentions import Attention
-from MaxText.layers.linears import MlpBlock
+from MaxText.layers.linears import MlpBlock, DenseGeneral
 from MaxText.layers.moe import RoutedMoE
-
-
+from MaxText.layers.embeddings import SinusoidsPositionEmbedding
+from MaxText.layers.initializers import nd_dense_init, variable_to_logically_partitioned
 # -----------------------------------------
 # Qwen3-Next Layer Implementations
 # -----------------------------------------
@@ -1060,6 +1063,350 @@ class Qwen3MoeDecoderLayer(AttentionWithNorm):
       return layer_output
 
 
+class Qwen3OmniAudioEncoderLayer(nnx.Module):
+    """Transformer encoder layer for audio model."""
+
+    def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs = None):
+        self.config = config
+        self.mesh = mesh
+        self.rngs = rngs
+
+        self.hidden_states_shape = (
+            self.config.per_device_batch_size,
+            self.config.max_source_positions_for_audio,
+            self.config.d_model_for_audio,
+        )
+
+        self.input_layer_norm = nnx.LayerNorm(
+            num_features=self.config.d_model_for_audio,
+            epsilon=1e-5,
+            dtype=self.config.dtype_mm,
+            rngs=self.rngs,
+        )
+
+        self.self_attention_audio = Attention(
+            config=self.config,
+            num_query_heads=self.config.encoder_attention_heads_for_audio,
+            num_kv_heads=self.config.encoder_attention_heads_for_audio,
+            head_dim=self.config.d_model_for_audio // self.config.encoder_attention_heads_for_audio,
+            max_target_length=self.config.max_source_positions_for_audio,
+            attention_kernel="dot_product",
+            inputs_q_shape=self.hidden_states_shape,
+            inputs_kv_shape=self.hidden_states_shape,
+            float32_qk_product=self.config.float32_qk_product,
+            float32_logits=self.config.float32_logits,
+            dtype=self.config.dtype_mm,
+            weight_dtype=self.config.weight_dtype,
+            mesh=self.mesh,
+            dropout_rate=self.config.attention_dropout_for_audio,
+            name="self_attention_audio",
+            attention_type=AttentionType.FULL,
+            is_nope_layer=True,  # No rotary position embeddings for audio
+            use_bias_in_projections=True,
+            use_qk_norm=False,
+            query_pre_attn_scalar=1 / math.sqrt(self.config.d_model_for_audio // self.config.encoder_attention_heads_for_audio),
+            model_mode=MODEL_MODE_TRAIN,
+            rngs=self.rngs,
+        )
+
+        self.post_attention_layer_norm = nnx.LayerNorm(
+            num_features=self.config.d_model_for_audio,
+            epsilon=1e-5,
+            dtype=self.config.dtype_mm,
+            rngs=self.rngs,
+        )
+
+        self.AudioMLP = linears.MlpBlock(
+            config=self.config,
+            mesh=self.mesh,
+            in_features=self.config.d_model_for_audio,
+            intermediate_dim=self.config.encoder_ffn_dim_for_audio,
+            activations=("gelu",),  # Single GELU activation
+            kernel_init=max_initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+            intermediate_dropout_rate=0.0,  # No dropout to match AudioMLP
+            dtype=self.config.dtype_mm,
+            weight_dtype=self.config.weight_dtype,
+            use_bias=True,  # AudioMLP uses bias
+            use_pre_norm=False,  # Norm is handled outside
+            quant=None,  # No quantization
+            model_mode=None,  # Not needed for encoder
+            rngs=rngs,
+        )
+
+    def __call__(
+        self,
+        hidden_states: Array,
+        deterministic: bool = False,
+    ):
+        residual = hidden_states
+        hidden_states = self.input_layer_norm(hidden_states)
+        hidden_states = self.self_attention_audio(
+            inputs_q=hidden_states,
+            inputs_kv=hidden_states,
+            deterministic=deterministic,
+        )
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.post_attention_layer_norm(hidden_states)
+        hidden_states = self.AudioMLP(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class Qwen3OmniAudioEncoder(nnx.Module):
+    """Full audio encoder with convs, positional embeddings, and transformer layers.
+
+    Attributes:
+        config: Config containing model parameters
+        mesh: Mesh, JAX device mesh (used for sharding)
+    """
+
+    def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs = None):
+        self.config = config
+        self.mesh = mesh
+        self.rngs = rngs
+
+        self.positional_embedding = SinusoidsPositionEmbedding(
+            length=self.config.max_source_positions_for_audio,
+            channels=self.config.d_model_for_audio,
+            max_timescale=self.config.max_timescale_for_audio,
+            cast_as_fprop_dtype=True,
+            fprop_dtype=self.config.dtype_mm,
+        )
+
+        self.layernorm_post = nnx.LayerNorm(
+            num_features=self.config.d_model_for_audio,
+            epsilon=1e-5,
+            dtype=self.config.dtype_mm,
+            rngs=self.rngs,
+        )
+
+        # Convolutional downsampling layers
+        self.conv2d1 = nnx.Conv(
+            in_features=1,
+            out_features=self.config.downsample_hidden_size_for_audio,
+            kernel_size=(3, 3),
+            strides=(2, 2),
+            padding=((1, 1), (1, 1)),
+            use_bias=True,
+            dtype=self.config.dtype_mm,
+            param_dtype=self.config.weight_dtype,
+            rngs=self.rngs,
+        )
+
+        self.conv2d2 = nnx.Conv(
+            in_features=self.config.downsample_hidden_size_for_audio,
+            out_features=self.config.downsample_hidden_size_for_audio,
+            kernel_size=(3, 3),
+            strides=(2, 2),
+            padding=((1, 1), (1, 1)),
+            use_bias=True,
+            dtype=self.config.dtype_mm,
+            param_dtype=self.config.weight_dtype,
+            rngs=self.rngs,
+        )
+
+        self.conv2d3 = nnx.Conv(
+            in_features=self.config.downsample_hidden_size_for_audio,
+            out_features=self.config.downsample_hidden_size_for_audio,
+            kernel_size=(3, 3),
+            strides=(2, 2),
+            padding=((1, 1), (1, 1)),
+            use_bias=True,
+            dtype=self.config.dtype_mm,
+            param_dtype=self.config.weight_dtype,
+            rngs=self.rngs,
+        )
+
+        conv_out_dim = self.config.downsample_hidden_size_for_audio * ((((self.config.num_mel_bins_for_audio + 1) // 2 + 1) // 2 + 1) // 2)
+        self.conv_out = DenseGeneral(
+            in_features_shape=conv_out_dim,
+            out_features_shape=self.config.d_model_for_audio,
+            use_bias=False,
+            dtype=self.config.dtype_mm,
+            weight_dtype=self.config.weight_dtype,
+            kernel_init=nd_dense_init(1.0, "fan_in", "normal"),
+            rngs=self.rngs,
+        )
+
+        # Transformer encoder layers
+        for lyr in range(self.config.encoder_layers_for_audio):
+            layer_name = f"layers_{lyr}"
+            layer = Qwen3OmniAudioEncoderLayer(
+                config=self.config,
+                mesh=self.mesh,
+                rngs=self.rngs,
+            )
+            setattr(self, layer_name, layer)
+
+    def __call__(
+        self,
+        audio_features: Array,
+        deterministic: bool = False,
+    ):
+        """Process audio features through convs + transformer encoder.
+
+        Args:
+            audio_features: Input of shape (batch, num_mel_bins, audio_length)
+            deterministic: Whether to use deterministic mode
+
+        Returns:
+            Encoded features of shape (batch, seq_len, d_model_for_audio)
+        """
+        batch_size, num_mel_bins, audio_length = audio_features.shape
+        chunk_size = self.config.n_window_for_audio * 2
+
+        # Reshape to chunks
+        num_chunks = audio_length // chunk_size
+        audio_chunks = audio_features.reshape(batch_size, num_mel_bins, num_chunks, chunk_size)
+        audio_chunks = audio_chunks.transpose(0, 2, 1, 3)
+        audio_chunks = audio_chunks.reshape(batch_size * num_chunks, num_mel_bins, chunk_size)
+
+        # Add channel dimension
+        hidden_states = audio_chunks[:, :, :, jnp.newaxis]
+
+        # Apply convolutional layers
+        hidden_states = self.conv2d1(hidden_states)
+        hidden_states = jax.nn.gelu(hidden_states)
+        hidden_states = self.conv2d2(hidden_states)
+        hidden_states = jax.nn.gelu(hidden_states)
+        hidden_states = self.conv2d3(hidden_states)
+        hidden_states = jax.nn.gelu(hidden_states)
+
+        # Reshape conv output
+        bc, f, t, c = hidden_states.shape
+        hidden_states = hidden_states.transpose(0, 2, 3, 1)
+        hidden_states = hidden_states.reshape(bc, t, c * f)
+        hidden_states = self.conv_out(hidden_states)
+
+        # Add positional embeddings
+        seq_len_per_chunk = hidden_states.shape[1]
+        pos_emb = self.positional_embedding(seq_len_per_chunk)
+        pos_emb = jnp.broadcast_to(pos_emb[None, :, :], (batch_size * num_chunks, seq_len_per_chunk, self.config.d_model_for_audio))
+        hidden_states = hidden_states + pos_emb
+
+        # Apply transformer encoder layers
+        for lyr in range(self.config.encoder_layers_for_audio):
+            layer_name = f"layers_{lyr}"
+            layer = getattr(self, layer_name)
+            hidden_states = layer(
+                hidden_states,
+                deterministic=deterministic,
+            )
+
+        hidden_states = self.layernorm_post(hidden_states)
+
+        # Reshape back: (batch*chunks, seq_len_per_chunk, d_model) -> (batch, chunks*seq_len_per_chunk, d_model)
+        hidden_states = hidden_states.reshape(batch_size, num_chunks * seq_len_per_chunk, self.config.d_model_for_audio)
+
+        return hidden_states
+
+
+@dataclasses.dataclass(repr=False)
+class Qwen3OmniAudioProjector(nnx.Module):
+    """Projection layer that converts audio encoder output to model embedding space."""
+    config: Config
+    proj1: DenseGeneral
+    proj2: DenseGeneral
+
+    def __init__(self, config: Config, *, rngs: nnx.Rngs = None):
+        self.config = config
+        self.proj1 = DenseGeneral(
+            in_features_shape=config.d_model_for_audio,
+            out_features_shape=config.d_model_for_audio,
+            use_bias=True,
+            dtype=config.dtype_mm,
+            weight_dtype=config.weight_dtype,
+            kernel_init=nd_dense_init(1.0, "fan_in", "normal"),
+            rngs=rngs,
+        )
+
+        self.proj2 = DenseGeneral(
+            in_features_shape=config.d_model_for_audio,
+            out_features_shape=config.output_dim_for_audio,
+            use_bias=True,
+            dtype=config.dtype_mm,
+            weight_dtype=config.weight_dtype,
+            kernel_init=nd_dense_init(1.0, "fan_in", "normal"),
+            rngs=rngs,
+        )
+
+    def __call__(self, hidden_states: Array) -> Array:
+        """
+        Args:
+            hidden_states: Encoder output of shape (num_chunks, seq_len, d_model_for_audio)
+
+        Returns:
+            Projected output of shape (num_chunks, seq_len, output_dim_for_audio)
+        """
+        hidden_states = self.proj1(hidden_states)
+        hidden_states = jax.nn.gelu(hidden_states)
+        hidden_states = self.proj2(hidden_states)
+        return hidden_states
+
+
+class Qwen3OmniAudioModel(nnx.Module):
+    """Audio model combining encoder and projector.
+
+    This model orchestrates the encoder (convs + transformer) and projector
+    to process audio features into model embedding space.
+
+    Attributes:
+        config: Config containing model parameters
+        mesh: Mesh, JAX device mesh (used for sharding)
+    """
+
+    def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs = None):
+        self.config = config
+        self.mesh = mesh
+        self.rngs = rngs
+
+        self.audio_encoder = Qwen3OmniAudioEncoder(config=self.config, mesh=self.mesh, rngs=self.rngs)
+        self.audio_projector = Qwen3OmniAudioProjector(config=self.config, rngs=self.rngs)
+
+    def __call__(
+        self,
+        audio_features: Array,
+        deterministic: None | bool = False,
+    ) -> Array:
+        """Forward pass combining encoder and projector.
+
+        Args:
+            audio_features: Input audio features of shape (batch_size, num_mel_bins, audio_length)
+            deterministic: Whether to use deterministic mode (disables dropout)
+
+        Returns:
+            Projected audio features of shape (batch_size, seq_len, output_dim_for_audio)
+        """
+        # Apply encoder (convs + transformer)
+        hidden_states = self.audio_encoder(audio_features, deterministic=deterministic)
+        # Apply projector
+        hidden_states = self.audio_projector(hidden_states)
+        return hidden_states
+
+
+def qwen3omni_audioencoder_as_linen(config: Config, mesh: Mesh):
+    """Convert AudioEncoder (convs + transformer layers, no projector) to Linen module."""
+    return nnx_wrappers.to_linen(
+        Qwen3OmniAudioEncoder,
+        config=config,
+        mesh=mesh,
+        name="Qwen3OmniAudioEncoder_0",
+        abstract_init=False,
+        metadata_fn=variable_to_logically_partitioned,
+    )
+
+
+def qwen3omni_audioprojector_as_linen(config: Config, mesh: Mesh):
+    """Convert AudioProjector to Linen module."""
+    return nnx_wrappers.to_linen(
+        Qwen3OmniAudioProjector,
+        config=config,
+        name="Qwen3OmniAudioProjector_0",
+        abstract_init=False,
+        metadata_fn=variable_to_logically_partitioned,
+    )
+    
 Qwen3DecoderLayerToLinen = nnx_wrappers.to_linen_class(
     Qwen3DecoderLayer,
     base_metadata_fn=max_initializers.variable_to_logically_partitioned,
@@ -1077,5 +1424,26 @@ Qwen3NextDecoderLayerToLinen = nnx_wrappers.to_linen_class(
 
 Qwen3NextScannableBlockToLinen = nnx_wrappers.to_linen_class(
     Qwen3NextScannableBlock,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+# Audio encoder Linen wrappers
+Qwen3OmniAudioEncoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioEncoderLayer,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniAudioEncoderToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioEncoder,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniAudioProjectorToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioProjector,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniAudioModelToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioModel,
     base_metadata_fn=max_initializers.variable_to_logically_partitioned,
 )

--- a/tests/check_qwen3_omni_audio_vs_reference.py
+++ b/tests/check_qwen3_omni_audio_vs_reference.py
@@ -1,0 +1,497 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import os
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import torch
+import torch.nn.functional as F
+from flax import nnx
+from jax.sharding import Mesh
+
+from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+    Qwen3OmniMoeAudioAttention as TorchQwen3OmniMoeAudioAttention,
+    Qwen3OmniMoeAudioEncoderLayer as TorchQwen3OmniMoeAudioEncoderLayer,
+    SinusoidsPositionEmbedding as TorchSinusoidsPositionEmbedding,
+    Qwen3OmniMoeAudioEncoder as TorchQwen3OmniMoeAudioEncoder,
+)
+from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import (
+    Qwen3OmniMoeAudioEncoderConfig,
+)
+
+from MaxText.layers.qwen3 import (
+    Qwen3OmniAudioEncoderLayer,
+    Qwen3OmniAudioEncoder,
+    Qwen3OmniAudioModel,
+)
+from MaxText.layers.embeddings import SinusoidsPositionEmbedding
+from MaxText.layers.attentions import Attention
+from MaxText import common_types
+from MaxText import pyconfig
+
+from multimodal_test_utils import (
+    copy_attention_weights_to_maxtext,
+    copy_audio_model,
+    copy_maxtext_encoder_layer_weights,
+    create_block_diagonal_attention_mask,
+    create_random_jax_torch,
+    assert_all_close_jax_torch,
+)
+
+
+base_config_path = os.path.join(os.path.dirname(__file__), "..", "src", "MaxText", "configs", "base.yml")
+jax_audio_config = pyconfig.initialize(
+    ["", base_config_path],
+    model_name="qwen3-omni-30b-a3b",
+    attention="dot_product",
+    attention_type="full",
+    dropout_rate=0.0,
+    dtype="float32",
+    weight_dtype="float32",
+    float32_logits=True,
+)
+
+torch_audio_encoder_config = Qwen3OmniMoeAudioEncoderConfig(
+    d_model=jax_audio_config.d_model_for_audio,
+    encoder_attention_heads=jax_audio_config.encoder_attention_heads_for_audio,
+    encoder_ffn_dim=jax_audio_config.encoder_ffn_dim_for_audio,
+    encoder_layers=jax_audio_config.encoder_layers_for_audio,
+    attention_dropout=jax_audio_config.attention_dropout_for_audio,
+    dropout=0.0,
+    activation_dropout=0.0,
+    activation_function="gelu",
+    num_mel_bins=jax_audio_config.num_mel_bins_for_audio,
+    max_source_positions=jax_audio_config.max_source_positions_for_audio,
+    scale_embedding=True,
+    n_window=jax_audio_config.n_window_for_audio,
+    n_window_infer=jax_audio_config.n_window_infer_for_audio,
+    conv_chunksize=jax_audio_config.conv_chunksize_for_audio,
+    downsample_hidden_size=jax_audio_config.downsample_hidden_size_for_audio,
+    output_dim=jax_audio_config.output_dim_for_audio,
+    torch_dtype=torch.float32,
+    weight_dtype=torch.float32,
+)
+torch_audio_encoder_config._attn_implementation = "eager"
+
+torch.set_grad_enabled(False)
+
+
+class TestMaxTextAttentionVsPyTorch(unittest.TestCase):
+    """Test that MaxText's Attention module matches PyTorch's audio attention implementation."""
+
+    def setUp(self):
+        self.batch_size = 1
+        self.seq_length = 16
+        self.config = jax_audio_config
+        self.embed_dim = self.config.d_model_for_audio
+        self.num_heads = self.config.encoder_attention_heads_for_audio
+        self.head_dim = self.embed_dim // self.num_heads
+        np.random.seed(42)
+        torch.manual_seed(42)
+        self.mesh = Mesh(np.array(jax.devices()[:1]), axis_names=("data",))
+
+    def test_attention_output_matches_torch(self):
+        """Test that MaxText Attention produces same output as PyTorch attention."""
+        torch_config = torch_audio_encoder_config
+        torch_model = TorchQwen3OmniMoeAudioAttention(torch_config)
+        torch_model.eval()
+
+        # Create input - PyTorch expects (seq_length, channels), MaxText expects (batch, seq, channels)
+        jax_hidden_states_2d, torch_hidden_states = create_random_jax_torch(
+            self.seq_length, self.embed_dim
+        )
+        jax_hidden_states = jax_hidden_states_2d[
+            jnp.newaxis, :, :
+        ]  # Add batch dimension for MaxText
+
+        # Create cu_seqlens for PyTorch (cumulative sequence lengths)
+        cu_seqlens = torch.tensor([0, self.seq_length], dtype=torch.long)
+
+        jax_attn = Attention(
+            config=self.config,
+            num_query_heads=self.num_heads,
+            num_kv_heads=self.num_heads,
+            head_dim=self.head_dim,
+            max_target_length=self.config.max_source_positions_for_audio,
+            attention_kernel="dot_product",
+            inputs_q_shape=(
+                self.config.per_device_batch_size,
+                self.seq_length,
+                self.embed_dim,
+            ),
+            inputs_kv_shape=(
+                self.config.per_device_batch_size,
+                self.seq_length,
+                self.embed_dim,
+            ),
+            float32_qk_product=self.config.float32_qk_product,
+            float32_logits=self.config.float32_logits,
+            dtype=self.config.dtype_mm,
+            weight_dtype=self.config.weight_dtype,
+            mesh=self.mesh,
+            dropout_rate=0.0,
+            name="test_attention",
+            attention_type=common_types.AttentionType.FULL,
+            is_nope_layer=True,
+            use_bias_in_projections=True,
+            use_qk_norm=False,
+            query_pre_attn_scalar=1 / math.sqrt(self.head_dim),
+            model_mode=common_types.MODEL_MODE_TRAIN,
+            rngs=nnx.Rngs(42),
+        )
+
+        copy_attention_weights_to_maxtext(torch_model, jax_attn)
+        torch_output = torch_model(torch_hidden_states, cu_seqlens=cu_seqlens)
+
+        jax_output = jax_attn(
+            inputs_q=jax_hidden_states, inputs_kv=jax_hidden_states, deterministic=True
+        )
+
+        assert_all_close_jax_torch(
+            jax_output[0],  # Remove batch dimension
+            torch_output,
+            rtol=1e-5,
+            atol=5e-3,
+            error_msg="Attention outputs differ",
+        )
+
+
+class TestAudioEncoderLayer(unittest.TestCase):
+    """Test MaxText AudioEncoderLayer against PyTorch implementation."""
+
+    def setUp(self):
+        self.config = jax_audio_config
+        self.torch_config = torch_audio_encoder_config
+        np.random.seed(42)
+        torch.manual_seed(42)
+
+        devices = jax.devices()
+        self.mesh = Mesh(np.array(devices[:1]), axis_names=("data",))
+
+    def _test_encoder_layer_with_batch_size(self, batch_size):
+        """Helper function to test encoder layer with a given batch size."""
+
+        torch_layer = TorchQwen3OmniMoeAudioEncoderLayer(self.torch_config)
+        torch_layer.eval()
+
+        maxtext_layer = Qwen3OmniAudioEncoderLayer(
+            config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0)
+        )
+
+        # Copy weights from PyTorch to MaxText
+        copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer)
+
+        # Create test input
+        seq_len = 12  # After conv layers
+        hidden_size = self.config.d_model_for_audio
+
+        jax_input, torch_input_3d = create_random_jax_torch(
+            batch_size, seq_len, hidden_size
+        )
+
+        # PyTorch forward pass - expects 2D input (total_seq_len, hidden_dim) with cu_seqlens
+        torch_input_2d = torch_input_3d.reshape(-1, hidden_size)
+
+        # Create cu_seqlens for PyTorch (cumulative sequence lengths for each batch)
+        # For batch_size=2, seq_len=12: [0, 12, 24] indicates two sequences of length 12 each
+        cu_seqlens = torch.tensor(
+            [i * seq_len for i in range(batch_size + 1)], dtype=torch.int32
+        )
+
+        attention_mask = create_block_diagonal_attention_mask(
+            cu_seqlens, torch_input_2d.dtype
+        )
+
+        torch_output_1d = torch_layer(
+            torch_input_2d, cu_seqlens=cu_seqlens, attention_mask=attention_mask
+        )[0]
+        torch_output = torch_output_1d.reshape(batch_size, seq_len, hidden_size)
+
+        jax_output = maxtext_layer(jax_input, deterministic=True)
+
+        assert_all_close_jax_torch(
+            jax_output,
+            torch_output,
+            rtol=1e-5,
+            atol=5e-3,
+            error_msg="AudioEncoderLayer outputs differ",
+        )
+
+    def test_encoder_layer_matches_torch_batch_1(self):
+        """Test that MaxText AudioEncoderLayer matches PyTorch with batch_size=1."""
+        self._test_encoder_layer_with_batch_size(batch_size=1)
+
+    def test_encoder_layer_matches_torch_batch_2(self):
+        """Test that MaxText AudioEncoderLayer matches PyTorch with batch_size=2."""
+        self._test_encoder_layer_with_batch_size(batch_size=2)
+
+    def test_encoder_layer_is_jittable(self):
+        """Test that encoder layer can be JIT compiled."""
+        with self.mesh:
+            jax_layer = Qwen3OmniAudioEncoderLayer(
+                config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0)
+            )
+
+        @nnx.jit
+        def forward(layer, x):
+            return layer(x, deterministic=True)
+
+        batch_size = 2
+        seq_len = 12
+        hidden_size = self.config.d_model_for_audio
+
+        hidden_states = jnp.ones((batch_size, seq_len, hidden_size))
+        output = forward(jax_layer, hidden_states)
+
+        self.assertEqual(output.shape, (batch_size, seq_len, hidden_size))
+
+
+class TestSinusoidsPositionEmbedding(unittest.TestCase):
+    def setUp(self):
+        self.length = 100
+        self.channels = 512
+        self.max_timescale = 10000.0
+        np.random.seed(42)
+        torch.manual_seed(42)
+
+    def test_positional_embedding_matches_torch(self):
+        torch_model = TorchSinusoidsPositionEmbedding(
+            self.length, self.channels, self.max_timescale
+        )
+        jax_model = SinusoidsPositionEmbedding(
+            self.length, self.channels, self.max_timescale, cast_as_fprop_dtype=False
+        )
+
+        # Test full sequence
+        torch_output = torch_model(self.length)
+        jax_output = jax_model(self.length)
+
+        assert_all_close_jax_torch(
+            jax_output,
+            torch_output,
+            rtol=1e-5,
+            atol=3e-4,
+            error_msg="Positional embedding outputs differ",
+        )
+
+    def test_positional_embedding_is_jittable(self):
+        model = SinusoidsPositionEmbedding(
+            self.length, self.channels, self.max_timescale
+        )
+
+        @nnx.jit(static_argnames=["seqlen"])
+        def forward(model, seqlen):
+            return model(seqlen)
+
+        output = forward(model, seqlen=self.length)
+        self.assertEqual(output.shape, (self.length, self.channels))
+
+
+class TestAudioEncoder(unittest.TestCase):
+    """Test AudioEncoder (convs + transformer, no projector) against PyTorch implementation."""
+
+    def setUp(self):
+        self.config = jax_audio_config
+        self.torch_config = torch_audio_encoder_config
+        np.random.seed(42)
+        torch.manual_seed(42)
+
+        devices = jax.devices()
+        self.mesh = Mesh(np.array(devices[:1]), axis_names=("data",))
+
+    def test_audio_encoder_matches_torch(self):
+        """Test that MaxText AudioEncoder matches PyTorch encoder (convs + transformer + layernorm, before projector)."""
+        torch_model = TorchQwen3OmniMoeAudioEncoder(self.torch_config)
+        torch_model.eval()
+
+        maxtext_encoder = Qwen3OmniAudioEncoder(
+            config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0)
+        )
+
+        from multimodal_test_utils import copy_maxtext_audio_encoder_weights
+        copy_maxtext_audio_encoder_weights(torch_model, maxtext_encoder, self.config)
+
+        batch_size = 1
+        num_mel_bins = self.config.num_mel_bins_for_audio
+        audio_length = 200  # n_window=50, chunk_size=100, gives 2 chunks
+
+        jax_audio_features, torch_audio_features_3d = create_random_jax_torch(
+            batch_size, num_mel_bins, audio_length
+        )
+
+        # PyTorch forward (manually run convs + transformer encoder without projector)
+        torch_audio_features = torch_audio_features_3d[0]
+        audio_lengths_np = np.array([audio_length], dtype=np.int64)
+        torch_audio_lengths = torch.from_numpy(audio_lengths_np)
+
+        # Run through PyTorch convs + positional + encoder
+        chunk_size = self.torch_config.n_window * 2
+        num_chunks = audio_length // chunk_size
+        chunk_lengths = torch.tensor([chunk_size] * num_chunks, dtype=torch.long)
+        chunk_list = torch_audio_features.T.split(chunk_lengths.tolist(), dim=0)
+        torch_padded_feature = torch.nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
+        torch_padded_feature = torch_padded_feature.unsqueeze(1)
+
+        torch_conv1 = F.gelu(torch_model.conv2d1(torch_padded_feature))
+        torch_conv2 = F.gelu(torch_model.conv2d2(torch_conv1))
+        torch_conv3 = F.gelu(torch_model.conv2d3(torch_conv2))
+
+        b, c, f, t = torch_conv3.size()
+        torch_conv_out = torch_model.conv_out(torch_conv3.permute(0, 3, 1, 2).contiguous().view(b, t, c * f))
+
+        torch_pos_emb = torch_model.positional_embedding.positional_embedding[:torch_conv_out.shape[1], :].unsqueeze(0).to(torch_conv_out.dtype)
+        torch_after_pos = torch_conv_out + torch_pos_emb
+
+        # Run through encoder layers + layernorm (but not projector)
+        # Process all chunks together
+        seq_len_per_chunk = torch_after_pos.shape[1]
+        cu_seqlens = torch.tensor([i * seq_len_per_chunk for i in range(num_chunks + 1)], dtype=torch.int32)
+        attention_mask = create_block_diagonal_attention_mask(cu_seqlens, torch_after_pos.dtype)
+
+        # Flatten: (num_chunks, seq_len_per_chunk, hidden) -> (num_chunks*seq_len_per_chunk, hidden)
+        hidden_state = torch_after_pos.reshape(-1, torch_after_pos.shape[-1])
+        for layer in torch_model.layers:
+            hidden_state = layer(hidden_state, cu_seqlens=cu_seqlens, attention_mask=attention_mask)[0]
+        hidden_state = torch_model.ln_post(hidden_state)
+
+        # Reshape back: (num_chunks*seq_len_per_chunk, hidden) -> (batch=1, num_chunks*seq_len_per_chunk, hidden)
+        torch_output = hidden_state.reshape(1, num_chunks * seq_len_per_chunk, -1)
+
+        # MaxText forward
+        jax_output = maxtext_encoder(jax_audio_features, deterministic=True)
+
+        assert_all_close_jax_torch(
+            jax_output,
+            torch_output,
+            rtol=1e-3,
+            atol=0.1,
+            error_msg="AudioEncoder outputs differ",
+        )
+
+
+class TestAudioModel(unittest.TestCase):
+    """Test full AudioModel end-to-end against PyTorch implementation."""
+
+    def setUp(self):
+        self.config = jax_audio_config
+        self.torch_config = torch_audio_encoder_config
+        np.random.seed(42)
+        torch.manual_seed(42)
+
+        devices = jax.devices()
+        self.mesh = Mesh(np.array(devices[:1]), axis_names=("data",))
+
+    def test_audio_model_end_to_end(self):
+        """Test full AudioModel pipeline against PyTorch."""
+        torch_model = TorchQwen3OmniMoeAudioEncoder(self.torch_config)
+        torch_model.eval()
+
+        maxtext_model = Qwen3OmniAudioModel(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+        copy_audio_model(torch_model, maxtext_model, self.config)
+
+        batch_size = 1
+        num_mel_bins = self.config.num_mel_bins_for_audio
+        audio_length = 200  # With n_window=50, chunk_size=100, gives 2 chunks
+
+        jax_audio_features, torch_audio_features_3d = create_random_jax_torch(
+            batch_size, num_mel_bins, audio_length
+        )
+        audio_lengths_np = np.array([audio_length], dtype=np.int64)
+
+        torch_audio_features = torch_audio_features_3d[0]
+        torch_audio_lengths = torch.from_numpy(audio_lengths_np)
+
+        torch_output = torch_model(
+            input_features=torch_audio_features, feature_lens=torch_audio_lengths
+        )
+        torch_output_tensor = torch_output.last_hidden_state
+
+        jax_output = maxtext_model(
+            audio_features=jax_audio_features,
+            deterministic=True,
+        )
+
+        assert_all_close_jax_torch(
+            jax_output[0],
+            torch_output_tensor,
+            rtol=1e-3,
+            atol=0.02,
+            error_msg="AudioModel outputs differ",
+        )
+
+    def test_audio_model_intermediates(self):
+        """Debug intermediate outputs to verify each stage matches PyTorch."""
+        torch_model = TorchQwen3OmniMoeAudioEncoder(self.torch_config)
+        torch_model.eval()
+
+        maxtext_model = Qwen3OmniAudioModel(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+        copy_audio_model(torch_model, maxtext_model, self.config)
+
+        batch_size = 1
+        num_mel_bins = self.config.num_mel_bins_for_audio
+        audio_length = 100
+
+        jax_audio_features, torch_audio_features_3d = create_random_jax_torch(
+            batch_size, num_mel_bins, audio_length
+        )
+        torch_audio_features = torch_audio_features_3d[0]
+
+        # PyTorch forward
+        chunk_size = self.torch_config.n_window * 2
+        num_chunks = audio_length // chunk_size
+        chunk_lengths = torch.tensor([chunk_size] * num_chunks, dtype=torch.long)
+        chunk_list = torch_audio_features.T.split(chunk_lengths.tolist(), dim=0)
+        torch_padded_feature = torch.nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
+        torch_padded_feature = torch_padded_feature.unsqueeze(1)
+
+        torch_conv1 = F.gelu(torch_model.conv2d1(torch_padded_feature))
+        torch_conv2 = F.gelu(torch_model.conv2d2(torch_conv1))
+        torch_conv3 = F.gelu(torch_model.conv2d3(torch_conv2))
+
+        b, c, f, t = torch_conv3.size()
+        torch_conv_out = torch_model.conv_out(torch_conv3.permute(0, 3, 1, 2).contiguous().view(b, t, c * f))
+
+        torch_pos_emb = torch_model.positional_embedding.positional_embedding[:torch_conv_out.shape[1], :].unsqueeze(0).to(torch_conv_out.dtype)
+        torch_after_pos = torch_conv_out + torch_pos_emb
+
+        # JAX forward
+        jax_audio_chunks = jax_audio_features.reshape(batch_size, num_mel_bins, num_chunks, chunk_size)
+        jax_audio_chunks = jax_audio_chunks.transpose(0, 2, 1, 3).reshape(batch_size * num_chunks, num_mel_bins, chunk_size)
+        jax_hidden = jax_audio_chunks[:, :, :, jnp.newaxis]
+
+        jax_conv1 = jax.nn.gelu(maxtext_model.conv2d1(jax_hidden))
+        jax_conv2 = jax.nn.gelu(maxtext_model.conv2d2(jax_conv1))
+        jax_conv3 = jax.nn.gelu(maxtext_model.conv2d3(jax_conv2))
+
+        bc, f_jax, t_jax, c_jax = jax_conv3.shape
+        jax_conv_out = maxtext_model.conv_out(jax_conv3.transpose(0, 2, 3, 1).reshape(bc, t_jax, c_jax * f_jax))
+
+        seq_len_per_chunk = jax_conv_out.shape[1]
+        jax_pos_emb = maxtext_model.positional_embedding(seq_len_per_chunk)
+        jax_pos_emb = jnp.broadcast_to(jax_pos_emb[None, :, :], (batch_size * num_chunks, seq_len_per_chunk, self.config.d_model_for_audio))
+        jax_after_pos = jax_conv_out + jax_pos_emb
+
+        # Verify all stages match
+        assert_all_close_jax_torch(jax_conv1[0], torch_conv1.permute(0, 2, 3, 1)[0], rtol=1e-4, atol=1e-3, error_msg="Conv1 differs")
+        assert_all_close_jax_torch(jax_conv2[0], torch_conv2.permute(0, 2, 3, 1)[0], rtol=1e-4, atol=1e-3, error_msg="Conv2 differs")
+        assert_all_close_jax_torch(jax_conv3[0], torch_conv3.permute(0, 2, 3, 1)[0], rtol=1e-4, atol=1e-3, error_msg="Conv3 differs")
+        assert_all_close_jax_torch(jax_conv_out[0], torch_conv_out[0], rtol=1e-4, atol=1e-3, error_msg="Conv out differs")
+        assert_all_close_jax_torch(jax_after_pos[0], torch_after_pos[0], rtol=1e-4, atol=1e-3, error_msg="After pos emb differs")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multimodal_test_utils.py
+++ b/tests/multimodal_test_utils.py
@@ -1,0 +1,812 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared utilities for MaxText tests."""
+
+import jax.numpy as jnp
+import numpy as np
+import torch
+
+
+def create_random_jax_torch(*shape, dtype=np.float32):
+  """Create random array and return both JAX and PyTorch versions.
+
+  Args:
+      *shape: Shape of the array
+      dtype: NumPy dtype (default: np.float32)
+
+  Returns:
+      tuple: (jax_array, torch_tensor)
+  """
+  np_array = np.random.randn(*shape).astype(dtype)
+  return jnp.array(np_array), torch.from_numpy(np_array)
+
+
+def split_into_patches(x, temporal_patch_size, patch_size):
+  """Split a 5D tensor into patches for PyTorch vision encoder input.
+
+  Converts from full image format (batch, channels, temporal, height, width) to
+  patch format (num_patches, channels, temporal_patch_size, patch_size, patch_size).
+
+  Returns:
+      Tensor of shape (num_patches, channels, temporal_patch_size, patch_size, patch_size)
+      where num_patches = (temporal//temporal_patch_size) * (height//patch_size) * (width//patch_size)
+  """
+  B, C, T, H, W = x.shape
+  assert T % temporal_patch_size == 0, f"Temporal dimension {T} must be divisible by {temporal_patch_size}"
+  assert H % patch_size == 0, f"Height {H} must be divisible by {patch_size}"
+  assert W % patch_size == 0, f"Width {W} must be divisible by {patch_size}"
+
+  x = x.reshape(B, C, T, H // patch_size, patch_size, W // patch_size, patch_size)
+  x = x.permute(0, 3, 5, 1, 2, 4, 6)  # (B, H//patch_size, W//patch_size, C, T, patch_size, patch_size)
+  return x.reshape(-1, C, T, patch_size, patch_size)
+
+
+def assert_all_close_jax_torch(jax_tensor, torch_tensor, rtol, atol, error_msg=""):
+  """Compare JAX and PyTorch tensors for numerical closeness.
+
+  Args:
+      jax_tensor: JAX array to compare
+      torch_tensor: PyTorch tensor to compare
+      rtol: Relative tolerance
+      atol: Absolute tolerance
+      error_msg: Optional error message prefix
+  """
+  np.testing.assert_allclose(
+      torch_tensor.numpy(),
+      np.array(jax_tensor),
+      rtol=rtol,
+      atol=atol,
+      err_msg=error_msg,
+  )
+
+
+def copy_linear_weights(torch_linear, jax_linear):
+  """Copy weights from PyTorch Linear to JAX nnx.Linear."""
+  jax_linear.kernel.value = jnp.array(torch_linear.weight.detach().cpu().numpy().T)
+  if torch_linear.bias is not None and jax_linear.bias is not None:
+    jax_linear.bias.value = jnp.array(torch_linear.bias.detach().cpu().numpy())
+
+
+def copy_layernorm_weights(torch_ln, jax_ln):
+  """Copy weights from PyTorch LayerNorm to JAX nnx.LayerNorm."""
+  jax_ln.scale.value = jnp.array(torch_ln.weight.detach().cpu().numpy())
+  jax_ln.bias.value = jnp.array(torch_ln.bias.detach().cpu().numpy())
+
+
+def copy_conv2d_weights(torch_conv, jax_conv):
+  """Copy weights from PyTorch Conv2d to JAX nnx.Conv."""
+  # PyTorch: (out_channels, in_channels, kH, kW)
+  # JAX: (kH, kW, in_channels, out_channels)
+  torch_weight = torch_conv.weight.detach().cpu().numpy()
+  jax_weight = np.transpose(torch_weight, (2, 3, 1, 0))
+  jax_conv.kernel.value = jnp.array(jax_weight)
+  jax_conv.bias.value = jnp.array(torch_conv.bias.detach().cpu().numpy())
+
+
+def copy_densegeneral_qkv_weights(torch_linear, jax_densegeneral, num_heads, head_dim):
+  """Copy weights from PyTorch Linear to JAX DenseGeneral for Q/K/V projections.
+
+  PyTorch Linear has weight shape (out_features, in_features)
+  JAX DenseGeneral has kernel shape (in_features, num_heads, head_dim)
+  """
+  # Get PyTorch weight: (out_features, in_features) where out_features = num_heads * head_dim
+  torch_weight = torch_linear.weight.detach().cpu().numpy()  # (out_features, in_features)
+
+  # Transpose and reshape: (in_features, out_features) -> (in_features, num_heads, head_dim)
+  torch_weight_t = torch_weight.T  # (in_features, out_features)
+  jax_weight = torch_weight_t.reshape(-1, num_heads, head_dim)  # (in_features, num_heads, head_dim)
+
+  jax_densegeneral.kernel.value = jnp.array(jax_weight)
+  if torch_linear.bias is not None and jax_densegeneral.bias is not None:
+    # Bias shape for DenseGeneral: (num_heads, head_dim)
+    torch_bias = torch_linear.bias.detach().cpu().numpy()
+    jax_bias = torch_bias.reshape(num_heads, head_dim)
+    jax_densegeneral.bias.value = jnp.array(jax_bias)
+
+
+def copy_densegeneral_out_weights(torch_linear, jax_densegeneral, num_heads, head_dim, output_dim):
+  """Copy weights from PyTorch Linear to JAX DenseGeneral for output projection.
+
+  PyTorch Linear has weight shape (output_dim, input_dim) where input_dim = num_heads * head_dim
+  JAX DenseGeneral has kernel shape (num_heads, head_dim, output_dim)
+  """
+  # Get PyTorch weight: (output_dim, num_heads * head_dim)
+  torch_weight = torch_linear.weight.detach().cpu().numpy()
+
+  # Transpose: (num_heads * head_dim, output_dim)
+  torch_weight_t = torch_weight.T
+
+  # Reshape: (num_heads, head_dim, output_dim)
+  jax_weight = torch_weight_t.reshape(num_heads, head_dim, output_dim)
+
+  jax_densegeneral.kernel.value = jnp.array(jax_weight)
+  if torch_linear.bias is not None and jax_densegeneral.bias is not None:
+    jax_densegeneral.bias.value = jnp.array(torch_linear.bias.detach().cpu().numpy())
+
+
+def copy_attention_weights(torch_attn, jax_attn):
+  """Copy attention layer weights from PyTorch to JAX."""
+  copy_linear_weights(torch_attn.q_proj, jax_attn.q_proj)
+  copy_linear_weights(torch_attn.k_proj, jax_attn.k_proj)
+  copy_linear_weights(torch_attn.v_proj, jax_attn.v_proj)
+  copy_linear_weights(torch_attn.out_proj, jax_attn.out_proj)
+
+
+def copy_attention_weights_to_maxtext(torch_attn, maxtext_attn, fused_qkv=False):
+  """Copy attention weights from PyTorch to MaxText's Attention module.
+
+  Args:
+      torch_attn: PyTorch attention with either:
+          - Separate q_proj, k_proj, v_proj, out_proj (fused_qkv=False, for audio)
+          - Fused qkv and proj (fused_qkv=True, for vision)
+      maxtext_attn: MaxText Attention module with separate q/k/v projections
+      fused_qkv: If True, torch_attn has fused qkv projection that needs splitting
+  """
+  if not hasattr(maxtext_attn, "query"):
+    raise NotImplementedError("Unsupported MaxText Attention structure")
+
+  num_heads = maxtext_attn.num_query_heads
+  head_dim = maxtext_attn.head_dim
+  hidden_size = num_heads * head_dim
+  output_dim = hidden_size
+
+  # Extract Q/K/V weights and biases
+  if fused_qkv:
+    # Vision: Split fused QKV projection
+    qkv_weight = torch_attn.qkv.weight.detach().cpu().numpy()
+    qkv_bias = torch_attn.qkv.bias.detach().cpu().numpy()
+
+    q_weight = qkv_weight[:hidden_size, :]
+    k_weight = qkv_weight[hidden_size : 2 * hidden_size, :]
+    v_weight = qkv_weight[2 * hidden_size :, :]
+    q_bias = qkv_bias[:hidden_size]
+    k_bias = qkv_bias[hidden_size : 2 * hidden_size]
+    v_bias = qkv_bias[2 * hidden_size :]
+
+    out_proj = torch_attn.proj
+  else:
+    # Audio: Extract from separate projections
+    q_weight = torch_attn.q_proj.weight.detach().cpu().numpy()
+    k_weight = torch_attn.k_proj.weight.detach().cpu().numpy()
+    v_weight = torch_attn.v_proj.weight.detach().cpu().numpy()
+    q_bias = torch_attn.q_proj.bias.detach().cpu().numpy()
+    k_bias = torch_attn.k_proj.bias.detach().cpu().numpy()
+    v_bias = torch_attn.v_proj.bias.detach().cpu().numpy()
+
+    out_proj = torch_attn.out_proj
+
+  # Copy Q/K/V weights (common logic for both)
+  maxtext_attn.query.kernel.value = jnp.array(q_weight.T.reshape(hidden_size, num_heads, head_dim))
+  maxtext_attn.query.bias.value = jnp.array(q_bias.reshape(num_heads, head_dim))
+
+  maxtext_attn.key.kernel.value = jnp.array(k_weight.T.reshape(hidden_size, num_heads, head_dim))
+  maxtext_attn.key.bias.value = jnp.array(k_bias.reshape(num_heads, head_dim))
+
+  maxtext_attn.value.kernel.value = jnp.array(v_weight.T.reshape(hidden_size, num_heads, head_dim))
+  maxtext_attn.value.bias.value = jnp.array(v_bias.reshape(num_heads, head_dim))
+
+  # Copy output projection (common logic for both)
+  out_weight = out_proj.weight.detach().cpu().numpy()
+  out_bias = out_proj.bias.detach().cpu().numpy()
+  maxtext_attn.out.kernel.value = jnp.array(out_weight.T.reshape(num_heads, head_dim, output_dim))
+  maxtext_attn.out.bias.value = jnp.array(out_bias)
+
+
+def copy_encoder_layer_weights(torch_layer, jax_layer):
+  """Copy encoder layer weights from PyTorch to JAX."""
+  copy_attention_weights(torch_layer.self_attn, jax_layer.self_attn)
+  copy_linear_weights(torch_layer.fc1, jax_layer.fc1)
+  copy_linear_weights(torch_layer.fc2, jax_layer.fc2)
+  copy_layernorm_weights(torch_layer.self_attn_layer_norm, jax_layer.self_attn_layer_norm)
+  copy_layernorm_weights(torch_layer.final_layer_norm, jax_layer.final_layer_norm)
+
+
+def copy_encoder_weights(torch_encoder, jax_encoder):
+  """Copy full encoder weights from PyTorch to JAX."""
+  # Copy convolutional layers
+  copy_conv2d_weights(torch_encoder.conv2d1, jax_encoder.conv2d1)
+  copy_conv2d_weights(torch_encoder.conv2d2, jax_encoder.conv2d2)
+  copy_conv2d_weights(torch_encoder.conv2d3, jax_encoder.conv2d3)
+
+  # Copy linear projections
+  copy_linear_weights(torch_encoder.conv_out, jax_encoder.conv_out)
+  copy_linear_weights(torch_encoder.proj1, jax_encoder.proj1)
+  copy_linear_weights(torch_encoder.proj2, jax_encoder.proj2)
+
+  # Copy layer norm
+  copy_layernorm_weights(torch_encoder.ln_post, jax_encoder.ln_post)
+
+  # Copy positional embeddings
+  jax_encoder.positional_embedding.positional_embedding.value = jnp.array(
+      torch_encoder.positional_embedding.positional_embedding.detach().cpu().numpy()
+  )
+
+  # Copy encoder layers
+  for torch_layer, jax_layer in zip(torch_encoder.layers, jax_encoder.layers):
+    copy_encoder_layer_weights(torch_layer, jax_layer)
+
+
+def copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer):
+  """Copy encoder layer weights from PyTorch to MaxText AudioEncoderLayer.
+
+  Args:
+      torch_layer: PyTorch TorchQwen3OmniMoeAudioEncoderLayer
+      maxtext_layer: MaxText AudioEncoderLayer
+  """
+  # Copy layer norms
+  copy_layernorm_weights(torch_layer.self_attn_layer_norm, maxtext_layer.input_layer_norm)
+  copy_layernorm_weights(torch_layer.final_layer_norm, maxtext_layer.post_attention_layer_norm)
+
+  # Copy attention weights to MaxText Attention module
+  copy_attention_weights_to_maxtext(torch_layer.self_attn, maxtext_layer.self_attention_audio)
+
+  copy_linear_weights(torch_layer.fc1, maxtext_layer.AudioMLP.wi)
+  copy_linear_weights(torch_layer.fc2, maxtext_layer.AudioMLP.wo)
+
+
+def copy_audio_model(torch_model, maxtext_model, config):
+  """Copy full AudioModel weights from PyTorch to MaxText.
+
+  Args:
+      torch_model: PyTorch TorchQwen3OmniMoeAudioEncoder
+      maxtext_model: MaxText AudioModel
+      config: MaxText config with encoder_layers
+  """
+  copy_conv2d_weights(torch_model.conv2d1, maxtext_model.conv2d1)
+  copy_conv2d_weights(torch_model.conv2d2, maxtext_model.conv2d2)
+  copy_conv2d_weights(torch_model.conv2d3, maxtext_model.conv2d3)
+  copy_linear_weights(torch_model.conv_out, maxtext_model.conv_out)
+
+  maxtext_model.positional_embedding.positional_embedding.value = jnp.array(
+      torch_model.positional_embedding.positional_embedding.detach().cpu().numpy()
+  )
+
+  copy_layernorm_weights(torch_model.ln_post, maxtext_model.layernorm_post)
+
+  for torch_layer, maxtext_layer in zip(
+      torch_model.layers,
+      [getattr(maxtext_model.audio_encoder, f"layers_{i}") for i in range(config.encoder_layers_for_audio)],
+  ):
+    copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer)
+
+  copy_linear_weights(torch_model.proj1, maxtext_model.audio_projector.proj1)
+  copy_linear_weights(torch_model.proj2, maxtext_model.audio_projector.proj2)
+
+
+def copy_maxtext_encoder_weights(torch_encoder, maxtext_encoder):
+  # Copy weights for each encoder layer
+  for torch_layer, maxtext_layer in zip(
+      torch_encoder.layers,
+      [getattr(maxtext_encoder, f"layers_{i}") for i in range(len(torch_encoder.layers))],
+  ):
+    copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer)
+
+
+# Vision-specific weight copying utilities
+def copy_conv3d_weights(torch_conv, jax_conv):
+  """Copy weights from PyTorch Conv3d to JAX nnx.Conv (3D)."""
+  # PyTorch Conv3d: (out_channels, in_channels, kD, kH, kW)
+  # JAX Conv (3D): (kD, kH, kW, in_channels, out_channels)
+  torch_weight = torch_conv.weight.detach().cpu().numpy()
+  jax_weight = np.transpose(torch_weight, (2, 3, 4, 1, 0))
+  jax_conv.kernel.value = jnp.array(jax_weight)
+  jax_conv.bias.value = jnp.array(torch_conv.bias.detach().cpu().numpy())
+
+
+def copy_patch_embed_weights(torch_embed, jax_embed):
+  """Copy patch embed weights from PyTorch to JAX."""
+  copy_conv3d_weights(torch_embed.proj, jax_embed.proj)
+
+
+def copy_mlp_weights(torch_mlp, jax_mlp):
+  """Copy MLP weights from PyTorch to JAX."""
+  copy_linear_weights(torch_mlp.linear_fc1, jax_mlp.linear_fc1)
+  copy_linear_weights(torch_mlp.linear_fc2, jax_mlp.linear_fc2)
+
+
+def copy_patch_merger_weights(torch_merger, jax_merger):
+  """Copy patch merger weights from PyTorch to JAX."""
+  copy_layernorm_weights(torch_merger.ln_q, jax_merger.ln_q)
+  copy_linear_weights(torch_merger.mlp[0], jax_merger.mlp_0)
+  copy_linear_weights(torch_merger.mlp[2], jax_merger.mlp_2)
+
+
+def copy_vision_encoder_weights(torch_encoder, jax_encoder):
+  """Copy all weights from PyTorch vision encoder to JAX vision encoder.
+
+  Args:
+      torch_encoder: PyTorch Qwen3OmniMoeVisionEncoder
+      jax_encoder: JAX Qwen3OmniMoeVisionEncoder
+  """
+  # Copy patch embedding
+  copy_patch_embed_weights(torch_encoder.patch_embed, jax_encoder.patch_embed)
+
+  # Copy positional embedding weights
+  torch_pos_embed = torch_encoder.pos_embed.weight.detach().cpu().numpy()
+  jax_encoder.pos_embed_interpolate.pos_embed.value = jnp.array(torch_pos_embed)
+
+  # Copy encoder blocks
+  for torch_block, jax_block in zip(torch_encoder.blocks, jax_encoder.blocks):
+    # Copy layer norms
+    copy_layernorm_weights(torch_block.norm1, jax_block.ln1)
+    copy_layernorm_weights(torch_block.norm2, jax_block.ln2)
+
+    # Copy attention weights (vision uses fused QKV)
+    copy_attention_weights_to_maxtext(torch_block.attn, jax_block.attn.attn, fused_qkv=True)
+
+    # Copy MLP weights (vision MLP uses DenseGeneral)
+    copy_linear_weights(torch_block.mlp.linear_fc1, jax_block.mlp)
+    copy_linear_weights(torch_block.mlp.linear_fc2, jax_block.mlp_out)
+
+  # Copy merger weights (deep mergers only, final_merger is now in projector)
+  for torch_merger, jax_merger in zip(torch_encoder.merger_list, jax_encoder.merger_list):
+    copy_patch_merger_weights(torch_merger, jax_merger)
+
+
+# Audio-specific utilities
+def create_block_diagonal_attention_mask(cu_seqlens, dtype):
+  """Create block-diagonal attention mask from cumulative sequence lengths.
+
+  PyTorch's eager attention implementation doesn't automatically respect cu_seqlens boundaries.
+  This function creates an explicit block-diagonal mask that prevents attention across
+  different sequences in the batch.
+
+  Args:
+      cu_seqlens: Cumulative sequence lengths, e.g., [0, 12, 24] for 2 sequences of length 12
+      dtype: Data type for the attention mask
+
+  Returns:
+      Attention mask of shape (1, 1, total_seq_len, total_seq_len) where:
+      - 0.0 means "can attend" (within same sequence)
+      - finfo(dtype).min means "cannot attend" (across sequences)
+
+  Example:
+      >>> cu_seqlens = torch.tensor([0, 12, 24], dtype=torch.int32)
+      >>> mask = create_block_diagonal_attention_mask(cu_seqlens, torch.float32)
+      >>> # Positions 0-11 can only attend to 0-11
+      >>> # Positions 12-23 can only attend to 12-23
+  """
+  total_seq_len = cu_seqlens[-1].item()
+  attention_mask = torch.full(
+      [1, 1, total_seq_len, total_seq_len],
+      torch.finfo(dtype).min,
+      device=cu_seqlens.device,
+      dtype=dtype,
+  )
+
+  # Create blocks: allow attention within each sequence boundary
+  for i in range(1, len(cu_seqlens)):
+    start = cu_seqlens[i - 1].item()
+    end = cu_seqlens[i].item()
+    attention_mask[..., start:end, start:end] = 0
+
+  return attention_mask
+
+
+def assert_all_close_jax_torch(jax_tensor, torch_tensor, rtol, atol, error_msg=""):
+    """Compare JAX and PyTorch tensors for numerical closeness.
+
+    Args:
+        jax_tensor: JAX array to compare
+        torch_tensor: PyTorch tensor to compare
+        rtol: Relative tolerance
+        atol: Absolute tolerance
+        error_msg: Optional error message prefix
+    """
+    np.testing.assert_allclose(
+        torch_tensor.numpy(),
+        np.array(jax_tensor),
+        rtol=rtol,
+        atol=atol,
+        err_msg=error_msg,
+    )
+
+
+def copy_linear_weights(torch_linear, jax_linear):
+    """Copy weights from PyTorch Linear to JAX nnx.Linear."""
+    jax_linear.kernel.value = jnp.array(torch_linear.weight.detach().cpu().numpy().T)
+    if torch_linear.bias is not None and jax_linear.bias is not None:
+        jax_linear.bias.value = jnp.array(torch_linear.bias.detach().cpu().numpy())
+
+
+def copy_layernorm_weights(torch_ln, jax_ln):
+    """Copy weights from PyTorch LayerNorm to JAX nnx.LayerNorm."""
+    jax_ln.scale.value = jnp.array(torch_ln.weight.detach().cpu().numpy())
+    jax_ln.bias.value = jnp.array(torch_ln.bias.detach().cpu().numpy())
+
+
+def copy_conv2d_weights(torch_conv, jax_conv):
+    """Copy weights from PyTorch Conv2d to JAX nnx.Conv."""
+    # PyTorch: (out_channels, in_channels, kH, kW)
+    # JAX: (kH, kW, in_channels, out_channels)
+    torch_weight = torch_conv.weight.detach().cpu().numpy()
+    jax_weight = np.transpose(torch_weight, (2, 3, 1, 0))
+    jax_conv.kernel.value = jnp.array(jax_weight)
+    jax_conv.bias.value = jnp.array(torch_conv.bias.detach().cpu().numpy())
+
+
+def copy_densegeneral_qkv_weights(torch_linear, jax_densegeneral, num_heads, head_dim):
+    """Copy weights from PyTorch Linear to JAX DenseGeneral for Q/K/V projections.
+
+    PyTorch Linear has weight shape (out_features, in_features)
+    JAX DenseGeneral has kernel shape (in_features, num_heads, head_dim)
+    """
+    # Get PyTorch weight: (out_features, in_features) where out_features = num_heads * head_dim
+    torch_weight = (
+        torch_linear.weight.detach().cpu().numpy()
+    )  # (out_features, in_features)
+
+    # Transpose and reshape: (in_features, out_features) -> (in_features, num_heads, head_dim)
+    torch_weight_t = torch_weight.T  # (in_features, out_features)
+    jax_weight = torch_weight_t.reshape(
+        -1, num_heads, head_dim
+    )  # (in_features, num_heads, head_dim)
+
+    jax_densegeneral.kernel.value = jnp.array(jax_weight)
+    if torch_linear.bias is not None and jax_densegeneral.bias is not None:
+        # Bias shape for DenseGeneral: (num_heads, head_dim)
+        torch_bias = torch_linear.bias.detach().cpu().numpy()
+        jax_bias = torch_bias.reshape(num_heads, head_dim)
+        jax_densegeneral.bias.value = jnp.array(jax_bias)
+
+
+def copy_densegeneral_out_weights(
+    torch_linear, jax_densegeneral, num_heads, head_dim, output_dim
+):
+    """Copy weights from PyTorch Linear to JAX DenseGeneral for output projection.
+
+    PyTorch Linear has weight shape (output_dim, input_dim) where input_dim = num_heads * head_dim
+    JAX DenseGeneral has kernel shape (num_heads, head_dim, output_dim)
+    """
+    # Get PyTorch weight: (output_dim, num_heads * head_dim)
+    torch_weight = torch_linear.weight.detach().cpu().numpy()
+
+    # Transpose: (num_heads * head_dim, output_dim)
+    torch_weight_t = torch_weight.T
+
+    # Reshape: (num_heads, head_dim, output_dim)
+    jax_weight = torch_weight_t.reshape(num_heads, head_dim, output_dim)
+
+    jax_densegeneral.kernel.value = jnp.array(jax_weight)
+    if torch_linear.bias is not None and jax_densegeneral.bias is not None:
+        jax_densegeneral.bias.value = jnp.array(
+            torch_linear.bias.detach().cpu().numpy()
+        )
+
+
+def copy_attention_weights(torch_attn, jax_attn):
+    """Copy attention layer weights from PyTorch to JAX."""
+    copy_linear_weights(torch_attn.q_proj, jax_attn.q_proj)
+    copy_linear_weights(torch_attn.k_proj, jax_attn.k_proj)
+    copy_linear_weights(torch_attn.v_proj, jax_attn.v_proj)
+    copy_linear_weights(torch_attn.out_proj, jax_attn.out_proj)
+
+
+def copy_attention_weights_to_maxtext(torch_attn, maxtext_attn, fused_qkv=False):
+    """Copy attention weights from PyTorch to MaxText's Attention module.
+
+    Args:
+        torch_attn: PyTorch attention with either:
+            - Separate q_proj, k_proj, v_proj, out_proj (fused_qkv=False, for audio)
+            - Fused qkv and proj (fused_qkv=True, for vision)
+        maxtext_attn: MaxText Attention module with separate q/k/v projections
+        fused_qkv: If True, torch_attn has fused qkv projection that needs splitting
+    """
+    if not hasattr(maxtext_attn, "query"):
+        raise NotImplementedError("Unsupported MaxText Attention structure")
+
+    num_heads = maxtext_attn.num_query_heads
+    head_dim = maxtext_attn.head_dim
+    hidden_size = num_heads * head_dim
+    output_dim = hidden_size
+
+    # Extract Q/K/V weights and biases
+    if fused_qkv:
+        # Vision: Split fused QKV projection
+        qkv_weight = torch_attn.qkv.weight.detach().cpu().numpy()
+        qkv_bias = torch_attn.qkv.bias.detach().cpu().numpy()
+
+        q_weight = qkv_weight[:hidden_size, :]
+        k_weight = qkv_weight[hidden_size : 2 * hidden_size, :]
+        v_weight = qkv_weight[2 * hidden_size :, :]
+        q_bias = qkv_bias[:hidden_size]
+        k_bias = qkv_bias[hidden_size : 2 * hidden_size]
+        v_bias = qkv_bias[2 * hidden_size :]
+
+        out_proj = torch_attn.proj
+    else:
+        # Audio: Extract from separate projections
+        q_weight = torch_attn.q_proj.weight.detach().cpu().numpy()
+        k_weight = torch_attn.k_proj.weight.detach().cpu().numpy()
+        v_weight = torch_attn.v_proj.weight.detach().cpu().numpy()
+        q_bias = torch_attn.q_proj.bias.detach().cpu().numpy()
+        k_bias = torch_attn.k_proj.bias.detach().cpu().numpy()
+        v_bias = torch_attn.v_proj.bias.detach().cpu().numpy()
+
+        out_proj = torch_attn.out_proj
+
+    # Copy Q/K/V weights (common logic for both)
+    maxtext_attn.query.kernel.value = jnp.array(
+        q_weight.T.reshape(hidden_size, num_heads, head_dim)
+    )
+    maxtext_attn.query.bias.value = jnp.array(q_bias.reshape(num_heads, head_dim))
+
+    maxtext_attn.key.kernel.value = jnp.array(
+        k_weight.T.reshape(hidden_size, num_heads, head_dim)
+    )
+    maxtext_attn.key.bias.value = jnp.array(k_bias.reshape(num_heads, head_dim))
+
+    maxtext_attn.value.kernel.value = jnp.array(
+        v_weight.T.reshape(hidden_size, num_heads, head_dim)
+    )
+    maxtext_attn.value.bias.value = jnp.array(v_bias.reshape(num_heads, head_dim))
+
+    # Copy output projection (common logic for both)
+    out_weight = out_proj.weight.detach().cpu().numpy()
+    out_bias = out_proj.bias.detach().cpu().numpy()
+    maxtext_attn.out.kernel.value = jnp.array(
+        out_weight.T.reshape(num_heads, head_dim, output_dim)
+    )
+    maxtext_attn.out.bias.value = jnp.array(out_bias)
+
+
+def copy_encoder_layer_weights(torch_layer, jax_layer):
+    """Copy encoder layer weights from PyTorch to JAX."""
+    copy_attention_weights(torch_layer.self_attn, jax_layer.self_attn)
+    copy_linear_weights(torch_layer.fc1, jax_layer.fc1)
+    copy_linear_weights(torch_layer.fc2, jax_layer.fc2)
+    copy_layernorm_weights(
+        torch_layer.self_attn_layer_norm, jax_layer.self_attn_layer_norm
+    )
+    copy_layernorm_weights(torch_layer.final_layer_norm, jax_layer.final_layer_norm)
+
+
+def copy_encoder_weights(torch_encoder, jax_encoder):
+    """Copy full encoder weights from PyTorch to JAX."""
+    # Copy convolutional layers
+    copy_conv2d_weights(torch_encoder.conv2d1, jax_encoder.conv2d1)
+    copy_conv2d_weights(torch_encoder.conv2d2, jax_encoder.conv2d2)
+    copy_conv2d_weights(torch_encoder.conv2d3, jax_encoder.conv2d3)
+
+    # Copy linear projections
+    copy_linear_weights(torch_encoder.conv_out, jax_encoder.conv_out)
+    copy_linear_weights(torch_encoder.proj1, jax_encoder.proj1)
+    copy_linear_weights(torch_encoder.proj2, jax_encoder.proj2)
+
+    # Copy layer norm
+    copy_layernorm_weights(torch_encoder.ln_post, jax_encoder.ln_post)
+
+    # Copy positional embeddings
+    jax_encoder.positional_embedding.positional_embedding.value = jnp.array(
+        torch_encoder.positional_embedding.positional_embedding.detach().cpu().numpy()
+    )
+
+    # Copy encoder layers
+    for torch_layer, jax_layer in zip(torch_encoder.layers, jax_encoder.layers):
+        copy_encoder_layer_weights(torch_layer, jax_layer)
+
+
+def copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer):
+    """Copy encoder layer weights from PyTorch to MaxText AudioEncoderLayer.
+
+    Args:
+        torch_layer: PyTorch TorchQwen3OmniMoeAudioEncoderLayer
+        maxtext_layer: MaxText AudioEncoderLayer
+    """
+    # Copy layer norms
+    copy_layernorm_weights(
+        torch_layer.self_attn_layer_norm, maxtext_layer.input_layer_norm
+    )
+    copy_layernorm_weights(
+        torch_layer.final_layer_norm, maxtext_layer.post_attention_layer_norm
+    )
+
+    # Copy attention weights to MaxText Attention module
+    copy_attention_weights_to_maxtext(
+        torch_layer.self_attn, maxtext_layer.self_attention_audio
+    )
+
+    copy_linear_weights(
+        torch_layer.fc1, maxtext_layer.AudioMLP.wi
+    )
+    copy_linear_weights(
+        torch_layer.fc2, maxtext_layer.AudioMLP.wo
+    )
+
+
+def copy_maxtext_audio_encoder_weights(torch_model, maxtext_encoder, config):
+    """Copy AudioEncoder weights (convs + transformer, no projector) from PyTorch to MaxText.
+
+    Args:
+        torch_model: PyTorch TorchQwen3OmniMoeAudioEncoder
+        maxtext_encoder: MaxText Qwen3OmniAudioEncoder (just encoder, no projector)
+        config: MaxText config with encoder_layers
+    """
+    copy_conv2d_weights(torch_model.conv2d1, maxtext_encoder.conv2d1)
+    copy_conv2d_weights(torch_model.conv2d2, maxtext_encoder.conv2d2)
+    copy_conv2d_weights(torch_model.conv2d3, maxtext_encoder.conv2d3)
+    copy_linear_weights(torch_model.conv_out, maxtext_encoder.conv_out)
+
+    maxtext_encoder.positional_embedding.positional_embedding.value = jnp.array(
+        torch_model.positional_embedding.positional_embedding.detach().cpu().numpy()
+    )
+
+    copy_layernorm_weights(torch_model.ln_post, maxtext_encoder.layernorm_post)
+
+    for torch_layer, maxtext_layer in zip(
+        torch_model.layers,
+        [
+            getattr(maxtext_encoder, f"layers_{i}")
+            for i in range(config.encoder_layers_for_audio)
+        ],
+    ):
+        copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer)
+
+
+def copy_audio_model(torch_model, maxtext_model, config):
+    """Copy full AudioModel weights from PyTorch to MaxText.
+
+    Args:
+        torch_model: PyTorch TorchQwen3OmniMoeAudioEncoder
+        maxtext_model: MaxText AudioModel (encoder + projector)
+        config: MaxText config with encoder_layers
+    """
+    encoder = maxtext_model.audio_encoder
+    copy_conv2d_weights(torch_model.conv2d1, encoder.conv2d1)
+    copy_conv2d_weights(torch_model.conv2d2, encoder.conv2d2)
+    copy_conv2d_weights(torch_model.conv2d3, encoder.conv2d3)
+    copy_linear_weights(torch_model.conv_out, encoder.conv_out)
+
+    encoder.positional_embedding.positional_embedding.value = jnp.array(
+        torch_model.positional_embedding.positional_embedding.detach().cpu().numpy()
+    )
+
+    copy_layernorm_weights(torch_model.ln_post, encoder.layernorm_post)
+
+    for torch_layer, maxtext_layer in zip(
+        torch_model.layers,
+        [
+            getattr(encoder, f"layers_{i}")
+            for i in range(config.encoder_layers_for_audio)
+        ],
+    ):
+        copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer)
+
+    copy_linear_weights(torch_model.proj1, maxtext_model.audio_projector.proj1)
+    copy_linear_weights(torch_model.proj2, maxtext_model.audio_projector.proj2)
+
+
+def copy_maxtext_encoder_weights(torch_encoder, maxtext_encoder):
+    # Copy weights for each encoder layer
+    for torch_layer, maxtext_layer in zip(
+        torch_encoder.layers,
+        [
+            getattr(maxtext_encoder, f"layers_{i}")
+            for i in range(len(torch_encoder.layers))
+        ],
+    ):
+        copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer)
+
+
+# Vision-specific weight copying utilities
+
+
+def copy_conv3d_weights(torch_conv, jax_conv):
+    """Copy weights from PyTorch Conv3d to JAX nnx.Conv (3D)."""
+    # PyTorch Conv3d: (out_channels, in_channels, kD, kH, kW)
+    # JAX Conv (3D): (kD, kH, kW, in_channels, out_channels)
+    torch_weight = torch_conv.weight.detach().cpu().numpy()
+    jax_weight = np.transpose(torch_weight, (2, 3, 4, 1, 0))
+    jax_conv.kernel.value = jnp.array(jax_weight)
+    jax_conv.bias.value = jnp.array(torch_conv.bias.detach().cpu().numpy())
+
+
+def copy_patch_embed_weights(torch_embed, jax_embed):
+    """Copy patch embed weights from PyTorch to JAX."""
+    copy_conv3d_weights(torch_embed.proj, jax_embed.proj)
+
+
+def copy_mlp_weights(torch_mlp, jax_mlp):
+    """Copy MLP weights from PyTorch to JAX."""
+    copy_linear_weights(torch_mlp.linear_fc1, jax_mlp.linear_fc1)
+    copy_linear_weights(torch_mlp.linear_fc2, jax_mlp.linear_fc2)
+
+
+def copy_patch_merger_weights(torch_merger, jax_merger):
+    """Copy patch merger weights from PyTorch to JAX."""
+    copy_layernorm_weights(torch_merger.ln_q, jax_merger.ln_q)
+    copy_linear_weights(torch_merger.mlp[0], jax_merger.mlp_0)
+    copy_linear_weights(torch_merger.mlp[2], jax_merger.mlp_2)
+
+
+def copy_vision_encoder_weights(torch_encoder, jax_encoder):
+    """Copy all weights from PyTorch vision encoder to JAX vision encoder.
+
+    Args:
+        torch_encoder: PyTorch Qwen3OmniMoeVisionEncoder
+        jax_encoder: JAX Qwen3OmniMoeVisionEncoder
+    """
+    import jax.numpy as jnp
+
+    # Copy patch embedding
+    copy_patch_embed_weights(torch_encoder.patch_embed, jax_encoder.patch_embed)
+
+    # Copy positional embedding weights
+    torch_pos_embed = torch_encoder.pos_embed.weight.detach().cpu().numpy()
+    jax_encoder.pos_embed_interpolate.pos_embed.value = jnp.array(torch_pos_embed)
+
+    # Copy encoder blocks
+    for torch_block, jax_block in zip(torch_encoder.blocks, jax_encoder.blocks):
+        # Copy layer norms
+        copy_layernorm_weights(torch_block.norm1, jax_block.ln1)
+        copy_layernorm_weights(torch_block.norm2, jax_block.ln2)
+
+        # Copy attention weights (vision uses fused QKV)
+        copy_attention_weights_to_maxtext(
+            torch_block.attn, jax_block.attn.attn, fused_qkv=True
+        )
+
+        # Copy MLP weights (vision MLP uses DenseGeneral)
+        copy_linear_weights(torch_block.mlp.linear_fc1, jax_block.mlp)
+        copy_linear_weights(torch_block.mlp.linear_fc2, jax_block.mlp_out)
+
+    # Copy merger weights (deep mergers only, final_merger is now in projector)
+    for torch_merger, jax_merger in zip(torch_encoder.merger_list, jax_encoder.merger_list):
+        copy_patch_merger_weights(torch_merger, jax_merger)
+
+
+# Audio-specific utilities
+
+
+def create_block_diagonal_attention_mask(
+    cu_seqlens, dtype
+):
+    """Create block-diagonal attention mask from cumulative sequence lengths.
+
+    PyTorch's eager attention implementation doesn't automatically respect cu_seqlens boundaries.
+    This function creates an explicit block-diagonal mask that prevents attention across
+    different sequences in the batch.
+
+    Args:
+        cu_seqlens: Cumulative sequence lengths, e.g., [0, 12, 24] for 2 sequences of length 12
+        dtype: Data type for the attention mask
+
+    Returns:
+        Attention mask of shape (1, 1, total_seq_len, total_seq_len) where:
+        - 0.0 means "can attend" (within same sequence)
+        - finfo(dtype).min means "cannot attend" (across sequences)
+
+    Example:
+        >>> cu_seqlens = torch.tensor([0, 12, 24], dtype=torch.int32)
+        >>> mask = create_block_diagonal_attention_mask(cu_seqlens, torch.float32)
+        >>> # Positions 0-11 can only attend to 0-11
+        >>> # Positions 12-23 can only attend to 12-23
+    """
+    import torch
+    total_seq_len = cu_seqlens[-1].item()
+    attention_mask = torch.full(
+        [1, 1, total_seq_len, total_seq_len],
+        torch.finfo(dtype).min,
+        device=cu_seqlens.device,
+        dtype=dtype,
+    )
+
+    # Create blocks: allow attention within each sequence boundary
+    for i in range(1, len(cu_seqlens)):
+        start = cu_seqlens[i - 1].item()
+        end = cu_seqlens[i].item()
+        attention_mask[..., start:end, start:end] = 0
+
+    return attention_mask


### PR DESCRIPTION
# Description

Add qwen3 omni audio encoder 

working with static shapes (assuming that audio has already been encoded)

# Tests

I compared with the torch implementation on randomly initialized models.

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).