### PR TITLE
Use threadpool when mixing multiple datasets in Grain

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -578,8 +578,15 @@ grain_eval_files: ''
 grain_file_type: 'arrayrecord' # arrayrecord or parquet
 grain_worker_count: 1
 grain_per_worker_buffer_size: 1
+# num_threads and prefetch_buffer_size are per-worker per-dataset. Used in ReadOptions (https://google-grain.readthedocs.io/en/latest/tutorials/data_loader_tutorial.html#per-worker-readoptions)
+# The default value matches that in the Grain package. If mixing multiple data sources, consider lowering these values to reduce memory usage.
+grain_num_threads: 16  
+grain_prefetch_buffer_size: 500
 grain_worker_count_eval: 1
 grain_per_worker_buffer_size_eval: 1
+grain_num_threads_eval: 16
+grain_prefetch_buffer_size_eval: 500
+grain_data_source_max_workers: 16  # Max workers for ThreadPoolExecutor when mixing multiple Grain data sources.
 # for using pathways
 colocated_python_data_input: False  # experimental feature, under testing
 

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -830,6 +830,15 @@ class GrainDataset(BaseModel):
   grain_per_worker_buffer_size_eval: int = Field(
       1, description="Buffer size for each worker for Grain data loading during evaluation."
   )
+  grain_num_threads: int = Field(16, description="Number of threads for Grain ReadOptions during training.")
+  grain_prefetch_buffer_size: int = Field(500, description="Prefetch buffer size for Grain ReadOptions during training.")
+  grain_num_threads_eval: int = Field(16, description="Number of threads for Grain ReadOptions during evaluation.")
+  grain_prefetch_buffer_size_eval: int = Field(
+      500, description="Prefetch buffer size for Grain ReadOptions during evaluation."
+  )
+  grain_data_source_max_workers: int = Field(
+      16, description="Max workers for ThreadPoolExecutor when mixing multiple Grain data sources."
+  )
 
 
 class FineTuning(BaseModel):


### PR DESCRIPTION
# Description
Use theadpool to speed up by initializing multiple data sources in parallel. Also use Iterdataset.mix instead of mapdataset.mix to prepare for supporting more features.

# Tests
Manually added timing loggings around the changed block, tested 3 times in v5p, with 2 data sources, each 1024 files:
Before this change: 10.37s, 11.40s, 11.24s
After this change: 8.33s, 7.79s, 9.48s


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
