### PR TITLE
Reduce memory requirements for checkpoint conversion 

### DIFF
--- a/src/MaxText/utils/ckpt_conversion/to_maxtext.py
+++ b/src/MaxText/utils/ckpt_conversion/to_maxtext.py
@@ -25,6 +25,9 @@ Key Parameters (to be set in the config file or as command-line overrides):
                          Defaults to "./mt_output/".
   scan_layers: (bool) Whether the MaxText model was trained with scanned layers.
                This must match the training configuration of the checkpoint.
+  lazy_load: (bool) If True, uses an on-demand loading strategy to minimize RAM
+             usage during conversion. Recommended if, 2 * model_size (GB) >= system RAM
+             Defaults to False.
 
 Environment Variables:
   HF_AUTH_TOKEN: (Required) HuggingFace authentication token, needed to
@@ -33,29 +36,44 @@ Environment Variables:
 Example Usage:
   To convert a gemma2-2b model and save it to a specific directory:
 
-  HF_AUTH_TOKEN="hf_YOUR_TOKEN" python src/MaxText/utils/ckpt_conversion/to_maxtext.py \
-    --model_name="gemma2-2b" \
-    --base_output_directory="/path/to/your/output/directory" \
-    --scan_layers=False
+    /usr/bin/time -v python src/MaxText/utils/ckpt_conversion/to_maxtext.py \
+    MaxText/configs/base.yml model_name="gemma2-2b" \
+    base_output_directory="/path/to/your/output/directory" \
+    hf_access_token=$HF_TOKEN hardware=cpu skip_jax_distributed_system=True \
+    scan_layers=False
 
   For models with scanned layers (e.g., some custom architectures), you might
   need to set scan_layers=True and param_scan_axis accordingly.
+
+  To convert a 70B model with minimal RAM usage:
+
+   /usr/bin/time -v python src/MaxText/utils/ckpt_conversion/to_maxtext.py \
+    MaxText/configs/base.yml model_name="meta-llama/Llama-3.1-70B" \
+    base_output_directory="gs://my-bucket/maxtext-checkpoints" \
+    hf_access_token=$HF_TOKEN hardware=cpu skip_jax_distributed_system=True \
+    --lazy_load_tensors=True
 """
 
+import argparse
 import os
 import sys
-from typing import Sequence, List, Dict, Any
-
+import json
+import threading
+from functools import partial
+from typing import Sequence, List, Any, Callable
+from benchmarks.benchmark_utils import str2bool
 import numpy as np
 import jax
 import psutil
-from absl import app
 from flax.training import train_state
 import flax.linen as nn
 from flax.linen import partitioning as nn_partitioning
 from transformers import AutoConfig, AutoModelForCausalLM
 from tqdm import tqdm
+from huggingface_hub import hf_hub_download, list_repo_files
+from safetensors import safe_open
 
+from orbax.checkpoint import type_handlers
 from MaxText import checkpointing
 from MaxText import max_logging
 from MaxText import max_utils
@@ -68,6 +86,13 @@ from MaxText.utils.ckpt_conversion.utils.param_mapping import HOOK_FNS, PARAM_MA
 from MaxText.utils.ckpt_conversion.utils.utils import apply_hook_fns, HF_IDS
 
 jax.config.update("jax_platform_name", "cpu")
+
+
+def print_ram_usage(stage=""):
+  memory = psutil.virtual_memory()
+  max_logging.log(
+      f"[{stage}] RAM Usage: {memory.used / (1024**3):.2f}/{memory.total / (1024**3):.2f} GB ({memory.percent:.1f}%)"
+  )
 
 
 class MemoryMonitorTqdm(tqdm):
@@ -103,8 +128,170 @@ class MemoryMonitorTqdm(tqdm):
     return super().format_meter(n=n, total=total, elapsed=elapsed, postfix=postfix, **extra_kwargs)
 
 
+class LazyHFLoader:
+  """
+  Loads Hugging Face weights on-demand to minimize RAM usage.
+
+  This class is the core of the "lazy loading" feature. Instead of loading the
+  entire model into memory at once, it reads the model's index file (e.g.,
+  `model.safetensors.index.json`) to understand the mapping between tensor names
+  and the shard files they belong to.
+
+  When a specific tensor is requested via `get_tensor`, this class:
+  1. Identifies the correct shard file.
+  2. Downloads the shard file if not already cached by `huggingface_hub`.
+  3. Opens the shard and extracts *only* the requested tensor into memory.
+
+  This approach is highly memory-efficient, especially for `safetensors`, as
+  it avoids loading entire multi-gigabyte shard files when only a small piece
+  is needed. A threading lock (`_ram_lock`) is used to ensure that memory-intensive
+  file-opening operations are serialized to prevent RAM spikes, while downloads
+  can still occur in parallel.
+  """
+
+  def __init__(self, model_id, token):
+    self.model_id = model_id
+    self.token = token
+    self.shard_map = {}
+    self.current_shard_name = None
+    self.current_shard_content = {}
+    # Use a lock to serialize heavy RAM operations, but NOT downloads
+    self._ram_lock = threading.Lock()
+    self._initialize_index()
+
+  def __getstate__(self):
+    """Allows pickling/copying by excluding the non-pickleable lock."""
+    state = self.__dict__.copy()
+    del state["_ram_lock"]
+    return state
+
+  def __setstate__(self, state):
+    """Restores state after pickling/copying and recreates a new lock."""
+    self.__dict__.update(state)
+    self._ram_lock = threading.Lock()
+
+  def _initialize_index(self):
+    """Fetches and parses the Hugging Face model index file to build a shard map."""
+    files = list_repo_files(self.model_id, token=self.token)
+
+    # Prefer safetensors
+    if "model.safetensors.index.json" in files:
+      index_file = "model.safetensors.index.json"
+    elif "model.safetensors" in files:
+      # Single file case
+      self.shard_map = {None: "model.safetensors"}
+      return
+    else:
+      raise ValueError("Could not find recognized model weights (safetensors) in HF repo.")
+
+    # Download and parse the index
+    max_logging.log(f"Loading index file: {index_file}")
+    index_path = hf_hub_download(repo_id=self.model_id, filename=index_file, token=self.token)
+    with open(index_path, "r", encoding="utf-8") as f:
+      index_data = json.load(f)
+    self.shard_map = index_data["weight_map"]
+
+  def get_tensor(self, key: str) -> np.ndarray:
+    """
+    Retrieves a specific tensor by name, lazily loading its shard if necessary.
+
+    This is the main entry point for accessing model weights. It determines
+    which shard file contains the tensor, ensures it's downloaded, and then
+    reads the tensor data.
+
+    For safetensors, this is extremely efficient as it memory-maps the file
+    and reads only the required tensor's data from disk.
+    """
+    # Handle single-file models (shard map key might be None or we just know the filename)
+    shard_name = self.shard_map.get(key)
+    if shard_name is None and None in self.shard_map:
+      shard_name = self.shard_map[None]
+    elif shard_name is None:
+      # Fallback: sometimes keys in index don't perfectly match requested keys if there are prefix mismatches.
+      # You might need advanced fuzzy matching here if you encounter errors.
+      raise ValueError(f"Key {key} not found in HF checkpoint index.")
+
+    # STEP 1: Download outside the lock.
+    # multiple threads can download different shards at the same time.
+    local_path = hf_hub_download(repo_id=self.model_id, filename=shard_name, token=self.token)
+
+    # STEP 2: Lock ONLY the reading into RAM.
+    # This prevents multiple threads from simultaneously allocating large chunks of RAM.
+    with self._ram_lock:
+      with safe_open(local_path, framework="np", device="cpu") as f:
+        return f.get_tensor(key)
+
+
+class LazyTensor:
+  """
+  A proxy object that looks like a NumPy array but delays actual loading
+  and transformation until __array__ is called (e.g., by Orbax during save).
+  """
+
+  def __init__(self, load_fn: Callable[[], np.ndarray], shape: tuple, dtype, name: str = "unknown"):
+    self._load_fn = load_fn
+    self.shape = shape
+    self.dtype = np.dtype(dtype)
+    self.ndim = len(shape)
+    self.name = name
+
+  @property
+  def size(self):
+    """Total number of elements in the tensor."""
+    return np.prod(self.shape)
+
+  @property
+  def nbytes(self):
+    """Return estimated nbytes so Orbax doesn't need to load the real array to find out."""
+    return self.size * self.dtype.itemsize
+
+  @property
+  def itemsize(self):
+    return self.dtype.itemsize
+
+  def __array__(self, dtype=None):
+    """
+    Materializes the tensor data.
+
+    When this method is invoked, it finally calls the `_load_fn` that was
+    provided during initialization. This function executes the actual loading
+    and transformation of the tensor from the Hugging Face checkpoint. The
+    resulting NumPy array is then returned to the caller.
+    """
+    # This method is called just-in-time by Orbax when saving this specific leaf.
+    try:
+      arr = self._load_fn()
+    except Exception as e:
+      max_logging.log(f"FATAL ERROR: Failed to load tensor '{self.name}' (shape {self.shape}). Error: {e}")
+      # Re-raise the original exception so it doesn't get masked by "object __array__..."
+      raise
+
+    # Ensure it's a standard numpy array (converts JAX arrays if necessary)
+    if not isinstance(arr, np.ndarray):
+      arr = np.array(arr)
+
+    if dtype is not None and arr.dtype != dtype:
+      return arr.astype(dtype)
+    return arr
+
+  def __repr__(self):
+    return f"LazyTensor(name={self.name}, shape={self.shape}, dtype={self.dtype})"
+
+
+class LazyTensorHandler(type_handlers.NumpyHandler):
+  """Custom Orbax handler for LazyTensor to avoid typestr collision with np.ndarray."""
+
+  def typestr(self):
+    return "LazyTensor"
+
+
+# Register LazyTensor with the custom handler.
+# It's safe to register this globally even if eager loading is used.
+type_handlers.register_type_handler(LazyTensor, LazyTensorHandler())
+
+
 def _build_multi_axis_stacked_tensor(
-    hf_source_keys: List[List[str]], hf_state_dict: Dict[str, np.ndarray], hook_fns: Any
+    hf_source_keys: List[List[str]], tensor_getter_fn: Callable[[str], np.ndarray], hook_fns: Any
 ) -> np.ndarray:
   """Builds a MaxText tensor by stacking HF weights along two axes (experts and layers).
 
@@ -114,7 +301,7 @@ def _build_multi_axis_stacked_tensor(
   Args:
       hf_source_keys: A nested (2D) list of Hugging Face parameter names.
                       Outer list iterates experts, inner list iterates layers.
-      hf_state_dict: The dictionary of loaded Hugging Face weights.
+      tensor_getter_fn: A callable that takes a HF key and returns the tensor (as numpy array).
       hook_fns: The hook function(s) to apply to each individual weight.
 
   Returns:
@@ -126,23 +313,19 @@ def _build_multi_axis_stacked_tensor(
     layer_tensors_for_expert = []
     # Inner loop iterates through layers for the current expert
     for hf_key_single in layer_keys_for_expert:
-      if hf_key_single not in hf_state_dict:
-        raise ValueError(f"HuggingFace key {hf_key_single} not found in state_dict.")
-      hf_tensor_numpy = hf_state_dict[hf_key_single]
-      # For this case, the hook function does not require the target_shape.
+      hf_tensor_numpy = tensor_getter_fn(hf_key_single)
       processed_hf_tensor = apply_hook_fns(hf_tensor_numpy, None, hook_fns)
       layer_tensors_for_expert.append(processed_hf_tensor)
-
-    # First, stack all layers for the current expert. This creates the 'layer' axis.
-    stacked_expert_tensor = np.stack(layer_tensors_for_expert, axis=0)
-    all_expert_tensors.append(stacked_expert_tensor)
-
-  # Second, stack all the expert tensors. This creates the 'expert' axis.
+    all_expert_tensors.append(np.stack(layer_tensors_for_expert, axis=0))
   return np.stack(all_expert_tensors, axis=0)
 
 
 def _build_single_axis_stacked_tensor(
-    hf_source_keys: List[str], hf_state_dict: Dict[str, np.ndarray], hook_fns: Any, target_shape: tuple, config
+    hf_source_keys: List[str],
+    tensor_getter_fn: Callable[[str], np.ndarray],
+    hook_fns: Any,
+    target_shape: tuple,
+    config,
 ) -> np.ndarray:
   """Builds a MaxText tensor by stacking HF weights along a single axis.
 
@@ -151,7 +334,7 @@ def _build_single_axis_stacked_tensor(
 
   Args:
       hf_source_keys: A 1D list of Hugging Face parameter names.
-      hf_state_dict: The dictionary of loaded Hugging Face weights.
+      tensor_getter_fn: A callable that takes a HF key and returns the tensor (as numpy array).
       hook_fns: The hook function(s) to apply to each individual weight.
       target_shape: The final shape of the target MaxText tensor.
       config: The MaxText pyconfig object.
@@ -173,9 +356,7 @@ def _build_single_axis_stacked_tensor(
   mt_slice_shape = tuple(mt_slice_shape_list)
 
   for hf_key_single in hf_source_keys:
-    if hf_key_single not in hf_state_dict:
-      raise ValueError(f"HuggingFace key {hf_key_single} not found in state_dict.")
-    hf_tensor_numpy = hf_state_dict[hf_key_single]
+    hf_tensor_numpy = tensor_getter_fn(hf_key_single)
     processed_hf_tensor = apply_hook_fns(hf_tensor_numpy, mt_slice_shape, hook_fns)
     tensors_to_stack.append(processed_hf_tensor)
 
@@ -184,7 +365,7 @@ def _build_single_axis_stacked_tensor(
 
 
 def _get_hf_model(model_id: str, token: str):
-  """Loads the HuggingFace model based on model_id."""
+  """Loads the HuggingFace model based on model_id (Eager mode only)."""
   # Some models require special classes to import
   if model_id in ["Qwen/Qwen3-Omni-30B-A3B-Instruct"]:
     from transformers import Qwen3OmniMoeForConditionalGeneration  # pylint: disable=import-outside-toplevel
@@ -195,22 +376,19 @@ def _get_hf_model(model_id: str, token: str):
   return hf_model
 
 
-def main(argv: Sequence[str]) -> None:
-  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
-  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"  # Suppress TensorFlow logging
-
+def main(args: Sequence[str], test_args: Sequence[str]) -> None:
   # Check if the user is using an Instruct version. If so, use the base model architecture
-  for i, arg in enumerate(argv):
+  for i, arg in enumerate(args):
     if arg.startswith("model_name="):
-      model_name_arg = argv[i].split("=")[1]
+      model_name_arg = args[i].split("=")[1]
       model_name_original = model_name_arg
       if "-Instruct" in model_name_arg:
         max_logging.log("Warning: You want an Instruct version, so we are using the base model architecture instead.")
         model_name_arg = model_name_arg.replace("-Instruct", "")
-        argv[i] = f"model_name={model_name_arg}"
+        args[i] = f"model_name={model_name_arg}"
       break
 
-  config = pyconfig.initialize(argv)
+  config = pyconfig.initialize(args)
   # check the supported model ids
   if model_name_original not in HF_IDS:
     raise ValueError(f"Unsupported model name: {model_name_original}. Supported models are: {list(HF_IDS.keys())}")
@@ -227,15 +405,31 @@ def main(argv: Sequence[str]) -> None:
   mesh = jax.sharding.Mesh(devices_array, config.mesh_axes)
 
   hf_token = config.hf_access_token
-  # Load HuggingFace model, config, and state_dict
-  max_logging.log(f"Loading HuggingFace model: {model_id}...")
-  hf_config_obj = AutoConfig.from_pretrained(model_id, token=hf_token)
-  hf_model = _get_hf_model(model_id, token=hf_token)
-  hf_state_dict_numpy = hf_model.state_dict()
-  for k, v in hf_state_dict_numpy.items():
-    hf_state_dict_numpy[k] = v.numpy()
-  del hf_model
-  max_logging.log("HuggingFace model loaded and converted to NumPy.")
+
+  use_lazy_load = test_args.lazy_load_tensors
+
+  if use_lazy_load and config.use_multimodal:
+    raise ValueError("lazy loading of HF tensors is not supported for multimodal models yet.")
+
+  hf_state_dict_numpy = None
+  hf_loader = None
+
+  if use_lazy_load:
+    max_logging.log(f"Lazy loading ENABLED. Initializing LazyHFLoader for: {model_id}...")
+    hf_loader = LazyHFLoader(model_id, hf_token)
+    hf_config_obj = AutoConfig.from_pretrained(model_id, token=hf_token)
+    print_ram_usage("After LazyLoader init")
+  else:
+    max_logging.log(f"Lazy loading DISABLED. Loading full HuggingFace model: {model_id}...")
+    hf_config_obj = AutoConfig.from_pretrained(model_id, token=hf_token)
+    hf_model = _get_hf_model(model_id, token=hf_token)
+    hf_state_dict_numpy = hf_model.state_dict()
+    # Convert all to numpy immediately in eager mode
+    for k, v in hf_state_dict_numpy.items():
+      hf_state_dict_numpy[k] = v.numpy()
+    del hf_model
+    max_logging.log("HuggingFace model loaded and converted to NumPy.")
+    print_ram_usage("After full HF model load")
 
   checkpoint_manager = checkpointing.create_orbax_checkpoint_manager(
       output_directory,
@@ -246,17 +440,16 @@ def main(argv: Sequence[str]) -> None:
       use_zarr3=config.checkpoint_storage_use_zarr3,
   )
 
-  max_logging.log("MaxText abstract model and state initializing...")
+  max_logging.log("Initializing MaxText abstract model...")
   quant = quantizations.configure_quantization(config)
   maxtext_model_flax = models.transformer_as_linen(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
 
   # Get abstract model structure (name, shape) without materializing the weights to save memory
   with maxtext_model_flax.mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
     abstract_params_tree = maxtext_utils.get_abstract_param(maxtext_model_flax, config)["params"]
-  # Get abstract_params_flat from abstract_params_tree
+
   abstract_params_flat, _ = jax.tree_util.tree_flatten_with_path(abstract_params_tree)
-  # Get abstract_params_treedef from transformed abstract_params_tree
-  # Otherwise the param name has extra "value" after unflatten
+  # Standardize abstract tree for later unflattening
   abstract_params_tree = jax.tree.map(
       lambda _: 0,
       abstract_params_tree,
@@ -280,9 +473,20 @@ def main(argv: Sequence[str]) -> None:
   hook_fn_map_mt = HOOK_FNS[model_key](hf_config_obj.to_dict(), config.scan_layers, saving_to_hf=False)
   max_logging.log("Parameter mappings and hooks obtained.")
 
-  # Transform weights
   max_logging.log("Starting weight transformation...")
   final_mt_weights = []
+
+  # Define the appropriate tensor getter based on mode
+  if use_lazy_load:
+    tensor_getter = hf_loader.get_tensor
+  else:
+
+    def _eager_getter(key):
+      if key not in hf_state_dict_numpy:
+        raise ValueError(f"HuggingFace key {key} not found in state_dict.")
+      return hf_state_dict_numpy[key]
+
+    tensor_getter = _eager_getter
 
   for path_tuple, abstract_leaf_value in MemoryMonitorTqdm(
       abstract_params_flat, desc="Transforming weights", unit="param", leave=True, dynamic_ncols=True
@@ -292,44 +496,58 @@ def main(argv: Sequence[str]) -> None:
     mt_target_shape_final = abstract_leaf_value.shape
 
     hf_source_keys_or_key = param_map_mt_to_hf.get(mt_param_key)
+
     if hf_source_keys_or_key is None:
       raise ValueError(f"MaxText parameter {mt_param_key} not found in mapping.")
 
-    hook_fn_list_or_fn = hook_fn_map_mt.get(mt_param_key)
-    final_mt_tensor_numpy = None
+    hook_fn = hook_fn_map_mt.get(mt_param_key)
 
+    # Determine the loading function for this specific parameter
+    load_fn = None
     if not isinstance(hf_source_keys_or_key, list):
       # Case 1: Simple 1-to-1 mapping
-      hf_key_single = hf_source_keys_or_key
-      if hf_key_single not in hf_state_dict_numpy:
-        raise ValueError(f"HuggingFace key {hf_key_single} not found in state_dict.")
-      hf_tensor_numpy = hf_state_dict_numpy[hf_key_single]
-      final_mt_tensor_numpy = apply_hook_fns(hf_tensor_numpy, mt_target_shape_final, hook_fn_list_or_fn)
+      def _loader(getter, key, shape, hook):
+        return apply_hook_fns(getter(key), shape, hook)
+
+      load_fn = partial(_loader, tensor_getter, hf_source_keys_or_key, mt_target_shape_final, hook_fn)
     else:
-      # It's a stacked parameter, so dispatch to a helper function.
-      is_multi_axis_stacked = isinstance(hf_source_keys_or_key[0], list)
-
-      if is_multi_axis_stacked:
-        # Case 2: Multi-Axis Stacked (Scanned MoE)
-        final_mt_tensor_numpy = _build_multi_axis_stacked_tensor(
-            hf_source_keys_or_key, hf_state_dict_numpy, hook_fn_list_or_fn
-        )
+      # Stacked mapping
+      if isinstance(hf_source_keys_or_key[0], list):
+        # Case 2: Multi-Axis Stacked
+        load_fn = partial(_build_multi_axis_stacked_tensor, hf_source_keys_or_key, tensor_getter, hook_fn)
       else:
-        # Case 3: Single-Axis Stacked (Standard Scanned or Unscanned MoE)
-        final_mt_tensor_numpy = _build_single_axis_stacked_tensor(
-            hf_source_keys_or_key, hf_state_dict_numpy, hook_fn_list_or_fn, mt_target_shape_final, config
+        # Case 3: Single-Axis Stacked
+        load_fn = partial(
+            _build_single_axis_stacked_tensor,
+            hf_source_keys_or_key,
+            tensor_getter,
+            hook_fn,
+            mt_target_shape_final,
+            config,
         )
 
-    if final_mt_tensor_numpy.shape != mt_target_shape_final:
-      raise ValueError(
-          f"Shape mismatch for {mt_param_key}: "
-          f"Expected {mt_target_shape_final}, got {final_mt_tensor_numpy.shape} "
-          f"from HF key(s) {hf_source_keys_or_key} after hooks."
-      )
-    final_mt_weights.append(final_mt_tensor_numpy)
+    # Execute based on mode
+    if use_lazy_load:
+      # In lazy mode, we don't execute the loading/transformation function
+      # immediately. Instead, we wrap it in a `LazyTensor` object. This
+      # object acts as a placeholder that holds all the information needed
+      # to load the tensor later (the `load_fn`, shape, dtype).
+      # The actual data will only be loaded when Orbax calls `__array__`
+      # on this object during the saving process.
+      final_mt_weights.append(LazyTensor(load_fn, mt_target_shape_final, abstract_leaf_value.dtype, name=mt_param_key))
+    else:
+      # In eager mode, we execute the function immediately to get the
+      # NumPy array and append it to our list of weights.
+      final_mt_tensor_numpy = load_fn()
+      if final_mt_tensor_numpy.shape != mt_target_shape_final:
+        raise ValueError(
+            f"Shape mismatch for {mt_param_key}: Expected {mt_target_shape_final}, got {final_mt_tensor_numpy.shape}"
+        )
+      final_mt_weights.append(final_mt_tensor_numpy)
 
   del abstract_params_flat, hf_state_dict_numpy
-  max_logging.log("Weight transformation complete.")
+  max_logging.log("Weight transformation preparation complete.")
+  print_ram_usage("Before creating full JAX tree")
 
   # Create final MaxText parameters tree
   jax_weights = jax.tree_util.tree_unflatten(abstract_params_treedef, final_mt_weights)
@@ -340,16 +558,40 @@ def main(argv: Sequence[str]) -> None:
   final_save_state = train_state.TrainState(step=0, apply_fn=None, params=final_params_for_state, tx=None, opt_state={})
   del final_params_for_state
 
+  print_ram_usage("Before saving")
   if checkpoint_manager is not None:
+    if use_lazy_load:
+      max_logging.log("Starting checkpoint save (loading weights just-in-time)...")
+    else:
+      max_logging.log("Starting checkpoint save...")
+
     if save_checkpoint(checkpoint_manager, 0, final_save_state):
       max_logging.log("saved a checkpoint at step 0")
+
     # Upon preemption, exit when and only when all ongoing saves are complete.
     if checkpoint_manager.reached_preemption(0):
       checkpoint_manager.wait_until_finished()
       sys.exit()
 
+  print_ram_usage("Program Ends")
   max_logging.log(f"Conversion complete. Checkpoint saved to {output_directory}")
 
 
 if __name__ == "__main__":
-  app.run(main)
+  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
+  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"  # Suppress TensorFlow logging
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      "--lazy_load_tensors",
+      type=str2bool,
+      required=False,
+      default=False,
+      help="Whether to use lazy loading of HF tensors.",
+  )
+  local_args, _ = parser.parse_known_args()
+  model_args = sys.argv
+  to_remove_args = ["--lazy_load_tensors"]
+  for a in to_remove_args:
+    model_args = [s for s in model_args if not s.startswith(a)]
+  main(model_args, local_args)


### PR DESCRIPTION
# Description

This PR introduces a lazy_load configuration option that reduces peak RAM usage by deferring the loading and transformation of weights until the exact moment Orbax needs to save them to disk.

Note: lazy loading feature is temporarily disabled for multimodal models because the key names in the files are different from what are seen when loading a HF model using AutoConfig.  

## Key Changes

- Lazy Loading Mechanism: Implemented LazyHFLoader and LazyTensor classes. Instead of eagerly loading all weights, we now create lightweight proxy objects that only load their specific tensor data from disk when Orbax calls __array__() during the saving phase.
- Orbax Integration: Registered a custom LazyTensorHandler with Orbax to allow it to correctly recognize and process our proxy objects as if they were standard NumPy arrays.
- Config: Added a new boolean flag lazy_load to the MaxText configuration to enable this mode. It defaults to False to preserve existing behavior for smaller models.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/458745828

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

x here denotes number of B parameters

## Llama.3.1-70B

old RAM usage: 616 GB (8.8x GB)
new RAM usage: 86.2 GB (1.2x GB)
Logs: https://paste.googleplex.com/6288510168465408#l=571

## LLama3.1-8B

old RAM usage: 51 GB (6.3x GB)
new RAM usage: 31GB (4x GB)
Logs: https://paste.googleplex.com/6128000672333824
forward pass logits test: https://paste.googleplex.com/5595374018494464

## Qwen3-4B

old RAM usage: 37 GB ( 9.2x GB)
new RAM usage: 15.7 GB ( 3.7x GB )
Logs: https://paste.googleplex.com/4933249042350080#l=543
forward pass logit test: https://paste.googleplex.com/5515770054443008

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
