### PR TITLE
[DRAFT] Enable test_default_hlo_match for unit testing with Pathways backend

### DIFF
--- a/.github/workflows/run_pathways_tests_internal.yml
+++ b/.github/workflows/run_pathways_tests_internal.yml
@@ -77,7 +77,7 @@ jobs:
           python3 -m pip install -e . --no-dependencies &&
           python3 -m pip uninstall -y libtpu &&
           # TODO(b/454659463): Enable test_default_hlo_match after volume mount is supported.
-          python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" -k "not test_default_hlo_match" --durations=0
+          python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" --durations=0
     
     services:
       resource_manager:


### PR DESCRIPTION
# Description

Enable test_default_hlo_match for unit testing with Pathways backend
- With Pathways as backend, the jax container and the proxy container should be able to access a shared directory for this test case to pass.
- Previously this unit test case is disabled because volume mounting is not supported by the runner. Now it is supported.

# Tests

Example runs:

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
