### PR TITLE
Add app-name to GCSFuse command for tracking usage

### DIFF
--- a/tools/setup/setup_gcsfuse.sh
+++ b/tools/setup/setup_gcsfuse.sh
@@ -42,12 +42,24 @@ if [[ -d ${MOUNT_PATH} ]]; then
 fi
 
 mkdir -p $MOUNT_PATH
+MAXTEXT_VERSION=$(pip list | grep '^MaxText ' | awk '{print $2}')
+if [[ -z "$MAXTEXT_VERSION" ]]; then
+  MAXTEXT_VERSION="unknown"
+fi
+GRAIN_VERSION=$(pip list | grep '^grain ' | awk '{print $2}')
+if [[ -z "$GRAIN_VERSION" ]]; then
+  GRAIN_VERSION="unknown"
+fi
+
+APP_NAME="maxtext-gcsfuse/maxtext-$MAXTEXT_VERSION/grain-$GRAIN_VERSION"
+
+
 
 # see https://cloud.google.com/storage/docs/gcsfuse-cli for all configurable options of gcsfuse CLI
 TIMESTAMP=$(date +%Y%m%d-%H%M)
 gcsfuse -o ro --implicit-dirs --log-severity=debug \
         --type-cache-max-size-mb=-1 --stat-cache-max-size-mb=-1 --kernel-list-cache-ttl-secs=-1 --metadata-cache-ttl-secs=-1 \
-        --log-file=$HOME/gcsfuse_$TIMESTAMP.json "$DATASET_GCS_BUCKET" "$MOUNT_PATH"
+        --log-file=$HOME/gcsfuse_$TIMESTAMP.json --app-name=$APP_NAME "$DATASET_GCS_BUCKET" "$MOUNT_PATH"
 
 # Use ls to prefill the metadata cache: https://cloud.google.com/storage/docs/cloud-storage-fuse/performance#improve-first-time-reads
 if [[ ! -z ${FILE_PATH} ]] ; then 


### PR DESCRIPTION
# Description

Add the app-name for better tracking of GCP resources. 

FIXES: b/427997035

# Tests

Small change will not require any new tests only validated the script runs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
