### PR TITLE
Fix random routing overflow issue

### DIFF
--- a/src/MaxText/layers/moe.py
+++ b/src/MaxText/layers/moe.py
@@ -114,9 +114,16 @@ def random_routing(rng_key, gate_logits, num_experts_per_tok):
                        representing the weights for the selected experts.
   """
   bs, seq_len, num_experts = gate_logits.shape
-  indices = jnp.arange(num_experts).repeat(bs * seq_len)
   selected_num = bs * seq_len * num_experts_per_tok
-  top_k_indices = jax.random.choice(rng_key, indices, shape=(selected_num,)).reshape(bs, seq_len, num_experts_per_tok)
+  # Directly generate random integers in the range [0, num_experts)
+  top_k_indices = jax.random.randint(
+      rng_key,
+      shape=(selected_num,),
+      minval=0,
+      maxval=num_experts,
+      dtype=jnp.int32,
+  )
+  top_k_indices = top_k_indices.reshape(bs, seq_len, num_experts_per_tok)
   top_k_weights = jnp.take_along_axis(gate_logits, top_k_indices, axis=-1)
   return top_k_weights, top_k_indices
 


### PR DESCRIPTION
# Description

Fix random routing overflow issue, b/462187476

# Tests

* on 256 chips: https://cloudlogging.app.goo.gl/apCqfecVzgo1LPRa9
* locally to see balanced routing

```
>>> expert_counts = jnp.bincount(flattened_indices, minlength=num_experts)
>>> expert_counts
Array([2611, 2469, 2634, 2600, 2527, 2614, 2646, 2611, 2616, 2500, 2503,
       2585, 2469, 2557, 2578, 2545, 2494, 2607, 2480, 2440, 2529, 2530,
       2595, 2497, 2507, 2518, 2611, 2570, 2600, 2605, 2491, 2669, 2628,
       2626, 2593, 2563, 2481, 2652, 2510, 2528, 2594, 2571, 2510, 2494,
       2602, 2562, 2647, 2490, 2531, 2489, 2600, 2553, 2586, 2588, 2503,
       2513, 2594, 2550, 2490, 2544, 2487, 2550, 2553, 2571, 2549, 2590,
       2462, 2601, 2502, 2623, 2542, 2665, 2562, 2559, 2582, 2535, 2580,
       2593, 2550, 2577, 2534, 2547, 2594, 2582, 2575, 2617, 2607, 2583,
       2495, 2583, 2519, 2454, 2577, 2516, 2602, 2555, 2575, 2530, 2452,
       2531, 2643, 2531, 2532, 2494, 2483, 2530, 2682, 2653, 2531, 2597,
       2528, 2539, 2564, 2552, 2574, 2606, 2644, 2569, 2567, 2537, 2555,
       2577, 2590, 2590, 2611, 2623, 2598, 2519], dtype=int32)
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
