### PR TITLE
FP8 support for tokamax gmm kernel

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -128,7 +128,9 @@ save_quantized_params_path: ""
 model_call_mode: ""
 use_qwix_quantization: False # Whether to use qwix for quantization. If set to True, the model will be quantized using qwix.
 # Quantization calibration method used for weights and activations. Supported methods can be found in https://github.com/google/qwix/blob/dc2a0770351c740e5ab3cce7c0efe9f7beacce9e/qwix/qconfig.py#L70-L80
-quantization_calibration_method: "absmax"
+weight_quantization_calibration_method: "absmax"
+act_quantization_calibration_method: "absmax"
+bwd_quantization_calibration_method: "absmax"
 # Shard the range finding operation for quantization. By default this is set to number of slices.
 quantization_local_shard_count: -1
 
@@ -177,10 +179,26 @@ load_balance_loss_weight: 0.01 # weight for the load balance loss
 use_random_routing: False # whether to use random routing for debug/test purpose
 use_custom_sort_vjp: True # whether to use a custom sort vjp for sparse matmul ops
 use_ring_of_experts: False # whether to use ring of experts for sparse matmul expert parallelism
-# Tunable tiling dimensions used for Megablox
-tile_batch_seq: 512
-tile_embed_dim: 1024
-tile_mlp_dim: 1024
+# Tunable tiling dimensions used for MLP GMM, includes Tokamax ragged_dot and Megablox
+wi_tile_fwd_batch_seq: 512
+wi_tile_fwd_embed_dim: 1024
+wi_tile_fwd_mlp_dim: 1024
+wi_tile_dlhs_batch_seq: 512
+wi_tile_dlhs_embed_dim: 1024
+wi_tile_dlhs_mlp_dim: 1024
+wi_tile_drhs_batch_seq: 512
+wi_tile_drhs_embed_dim: 1024
+wi_tile_drhs_mlp_dim: 1024
+
+wo_tile_fwd_batch_seq: 512
+wo_tile_fwd_embed_dim: 1024
+wo_tile_fwd_mlp_dim: 1024
+wo_tile_dlhs_batch_seq: 512
+wo_tile_dlhs_embed_dim: 1024
+wo_tile_dlhs_mlp_dim: 1024
+wo_tile_drhs_batch_seq: 512
+wo_tile_drhs_embed_dim: 1024
+wo_tile_drhs_mlp_dim: 1024
 norm_topk_prob: False # Boolean to enable the top-k probability normalization. Qwen3-specific normalization of router weights.
 
 # How the expert axis is used to shard attention weights and activations

--- a/src/MaxText/kernels/megablox/backend.py
+++ b/src/MaxText/kernels/megablox/backend.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 import dataclasses
 import functools
 from typing import Any, Optional
+import json
 
 import jax
 from jax import lax
@@ -514,6 +515,11 @@ def gmm(
   bytes_accessed = (lhs_bytes * tiles_n) + (rhs_bytes * max_active_tiles) + out_bytes
   flops = 2 * m * k * n
   cost_estimate = pl.CostEstimate(flops=flops, bytes_accessed=bytes_accessed, transcendentals=0)
+  metadata = {
+      "preferred_element_type": jnp.dtype(preferred_element_type).name,
+      "tiling": {"tile_m": tm, "tile_k": tk, "tile_n": tn},
+      "transpose_rhs": transpose_rhs,
+  }
   call_gmm = qpl.pallas_call(
       kernel,
       out_shape=jax.ShapeDtypeStruct((m, n), preferred_element_type),
@@ -532,6 +538,7 @@ def gmm(
       compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "arbitrary", "arbitrary")),
       interpret=interpret,
       cost_estimate=cost_estimate,
+      metadata={"xprof_metadata": json.dumps(metadata)},
   )
 
   out = call_gmm(
@@ -761,6 +768,11 @@ def tgmm(
   flops = 2 * m * k * n
   cost_estimate = pl.CostEstimate(flops=flops, bytes_accessed=bytes_accessed, transcendentals=0)
   lhs = lhs.swapaxes(0, 1)
+  metadata = {
+      "tiling": {"tile_m": tm, "tile_k": tk, "tile_n": tn},
+      "prefer_element_type": jnp.dtype(preferred_element_type).name,
+      "num_actual_groups": num_actual_groups,
+  }
   call_gmm = qpl.pallas_call(
       kernel,
       out_shape=jax.ShapeDtypeStruct((num_actual_groups, k, n), preferred_element_type),
@@ -779,6 +791,7 @@ def tgmm(
       compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "arbitrary", "arbitrary")),
       interpret=interpret,
       cost_estimate=cost_estimate,
+      metadata={"xprof_metadata": json.dumps(metadata)},
   )
 
   out = call_gmm(

--- a/src/MaxText/layers/moe.py
+++ b/src/MaxText/layers/moe.py
@@ -785,7 +785,7 @@ class RoutedMoE(nnx.Module):
     """Perform sparse matrix multiplication of inputs and Experts."""
 
     def gmm(inputs, kernel, tiling, group_sizes, expert_assignments):
-      pad_length = self.config.tile_batch_seq
+      pad_length = self.config.wi_tile_fwd_batch_seq
       hs_shape = inputs.shape
       # pad length is the 1st dimension of tiling size in gmm call
       if inputs.shape[0] != expert_assignments.shape[0]:
@@ -804,20 +804,35 @@ class RoutedMoE(nnx.Module):
         lhs_quantize_dtype = quant_dg.fwd.dg_quantizer.lhs.numerics.get_dtype()
         rhs_quantize_dtype = quant_dg.fwd.dg_quantizer.rhs.numerics.get_dtype()
       m, k, n = inputs.shape[0], inputs.shape[1], kernel.shape[2]
-      tiling = (
-          min(tiling[0], m),
-          min(tiling[1], k),
-          min(tiling[2], n),
-      )
-      if self.config.use_tokamax_gmm:
-        output = tokamax.ragged_dot(
-            lhs=inputs,
-            rhs=kernel,
-            group_sizes=group_sizes,
-            precision=jax.lax.Precision.DEFAULT,
-            preferred_element_type=self.dtype,
-            implementation="mosaic",
+      if not self.config.megablox and not self.config.use_tokamax_gmm:
+        tiling = (
+            min(tiling[0], m),
+            min(tiling[1], k),
+            min(tiling[2], n),
         )
+      if self.config.use_tokamax_gmm:
+        if self.config.quantization:
+          output = mblx.gmm(
+              lhs=inputs,
+              rhs=kernel,
+              group_sizes=group_sizes,
+              preferred_element_type=self.dtype,
+              tiling=tiling,
+              lhs_quantize_dtype=lhs_quantize_dtype,
+              rhs_quantize_dtype=rhs_quantize_dtype,
+              use_qwix_quantization=self.config.use_qwix_quantization,
+              use_tokamax_backend=self.config.use_tokamax_gmm,
+              is_fsdp_shard_on_exp=self.config.fsdp_shard_on_exp,
+          )
+        else:
+          output = tokamax.ragged_dot(
+              lhs=inputs,
+              rhs=kernel,
+              group_sizes=group_sizes,
+              precision=jax.lax.Precision.DEFAULT,
+              preferred_element_type=self.dtype,
+              implementation="mosaic",
+          )
       else:
         if self.config.megablox:
           output = mblx.gmm(
@@ -829,6 +844,8 @@ class RoutedMoE(nnx.Module):
               lhs_quantize_dtype=lhs_quantize_dtype,
               rhs_quantize_dtype=rhs_quantize_dtype,
               use_qwix_quantization=self.config.use_qwix_quantization,
+              use_tokamax_backend=self.config.use_tokamax_gmm,
+              is_fsdp_shard_on_exp=self.config.fsdp_shard_on_exp,
           )
         else:
           rhs_inputs = kernel
@@ -904,10 +921,16 @@ class RoutedMoE(nnx.Module):
     # w0, w1, wo needs to be un sharded on fsdp / fsdp_transpose axis, so use
     # mlp_no_fsdp axis
     if self.config.fsdp_shard_on_exp:
-      # special sharding for dsv3 to remove overhead between gmm/AG
-      w0_pspec = nn.logical_to_mesh_axes(("embed_tensor_transpose", None, "mlp_no_fsdp"))
-      w1_pspec = nn.logical_to_mesh_axes(("embed_tensor_transpose", None, "mlp_no_fsdp"))
-      wo_pspec = nn.logical_to_mesh_axes(("embed_tensor_transpose", "mlp_no_fsdp", None))
+      if self.config.quantization:
+        # special sharding when quantization is enabled with fsdp_shard_on_exp
+        w0_pspec = nn.logical_to_mesh_axes(self.wi_kernel_axes)
+        w1_pspec = nn.logical_to_mesh_axes(self.wi_kernel_axes)
+        wo_pspec = nn.logical_to_mesh_axes(self.wo_kernel_axes)
+      else:
+        # special sharding for dsv3 to remove overhead between gmm/AG
+        w0_pspec = nn.logical_to_mesh_axes(("embed_tensor_transpose", None, "mlp_no_fsdp"))
+        w1_pspec = nn.logical_to_mesh_axes(("embed_tensor_transpose", None, "mlp_no_fsdp"))
+        wo_pspec = nn.logical_to_mesh_axes(("embed_tensor_transpose", "mlp_no_fsdp", None))
     else:
       w0_pspec = nn.logical_to_mesh_axes(("exp", "embed_tensor_transpose", "mlp_no_fsdp"))
       w1_pspec = nn.logical_to_mesh_axes(("exp", "embed_tensor_transpose", "mlp_no_fsdp"))
@@ -1043,14 +1066,26 @@ class RoutedMoE(nnx.Module):
           expert_assignments=selected_experts,
       )
       wi_tile_size = (
-          self.config.tile_batch_seq,
-          self.config.tile_embed_dim,
-          self.config.tile_mlp_dim,
+          self.config.wi_tile_fwd_batch_seq,
+          self.config.wi_tile_fwd_embed_dim,
+          self.config.wi_tile_fwd_mlp_dim,
+          self.config.wi_tile_dlhs_batch_seq,
+          self.config.wi_tile_dlhs_embed_dim,
+          self.config.wi_tile_dlhs_mlp_dim,
+          self.config.wi_tile_drhs_batch_seq,
+          self.config.wi_tile_drhs_embed_dim,
+          self.config.wi_tile_drhs_mlp_dim,
       )
       wo_tile_size = (
-          self.config.tile_batch_seq,
-          self.config.tile_mlp_dim,
-          self.config.tile_embed_dim,
+          self.config.wo_tile_fwd_batch_seq,
+          self.config.wo_tile_fwd_embed_dim,
+          self.config.wo_tile_fwd_mlp_dim,
+          self.config.wo_tile_dlhs_batch_seq,
+          self.config.wo_tile_dlhs_embed_dim,
+          self.config.wo_tile_dlhs_mlp_dim,
+          self.config.wo_tile_drhs_batch_seq,
+          self.config.wo_tile_drhs_embed_dim,
+          self.config.wo_tile_drhs_mlp_dim,
       )
       layer_w0 = gmm_fn(x, w0, tiling=wi_tile_size)
       if self.get_tensor_transpose_parallelism_size() > 1:

--- a/src/MaxText/layers/quantizations.py
+++ b/src/MaxText/layers/quantizations.py
@@ -669,9 +669,9 @@ def get_quantization_rule(config: Config):
           weight_qtype=jnp.float8_e4m3fn,
           act_qtype=jnp.float8_e4m3fn,
           bwd_qtype=jnp.float8_e5m2,
-          weight_calibration_method=config.quantization_calibration_method,
-          act_calibration_method=config.quantization_calibration_method,
-          bwd_calibration_method=config.quantization_calibration_method,
+          weight_calibration_method=config.weight_quantization_calibration_method,
+          act_calibration_method=config.act_quantization_calibration_method,
+          bwd_calibration_method=config.bwd_quantization_calibration_method,
           op_names=("dot_general", "gmm"),
       )
     case "fp8_gpu":


### PR DESCRIPTION
# Description

This PR calls tokamax_api.gmm in megablox/ops.py for supporting FP8 quantization using tokamax's gmm kernel. It also extends the tiling configs to 18 values, 9 for wi-* and 9 for wo tensors.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/458461066

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Command to repro: https://paste.googleplex.com/6669707558125568
Xprof: http://shortn/_HoU0Xj2IZ9

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
