### PR TITLE
Modifying decoders and attention for vllm

### DIFF
--- a/src/MaxText/layers/attention_mla.py
+++ b/src/MaxText/layers/attention_mla.py
@@ -672,7 +672,9 @@ class MLA(Attention):
       page_state: Optional[page_manager.PageState] = None,
       bidirectional_mask: Optional[Any] = None,
       rope_kwargs: dict | None = None,
-  ) -> Array:
+      kv_cache: Optional[Array] = None,
+      attention_metadata: Optional[dict[str, Any]] = None,
+  ) -> tuple[Array, Optional[Array]]:
     """Forward pass for MLA, reusing `AttentionOp` for the actual attention.
 
     Args:
@@ -686,6 +688,8 @@ class MLA(Attention):
       slot: The batch slot index for paged attention.
       page_state: The current state of the paged attention manager.
       bidirectional_mask: A mask for bidirectional attention, used in multimodal models.
+      kv_cache: Optional key-value cache used when serving models with vLLM.
+      attention_metadata: Optional attention-related metadata used when serving models with vLLM.
 
     Returns:
       A tensor of shape [batch, length, embed_dim] containing the
@@ -726,4 +730,4 @@ class MLA(Attention):
 
     out = self.out_projection(out)
     out = checkpoint_name(out, "out_proj")
-    return out
+    return out, kv_cache

--- a/src/MaxText/layers/attention_op.py
+++ b/src/MaxText/layers/attention_op.py
@@ -847,11 +847,14 @@ class AttentionOp(nnx.Module):
         raise NotImplementedError(target_hardware)
       return impl(query, key, value, lengths, self.ragged_block_size)
 
+    # 'vllm_rpa' uses the same dot-attention wrapper but routes to the vLLM
+    # ragged paged attention kernel in `Attention.__call__`.
     elif (
         self.attention_kernel == "dot_product"
         or (self.attention_kernel == "autoselected" and model_mode == MODEL_MODE_AUTOREGRESSIVE)
         or (self.attention_kernel == "autoselected" and length < 128)
         or (self.attention_kernel == "paged")
+        or (self.attention_kernel == "vllm_rpa")
     ):
       return self.apply_attention_dot(
           query,

--- a/src/MaxText/layers/deepseek.py
+++ b/src/MaxText/layers/deepseek.py
@@ -99,7 +99,7 @@ def self_attention_with_norm(
       model_mode=model_mode,
   )
 
-  attention_lnx = attention_layer(
+  attention_lnx, _ = attention_layer(
       lnx,
       lnx,
       decoder_positions,
@@ -127,7 +127,7 @@ def self_attention_with_norm(
   return hidden_states, intermediate_inputs
 
 
-def post_process(cfg, layer_output, sow):
+def post_process(cfg, layer_output, sow, kv_cache=None):
   """postprocessing."""
   if cfg.record_internal_nn_metrics:
     sow("intermediates", "activation_mean", jnp.mean(layer_output))
@@ -141,7 +141,7 @@ def post_process(cfg, layer_output, sow):
   if cfg.scan_layers:
     return layer_output, None
   else:
-    return layer_output
+    return layer_output, kv_cache
 
 
 class DeepSeekDenseLayer(nn.Module):
@@ -163,6 +163,8 @@ class DeepSeekDenseLayer(nn.Module):
       previous_chunk=None,
       page_state: None | page_manager.PageState = None,
       slot: None | int = None,
+      kv_cache=None,
+      attention_metadata=None,
   ):
     cfg = self.config
     if model_mode == MODEL_MODE_PREFILL:
@@ -230,6 +232,8 @@ class DeepSeekMoELayer(nn.Module):
       previous_chunk=None,
       page_state: None | page_manager.PageState = None,
       slot: None | int = None,
+      kv_cache=None,
+      attention_metadata=None,
   ):
     cfg = self.config
     if model_mode == MODEL_MODE_PREFILL:

--- a/src/MaxText/layers/deepseek_batchsplit.py
+++ b/src/MaxText/layers/deepseek_batchsplit.py
@@ -58,6 +58,8 @@ class DeepSeekGenericLayer(nn.Module):
       previous_chunk=None,
       page_state: None | page_manager.PageState = None,
       slot: None | int = None,
+      kv_cache=None,
+      attention_metadata=None,
   ):
     x = self.with_logical_constraint(inputs)
     x = jax.ad_checkpoint.checkpoint_name(x, "decoder_layer_input")
@@ -74,7 +76,7 @@ class DeepSeekGenericLayer(nn.Module):
 
     x += self.mlp(self.post_attention_norm(x), deterministic)
     x = self.dropout(x, deterministic)
-    return self.post_process(x)
+    return self.post_process(x, kv_cache)
 
   def setup(self):
     self.pre_attention_norm_op = self.rms_norm_layer("pre_attention_layer_norm")
@@ -177,7 +179,7 @@ class DeepSeekGenericLayer(nn.Module):
             previous_chunk=previous_chunk,
             page_state=page_state,
             slot=slot,
-        )
+        )[0]
     )
 
   def mlp_layer(self):
@@ -194,7 +196,7 @@ class DeepSeekGenericLayer(nn.Module):
         self.dropout_op(x, deterministic=deterministic)
     )
 
-  def post_process(self, x):
+  def post_process(self, x, kv_cache=None):
     """Collect statistics about the output of the layer."""
     if self.config.record_internal_nn_metrics:
       self.sow("intermediates", "activation_mean", jnp.mean(x))
@@ -208,7 +210,7 @@ class DeepSeekGenericLayer(nn.Module):
     if self.config.scan_layers:
       return x, None
     else:
-      return x
+      return x, kv_cache
 
 
 class DeepSeekDenseLayer(DeepSeekGenericLayer):
@@ -245,6 +247,8 @@ class DeepSeekMoELayer(DeepSeekGenericLayer):
       previous_chunk=None,
       page_state: None | page_manager.PageState = None,
       slot: None | int = None,
+      kv_cache=None,
+      attention_metadata=None,
       split_factor: int = 2,
   ):
     x = self.with_logical_constraint(inputs)
@@ -289,7 +293,7 @@ class DeepSeekMoELayer(DeepSeekGenericLayer):
     x = _merge(x)
 
     x = self.dropout(x, deterministic)
-    return self.post_process(x)
+    return self.post_process(x, kv_cache)
 
   def init(self, *args, **kwargs):
     # Calls the parent init method for testing parity.

--- a/src/MaxText/layers/gemma3.py
+++ b/src/MaxText/layers/gemma3.py
@@ -189,6 +189,8 @@ class Gemma3DecoderLayer(nnx.Module):
       page_state=None,
       slot=None,
       bidirectional_mask=None,
+      kv_cache=None,
+      attention_metadata=None,
   ):
     cfg = self.config
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
@@ -198,7 +200,7 @@ class Gemma3DecoderLayer(nnx.Module):
     lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
 
     # Self-attention block
-    attention_lnx = self.self_attention(
+    attention_lnx, kv_cache = self.self_attention(
         lnx,
         lnx,
         decoder_positions,
@@ -206,6 +208,8 @@ class Gemma3DecoderLayer(nnx.Module):
         deterministic=deterministic,
         model_mode=model_mode,
         bidirectional_mask=bidirectional_mask,
+        kv_cache=kv_cache,
+        attention_metadata=attention_metadata,
     )
     if cfg.use_post_attn_norm:
       attention_lnx = self.post_self_attention_norm(attention_lnx)
@@ -240,7 +244,7 @@ class Gemma3DecoderLayer(nnx.Module):
     if cfg.scan_layers:
       return layer_output, None
     else:
-      return layer_output
+      return layer_output, kv_cache
 
 
 Gemma3DecoderLayerToLinen = nnx_wrappers.to_linen_class(

--- a/src/MaxText/layers/mistral.py
+++ b/src/MaxText/layers/mistral.py
@@ -132,6 +132,8 @@ class MistralDecoderLayer(nnx.Module):
       page_state: None | int = None,
       slot: None | int = None,
       previous_chunk=None,
+      kv_cache=None,
+      attention_metadata=None,
   ):
 
     cfg = self.config
@@ -141,7 +143,7 @@ class MistralDecoderLayer(nnx.Module):
     lnx = self.pre_self_attention_layer_norm(inputs)
     lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
 
-    attention_lnx = self.self_attention(
+    attention_lnx, kv_cache = self.self_attention(
         lnx,
         lnx,
         decoder_positions,
@@ -151,6 +153,8 @@ class MistralDecoderLayer(nnx.Module):
         slot=slot,
         page_state=page_state,
         previous_chunk=previous_chunk,
+        kv_cache=kv_cache,
+        attention_metadata=attention_metadata,
     )
 
     attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
@@ -180,7 +184,7 @@ class MistralDecoderLayer(nnx.Module):
     if cfg.scan_layers:
       return layer_output, None
     else:
-      return layer_output
+      return layer_output, kv_cache
 
 
 MistralDecoderLayerToLinen = nnx_wrappers.to_linen_class(

--- a/src/MaxText/layers/mixtral.py
+++ b/src/MaxText/layers/mixtral.py
@@ -137,6 +137,8 @@ class MixtralDecoderLayer(nnx.Module):
       previous_chunk=None,
       page_state=None,
       slot=None,
+      kv_cache=None,
+      attention_metadata=None,
   ):
 
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
@@ -145,7 +147,7 @@ class MixtralDecoderLayer(nnx.Module):
     lnx = self.pre_self_attention_layer_norm(inputs)
     lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
 
-    attention_lnx = self.self_attention(
+    attention_lnx, kv_cache = self.self_attention(
         lnx,
         lnx,
         decoder_positions,
@@ -153,6 +155,8 @@ class MixtralDecoderLayer(nnx.Module):
         deterministic=deterministic,
         model_mode=model_mode,
         previous_chunk=previous_chunk,
+        kv_cache=kv_cache,
+        attention_metadata=attention_metadata,
     )
 
     attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
@@ -188,7 +192,7 @@ class MixtralDecoderLayer(nnx.Module):
     if self.config.scan_layers:
       return layer_output, None
     else:
-      return layer_output
+      return layer_output, kv_cache
 
 
 MixtralDecoderLayerToLinen = nnx_wrappers.to_linen_class(

--- a/src/MaxText/layers/models.py
+++ b/src/MaxText/layers/models.py
@@ -19,6 +19,7 @@
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
+from typing import Any
 
 from flax import linen as nn
 from flax import nnx
@@ -127,6 +128,8 @@ class TransformerLinenPure(nn.Module):
       decoder_target_tokens: None | jnp.ndarray = None,
       decoder_target_mask: None | jnp.ndarray = None,
       nnx_method=None,
+      kv_caches: list[jax.Array] | None = None,
+      attention_metadata: dict[str, Any] | None = None,
   ):
     """Applies Transformer decoder-branch on encoded-input and target.
 
@@ -154,7 +157,7 @@ class TransformerLinenPure(nn.Module):
       elif self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
         bidirectional_mask = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN
 
-    logits, hidden_state = self.decoder(
+    logits, hidden_state, kv_caches = self.decoder(
         shared_embedding=self.shared_embedding,
         decoder_input_tokens=decoder_input_tokens,
         decoder_positions=decoder_positions,
@@ -167,6 +170,8 @@ class TransformerLinenPure(nn.Module):
         bidirectional_mask=bidirectional_mask,
         image_embeddings=image_embeddings,
         image_masks=encoder_image_masks,
+        kv_caches=kv_caches,
+        attention_metadata=attention_metadata,
     )
 
     # If we are initializing the model AND MTP is enabled, we must create
@@ -200,6 +205,10 @@ class TransformerLinenPure(nn.Module):
           deterministic=not enable_dropout,
           model_mode=model_mode,
       )
+
+    if self.config.attention == "vllm_rpa":
+      # In vLLM, logits are computed separately after updating the KV cache.
+      return logits, hidden_state, kv_caches
 
     return logits
 
@@ -306,10 +315,30 @@ class Transformer(nnx.Module):
     dummy_decoder_input_tokens = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
     dummy_decoder_positions = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
 
+    if self.config.attention == "vllm_rpa":
+      try:
+        # pylint: disable=import-outside-toplevel
+        # pytype: disable=import-error
+        from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+      except ImportError as e:
+        raise ImportError(
+            "vLLM RPA attention requires the vllm-tpu package. Please install it with `pip install vllm-tpu`."
+        ) from e
+      dummy_attention_metadata = AttentionMetadata(
+          input_positions=jnp.ones((batch_size * seq_len,), dtype=jnp.int32),
+          block_tables=jnp.ones((seq_len,), dtype=jnp.int32),
+          seq_lens=jnp.ones((1), dtype=jnp.int32),
+          query_start_loc=jnp.ones((2), dtype=jnp.int32),
+          request_distribution=jnp.ones((3), dtype=jnp.int32),
+      )
+    else:
+      dummy_attention_metadata = None
+
     self.decoder.lazy_init(
         shared_embedding=self.token_embedder,
         decoder_input_tokens=dummy_decoder_input_tokens,
         decoder_positions=dummy_decoder_positions,
+        attention_metadata=dummy_attention_metadata,
     )
 
     # If MTP is enabled via config, set up the MTP block.
@@ -368,6 +397,8 @@ class Transformer(nnx.Module):
       page_state: page_manager.PageState | None = None,
       decoder_target_tokens: jax.Array | None = None,
       decoder_target_mask: jax.Array | None = None,
+      kv_caches: list[jax.Array] | None = None,
+      attention_metadata: dict[str, Any] | None = None,
   ):
     """Applies the Zero-1 FSDP wrapped Transformer model.
 
@@ -388,9 +419,11 @@ class Transformer(nnx.Module):
       decoder_target_tokens: Target tokens for the decoder (optional, used in MTP).
       decoder_target_mask: Target mask for the decoder (optional, used in MTP).
       nnx_method: Method to call on the NNX module (optional).
+      kv_caches: List of KV caches for each attention layer, used when invoking from vLLM (optional).
+      attention_metadata: Mapping to store attention metadata, used when invoking from vLLM (optional).
 
     Returns:
-      Logits from the Transformer model.
+      Logits from the Transformer model. Logits, hidden_state, kv_caches if called by vLLM.
     """
     if decoder_segment_ids is not None and model_mode == MODEL_MODE_AUTOREGRESSIVE:
       raise ValueError(
@@ -410,7 +443,7 @@ class Transformer(nnx.Module):
       elif self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
         bidirectional_mask = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN
 
-    logits, hidden_state = self.decoder(
+    logits, hidden_state, kv_caches = self.decoder(
         shared_embedding=self.token_embedder,
         decoder_input_tokens=decoder_input_tokens,
         decoder_positions=decoder_positions,
@@ -423,6 +456,8 @@ class Transformer(nnx.Module):
         bidirectional_mask=bidirectional_mask,
         image_embeddings=image_embeddings,
         image_masks=encoder_image_masks,
+        kv_caches=kv_caches,
+        attention_metadata=attention_metadata,
     )
 
     # Materialize hidden state when vocab tiling is enabled
@@ -460,6 +495,10 @@ class Transformer(nnx.Module):
           deterministic=not enable_dropout,
           model_mode=model_mode,
       )
+
+    if self.config.attention == "vllm_rpa":
+      # In vLLM, logits are computed separately after updating the KV cache.
+      return logits, hidden_state, kv_caches
 
     return logits
 

--- a/src/MaxText/pyconfig_deprecated.py
+++ b/src/MaxText/pyconfig_deprecated.py
@@ -99,7 +99,15 @@ def validate_kv_quant_axis(s: str, quantize_kvcache: bool) -> None:
 
 
 def validate_attention_kernel(s: str) -> None:
-  valid_attention_kernels = ("autoselected", "dot_product", "flash", "cudnn_flash_te", "cudnn_flash_jax", "paged")
+  valid_attention_kernels = (
+      "autoselected",
+      "dot_product",
+      "flash",
+      "cudnn_flash_te",
+      "cudnn_flash_jax",
+      "paged",
+      "vllm_rpa",
+  )
   if s not in valid_attention_kernels:  # currently supported attention
     raise ValueError("Invalid attention kernel was passed. Valid options ", valid_attention_kernels)
 

--- a/tests/attention_test.py
+++ b/tests/attention_test.py
@@ -19,6 +19,7 @@ import os.path
 import random
 import sys
 import unittest
+from unittest import mock
 
 import pytest
 
@@ -373,7 +374,7 @@ class AttentionTest(parameterized.TestCase):
     decode_total_length = self.cfg.max_target_length
     lnx, decoder_segment_ids, decoder_positions = self.get_structured_data(self.dtype)
 
-    mha_full = self._attention_as_mha_generic(
+    mha_full, _ = self._attention_as_mha_generic(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -386,7 +387,7 @@ class AttentionTest(parameterized.TestCase):
     decoder_segment_ids_prefill = decoder_segment_ids[:, 0:prefill_length]
     decoder_positions_prefill = decoder_positions[:, 0:prefill_length]
 
-    mha_prefill = self._attention_as_mha_generic(
+    mha_prefill, _ = self._attention_as_mha_generic(
         lnx_prefill,
         lnx_prefill,
         decoder_segment_ids=decoder_segment_ids_prefill,
@@ -402,7 +403,7 @@ class AttentionTest(parameterized.TestCase):
     for idx in range(prefill_length, decode_total_length):
       lnx_idx = lnx[:, idx : idx + 1, :]
       decoder_positions_idx = decoder_positions[:, idx : idx + 1]
-      mha_idx = self._attention_as_mha_generic(
+      mha_idx, _ = self._attention_as_mha_generic(
           lnx_idx,
           lnx_idx,
           inputs_positions=decoder_positions_idx,
@@ -450,7 +451,7 @@ class AttentionTest(parameterized.TestCase):
         rngs=self.nnx_rng,
     )
 
-    mha_prefill = attention_as_mha_generic(
+    mha_prefill, _ = attention_as_mha_generic(
         lnx_prefill,
         lnx_prefill,
         decoder_segment_ids=decoder_segment_ids_prefill,
@@ -498,7 +499,7 @@ class AttentionTest(parameterized.TestCase):
 
     generic_state = nnx.state(attention_as_mha_generic)
 
-    mha_generic_output = attention_as_mha_generic(
+    mha_generic_output, _ = attention_as_mha_generic(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -526,7 +527,7 @@ class AttentionTest(parameterized.TestCase):
     )
     nnx.update(attention_as_mha_flash, generic_state)
 
-    mha_generic_flash_output = attention_as_mha_flash(
+    mha_generic_flash_output, _ = attention_as_mha_flash(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -596,7 +597,7 @@ class AttentionTest(parameterized.TestCase):
     num_kv_heads = self.num_kv_heads
     lnx, decoder_segment_ids, decoder_positions = self.get_data(self.dtype)
     # Dot product
-    mha_generic_output = self._attention_as_mha_generic(
+    mha_generic_output, _ = self._attention_as_mha_generic(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -714,7 +715,7 @@ class AttentionTest(parameterized.TestCase):
         model_mode=MODEL_MODE_PREFILL,
         rngs=self.nnx_rng,
     )
-    attention_w_layout_full = attention_w_layout(
+    attention_w_layout_full, _ = attention_w_layout(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -723,7 +724,7 @@ class AttentionTest(parameterized.TestCase):
         model_mode=MODEL_MODE_TRAIN,
     )
 
-    attention_w_layout_prefill = attention_w_layout(
+    attention_w_layout_prefill, _ = attention_w_layout(
         lnx_prefill,
         lnx_prefill,
         decoder_segment_ids=decoder_segment_ids_prefill,
@@ -739,7 +740,7 @@ class AttentionTest(parameterized.TestCase):
       lnx_idx = lnx[:, idx : idx + 1, :]
       decoder_positions_idx = decoder_positions[:, idx : idx + 1]
 
-      attention_w_layout_idx = attention_w_layout(
+      attention_w_layout_idx, _ = attention_w_layout(
           lnx_idx,
           lnx_idx,
           inputs_positions=decoder_positions_idx,
@@ -828,7 +829,7 @@ class AttentionTest(parameterized.TestCase):
     attention_wo_reshape_q_state = nnx.state(attention_wo_reshape_q)
     nnx.update(attention_w_reshape_q, attention_wo_reshape_q_state)
 
-    attention_wo_reshape_q_full = attention_wo_reshape_q(
+    attention_wo_reshape_q_full, _ = attention_wo_reshape_q(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -837,7 +838,7 @@ class AttentionTest(parameterized.TestCase):
         model_mode=MODEL_MODE_TRAIN,
     )
 
-    attention_w_reshape_q_full = attention_w_reshape_q(
+    attention_w_reshape_q_full, _ = attention_w_reshape_q(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -846,7 +847,7 @@ class AttentionTest(parameterized.TestCase):
         model_mode=MODEL_MODE_TRAIN,
     )
 
-    attention_wo_reshape_q_prefill = attention_wo_reshape_q(
+    attention_wo_reshape_q_prefill, _ = attention_wo_reshape_q(
         lnx_prefill,
         lnx_prefill,
         decoder_segment_ids=decoder_segment_ids_prefill,
@@ -860,7 +861,7 @@ class AttentionTest(parameterized.TestCase):
         )
     )
 
-    attention_w_reshape_q_prefill = attention_w_reshape_q(
+    attention_w_reshape_q_prefill, _ = attention_w_reshape_q(
         lnx_prefill,
         lnx_prefill,
         decoder_segment_ids=decoder_segment_ids_prefill,
@@ -887,7 +888,7 @@ class AttentionTest(parameterized.TestCase):
       lnx_idx = lnx[:, idx : idx + 1, :]
       decoder_positions_idx = decoder_positions[:, idx : idx + 1]
 
-      attention_wo_reshape_q_idx = attention_wo_reshape_q(
+      attention_wo_reshape_q_idx, _ = attention_wo_reshape_q(
           lnx_idx,
           lnx_idx,
           inputs_positions=decoder_positions_idx,
@@ -903,7 +904,7 @@ class AttentionTest(parameterized.TestCase):
           )
       )
 
-      attention_w_reshape_q_idx = attention_w_reshape_q(
+      attention_w_reshape_q_idx, _ = attention_w_reshape_q(
           lnx_idx,
           lnx_idx,
           inputs_positions=decoder_positions_idx,
@@ -974,7 +975,7 @@ class AttentionTest(parameterized.TestCase):
     sliding_attn_state = nnx.state(sliding_attn)
     nnx.update(global_attn, sliding_attn_state)
 
-    global_attn_output = global_attn(
+    global_attn_output, _ = global_attn(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -983,7 +984,7 @@ class AttentionTest(parameterized.TestCase):
         model_mode=MODEL_MODE_TRAIN,
     )
 
-    sliding_window_output = sliding_attn(
+    sliding_window_output, _ = sliding_attn(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -1022,7 +1023,7 @@ class AttentionTest(parameterized.TestCase):
 
     nnx.update(sliding_attn_full_window, sliding_attn_state)
 
-    sliding_window_output_full = sliding_attn_full_window(
+    sliding_window_output_full, _ = sliding_attn_full_window(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -1043,6 +1044,83 @@ class AttentionTest(parameterized.TestCase):
             atol=1e-04,
         )
     )
+
+  @pytest.mark.skip(reason="Requires `vllm-tpu` package which is not yet a MaxText dependency.")
+  @pytest.mark.tpu_only
+  @mock.patch("tpu_inference.layers.jax.attention_interface.sharded_ragged_paged_attention", create=True)
+  def test_forward_serve_vllm(self, mock_sharded_ragged_paged_attention):
+    """Tests the forward_serve_vllm method with mocked RPA attention."""
+    # Setup config for vLLM RPA
+    vllm_config_arguments = self.config_arguments.copy()
+    vllm_config_arguments["attention"] = "vllm_rpa"
+    vllm_config_arguments["chunk_attn_window_size"] = 128
+    config = pyconfig.initialize(
+        [sys.argv[0], os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")],
+        **vllm_config_arguments,
+    )
+
+    seq_len = self.max_target_length
+
+    # Create Attention instance
+    dummy_inputs_q = jnp.ones((self.global_batch_size, seq_len, self.embed_dim))
+    dummy_inputs_kv = jnp.ones((self.global_batch_size, seq_len, self.embed_dim))
+    attention_vllm = Attention(
+        config=config,
+        num_query_heads=self.num_query_heads,
+        num_kv_heads=self.num_kv_heads,
+        head_dim=self.head_dim,
+        max_target_length=self.max_target_length,
+        max_prefill_predict_length=self.max_prefill_predict_length,
+        inputs_q_shape=dummy_inputs_q.shape,
+        inputs_kv_shape=dummy_inputs_kv.shape,
+        mesh=self.mesh,
+        attention_kernel="dot_product",
+        dtype=self.dtype,
+        model_mode=MODEL_MODE_AUTOREGRESSIVE,
+        rngs=self.nnx_rng,
+    )
+
+    # Prepare inputs
+    lnx, decoder_segment_ids, decoder_positions = self.get_structured_data(self.dtype)
+    mock_kv_cache = [jnp.ones((1,))]
+
+    mock_attention_metadata = mock.Mock()
+    mock_attention_metadata.seq_lens = jnp.array([1] * self.global_batch_size)
+    mock_attention_metadata.block_tables = jnp.array([[0]] * self.global_batch_size)
+    mock_attention_metadata.query_start_loc = jnp.array(list(range(self.global_batch_size)))
+    mock_attention_metadata.request_distribution = jnp.array([self.global_batch_size])
+
+    # Mock the return value of sharded_ragged_paged_attention
+    total_tokens = self.global_batch_size * seq_len
+    mock_output_shape = (total_tokens, self.num_query_heads, self.head_dim)
+    mock_output = jnp.ones(mock_output_shape, dtype=self.dtype)
+    mock_updated_kv_cache = [jnp.zeros((1,))]
+
+    mock_callable = mock.Mock(return_value=(mock_output, mock_updated_kv_cache))
+    mock_sharded_ragged_paged_attention.return_value = mock_callable
+
+    # Call the attention layer
+    output, updated_kv_cache = attention_vllm(
+        lnx,
+        lnx,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
+        deterministic=True,
+        model_mode=MODEL_MODE_AUTOREGRESSIVE,
+        kv_cache=mock_kv_cache,
+        attention_metadata=mock_attention_metadata,
+    )
+
+    # Assertions
+    mock_sharded_ragged_paged_attention.assert_called_once()
+    mock_callable.assert_called_once()
+    self.assertEqual(updated_kv_cache, mock_updated_kv_cache)
+
+    # The output of forward_serve_vllm is reshaped back to (batch, seq, ...)
+    reshaped_mock_output = mock_output.reshape(self.global_batch_size, seq_len, self.num_query_heads, self.head_dim)
+    expected_output = attention_vllm.out_projection(reshaped_mock_output)
+    self.assertTrue(jnp.allclose(output, expected_output))
+    self.assertEqual(output.shape, (self.global_batch_size, seq_len, self.embed_dim))
 
 
 class MLATest(parameterized.TestCase):
@@ -1164,7 +1242,7 @@ class MLATest(parameterized.TestCase):
     decode_total_length = cfg.max_target_length
     lnx, decoder_segment_ids, decoder_positions = self.get_structured_data(cfg, cfg.dtype)
 
-    mla_full = mla(
+    mla_full, _ = mla(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -1177,7 +1255,7 @@ class MLATest(parameterized.TestCase):
     decoder_segment_ids_prefill = decoder_segment_ids[:, 0:prefill_length]
     decoder_positions_prefill = decoder_positions[:, 0:prefill_length]
 
-    mla_prefill = mla(
+    mla_prefill, _ = mla(
         lnx_prefill,
         lnx_prefill,
         decoder_segment_ids=decoder_segment_ids_prefill,
@@ -1193,7 +1271,7 @@ class MLATest(parameterized.TestCase):
     for idx in range(prefill_length, decode_total_length):
       lnx_idx = lnx[:, idx : idx + 1, :]
       decoder_positions_idx = decoder_positions[:, idx : idx + 1]
-      mla_idx = mla(
+      mla_idx, _ = mla(
           lnx_idx,
           lnx_idx,
           inputs_positions=decoder_positions_idx,
@@ -1340,7 +1418,7 @@ class MLATest(parameterized.TestCase):
     cfg, mla = self.init_mla(config_arguments, rope_type="default")
     lnx, decoder_segment_ids, decoder_positions = self.get_data(cfg, cfg.dtype)
     # Dot product
-    mla_generic_output = mla(
+    mla_generic_output, _ = mla(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -1424,7 +1502,7 @@ def _forward_with_context_expert_parallelism(cfg_cp, mesh_cp, attention_cp, lnx,
     decoder_segment_ids = jax.device_put(decoder_segment_ids, pos_sharding)
     decoder_positions = jax.device_put(decoder_positions, pos_sharding)
 
-    attention_cp_output = attention_cp(
+    attention_cp_output, _ = attention_cp(
         lnx,
         lnx,
         decoder_segment_ids=decoder_segment_ids,
@@ -1432,6 +1510,8 @@ def _forward_with_context_expert_parallelism(cfg_cp, mesh_cp, attention_cp, lnx,
         deterministic=True,
         model_mode=MODEL_MODE_TRAIN,
     )
+    attention_cp_output = attention_cp_output[0] if isinstance(attention_cp_output, tuple) else attention_cp_output
+
   # If load balanced cp, de-shuffle and gather along seq dim for output
   # Note training does not need post-shuffle. Since the target seq is also pre-shuffled, the loss remains correct
   if context_parallel_size > 1 and cfg_cp.context_parallel_load_balance:


### PR DESCRIPTION
# Description

This PR introduces new optional arguments `kv_cache` and `attention_metadata` for model decoder blocks and for the `attentions.py` module. These arguments are provided by vLLM when executing a MaxText model from vLLM Engine and are used when calling the ragged paged attention kernel in `tpu-inference`.

This PR builds on the work started in #2612.

**Note: This PR changes the expected method signature from Attention layers and decoder layers.**

# Tests

Includes a new unit-test in `attention_test.py`. 

Additionally, end-to-end tests were performed locally on a v6e VM using the following test command:

In one process, start the vLLM server. This requires a local `config.json` file for the corresponding model you are trying to test from HuggingFace. Modify this file such that `architectures: "MaxTextForCausalLM"` is set.
```
HF_TOKEN=<YOUR_HF_TOKEN> TPU_BACKEND_TYPE=jax \
  python -m vllm.entrypoints.cli.main serve \
  <HF_MODEL> \
  --max-num-batched-tokens=32 \
  --max-model-len=32 \
  --max-num-seqs=1 \
  --tensor-parallel-size=4 \
  --hf_config_path=<PATH_TO_LOCAL_HF_CONFIG_JSON> \
  --additional-config='{"maxtext_config": {"model_name": "<MAXTEXT_MODEL_NAME>", "max_prefill_predict_length": 28, "max_target_length": 32, "ici_tensor_parallelism": 4, "load_parameters_path": "<MAXTEXT_CHECKPOINT_PATH>"}}'
```

In a second process, issue the query to the model:
```
curl http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
       "model": "<HF_MODEL>",
       "prompt": ["Seattle is a"],
       "max_tokens": 16,
       "temperature": 0
   }'
```
Results for different tested models are shown below:
## llama3.1-8b
```
output: " city that is known for its coffee culture, and it's not hard to see"
```

## gemma3-4b
```
output: " vibrant city with a lot to offer, and it's a great place to"
```

## qwen3-8b
```
output: " city in the state of Washington, in the Pacific Northwest region of the United States"
```
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
