### PR TITLE
Adding the required base_mlp_dim

### DIFF
--- a/src/MaxText/configs/models/qwen3-235b-a22b.yml
+++ b/src/MaxText/configs/models/qwen3-235b-a22b.yml
@@ -17,6 +17,7 @@
 # Core Architectural Parameters
 decoder_block: "qwen3_moe"
 base_emb_dim: 4096
+base_mlp_dim: 1536
 base_num_query_heads: 64
 base_num_kv_heads: 4
 base_num_decoder_layers: 94


### PR DESCRIPTION
# Description

Adding the required base_mlp_dim to avoid the error 

```
ValueError: For a fully MoE model, base_mlp_dim must be equal to base_moe_mlp_dim. Received base_mlp_dim=7168 and base_moe_mlp_dim=1536.
```

# Tests

Locally

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
