### PR TITLE
Disable AotHloIdenticalTest unit tests with Pathways

### DIFF
--- a/.github/workflows/run_pathways_tests_internal.yml
+++ b/.github/workflows/run_pathways_tests_internal.yml
@@ -56,8 +56,6 @@ jobs:
     runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
     container:
       image: gcr.io/tpu-prod-env-multipod/maxtext_${{ github.run_id }}:${{ inputs.image_type != '' && inputs.image_type || inputs.device_type }}
-      volumes:
-        - ${{ github.workspace }}:/tmp
       env:
         XLA_PYTHON_CLIENT_MEM_FRACTION: ${{ inputs.xla_python_client_mem_fraction }}
         TF_FORCE_GPU_ALLOW_GROWTH: ${{ inputs.tf_force_gpu_allow_growth }}
@@ -77,7 +75,7 @@ jobs:
           python3 -m pip install -e . --no-dependencies &&
           python3 -m pip uninstall -y libtpu &&
           # TODO(b/454659463): Enable test_default_hlo_match after volume mount is supported.
-          python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" -k "not test_default_hlo_match" --durations=0
+          python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" -k "not AotHloIdenticalTest" --durations=0
     
     services:
       resource_manager:
@@ -103,8 +101,6 @@ jobs:
 
       proxy:
         image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest
-        volumes:
-          - ${{ github.workspace }}:/tmp
         ports:
           - "29000:29000"
         env:


### PR DESCRIPTION
# Description

Disable AotHloIdenticalTest unit tests with Pathways https://github.com/AI-Hypercomputer/maxtext/actions/runs/19277074406/job/55119833092

Currently the scheduled run failed because of AotHloIdenticalTest unit tests with Pathways. Will re-enable them after confirming the volume mount works on the self-hosted runners.

# Tests


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
