### PR TITLE
Use correct extra_deps_from_github.txt file path in setup.sh

### DIFF
--- a/tools/setup/setup.sh
+++ b/tools/setup/setup.sh
@@ -160,7 +160,7 @@ if [[ "$MODE" == "nightly" ]]; then
     echo "-------------------------------------------------"
     
     python3 -m uv pip install --no-cache-dir -U -r "$nightly_txt" \
-                                                -r 'dependencies/requirements/extra_deps_from_github.txt'
+                                                -r 'src/install_maxtext_extra_deps/extra_deps_from_github.txt'
     rm -fv -- "$nightly_txt"
 else
     # stable or stable_stack mode: Install with pinned commits
@@ -185,7 +185,7 @@ else
       exit 2
     else
       python3 -m uv pip install --resolution=lowest -r "$requirements_txt" \
-                                                    -r 'dependencies/requirements/extra_deps_from_github.txt'
+                                                    -r 'src/install_maxtext_extra_deps/extra_deps_from_github.txt'
     fi
 fi
 


### PR DESCRIPTION
# Description

`setup.sh` was updated in #2541 as part of the ongoing restructuring effort. @NuojCheng saw an error when running `bash setup.sh` after this change:

```
Installing "tpu-requirements.txt" with pinned commits.
error: File not found: `dependencies/requirements/extra_deps_from_github.txt
```

This PR points the setup script to the correct file location

# Tests

* Reproduced the error on main with `bash tools/setup/setup.sh` and `bash tools/setup/setup.sh MODE=nightly`
* Re-ran both commands on this branch and the script finished successfully

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
