### PR TITLE
Enable vllm standalone mappings by default.

### DIFF
--- a/src/MaxText/integration/tunix/tunix_adapter.py
+++ b/src/MaxText/integration/tunix/tunix_adapter.py
@@ -36,7 +36,7 @@ class TunixMaxTextAdapter(nnx.Module):
   def __init__(
       self,
       base_model: Transformer,
-      use_standalone_mappings: bool = False,
+      use_standalone_mappings: bool = True,
   ):
     super().__init__()
     self.base = base_model


### PR DESCRIPTION
# Description

Enable vllm standalone mappings by default.

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
