### PR TITLE
Fix bug for qk norm in attentions.py

### DIFF
--- a/src/MaxText/layers/attentions.py
+++ b/src/MaxText/layers/attentions.py
@@ -481,9 +481,6 @@ class Attention(nnx.Module):
     else:
       self.sinks = None
 
-    self.query_norm = None
-    self.key_norm = None
-
     is_llama4_decoder_block = self.config.decoder_block == DecoderBlockType.LLAMA4
     if self.use_qk_norm and not is_llama4_decoder_block:
       self.query_norm = RMSNorm(
@@ -519,6 +516,9 @@ class Attention(nnx.Module):
           weight_dtype=self.config.weight_dtype,
           rngs=self.rngs,
       )
+    else:
+      self.query_norm = None
+      self.key_norm = None
 
     self._maybe_shard_with_logical = functools.partial(
         maybe_shard_with_logical,

--- a/tests/train_compile_test.py
+++ b/tests/train_compile_test.py
@@ -701,3 +701,19 @@ class TrainCompile(unittest.TestCase):
             "per_device_batch_size=1",
         )
     )
+
+  @pytest.mark.cpu_only
+  def test_qwen3_qk_norm(self):
+    """AOT test for non-llama qk norm models"""
+    compiled_trainstep_file = "/tmp/test_qwen3_qk_norm"
+    train_compile_main(
+        (
+            "",
+            os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3-0.6b",
+            "per_device_batch_size=1",
+        )
+    )


### PR DESCRIPTION
# Description

Bug in attentions.py where query_norm and key_norm were initialized to None first and then assigned to nnx modules. However, nnx was treating query_norm and key_norm as static variables, throwing an error. This pr fixes that issue.

Also, added an AOT test that tests this code block to prevent such issues from happening again: https://github.com/AI-Hypercomputer/maxtext/blob/cb136bc404c226bd618ff19b283e4887db23adee/src/MaxText/layers/attentions.py#L488 

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: https://github.com/AI-Hypercomputer/maxtext/issues/2602

# Tests

Was able to get a successful run with the changes from this pr: https://paste.googleplex.com/6601423567585280 

The AOT test also passes locally on cpu vm: https://paste.googleplex.com/5073430399549440  

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
