### PR TITLE
Add progress bar for to_maxtext ckpt conversion

### DIFF
--- a/src/MaxText/checkpointing.py
+++ b/src/MaxText/checkpointing.py
@@ -427,7 +427,9 @@ def _restore_grain_iterator(
   elif expansion_factor_real_data > 1 and process_count_stored == process_count_jax // expansion_factor_real_data:
     # Scaling up to a larger number of hosts.(e.g., 32 files -> 64 processes)
     # In this case, a subset of hosts restore the data iterator.
-    assert not isinstance(data_iterator, list), "when expansion_factor_real_data > 1, the data iterator should not be a list."
+    assert not isinstance(
+        data_iterator, list
+    ), "when expansion_factor_real_data > 1, the data iterator should not be a list."
     grain_restore_args = GrainCheckpointRestore(
         data_iterator.local_iterator, process_index=jax.process_index(), process_count=process_count_stored
     )


### PR DESCRIPTION
# Description

Add a progress bar for the checkpoint conversion. It shows the current progress (number of params processed/total number of params), estimated remaining time and RAM usage.

Also fix some pylint/pyink issues in `checkpointing.py`.

# Tests

Tested with command on CPU VM:
```
python -m MaxText.utils.ckpt_conversion.to_maxtext MaxText/configs/base.yml hardware=cpu skip_jax_distributed_system=True hf_access_token=<hf_token> model_name=llama3.1-70b base_output_directory=<gcs_path> scan_layers=false
```

Before:
```
Parameter mappings and hooks obtained.
Starting weight transformation...
```

After:
```
Parameter mappings and hooks obtained.
Starting weight transformation...
Transforming weights:  76%|████████████▉    | 549/723 [01:07<00:09, 18.6param/s, RAM: 1113.1/3783.8GB (29.4%)]
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
