### PR TITLE
Fix vllm weight mapping import issue.

### DIFF
--- a/src/MaxText/integration/tunix/utils.py
+++ b/src/MaxText/integration/tunix/utils.py
@@ -16,11 +16,11 @@
 
 import re
 
-import maxtext.src.maxtext.integration.tunix.weight_mapping as weight_mapping  # pylint: disable=consider-using-from-import
+from MaxText.integration.tunix.weight_mapping import StandaloneVllmWeightMapping
 from MaxText.utils.ckpt_conversion.utils.param_mapping import PARAM_MAPPING
 from MaxText.utils.ckpt_conversion.utils.param_mapping import VLLM_HOOK_FNS
 
-STANDALONE_VLLM_WEIGHT_MAPPING = weight_mapping.StandaloneVllmWeightMapping()
+STANDALONE_VLLM_WEIGHT_MAPPING = StandaloneVllmWeightMapping()
 
 # This static map provides the architectural knowledge (sharding) that is
 # not present in the original HF mapping.


### PR DESCRIPTION
# Description

Fix vllm weight mapping import issue.

FIXES: b/458679845

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
