### PR TITLE
Fix  import error in ckpt_scripts

### DIFF
--- a/src/MaxText/utils/ckpt_scripts/llama_mistral_mixtral_orbax_to_hf.py
+++ b/src/MaxText/utils/ckpt_scripts/llama_mistral_mixtral_orbax_to_hf.py
@@ -48,7 +48,7 @@ from jax.sharding import Mesh
 from transformers import LlamaForCausalLM, MistralForCausalLM, AutoModelForCausalLM, AutoConfig
 
 from MaxText import checkpointing
-from MaxText import llama_or_mistral_ckpt
+import llama_or_mistral_ckpt
 from MaxText import max_logging
 from MaxText import maxtext_utils
 from MaxText import pyconfig


### PR DESCRIPTION
# Description

Resolve ```import error``` in `src/MaxText/utils/ckpt_scripts/llama_mistral_mixtral_orbax_to_hf.py` (line 51), introduced in PR#2601: "Consolidate legacy checkpoint scripts into folder".

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/458573192

# Tests

Will monitor the test in XLML

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
