### PR TITLE
Upgrade MaxText to work with Goodput v15

### DIFF
--- a/src/MaxText/elastic_train.py
+++ b/src/MaxText/elastic_train.py
@@ -384,8 +384,7 @@ def main(argv: Sequence[str]) -> None:
   if config.use_vertex_tensorboard or os.environ.get("UPLOAD_DATA_TO_TENSORBOARD"):
     vertex_tensorboard_manager.configure_vertex_tensorboard(config)
 
-  # Goodput configurations
-  maybe_monitor_goodput(config)
+  # Create the Goodput recorder
   recorder = create_goodput_recorder(config)
 
   # Stack traces configurations
@@ -399,7 +398,7 @@ def main(argv: Sequence[str]) -> None:
   diagnostic_config = diagnostic_configuration.DiagnosticConfig(debug_config)
 
   with diagnostic.diagnose(diagnostic_config):
-    with maybe_record_goodput(recorder, GoodputEvent.JOB):
+    with maybe_record_goodput(recorder, GoodputEvent.JOB), maybe_monitor_goodput(config):
       train_loop(config, elastic_manager, recorder)
 
 

--- a/src/MaxText/experimental/rl/grpo_trainer.py
+++ b/src/MaxText/experimental/rl/grpo_trainer.py
@@ -946,8 +946,7 @@ def main(argv: Sequence[str]) -> None:
   if config.use_vertex_tensorboard or os.environ.get("UPLOAD_DATA_TO_TENSORBOARD"):
     vertex_tensorboard_manager.configure_vertex_tensorboard(config)
 
-  # Goodput configurations
-  maybe_monitor_goodput(config)
+  # Create the Goodput recorder
   recorder = create_goodput_recorder(config)
 
   # Stack traces configurations
@@ -961,7 +960,7 @@ def main(argv: Sequence[str]) -> None:
   diagnostic_config = diagnostic_configuration.DiagnosticConfig(debug_config)
 
   with diagnostic.diagnose(diagnostic_config):
-    with maybe_record_goodput(recorder, GoodputEvent.JOB):
+    with maybe_record_goodput(recorder, GoodputEvent.JOB), maybe_monitor_goodput(config):
       train_loop(config, config_inference, recorder)
 
 

--- a/src/MaxText/sft/sft_trainer.py
+++ b/src/MaxText/sft/sft_trainer.py
@@ -194,10 +194,9 @@ def main(argv: Sequence[str]) -> None:
   mt_config = pyconfig.initialize(argv)
   max_utils.print_system_information()
 
-  maybe_monitor_goodput(mt_config)
   goodput_recorder = create_goodput_recorder(mt_config)
 
-  with maybe_record_goodput(goodput_recorder, GoodputEvent.JOB):
+  with maybe_record_goodput(goodput_recorder, GoodputEvent.JOB), maybe_monitor_goodput(mt_config):
     train(mt_config, goodput_recorder)
 
 

--- a/src/MaxText/sft_trainer.py
+++ b/src/MaxText/sft_trainer.py
@@ -168,9 +168,8 @@ def main(argv: Sequence[str]) -> None:
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path
 
-  maybe_monitor_goodput(config)
   recorder = create_goodput_recorder(config)
-  with maybe_record_goodput(recorder, GoodputEvent.JOB):
+  with maybe_record_goodput(recorder, GoodputEvent.JOB), maybe_monitor_goodput(config):
     train_loop(config, recorder)
 
 

--- a/src/MaxText/train.py
+++ b/src/MaxText/train.py
@@ -502,8 +502,7 @@ def initialize(argv: Sequence[str]) -> tuple[pyconfig.HyperParameters, Any, Any]
   if config.use_vertex_tensorboard or os.environ.get("UPLOAD_DATA_TO_TENSORBOARD"):
     vertex_tensorboard_manager.configure_vertex_tensorboard(config)
 
-  # Goodput configurations
-  maybe_monitor_goodput(config)
+  # Create the Goodput recorder
   recorder = create_goodput_recorder(config)
 
   # Stack traces configurations
@@ -524,6 +523,7 @@ def run(config, recorder, diagnostic_config):
       diagnostic.diagnose(diagnostic_config),
       maybe_record_goodput(recorder, GoodputEvent.JOB),
       max_utils.maybe_get_transformer_engine_context(config),
+      maybe_monitor_goodput(config),
   ):
     train_loop(config, recorder)
 


### PR DESCRIPTION
# Description

This PR upgrades MaxText to use the Goodput v15 library correctly. This also fixes a potential process contention bug by removing an outdated API call. Additionally, this PR moves monitoring API to use context managers and adds the safe exit + flushing of metrics at the end of the run.

The Goodput library used to previously be pinned to v10. This [change](https://github.com/AI-Hypercomputer/maxtext/commit/13543e87e62418acf6aeedf008ab0dadca4e0e88) removed the pin, causing an automatic upgrade to latest version (`ml-goodput-measurement v0.0.15`). This version has multiple changes including the move from multithreaded monitoring system to a multiprocess system. It also moved all cumulative computation and monitoring to a single monitoring process to reduce the need to synchronize shared data sources (the goodput cache, cloud logs) and fix critical performance bottlenecks. We recently found an issue where launching two separate processes sequentially (one for cumulative Goodput, one for cumulative step deviation) caused the primary Goodput monitoring process to crash and shut down upon the secondary process starting:

```
I1029 08:08:10.968331 140099251349312 monitoring.py:754] Cumulative goodput monitoring process started for job: lid-pw-deepsee-1-ylg (PID: 185)
Started Goodput upload to Tensorboard & GCM in the background!
I1029 08:08:10.969586 140099251349312 monitoring.py:45] [PID: 185] Goodput worker process started for job: lid-pw-deepsee-1-ylg
I1029 08:08:10.979298 140099251349312 monitoring.py:858] Step deviation process started for job: lid-pw-deepsee-1-ylg (PID: 222)
Started step time deviation upload to Tensorboard & GCM in the background!
I1029 08:08:10.980461 140099251349312 monitoring.py:114] [PID: 222] Step deviation worker process started for job: lid-pw-deepsee-1-ylg
I1029 08:08:10.979673 140099251349312 monitoring.py:767] Shutting down cumulative goodput process (PID: 185)
I1029 08:08:11.371815 140099251349312 monitoring.py:104] [PID: 185] Goodput worker process for job lid-pw-deepsee-1-ylg stopped.
```

The `ml-goodput-measurement v0.0.15` consolidated the cumulative goodput and step deviation metrics computation and upload into the main Goodput monitoring process. The correct integration in MaxText that previously spun off separate processes for these metrics, is to remove the redundant API call and eliminate the source of contention between two processes that are doing repeated work.

FIXES: b/456054371

# Tests

E2E run 1 with no disruptions:
- [Logs](https://cloudlogging.app.goo.gl/79fWjFjEhrFJuaR58)
- Cloud Monitoring: 
<img width="1621" height="852" alt="image" src="https://github.com/user-attachments/assets/a2cfa74e-b48b-4280-b765-5f83349de042" />


E2E run 2 with disruptions:
- [Logs](https://cloudlogging.app.goo.gl/xf9UgWxPuwSxqDiC6)
- Cloud Monitoring: 
<img width="1619" height="848" alt="image" src="https://github.com/user-attachments/assets/dc7a7f70-c283-4c87-97ae-2dc853e145b2" />



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
