### PR TITLE
Refactor transformer engine context manager

### DIFF
--- a/src/MaxText/train.py
+++ b/src/MaxText/train.py
@@ -521,36 +521,18 @@ def initialize(argv: Sequence[str]) -> tuple[pyconfig.HyperParameters, Any, Any]
 
 def run(config, recorder, diagnostic_config):
   """Run the job given hyperparameters and utilities"""
-  with diagnostic.diagnose(diagnostic_config):
-    with maybe_record_goodput(recorder, GoodputEvent.JOB):
-      train_loop(config, recorder)
+  with (
+    diagnostic.diagnose(diagnostic_config),
+    maybe_record_goodput(recorder, GoodputEvent.JOB),
+    max_utils.maybe_get_transformer_engine_context(config)
+  ):
+    train_loop(config, recorder)
 
-
-@contextmanager
-def transformer_engine_context():
-  """If TransformerEngine is available, this context manager will provide
-  the library with MaxText-specific details needed for correcct operation."""
-  try:
-    from transformer_engine.jax.sharding import global_shard_guard, MeshResource  # pylint: disable=import-outside-toplevel
-    # Inform TransformerEngine of MaxText's physical mesh resources.
-    mesh_resource = MeshResource(  # pytype: disable=wrong-arg-types
-        dp_resource="data",
-        tp_resource="tensor",
-        # tpsp_resource = "tensor_sequence", #TODO(Phuong): add this back when upstreaming CGEMM
-        fsdp_resource="fsdp",
-        pp_resource=None,
-        cp_resource="context",
-    )
-    with global_shard_guard(mesh_resource):
-      yield
-  except (ImportError, AttributeError):
-    yield
 
 
 def main(argv: Sequence[str]) -> None:
-  with transformer_engine_context():
-    config, recorder, diagnostic_config = initialize(argv)
-    run(config, recorder, diagnostic_config)
+  config, recorder, diagnostic_config = initialize(argv)
+  run(config, recorder, diagnostic_config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Refactor Transformer Engine Context manager. This moves code out of train.py and hides running transformer engine imports only for GPU device types which fixes some import errors on TPUs.

FIXES: b/458480489

# Tests

Relying mainly on existing tests, will ask NVIDIA and @phu0ngng to test manually

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
