### PR TITLE
Fix str2bool import in to_maxtext.py

### DIFF
--- a/src/MaxText/utils/ckpt_conversion/to_maxtext.py
+++ b/src/MaxText/utils/ckpt_conversion/to_maxtext.py
@@ -61,7 +61,7 @@ import json
 import threading
 from functools import partial
 from typing import Sequence, List, Any, Callable
-from benchmarks.benchmark_utils import str2bool
+from MaxText.inference_utils import str2bool
 import numpy as np
 import jax
 import psutil


### PR DESCRIPTION
# Description

Changing the import because we don't install benchmark_utils for pypi.


If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Ran locally 
```
/usr/bin/time -v python -m MaxText.utils.ckpt_conversion.to_maxtext MaxText/configs/base.yml hardware=cpu skip_jax_distributed_system=True hf_access_token=${HF_TOKEN} model_name=llama3.1-8b base_output_directory=gs://runner-maxtext-logs/checkpoints/llama3.1-70b/unscanned/2025-11-03-01-8 scan_layers=false --lazy_load_tensors=true
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
