### PR TITLE
Enable Tunix-managed metrics

### DIFF
--- a/src/MaxText/configs/rl.yml
+++ b/src/MaxText/configs/rl.yml
@@ -76,6 +76,9 @@ log_period: 20
 # ====== Debugging ======
 debug:
   rl: True
+# If True, Tunix-managed metrics measurement will be enabled. The metrics will be
+# uploaded to tensorboard.
+enable_tunix_perf_metrics: False
 
 # ====== Training ======
 batch_size: 1


### PR DESCRIPTION
# Description

Enable Tunix-managed metrics.

It doesn't work with public Tunix versions, so the relevant imports are protected with `try... except...`.

# Tests

Manually tested with the latest Tunix.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
