### PR TITLE
Remove tunix installation from setup.sh to prevent qwix version override

### DIFF
--- a/tools/setup/setup.sh
+++ b/tools/setup/setup.sh
@@ -220,9 +220,6 @@ fi
 if [[ "$MODE" == "stable" || ! -v MODE ]]; then
 # Stable mode
     if [[ $DEVICE == "tpu" ]]; then
-        # TODO: Once tunix has support for GPUs, move it from here to requirements.txt
-        echo "Installing google-tunix for stable TPU environment"
-        python3 -m uv pip install 'google-tunix>=0.1.2'
         echo "Installing stable jax, jaxlib for tpu"
         if [[ -n "$JAX_VERSION" ]]; then
             echo "Installing stable jax, jaxlib, libtpu version ${JAX_VERSION}"
@@ -275,8 +272,6 @@ elif [[ $MODE == "nightly" ]]; then
     elif [[ $DEVICE == "tpu" ]]; then
         echo "Installing nightly tensorboard plugin profile"
         python3 -m uv pip install tbp-nightly --upgrade
-        # Installing tunix
-        python3 -m uv pip install 'git+https://github.com/google/tunix.git'
         echo "Installing jax-nightly, jaxlib-nightly"
         # Install jax-nightly
         python3 -m uv pip install --pre -U jax -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/


### PR DESCRIPTION
# Description

Remove `google-tunix` installation from setup.sh to prevent qwix version override. `google-tunix` is already installed from `tpu_requirements.txt`.

FIXES: [b/460832189](b/460832189)



# Tests

`bash tools/setup/setup.sh` and `pip show qwix`
```
Name: qwix
Version: 0.1.4
```

`bash tools/setup/setup.sh MODe=nightly` and `pip show qwix`
```
Name: qwix
Version: 0.1.4
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
