### PR TITLE
Add deepseek3 conversion utility: orbax scan to hf 

### DIFF
--- a/src/MaxText/scratch_code/generate_hf_golden_logits.py
+++ b/src/MaxText/scratch_code/generate_hf_golden_logits.py
@@ -60,7 +60,16 @@ def upload_blob(bucket_name, source_file_name, destination_blob_name):
 
 
 def save_golden_logits(
-    model_id, output_path, prompt_texts, apply_chat_template, gcs_bucket, hf_model_path, image_paths, output_format
+    model_id,
+    output_path,
+    prompt_texts,
+    apply_chat_template,
+    gcs_bucket,
+    hf_model_path,
+    hf_load_dtype,
+    trust_remote_code,
+    image_paths,
+    output_format,
 ):
   """save golden logits"""
   if hf_model_path is None:
@@ -77,10 +86,18 @@ def save_golden_logits(
 
   tokenizer = AutoTokenizer.from_pretrained(model_id)
   print(f"loading model from {hf_model_path}")
+
+  if hf_load_dtype == "float32":
+    torch_dtype = torch.float32
+  elif hf_load_dtype == "bfloat16":
+    torch_dtype = torch.bfloat16
+  else:
+    raise ValueError
+
   model = model_class.from_pretrained(
       hf_model_path,
-      torch_dtype=torch.float32,
-      trust_remote_code=True,
+      dtype=torch_dtype,
+      trust_remote_code=trust_remote_code,
   )
 
   all_data_to_save = []
@@ -110,7 +127,7 @@ def save_golden_logits(
     # 2. Run inference
     with torch.no_grad():
       outputs = model(**inputs)
-      logits = outputs.logits.cpu().numpy().astype("float32")
+      logits = outputs.logits.cpu().to(torch.float32).numpy()
 
     # 3. Populate final data dictionary with tensors from inputs and logits
     for key, value in inputs.items():
@@ -160,6 +177,21 @@ def main(raw_args=None) -> None:
       "--hf-model-path", type=str, required=False, default=None, help="local path to checkpoint if exists."
   )
   parser.add_argument(
+      "--hf-load-dtype",
+      type=str,
+      required=False,
+      choices=["float32", "bfloat16"],
+      default="float32",
+      help="model_class.from_pretrained: dtype",
+  )
+  # variable `args.trust_remote_code` is True by default, False only if with flag `--not-trust-remote-code`
+  parser.add_argument(
+      "--not-trust-remote-code",
+      dest="trust_remote_code",
+      action="store_false",
+      help="model_class.from_pretrained: trust_remote_code",
+  )
+  parser.add_argument(
       "--image-paths", type=str, required=False, default=None, help="A semicolon-separated list of image_paths."
   )
   parser.add_argument(
@@ -185,6 +217,8 @@ def main(raw_args=None) -> None:
       args.apply_chat_template,
       args.gcs_bucket,
       args.hf_model_path,
+      args.hf_load_dtype,
+      args.trust_remote_code,
       image_paths,
       args.output_format,
   )

--- a/src/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -469,6 +469,65 @@ qwen3_coder_480b_a35b_config = transformers.Qwen3MoeConfig(
     vocab_size=151936,
 )
 
+deepseek3_671b_dict = {
+    "architectures": ["DeepseekV3ForCausalLM"],
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "auto_map": {
+        "AutoConfig": "configuration_deepseek.DeepseekV3Config",
+        "AutoModel": "modeling_deepseek.DeepseekV3Model",
+        "AutoModelForCausalLM": "modeling_deepseek.DeepseekV3ForCausalLM",
+    },
+    "bos_token_id": 0,
+    "eos_token_id": 1,
+    "ep_size": 1,
+    "first_k_dense_replace": 3,
+    "hidden_act": "silu",
+    "hidden_size": 7168,
+    "initializer_range": 0.02,
+    "intermediate_size": 18432,
+    "kv_lora_rank": 512,
+    "max_position_embeddings": 163840,
+    "model_type": "deepseek_v3",
+    "moe_intermediate_size": 2048,
+    "moe_layer_freq": 1,
+    "n_group": 8,
+    "n_routed_experts": 256,
+    "n_shared_experts": 1,
+    "norm_topk_prob": True,
+    "num_attention_heads": 128,
+    "num_experts_per_tok": 8,
+    "num_hidden_layers": 61,
+    "num_key_value_heads": 128,
+    "num_nextn_predict_layers": 1,
+    "q_lora_rank": 1536,
+    "qk_nope_head_dim": 128,
+    "qk_rope_head_dim": 64,
+    "rms_norm_eps": 1e-06,
+    "rope_scaling": {
+        "beta_fast": 32,
+        "beta_slow": 1,
+        "factor": 40,
+        "mscale": 1.0,
+        "mscale_all_dim": 1.0,
+        "original_max_position_embeddings": 4096,
+        "type": "yarn",
+    },
+    "rope_theta": 10000,
+    "routed_scaling_factor": 2.5,
+    "scoring_func": "sigmoid",
+    "tie_word_embeddings": False,
+    "topk_group": 4,
+    "topk_method": "noaux_tc",
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.33.1",
+    "use_cache": True,
+    "v_head_dim": 128,
+    "vocab_size": 129280,
+}
+deepseek3_671b_config = transformers.DeepseekV3Config(**deepseek3_671b_dict)
+
+# {maxtext model name: hf model config}
 qwen3_omni_30b_a3b_config = transformers.Qwen3OmniMoeConfig(
     # TODO(hengtaoguo): Pure-text Omni model, need to fill in visual/audio/code2wav parts
     architectures=["Qwen3OmniMoeForConditionalGeneration"],
@@ -500,5 +559,6 @@ HF_MODEL_CONFIGS = {
     "qwen3-30b-a3b": qwen3_30b_a3b_thinking_2507_config,
     "qwen3-235b-a22b": qwen3_235b_a22b_thinking_2507_config,
     "qwen3-480b-a35b": qwen3_coder_480b_a35b_config,
+    "deepseek3-671b": deepseek3_671b_config,
     "qwen3-omni-30b-a3b": qwen3_omni_30b_a3b_config,
 }

--- a/src/MaxText/utils/ckpt_conversion/utils/param_mapping.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/param_mapping.py
@@ -814,6 +814,127 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=Fa
   return mapping
 
 
+def DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
+  """Returns mapping from MaxText to HuggingFace Deepseek weight paths using f-strings."""
+  # TODO(shuningjin): add unscan support, b/457820735
+  if not scan_layers:
+    raise NotImplementedError("This conversion only supports scanned MaxText models.")
+
+  # Extract hf configuration parameters, without mtp
+  num_main_layers = config["num_hidden_layers"]
+  first_num_dense_layers = config["first_k_dense_replace"]
+  num_experts = config.get("n_routed_experts", 0)
+
+  # Mapping for non-layer-specific weights
+  mapping = {
+      "params-token_embedder-embedding": "model.embed_tokens.weight",
+      "params-decoder-decoder_norm-scale": "model.norm.weight",
+      "params-decoder-logits_dense-kernel": "lm_head.weight",
+  }
+  # Attention keys are shared by both dense and MoE
+  attention_keys = {
+      "pre_self_attention_layer_norm-scale": "input_layernorm.weight",
+      "post_self_attention_layer_norm-scale": "post_attention_layernorm.weight",
+      "self_attention-query-kernel": "self_attn.q_proj.weight",
+      "self_attention-wq_a-kernel": "self_attn.q_a_proj.weight",
+      "self_attention-q_norm-scale": "self_attn.q_a_layernorm.weight",
+      "self_attention-wq_b-kernel": "self_attn.q_b_proj.weight",
+      "self_attention-wkv_a-kernel": "self_attn.kv_a_proj_with_mqa.weight",
+      "self_attention-kv_norm-scale": "self_attn.kv_a_layernorm.weight",
+      "self_attention-wkv_b-kernel": "self_attn.kv_b_proj.weight",
+      "self_attention-out-kernel": "self_attn.o_proj.weight",
+  }
+  # Dense Layers
+  dense_layer_keys = attention_keys | {
+      "mlp-wi_0-kernel": "mlp.gate_proj.weight",
+      "mlp-wi_1-kernel": "mlp.up_proj.weight",
+      "mlp-wo-kernel": "mlp.down_proj.weight",
+  }
+  for maxtext_key, hf_key in dense_layer_keys.items():
+    mapping[f"params-decoder-dense_layers-{maxtext_key}"] = [
+        f"model.layers.{i}.{hf_key}" for i in range(first_num_dense_layers)
+    ]
+
+  # MoE Layers
+  moe_layer_keys = attention_keys | {
+      "DeepSeekMoeBlock_0-shared_experts-wi_0-kernel": "mlp.shared_experts.gate_proj.weight",
+      "DeepSeekMoeBlock_0-shared_experts-wi_1-kernel": "mlp.shared_experts.up_proj.weight",
+      "DeepSeekMoeBlock_0-shared_experts-wo-kernel": "mlp.shared_experts.down_proj.weight",
+      "DeepSeekMoeBlock_0-MoeBlock_0-gate-kernel": "mlp.gate.weight",
+      "DeepSeekMoeBlock_0-MoeBlock_0-gate-bias": "mlp.gate.e_score_correction_bias",
+  }
+  for maxtext_key, hf_key in moe_layer_keys.items():
+    mapping[f"params-decoder-moe_layers-{maxtext_key}"] = [
+        f"model.layers.{i}.{hf_key}" for i in range(first_num_dense_layers, num_main_layers)
+    ]
+
+  # MoE Experts (nested list mapping: [[e0_l0, e0_l1..], [e1_l0, e1_l1..]..])
+  moe_expert_keys = {
+      "DeepSeekMoeBlock_0-MoeBlock_0-wi_0": "gate_proj.weight",
+      "DeepSeekMoeBlock_0-MoeBlock_0-wi_1": "up_proj.weight",
+      "DeepSeekMoeBlock_0-MoeBlock_0-wo": "down_proj.weight",
+  }
+  for maxtext_key, hf_key in moe_expert_keys.items():
+    mapping[f"params-decoder-moe_layers-{maxtext_key}"] = [
+        [f"model.layers.{l}.mlp.experts.{e}.{hf_key}" for l in range(first_num_dense_layers, num_main_layers)]
+        for e in range(num_experts)
+    ]
+  return mapping
+
+
+def DEEPSEEK_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=False):
+  """Creates parameter transformation functions for Deepseek using f-strings."""
+  # TODO(shuningjin): support hf->orbax(scan), b/457820372
+  if not saving_to_hf:
+    raise NotImplementedError("This conversion only supports saving_to_hf")
+  # TODO(shuningjin): add unscan support, b/457820735
+  if not scan_layers:
+    raise NotImplementedError("This conversion only supports scanned MaxText models.")
+
+  def reshape_kernel(input_tensor, target_shape):
+    """Reshapes and transposes kernel weights between MaxText and HF."""
+    if saving_to_hf:
+      flipped_target_shape = np.flip(np.array(target_shape))
+      return input_tensor.reshape(flipped_target_shape).T
+    else:
+      return input_tensor.T.reshape(target_shape)
+
+  mapping = {
+      "params-decoder-logits_dense-kernel": reshape_kernel,
+  }
+  # all keys that need the reshape hook
+  params_need_reshape = {
+      # Dense Layers
+      "params-decoder-dense_layers-self_attention-query-kernel",
+      "params-decoder-dense_layers-self_attention-wq_a-kernel",
+      "params-decoder-dense_layers-self_attention-wq_b-kernel",
+      "params-decoder-dense_layers-self_attention-wkv_a-kernel",
+      "params-decoder-dense_layers-self_attention-wkv_b-kernel",
+      "params-decoder-dense_layers-self_attention-out-kernel",
+      "params-decoder-dense_layers-mlp-wi_0-kernel",
+      "params-decoder-dense_layers-mlp-wi_1-kernel",
+      "params-decoder-dense_layers-mlp-wo-kernel",
+      # MoE Layers
+      "params-decoder-moe_layers-self_attention-query-kernel",
+      "params-decoder-moe_layers-self_attention-wq_a-kernel",
+      "params-decoder-moe_layers-self_attention-wq_b-kernel",
+      "params-decoder-moe_layers-self_attention-wkv_a-kernel",
+      "params-decoder-moe_layers-self_attention-wkv_b-kernel",
+      "params-decoder-moe_layers-self_attention-out-kernel",
+      "params-decoder-moe_layers-DeepSeekMoeBlock_0-shared_experts-wi_0-kernel",
+      "params-decoder-moe_layers-DeepSeekMoeBlock_0-shared_experts-wi_1-kernel",
+      "params-decoder-moe_layers-DeepSeekMoeBlock_0-shared_experts-wo-kernel",
+      "params-decoder-moe_layers-DeepSeekMoeBlock_0-MoeBlock_0-gate-kernel",
+      "params-decoder-moe_layers-DeepSeekMoeBlock_0-MoeBlock_0-wi_0",
+      "params-decoder-moe_layers-DeepSeekMoeBlock_0-MoeBlock_0-wi_1",
+      "params-decoder-moe_layers-DeepSeekMoeBlock_0-MoeBlock_0-wo",
+  }
+
+  for key in params_need_reshape:
+    mapping[key] = reshape_kernel
+  return mapping
+
+
 def QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
   """Returns mapping from MaxText to HuggingFace Qwen3-Omni weight paths.
 
@@ -1060,6 +1181,7 @@ def LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=
   return hook_fns
 
 
+# {maxtext model name: {maxtext weight name: hf weight name}}
 PARAM_MAPPING = {
     "gemma2-2b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma2-9b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
@@ -1079,9 +1201,11 @@ PARAM_MAPPING = {
     "qwen3-30b-a3b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen3-235b-a22b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen3-coder-480b-a35b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "deepseek3-671b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen3-omni-30b-a3b": QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_MAPPING,
 }
 
+# {maxtext model name: {maxtext weight name: bi-directional transform}}
 HOOK_FNS = {
     "gemma2-2b": GEMMA2_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "gemma2-9b": GEMMA2_MAXTEXT_TO_HF_PARAM_HOOK_FN,
@@ -1101,5 +1225,6 @@ HOOK_FNS = {
     "qwen3-30b-a3b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen3-235b-a22b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen3-coder-480b-a35b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "deepseek3-671b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen3-omni-30b-a3b": QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_HOOK_FN,
 }

--- a/src/MaxText/utils/ckpt_conversion/utils/utils.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/utils.py
@@ -72,6 +72,7 @@ HF_IDS = {
     "qwen3-30b-a3b": "Qwen/Qwen3-30B-A3B-Thinking-2507",
     "qwen3-235b-a22b": "Qwen/Qwen3-235B-A22B-Thinking-2507",
     "qwen3-480b-a35b": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+    "deepseek3-671b": "deepseek-ai/DeepSeek-V3",
     "qwen3-omni-30b-a3b": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
 }
 
@@ -85,6 +86,19 @@ def _get_local_directory(output_dir: str) -> str:
     local_dir = output_dir
   os.makedirs(local_dir, exist_ok=True)
   return local_dir
+
+
+def _process(hf_path, processed_slice, output_weights, current_hook_fns, shape_map_local):
+  """Applies hooks, converts a JAX slice to NumPy, and appends it to the output list."""
+  target_hf_shape = shape_map_local[hf_path]
+  if current_hook_fns:
+    # otherwise identity
+    processed_slice = apply_hook_fns(processed_slice, target_hf_shape, current_hook_fns)
+  numpy_slice = convert_jax_weight_to_numpy(processed_slice).squeeze()
+  assert len(target_hf_shape) == len(
+      numpy_slice.shape
+  ), f"shape mismatch {len(target_hf_shape)} and {len(numpy_slice.shape)}"
+  output_weights.append((hf_path, numpy_slice))
 
 
 def process_leaf_param(
@@ -106,6 +120,7 @@ def process_leaf_param(
       return []  # Skip this parameter
 
   maxtext_param_key = "params-" + "-".join(key_parts)
+  max_logging.log(f"mt param: {maxtext_param_key}")
 
   if not isinstance(leaf_value, (jax.Array, np.ndarray)):
     max_logging.log(f"Warning: Leaf value for {maxtext_param_key} is not an array. Type: {type(leaf_value)}. Skipping.")
@@ -126,80 +141,78 @@ def process_leaf_param(
   current_hook_fns = hook_fn_map_local.get(maxtext_param_key)
   output_weights = []
 
+  # Case 0: Unscan, or Scan with single layer
   if len(hf_target_paths) == 1:
+    max_logging.log("\tunscan or scan single layer")
     hf_path = hf_target_paths[0]
     if hf_path not in shape_map_local:
       max_logging.log(
           f"Warning: HF path '{hf_path}' not found in shape_map for MaxText key '{maxtext_param_key}'. Skipping."
       )
       return []
-    target_hf_shape = shape_map_local[hf_path]
+    _process(hf_path, leaf_value, output_weights, current_hook_fns, shape_map_local)
+    return output_weights
 
-    processed_weight = leaf_value
-    if current_hook_fns:
-      processed_weight = apply_hook_fns(processed_weight, target_hf_shape, current_hook_fns)
-    numpy_weight = convert_jax_weight_to_numpy(processed_weight)
-    output_weights.append((hf_path, numpy_weight))
-  else:  # Stacked MaxText weight
-    # This now handles three cases:
-    # 1. Scanned MoE layers (2D list of targets from a tensor stacked on expert and layer axes)
-    # 2. Unscanned MoE layers (1D list of targets from a tensor stacked only on the expert axis)
-    # 3. Standard scanned layers (1D list of targets from a tensor stacked only on the layer axis)
+  # Stacked MaxText weight
+  # This now handles three cases:
+  # 1. Scanned MoE layers (2D list of targets from a tensor stacked on expert and layer axes)
+  # 2. Unscanned MoE layers (1D list of targets from a tensor stacked only on the expert axis)
+  # 3. Standard scanned layers (1D list of targets from a tensor stacked only on the layer axis)
+  is_scanned_moe_layer = isinstance(hf_target_paths[0], list)
 
-    is_scanned_moe_layer = isinstance(hf_target_paths[0], list)
+  if is_scanned_moe_layer:
+    max_logging.log("\tscan moe")
+    # Case 1: Scanned MoE layer, e.g., from 'layers-moe_block-wi_0'.
+    # The tensor is stacked on expert and layer axes. We slice experts first, then layers.
+    # MaxText format is (experts, layers, ...), so expert axis is 0, layer axis is 1.
+    expert_axis_to_slice = 0
 
-    if is_scanned_moe_layer:
-      # Case 1: Scanned MoE layer, e.g., from 'layers-moe_block-wi_0'.
-      # The tensor is stacked on expert and layer axes. We slice experts first, then layers.
-      # MaxText format is (experts, layers, ...), so expert axis is 0, layer axis is 1.
-      expert_axis_to_slice = 0
-
-      # Outer loop for experts
-      for expert_idx, expert_paths_for_layer in enumerate(hf_target_paths):
-        # Slice along the expert axis to get the tensor for the current expert across all layers.
-        expert_tensor_slice = jax.lax.index_in_dim(leaf_value, expert_idx, axis=expert_axis_to_slice, keepdims=False)
-
-        # Inner loop for layers
-        for layer_idx, hf_path in enumerate(expert_paths_for_layer):
-          if hf_path not in shape_map_local:
-            max_logging.log(f"Warning: HF path '{hf_path}' not found. Skipping.")
-            continue
-
-          # Slice the expert tensor along the layer axis to get the final individual weight.
-          layer_tensor_slice = jax.lax.index_in_dim(
-              expert_tensor_slice, layer_idx, axis=0, keepdims=False
-          )  # axis is 0 on the new sliced tensor
-
-          target_hf_shape = shape_map_local[hf_path]
-          processed_slice = apply_hook_fns(layer_tensor_slice, target_hf_shape, current_hook_fns)
-          numpy_slice = convert_jax_weight_to_numpy(processed_slice)
-          output_weights.append((hf_path, numpy_slice))
-    else:
-      # Case 2 or 3: The source tensor is stacked on a single axis.
-      # We determine if it's an unscanned MoE (expert axis) or standard scanned (layer axis).
-      is_unscanned_moe = "moe_block" in maxtext_param_key and any(
-          f"_{i}-" in maxtext_param_key for i in range(current_config.base_num_decoder_layers)
-      )
-
-      if is_unscanned_moe:
-        # Case 2: Unscanned MoE layer, e.g., from 'layers_0-moe_block-wi_0'.
-        # The tensor is stacked ONLY on the expert axis.
-        axis_to_slice = 0  # Assuming expert is axis 0.
-      else:
-        # Case 3: Standard scanned layer.
-        # The tensor is stacked ONLY on the layer axis.
-        axis_to_slice = current_config.param_scan_axis
-
-      for i, hf_path in enumerate(hf_target_paths):
+    # Outer loop for experts
+    for expert_idx, expert_paths_for_layer in enumerate(hf_target_paths):
+      # Slice along the expert axis to get the tensor for the current expert across all layers.
+      expert_tensor_slice = jax.lax.index_in_dim(leaf_value, expert_idx, axis=expert_axis_to_slice, keepdims=False)
+      # Inner loop for layers
+      for layer_idx, hf_path in enumerate(expert_paths_for_layer):
         if hf_path not in shape_map_local:
-          max_logging.log(f"Warning: HF path '{hf_path}' not found. Skipping.")
+          max_logging.log(
+              f"Warning: HF path '{hf_path}' not found in shape_map for MaxText key '{maxtext_param_key}'. Skipping."
+          )
           continue
 
-        target_hf_shape = shape_map_local[hf_path]
-        weight_slice = jax.lax.index_in_dim(leaf_value, i, axis=axis_to_slice, keepdims=False)
-        processed_slice = apply_hook_fns(weight_slice, target_hf_shape, current_hook_fns)
-        numpy_slice = convert_jax_weight_to_numpy(processed_slice)
-        output_weights.append((hf_path, numpy_slice))
+        # Slice the expert tensor along the layer axis to get the final individual weight.
+        # axis is 0 on the new sliced tensor
+        layer_tensor_slice = jax.lax.index_in_dim(expert_tensor_slice, layer_idx, axis=0, keepdims=False)
+        _process(hf_path, layer_tensor_slice, output_weights, current_hook_fns, shape_map_local)
+
+    return output_weights
+
+  # Case 2 or 3: The source tensor is stacked on a single axis.
+  # We determine if it's an unscanned MoE (expert axis) or standard scanned (layer axis).
+  is_unscanned_moe = "moe_block" in maxtext_param_key and any(
+      f"_{i}-" in maxtext_param_key for i in range(current_config.base_num_decoder_layers)
+  )
+
+  if is_unscanned_moe:
+    max_logging.log("\tunscan moe")
+    # Case 2: Unscanned MoE layer, e.g., from 'layers_0-moe_block-wi_0'.
+    # The tensor is stacked ONLY on the expert axis.
+    axis_to_slice = 0  # Assuming expert is axis 0.
+  else:
+    max_logging.log("\tscan")
+    # Case 3: Standard scanned layer.
+    # The tensor is stacked ONLY on the layer axis.
+    axis_to_slice = current_config.param_scan_axis
+
+  for i, hf_path in enumerate(hf_target_paths):
+    if hf_path not in shape_map_local:
+      max_logging.log(
+          f"Warning: HF path '{hf_path}' not found in shape_map for MaxText key '{maxtext_param_key}'. Skipping."
+      )
+      continue
+
+    weight_slice = jax.lax.index_in_dim(leaf_value, i, axis=axis_to_slice, keepdims=False)
+    _process(hf_path, weight_slice, output_weights, current_hook_fns, shape_map_local)
+
   return output_weights
 
 
@@ -559,6 +572,7 @@ def upload_state_dict_to_gcs(state_dict: dict, gs_bucket_path: str):
       state_dict: A PyTorch model's state_dict.
       gs_bucket_path: GCS destination (e.g., "gs://my-bucket/models/model.pt").
   """
+  # TODO(shuningjin): max retries exceeded when uploading hf checkpoint for deepseek3-671b, b/457821616
   # Standardize bucket path format
   gs_bucket_path = gs_bucket_path.removeprefix("gs://")
   bucket_name, *blob_path_parts = gs_bucket_path.split("/")

--- a/tests/forward_pass_logit_checker.py
+++ b/tests/forward_pass_logit_checker.py
@@ -377,8 +377,8 @@ def main(config, test_args):  # pylint: disable=W0621
   else:
     """Comparing maxtext model with HF model on-the-fly"""
     if test_args.hf_model_path == "":
-      raise ValueError
-    hf_model = AutoModelForCausalLM.from_pretrained(test_args.hf_model_path, torch_dtype=torch.bfloat16)
+      raise ValueError("run_hf_model requires hf_model_path")
+    hf_model = AutoModelForCausalLM.from_pretrained(test_args.hf_model_path, dtype=torch.bfloat16)
     tokenizer = AutoTokenizer.from_pretrained(test_args.hf_model_path)
     if "Llama-3.1" in test_args.hf_model_path:
       tokenizer.pad_token = tokenizer.eos_token


### PR DESCRIPTION
# Description
Onboard deepseek3-671b to checkpoint conversion utility, orbax scan -> hf

Other changes:
- `utils.py` - refactor of `process_leaf_param` function for clarity
-  `to_huggingface.py`- add timing and log.
-  `generate_hf_golden_logits.py` - add options to facilitate deepseek load

future work
- only works with local save, gcs save has max retries exceed: b/457821616
- hf -> orbax scan: mapping is there, need change stacking and optimize for to_maxtext, need test: b/457820372
- hf <-> orbax unscan: b/457820735

Fix: b/450671690

# Tests

Test details: b/450671690#comment12

## conversion
```
ID=$(date +%Y-%m-%d-%H-%M-%S)
RUN_NAME=ds3-hf-$ID

python3 -m MaxText.utils.ckpt_conversion.to_huggingface src/MaxText/configs/base.yml \
model_name=deepseek3-671b \
load_parameters_path=gs://ranran-multipod-dev/deepseek3/conversion/bf16/1/0/items \
base_output_directory=/home/shuningjin/deepseek3-671b/deepseek3-671b-hf-$ID \
scan_layers=true use_multimodal=false \
skip_jax_distributed_system=True attention=dot_product mla_naive_kvcache=false \
checkpoint_storage_concurrent_gb=1024 \
dtype=bfloat16 weight_dtype=bfloat16
```

- log: https://paste.googleplex.com/6229080404000768
- CPU, load orbax: 80min, transform: 50min, save to local: 440min

## forward logit check 

generate logits from newly generated hf checkpoint, compare it with the logit from orbax checkpoint, max KL=0.14


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
