### PR TITLE
Alphabetize ReadTheDocs explanations and references

### DIFF
--- a/docs/explanations.md
+++ b/docs/explanations.md
@@ -19,11 +19,11 @@
 ```{toctree}
 :maxdepth: 1
 
-explanations/jax_ai_libraries_chosen.md
-explanations/alternatives.md
 explanations/checkpoints.md
+explanations/alternatives.md
+explanations/jax_ai_libraries_chosen.md
+explanations/performance_metrics.md
 explanations/quantization.md
 explanations/sharding.md
 explanations/tiling.md
-explanations/performance_metrics.md
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,10 +20,10 @@
 :maxdepth: 1
 
 reference/config_base.md
-reference/terminology.md
-reference/supported_models_and_architectures.md
 reference/benchmark_and_performance.md
-reference/architecture_overview.md
 reference/jax_xla_and_pallas.md
+reference/architecture_overview.md
 reference/tiering.md
+reference/supported_models_and_architectures.md
+reference/terminology.md
 ```


### PR DESCRIPTION
# Description

Alphabetize ReadTheDocs sidebars for explanations and references. The actual doc titles are alphabetical, not the file names, since RTS shows the doc title in the sidebar

# Tests

N/A. Small doc changes only

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
