### PR TITLE
Rampup batch size checkpoint support

### DIFF
--- a/src/MaxText/elastic_train.py
+++ b/src/MaxText/elastic_train.py
@@ -124,6 +124,8 @@ def elastic_handler(
         learning_rate_schedule,
         data_iterator,
         _,
+        _,
+        _,
         state,
     ) = setup_train_loop(config, recorder, elastic_manager.good_devices)
 
@@ -177,6 +179,8 @@ def train_loop(config, elastic_manager, recorder, state=None):
       mesh,
       learning_rate_schedule,
       data_iterator,
+      _,
+      _,
       _,
       state,
   ) = setup_train_loop(config, recorder)

--- a/src/MaxText/rampup_batch.py
+++ b/src/MaxText/rampup_batch.py
@@ -1,0 +1,112 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pytype: disable=unsupported-operands
+"""Module to save batch size managing classes."""
+
+import math
+
+
+class RampupBatchManager:
+  """
+  A stateful class tracking current batch size given train step
+  """
+
+  def __init__(self, config, step_num):
+    self._verify_inputs(config)
+    self._init_values(config)
+    self.num_accum_samples = 0
+
+    # Compute the number of samples already used given recovered step num
+    self._recover_states(step_num)
+
+  def _verify_inputs(self, config):
+    """Verify the rampup batch related inputs."""
+    diff_batch_size = config.per_device_batch_size - config.per_device_batch_size_start
+    if diff_batch_size <= 0:
+      raise ValueError(
+          "per_device_batch_size must be greater than per_device_batch_size_start. "
+          f"get batch size is {config.per_device_batch_size} and "
+          f"batch size start is {config.per_device_batch_size_start}."
+      )
+    if diff_batch_size % config.per_device_batch_size_increment:
+      raise ValueError(
+          "Expect rampup batch size change divisible by batch size increment."
+          f"Got per_device_batch_size={config.per_device_batch_size} and "
+          f"per_device_batch_size_start={config.per_device_batch_size_start}."
+      )
+
+  def _init_values(self, config):
+    """Initialize rampup batch related parameters"""
+    diff_batch_size = config.per_device_batch_size - config.per_device_batch_size_start
+    num_increments = diff_batch_size // config.per_device_batch_size_increment
+    self.samples_per_increment = config.global_rampup_samples / num_increments
+    num_devices = int(config.num_target_devices)
+    self.global_batch_size_end = int(num_devices * config.per_device_batch_size)
+    self.global_batch_size_start = int(num_devices * config.per_device_batch_size_start)
+    self.increment = int(num_devices * config.per_device_batch_size_increment)
+    self.global_rampup_samples = config.global_rampup_samples
+    self.global_batch_size_current = self.global_batch_size_start
+    self.total_rampup_steps = self._compute_total_rampup_steps(config)
+    self.total_used_samples = 0
+
+  def _compute_total_rampup_steps(self, config):
+    """Compute total number of rampup steps"""
+    batch_size_start = config.per_device_batch_size_start
+    batch_size_end = config.per_device_batch_size
+    batch_size_increment = config.per_device_batch_size_increment
+    diff_batch_size = batch_size_end - batch_size_start
+    num_increments = diff_batch_size // batch_size_increment
+    rampup_samples = config.global_rampup_samples / config.num_target_devices
+    rampup_samples_per_increment = rampup_samples / num_increments
+    total_rampup_steps = 0
+    current_batch_size = batch_size_start
+
+    while current_batch_size < batch_size_end:
+      steps_for_this_stage = math.ceil(rampup_samples_per_increment / current_batch_size)
+      total_rampup_steps += steps_for_this_stage
+      current_batch_size += batch_size_increment
+    return total_rampup_steps
+
+  def _recover_states(self, step_num):
+    """Recover the number of samples already used"""
+    if step_num < 0:
+      return
+    for _ in range(step_num):
+      _ = self.update()
+    return
+
+  def update(self):
+    """Update values when load_batch is called"""
+    self.total_used_samples += self.global_batch_size_current
+    self.num_accum_samples += self.global_batch_size_current
+    # Check if it's time to increment the batch size
+    is_time_to_increment = self.num_accum_samples >= self.samples_per_increment
+    if is_time_to_increment:
+      self.global_batch_size_current = min(self.increment + self.global_batch_size_current, self.global_batch_size_end)
+      self.num_accum_samples = 0
+    # return whether rampup phase is active or not
+    return self.global_batch_size_current < self.global_batch_size_end
+
+
+def create_rampup_manager(config, checkpoint_manager):
+  if not config.enable_rampup_batch_size:
+    return None
+
+  # Current step default as -1 if no checkpoint exists
+  current_step = -1
+  if checkpoint_manager and checkpoint_manager.latest_step():
+    current_step = checkpoint_manager.latest_step()
+
+  return RampupBatchManager(config, current_step)

--- a/src/MaxText/sft_trainer.py
+++ b/src/MaxText/sft_trainer.py
@@ -65,6 +65,8 @@ def train_loop(config, recorder, state=None):
       mesh,
       learning_rate_schedule,
       data_iterator,
+      _,
+      _,
       eval_data_iterator,
       state,
   ) = setup_train_loop(config, recorder)

--- a/src/MaxText/train_utils.py
+++ b/src/MaxText/train_utils.py
@@ -23,6 +23,8 @@ from MaxText import maxtext_utils
 from MaxText import sharding
 from MaxText import optimizers
 from MaxText.dpo_utils import _merge_dpo_state
+from MaxText.data_loader import create_dataloader
+from MaxText.rampup_batch import create_rampup_manager
 from MaxText.input_pipeline.input_pipeline_interface import create_data_iterator
 from MaxText.utils.goodput_utils import GoodputEvent
 from MaxText.utils.goodput_utils import maybe_record_goodput
@@ -167,6 +169,8 @@ def setup_train_loop(config, recorder, devices=None):
     mesh:
     learning_rate_schedule:
     data_iterator:
+    data_loader:
+    rampup_manager: the class managing rampup batch sizes
     state: the initialized train state
   """
 
@@ -177,6 +181,8 @@ def setup_train_loop(config, recorder, devices=None):
 
   with maybe_record_goodput(recorder, GoodputEvent.TRAINING_PREPARATION):
     data_iterator, eval_data_iterator = create_data_iterator(config, mesh)
+    rampup_manager = create_rampup_manager(config, checkpoint_manager)
+    data_loader = create_dataloader(config, mesh, data_iterator, recorder, rampup_manager)
     context_parallel_size = mesh.shape["context"]
     # Check if context parallelism is being used with sequence packing
     if context_parallel_size > 1 and config.packing and config.dataset_type != "synthetic":
@@ -245,6 +251,8 @@ def setup_train_loop(config, recorder, devices=None):
       mesh,
       learning_rate_schedule,
       data_iterator,
+      data_loader,
+      rampup_manager,
       eval_data_iterator,
       state,
   )

--- a/tests/sft_hooks_test.py
+++ b/tests/sft_hooks_test.py
@@ -24,10 +24,10 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 from jax.sharding import Mesh
-from jax.experimental import mesh_utils
 
 from MaxText import maxtext_utils
 from MaxText import pyconfig
+from MaxText.maxtext_utils import create_device_mesh
 from MaxText.globals import MAXTEXT_PKG_DIR
 from MaxText.sft import hooks
 
@@ -40,13 +40,10 @@ class SFTHooksTest(unittest.TestCase):
         [os.path.join(MAXTEXT_PKG_DIR, "sft.hooks"), os.path.join(MAXTEXT_PKG_DIR, "configs", "sft.yml")],
         per_device_batch_size=1,
         run_name="test",
-        mesh_axes=["data"],
-        logical_axis_rules=[["batch", "data"]],
         base_output_directory="test",
         skip_jax_distributed_system=True,
     )
-    mesh_shape_1d = (len(jax.devices()),)
-    self.mesh = Mesh(mesh_utils.create_device_mesh(mesh_shape_1d), self.config.mesh_axes)
+    self.mesh = Mesh(create_device_mesh(self.config), self.config.mesh_axes)
     learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(self.config)
 
     self.training_hooks = hooks.SFTTrainingHooks(self.config, self.mesh, learning_rate_schedule, goodput_recorder=None)

--- a/tools/gcs_benchmarks/standalone_dataloader.py
+++ b/tools/gcs_benchmarks/standalone_dataloader.py
@@ -38,7 +38,7 @@ def data_load_loop(config, state=None):
   """Main data loader loop.
   Loads batches of data for each training step.
   """
-  _, _, _, _, mesh, _, data_iterator, _, state = setup_train_loop(config, recorder=None)
+  _, _, _, _, mesh, _, data_iterator, _, _, _, state = setup_train_loop(config, recorder=None)
   data_loader = DataLoader(config, mesh, data_iterator, None)
 
   example_batch = None


### PR DESCRIPTION
# Description

This PR introduces checkpointing support for the batch size ramp-up feature in MaxText. Previously, if a training job with batch size ramp-up was pre-empted, it would restart the ramp-up from the beginning upon resumption. With these changes, the ramp-up state is now saved in checkpoints, allowing the training to resume from the correct batch size.

## Changes

-   A new stateful class, `RampupBatchManager`, has been introduced in `src/MaxText/rampup_batch.py`. This class encapsulates the logic for managing the batch size ramp-up, including tracking the current batch size, the number of samples processed, and the ramp-up schedule. Crucially, it can recover its state from a given step number, which is retrieved from a checkpoint.

-  The `RampUpDataLoader` in `src/MaxText/data_loader.py` has been refactored to be stateless. It now relies on the `RampupBatchManager` to provide the current batch size and to update the ramp-up state at each step. This separation of concerns makes the data loader simpler and delegates the state management to the new `RampupBatchManager`.

-    The `setup_train_loop` function in `src/MaxText/train_utils.py` has been updated to create and manage the `RampupBatchManager`. It retrieves the latest step from the `checkpoint_manager` and uses it to initialize the `RampupBatchManager`, ensuring that the ramp-up state is correctly restored when resuming from a checkpoint.

-   Various function signatures in `train.py`, `sft_trainer.py`, and other files have been updated to pass the `rampup_manager` instance where needed.

-   A new unit test, `test_rampup_data_loader_from_checkpointing`, has been added to `tests/data_loader_test.py`. This test specifically validates that the `RampUpDataLoader` and `RampupBatchManager` correctly resume the ramp-up process from a given checkpoint step.


We expect to have three PRs fully implementing rampup batch size, and this PR is the second one.

# Tests

For testing purposes, we configured the following parameters:

* `enable_rampup_batch_size=True`
* `per_device_batch_size_start=1.0`
* `per_device_batch_size_increment=1.0`
* `per_device_batch_size=4.0`
* `global_rampup_samples=120`

First, we determine how many batch sizes are involved in the rampup phase (specifically 1, 2, and 3). 

```text
(4.0  -  1.0)  /  1.0   =   3
  ^       ^        ^        ^
  |       |        |        |
  |       |        |        Number of rampup iterations
  |       |        per_device_batch_size_increment
  |       per_device_batch_size_start
  per_device_batch_size
```

The global rampup samples are then distributed evenly across these batch sizes. Assuming a 4-device setup, the calculation is:

```text
120   =   4    *    3    *    10
  ^        ^        ^         ^
  |        |        |         |
  |        |        |         Samples per device (for each iteration)
  |        |        Number of rampup iterations
  |        Count of devices
  Global_rampup_samples
```

Consequently, the number of steps for each batch size is calculated by dividing the samples by the batch size: $10/1 = 10$ steps, $10/2 = 5$ steps, and $\lceil 10/3 \rceil = 4$ steps.  There are totally 19 rampup steps.

**Note:** We increment the step count by one if the number of per-device rampup samples cannot be evenly divided by the corresponding batch size (a ceiling operation). As a result, the total number of rampup samples actually used may slightly exceed the value set in the `global_rampup_samples` config flag.

## Standard Rampup Batch Size

Command: 
```bash
smoke_train model_name=llama2-7b max_target_length=512 opt_type=sgd per_device_batch_size=4.0 per_device_batch_size_start=1.0 per_device_batch_size_increment=1.0 global_rampup_samples=120 dataset_type=synthetic enable_rampup_batch_size=True steps=30
```

Log: [log](https://paste.googleplex.com/6535930406109184)

## Recover from Checkpointing

Establish the checkpoint:

```bash
python -m MaxText.train MaxText/configs/base.yml   run_name=nc_test_rampup_pre   steps=15   base_output_directory=gs://chengnuojin-maxtext-logs   dataset_path=gs://chengnuojin-maxtext-dataset   model_name=llama2-7b max_target_length=512 opt_type=sgd enable_checkpointing=True   per_device_batch_size=4.0 per_device_batch_size_start=1.0 per_device_batch_size_increment=1.0 global_rampup_samples=120 enable_goodput_recording=False log_config=False dataset_type=synthetic enable_rampup_batch_size=True
```

Log: [log](https://paste.googleplex.com/5833656612552704)

Coninue:

```bash
python -m MaxText.train MaxText/configs/base.yml   run_name=nc_test_rampup_pre   steps=30   base_output_directory=gs://chengnuojin-maxtext-logs   dataset_path=gs://chengnuojin-maxtext-dataset   model_name=llama2-7b max_target_length=512 opt_type=sgd enable_checkpointing=True per_device_batch_size=4.0 per_device_batch_size_start=1.0 per_device_batch_size_increment=1.0 global_rampup_samples=120 enable_goodput_recording=False log_config=False dataset_type=synthetic enable_rampup_batch_size=True
```

Log: [log](https://paste.googleplex.com/4767243143610368)

## XPK Test using More Devices

Let's expand tests to 16 chips! Now we set `global_rampup_samples=480` instead while keep other related configs the same. The following tests are conducted through XPK.

### Standard Rampup Batch Size

Command: [command](https://paste.googleplex.com/5271301881200640)
Log: [log](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22chengnuojin-v5p-32%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22chengnuojin-rampup-test-xpk-8394-slice-job-0-0-%22%20severity%3E%3DDEFAULT;storageScope=project;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)

### Recover from Checkpointing

Establish the checkpoint:

Command: [command](https://paste.googleplex.com/4960427954012160)
Log: [log](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22chengnuojin-v5p-32%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22chengnuojin-rampup-test-xpk-8792-slice-job-0-0-%22%20severity%3E%3DDEFAULT;storageScope=project;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)

Continue:

Command: [command](https://paste.googleplex.com/5741124796940288)
Log: [log](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22chengnuojin-v5p-32%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22chengnuojin-rampup-test-xpk-9047-slice-job-0-0-%22%20severity%3E%3DDEFAULT;storageScope=project;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
