### PR TITLE
Enable packed sequences and ring attention for CUDNN Flash Attention

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -519,6 +519,11 @@ packing: True
 num_epoch: 1  # only grain and tfds pipeline supports num_epoch > 1
 generate_padding_batch_train: False
 generate_padding_batch_eval: False
+# Maximum number of segments that can be packed into a single sequence
+# This needs to be passed to TransformerEngine's DotProductAttention layer for packing
+# NOTE: This parameter is only relevant for GPU packed attention.
+# When using TPU, this parameter will be ignored.
+max_segments_per_seq: 32
 # Rampup batch size, similar to Megatron-LM, see
 # https://github.com/NVIDIA/Megatron-LM/blob/2a01637aa54ccdaf7ea9afc1f1b80f58c53d7f3c/megatron/core/num_microbatches_calculator.py#L233-L237
 # The ramp-up proceeds in stages from `per_device_batch_size_start` up to
@@ -814,6 +819,7 @@ cost_estimate_flops_bwd: -1 # -1 means using splash default cost estmiation, any
 dq_reduction_steps: 0 #the number of reduction steps. For now, only 3 or all the kv steps are supported.
 ### Determine if we want to use load balance for context parallelism
 context_parallel_load_balance: True
+context_parallel_strategy: "all_gather" # "all_gather" or "ring"
 
 ### Paged Attention ###
 # These settings take effect only when `attention=paged`.

--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -208,6 +208,15 @@ def validate_rampup_batch_size(batch_size_start, batch_size_end, batch_size_incr
   )
 
 
+def validate_context_parallel_strategy_ring(
+    context_parallel_size: int, context_parallel_strategy: str, hardware: str
+) -> None:
+  """Validates that ring context parallelism strategy is only used on GPU hardware."""
+  if context_parallel_size > 1 and context_parallel_strategy.lower() == "ring":
+    if "gpu" not in hardware:
+      raise ValueError("Ring context parallelism strategy (context_parallel_strategy='ring') is only supported on GPUs.")
+
+
 def validate_keys(keys):
   validate_attention_kernel(keys["attention"])
   validate_attention_type(keys["attention_type"])
@@ -237,6 +246,10 @@ def validate_keys(keys):
   # TODO remove after b/435512699 resolved
   if keys["context_parallel_size"] > 1 and keys["context_parallel_load_balance"] and keys["attention_type"] == "chunk":
     raise ValueError("Currently load-balanced context parallelism is not supported for chunk attention.")
+
+  validate_context_parallel_strategy_ring(
+      keys["context_parallel_size"], keys["context_parallel_strategy"], keys["hardware"]
+  )
 
   if keys["mtp_eval_target_module"] < 0:
     raise ValueError("mtp_eval_target_module cannot be negative. Set to 0 to disable evaluation.")

--- a/src/MaxText/train_utils.py
+++ b/src/MaxText/train_utils.py
@@ -180,11 +180,9 @@ def setup_train_loop(config, recorder, devices=None):
     # Check if context parallelism is being used with sequence packing
     if context_parallel_size > 1 and config.packing and config.dataset_type != "synthetic":
       raise ValueError(
-          "Context parallelism cannot be used with sequence packing except for"
-          " synthetic data where packing is not applied. Either disable"
-          " sequence packing (set packing=False) or disable context"
-          " parallelism. Context parallelism with packing support will be added"
-          " soon."
+          "Context parallelism cannot be used with sequence packing. "
+          "Disable sequence packing (set packing=False). "
+          "Context parallelism with packing support will be added soon."
       )
 
     # Apply reordering wrapper to data iterators if context parallelism is enabled
@@ -268,12 +266,8 @@ def validate_train_config(config):
         " use other quantization or set gradient_accumulation_steps to 1"
     )
 
-  # Check if GPU Flash Attention is being used with sequence packing
-  if config.attention == "cudnn_flash_te" and config.packing and config.dataset_type != "synthetic":
-    raise ValueError(
-        "cudnn_flash_te only supports BSHD format. The THD (seq packing)"
-        " support is going to be available in Transformer Engine 2.0 release."
-        " Please disable sequence packing (set packing=False) or use a"
-        " different attention mechanism. With synthetic data, the format is not"
-        " important as packing is not applied."
+  if config.packing and config.dataset_type == "synthetic":
+    max_logging.log(
+        "WARNING: Sequence packing is essentially ignored for synthetic data. "
+        "Please use a real dataset to use sequence packing."
     )


### PR DESCRIPTION
# Description

Added THD packed format support and configurable context parallel strategies (all_gather/ring) for TransformerEngine's DotProductAttention. Included comprehensive GPU tests for packed attention (sm90+) and ring attention modes.

- Added max_segments_per_seq config for packed sequence control
- Supported context_parallel_strategy selection (all_gather vs ring)
- Add GPU tests for both packed and ring attention scenarios

Note: Context parallelism with packing temporarily disabled pending full support soon.

# Tests

Appropriate tests for packed sequence with fused attention and ring attention have been added.

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
