### PR TITLE
[.github/workflows/CPUTests.yml] Run pre-commit hooks and only against the changed files rather than whole codebase

### DIFF
--- a/.github/workflows/CPUTests.yml
+++ b/.github/workflows/CPUTests.yml
@@ -44,13 +44,6 @@ jobs:
     - name: Install Dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install pylint pyink pytype==2024.2.27
-    - name: Typecheck the code with pytype
-      run: |
-        pytype --jobs auto --disable 'import-error,late-directive,wrong-arg-types,module-attr,unsupported-operands' src/MaxText/ || true
-    - name: pylint
-      run: |
-         pylint --disable=R0401,R0917,W0201,W0613 --ignore-patterns='.pytype,.*pyi$' benchmarks end_to_end src tests
-    - name: pyink
-      run: |
-        pyink --pyink-indentation=2 --line-length=122 --check .
+        python3 -m pip install pre-commit
+    - name: Run pre-commit checks on just the files that have changed
+      run: pre-commit run


### PR DESCRIPTION
# Description

CI breaks on changes unrelated to their PR. This PR changes it to only check the files that were changed. This PR makes it easier for people to prioritise their changes ahead of codebase wide quality approaches. For the record, I prefer that codebase-wide quality checks are always run on the CI.

# Tests

Ran it on the CI.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).