### PR TITLE
add reset to PlaceHolderDataIterator

### DIFF
--- a/src/MaxText/input_pipeline/synthetic_data_processing.py
+++ b/src/MaxText/input_pipeline/synthetic_data_processing.py
@@ -94,6 +94,9 @@ class PlaceHolderDataIterator:
   def __next__(self):
     return next(self.data_generator)
 
+  def reset(self):
+    pass
+
   @staticmethod
   def get_place_holder_synthetic_data(config: pyconfig.HyperParameters):
     """fill negative value in synthetic data"""


### PR DESCRIPTION
# Description
Add reset method to PlaceHolderDataIterator to align with MultiHostDataLoadIterator

FIXES: b/450195576

# Tests
Will monitor the test in XLML

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
