### PR TITLE
soften the EP check for ICI and DCN with GPUs

### DIFF
--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -1397,8 +1397,12 @@ def using_sequence_parallelism(raw_keys) -> bool:
 
 
 def using_expert_parallelism(raw_keys) -> bool:
-  if int(raw_keys["ici_expert_parallelism"]) > 1 and int(raw_keys["dcn_expert_parallelism"]) > 1:
-    raise ValueError("Expert parallelism can only be enabled on ICI or DCN, not both.")
+  if (
+      int(raw_keys["ici_expert_parallelism"]) > 1
+      and int(raw_keys["dcn_expert_parallelism"]) > 1
+      and raw_keys["hardware"] == "tpu"
+  ):
+    raise ValueError("Expert parallelism can only be enabled on ICI or DCN on TPU, not both.")
   return int(raw_keys["ici_expert_parallelism"]) > 1 or int(raw_keys["dcn_expert_parallelism"]) > 1
 
 


### PR DESCRIPTION
# Description

Soften the EP check for GPUs. Currently the check is there for some TPU constraints. However, with GPUs, there are no functional limitations on using EP across both ICI and DCN. Hence, added a hardware check to the logic.

# Tests

Sample end-2-end test script for GPUs
```
export XLA_FLAGS= "--xla_gpu_enable_latency_hiding_scheduler=true
                --xla_gpu_enable_latency_hiding_scheduler=true
                --xla_gpu_all_reduce_combine_threshold_bytes=134217728
                --xla_gpu_all_gather_combine_threshold_bytes=352321536
                --xla_gpu_reduce_scatter_combine_threshold_bytes=44040192
                --xla_gpu_enable_pipelined_all_gather=true
                --xla_gpu_enable_pipelined_reduce_scatter=true
                --xla_gpu_enable_pipelined_all_reduce=true
                --xla_gpu_enable_while_loop_double_buffering=true
                --xla_gpu_enable_all_gather_combine_by_dim=false
                --xla_gpu_enable_reduce_scatter_combine_by_dim=false
                --xla_disable_hlo_passes=rematerialization"
                
export XLA_PYTHON_CLIENT_MEM_FRACTION=0.90
export NVTE_FUSED_ATTN=1

python3 -m MaxText.train /opt/maxtext/src/MaxText/configs/base.yml \
    run_name=logdir \
    use_iota_embed=false \
    scan_layers=True \
    steps=31 \
    per_device_batch_size=1 \
    model_name=llama4-17b-16e \
    remat_policy=full \
    enable_checkpointing=false \
    logits_dot_in_fp32=false \
    base_output_directory=/opt/maxtext/local_train \
    dataset_type=synthetic \
    attention=cudnn_flash_te \
    max_target_length=8192 \
    sparse_matmul=True \
    megablox=false \
    enable_goodput_recording=false \
    monitor_goodput=false \
    hardware=gpu_multiprocess \
    dcn_fsdp_parallelism=2 \
    ici_fsdp_parallelism=1 \
    ici_expert_parallelism=8 \
    dcn_expert_parallelism=2 \
    ici_data_parallelism=1 \
    dcn_data_parallelism=1
```
Please note that the above example is for JAX distributed setting using 4 nodes (32 GPUs).

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
