### PR TITLE
Temporarily remove profiler (de)activation metric logging

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -624,6 +624,7 @@ upload_all_profiler_results: False
 skip_first_n_steps_for_profiler: 1
 # Profile for a small number of steps to avoid a large profile file size.
 profiler_steps: 5
+hide_profiler_step_metric: False
 profile_cleanly: True # If set to true, adds a block_until_ready on train state which aligns the profile for each step.
 profile_periodically_period: -1 # If set to a positive integer, profile every profile_periodically_period steps.
 # This is useful to debug scenarios where performance is changing.


### PR DESCRIPTION
Introduce a new config `hide_profiler_step_metric` to omit metric logging for profiler start/stop and subsequent steps.

This change temporarily removes metric logging for four specific steps:
1.  The step where the profiler is activated.
2.  The step immediately following profiler activation.
3.  The step where the profiler is deactivated.
4.  The step immediately following profiler deactivation.

These steps produce outlier timings because profiler activation/deactivation overhead is currently included in the step time, which skews MFU and other benchmark metrics. This is a short-term fix to address the benchmarking inaccuracies described in b/456828037.

A long-term solution, moving the profiler to a separate subprocess to isolate its overhead, is planned.

# Tests



1. Tested with the command:
`smoke_train skip_first_n_steps_for_profiler=10 profiler_steps=3 profiler=xplane steps=20`

The log difference can be viewed here: https://diff.googleplex.com/#key=JIA9QUANVfdW

2. Tested with the command:
`smoke_train skip_first_n_steps_for_profiler=10 profiler_steps=3 profiler=xplane steps=20 hide_profiler_step_metric=true`

The log difference can be viewed here: https://diff.googleplex.com/#key=LbBZkoUsDAW5


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
