### PR TITLE
Introduce Multislice RL

### DIFF
--- a/src/MaxText/configs/rl.yml
+++ b/src/MaxText/configs/rl.yml
@@ -21,6 +21,8 @@ base_config: "base.yml"
 trainer_devices_fraction: 0.5
 sampler_devices_fraction: 0.5
 chips_per_vm: 4  # depends on hardware, for v5p this is 4
+num_trainer_slices: -1
+num_samplers_slices: -1
 
 # ====== Reproducibility ======
 data_shuffle_seed: 42

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -1218,6 +1218,8 @@ class RLHardware(BaseModel):
   sampler_devices_fraction: float = Field(0.5, description="Fraction of devices to use for the sampler.")
   chips_per_vm: int = Field(4, description="Number of accelerator chips per VM.")
   use_pathways: bool = Field(True, description="Whether to use Pathways for multihost orchestration.")
+  num_trainer_slices: int = Field(-1, description="Number of slices for the trainer.")
+  num_samplers_slices: int = Field(-1, description="Number of slices for the samplers.")
 
 
 class VLLM(BaseModel):


### PR DESCRIPTION
# Description

It works with vllm at `4507a6` and tpu-inference at `53f2a8`, but not at their HEADs. It supports multiple trainer slices. Currently, it only supports one sampler slice with one model replica. Further work is required to support multiple sampler slices and multiple replicas per slice.

# Tests

Manually tested with Llama3 70B with 2 v5p-64 slices for the trainer and 1 v5p-64 as the sampler.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
