### PR TITLE
Install tpu requirements by default in pypi

### DIFF
--- a/build_hooks.py
+++ b/build_hooks.py
@@ -1,0 +1,41 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom build hooks for PyPI."""
+
+import os
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+TPU_REQUIREMENTS_PATH = "dependencies/requirements/generated_requirements/tpu-requirements.txt"
+
+
+def get_tpu_dependencies():
+  """Reads the TPU requirements file and returns a list of dependencies."""
+  if not os.path.exists(TPU_REQUIREMENTS_PATH):
+    print(f"Warning: TPU requirements file not found at {TPU_REQUIREMENTS_PATH}. Skipping dependency injection.")
+    return []
+
+  with open(TPU_REQUIREMENTS_PATH, "r") as f:  # pylint: disable=unspecified-encoding
+    # Filter out comments and empty lines
+    deps = [line.strip() for line in f if line.strip() and not line.strip().startswith("#")]
+  return deps
+
+
+class CustomBuildHook(BuildHookInterface):
+  """A custom hook to inject TPU dependencies into the core wheel dependencies."""
+
+  def initialize(self, version, build_data):  # pylint: disable=unused-argument
+    tpu_deps = get_tpu_dependencies()
+    build_data["dependencies"] = tpu_deps
+    print(f"Successfully injected {len(tpu_deps)} TPU dependencies into the wheel's core requirements.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,5 +39,8 @@ allow-direct-references = true
 [tool.hatch.build.targets.wheel]
 packages = ["src/MaxText", "src/install_maxtext_extra_deps"]
 
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "build_hooks.py"
+
 [project.scripts]
 install_maxtext_github_deps = "install_maxtext_extra_deps.install_github_deps:main"


### PR DESCRIPTION
# Description

Adds TPU dependencies as default dependencies to `pyproject.toml`. This ensures that when we release new version of MaxText, then both `pip install maxtext` and `pip install maxtext[tpu]` will install TPU-specific dependencies, and `pip install maxtext[gpu]` will install GPU-specific dependencies.

# Tests

Build wheel file, installed MaxText and dependencies using wheel file & tested training

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
