### PR TITLE
Add Qwen3 Omni Vision Encoder

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -897,6 +897,13 @@ vision_output_dim_for_vit: 4096
 pixel_shuffle_ratio_for_vit: 0.5
 projector_dropout_for_vit: 0.0
 
+# Qwen3-OmniMoe vision encoder
+spatial_merge_size_for_vit: 2
+out_hidden_size_for_vit: 512
+temporal_patch_size_for_vit: 2
+num_position_embeddings_for_vit: 1024
+deepstack_visual_indexes_for_vit: []
+
 # Subslice shape in the form of "x,y,z" when using pathways (single controller). 
 # Example: "8,8" to use a 8x8 subgrid (64 chips) of a full pod (16x16) of trillium.
 subslice_shape: ""

--- a/src/MaxText/configs/models/qwen3-omni-30b-a3b.yml
+++ b/src/MaxText/configs/models/qwen3-omni-30b-a3b.yml
@@ -34,7 +34,25 @@ base_moe_mlp_dim: 768
 norm_topk_prob: true
 
 # RoPE Settings
-rope_max_timescale: 10_000_000
+rope_max_timescale: 1_000_000
+max_position_embeddings: 65536
 
 # General Model Settings
 enable_dropout: False
+
+# Vision Encoder Configuration
+# Based on https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
+image_size_for_vit: 768
+hidden_size_for_vit: 1152
+intermediate_size_for_vit: 4304
+num_attention_heads_for_vit: 16
+num_hidden_layers_for_vit: 27
+num_channels_for_vit: 3
+patch_size_for_vit: 16
+temporal_patch_size_for_vit: 2
+spatial_merge_size_for_vit: 2
+out_hidden_size_for_vit: 2048
+num_position_embeddings_for_vit: 2304
+deepstack_visual_indexes_for_vit: [8, 16, 24]
+
+use_multimodal: true

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -1194,6 +1194,11 @@ class VisionTower(BaseModel):
   num_hidden_layers_for_vit: int = Field(34, description="Number of hidden layers in the Vision Transformer.")
   rope_theta_for_vit: int = Field(10000, description="RoPE theta value for the Vision Transformer.")
   vision_output_dim_for_vit: int = Field(4096, description="Final output dimension of the vision-to-language projection.")
+  spatial_merge_size_for_vit: int = Field(2, description="Spatial merge factor for vision patches.")
+  out_hidden_size_for_vit: int = Field(512, description="Output dimension of ViT.")
+  temporal_patch_size_for_vit: int = Field(2, description="Temporal patch size for video inputs.")
+  num_position_embeddings_for_vit: int = Field(1024, description="Number of position embeddings for ViT.")
+  deepstack_visual_indexes_for_vit: list[int] = Field([], description="Layer indices to extract deep visual features.")
 
 
 class VisionProjector(BaseModel):

--- a/src/MaxText/layers/attention_mla.py
+++ b/src/MaxText/layers/attention_mla.py
@@ -671,6 +671,7 @@ class MLA(Attention):
       slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
       bidirectional_mask: Optional[Any] = None,
+      rope_kwargs: dict | None = None,
   ) -> Array:
     """Forward pass for MLA, reusing `AttentionOp` for the actual attention.
 

--- a/src/MaxText/layers/attentions.py
+++ b/src/MaxText/layers/attentions.py
@@ -16,7 +16,7 @@
 
 import dataclasses
 import functools
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple, Union, cast
 
 from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh, NamedSharding
@@ -63,6 +63,7 @@ from MaxText.layers.attention_op import AttentionOp
 from MaxText.layers.embeddings import (
     LLaMARotaryEmbedding,
     LlamaVisionRotaryEmbedding,
+    Qwen3OmniMoeVisionRotaryEmbedding,
     RotaryEmbedding,
     YarnRotaryEmbedding,
     Qwen3NextRotaryEmbedding,
@@ -720,15 +721,29 @@ class Attention(nnx.Module):
     rope_type = self.config.rope_type.lower()
     rope_use_scale = self.config.rope_use_scale
     if self.is_vision:
-      rotary_embedding = LlamaVisionRotaryEmbedding(
-          image_size=self.config.image_size_for_vit,
-          patch_size=self.config.patch_size_for_vit,
-          hidden_size=self.config.hidden_size_for_vit,
-          num_attention_heads=self.config.num_attention_heads_for_vit,
-          rope_theta=self.config.rope_theta_for_vit,
-          fprop_dtype=self.dtype,
-          rngs=self.rngs,
-      )
+      if self.config.model_name.startswith("qwen3-omni"):
+        rotary_embedding = Qwen3OmniMoeVisionRotaryEmbedding(
+            hidden_size=self.config.hidden_size_for_vit,
+            num_attention_heads=self.config.num_attention_heads_for_vit,
+            spatial_merge_size=self.config.spatial_merge_size_for_vit,
+            rope_theta=self.config.rope_theta_for_vit,
+            fprop_dtype=self.dtype,
+            rngs=self.rngs,
+        )
+      elif self.config.model_name.startswith("llama4"):
+        rotary_embedding = LlamaVisionRotaryEmbedding(
+            image_size=self.config.image_size_for_vit,
+            patch_size=self.config.patch_size_for_vit,
+            hidden_size=self.config.hidden_size_for_vit,
+            num_attention_heads=self.config.num_attention_heads_for_vit,
+            rope_theta=self.config.rope_theta_for_vit,
+            cast_as_fprop_dtype=True,
+            fprop_dtype=self.dtype,
+            rngs=self.rngs,
+        )
+      else:
+        raise ValueError(f"Unsupported model type for vision rotary embedding: {self.config.model_name}")
+
     elif self.config.model_name.startswith("llama3.1") or rope_type.startswith("llama3.1"):
       rotary_embedding = LLaMARotaryEmbedding(
           min_timescale=self.config.rope_min_timescale,
@@ -784,18 +799,28 @@ class Attention(nnx.Module):
       )
     return rotary_embedding
 
-  def apply_rotary_embedding(self, inputs: Array, inputs_positions: Optional[Array | None] = None):
+  def apply_rotary_embedding(
+      self, inputs: Array, inputs_positions: Optional[Array | None] = None, rope_kwargs: dict | None = None
+  ):
     """Applies rotary embeddings, handling different model types.
 
     Args:
       inputs: The input tensor to apply rotary embeddings to.
       inputs_positions: The positions of the inputs.
-      name: A name for the embedding layer.
+      rope_kwargs: A dictionary of keyword arguments for the rotary embedding.
 
     Returns:
       The input tensor with rotary embeddings applied.
     """
-    return self.rotary_embedding(inputs, inputs_positions)
+    if isinstance(self.rotary_embedding, Qwen3OmniMoeVisionRotaryEmbedding):
+      # For Qwen3OmniMoe vision, pass static dimensions from kwargs.
+      num_frames = rope_kwargs.get("num_frames")
+      height = rope_kwargs.get("height")
+      width = rope_kwargs.get("width")
+      # Type cast required: Omni rotary embedding uses different __call__ parameters than other embeddings.
+      return cast(Qwen3OmniMoeVisionRotaryEmbedding, self.rotary_embedding)(inputs, num_frames, height, width)
+    else:
+      return self.rotary_embedding(inputs, inputs_positions)
 
   def init_kv_caches(self, inputs_kv_shape: Tuple):
     """Initializes KVCache.
@@ -878,6 +903,7 @@ class Attention(nnx.Module):
       slot: Optional[int] = None,
       page_state: Optional[page_manager.PageState] = None,
       bidirectional_mask: Any = None,
+      rope_kwargs: dict | None = None,
   ):
     """Applies Attention on the input data.
 
@@ -952,8 +978,8 @@ class Attention(nnx.Module):
     use_qk_norm = self.use_qk_norm and use_rope
 
     if use_rope:
-      query = self.apply_rotary_embedding(query, inputs_positions=inputs_positions)
-      key = self.apply_rotary_embedding(key, inputs_positions=inputs_positions)
+      query = self.apply_rotary_embedding(query, inputs_positions=inputs_positions, rope_kwargs=rope_kwargs)
+      key = self.apply_rotary_embedding(key, inputs_positions=inputs_positions, rope_kwargs=rope_kwargs)
 
     if use_qk_norm and is_llama4_decoder_block:
       l2_norm = L2Norm(eps=self.config.normalization_layer_epsilon)

--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -558,7 +558,14 @@ class Decoder(nn.Module):
 
     # Merge the image embeddings with the text embeddings for multimodal models
     if image_embeddings is not None and cfg.use_multimodal:
-      if cfg.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b", "llama4-17b-16e", "llama4-17b-128e"]:
+      if cfg.model_name in [
+          "gemma3-4b",
+          "gemma3-12b",
+          "gemma3-27b",
+          "llama4-17b-16e",
+          "llama4-17b-128e",
+          "qwen3-omni-30b-a3b",
+      ]:
         y = multimodal_utils.merge_mm_embeddings(
             text_embeddings=y,
             vision_embeddings=image_embeddings,

--- a/src/MaxText/layers/embeddings.py
+++ b/src/MaxText/layers/embeddings.py
@@ -127,7 +127,11 @@ class Embed(nnx.Module):
     self.attend_dtype = attend_dtype
 
     self.embedding = nnx.Param(
-        embedding_init(rngs.params(), (self.num_embeddings, self.num_features), self.config.weight_dtype),
+        embedding_init(
+            rngs.params(),
+            (self.num_embeddings, self.num_features),
+            self.config.weight_dtype,
+        ),
         sharding=("vocab", "embed"),
     )
 
@@ -153,9 +157,17 @@ class Embed(nnx.Module):
     )
 
     output_axis_names = (
-        ("activation_embed_and_logits_batch", "prefill_activation_length", "activation_embed")
+        (
+            "activation_embed_and_logits_batch",
+            "prefill_activation_length",
+            "activation_embed",
+        )
         if model_mode == MODEL_MODE_PREFILL
-        else ("activation_embed_and_logits_batch", "activation_length_no_exp", "activation_embed")
+        else (
+            "activation_embed_and_logits_batch",
+            "activation_length_no_exp",
+            "activation_embed",
+        )
     )
     out_pspec = nn.logical_to_mesh_axes(output_axis_names)
 
@@ -750,7 +762,13 @@ class YarnRotaryEmbedding(nnx.Module):
     return dim * math.log(max_position_embeddings / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
 
   def _find_correction_range(
-      self, low_rot: float, high_rot: float, dim: int, base: float, max_position_embeddings: int, truncate: bool
+      self,
+      low_rot: float,
+      high_rot: float,
+      dim: int,
+      base: float,
+      max_position_embeddings: int,
+      truncate: bool,
   ):
     """Computes the range of correction dimensions for rotary positional embeddings.
 
@@ -1035,3 +1053,381 @@ class LlamaVisionRotaryEmbedding(nnx.Module):
       output = output.astype(self.fprop_dtype)
 
     return output
+
+
+class Qwen3OmniMoeVisionRotaryEmbedding(nnx.Module):
+  """Rotary position embedding for Qwen3OmniMoe vision encoder.
+
+  Attributes:
+    hidden_size: Hidden dimension size
+    num_attention_heads: Number of attention heads
+    spatial_merge_size: Spatial merge block size (e.g., 2 for 2x2 blocks)
+    rope_theta: Base theta for frequency computation (default 10000.0)
+    cast_as_fprop_dtype: Whether to cast to fprop dtype
+    fprop_dtype: Output dtype
+    rngs: RNG state passed in by nnx.bridge.to_linen, not used in this module
+  """
+
+  def __init__(
+      self,
+      hidden_size: int,
+      num_attention_heads: int,
+      spatial_merge_size: int,
+      rope_theta: float = 10000.0,
+      cast_as_fprop_dtype: bool = True,
+      fprop_dtype: DType = jnp.bfloat16,
+      rngs: nnx.Rngs = None,
+  ):
+    """Initializes the Qwen3OmniMoe vision rotary embedding.
+
+    Args:
+      hidden_size: Hidden dimension size
+      num_attention_heads: Number of attention heads
+      spatial_merge_size: Spatial merge block size (e.g., 2 for 2x2 blocks)
+      rope_theta: Base theta for frequency computation (default 10000.0)
+      cast_as_fprop_dtype: Whether to cast to fprop dtype
+      fprop_dtype: Output dtype
+      rngs: RNG state passed in by nnx.bridge.to_linen, not used in this module
+    """
+    self.hidden_size = hidden_size
+    self.num_attention_heads = num_attention_heads
+    self.spatial_merge_size = spatial_merge_size
+    self.rope_theta = rope_theta
+    self.cast_as_fprop_dtype = cast_as_fprop_dtype
+    self.fprop_dtype = fprop_dtype
+    self.rngs = rngs
+    self.head_dim = self.hidden_size // self.num_attention_heads
+
+  def _compute_freq_table(self, max_hw: int) -> Array:
+    """Precompute frequency table for positions up to max_hw.
+
+    Args:
+      max_hw: Maximum height or width dimension
+
+    Returns:
+      Array of shape [max_hw, head_dim//4] containing frequencies for each position
+    """
+
+    inv_freq = 1.0 / (self.rope_theta ** (jnp.arange(0, self.head_dim // 2, 2, dtype=jnp.float32) / (self.head_dim // 2)))
+    # Compute for all positions [0, max_hw)
+    positions = jnp.arange(max_hw, dtype=jnp.float32)
+    freqs = jnp.outer(positions, inv_freq)  # [max_hw, head_dim//4]
+    return freqs
+
+  def _generate_position_ids_single(self, num_frames: int, height: int, width: int) -> Array:
+    """Generate 2D position IDs for a single image or video.
+
+    Args:
+      num_frames: Number of temporal frames (1 for images, >1 for videos)
+      height: Height in patches
+      width: Width in patches
+
+    Returns:
+      Array of shape [num_frames * height * width, 2] with (row_id, col_id)
+    """
+    merge_size = self.spatial_merge_size
+    merged_h = height // merge_size
+    merged_w = width // merge_size
+
+    # Block indices
+    block_rows = jnp.arange(merged_h)  # [merged_h]
+    block_cols = jnp.arange(merged_w)  # [merged_w]
+
+    # Intra-block offsets
+    intra_row = jnp.arange(merge_size)  # [merge_size]
+    intra_col = jnp.arange(merge_size)  # [merge_size]
+
+    # Full resolution positions using broadcasting
+    # Shape: [merged_h, 1, merge_size, 1]
+    row_idx = block_rows[:, None, None, None] * merge_size + intra_row[None, None, :, None]
+    # Shape: [1, merged_w, 1, merge_size]
+    col_idx = block_cols[None, :, None, None] * merge_size + intra_col[None, None, None, :]
+
+    # Expand to full grid and flatten
+    row_idx = jnp.broadcast_to(row_idx, (merged_h, merged_w, merge_size, merge_size)).reshape(-1)
+    col_idx = jnp.broadcast_to(col_idx, (merged_h, merged_w, merge_size, merge_size)).reshape(-1)
+
+    coords = jnp.stack([row_idx, col_idx], axis=-1)  # [h*w, 2]
+
+    # Repeat for video frames
+    if num_frames > 1:
+      coords = jnp.tile(coords, (num_frames, 1))
+
+    return coords
+
+  def compute_cos_sin(self, num_frames: int, height: int, width: int) -> tuple[Array, Array]:
+    """Compute cos and sin embeddings for given static grid dimensions.
+
+    Args:
+      num_frames: Number of temporal frames
+      height: Height in patches
+      width: Width in patches
+
+    Returns:
+      Tuple of (cos_emb, sin_emb) each of shape [num_frames * height * width, head_dim]
+    """
+    max_hw = max(height, width)
+    freq_table = self._compute_freq_table(max_hw)  # [max_hw, head_dim//4]
+    coords = self._generate_position_ids_single(num_frames, height, width)  # [T*H*W, 2]
+
+    row_freqs = freq_table[coords[:, 0]]  # [T*H*W, head_dim//4]
+    col_freqs = freq_table[coords[:, 1]]  # [T*H*W, head_dim//4]
+
+    # Concatenate row and column frequencies
+    embeddings = jnp.concatenate([row_freqs, col_freqs], axis=-1)  # [T*H*W, head_dim//2]
+
+    # Double the embeddings to match head_dim
+    embeddings = jnp.concatenate([embeddings, embeddings], axis=-1)  # [T*H*W, head_dim]
+
+    cos_emb = jnp.cos(embeddings)
+    sin_emb = jnp.sin(embeddings)
+
+    if self.cast_as_fprop_dtype:
+      cos_emb = cos_emb.astype(self.fprop_dtype)
+      sin_emb = sin_emb.astype(self.fprop_dtype)
+
+    return cos_emb, sin_emb
+
+  def _rotate_half(self, x: Array) -> Array:
+    """Rotates half the hidden dims of the input.
+
+    Args:
+      x: Input tensor of any shape with last dimension divisible by 2
+
+    Returns:
+      Rotated tensor where (x1, x2) -> (-x2, x1)
+    """
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return jnp.concatenate([-x2, x1], axis=-1)
+
+  def __call__(self, inputs: Array, num_frames: int, height: int, width: int) -> Array:
+    """Apply rotary position embeddings directly to inputs (Q or K tensors).
+
+    Args:
+      inputs: Input tensor of shape [B, T*H*W, N, head_dim] (batch, sequence, heads, head_dim)
+             where T=num_frames, H=height, W=width (all static)
+      num_frames: Number of temporal frames (static)
+      height: Height in patches (static)
+      width: Width in patches (static)
+
+    Returns:
+      Rotated inputs with same shape [B, T*H*W, N, head_dim]
+    """
+    cos_emb, sin_emb = self.compute_cos_sin(num_frames, height, width)
+
+    if len(inputs.shape) == 4:
+      cos_emb = cos_emb[None, :, None, :]  # [1, S, 1, H]
+      sin_emb = sin_emb[None, :, None, :]
+    elif len(inputs.shape) == 3:
+      # For [S, N, H] case
+      cos_emb = cos_emb[:, None, :]  # [S, 1, H]
+      sin_emb = sin_emb[:, None, :]
+
+    rotated = inputs * cos_emb + self._rotate_half(inputs) * sin_emb
+
+    return rotated
+
+
+def qwen3omnimoe_vision_pos_embed_interpolate_as_linen(
+    *,
+    num_position_embeddings: int,
+    hidden_size: int,
+    spatial_merge_size: int,
+    dtype: DType = jnp.float32,
+    cast_as_fprop_dtype: bool = True,
+    fprop_dtype: DType = jnp.bfloat16,
+    name: str | None = None,
+):
+  """Initializes Qwen3OmniMoe bilinear position embedding interpolation as Linen module.
+
+  This implements fast bilinear interpolation of learned 2D positional embeddings
+  for dynamic input sizes. The embeddings are learned on a fixed grid and interpolated
+  to match the actual image/video dimensions.
+
+  Args:
+    num_position_embeddings: Number of position embeddings in the fixed grid (e.g., 1024 for 32x32)
+    hidden_size: Hidden dimension size
+    spatial_merge_size: Size of spatial merging blocks
+    dtype: Data type for embeddings
+    cast_as_fprop_dtype: Whether to cast the output to the fprop dtype
+    fprop_dtype: The dtype of the output
+    name: Module name
+
+  Returns:
+    A Linen module that wraps the NNX Qwen3OmniMoeVisionPosEmbedInterpolate module.
+  """
+  return nnx_wrappers.to_linen(
+      Qwen3OmniMoeVisionPosEmbedInterpolate,
+      num_position_embeddings=num_position_embeddings,
+      hidden_size=hidden_size,
+      spatial_merge_size=spatial_merge_size,
+      dtype=dtype,
+      cast_as_fprop_dtype=cast_as_fprop_dtype,
+      fprop_dtype=fprop_dtype,
+      metadata_fn=variable_to_logically_partitioned,
+      name=name,
+  )
+
+
+class Qwen3OmniMoeVisionPosEmbedInterpolate(nnx.Module):
+  """Bilinear interpolation of learned 2D positional embeddings for Qwen3OmniMoe vision.
+
+  This module maintains a fixed grid of learned positional embeddings and interpolates
+  them to match dynamic input dimensions using bilinear interpolation. This allows
+  the model to handle images/videos of varying sizes while using a fixed embedding table.
+
+  Attributes:
+    num_position_embeddings: Number of position embeddings in the fixed grid
+    hidden_size: Hidden dimension size
+    spatial_merge_size: Spatial merge block size
+    dtype: Data type for embeddings
+    cast_as_fprop_dtype: Whether to cast to fprop dtype
+    fprop_dtype: Output dtype
+    rngs: RNG state passed in by nnx.bridge.to_linen
+  """
+
+  def __init__(
+      self,
+      num_position_embeddings: int,
+      hidden_size: int,
+      spatial_merge_size: int,
+      dtype: DType = jnp.float32,
+      cast_as_fprop_dtype: bool = True,
+      fprop_dtype: DType = jnp.bfloat16,
+      rngs: nnx.Rngs = None,
+  ):
+    """Initializes the Qwen3OmniMoe vision position embedding interpolation module.
+
+    Args:
+      num_position_embeddings: Number of position embeddings in the fixed grid
+      hidden_size: Hidden dimension size
+      spatial_merge_size: Spatial merge block size
+      dtype: Data type for embeddings
+      cast_as_fprop_dtype: Whether to cast to fprop dtype
+      fprop_dtype: Output dtype
+      rngs: RNG state passed in by nnx.bridge.to_linen
+    """
+    self.num_position_embeddings = num_position_embeddings
+    self.hidden_size = hidden_size
+    self.spatial_merge_size = spatial_merge_size
+    self.dtype = dtype
+    self.cast_as_fprop_dtype = cast_as_fprop_dtype
+    self.fprop_dtype = fprop_dtype
+    self.rngs = rngs
+
+    # Initialize the learned position embedding table
+    if self.rngs is not None:
+      # Initialize with normal distribution scaled by hidden_size^(-0.5)
+      init_fn = nnx.initializers.normal(stddev=self.hidden_size**-0.5)
+      self.pos_embed = nnx.Param(
+          init_fn(
+              self.rngs.params(),
+              (self.num_position_embeddings, self.hidden_size),
+              self.dtype,
+          ),
+      )
+    self.num_grid_per_side = int(self.num_position_embeddings**0.5)
+
+  def _interpolate_single(self, t: int, h: int, w: int) -> tuple[Array, Array]:
+    """Compute bilinear interpolation indices and weights for a single image/video.
+
+    Args:
+      t: Number of temporal frames
+      h: Target height in patches
+      w: Target width in patches
+
+    Returns:
+      Tuple of (indices, weights) where:
+        - indices: [4, h*w] indices into pos_embed for 4 corners
+        - weights: [4, h*w] bilinear weights for 4 corners
+    """
+    N = self.num_grid_per_side
+
+    # Create interpolation coordinates
+    h_idxs = jnp.linspace(0, N - 1, h)
+    w_idxs = jnp.linspace(0, N - 1, w)
+
+    # Floor and ceiling indices
+    h_idxs_floor = jnp.floor(h_idxs).astype(jnp.int32)
+    w_idxs_floor = jnp.floor(w_idxs).astype(jnp.int32)
+    h_idxs_ceil = jnp.minimum(h_idxs_floor + 1, N - 1)
+    w_idxs_ceil = jnp.minimum(w_idxs_floor + 1, N - 1)
+
+    # Fractional parts for interpolation weights
+    dh = h_idxs - h_idxs_floor
+    dw = w_idxs - w_idxs_floor
+
+    # Compute flat indices for 2D grid
+    base_h = h_idxs_floor * N
+    base_h_ceil = h_idxs_ceil * N
+
+    # 4 corner indices: (floor_h, floor_w), (floor_h, ceil_w), (ceil_h, floor_w), (ceil_h, ceil_w)
+    indices = jnp.stack(
+        [
+            (base_h[:, None] + w_idxs_floor[None, :]).reshape(-1),
+            (base_h[:, None] + w_idxs_ceil[None, :]).reshape(-1),
+            (base_h_ceil[:, None] + w_idxs_floor[None, :]).reshape(-1),
+            (base_h_ceil[:, None] + w_idxs_ceil[None, :]).reshape(-1),
+        ],
+        axis=0,
+    )  # [4, h*w]
+
+    # Bilinear weights
+    weights = jnp.stack(
+        [
+            ((1 - dh)[:, None] * (1 - dw)[None, :]).reshape(-1),
+            ((1 - dh)[:, None] * dw[None, :]).reshape(-1),
+            (dh[:, None] * (1 - dw)[None, :]).reshape(-1),
+            (dh[:, None] * dw[None, :]).reshape(-1),
+        ],
+        axis=0,
+    )  # [4, h*w]
+
+    return indices, weights
+
+  def __call__(self, num_frames: int, height: int, width: int) -> Array:
+    """Interpolate positional embeddings for given static grid dimensions.
+
+    Args:
+      num_frames: Number of temporal frames (static)
+      height: Height in patches (static)
+      width: Width in patches (static)
+
+    Returns:
+      Interpolated positional embeddings of shape [num_frames * height * width, hidden_size]
+    """
+    # Get interpolation indices and weights
+    indices, weights = self._interpolate_single(num_frames, height, width)  # [4, h*w], [4, h*w]
+
+    # Lookup embeddings for all 4 corners
+    corner_embeds = self.pos_embed.value[indices]  # [4, h*w, hidden_size]
+
+    # Apply bilinear weights and sum
+    weighted_embeds = corner_embeds * weights[:, :, None]  # [4, h*w, hidden_size]
+    interpolated = jnp.sum(weighted_embeds, axis=0)  # [h*w, hidden_size]
+
+    # Repeat for temporal frames
+    if num_frames > 1:
+      interpolated = jnp.tile(interpolated, (num_frames, 1))  # [t*h*w, hidden_size]
+
+    # Apply spatial merge permutation
+    # Reshape to [t, h, w, hidden_size] then permute for block-based processing
+    merge_size = self.spatial_merge_size
+    merged_h = height // merge_size
+    merged_w = width // merge_size
+
+    # Reshape: [t*h*w, hidden_size] -> [t, h, w, hidden_size]
+    interpolated = interpolated.reshape(num_frames, height, width, self.hidden_size)
+
+    # Permute for spatial merging: [t, merged_h, merge_size, merged_w, merge_size, hidden_size]
+    interpolated = interpolated.reshape(num_frames, merged_h, merge_size, merged_w, merge_size, self.hidden_size)
+    # -> [t, merged_h, merged_w, merge_size, merge_size, hidden_size]
+    interpolated = jnp.transpose(interpolated, (0, 1, 3, 2, 4, 5))
+    # Flatten back to [t*merged_h*merged_w*merge_size*merge_size, hidden_size]
+    interpolated = interpolated.reshape(-1, self.hidden_size)
+
+    if self.cast_as_fprop_dtype:
+      interpolated = interpolated.astype(self.fprop_dtype)
+
+    return interpolated

--- a/src/MaxText/layers/encoders.py
+++ b/src/MaxText/layers/encoders.py
@@ -44,6 +44,10 @@ class VisionEncoder(nn.Module):
       from MaxText.layers import llama4  # pylint: disable=import-outside-toplevel
 
       return [llama4.llama4visionmodel_as_linen, llama4.llama4multimodalprojector_as_linen]
+    elif self.config.model_name in ["qwen3-omni-30b-a3b"]:
+      from MaxText.layers import qwen3  # pylint: disable=import-outside-toplevel
+
+      return [qwen3.qwen3omni_visionencoder_as_linen, qwen3.qwen3omni_visionprojector_as_linen]
     else:
       raise ValueError(f"No VisionEncoder implemented for {self.config.model_name} yet")
 
@@ -53,6 +57,9 @@ class VisionEncoder(nn.Module):
     mesh = self.mesh
     # vision encoder output, frozen params in many cases
     embeddings = self.vision_encoder_layer[0](config=cfg, mesh=mesh)(input_images, deterministic=deterministic)
+    if cfg.model_name in ["qwen3-omni-30b-a3b"]:
+      embeddings = embeddings[0]  # todo(eitanporat) add deepstack support
+
     if cfg.freeze_vision_encoder_params:
       embeddings = jax.lax.stop_gradient(embeddings)
 

--- a/src/MaxText/layers/gemma3.py
+++ b/src/MaxText/layers/gemma3.py
@@ -438,7 +438,6 @@ class Encoder1DBlock(nnx.Module):
         use_qk_norm=False,
         query_pre_attn_scalar=1 / (self.config.hidden_size_for_vit // self.config.num_attention_heads_for_vit) ** 0.5,
         model_mode="train",
-        is_vision=True,
         rngs=self.rngs,
     )
     self.LayerNorm_1 = nnx.LayerNorm(

--- a/src/MaxText/layers/models.py
+++ b/src/MaxText/layers/models.py
@@ -151,6 +151,8 @@ class TransformerLinenPure(nn.Module):
         bidirectional_mask = decoder_input_tokens == multimodal_utils.GEMMA_TOKEN_PLACEHOLDER
       elif self.config.decoder_block == DecoderBlockType.LLAMA4:
         bidirectional_mask = decoder_input_tokens == multimodal_utils.LLAMA4_PATCH_TOKEN
+      elif self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
+        bidirectional_mask = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN
 
     logits, hidden_state = self.decoder(
         shared_embedding=self.shared_embedding,
@@ -405,6 +407,8 @@ class Transformer(nnx.Module):
         bidirectional_mask = decoder_input_tokens == multimodal_utils.GEMMA_TOKEN_PLACEHOLDER
       elif self.config.decoder_block == DecoderBlockType.LLAMA4:
         bidirectional_mask = decoder_input_tokens == multimodal_utils.LLAMA4_PATCH_TOKEN
+      elif self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
+        bidirectional_mask = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN
 
     logits, hidden_state = self.decoder(
         shared_embedding=self.token_embedder,

--- a/src/MaxText/layers/qwen3.py
+++ b/src/MaxText/layers/qwen3.py
@@ -28,18 +28,19 @@ from flax import linen as nn
 from flax import nnx
 
 from MaxText import max_utils
-from MaxText.common_types import Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED
+from MaxText.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED
 from MaxText.layers import attentions
 from MaxText.layers import initializers as max_initializers
 from MaxText.layers import linears
 from MaxText.layers import moe
 from MaxText.layers import nnx_wrappers
 from MaxText.layers import quantizations
+from MaxText.layers.embeddings import Qwen3OmniMoeVisionPosEmbedInterpolate
 from MaxText.layers.normalizations import RMSNorm, l2norm, Qwen3NextRMSNorm, Qwen3NextRMSNormGated
 from MaxText.layers.quantizations import AqtQuantization as Quant
 from MaxText.inference import page_manager
 from MaxText.layers.attentions import Attention
-from MaxText.layers.linears import MlpBlock
+from MaxText.layers.linears import DenseGeneral, MlpBlock
 from MaxText.layers.moe import RoutedMoE
 
 
@@ -1059,6 +1060,594 @@ class Qwen3MoeDecoderLayer(AttentionWithNorm):
     else:
       return layer_output
 
+
+class Qwen3OmniMoeVisionPatchMerger(nnx.Module):
+  """Vision patch merger that spatially merges patches using an MLP.
+
+  Attributes:
+      config: Config containing model parameters
+      hidden_size: Hidden dimension after spatial merging
+      use_postshuffle_norm: Whether to apply normalization after spatial shuffle
+      dtype: Data type for computation
+      weight_dtype: Data type for weights
+      kernel_init: Initializer for kernel weights
+      rngs: RNG state for initialization
+      ln_q: LayerNorm before MLP
+      mlp_0: First MLP layer
+      mlp_2: Second MLP layer
+  """
+
+  def __init__(
+      self,
+      config: Config,
+      use_postshuffle_norm: bool = False,
+      dtype: DType = jnp.float32,
+      weight_dtype: DType = jnp.float32,
+      kernel_init: max_initializers.NdInitializer = max_initializers.nd_dense_init(1.0, "fan_in", "normal"),
+      rngs: nnx.Rngs = None,
+  ):
+    """Initializes the Qwen3Omni vision patch merger.
+
+    Args:
+        config: Config containing model parameters
+        use_postshuffle_norm: Whether to apply normalization after spatial shuffle
+        dtype: Data type for computation
+        weight_dtype: Data type for weights
+        kernel_init: Initializer for kernel weights
+        rngs: RNG state for initialization
+    """
+    self.config = config
+    self.use_postshuffle_norm = use_postshuffle_norm
+    self.dtype = dtype
+    self.weight_dtype = weight_dtype
+    self.kernel_init = kernel_init
+    self.rngs = rngs
+
+    # Calculate hidden_size after spatial merge
+    spatial_merge_size = config.spatial_merge_size_for_vit
+    base_hidden_size = config.hidden_size_for_vit
+    out_hidden_size = config.out_hidden_size_for_vit
+
+    self.hidden_size = base_hidden_size * (spatial_merge_size**2)
+
+    # LayerNorm before MLP
+    ln_features = self.hidden_size if use_postshuffle_norm else base_hidden_size
+    self.ln_q = nnx.LayerNorm(
+        num_features=ln_features,
+        epsilon=config.normalization_layer_epsilon,
+        dtype=dtype,
+        rngs=rngs,
+    )
+
+    # MLP layers: Linear -> GELU -> Linear
+    self.mlp_0 = DenseGeneral(
+        in_features_shape=self.hidden_size,
+        out_features_shape=self.hidden_size,
+        use_bias=True,
+        dtype=dtype,
+        weight_dtype=weight_dtype,
+        kernel_init=kernel_init,
+        matmul_precision=config.matmul_precision,
+        rngs=rngs,
+    )
+
+    self.mlp_2 = DenseGeneral(
+        in_features_shape=self.hidden_size,
+        out_features_shape=out_hidden_size,
+        use_bias=True,
+        dtype=dtype,
+        weight_dtype=weight_dtype,
+        kernel_init=kernel_init,
+        matmul_precision=config.matmul_precision,
+        rngs=rngs,
+    )
+
+  def __call__(self, hidden: Array) -> Array:
+    """
+    Args:
+        hidden: Input tensor of shape (batch, seq_len, base_hidden_size) after spatial reordering
+
+    Returns:
+        Output tensor of shape (batch, seq_len//merge_size**2, out_hidden_size) - spatially merged
+    """
+    # Get dimensions
+    spatial_merge_size = self.config.spatial_merge_size_for_vit
+    base_hidden_size = self.config.hidden_size_for_vit
+    tokens_per_block = spatial_merge_size**2
+
+    batch_size = hidden.shape[0]
+    seq_len = hidden.shape[1]
+    num_blocks = seq_len // tokens_per_block
+
+    hidden = hidden.reshape(batch_size, num_blocks, tokens_per_block * base_hidden_size)
+
+    # Apply layer norm
+    if self.use_postshuffle_norm:
+      hidden = self.ln_q(hidden)
+    else:
+      hidden_unmerged = hidden.reshape(batch_size, seq_len, base_hidden_size)
+      hidden_unmerged = self.ln_q(hidden_unmerged)
+      hidden = hidden_unmerged.reshape(batch_size, num_blocks, tokens_per_block * base_hidden_size)
+
+    # MLP: Linear -> GELU -> Linear
+    hidden = self.mlp_0(hidden)
+    hidden = jax.nn.gelu(hidden)
+    hidden = self.mlp_2(hidden)
+
+    return hidden
+
+
+class Qwen3OmniMoeVisionMLP(nnx.Module):
+  """Vision MLP block with GELU activation.
+
+  Attributes:
+      config: Config containing model parameters
+      hidden_size: Hidden dimension size
+      intermediate_size: Intermediate dimension size
+      dtype: Data type for computation
+      weight_dtype: Data type for weights
+      kernel_init: Initializer for kernel weights
+      rngs: RNG state for initialization
+      linear_fc1: First linear layer
+      linear_fc2: Second linear layer
+  """
+
+  def __init__(
+      self,
+      config: Config,
+      dtype: DType = jnp.float32,
+      weight_dtype: DType = jnp.float32,
+      kernel_init: max_initializers.NdInitializer = max_initializers.nd_dense_init(1.0, "fan_in", "normal"),
+      rngs: nnx.Rngs = None,
+  ):
+    """Initializes the Qwen3Omni vision MLP.
+
+    Args:
+        config: Config containing model parameters
+        dtype: Data type for computation
+        weight_dtype: Data type for weights
+        kernel_init: Initializer for kernel weights
+        rngs: RNG state for initialization
+    """
+    self.config = config
+    self.dtype = dtype
+    self.weight_dtype = weight_dtype
+    self.kernel_init = kernel_init
+    self.rngs = rngs
+
+    self.hidden_size = config.hidden_size_for_vit
+    self.intermediate_size = config.intermediate_size_for_vit
+
+    self.linear_fc1 = DenseGeneral(
+        in_features_shape=self.hidden_size,
+        out_features_shape=self.intermediate_size,
+        use_bias=True,
+        dtype=dtype,
+        weight_dtype=weight_dtype,
+        kernel_init=kernel_init,
+        matmul_precision=config.matmul_precision,
+        rngs=rngs,
+    )
+
+    self.linear_fc2 = DenseGeneral(
+        in_features_shape=self.intermediate_size,
+        out_features_shape=self.hidden_size,
+        use_bias=True,
+        dtype=dtype,
+        weight_dtype=weight_dtype,
+        kernel_init=kernel_init,
+        matmul_precision=config.matmul_precision,
+        rngs=rngs,
+    )
+
+  def __call__(self, hidden_state: Array) -> Array:
+    """
+    Args:
+        hidden_state: Input tensor of shape (..., hidden_size) - supports packed sequences
+
+    Returns:
+        Output tensor of shape (..., hidden_size)
+    """
+    hidden_state = self.linear_fc1(hidden_state)
+    hidden_state = jax.nn.gelu(hidden_state)
+    hidden_state = self.linear_fc2(hidden_state)
+    return hidden_state
+
+
+class Qwen3OmniMoeVisionPatchEmbed(nnx.Module):
+  """3D convolution-based patch embedding for vision inputs.
+
+  Attributes:
+      config: Config containing model parameters
+      patch_size: Spatial patch size
+      temporal_patch_size: Temporal patch size
+      in_channels: Number of input channels
+      embed_dim: Embedding dimension
+      dtype: Data type for computation
+      weight_dtype: Data type for weights
+      rngs: RNG state for initialization
+      proj: Convolution projection layer
+  """
+
+  def __init__(
+      self,
+      config: Config,
+      dtype: DType = jnp.float32,
+      weight_dtype: DType = jnp.float32,
+      rngs: nnx.Rngs = None,
+  ):
+    """Initializes the Qwen3Omni vision patch embedding.
+
+    Args:
+        config: Config containing model parameters
+        dtype: Data type for computation
+        weight_dtype: Data type for weights
+        rngs: RNG state for initialization
+    """
+    self.config = config
+    self.dtype = dtype
+    self.weight_dtype = weight_dtype
+    self.rngs = rngs
+
+    self.patch_size = config.patch_size_for_vit
+    self.temporal_patch_size = config.temporal_patch_size_for_vit
+    self.in_channels = config.num_channels_for_vit
+    self.embed_dim = config.hidden_size_for_vit
+
+    kernel_size = (self.temporal_patch_size, self.patch_size, self.patch_size)
+
+    self.proj = nnx.Conv(
+        in_features=self.in_channels,
+        out_features=self.embed_dim,
+        kernel_size=kernel_size,
+        strides=kernel_size,
+        use_bias=True,
+        dtype=dtype,
+        param_dtype=weight_dtype,
+        rngs=rngs,
+    )
+
+  def __call__(self, hidden_states: Array) -> Array:
+    """
+    Args:
+        hidden_states: Input tensor of shape (batch, in_channels, temporal*patch_size, height*patch_size, width*patch_size)
+    Returns:
+        Output tensor of shape (batch, T*H*W, embed_dim) where T, H, W are the number of patches
+    """
+    hidden_states = jnp.transpose(hidden_states, (0, 2, 3, 4, 1))
+    hidden_states = self.proj(hidden_states)
+    batch_size = hidden_states.shape[0]
+    seq_len = hidden_states.shape[1] * hidden_states.shape[2] * hidden_states.shape[3]
+    hidden_states = hidden_states.reshape(batch_size, seq_len, self.embed_dim)
+    return hidden_states
+
+
+class Qwen3OmniMoeVisionAttention(nnx.Module):
+  """Vision attention layer wrapper.
+
+  Attributes:
+      config: Config containing model parameters
+      attn: Underlying attention module
+  """
+
+  def __init__(self, config: Config, *, mesh=None, rngs: nnx.Rngs = None):
+    """Initializes the Qwen3Omni vision attention layer.
+
+    Args:
+        config: Config containing model parameters
+        mesh: JAX device mesh for sharding
+        rngs: RNG state for initialization
+    """
+    self.config = config
+    head_dim = self.config.hidden_size_for_vit // self.config.num_attention_heads_for_vit
+    # Vision uses full SA, no kv cache
+    self.attn = Attention(
+        config=self.config,
+        num_query_heads=self.config.num_attention_heads_for_vit,
+        num_kv_heads=self.config.num_attention_heads_for_vit,
+        head_dim=head_dim,
+        max_target_length=self.config.num_position_embeddings_for_vit,
+        attention_kernel="dot_product",
+        inputs_q_shape=(1, 1, self.config.hidden_size_for_vit),
+        inputs_kv_shape=(1, 1, self.config.hidden_size_for_vit),
+        float32_qk_product=self.config.float32_qk_product,
+        float32_logits=self.config.float32_logits,
+        dtype=self.config.dtype_mm,
+        weight_dtype=self.config.weight_dtype,
+        mesh=mesh,
+        dropout_rate=0.0,
+        attention_type=AttentionType.FULL,
+        is_nope_layer=False,
+        use_bias_in_projections=True,
+        is_vision=True,
+        use_qk_norm=False,
+        query_pre_attn_scalar=head_dim ** (-0.5),
+        model_mode="train",
+        rngs=rngs,
+    )
+
+  def __call__(
+      self,
+      hidden_states: Array,
+      num_frames: int,
+      height: int,
+      width: int,
+      deterministic: bool = True,
+  ) -> Array:
+    """
+    Args:
+        hidden_states: Input tensor of shape (batch, T*H*W, hidden_size)
+        num_frames: Number of temporal frames (static)
+        height: Height in patches (static)
+        width: Width in patches (static)
+        deterministic: Whether to use deterministic mode (disable dropout)
+
+    Returns:
+        Output tensor of shape (batch, T*H*W, hidden_size)
+    """
+    # Pass through attention with static dimensions via rope_kwargs
+    rope_kwargs = {
+        "num_frames": num_frames,
+        "height": height,
+        "width": width,
+    }
+    output = self.attn(
+        inputs_q=hidden_states,
+        inputs_kv=hidden_states,
+        deterministic=deterministic,
+        rope_kwargs=rope_kwargs,
+    )
+
+    return output
+
+
+class Qwen3OmniMoeVisionBlock(nnx.Module):
+  """Vision transformer block with attention and MLP.
+
+  Attributes:
+      config: Config containing model parameters
+      ln1: LayerNorm before attention
+      ln2: LayerNorm before MLP
+      attn: Attention module
+      mlp: First MLP layer
+      mlp_out: Second MLP layer
+  """
+
+  def __init__(self, config: Config, *, mesh=None, rngs: nnx.Rngs = None):
+    """Initializes the Qwen3Omni vision transformer block.
+
+    Args:
+        config: Config containing model parameters
+        mesh: JAX device mesh for sharding
+        rngs: RNG state for initialization
+    """
+    self.config = config
+    hs = self.config.hidden_size_for_vit
+    self.ln1 = nnx.LayerNorm(num_features=hs, epsilon=config.normalization_layer_epsilon, rngs=rngs)
+    self.ln2 = nnx.LayerNorm(num_features=hs, epsilon=config.normalization_layer_epsilon, rngs=rngs)
+    self.attn = Qwen3OmniMoeVisionAttention(config=config, mesh=mesh, rngs=rngs)
+    self.mlp = DenseGeneral(
+        in_features_shape=hs,
+        out_features_shape=self.config.intermediate_size_for_vit,
+        use_bias=True,
+        matmul_precision=config.matmul_precision,
+        rngs=rngs,
+    )
+    self.mlp_out = DenseGeneral(
+        in_features_shape=self.config.intermediate_size_for_vit,
+        out_features_shape=hs,
+        use_bias=True,
+        matmul_precision=config.matmul_precision,
+        rngs=rngs,
+    )
+
+  def __call__(
+      self,
+      x: Array,
+      num_frames: int,
+      height: int,
+      width: int,
+  ) -> Array:
+    """
+    Args:
+        x: Input tensor of shape (batch, T*H*W, hidden_size)
+        num_frames: Number of temporal frames (static)
+        height: Height in patches (static)i
+        width: Width in patches (static)
+
+    Returns:
+        Output tensor of shape (batch, T*H*W, hidden_size)
+    """
+    x = x + self.attn(self.ln1(x), num_frames=num_frames, height=height, width=width)
+    y = self.ln2(x)
+    y = self.mlp(y)
+    y = jax.nn.gelu(y)
+    y = self.mlp_out(y)
+    return x + y
+
+
+class Qwen3OmniMoeVisionEncoder(nnx.Module):
+  """Vision encoder with patch embedding, positional embedding, and transformer blocks.
+
+  Attributes:
+      config: Config containing model parameters
+      patch_embed: Patch embedding module
+      pos_embed_interpolate: Position embedding interpolation module
+      blocks: List of transformer blocks
+      merger_list: List of patch mergers for deep supervision
+      spatial_merge_size: Size of spatial merging
+      deep_idx: Indices of layers to extract deep features from
+  """
+
+  def __init__(self, config: Config, *, mesh=None, rngs: nnx.Rngs = None):
+    """Initializes the Qwen3Omni vision encoder.
+
+    Args:
+        config: Config containing model parameters
+        mesh: JAX device mesh for sharding
+        rngs: RNG state for initialization
+    """
+    self.config = config
+    self.patch_embed = Qwen3OmniMoeVisionPatchEmbed(config=config, rngs=rngs)
+
+    num_pos = config.num_position_embeddings_for_vit
+    hs = config.hidden_size_for_vit
+    self.spatial_merge_size = config.spatial_merge_size_for_vit
+
+    self.pos_embed_interpolate = Qwen3OmniMoeVisionPosEmbedInterpolate(
+        num_position_embeddings=num_pos,
+        hidden_size=hs,
+        spatial_merge_size=self.spatial_merge_size,
+        rngs=rngs,
+    )
+
+    self.depth = config.num_hidden_layers_for_vit
+
+    # Use setattr with string names instead of nnx.List to avoid Orbax integer key bug
+    for i in range(self.depth):
+      block_name = f"blocks_{i}"
+      block = Qwen3OmniMoeVisionBlock(config=config, mesh=mesh, rngs=rngs)
+      setattr(self, block_name, block)
+
+    self.deep_idx = tuple(config.deepstack_visual_indexes_for_vit)
+    # Use setattr with string names instead of nnx.List to avoid Orbax integer key bug
+    for i, _ in enumerate(self.deep_idx):
+      merger_name = f"merger_{i}"
+      merger = Qwen3OmniMoeVisionPatchMerger(config=config, use_postshuffle_norm=True, rngs=rngs)
+      setattr(self, merger_name, merger)
+
+  def __call__(
+      self,
+      hidden_states: Array,
+      deterministic: bool = True,
+  ):
+    """
+    Args:
+        hidden_states: Input visual tokens of shape (batch, in_channels, T*patch_size, H*patch_size, W*patch_size)
+        deterministic: Whether to use deterministic mode
+
+    Returns:
+        Tuple of:
+        - encoder_output: shape (batch, T*H*W, hidden_size_for_vit)
+        - deep_features: List of intermediate features, each of shape (batch, T*H*W, out_hidden_size)
+    """
+    _, _, num_frames, height, width = hidden_states.shape
+    num_frames = num_frames // self.config.temporal_patch_size_for_vit
+    height = height // self.config.patch_size_for_vit
+    width = width // self.config.patch_size_for_vit
+
+    x = self.patch_embed(hidden_states)
+    pos = self.pos_embed_interpolate(num_frames, height, width)
+
+    pos = pos[jnp.newaxis, :, :]
+    x = x + pos
+
+    h_traj = []
+    for i in range(self.depth):
+      block_name = f"blocks_{i}"
+      blk = getattr(self, block_name)
+      x = blk(x, num_frames=num_frames, height=height, width=width)
+      h_traj.append(x)
+
+    deep_feats = []
+    for i, idx in enumerate(self.deep_idx):
+      h = h_traj[idx]
+      merger_name = f"merger_{i}"
+      merger = getattr(self, merger_name)
+      deep_feat = merger(h)
+      deep_feats.append(deep_feat)
+
+    return x, deep_feats
+
+
+class Qwen3OmniMoeVisionProjector(nnx.Module):
+  """Projection layer that converts vision encoder output to model embedding space.
+
+  Attributes:
+      config: Config containing model parameters
+      merger: Patch merger for spatial reduction
+  """
+
+  def __init__(self, config: Config, *, rngs: nnx.Rngs = None):
+    """Initializes the Qwen3Omni vision projector.
+
+    Args:
+        config: Config containing model parameters
+        rngs: RNG state for initialization
+    """
+    self.config = config
+    self.merger = Qwen3OmniMoeVisionPatchMerger(config=config, use_postshuffle_norm=False, rngs=rngs)
+
+  def __call__(self, hidden_states: Array) -> Array:
+    """
+    Args:
+        hidden_states: Encoder output of shape (batch, T*H*W, hidden_size_for_vit)
+
+    Returns:
+        Projected output of shape (batch, T*H*W//merge_size**2, out_hidden_size_for_vit)
+    """
+    output = self.merger(hidden_states)
+    return output
+
+
+def qwen3omni_visionencoder_as_linen(config: Config, mesh: Mesh) -> nn.Module:
+  """Convert Qwen3OmniMoeVisionEncoder to Linen module."""
+  return nnx_wrappers.to_linen(
+      Qwen3OmniMoeVisionEncoder,
+      config=config,
+      mesh=mesh,
+      name="Qwen3OmniMoeVisionEncoder_0",
+      abstract_init=False,
+      metadata_fn=max_initializers.variable_to_logically_partitioned,
+  )
+
+
+def qwen3omni_visionprojector_as_linen(config: Config, mesh: Mesh) -> nn.Module:
+  """Convert Qwen3OmniMoeVisionProjector to Linen module."""
+  return nnx_wrappers.to_linen(
+      Qwen3OmniMoeVisionProjector,
+      config=config,
+      name="Qwen3OmniMoeVisionProjector_0",
+      abstract_init=False,
+      metadata_fn=max_initializers.variable_to_logically_partitioned,
+  )
+
+
+# Vision encoder Linen wrappers
+Qwen3OmniMoeVisionPatchMergerToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniMoeVisionPatchMerger,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniMoeVisionMLPToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniMoeVisionMLP,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniMoeVisionPatchEmbedToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniMoeVisionPatchEmbed,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniMoeVisionAttentionToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniMoeVisionAttention,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniMoeVisionBlockToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniMoeVisionBlock,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniMoeVisionEncoderToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniMoeVisionEncoder,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniMoeVisionProjectorToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniMoeVisionProjector,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
 
 Qwen3DecoderLayerToLinen = nnx_wrappers.to_linen_class(
     Qwen3DecoderLayer,

--- a/src/MaxText/multimodal_utils.py
+++ b/src/MaxText/multimodal_utils.py
@@ -62,6 +62,13 @@ LLAMA4_TILE_X_SEPARATOR_TOKEN = 200084  # <|tile_x_separator|>
 LLAMA4_TILE_Y_SEPARATOR_TOKEN = 200085  # <|tile_y_separator|>
 LLAMA4_PIXEL_SHUFFLE_RATIO = 0.5  # TODO(hengtaoguo): We should reuse config.pixel_shuffle_ratio_for_vit
 
+# Qwen3OmniMoe-specific processing
+QWEN3_OMNI_IMAGE_TOKEN = 151655
+QWEN3_OMNI_VIDEO_TOKEN = 151656
+QWEN3_OMNI_AUDIO_TOKEN = 151675
+QWEN3_TEMPORAL_PATCH_SIZE = 2
+QWEN3_OMNI_IMAGE_SIZE = 768
+
 
 @dataclass
 class PreprocessorOutput:
@@ -549,6 +556,14 @@ def get_dummy_image_shape_for_init(
         NUM_IMAGE_CHANNELS,
         LLAMA4_TILE_SIZE,
         LLAMA4_TILE_SIZE,
+    )
+  elif model_name.startswith("qwen3-omni-30b-a3b"):
+    image_shape = (
+        batch_size,
+        NUM_IMAGE_CHANNELS,
+        QWEN3_TEMPORAL_PATCH_SIZE,
+        QWEN3_OMNI_IMAGE_SIZE,  # image_size_for_vit (height)
+        QWEN3_OMNI_IMAGE_SIZE,  # video_num_frames
     )
   return image_shape
 

--- a/tests/check_qwen3_embedding_vs_reference.py
+++ b/tests/check_qwen3_embedding_vs_reference.py
@@ -1,0 +1,529 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Qwen3 Omni Moe Vision Encoder layers."""
+
+import os
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import torch
+from flax import nnx
+from jax.sharding import Mesh
+from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import Qwen3OmniMoeVisionEncoderConfig
+from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+    Qwen3OmniMoeVisionEncoder as TorchQwen3OmniMoeVisionEncoder,
+    Qwen3OmniMoeVisionMLP as TorchQwen3OmniMoeVisionMLP,
+    Qwen3OmniMoeVisionPatchEmbed as TorchQwen3OmniMoeVisionPatchEmbed,
+    Qwen3OmniMoeVisionPatchMerger as TorchQwen3OmniMoeVisionPatchMerger,
+    apply_rotary_pos_emb_vision,
+)
+
+from MaxText import pyconfig
+from MaxText.globals import MAXTEXT_REPO_ROOT
+from MaxText.layers.embeddings import (
+    Qwen3OmniMoeVisionPosEmbedInterpolate as JaxQwen3OmniMoeVisionPosEmbedInterpolate,
+    Qwen3OmniMoeVisionRotaryEmbedding as JaxQwen3OmniMoeVisionRotaryEmbedding,
+)
+from MaxText.layers.qwen3 import (
+    Qwen3OmniMoeVisionAttention as JaxQwen3OmniMoeVisionAttention,
+    Qwen3OmniMoeVisionEncoder as JaxQwen3OmniMoeVisionEncoder,
+    Qwen3OmniMoeVisionMLP as JaxQwen3OmniMoeVisionMLP,
+    Qwen3OmniMoeVisionPatchEmbed as JaxQwen3OmniMoeVisionPatchEmbed,
+    Qwen3OmniMoeVisionPatchMerger as JaxQwen3OmniMoeVisionPatchMerger,
+    Qwen3OmniMoeVisionProjector as JaxQwen3OmniMoeVisionProjector,
+)
+from tests.multimodal_test_utils import (
+    assert_all_close_jax_torch,
+    copy_attention_weights_to_maxtext,
+    copy_mlp_weights,
+    copy_patch_embed_weights,
+    copy_patch_merger_weights,
+    copy_vision_encoder_weights,
+    create_random_jax_torch,
+    split_into_patches,
+)
+
+
+base_config_path = os.path.join(MAXTEXT_REPO_ROOT, "src", "MaxText", "configs", "base.yml")
+jax_vision_config = pyconfig.initialize(
+    ["", base_config_path],
+    model_name="qwen3-omni-30b-a3b",
+    attention="dot_product",
+    attention_type="full",
+    matmul_precision="highest",
+    dtype="float32",
+    dtype_mm="float32",
+    weight_dtype="float32",
+    float32_logits=True,
+    float32_qk_product=True,
+)
+
+torch_vision_config = Qwen3OmniMoeVisionEncoderConfig(
+    hidden_size=jax_vision_config.hidden_size_for_vit,
+    num_heads=jax_vision_config.num_attention_heads_for_vit,
+    intermediate_size=jax_vision_config.intermediate_size_for_vit,
+    spatial_merge_size=jax_vision_config.spatial_merge_size_for_vit,
+    depth=jax_vision_config.num_hidden_layers_for_vit,
+    rope_theta=jax_vision_config.rope_theta_for_vit,
+    patch_size=jax_vision_config.patch_size_for_vit,
+    temporal_patch_size=jax_vision_config.temporal_patch_size_for_vit,
+    in_channels=jax_vision_config.num_channels_for_vit,
+    num_position_embeddings=jax_vision_config.num_position_embeddings_for_vit,
+    out_hidden_size=jax_vision_config.out_hidden_size_for_vit,
+    deepstack_visual_indexes=list(jax_vision_config.deepstack_visual_indexes_for_vit),
+    hidden_act="gelu_pytorch_tanh",
+)
+torch_vision_config._attn_implementation = "eager"  # pylint: disable=protected-access
+
+torch.set_grad_enabled(False)
+
+
+def create_torch_encoder():
+  """Create and configure PyTorch vision encoder."""
+  encoder = TorchQwen3OmniMoeVisionEncoder(torch_vision_config)
+  encoder.eval()
+  return encoder
+
+
+def setup_test_seeds():
+  """Set random seeds for reproducibility."""
+  np.random.seed(42)
+  torch.manual_seed(42)
+
+
+class BaseVisionTestCase(unittest.TestCase):
+  """Base class for vision tests with common setup."""
+
+  def setUp(self):
+    self.config = jax_vision_config
+    setup_test_seeds()
+
+
+class BaseVisionTestCaseWithMesh(BaseVisionTestCase):
+  """Base class for vision tests that require mesh setup."""
+
+  def setUp(self):
+    super().setUp()
+    devices = jax.devices()
+    self.mesh = Mesh(np.array(devices[:1]), axis_names=("data",))
+
+
+class TestQwen3OmniMoeVisionAttention(BaseVisionTestCaseWithMesh):
+  """Test cases for Qwen3 Omni Moe Vision Attention layer."""
+
+  def setUp(self):
+    super().setUp()
+    self.seq_length = 16
+    self.hidden_size = self.config.hidden_size_for_vit
+    self.num_heads = self.config.num_attention_heads_for_vit
+
+  def test_attention_output_matches_torch(self):
+    """Test that JAX vision attention output matches PyTorch implementation."""
+    torch_encoder = create_torch_encoder()
+    torch_model = torch_encoder.blocks[0].attn
+
+    jax_model = JaxQwen3OmniMoeVisionAttention(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(42))
+
+    copy_attention_weights_to_maxtext(torch_model, jax_model.attn, fused_qkv=True)
+
+    jax_hidden_states_2d, torch_hidden_states = create_random_jax_torch(self.seq_length, self.hidden_size)
+    grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.int32)
+
+    cu_seqlens = torch.tensor([0, self.seq_length], dtype=torch.int32)
+
+    # Compute rotary position embeddings for PyTorch
+    rotary_pos_emb = torch_encoder.rot_pos_emb(grid_thw)
+    rotary_pos_emb = rotary_pos_emb.reshape(self.seq_length, -1)
+    emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+    position_embeddings = (emb.cos(), emb.sin())
+
+    torch_output = torch_model(
+        torch_hidden_states,
+        cu_seqlens=cu_seqlens,
+        position_embeddings=position_embeddings,
+    )
+
+    jax_hidden_states_3d = jax_hidden_states_2d[jnp.newaxis, :, :]
+    jax_output = jax_model(
+        jax_hidden_states_3d,  # Shape: (1, seq_len, hidden_size)
+        num_frames=1,
+        height=4,
+        width=4,
+        deterministic=True,
+    )
+    jax_output = jax_output[0]
+
+    assert_all_close_jax_torch(
+        jax_output,
+        torch_output,
+        rtol=1e-2,
+        atol=1e-2,
+        error_msg="Vision attention outputs differ",
+    )
+
+  def test_attention_is_jittable(self):
+    """Test that attention is JIT-compilable."""
+    model = JaxQwen3OmniMoeVisionAttention(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(42))
+    hidden_states = jnp.ones((1, 16, self.hidden_size))
+
+    @nnx.jit
+    def forward(model, hidden_states):
+      return model(hidden_states, num_frames=1, height=4, width=4, deterministic=True)
+
+    _ = forward(model, hidden_states)
+
+
+class TestQwen3OmniMoeVisionPatchMerger(BaseVisionTestCase):
+  """Test cases for Qwen3 Omni Moe Vision Patch Merger layer."""
+
+  def _test_patch_merger_with_postshuffle(self, use_postshuffle_norm):
+    """Helper method to test patch merger with/without postshuffle_norm."""
+    torch_model = TorchQwen3OmniMoeVisionPatchMerger(torch_vision_config, use_postshuffle_norm=use_postshuffle_norm)
+    torch_model.eval()
+
+    jax_model = JaxQwen3OmniMoeVisionPatchMerger(
+        config=self.config,
+        use_postshuffle_norm=use_postshuffle_norm,
+        rngs=nnx.Rngs(42),
+    )
+
+    copy_patch_merger_weights(torch_model, jax_model)
+
+    batch_size = 2
+    seq_len = 64
+    jax_hidden_states, torch_hidden_states = create_random_jax_torch(
+        batch_size * seq_len, self.config.hidden_size_for_vit
+    )
+
+    jax_hidden_states = jax_hidden_states.reshape(batch_size, seq_len, self.config.hidden_size_for_vit)
+    torch_output = torch_model(torch_hidden_states)
+    jax_output = jax_model(jax_hidden_states)
+    jax_output = jax_output.reshape(-1, jax_output.shape[-1])
+
+    assert_all_close_jax_torch(jax_output, torch_output, rtol=1e-3, atol=3e-3)
+
+  def test_patch_merger_output_matches_torch_without_postshuffle(self):
+    """Test patch merger without postshuffle_norm matches PyTorch."""
+    self._test_patch_merger_with_postshuffle(use_postshuffle_norm=False)
+
+  def test_patch_merger_output_matches_torch_with_postshuffle(self):
+    """Test patch merger with postshuffle_norm matches PyTorch."""
+    self._test_patch_merger_with_postshuffle(use_postshuffle_norm=True)
+
+  def test_patch_merger_is_jittable(self):
+    """Test that patch merger is JIT-compilable."""
+    model = JaxQwen3OmniMoeVisionPatchMerger(config=self.config, use_postshuffle_norm=False, rngs=nnx.Rngs(42))
+
+    @nnx.jit
+    def forward(model, hidden_states):
+      return model(hidden_states)
+
+    batch_size = 2
+    seq_len = 64
+    hidden_states = jnp.ones((batch_size, seq_len, self.config.hidden_size_for_vit))
+    forward(model, hidden_states)
+
+
+class TestQwen3OmniMoeVisionMLP(BaseVisionTestCase):
+  """Test cases for Qwen3 Omni Moe Vision MLP layer."""
+
+  def setUp(self):
+    super().setUp()
+    self.torch_model = TorchQwen3OmniMoeVisionMLP(torch_vision_config)
+    self.torch_model.eval()
+    self.jax_model = JaxQwen3OmniMoeVisionMLP(config=self.config, rngs=nnx.Rngs(42))
+    copy_mlp_weights(self.torch_model, self.jax_model)
+
+  def test_mlp_output_matches_torch(self):
+    """Test that JAX MLP output matches PyTorch implementation."""
+    # Create test input
+    seq_len = 16
+    jax_hidden_states, torch_hidden_states = create_random_jax_torch(seq_len, self.config.hidden_size_for_vit)
+
+    # Forward pass
+    torch_output = self.torch_model(torch_hidden_states)
+    jax_output = self.jax_model(jax_hidden_states)
+
+    # Compare outputs
+    assert_all_close_jax_torch(jax_output, torch_output, rtol=1e-4, atol=3e-3)
+
+  def test_mlp_is_jittable(self):
+    """Test that MLP is JIT-compilable."""
+
+    @nnx.jit
+    def forward(model, hidden_states):
+      return model(hidden_states)
+
+    hidden_states = jnp.ones((16, self.config.hidden_size_for_vit))
+    output = forward(self.jax_model, hidden_states)
+
+    self.assertEqual(output.shape, (16, self.config.hidden_size_for_vit))
+
+
+class TestQwen3OmniMoeVisionPatchEmbed(BaseVisionTestCase):
+  """Test cases for Qwen3 Omni Moe Vision Patch Embed layer."""
+
+  def setUp(self):
+    super().setUp()
+    self.torch_model = TorchQwen3OmniMoeVisionPatchEmbed(torch_vision_config)
+    self.torch_model.eval()
+    self.jax_model = JaxQwen3OmniMoeVisionPatchEmbed(config=self.config, rngs=nnx.Rngs(42))
+    copy_patch_embed_weights(self.torch_model, self.jax_model)
+
+  def test_patch_embed_output_matches_torch(self):
+    """Test that JAX patch embed output matches PyTorch implementation."""
+    batch_size = 2
+    total_elements = (
+        batch_size
+        * self.config.num_channels_for_vit
+        * self.config.temporal_patch_size_for_vit
+        * self.config.patch_size_for_vit
+        * self.config.patch_size_for_vit
+    )
+    jax_hidden_states, torch_hidden_states = create_random_jax_torch(total_elements)
+
+    # Reshape JAX input to proper 5D shape: (batch, in_channels, temporal, height, width)
+    jax_hidden_states = jax_hidden_states.reshape(
+        batch_size,
+        self.config.num_channels_for_vit,
+        self.config.temporal_patch_size_for_vit,
+        self.config.patch_size_for_vit,
+        self.config.patch_size_for_vit,
+    )
+
+    torch_output = self.torch_model(torch_hidden_states)
+    jax_output = self.jax_model(jax_hidden_states)
+
+    torch_output_squeezed = torch_output.squeeze(1)
+    jax_output_squeezed = jax_output.squeeze(1)
+
+    assert_all_close_jax_torch(jax_output_squeezed, torch_output_squeezed, rtol=1e-3, atol=5e-3)
+
+  def test_patch_embed_is_jittable(self):
+    """Test that patch embed is JIT-compilable."""
+
+    @nnx.jit
+    def forward(model, hidden_states):
+      return model(hidden_states)
+
+    batch_size = 2
+
+    # Patch embed expects 5D input: (batch, in_channels, temporal, height, width)
+    hidden_states = jnp.ones(
+        (
+            batch_size,
+            self.config.num_channels_for_vit,
+            self.config.temporal_patch_size_for_vit,
+            self.config.patch_size_for_vit,
+            self.config.patch_size_for_vit,
+        )
+    )
+    forward(self.jax_model, hidden_states)
+
+
+class TestQwen3OmniMoeVisionRotaryEmbedding(BaseVisionTestCase):
+  """Test the grid-based rotary embedding from embeddings.py against PyTorch."""
+
+  def setUp(self):
+    super().setUp()
+    self.jax_model = JaxQwen3OmniMoeVisionRotaryEmbedding(
+        hidden_size=self.config.hidden_size_for_vit,
+        num_attention_heads=self.config.num_attention_heads_for_vit,
+        spatial_merge_size=self.config.spatial_merge_size_for_vit,
+        rope_theta=self.config.rope_theta_for_vit,
+        cast_as_fprop_dtype=False,
+        fprop_dtype=jnp.float32,
+        rngs=nnx.Rngs(42),
+    )
+    self.torch_encoder = create_torch_encoder()
+
+  def _create_jax_rotary_model(self):
+    """Helper to create JAX rotary embedding model."""
+    return JaxQwen3OmniMoeVisionRotaryEmbedding(
+        hidden_size=self.config.hidden_size_for_vit,
+        num_attention_heads=self.config.num_attention_heads_for_vit,
+        spatial_merge_size=self.config.spatial_merge_size_for_vit,
+        rope_theta=self.config.rope_theta_for_vit,
+        cast_as_fprop_dtype=False,
+        fprop_dtype=jnp.float32,
+        rngs=nnx.Rngs(42),
+    )
+
+  def test_grid_based_embedding_matches_torch(self):
+    """Test that JAX grid-based rotary embedding matches PyTorch implementation."""
+    num_frames, height, width = 1, 8, 8
+    grid_thw_np = np.array([[num_frames, height, width]], dtype=np.int64)
+    grid_thw_torch = torch.from_numpy(grid_thw_np)
+
+    cos_emb_jax, sin_emb_jax = self.jax_model.compute_cos_sin(num_frames, height, width)
+
+    rotary_pos_emb = self.torch_encoder.rot_pos_emb(grid_thw_torch)
+    embeddings = torch.cat([rotary_pos_emb, rotary_pos_emb], dim=-1)
+    cos_emb_torch = embeddings.cos()
+    sin_emb_torch = embeddings.sin()
+
+    assert_all_close_jax_torch(cos_emb_jax, cos_emb_torch, rtol=1e-5, atol=1e-5)
+    assert_all_close_jax_torch(sin_emb_jax, sin_emb_torch, rtol=1e-5, atol=1e-5)
+
+  def test_rotation_application_matches_torch(self):
+    """Test that applying rotary embedding to Q/K tensors matches PyTorch."""
+    head_dim = self.config.hidden_size_for_vit // self.config.num_attention_heads_for_vit
+
+    num_frames, height, width = 1, 8, 8
+    grid_thw_np = np.array([[num_frames, height, width]], dtype=np.int64)
+    grid_thw_torch = torch.from_numpy(grid_thw_np)
+
+    seq_len = 64
+    q_jax, q_torch = create_random_jax_torch(seq_len, self.config.num_attention_heads_for_vit, head_dim)
+    k_jax, k_torch = create_random_jax_torch(seq_len, self.config.num_attention_heads_for_vit, head_dim)
+
+    q_rotated_jax = self.jax_model(q_jax, num_frames, height, width)
+    k_rotated_jax = self.jax_model(k_jax, num_frames, height, width)
+
+    rotary_pos_emb = self.torch_encoder.rot_pos_emb(grid_thw_torch)
+    embeddings = torch.cat([rotary_pos_emb, rotary_pos_emb], dim=-1)
+    cos = embeddings.cos()  # [seq_len, head_dim]
+    sin = embeddings.sin()  # [seq_len, head_dim]
+
+    q_rotated_torch, k_rotated_torch = apply_rotary_pos_emb_vision(q_torch, k_torch, cos, sin)
+
+    assert_all_close_jax_torch(
+        q_rotated_jax,
+        q_rotated_torch,
+        rtol=1e-3,
+        atol=1e-4,
+        error_msg="Q rotation mismatch",
+    )
+    assert_all_close_jax_torch(
+        k_rotated_jax,
+        k_rotated_torch,
+        rtol=1e-3,
+        atol=1e-4,
+        error_msg="K rotation mismatch",
+    )
+
+
+class TestQwen3OmniMoeVisionPosEmbedInterpolate(BaseVisionTestCase):
+  """Test bilinear position embedding interpolation from embeddings.py."""
+
+  def setUp(self):
+    super().setUp()
+    self.jax_model = JaxQwen3OmniMoeVisionPosEmbedInterpolate(
+        num_position_embeddings=self.config.num_position_embeddings_for_vit,
+        hidden_size=self.config.hidden_size_for_vit,
+        spatial_merge_size=self.config.spatial_merge_size_for_vit,
+        dtype=jnp.float32,
+        rngs=nnx.Rngs(42),
+    )
+    self.torch_encoder = create_torch_encoder()
+    torch_pos_embed_weight = self.torch_encoder.pos_embed.weight.detach().cpu().numpy()
+    self.jax_model.pos_embed.value = jnp.array(torch_pos_embed_weight)
+
+  def _create_jax_pos_embed_model(self):
+    """Helper to create JAX position embedding model."""
+    return JaxQwen3OmniMoeVisionPosEmbedInterpolate(
+        num_position_embeddings=self.config.num_position_embeddings_for_vit,
+        hidden_size=self.config.hidden_size_for_vit,
+        spatial_merge_size=self.config.spatial_merge_size_for_vit,
+        dtype=jnp.float32,
+        rngs=nnx.Rngs(42),
+    )
+
+  def _copy_weights_and_test(self, num_frames, height, width):
+    """Helper to copy weights and test position embedding interpolation."""
+    grid_thw_np = np.array([[num_frames, height, width]], dtype=np.int64)
+    grid_thw_torch = torch.from_numpy(grid_thw_np)
+
+    pos_embed_jax = self.jax_model(num_frames, height, width)
+    pos_embed_torch = self.torch_encoder.fast_pos_embed_interpolate(grid_thw_torch)
+
+    assert_all_close_jax_torch(pos_embed_jax, pos_embed_torch, rtol=1e-2, atol=1e-2)
+
+  def test_pos_embed_interpolate_matches_torch(self):
+    """Test that JAX position embedding interpolation matches PyTorch encoder."""
+    self._copy_weights_and_test(num_frames=1, height=16, width=16)
+
+  def test_pos_embed_interpolate_multiple_images(self):
+    """Test position embedding interpolation with multiple images/videos."""
+    self._copy_weights_and_test(num_frames=1, height=8, width=8)
+
+
+class TestQwen3OmniMoeVisionEncoderEndToEnd(BaseVisionTestCaseWithMesh):
+  """End-to-end test for the full vision encoder."""
+
+  def test_vision_encoder_single_image(self):
+    """Test full vision encoder with single image matches PyTorch."""
+    torch_encoder = create_torch_encoder()
+
+    jax_encoder = JaxQwen3OmniMoeVisionEncoder(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(42))
+    jax_projector = JaxQwen3OmniMoeVisionProjector(config=self.config, rngs=nnx.Rngs(43))
+
+    copy_vision_encoder_weights(torch_encoder, jax_encoder)
+    copy_patch_merger_weights(torch_encoder.merger, jax_projector.merger)
+
+    patch_size = self.config.patch_size_for_vit
+    temporal_patch_size = self.config.temporal_patch_size_for_vit
+    in_channels = self.config.num_channels_for_vit
+    h, w = 8, 8  # 8x8 patches
+
+    total_elements = 1 * in_channels * temporal_patch_size * (h * patch_size) * (w * patch_size)
+    jax_hidden_states, _ = create_random_jax_torch(total_elements)
+
+    jax_hidden_states = jax_hidden_states.reshape(1, in_channels, temporal_patch_size, h * patch_size, w * patch_size)
+
+    torch_hidden_states = split_into_patches(
+        torch.from_numpy(np.array(jax_hidden_states)),
+        temporal_patch_size,
+        patch_size,
+    )
+
+    grid_thw = np.array([[1, h, w]], dtype=np.int64)
+    grid_thw_torch = torch.from_numpy(grid_thw)
+
+    torch_output, torch_deep_feats = torch_encoder(torch_hidden_states, grid_thw_torch)
+    jax_encoder_output, jax_deep_feats = jax_encoder(jax_hidden_states)
+    jax_output = jax_projector(jax_encoder_output)
+
+    jax_output = jax_output[0]
+    jax_deep_feats = [feat[0] for feat in jax_deep_feats]
+
+    assert_all_close_jax_torch(
+        jax_output,
+        torch_output,
+        rtol=1e-2,
+        atol=1e-2,
+        error_msg="Vision encoder final output differs",
+    )
+
+    # Compare deep features
+    self.assertEqual(
+        len(jax_deep_feats),
+        len(torch_deep_feats),
+        "Number of deep features should match",
+    )
+    for i, (jax_feat, torch_feat) in enumerate(zip(jax_deep_feats, torch_deep_feats)):
+      assert_all_close_jax_torch(
+          jax_feat,
+          torch_feat,
+          rtol=1e-2,
+          atol=1e-2,
+          error_msg=f"Deep feature {i} differs",
+      )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/multimodal_test_utils.py
+++ b/tests/multimodal_test_utils.py
@@ -1,0 +1,395 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared utilities for MaxText tests."""
+
+import jax.numpy as jnp
+import numpy as np
+import torch
+
+
+def create_random_jax_torch(*shape, dtype=np.float32):
+  """Create random array and return both JAX and PyTorch versions.
+
+  Args:
+      *shape: Shape of the array
+      dtype: NumPy dtype (default: np.float32)
+
+  Returns:
+      tuple: (jax_array, torch_tensor)
+  """
+  np_array = np.random.randn(*shape).astype(dtype)
+  return jnp.array(np_array), torch.from_numpy(np_array)
+
+
+def split_into_patches(x, temporal_patch_size, patch_size):
+  """Split a 5D tensor into patches for PyTorch vision encoder input.
+
+  Converts from full image format (batch, channels, temporal, height, width) to
+  patch format (num_patches, channels, temporal_patch_size, patch_size, patch_size).
+
+  Returns:
+      Tensor of shape (num_patches, channels, temporal_patch_size, patch_size, patch_size)
+      where num_patches = (temporal//temporal_patch_size) * (height//patch_size) * (width//patch_size)
+  """
+  B, C, T, H, W = x.shape
+  assert T % temporal_patch_size == 0, f"Temporal dimension {T} must be divisible by {temporal_patch_size}"
+  assert H % patch_size == 0, f"Height {H} must be divisible by {patch_size}"
+  assert W % patch_size == 0, f"Width {W} must be divisible by {patch_size}"
+
+  x = x.reshape(B, C, T, H // patch_size, patch_size, W // patch_size, patch_size)
+  x = x.permute(0, 3, 5, 1, 2, 4, 6)  # (B, H//patch_size, W//patch_size, C, T, patch_size, patch_size)
+  return x.reshape(-1, C, T, patch_size, patch_size)
+
+
+def assert_all_close_jax_torch(jax_tensor, torch_tensor, rtol, atol, error_msg=""):
+  """Compare JAX and PyTorch tensors for numerical closeness.
+
+  Args:
+      jax_tensor: JAX array to compare
+      torch_tensor: PyTorch tensor to compare
+      rtol: Relative tolerance
+      atol: Absolute tolerance
+      error_msg: Optional error message prefix
+  """
+  np.testing.assert_allclose(
+      torch_tensor.numpy(),
+      np.array(jax_tensor),
+      rtol=rtol,
+      atol=atol,
+      err_msg=error_msg,
+  )
+
+
+def copy_linear_weights(torch_linear, jax_linear):
+  """Copy weights from PyTorch Linear to JAX nnx.Linear."""
+  jax_linear.kernel.value = jnp.array(torch_linear.weight.detach().cpu().numpy().T)
+  if torch_linear.bias is not None and jax_linear.bias is not None:
+    jax_linear.bias.value = jnp.array(torch_linear.bias.detach().cpu().numpy())
+
+
+def copy_layernorm_weights(torch_ln, jax_ln):
+  """Copy weights from PyTorch LayerNorm to JAX nnx.LayerNorm."""
+  jax_ln.scale.value = jnp.array(torch_ln.weight.detach().cpu().numpy())
+  jax_ln.bias.value = jnp.array(torch_ln.bias.detach().cpu().numpy())
+
+
+def copy_conv2d_weights(torch_conv, jax_conv):
+  """Copy weights from PyTorch Conv2d to JAX nnx.Conv."""
+  # PyTorch: (out_channels, in_channels, kH, kW)
+  # JAX: (kH, kW, in_channels, out_channels)
+  torch_weight = torch_conv.weight.detach().cpu().numpy()
+  jax_weight = np.transpose(torch_weight, (2, 3, 1, 0))
+  jax_conv.kernel.value = jnp.array(jax_weight)
+  jax_conv.bias.value = jnp.array(torch_conv.bias.detach().cpu().numpy())
+
+
+def copy_densegeneral_qkv_weights(torch_linear, jax_densegeneral, num_heads, head_dim):
+  """Copy weights from PyTorch Linear to JAX DenseGeneral for Q/K/V projections.
+
+  PyTorch Linear has weight shape (out_features, in_features)
+  JAX DenseGeneral has kernel shape (in_features, num_heads, head_dim)
+  """
+  # Get PyTorch weight: (out_features, in_features) where out_features = num_heads * head_dim
+  torch_weight = torch_linear.weight.detach().cpu().numpy()  # (out_features, in_features)
+
+  # Transpose and reshape: (in_features, out_features) -> (in_features, num_heads, head_dim)
+  torch_weight_t = torch_weight.T  # (in_features, out_features)
+  jax_weight = torch_weight_t.reshape(-1, num_heads, head_dim)  # (in_features, num_heads, head_dim)
+
+  jax_densegeneral.kernel.value = jnp.array(jax_weight)
+  if torch_linear.bias is not None and jax_densegeneral.bias is not None:
+    # Bias shape for DenseGeneral: (num_heads, head_dim)
+    torch_bias = torch_linear.bias.detach().cpu().numpy()
+    jax_bias = torch_bias.reshape(num_heads, head_dim)
+    jax_densegeneral.bias.value = jnp.array(jax_bias)
+
+
+def copy_densegeneral_out_weights(torch_linear, jax_densegeneral, num_heads, head_dim, output_dim):
+  """Copy weights from PyTorch Linear to JAX DenseGeneral for output projection.
+
+  PyTorch Linear has weight shape (output_dim, input_dim) where input_dim = num_heads * head_dim
+  JAX DenseGeneral has kernel shape (num_heads, head_dim, output_dim)
+  """
+  # Get PyTorch weight: (output_dim, num_heads * head_dim)
+  torch_weight = torch_linear.weight.detach().cpu().numpy()
+
+  # Transpose: (num_heads * head_dim, output_dim)
+  torch_weight_t = torch_weight.T
+
+  # Reshape: (num_heads, head_dim, output_dim)
+  jax_weight = torch_weight_t.reshape(num_heads, head_dim, output_dim)
+
+  jax_densegeneral.kernel.value = jnp.array(jax_weight)
+  if torch_linear.bias is not None and jax_densegeneral.bias is not None:
+    jax_densegeneral.bias.value = jnp.array(torch_linear.bias.detach().cpu().numpy())
+
+
+def copy_attention_weights(torch_attn, jax_attn):
+  """Copy attention layer weights from PyTorch to JAX."""
+  copy_linear_weights(torch_attn.q_proj, jax_attn.q_proj)
+  copy_linear_weights(torch_attn.k_proj, jax_attn.k_proj)
+  copy_linear_weights(torch_attn.v_proj, jax_attn.v_proj)
+  copy_linear_weights(torch_attn.out_proj, jax_attn.out_proj)
+
+
+def copy_attention_weights_to_maxtext(torch_attn, maxtext_attn, fused_qkv=False):
+  """Copy attention weights from PyTorch to MaxText's Attention module.
+
+  Args:
+      torch_attn: PyTorch attention with either:
+          - Separate q_proj, k_proj, v_proj, out_proj (fused_qkv=False, for audio)
+          - Fused qkv and proj (fused_qkv=True, for vision)
+      maxtext_attn: MaxText Attention module with separate q/k/v projections
+      fused_qkv: If True, torch_attn has fused qkv projection that needs splitting
+  """
+  if not hasattr(maxtext_attn, "query"):
+    raise NotImplementedError("Unsupported MaxText Attention structure")
+
+  num_heads = maxtext_attn.num_query_heads
+  head_dim = maxtext_attn.head_dim
+  hidden_size = num_heads * head_dim
+  output_dim = hidden_size
+
+  # Extract Q/K/V weights and biases
+  if fused_qkv:
+    # Vision: Split fused QKV projection
+    qkv_weight = torch_attn.qkv.weight.detach().cpu().numpy()
+    qkv_bias = torch_attn.qkv.bias.detach().cpu().numpy()
+
+    q_weight = qkv_weight[:hidden_size, :]
+    k_weight = qkv_weight[hidden_size : 2 * hidden_size, :]
+    v_weight = qkv_weight[2 * hidden_size :, :]
+    q_bias = qkv_bias[:hidden_size]
+    k_bias = qkv_bias[hidden_size : 2 * hidden_size]
+    v_bias = qkv_bias[2 * hidden_size :]
+
+    out_proj = torch_attn.proj
+  else:
+    # Audio: Extract from separate projections
+    q_weight = torch_attn.q_proj.weight.detach().cpu().numpy()
+    k_weight = torch_attn.k_proj.weight.detach().cpu().numpy()
+    v_weight = torch_attn.v_proj.weight.detach().cpu().numpy()
+    q_bias = torch_attn.q_proj.bias.detach().cpu().numpy()
+    k_bias = torch_attn.k_proj.bias.detach().cpu().numpy()
+    v_bias = torch_attn.v_proj.bias.detach().cpu().numpy()
+
+    out_proj = torch_attn.out_proj
+
+  # Copy Q/K/V weights (common logic for both)
+  maxtext_attn.query.kernel.value = jnp.array(q_weight.T.reshape(hidden_size, num_heads, head_dim))
+  maxtext_attn.query.bias.value = jnp.array(q_bias.reshape(num_heads, head_dim))
+
+  maxtext_attn.key.kernel.value = jnp.array(k_weight.T.reshape(hidden_size, num_heads, head_dim))
+  maxtext_attn.key.bias.value = jnp.array(k_bias.reshape(num_heads, head_dim))
+
+  maxtext_attn.value.kernel.value = jnp.array(v_weight.T.reshape(hidden_size, num_heads, head_dim))
+  maxtext_attn.value.bias.value = jnp.array(v_bias.reshape(num_heads, head_dim))
+
+  # Copy output projection (common logic for both)
+  out_weight = out_proj.weight.detach().cpu().numpy()
+  out_bias = out_proj.bias.detach().cpu().numpy()
+  maxtext_attn.out.kernel.value = jnp.array(out_weight.T.reshape(num_heads, head_dim, output_dim))
+  maxtext_attn.out.bias.value = jnp.array(out_bias)
+
+
+def copy_encoder_layer_weights(torch_layer, jax_layer):
+  """Copy encoder layer weights from PyTorch to JAX."""
+  copy_attention_weights(torch_layer.self_attn, jax_layer.self_attn)
+  copy_linear_weights(torch_layer.fc1, jax_layer.fc1)
+  copy_linear_weights(torch_layer.fc2, jax_layer.fc2)
+  copy_layernorm_weights(torch_layer.self_attn_layer_norm, jax_layer.self_attn_layer_norm)
+  copy_layernorm_weights(torch_layer.final_layer_norm, jax_layer.final_layer_norm)
+
+
+def copy_encoder_weights(torch_encoder, jax_encoder):
+  """Copy full encoder weights from PyTorch to JAX."""
+  # Copy convolutional layers
+  copy_conv2d_weights(torch_encoder.conv2d1, jax_encoder.conv2d1)
+  copy_conv2d_weights(torch_encoder.conv2d2, jax_encoder.conv2d2)
+  copy_conv2d_weights(torch_encoder.conv2d3, jax_encoder.conv2d3)
+
+  # Copy linear projections
+  copy_linear_weights(torch_encoder.conv_out, jax_encoder.conv_out)
+  copy_linear_weights(torch_encoder.proj1, jax_encoder.proj1)
+  copy_linear_weights(torch_encoder.proj2, jax_encoder.proj2)
+
+  # Copy layer norm
+  copy_layernorm_weights(torch_encoder.ln_post, jax_encoder.ln_post)
+
+  # Copy positional embeddings
+  jax_encoder.positional_embedding.positional_embedding.value = jnp.array(
+      torch_encoder.positional_embedding.positional_embedding.detach().cpu().numpy()
+  )
+
+  # Copy encoder layers
+  for torch_layer, jax_layer in zip(torch_encoder.layers, jax_encoder.layers):
+    copy_encoder_layer_weights(torch_layer, jax_layer)
+
+
+def copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer):
+  """Copy encoder layer weights from PyTorch to MaxText AudioEncoderLayer.
+
+  Args:
+      torch_layer: PyTorch TorchQwen3OmniMoeAudioEncoderLayer
+      maxtext_layer: MaxText AudioEncoderLayer
+  """
+  # Copy layer norms
+  copy_layernorm_weights(torch_layer.self_attn_layer_norm, maxtext_layer.input_layer_norm)
+  copy_layernorm_weights(torch_layer.final_layer_norm, maxtext_layer.post_attention_layer_norm)
+
+  # Copy attention weights to MaxText Attention module
+  copy_attention_weights_to_maxtext(torch_layer.self_attn, maxtext_layer.self_attention_audio)
+
+  copy_linear_weights(torch_layer.fc1, maxtext_layer.AudioMLP.wi)
+  copy_linear_weights(torch_layer.fc2, maxtext_layer.AudioMLP.wo)
+
+
+def copy_audio_model(torch_model, maxtext_model, config):
+  """Copy full AudioModel weights from PyTorch to MaxText.
+
+  Args:
+      torch_model: PyTorch TorchQwen3OmniMoeAudioEncoder
+      maxtext_model: MaxText AudioModel
+      config: MaxText config with encoder_layers
+  """
+  copy_conv2d_weights(torch_model.conv2d1, maxtext_model.conv2d1)
+  copy_conv2d_weights(torch_model.conv2d2, maxtext_model.conv2d2)
+  copy_conv2d_weights(torch_model.conv2d3, maxtext_model.conv2d3)
+  copy_linear_weights(torch_model.conv_out, maxtext_model.conv_out)
+
+  maxtext_model.positional_embedding.positional_embedding.value = jnp.array(
+      torch_model.positional_embedding.positional_embedding.detach().cpu().numpy()
+  )
+
+  copy_layernorm_weights(torch_model.ln_post, maxtext_model.layernorm_post)
+
+  for torch_layer, maxtext_layer in zip(
+      torch_model.layers,
+      [getattr(maxtext_model.audio_encoder, f"layers_{i}") for i in range(config.encoder_layers_for_audio)],
+  ):
+    copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer)
+
+  copy_linear_weights(torch_model.proj1, maxtext_model.audio_projector.proj1)
+  copy_linear_weights(torch_model.proj2, maxtext_model.audio_projector.proj2)
+
+
+def copy_maxtext_encoder_weights(torch_encoder, maxtext_encoder):
+  # Copy weights for each encoder layer
+  for torch_layer, maxtext_layer in zip(
+      torch_encoder.layers,
+      [getattr(maxtext_encoder, f"layers_{i}") for i in range(len(torch_encoder.layers))],
+  ):
+    copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer)
+
+
+# Vision-specific weight copying utilities
+def copy_conv3d_weights(torch_conv, jax_conv):
+  """Copy weights from PyTorch Conv3d to JAX nnx.Conv (3D)."""
+  # PyTorch Conv3d: (out_channels, in_channels, kD, kH, kW)
+  # JAX Conv (3D): (kD, kH, kW, in_channels, out_channels)
+  torch_weight = torch_conv.weight.detach().cpu().numpy()
+  jax_weight = np.transpose(torch_weight, (2, 3, 4, 1, 0))
+  jax_conv.kernel.value = jnp.array(jax_weight)
+  jax_conv.bias.value = jnp.array(torch_conv.bias.detach().cpu().numpy())
+
+
+def copy_patch_embed_weights(torch_embed, jax_embed):
+  """Copy patch embed weights from PyTorch to JAX."""
+  copy_conv3d_weights(torch_embed.proj, jax_embed.proj)
+
+
+def copy_mlp_weights(torch_mlp, jax_mlp):
+  """Copy MLP weights from PyTorch to JAX."""
+  copy_linear_weights(torch_mlp.linear_fc1, jax_mlp.linear_fc1)
+  copy_linear_weights(torch_mlp.linear_fc2, jax_mlp.linear_fc2)
+
+
+def copy_patch_merger_weights(torch_merger, jax_merger):
+  """Copy patch merger weights from PyTorch to JAX."""
+  copy_layernorm_weights(torch_merger.ln_q, jax_merger.ln_q)
+  copy_linear_weights(torch_merger.mlp[0], jax_merger.mlp_0)
+  copy_linear_weights(torch_merger.mlp[2], jax_merger.mlp_2)
+
+
+def copy_vision_encoder_weights(torch_encoder, jax_encoder):
+  """Copy all weights from PyTorch vision encoder to JAX vision encoder.
+
+  Args:
+      torch_encoder: PyTorch Qwen3OmniMoeVisionEncoder
+      jax_encoder: JAX Qwen3OmniMoeVisionEncoder
+  """
+  # Copy patch embedding
+  copy_patch_embed_weights(torch_encoder.patch_embed, jax_encoder.patch_embed)
+
+  # Copy positional embedding weights
+  torch_pos_embed = torch_encoder.pos_embed.weight.detach().cpu().numpy()
+  jax_encoder.pos_embed_interpolate.pos_embed.value = jnp.array(torch_pos_embed)
+
+  # Copy encoder blocks
+  for torch_block, jax_block in zip(torch_encoder.blocks, jax_encoder.blocks):
+    # Copy layer norms
+    copy_layernorm_weights(torch_block.norm1, jax_block.ln1)
+    copy_layernorm_weights(torch_block.norm2, jax_block.ln2)
+
+    # Copy attention weights (vision uses fused QKV)
+    copy_attention_weights_to_maxtext(torch_block.attn, jax_block.attn.attn, fused_qkv=True)
+
+    # Copy MLP weights (vision MLP uses DenseGeneral)
+    copy_linear_weights(torch_block.mlp.linear_fc1, jax_block.mlp)
+    copy_linear_weights(torch_block.mlp.linear_fc2, jax_block.mlp_out)
+
+  # Copy merger weights (deep mergers only, final_merger is now in projector)
+  for torch_merger, jax_merger in zip(torch_encoder.merger_list, jax_encoder.merger_list):
+    copy_patch_merger_weights(torch_merger, jax_merger)
+
+
+# Audio-specific utilities
+def create_block_diagonal_attention_mask(cu_seqlens, dtype):
+  """Create block-diagonal attention mask from cumulative sequence lengths.
+
+  PyTorch's eager attention implementation doesn't automatically respect cu_seqlens boundaries.
+  This function creates an explicit block-diagonal mask that prevents attention across
+  different sequences in the batch.
+
+  Args:
+      cu_seqlens: Cumulative sequence lengths, e.g., [0, 12, 24] for 2 sequences of length 12
+      dtype: Data type for the attention mask
+
+  Returns:
+      Attention mask of shape (1, 1, total_seq_len, total_seq_len) where:
+      - 0.0 means "can attend" (within same sequence)
+      - finfo(dtype).min means "cannot attend" (across sequences)
+
+  Example:
+      >>> cu_seqlens = torch.tensor([0, 12, 24], dtype=torch.int32)
+      >>> mask = create_block_diagonal_attention_mask(cu_seqlens, torch.float32)
+      >>> # Positions 0-11 can only attend to 0-11
+      >>> # Positions 12-23 can only attend to 12-23
+  """
+  total_seq_len = cu_seqlens[-1].item()
+  attention_mask = torch.full(
+      [1, 1, total_seq_len, total_seq_len],
+      torch.finfo(dtype).min,
+      device=cu_seqlens.device,
+      dtype=dtype,
+  )
+
+  # Create blocks: allow attention within each sequence boundary
+  for i in range(1, len(cu_seqlens)):
+    start = cu_seqlens[i - 1].item()
+    end = cu_seqlens[i].item()
+    attention_mask[..., start:end, start:end] = 0
+
+  return attention_mask


### PR DESCRIPTION
# Description

**Original author @eitanporat in https://github.com/AI-Hypercomputer/maxtext/pull/2582.**

Add Qwen video encoder on static shapes [B x C x T x H x W]. (This copy aims to solve internal conflicts with less back-and-forth.)

# Tests

Comparing against the torch implementation on random input

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
