### PR TITLE
Fix matmul precision and vmem in test scripts

### DIFF
--- a/end_to_end/tpu/gpt_oss/20b/test_gpt_oss.sh
+++ b/end_to_end/tpu/gpt_oss/20b/test_gpt_oss.sh
@@ -49,6 +49,8 @@ export UNSCANNED_CKPT_PATH=${BASE_OUTPUT_PATH}/unscanned/0/items
 # Non-Googlers please remember to point `DATASET_PATH` to the GCS bucket where you have your training data
 export DATASET_PATH=gs://maxtext-dataset
 
+export LIBTPU_INIT_ARGS='--xla_tpu_scoped_vmem_limit_kib=81920'
+
 # Test whether the forward pass logits match the golden logits
 # default golden_logits_path=/deps/src/MaxText/test_assets/golden_data_{MODEL_NAME}.jsonl, copied from gs://maxtext-test-assets/golden_data_${MODEL_NAME}.jsonl
 python3 -m tests.forward_pass_logit_checker "${MAXTEXT_PKG_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/MaxText}/"configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} run_name=forward_logits_check model_name=${MODEL_NAME} load_parameters_path=${UNSCANNED_CKPT_PATH} scan_layers=false attention=dot_product sparse_matmul=True megablox=True per_device_batch_size=1 max_target_length=4 max_prefill_predict_length=4 dtype=float32 --atol=0.1 --rtol=0.1 --max_kl_div=3e-4

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -61,6 +61,10 @@ class MatmulPrecision(str, Enum):
   DEFAULT = "default"
   HIGH = "high"
   HIGHEST = "highest"
+  # same as default
+  BFLOAT16 = "bfloat16"
+  # same as highest
+  FLOAT32 = "float32"
 
 
 class QuantizationType(str, Enum):


### PR DESCRIPTION
# Description

1. fix vmem for gpt oss test 
- Problem: gpt oss test has `RESOURCE_EXHAUSTED: Ran out of memory in memory space vmem` in megablox gmm operation during forward pass. 
- Fix b/461483388
- Solution: `export LIBTPU_INIT_ARGS='--xla_tpu_scoped_vmem_limit_kib=81920'`

2. fix matmul precision in multiple tests
- Problem:`matmul_precision=float32` used by [multiple test scripts](https://screenshot.googleplex.com/9EDpbL5M725jK9k) was working previously. It now gives error `Input should be 'default', 'high' or 'highest' [type=enum, input_value='float32', input_type=str]` (see deepseek run: [cmd](https://paste.googleplex.com/5555071505006592), [log](https://cloudlogging.app.goo.gl/Bkc7FrhEqVqXhFi99)). This is due to [recent commit](https://github.com/AI-Hypercomputer/maxtext/commit/81d653c93f6868984090e5959a8e26c972d13fab#diff-9f8497131f8bddf288f66ad130e80317426f5cc8014682da206dec0e93dd818b).
- Solution: adding `float32` to enum value now. Note it is equivalent to `matmul_precision=highest`, [reference](https://kolonist26-jax-kr.readthedocs.io/en/latest/jax.lax.html#jax.lax.Precision)


# Tests

run forward pass for gpt-oss on v5p-8 (xpk), with `export LIBTPU_INIT_ARGS='--xla_tpu_scoped_vmem_limit_kib=81920'` and `matmul_precision=float32`
- cmd: https://paste.googleplex.com/6504516713316352
- log: https://cloudlogging.app.goo.gl/wrjVTB5HPji9uJ8B6

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
