### PR TITLE
Checkpoint conversion utility: gpt-oss orbax scan to hf, many-to-one transform, inhomogeneous scan block

### DIFF
--- a/src/MaxText/integration/tunix/utils.py
+++ b/src/MaxText/integration/tunix/utils.py
@@ -130,7 +130,9 @@ class VllmWeightMapping:
       return STANDALONE_VLLM_WEIGHT_MAPPING[self.model_name].to_hf_mapping()
 
     config = self.config
-    mapping = self.convert_hf_map_to_sharding_map(PARAM_MAPPING[self.model_name](config, scan_layers=True))
+    mapping = self.convert_hf_map_to_sharding_map(
+        PARAM_MAPPING[self.model_name](config, maxtext_config=None, scan_layers=True)
+    )
     return mapping
 
   def to_hf_transpose_keys(self):

--- a/src/MaxText/utils/ckpt_conversion/to_maxtext.py
+++ b/src/MaxText/utils/ckpt_conversion/to_maxtext.py
@@ -466,11 +466,11 @@ def main(args: Sequence[str], test_args: Sequence[str]) -> None:
   #   f"model.layers.{global_layer_idx}.input_layernorm.weight",
 
   model_key = config.model_name
-  param_map_mt_to_hf = PARAM_MAPPING[model_key](hf_config_obj.to_dict(), config.scan_layers)
+  param_map_mt_to_hf = PARAM_MAPPING[model_key](hf_config_obj.to_dict(), config, config.scan_layers)
 
   # Example of Hook FN mapping, to perform reshape:
   # f"params-decoder-layers_{maxtext_layer_idx}-self_attention_global-key-kernel": reshape_kernel,
-  hook_fn_map_mt = HOOK_FNS[model_key](hf_config_obj.to_dict(), config.scan_layers, saving_to_hf=False)
+  hook_fn_map_mt = HOOK_FNS[model_key](hf_config_obj.to_dict(), config, config.scan_layers, saving_to_hf=False)
   max_logging.log("Parameter mappings and hooks obtained.")
 
   max_logging.log("Starting weight transformation...")

--- a/src/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -469,6 +469,8 @@ qwen3_coder_480b_a35b_config = transformers.Qwen3MoeConfig(
     vocab_size=151936,
 )
 
+# copy from https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/config.json
+# remove fp8 quantization_config, since we are using bf16
 deepseek3_671b_dict = {
     "architectures": ["DeepseekV3ForCausalLM"],
     "attention_bias": False,
@@ -527,7 +529,157 @@ deepseek3_671b_dict = {
 }
 deepseek3_671b_config = transformers.DeepseekV3Config(**deepseek3_671b_dict)
 
-# {maxtext model name: hf model config}
+# copy from https://huggingface.co/openai/gpt-oss-20b/blob/main/config.json
+# remove mxfp4 quantization_config, since we are using bf16
+gpt_oss_20b_dict = {
+    "architectures": ["GptOssForCausalLM"],
+    "attention_bias": True,
+    "attention_dropout": 0.0,
+    "eos_token_id": 200002,
+    "experts_per_token": 4,
+    "head_dim": 64,
+    "hidden_act": "silu",
+    "hidden_size": 2880,
+    "initial_context_length": 4096,
+    "initializer_range": 0.02,
+    "intermediate_size": 2880,
+    "layer_types": [
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+    ],
+    "max_position_embeddings": 131072,
+    "model_type": "gpt_oss",
+    "num_attention_heads": 64,
+    "num_experts_per_tok": 4,
+    "num_hidden_layers": 24,
+    "num_key_value_heads": 8,
+    "num_local_experts": 32,
+    "output_router_logits": False,
+    "pad_token_id": 199999,
+    "rms_norm_eps": 1e-05,
+    "rope_scaling": {
+        "beta_fast": 32.0,
+        "beta_slow": 1.0,
+        "factor": 32.0,
+        "original_max_position_embeddings": 4096,
+        "rope_type": "yarn",
+        "truncate": False,
+    },
+    "rope_theta": 150000,
+    "router_aux_loss_coef": 0.9,
+    "sliding_window": 128,
+    "swiglu_limit": 7.0,
+    "tie_word_embeddings": False,
+    "transformers_version": "4.55.0.dev0",
+    "use_cache": True,
+    "vocab_size": 201088,
+}
+gpt_oss_20b_config = transformers.GptOssConfig(**gpt_oss_20b_dict)
+
+# copy from https://huggingface.co/openai/gpt-oss-120b/blob/main/config.json
+# remove mxfp4 quantization_config, since we are using bf16
+gpt_oss_120b_dict = {
+    "architectures": ["GptOssForCausalLM"],
+    "attention_bias": True,
+    "attention_dropout": 0.0,
+    "eos_token_id": 200002,
+    "experts_per_token": 4,
+    "head_dim": 64,
+    "hidden_act": "silu",
+    "hidden_size": 2880,
+    "initial_context_length": 4096,
+    "initializer_range": 0.02,
+    "intermediate_size": 2880,
+    "layer_types": [
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+    ],
+    "max_position_embeddings": 131072,
+    "model_type": "gpt_oss",
+    "num_attention_heads": 64,
+    "num_experts_per_tok": 4,
+    "num_hidden_layers": 36,
+    "num_key_value_heads": 8,
+    "num_local_experts": 128,
+    "output_router_logits": False,
+    "pad_token_id": 199999,
+    "rms_norm_eps": 1e-05,
+    "rope_scaling": {
+        "beta_fast": 32.0,
+        "beta_slow": 1.0,
+        "factor": 32.0,
+        "original_max_position_embeddings": 4096,
+        "rope_type": "yarn",
+        "truncate": False,
+    },
+    "rope_theta": 150000,
+    "router_aux_loss_coef": 0.9,
+    "sliding_window": 128,
+    "swiglu_limit": 7.0,
+    "tie_word_embeddings": False,
+    "transformers_version": "4.55.0.dev0",
+    "use_cache": True,
+    "vocab_size": 201088,
+}
+gpt_oss_120b_config = transformers.GptOssConfig(**gpt_oss_120b_dict)
+
+
 qwen3_omni_30b_a3b_config = transformers.Qwen3OmniMoeConfig(
     # TODO(hengtaoguo): Pure-text Omni model, need to fill in visual/audio/code2wav parts
     architectures=["Qwen3OmniMoeForConditionalGeneration"],
@@ -539,6 +691,7 @@ qwen3_omni_30b_a3b_config = transformers.Qwen3OmniMoeConfig(
     },
 )
 
+# {maxtext model name: hf model config}
 HF_MODEL_CONFIGS = {
     "gemma2-2b": gemma2_2b_config,
     "gemma2-9b": gemma2_9b_config,
@@ -560,5 +713,7 @@ HF_MODEL_CONFIGS = {
     "qwen3-235b-a22b": qwen3_235b_a22b_thinking_2507_config,
     "qwen3-480b-a35b": qwen3_coder_480b_a35b_config,
     "deepseek3-671b": deepseek3_671b_config,
+    "gpt-oss-20b": gpt_oss_20b_config,
+    "gpt-oss-120b": gpt_oss_120b_config,
     "qwen3-omni-30b-a3b": qwen3_omni_30b_a3b_config,
 }

--- a/src/MaxText/utils/ckpt_conversion/utils/param_mapping.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/param_mapping.py
@@ -41,7 +41,7 @@ import jax
 import jax.numpy as jnp
 
 
-def GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
+def GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
   """Generates a parameter mapping from MaxText to Hugging Face for Gemma3.
 
   This function creates a dictionary that maps the parameter names from a
@@ -143,7 +143,7 @@ def GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
   return mapping
 
 
-def GEMMA3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=False):
+def GEMMA3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
   """Hook functions for Gemma3 parameter conversion.
 
   This function provides a dictionary of transformation functions (hooks) for
@@ -298,7 +298,7 @@ def GEMMA3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=F
   return hooks
 
 
-def GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
+def GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
   """Returns mapping between MaxText and HuggingFace Gemma2 weight paths.
 
   Args:
@@ -431,7 +431,7 @@ def GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
   return mapping
 
 
-def GEMMA2_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=False):
+def GEMMA2_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
   """Creates parameter transformation functions for Gemma2 conversion.
 
   This function generates a mapping of transformation functions that handle the
@@ -596,7 +596,7 @@ def GEMMA2_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=F
   return mapping
 
 
-def QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING(config=None, scan_layers=False):
+def QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
   """Returns mapping from MaxText to HuggingFace Qwen3 weight paths.
 
   This function generates a dictionary that maps parameter names from a MaxText
@@ -729,7 +729,7 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING(config=None, scan_layers=False):
   return mapping
 
 
-def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=False):
+def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
   """Creates parameter transformation functions for Qwen3.
 
   This function provides a dictionary of transformation functions (hooks) for
@@ -814,7 +814,7 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=Fa
   return mapping
 
 
-def DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
+def DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
   """Returns mapping from MaxText to HuggingFace Deepseek weight paths using f-strings."""
   # TODO(shuningjin): add unscan support, b/457820735
   if not scan_layers:
@@ -835,14 +835,16 @@ def DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
   attention_keys = {
       "pre_self_attention_layer_norm-scale": "input_layernorm.weight",
       "post_self_attention_layer_norm-scale": "post_attention_layernorm.weight",
-      "self_attention-query-kernel": "self_attn.q_proj.weight",
-      "self_attention-wq_a-kernel": "self_attn.q_a_proj.weight",
-      "self_attention-q_norm-scale": "self_attn.q_a_layernorm.weight",
-      "self_attention-wq_b-kernel": "self_attn.q_b_proj.weight",
       "self_attention-wkv_a-kernel": "self_attn.kv_a_proj_with_mqa.weight",
       "self_attention-kv_norm-scale": "self_attn.kv_a_layernorm.weight",
       "self_attention-wkv_b-kernel": "self_attn.kv_b_proj.weight",
       "self_attention-out-kernel": "self_attn.o_proj.weight",
+      # v3
+      "self_attention-wq_a-kernel": "self_attn.q_a_proj.weight",
+      "self_attention-q_norm-scale": "self_attn.q_a_layernorm.weight",
+      "self_attention-wq_b-kernel": "self_attn.q_b_proj.weight",
+      # v2
+      "self_attention-query-kernel": "self_attn.q_proj.weight",
   }
   # Dense Layers
   dense_layer_keys = attention_keys | {
@@ -861,6 +863,7 @@ def DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
       "DeepSeekMoeBlock_0-shared_experts-wi_1-kernel": "mlp.shared_experts.up_proj.weight",
       "DeepSeekMoeBlock_0-shared_experts-wo-kernel": "mlp.shared_experts.down_proj.weight",
       "DeepSeekMoeBlock_0-MoeBlock_0-gate-kernel": "mlp.gate.weight",
+      # v3
       "DeepSeekMoeBlock_0-MoeBlock_0-gate-bias": "mlp.gate.e_score_correction_bias",
   }
   for maxtext_key, hf_key in moe_layer_keys.items():
@@ -882,7 +885,7 @@ def DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
   return mapping
 
 
-def DEEPSEEK_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=False):
+def DEEPSEEK_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
   """Creates parameter transformation functions for Deepseek using f-strings."""
   # TODO(shuningjin): support hf->orbax(scan), b/457820372
   if not saving_to_hf:
@@ -940,7 +943,171 @@ def DEEPSEEK_NNX_TO_VLLM_PARAM_HOOK_FN():
   return {}
 
 
-def QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
+def GPT_OSS_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
+  """Returns mapping from MaxText gpt-oss to Hugging Face weight paths.
+
+  Handles the inhomogeneous scan block structure (inhomogeneous_layer_cycle_interval)
+
+  Handles N-to-1 mapping from maxtext to huggingface
+  - (GptOssMlp-wi_0, GptOssMlp-wi_1): mlp.experts.gate_up_proj
+  - (GptOssMlp-wi_0_bias, GptOssMlp-wi_1_bias): mlp.experts.gate_up_proj_bias
+  """
+  # TODO(shuningjin): add unscan support, b/459541579
+  if not scan_layers:
+    raise NotImplementedError("Current gpt-oss mapping only supports scan_layers=True")
+
+  n_layers = config["num_hidden_layers"]  # hf config
+  layer_cycle_interval = maxtext_config.inhomogeneous_layer_cycle_interval
+
+  # Base mapping for non-layer parameters (targeting standard HF keys)
+  mapping = {
+      "params-token_embedder-embedding": "model.embed_tokens.weight",
+      "params-decoder-decoder_norm-scale": "model.norm.weight",
+      "params-decoder-logits_dense-kernel": "lm_head.weight",
+  }
+
+  for block_idx in range(layer_cycle_interval):
+    # Identify all original HF layer indices that collapse into this block
+    hf_indices = list(range(block_idx, n_layers, layer_cycle_interval))
+    prefix = f"params-decoder-layers-layers_{block_idx}"
+
+    # Layer Norms
+    mapping[f"{prefix}-pre_self_attention_layer_norm-scale"] = [
+        f"model.layers.{i}.input_layernorm.weight" for i in hf_indices
+    ]
+    mapping[f"{prefix}-post_self_attention_layer_norm-scale"] = [
+        f"model.layers.{i}.post_attention_layernorm.weight" for i in hf_indices
+    ]
+
+    # GptOssAttention
+    mapping.update(
+        {
+            f"{prefix}-GptOssAttention-query-kernel": [f"model.layers.{i}.self_attn.q_proj.weight" for i in hf_indices],
+            f"{prefix}-GptOssAttention-query-bias": [f"model.layers.{i}.self_attn.q_proj.bias" for i in hf_indices],
+            f"{prefix}-GptOssAttention-key-kernel": [f"model.layers.{i}.self_attn.k_proj.weight" for i in hf_indices],
+            f"{prefix}-GptOssAttention-key-bias": [f"model.layers.{i}.self_attn.k_proj.bias" for i in hf_indices],
+            f"{prefix}-GptOssAttention-value-kernel": [f"model.layers.{i}.self_attn.v_proj.weight" for i in hf_indices],
+            f"{prefix}-GptOssAttention-value-bias": [f"model.layers.{i}.self_attn.v_proj.bias" for i in hf_indices],
+            f"{prefix}-GptOssAttention-out-kernel": [f"model.layers.{i}.self_attn.o_proj.weight" for i in hf_indices],
+            f"{prefix}-GptOssAttention-out-bias": [f"model.layers.{i}.self_attn.o_proj.bias" for i in hf_indices],
+            f"{prefix}-GptOssAttention-sinks": [f"model.layers.{i}.self_attn.sinks" for i in hf_indices],
+        }
+    )
+
+    # GptOssMlp
+    # 1. Gate/Router
+    mapping.update(
+        {
+            f"{prefix}-GptOssMlp-gate-kernel": [f"model.layers.{i}.mlp.router.weight" for i in hf_indices],
+            f"{prefix}-GptOssMlp-gate-bias": [f"model.layers.{i}.mlp.router.bias" for i in hf_indices],
+        }
+    )
+
+    # 2. Experts (Down Projection)
+    mapping.update(
+        {
+            f"{prefix}-GptOssMlp-wo": [f"model.layers.{i}.mlp.experts.down_proj" for i in hf_indices],
+            f"{prefix}-GptOssMlp-wo_bias": [f"model.layers.{i}.mlp.experts.down_proj_bias" for i in hf_indices],
+        }
+    )
+
+    # 3. Experts (Gate/Up Fused Projection)
+    # N-to-1 mapping
+    mapping.update(
+        {
+            (f"{prefix}-GptOssMlp-wi_0", f"{prefix}-GptOssMlp-wi_1"): [
+                f"model.layers.{i}.mlp.experts.gate_up_proj" for i in hf_indices
+            ],
+            (f"{prefix}-GptOssMlp-wi_0_bias", f"{prefix}-GptOssMlp-wi_1_bias"): [
+                f"model.layers.{i}.mlp.experts.gate_up_proj_bias" for i in hf_indices
+            ],
+        }
+    )
+
+  return mapping
+
+
+def GPT_OSS_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
+  """Transformation hooks for gpt-oss parameters.
+
+  Handles the inhomogeneous scan block structure (inhomogeneous_layer_cycle_interval)
+
+  Handles N-to-1 mapping from maxtext to huggingface
+  - (GptOssMlp-wi_0, GptOssMlp-wi_1): mlp.experts.gate_up_proj
+  - (GptOssMlp-wi_0_bias, GptOssMlp-wi_1_bias): mlp.experts.gate_up_proj_bias
+  """
+  # TODO(shuningjin): support hf->orbax(scan), b/459541579
+  if not saving_to_hf:
+    raise NotImplementedError("Currently gpt-oss only supports saving_to_hf=True.")
+  # TODO(shuningjin): add unscan support, b/459541579
+  if not scan_layers:
+    raise NotImplementedError("Currently gpt-oss only supports scan_layers=True.")
+
+  def transpose(input_tensor, target_shape=None):
+    if saving_to_hf:
+      return input_tensor.T
+    else:
+      return input_tensor.T
+
+  def reshape_kernel(input_tensor, target_shape):
+    """Reshapes and transposes kernel weights between MaxText and HF."""
+    if saving_to_hf:
+      flipped_target_shape = np.flip(np.array(target_shape))
+      return input_tensor.reshape(flipped_target_shape).T
+    else:
+      return input_tensor.T.reshape(target_shape)
+
+  def reshape_bias(input_tensor, target_shape=None):
+    """Reshapes biases between MaxText 2D (heads, dim) and HF 1D (hidden)."""
+    if saving_to_hf:
+      # MaxText [heads, head_dim] -> HF [hidden_dim] (flatten)
+      return input_tensor.reshape(target_shape)
+    else:
+      # HF [hidden_dim] -> MaxText [heads, head_dim]
+      return input_tensor.reshape(target_shape)
+
+  def interleave(input_tensor, target_shape=None):
+    """
+    N-to-1 mapping: maxtext (wi_0, wi_1) <-> hf (wi_0_1)
+    if saving_to_hf, input_tensor is a list of tensors
+    """
+    if saving_to_hf:
+      # (wi_0, wi_1) -> wi_0_1
+      wi_0, wi_1 = input_tensor
+      wi_0_1 = np.empty(target_shape, dtype=wi_0.dtype)
+      wi_0_1[..., ::2] = wi_0
+      wi_0_1[..., 1::2] = wi_1
+      return wi_0_1
+    else:
+      # wi_0_1 -> (wi_0, wi_1)
+      # TODO(shuningjin): support hf->orbax(scan), b/459541579
+      raise NotImplementedError
+
+  hooks = {
+      "params-decoder-logits_dense-kernel": transpose,
+  }
+
+  # Scan over blocks
+  layer_cycle_interval = maxtext_config.inhomogeneous_layer_cycle_interval
+  for block_idx in range(layer_cycle_interval):
+    prefix = f"params-decoder-layers-layers_{block_idx}"
+    # Attention Kernels & Biases
+    for key in ["query", "key", "value"]:
+      hooks[f"{prefix}-GptOssAttention-{key}-kernel"] = reshape_kernel
+      hooks[f"{prefix}-GptOssAttention-{key}-bias"] = reshape_bias
+
+    hooks[f"{prefix}-GptOssAttention-out-kernel"] = reshape_kernel
+
+    # MLP Kernels & Biases
+    hooks[f"{prefix}-GptOssMlp-gate-kernel"] = transpose
+    # Experts (Gate/Up Fused Projection), N-to-1 mapping
+    hooks[(f"{prefix}-GptOssMlp-wi_0", f"{prefix}-GptOssMlp-wi_1")] = interleave
+    hooks[(f"{prefix}-GptOssMlp-wi_0_bias", f"{prefix}-GptOssMlp-wi_1_bias")] = interleave
+
+  return hooks
+
+
+def QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
   """Returns mapping from MaxText to HuggingFace Qwen3-Omni weight paths.
 
   This function combines mappings from different modalities (text, vision, audio, etc.)
@@ -960,7 +1127,9 @@ def QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
   num_experts_text = config["thinker_config"]["text_config"].get("num_experts", 0)
   n_layers_text = config["thinker_config"]["text_config"]["num_hidden_layers"]
   text_mapping = QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING(
-      config={"num_hidden_layers": n_layers_text, "num_experts": num_experts_text}, scan_layers=scan_layers
+      config={"num_hidden_layers": n_layers_text, "num_experts": num_experts_text},
+      maxtext_config=maxtext_config,
+      scan_layers=scan_layers,
   )
 
   # Add "thinker." prefix to text mapping values
@@ -974,7 +1143,7 @@ def QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
   return mapping
 
 
-def QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=False):
+def QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
   """Creates parameter transformation functions for Qwen3-Omni.
 
   This function provides a dictionary of transformation functions (hooks) for
@@ -1001,6 +1170,7 @@ def QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving
   n_layers_text = config["thinker_config"]["text_config"]["num_hidden_layers"]
   text_hooks = QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(
       config={"num_hidden_layers": n_layers_text, "num_experts": num_experts_text},
+      maxtext_config=maxtext_config,
       scan_layers=scan_layers,
       saving_to_hf=saving_to_hf,
   )
@@ -1025,7 +1195,7 @@ def QWEN3_NNX_TO_VLLM_PARAM_HOOK_FN(target_shape=None):
   return {}
 
 
-def LLAMA31_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
+def LLAMA31_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
   """
   Returns a dictionary mapping from MaxText parameter names to
   HuggingFace LLaMA3.1 parameter names.
@@ -1103,7 +1273,7 @@ def LLAMA31_MAXTEXT_TO_HF_PARAM_MAPPING(config, scan_layers=False):
   return mapping
 
 
-def LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=False):
+def LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
   """Creates parameter transformation functions for converting between MaxText and
   HuggingFace formats.
 
@@ -1199,7 +1369,6 @@ def LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, scan_layers=False, saving_to_hf=
   return hook_fns
 
 
-# {maxtext model name: {maxtext weight name: hf weight name}}
 def LLAMA31_NNX_TO_VLLM_PARAM_HOOK_FN():
   """Defines and returns hook functions for weight transformations.
 
@@ -1255,6 +1424,7 @@ def LLAMA31_NNX_TO_VLLM_PARAM_HOOK_FN():
   return hook_fns
 
 
+# {maxtext model name: {maxtext weight name: hf weight name}}
 PARAM_MAPPING = {
     "gemma2-2b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma2-9b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
@@ -1275,6 +1445,8 @@ PARAM_MAPPING = {
     "qwen3-235b-a22b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen3-coder-480b-a35b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "deepseek3-671b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "gpt-oss-20b": GPT_OSS_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "gpt-oss-120b": GPT_OSS_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen3-omni-30b-a3b": QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_MAPPING,
 }
 
@@ -1299,6 +1471,8 @@ HOOK_FNS = {
     "qwen3-235b-a22b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen3-coder-480b-a35b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "deepseek3-671b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "gpt-oss-20b": GPT_OSS_TO_HF_PARAM_HOOK_FN,
+    "gpt-oss-120b": GPT_OSS_TO_HF_PARAM_HOOK_FN,
     "qwen3-omni-30b-a3b": QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_HOOK_FN,
 }
 


### PR DESCRIPTION
# Description

The goal is to support gpt-oss in the checkpoint utility tool. However, two features are previously missing from the utility, which need to be implemented first
- multiple maxtext param are mapped to a single hf param
- inhomogeneous scan block

## 1 Support many-to-one transform

gpt-oss has two maxtext params mapped to one huggingface key
- GptOssMlp-wi_0, GptOssMlp-wi_1 -- mlp.experts.gate_up_proj
- GptOssMlp-wi_0_bias, GptOssMlp-wi_1_bias -- mlp.experts.gate_up_proj_bias
-  wi_0=wi_0_1[..., ::2], wi_1 = wi_0_1[..., 1::2]  -- wi_0_1

To implement this many-to-one mapping
- `param_mapping.py`:  previous  `mt: hf`, now also has tuple as key`(mt1, mt2): hf`
- `to_huggingface.py`: loop over param_map instead leaves (pre-check coverage), when key is tuple,  collect weights into a list 
- `utils.py` - `process_maxtext_param`, previously handle key is str + weight is single array,  now also handle key tuple + list weights 

other models can follow the structure similarly, e.g.,
- llama4, hf weight is split into two maxtext keys ([here](https://github.com/AI-Hypercomputer/maxtext/blob/bfdb7edb1cdb5c3d4679a034360ad744ea197790/src/MaxText/utils/ckpt_scripts/llama_or_mistral_ckpt.py#L935))

## 2 Support inhomogeneous scan block

gpt-oss has inhomogenous cycle interval = 2, both [20b](https://paste.googleplex.com/5726637198671872) and 120b: sliding attention->full attention

`param_mapping.py`
- add `maxtext_config` argument to all `MAXTEXT_TO_HF_PARAM_MAPPING` and `MAXTEXT_TO_HF_PARAM_HOOK_FN`
- used in `GPT_OSS_MAXTEXT_TO_HF_PARAM_MAPPING` and `GPT_OSS_TO_HF_PARAM_HOOK_FN`
  -  interval = 2, maxtext block 0  -- hf layer 0, 2, 4, ..., maxtext block 1 -- hf layer 1, 3, 5, ...

other models can follow the structure similarly, e.g.,
- llama4. interval = 4. [scout](https://paste.googleplex.com/4913624967675904): rope->rope->rope->nope, [maverick](https://paste.googleplex.com/5370986438459392): mlp+rope->moe+rope->mlp+rope->moe+nope
- qwen3-next, interval = 4, interleaved attention
- note gemma3 is slightly different: it has extra layers, as  n_layers is not divisible by interval 


## 3 Add gpt-oss: orbax (scan) to hf

## Future work
- gpt-oss: hf -> orbax (scan), accomodate the other direction of many-to-one transform 
- gpt-oss: add unscan
- both track in b/459541579


# Tests

run orbax scan -> hf,  and forward logit check

## gpt-oss-20b

```
# cpu
ID=$(date +%Y-%m-%d-%H-%M-%S); \
python3 -m MaxText.utils.ckpt_conversion.to_huggingface src/MaxText/configs/base.yml \
model_name=gpt-oss-20b \
load_parameters_path=gs://shuningjin-multipod-dev/gpt-oss-20b/scan-bf16-v2-2025-09-08-06-52-03/0/items \
base_output_directory=/home/shuningjin/gpt-oss-20b/gpt-oss-20b-hf-$ID \
scan_layers=true \
attention=dot_product skip_jax_distributed_system=True \
weight_dtype=bfloat16 checkpoint_storage_concurrent_gb=1024
```


https://paste.googleplex.com/6054915302621184

/home/shuningjin/gpt-oss-20b/gpt-oss-20b-hf-2025-11-13-08-11-24


```
# cpu
python3 -m tests.forward_pass_logit_checker src/MaxText/configs/base.yml \
model_name=gpt-oss-20b \
load_parameters_path=gs://shuningjin-multipod-dev/gpt-oss-20b/scan-bf16-v2-2025-09-08-06-52-03/0/items \
scan_layers=true \
per_device_batch_size=1 max_prefill_predict_length=4 max_target_length=4 \
attention=dot_product sparse_matmul=false \
--max_kl_div=0.015 --atol=0.5 --rtol=0.5 \
--run_hf_model=True \
--hf_model_path=/home/shuningjin/gpt-oss-20b/gpt-oss-20b-hf-2025-11-13-08-11-24 \
tokenizer_path=openai/gpt-oss-20b tokenizer_type=huggingface \
skip_jax_distributed_system=True
```

https://paste.googleplex.com/4806878806802432


## gpt-oss-120b

```
# cpu
ID=$(date +%Y-%m-%d-%H-%M-%S); \
python3 -m MaxText.utils.ckpt_conversion.to_huggingface src/MaxText/configs/base.yml \
model_name=gpt-oss-120b \
load_parameters_path=gs://shuningjin-multipod-dev/gpt-oss-120b/scan-bf16-v2-2025-09-08-07-19-09/0/items \
base_output_directory=/home/shuningjin/gpt-oss-120b/gpt-oss-120b-hf-$ID \
scan_layers=true \
attention=dot_product skip_jax_distributed_system=True \
weight_dtype=bfloat16 checkpoint_storage_concurrent_gb=1024
```

https://paste.googleplex.com/6024552484306944

/home/shuningjin/gpt-oss-120b/gpt-oss-120b-hf-2025-11-10-11-55-23


```
# cpu
python3 -m tests.forward_pass_logit_checker src/MaxText/configs/base.yml \
model_name=gpt-oss-120b \
load_parameters_path=gs://shuningjin-multipod-dev/gpt-oss-120b/scan-bf16-v2-2025-09-08-07-19-09/0/items \
scan_layers=true \
per_device_batch_size=1 max_prefill_predict_length=4 max_target_length=4 \
attention=dot_product sparse_matmul=false \
--max_kl_div=0.015 --atol=0.5 --rtol=0.5 \
--run_hf_model=True \
--hf_model_path=/home/shuningjin/gpt-oss-120b/gpt-oss-120b-hf-2025-11-10-11-55-23 \
tokenizer_path=openai/gpt-oss-120b tokenizer_type=huggingface \
skip_jax_distributed_system=True
```

https://paste.googleplex.com/5431988781711360

## check other models just in case

### qwen3-4b

```
# cpu
ID=$(date +%Y-%m-%d-%H-%M-%S); \
python3 -m MaxText.utils.ckpt_conversion.to_huggingface src/MaxText/configs/base.yml \
model_name=qwen3-4b \
load_parameters_path=gs://maxtext-qwen/qwen3/4b/unscanned/2025-08-04-21-31/0/items \
base_output_directory=/tmp/conversion/$ID \
scan_layers=false \
attention=dot_product skip_jax_distributed_system=True \
weight_dtype=bfloat16 checkpoint_storage_concurrent_gb=1024
```

https://paste.googleplex.com/4788178485641216

```
CKPT=gs://maxtext-qwen/qwen3/4b/unscanned/2025-08-04-21-31/0/items
hf_model_path=/tmp/conversion/2025-11-13-08-31-06
python3 -m tests.forward_pass_logit_checker src/MaxText/configs/base.yml \
model_name=qwen3-4b attention=dot_product \
override_model_config=true enable_dropout=false tokenizer_type=huggingface \
load_parameters_path=$CKPT scan_layers=false \
per_device_batch_size=1 max_prefill_predict_length=4 max_target_length=8 \
tokenizer_path=Qwen/Qwen3-4B --run_hf_model=True --hf_model_path=$hf_model_path \
--max_kl_div=0.015 --atol=0.5 --rtol=0.5 \
skip_jax_distributed_system=True
```

https://paste.googleplex.com/5246501760663552



### gemma3-4b


```
ID=$(date +%Y-%m-%d-%H-%M-%S); \
python3 -m MaxText.utils.ckpt_conversion.to_huggingface src/MaxText/configs/base.yml \
model_name=gemma3-4b \
load_parameters_path=gs://maxtext-gemma/unified/gemma3/4b/unscanned/2025-08-05-18-18/0/items \
base_output_directory=/tmp/conversion/$ID \
scan_layers=false \
attention=dot_product skip_jax_distributed_system=True \
weight_dtype=bfloat16 checkpoint_storage_concurrent_gb=1024 \
hf_access_token=$HF_TOKEN
```

https://paste.googleplex.com/5830899908345856


```
CKPT=gs://maxtext-gemma/unified/gemma3/4b/unscanned/2025-08-05-18-18/0/items
hf_model_path=/tmp/conversion/2025-11-13-08-37-47
python3 -m tests.forward_pass_logit_checker src/MaxText/configs/base.yml \
model_name=gemma3-4b attention=dot_product \
override_model_config=true enable_dropout=false tokenizer_type=huggingface \
load_parameters_path=$CKPT scan_layers=false \
per_device_batch_size=1 max_prefill_predict_length=4 max_target_length=8 \
tokenizer_path=$hf_model_path --run_hf_model=True --hf_model_path=$hf_model_path \
--max_kl_div=0.015 --atol=0.5 --rtol=0.5 \
skip_jax_distributed_system=True
```

https://paste.googleplex.com/6449070222737408



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
