### PR TITLE
feat: migrate models.py to use nnx

### DIFF
--- a/src/MaxText/checkpointing.py
+++ b/src/MaxText/checkpointing.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 
 from absl import flags
 from etils import epath
-from flax.training import train_state
+from flax.nnx import TrainState
 import jax
 from MaxText import exceptions
 from MaxText import max_logging
@@ -456,7 +456,7 @@ def load_state_if_possible(
     load_parameters_from_path: str,
     load_full_state_from_path: str,
     checkpoint_storage_concurrent_gb: int,
-    abstract_unboxed_pre_state: train_state.TrainState,
+    abstract_unboxed_pre_state: TrainState,
     enable_single_replica_ckpt_restoring: bool | None = False,
     dataset_type: str | None = "tfds",
     step: int = -1,  # -1 means latest
@@ -694,9 +694,7 @@ def save_checkpoint(checkpoint_manager, step, state, config=None, data_iterator=
       )
 
   # specify chunk_byte_size to force orbax to control maximum file size in checkpoint
-  chunk_byte_size = (
-      config.checkpoint_storage_target_data_file_size_bytes if config else DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE
-  )
+  chunk_byte_size = config.checkpoint_storage_target_data_file_size_bytes if config else DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE
 
   checkpoint_args = ocp.args.PyTreeSave(
       item=state,

--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -933,9 +933,6 @@ deepstack_visual_indexes_for_vit: []
 # Example: "8,8" to use a 8x8 subgrid (64 chips) of a full pod (16x16) of trillium.
 subslice_shape: ""
 
-# NNX
-enable_nnx: false
-
 ################################## Qwen3-Next Specific Configs ##################################
 # Kernel size for the 1D convolution in the Gated Delta Net
 gdn_conv_kernel_dim: 4

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -642,7 +642,6 @@ class HardwareAndMesh(BaseModel):
   )
   custom_mesh: str = Field("", description="Available options: ['hybrid_ring_64x4', 'hybrid_ring_32x8']")
   allow_split_physical_axes: bool = Field(False, description="Allow splitting physical axes for device mesh creation.")
-  enable_nnx: bool = Field(False, description="Whether to use NNX for model definition.")
   optimize_mesh_for_tpu_v6e: bool = Field(False, description="Apply transformations to the mesh for TPU v6e.")
   shardy: bool = Field(True, description="Whether to use shardy XLA backend.")
 
@@ -1902,7 +1901,7 @@ class MaxTextConfig(
         and (self.per_device_batch_size * self.max_target_length) % self.num_vocab_tiling != 0
     ):
       raise ValueError("Per device batch size times sequence length should be divisible by the number of vocab tiles.")
-    if self.num_vocab_tiling > 1 and self.enable_nnx:
+    if self.num_vocab_tiling > 1:
       raise ValueError("We currently don't support vocab tiling on NNX module.")
     if self.context_parallel_size > 1 and self.context_parallel_strategy.lower() == "ring":
       if "gpu" not in self.hardware:

--- a/src/MaxText/configs/vllm.yml
+++ b/src/MaxText/configs/vllm.yml
@@ -14,8 +14,6 @@
 
 base_config: "base.yml"
 attention: "vllm_rpa"
-# NNX required for vLLM integration
-enable_nnx: True
 # Avoid re-initializing JAX distributed system when using vLLM
 skip_jax_distributed_system: True
 # Scanned layers are not supported with vLLM integration

--- a/src/MaxText/layers/initializers.py
+++ b/src/MaxText/layers/initializers.py
@@ -28,16 +28,16 @@ Initializer = Callable[[PRNGKey, Shape, DType], Array]
 InitializerAxis = int | tuple[int, ...]
 NdInitializer = Callable[[PRNGKey, Shape, DType, InitializerAxis, InitializerAxis], Array]
 
-default_embed_init = nn.initializers.variance_scaling(1.0, "fan_in", "normal", out_axis=0)
+default_embed_init = nnx.initializers.variance_scaling(1.0, "fan_in", "normal", out_axis=0)
 
-default_bias_init = jax.nn.initializers.constant(0.0)
+default_bias_init = nnx.initializers.constant(0.0)
 
 
 def nd_dense_init(scale, mode, distribution):
   """Creates a variance-scaling initializer with dynamic in/out axes.
 
   This function is a factory that returns an initializer function. The returned
-  function is a wrapper around `jax.nn.initializers.variance_scaling` that
+  function is a wrapper around `nnx.initializers.variance_scaling` that
   allows the `in_axis` and `out_axis` to be specified at call time, rather
   than at creation time.
 
@@ -53,7 +53,7 @@ def nd_dense_init(scale, mode, distribution):
 
   def init_fn(key, shape, dtype, in_axis, out_axis):
     """Initializes an array using variance scaling with specified axes."""
-    fn = jax.nn.initializers.variance_scaling(scale, mode, distribution, in_axis, out_axis)
+    fn = nnx.initializers.variance_scaling(scale, mode, distribution, in_axis, out_axis)
     return fn(key, shape, dtype)
 
   return init_fn

--- a/tests/quantizations_test.py
+++ b/tests/quantizations_test.py
@@ -23,16 +23,14 @@ import numpy as np
 import jax
 from jax import numpy as jnp
 from jax import random, lax
-from jax.sharding import Mesh
 
 from flax import linen as nn
-
+from flax import nnx
 from aqt.jax.v2 import aqt_tensor
 
 from MaxText.globals import MAXTEXT_PKG_DIR
 from MaxText import pyconfig
 from MaxText.layers import quantizations
-from MaxText import maxtext_utils
 from MaxText import model_creation_utils
 from MaxText.kernels.megablox import gmm
 from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR
@@ -193,32 +191,24 @@ class QuantizationTest(unittest.TestCase):
                 "mlp": {
                     "wi_0": {
                         "AqtDotGeneral_0": {
-                            "qrhs": {
-                                "frozen": aqt_tensor.QTensor(qvalue=[1.1, 1.0], scale=[1.0], scale_t=[1.0], bias=1.0)
-                            }
+                            "qrhs": {"frozen": aqt_tensor.QTensor(qvalue=[1.1, 1.0], scale=[1.0], scale_t=[1.0], bias=1.0)}
                         }
                     },
                     "wi_1": {
                         "AqtDotGeneral_0": {
-                            "qrhs": {
-                                "frozen": aqt_tensor.QTensor(qvalue=[1.1, 1.0], scale=[1.0], scale_t=[1.0], bias=1.0)
-                            }
+                            "qrhs": {"frozen": aqt_tensor.QTensor(qvalue=[1.1, 1.0], scale=[1.0], scale_t=[1.0], bias=1.0)}
                         }
                     },
                     "wo": {
                         "AqtDotGeneral_0": {
-                            "qrhs": {
-                                "frozen": aqt_tensor.QTensor(qvalue=[1.1, 1.0], scale=[1.0], scale_t=[1.0], bias=1.0)
-                            }
+                            "qrhs": {"frozen": aqt_tensor.QTensor(qvalue=[1.1, 1.0], scale=[1.0], scale_t=[1.0], bias=1.0)}
                         }
                     },
                 },
                 "self_attention": {
                     "key": {
                         "AqtDotGeneral_0": {
-                            "qrhs": {
-                                "frozen": aqt_tensor.QTensor(qvalue=[1.1, 1.0], scale=[1.0], scale_t=[1.0], bias=1.0)
-                            }
+                            "qrhs": {"frozen": aqt_tensor.QTensor(qvalue=[1.1, 1.0], scale=[1.0], scale_t=[1.0], bias=1.0)}
                         }
                     }
                 },
@@ -246,8 +236,6 @@ class QuantTest(unittest.TestCase):
 
   def setUp(self):
     self.cfg = self.init_pyconfig()
-    devices_array = maxtext_utils.create_device_mesh(self.cfg)
-    self.mesh = Mesh(devices_array, self.cfg.mesh_axes)
     self.inputs = jnp.ones((4, 16))
     self.rng = jax.random.PRNGKey(0)
     self.rtol = 5e-1
@@ -307,8 +295,8 @@ class QuantTest(unittest.TestCase):
   def quantization_config(self, quant, logits_tolerance=2e-1, grad_tolerance=5e-1):
     """Run forward pass and backward pass for quantized model and compare with base model."""
     cfg = self.init_pyconfig(quantization=quant)
-    model = model_creation_utils.create_model(self.cfg, self.mesh)
-    qt_model = model_creation_utils.create_model(cfg, self.mesh)
+    model = model_creation_utils.from_config(self.cfg)
+    qt_model = model_creation_utils.from_config(cfg)
 
     ids, decoder_segment_ids, decoder_positions = self.get_data()
     var = model.init(


### PR DESCRIPTION
# Description

Enable generalized usage of nnx class `Transformer`

## Model and logs:
[gs://mesa-maxtext-bucket/modelspy-nnx-porting/
](https://pantheon.corp.google.com/storage/browser/mesa-maxtext-bucket/modelspy-nnx-porting/training-logs/modelspy?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&e=13803378&inv=1&invt=AbgFEA&jsmode=o&mods=allow_workbench_image_override&project=tpu-prod-env-multipod)

## Profiling:
- before migration : https://xprof.corp.google.com/overview_page/mesakh-15535109900813885609
- after migration : https://xprof.corp.google.com/overview_page/mesakh-2106845934401945903

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
