### PR TITLE
Add Qwen3 Audio Encoder

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -869,7 +869,9 @@ temperature_tuning: False
 
 # Multimodal flags
 use_multimodal: False
+use_audio: False
 freeze_vision_encoder_params: True
+freeze_audio_encoder_params: True
 dtype_mm: "float32"  # Data type for multimodal model's vision encoder
 remat_policy_for_vit: "minimal"  # Remat policy for multimodal model's vision encoder. Check `remat_policy` for options.
 image_size_for_vit: 896 # Default for Gemma3, and should be overwritten by model's config
@@ -903,6 +905,26 @@ out_hidden_size_for_vit: 512
 temporal_patch_size_for_vit: 2
 num_position_embeddings_for_vit: 1024
 deepstack_visual_indexes_for_vit: []
+
+### Audio encoder configs (Qwen3-OmniMoe)
+d_model_for_audio: 256
+encoder_attention_heads_for_audio: 4
+encoder_ffn_dim_for_audio: 512
+encoder_layers_for_audio: 2
+attention_dropout_for_audio: 0.0
+activation_dropout_for_audio: 0.0
+activation_function_for_audio: "gelu"
+num_mel_bins_for_audio: 128
+max_source_positions_for_audio: 1500
+scale_embedding_for_audio: True
+n_window_for_audio: 50
+n_window_infer_for_audio: 800
+conv_chunksize_for_audio: 500
+downsample_hidden_size_for_audio: 256
+output_dim_for_audio: 512
+num_conv_layers_for_audio: 3
+max_timescale_for_audio: 10000.0
+max_sample_len_for_audio: 10000
 
 # Subslice shape in the form of "x,y,z" when using pathways (single controller). 
 # Example: "8,8" to use a 8x8 subgrid (64 chips) of a full pod (16x16) of trillium.

--- a/src/MaxText/configs/models/qwen3-omni-30b-a3b.yml
+++ b/src/MaxText/configs/models/qwen3-omni-30b-a3b.yml
@@ -56,3 +56,24 @@ num_position_embeddings_for_vit: 2304
 deepstack_visual_indexes_for_vit: [8, 16, 24]
 
 use_multimodal: true
+use_audio: true
+# Audio Encoder Configuration (need to set use_audio=true to enable)
+# Based on https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
+d_model_for_audio: 1280
+encoder_layers_for_audio: 32
+encoder_attention_heads_for_audio: 20
+encoder_ffn_dim_for_audio: 5120
+max_source_positions_for_audio: 1500
+num_mel_bins_for_audio: 128
+downsample_hidden_size_for_audio: 480
+output_dim_for_audio: 2048
+attention_dropout_for_audio: 0.0
+n_window_for_audio: 50
+n_window_infer_for_audio: 400
+conv_chunksize_for_audio: 500
+num_conv_layers_for_audio: 3
+max_timescale_for_audio: 10000.0
+max_sample_len_for_audio: 10000
+
+freeze_audio_encoder_params: false
+freeze_vision_encoder_params: false

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -1172,6 +1172,8 @@ class MultimodalGeneral(BaseModel):
 
   use_multimodal: bool = Field(False, description="Enable multimodal capabilities.")
   freeze_vision_encoder_params: bool = Field(True, description="Freeze the parameters of the vision encoder.")
+  freeze_audio_encoder_params: bool = Field(True, description="Freeze the parameters of the audio encoder.")
+  use_audio: bool = Field(False, description="Enable audio encoder for multimodal models.")
   image_size_for_vit: int = Field(896, description="Input image size for the Vision Transformer.")
   image_path: PathStr = Field("", description="Path to an image for decoding.")
   image_placeholder: str = Field("<|image|>", description="Placeholder string for images in text prompts.")
@@ -1212,6 +1214,29 @@ class VisionProjector(BaseModel):
   projector_output_dim_for_vit: int = Field(4096, description="Output dimension for the vision projector.")
   pixel_shuffle_ratio_for_vit: float = Field(0.5, description="Pixel shuffle ratio for the Vision Transformer.")
   projector_dropout_for_vit: float = Field(0.0, description="Dropout rate for the vision projector.")
+
+
+class AudioEncoder(BaseModel):
+  """Configuration for the Audio Encoder in a multimodal model."""
+
+  d_model_for_audio: int = Field(256, description="Model dimension for the audio encoder.")
+  encoder_attention_heads_for_audio: int = Field(4, description="Number of attention heads in the audio encoder.")
+  encoder_ffn_dim_for_audio: int = Field(512, description="Feed-forward network dimension for the audio encoder.")
+  encoder_layers_for_audio: int = Field(2, description="Number of encoder layers for audio.")
+  attention_dropout_for_audio: float = Field(0.0, description="Attention dropout rate for audio encoder.")
+  activation_dropout_for_audio: float = Field(0.0, description="Activation dropout rate for audio encoder.")
+  activation_function_for_audio: str = Field("gelu", description="Activation function for audio encoder.")
+  num_mel_bins_for_audio: int = Field(128, description="Number of mel-frequency bins for audio input.")
+  max_source_positions_for_audio: int = Field(1500, description="Maximum source positions for audio encoder.")
+  scale_embedding_for_audio: bool = Field(True, description="Whether to scale embeddings in audio encoder.")
+  n_window_for_audio: int = Field(50, description="Window size for audio processing.")
+  n_window_infer_for_audio: int = Field(800, description="Window size for audio inference.")
+  conv_chunksize_for_audio: int = Field(500, description="Chunk size for convolutional layers in audio encoder.")
+  downsample_hidden_size_for_audio: int = Field(256, description="Hidden size for downsampling in audio encoder.")
+  output_dim_for_audio: int = Field(512, description="Output dimension for audio encoder.")
+  num_conv_layers_for_audio: int = Field(3, description="Number of convolutional layers in audio encoder.")
+  max_timescale_for_audio: float = Field(10000.0, description="Maximum timescale for audio positional encoding.")
+  max_sample_len_for_audio: int = Field(10000, description="Maximum sample length for audio input.")
 
 
 class Debug(BaseModel):
@@ -1507,6 +1532,7 @@ class MaxTextConfig(
     MultimodalGeneral,
     VisionTower,
     VisionProjector,
+    AudioEncoder,
     # Derived
     DerivedValues,
 ):
@@ -1850,7 +1876,14 @@ class MaxTextConfig(
       if self.decoder_block == DecoderBlockType.GPT_OSS and not self.sparse_matmul and self.capacity_factor != -1:
         raise ValueError("GPT-OSS MoE only supports dropless (capacity_factor=-1) with dense matmul.")
     if self.use_multimodal:
-      valid_mm_models = ("gemma3-4b", "gemma3-12b", "gemma3-27b", "llama4-17b-16e", "llama4-17b-128e")
+      valid_mm_models = (
+          "gemma3-4b",
+          "gemma3-12b",
+          "gemma3-27b",
+          "llama4-17b-16e",
+          "llama4-17b-128e",
+          "qwen3-omni-30b-a3b",
+      )
       if self.model_name not in valid_mm_models and self.model_name != "default":
         raise ValueError(f"Multimodal is only supported for {valid_mm_models}, not {self.model_name}")
       if self.use_sft:

--- a/src/MaxText/decode.py
+++ b/src/MaxText/decode.py
@@ -150,6 +150,8 @@ def main(argv: Sequence[str]) -> None:
           padded_tokens=tokens,
           images=processor_outputs.pixel_values if config.use_multimodal else None,
           image_masks=processor_outputs.pixel_mask if config.use_multimodal and "llama4" in config.model_name else None,
+          audio_values=processor_outputs.audio_values if config.use_multimodal and config.use_audio else None,
+          audio_masks=processor_outputs.audio_mask if config.use_multimodal and config.use_audio else None,
           true_length=true_length,
           rng=rng_prefill,
           slot=i,

--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -557,6 +557,8 @@ class Decoder(nn.Module):
       image_embeddings=None,
       bidirectional_mask=None,
       image_masks=None,
+      audio_embeddings=None,
+      audio_mask=None,
   ):
     """Applies token and positional embeddings to the input tokens."""
     cfg = self.config
@@ -575,13 +577,24 @@ class Decoder(nn.Module):
       ]:
         y = multimodal_utils.merge_mm_embeddings(
             text_embeddings=y,
-            vision_embeddings=image_embeddings,
+            multimodal_embeddings=image_embeddings,
             mask=bidirectional_mask,
-            image_masks=image_masks,
+            token_masks=image_masks,
         )
       # TODO(hengtaoguo): Add support for other multimodal models such as Llama4, refactor if needed
       else:
         raise ValueError(f"Unsupported model_name for multimodal: {cfg.model_name}")
+
+    if audio_embeddings is not None and cfg.use_audio:
+      if cfg.model_name in ["qwen3-omni-30b-a3b"]:
+        y = multimodal_utils.merge_mm_embeddings(
+            text_embeddings=y,
+            multimodal_embeddings=audio_embeddings,
+            mask=audio_mask,
+            token_masks=None,
+        )
+      else:
+        raise ValueError(f"Unsupported model_name for audio: {cfg.model_name}")
 
     y = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(y, deterministic=deterministic)
     y = y.astype(cfg.dtype)
@@ -700,6 +713,8 @@ class Decoder(nn.Module):
       image_masks: None | jnp.ndarray = None,
       kv_caches: list[jax.Array] | None = None,
       attention_metadata=None,
+      audio_embeddings: None | jnp.ndarray = None,
+      audio_mask: None | jnp.ndarray = None,
   ):
     cfg = self.config
     mesh = self.mesh
@@ -715,6 +730,8 @@ class Decoder(nn.Module):
         image_embeddings,
         bidirectional_mask,
         image_masks,
+        audio_embeddings,
+        audio_mask,
     )
 
     policy = self.get_remat_policy()

--- a/src/MaxText/layers/encoders.py
+++ b/src/MaxText/layers/encoders.py
@@ -66,4 +66,38 @@ class VisionEncoder(nn.Module):
     if len(self.vision_encoder_layer) > 1:
       # vision embedder / projection layer, not frozen in most cases, trained / finetuned together with main model
       embeddings = self.vision_encoder_layer[1](config=cfg, mesh=mesh)(embeddings)
+
+
+class AudioEncoder(nn.Module):
+  """Audio encoder to encode audio features into soft tokens."""
+
+  config: Config
+  mesh: Mesh
+
+  def setup(self):
+    self.audio_encoder_layer = self.get_audio_encoder_layers()
+
+  def get_audio_encoder_layers(self):
+    """Get audio encoder layers specific to the model, classes of nn.Module type."""
+    if self.config.deepstack_visual_indexes_for_vit:
+      from MaxText.layers import qwen3  # pylint: disable=import-outside-toplevel
+
+      return [qwen3.qwen3omni_audioencoder_as_linen, qwen3.qwen3omni_audioprojector_as_linen]
+    else:
+      raise ValueError(f"No AudioEncoder implemented for {self.config.model_name} yet")
+
+  @nn.compact
+  def __call__(self, input_audio, deterministic=False):
+    cfg = self.config
+    mesh = self.mesh
+    # audio encoder output (includes convs + encoder, outputs before projector)
+    embeddings = self.audio_encoder_layer[0](config=cfg, mesh=mesh)(input_audio, deterministic=deterministic)
+
+    if cfg.freeze_audio_encoder_params:
+      embeddings = jax.lax.stop_gradient(embeddings)
+
+    if len(self.audio_encoder_layer) > 1:
+      # audio projector layer
+      embeddings = self.audio_encoder_layer[1](config=cfg, mesh=mesh)(embeddings)
+
     return embeddings

--- a/src/MaxText/layers/models.py
+++ b/src/MaxText/layers/models.py
@@ -32,7 +32,7 @@ from MaxText import max_utils
 from MaxText.layers import nnx_wrappers
 from MaxText.layers.decoders import Decoder
 from MaxText.layers.embeddings import Embed, embed_as_linen
-from MaxText.layers.encoders import VisionEncoder
+from MaxText.layers.encoders import VisionEncoder, AudioEncoder
 from MaxText.layers.quantizations import AqtQuantization as Quant
 from MaxText.layers.multi_token_prediction import MultiTokenPredictionBlock
 from MaxText.sharding import all_gather_over_fsdp
@@ -86,6 +86,7 @@ class TransformerLinenPure(nn.Module):
         mesh=self.mesh,
     )
     self.vision_encoder = VisionEncoder(config=cfg, mesh=mesh) if cfg.use_multimodal else None
+    self.audio_encoder = AudioEncoder(config=cfg, mesh=mesh) if cfg.use_audio else None
     self.decoder = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
     # If MTP is enabled via config, set up the MTP block.
     if self.config.mtp_num_layers > 0:
@@ -118,6 +119,7 @@ class TransformerLinenPure(nn.Module):
       decoder_segment_ids=None,
       encoder_images: None | jnp.ndarray = None,
       encoder_image_masks: None | jnp.ndarray = None,
+      encoder_audios: None | jnp.ndarray = None,
       enable_dropout=True,
       model_mode=MODEL_MODE_TRAIN,
       previous_chunk=None,
@@ -146,6 +148,8 @@ class TransformerLinenPure(nn.Module):
 
     bidirectional_mask = None
     image_embeddings = None
+    audio_embeddings = None
+
     if self.config.use_multimodal and encoder_images is not None:
       image_embeddings = self.vision_encoder(input_images=encoder_images, deterministic=not enable_dropout)
 
@@ -154,7 +158,18 @@ class TransformerLinenPure(nn.Module):
       elif self.config.decoder_block == DecoderBlockType.LLAMA4:
         bidirectional_mask = decoder_input_tokens == multimodal_utils.LLAMA4_PATCH_TOKEN
       elif self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
-        bidirectional_mask = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN
+        # Create bidirectional_mask for vision/video token merging
+        bidirectional_mask = (decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN) | (
+            decoder_input_tokens == multimodal_utils.QWEN3_OMNI_VIDEO_TOKEN
+        )
+        # Create image/video mask for deepstack visual embedding injection
+    if self.config.use_multimodal and encoder_audios is not None and self.audio_encoder is not None:
+      audio_embeddings = self.audio_encoder(input_audio=encoder_audios, deterministic=not enable_dropout)
+
+    # Create audio mask for placeholder tokens (qwen3-omni models)
+    audio_mask = None
+    if audio_embeddings is not None and self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
+      audio_mask = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_AUDIO_TOKEN
 
     logits, hidden_state, kv_caches = self.decoder(
         shared_embedding=self.shared_embedding,
@@ -169,6 +184,8 @@ class TransformerLinenPure(nn.Module):
         bidirectional_mask=bidirectional_mask,
         image_embeddings=image_embeddings,
         image_masks=encoder_image_masks,
+        audio_embeddings=audio_embeddings,
+        audio_mask=audio_mask,
         kv_caches=kv_caches,
         attention_metadata=attention_metadata,
     )
@@ -305,6 +322,7 @@ class Transformer(nnx.Module):
         rngs=rngs,
     )
     self.vision_encoder = VisionEncoder(config=cfg, mesh=mesh) if cfg.use_multimodal else None
+    self.audio_encoder = AudioEncoder(config=cfg, mesh=mesh) if cfg.use_audio else None
 
     decoder_linen = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
     self.decoder = nnx_wrappers.ToNNX(decoder_linen, rngs=rngs)
@@ -388,6 +406,7 @@ class Transformer(nnx.Module):
       cache=None,
       encoder_images: jax.Array | None = None,
       encoder_image_masks: jax.Array | None = None,
+      encoder_audios: jax.Array | None = None,
       enable_dropout=True,
       model_mode=MODEL_MODE_TRAIN,
       previous_chunk=None,
@@ -440,7 +459,18 @@ class Transformer(nnx.Module):
       elif self.config.decoder_block == DecoderBlockType.LLAMA4:
         bidirectional_mask = decoder_input_tokens == multimodal_utils.LLAMA4_PATCH_TOKEN
       elif self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
-        bidirectional_mask = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN
+        bidirectional_mask = (decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN) | (
+            decoder_input_tokens == multimodal_utils.QWEN3_OMNI_VIDEO_TOKEN
+        )
+
+    audio_embeddings = None
+    if self.config.use_multimodal and encoder_audios is not None and self.audio_encoder is not None:
+      audio_embeddings = self.audio_encoder(input_audio=encoder_audios, deterministic=not enable_dropout)
+
+    # Create audio mask for placeholder tokens (qwen3-omni models)
+    audio_mask = None
+    if audio_embeddings is not None and self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
+      audio_mask = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_AUDIO_TOKEN
 
     logits, hidden_state, kv_caches = self.decoder(
         shared_embedding=self.token_embedder,
@@ -455,6 +485,8 @@ class Transformer(nnx.Module):
         bidirectional_mask=bidirectional_mask,
         image_embeddings=image_embeddings,
         image_masks=encoder_image_masks,
+        audio_embeddings=audio_embeddings,
+        audio_mask=audio_mask,
         kv_caches=kv_caches,
         attention_metadata=attention_metadata,
     )

--- a/src/MaxText/layers/qwen3.py
+++ b/src/MaxText/layers/qwen3.py
@@ -17,6 +17,8 @@
 # pylint: disable=no-name-in-module
 
 from typing import Any, cast
+import dataclasses
+import math
 
 import jax
 import jax.nn
@@ -28,22 +30,21 @@ from flax import linen as nn
 from flax import nnx
 
 from MaxText import max_utils
-from MaxText.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED
+from MaxText.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED, MODEL_MODE_TRAIN
 from MaxText.layers import attentions
 from MaxText.layers import initializers as max_initializers
 from MaxText.layers import linears
 from MaxText.layers import moe
 from MaxText.layers import nnx_wrappers
 from MaxText.layers import quantizations
-from MaxText.layers.embeddings import Qwen3OmniMoeVisionPosEmbedInterpolate
+from MaxText.layers.embeddings import Qwen3OmniMoeVisionPosEmbedInterpolate, SinusoidsPositionEmbedding
 from MaxText.layers.normalizations import RMSNorm, l2norm, Qwen3NextRMSNorm, Qwen3NextRMSNormGated
 from MaxText.layers.quantizations import AqtQuantization as Quant
 from MaxText.inference import page_manager
 from MaxText.layers.attentions import Attention
 from MaxText.layers.linears import DenseGeneral, MlpBlock
 from MaxText.layers.moe import RoutedMoE
-
-
+from MaxText.layers.initializers import nd_dense_init, variable_to_logically_partitioned
 # -----------------------------------------
 # Qwen3-Next Layer Implementations
 # -----------------------------------------
@@ -1641,6 +1642,357 @@ def qwen3omni_visionprojector_as_linen(config: Config, mesh: Mesh) -> nn.Module:
   )
 
 
+class Qwen3OmniAudioEncoderLayer(nnx.Module):
+  """Transformer encoder layer for audio model."""
+
+  def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs = None):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
+
+    self.hidden_states_shape = (
+        self.config.per_device_batch_size,
+        self.config.max_source_positions_for_audio,
+        self.config.d_model_for_audio,
+    )
+
+    self.input_layer_norm = nnx.LayerNorm(
+        num_features=self.config.d_model_for_audio,
+        epsilon=1e-5,
+        dtype=self.config.dtype_mm,
+        rngs=self.rngs,
+    )
+
+    self.self_attention_audio = Attention(
+        config=self.config,
+        num_query_heads=self.config.encoder_attention_heads_for_audio,
+        num_kv_heads=self.config.encoder_attention_heads_for_audio,
+        head_dim=self.config.d_model_for_audio // self.config.encoder_attention_heads_for_audio,
+        max_target_length=self.config.max_source_positions_for_audio,
+        attention_kernel="dot_product",
+        inputs_q_shape=self.hidden_states_shape,
+        inputs_kv_shape=self.hidden_states_shape,
+        float32_qk_product=self.config.float32_qk_product,
+        float32_logits=self.config.float32_logits,
+        dtype=self.config.dtype_mm,
+        weight_dtype=self.config.weight_dtype,
+        mesh=self.mesh,
+        dropout_rate=self.config.attention_dropout_for_audio,
+        name="self_attention_audio",
+        attention_type=AttentionType.FULL,
+        is_nope_layer=True,  # No rotary position embeddings for audio
+        use_bias_in_projections=True,
+        use_qk_norm=False,
+        query_pre_attn_scalar=1
+        / math.sqrt(self.config.d_model_for_audio // self.config.encoder_attention_heads_for_audio),
+        model_mode=MODEL_MODE_TRAIN,
+        rngs=self.rngs,
+    )
+
+    self.post_attention_layer_norm = nnx.LayerNorm(
+        num_features=self.config.d_model_for_audio,
+        epsilon=1e-5,
+        dtype=self.config.dtype_mm,
+        rngs=self.rngs,
+    )
+
+    self.AudioMLP = linears.MlpBlock(
+        config=self.config,
+        mesh=self.mesh,
+        in_features=self.config.d_model_for_audio,
+        intermediate_dim=self.config.encoder_ffn_dim_for_audio,
+        activations=("gelu",),  # Single GELU activation
+        kernel_init=max_initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        intermediate_dropout_rate=0.0,  # No dropout to match AudioMLP
+        dtype=self.config.dtype_mm,
+        weight_dtype=self.config.weight_dtype,
+        use_bias=True,  # AudioMLP uses bias
+        use_pre_norm=False,  # Norm is handled outside
+        quant=None,  # No quantization
+        model_mode=None,  # Not needed for encoder
+        rngs=rngs,
+    )
+
+  def __call__(
+      self,
+      hidden_states: Array,
+      deterministic: bool = False,
+  ):
+    residual = hidden_states
+    hidden_states = self.input_layer_norm(hidden_states)
+    hidden_states, _ = self.self_attention_audio(
+        inputs_q=hidden_states,
+        inputs_kv=hidden_states,
+        deterministic=deterministic,
+    )
+    hidden_states = residual + hidden_states
+    residual = hidden_states
+    hidden_states = self.post_attention_layer_norm(hidden_states)
+    hidden_states = self.AudioMLP(hidden_states)
+    hidden_states = residual + hidden_states
+    return hidden_states
+
+
+class Qwen3OmniAudioEncoder(nnx.Module):
+  """Full audio encoder with convs, positional embeddings, and transformer layers.
+
+  Attributes:
+      config: Config containing model parameters
+      mesh: Mesh, JAX device mesh (used for sharding)
+  """
+
+  def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs = None):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
+
+    self.positional_embedding = SinusoidsPositionEmbedding(
+        length=self.config.max_source_positions_for_audio,
+        channels=self.config.d_model_for_audio,
+        max_timescale=self.config.max_timescale_for_audio,
+        cast_as_fprop_dtype=True,
+        fprop_dtype=self.config.dtype_mm,
+    )
+
+    self.layernorm_post = nnx.LayerNorm(
+        num_features=self.config.d_model_for_audio,
+        epsilon=1e-5,
+        dtype=self.config.dtype_mm,
+        rngs=self.rngs,
+    )
+
+    # Convolutional downsampling layers
+    self.conv2d1 = nnx.Conv(
+        in_features=1,
+        out_features=self.config.downsample_hidden_size_for_audio,
+        kernel_size=(3, 3),
+        strides=(2, 2),
+        padding=((1, 1), (1, 1)),
+        use_bias=True,
+        dtype=self.config.dtype_mm,
+        param_dtype=self.config.weight_dtype,
+        rngs=self.rngs,
+    )
+
+    self.conv2d2 = nnx.Conv(
+        in_features=self.config.downsample_hidden_size_for_audio,
+        out_features=self.config.downsample_hidden_size_for_audio,
+        kernel_size=(3, 3),
+        strides=(2, 2),
+        padding=((1, 1), (1, 1)),
+        use_bias=True,
+        dtype=self.config.dtype_mm,
+        param_dtype=self.config.weight_dtype,
+        rngs=self.rngs,
+    )
+
+    self.conv2d3 = nnx.Conv(
+        in_features=self.config.downsample_hidden_size_for_audio,
+        out_features=self.config.downsample_hidden_size_for_audio,
+        kernel_size=(3, 3),
+        strides=(2, 2),
+        padding=((1, 1), (1, 1)),
+        use_bias=True,
+        dtype=self.config.dtype_mm,
+        param_dtype=self.config.weight_dtype,
+        rngs=self.rngs,
+    )
+
+    conv_out_dim = self.config.downsample_hidden_size_for_audio * (
+        (((self.config.num_mel_bins_for_audio + 1) // 2 + 1) // 2 + 1) // 2
+    )
+    self.conv_out = DenseGeneral(
+        in_features_shape=conv_out_dim,
+        out_features_shape=self.config.d_model_for_audio,
+        use_bias=False,
+        dtype=self.config.dtype_mm,
+        weight_dtype=self.config.weight_dtype,
+        kernel_init=nd_dense_init(1.0, "fan_in", "normal"),
+        rngs=self.rngs,
+    )
+
+    # Transformer encoder layers
+    for lyr in range(self.config.encoder_layers_for_audio):
+      layer_name = f"layers_{lyr}"
+      layer = Qwen3OmniAudioEncoderLayer(
+          config=self.config,
+          mesh=self.mesh,
+          rngs=self.rngs,
+      )
+      setattr(self, layer_name, layer)
+
+  def __call__(
+      self,
+      audio_features: Array,
+      deterministic: bool = False,
+  ):
+    """Process audio features through convs + transformer encoder.
+
+    Args:
+        audio_features: Input of shape (batch, num_mel_bins, audio_length)
+        deterministic: Whether to use deterministic mode
+
+    Returns:
+        Encoded features of shape (batch, seq_len, d_model_for_audio)
+    """
+    batch_size, num_mel_bins, audio_length = audio_features.shape
+    chunk_size = self.config.n_window_for_audio * 2
+
+    # Reshape to chunks
+    num_chunks = audio_length // chunk_size
+    audio_chunks = audio_features.reshape(batch_size, num_mel_bins, num_chunks, chunk_size)
+    audio_chunks = audio_chunks.transpose(0, 2, 1, 3)
+    audio_chunks = audio_chunks.reshape(batch_size * num_chunks, num_mel_bins, chunk_size)
+
+    # Add channel dimension
+    hidden_states = audio_chunks[:, :, :, jnp.newaxis]
+
+    # Apply convolutional layers
+    hidden_states = self.conv2d1(hidden_states)
+    hidden_states = jax.nn.gelu(hidden_states)
+    hidden_states = self.conv2d2(hidden_states)
+    hidden_states = jax.nn.gelu(hidden_states)
+    hidden_states = self.conv2d3(hidden_states)
+    hidden_states = jax.nn.gelu(hidden_states)
+
+    # Reshape conv output
+    bc, f, t, c = hidden_states.shape
+    hidden_states = hidden_states.transpose(0, 2, 3, 1)
+    hidden_states = hidden_states.reshape(bc, t, c * f)
+    hidden_states = self.conv_out(hidden_states)
+
+    # Add positional embeddings
+    seq_len_per_chunk = hidden_states.shape[1]
+    pos_emb = self.positional_embedding(seq_len_per_chunk)
+    pos_emb = jnp.broadcast_to(
+        pos_emb[None, :, :], (batch_size * num_chunks, seq_len_per_chunk, self.config.d_model_for_audio)
+    )
+    hidden_states = hidden_states + pos_emb
+
+    # Apply transformer encoder layers
+    for lyr in range(self.config.encoder_layers_for_audio):
+      layer_name = f"layers_{lyr}"
+      layer = getattr(self, layer_name)
+      hidden_states = layer(
+          hidden_states,
+          deterministic=deterministic,
+      )
+
+    hidden_states = self.layernorm_post(hidden_states)
+
+    # Reshape back: (batch*chunks, seq_len_per_chunk, d_model) -> (batch, chunks*seq_len_per_chunk, d_model)
+    hidden_states = hidden_states.reshape(batch_size, num_chunks * seq_len_per_chunk, self.config.d_model_for_audio)
+
+    return hidden_states
+
+
+@dataclasses.dataclass(repr=False)
+class Qwen3OmniAudioProjector(nnx.Module):
+  """Projection layer that converts audio encoder output to model embedding space."""
+
+  config: Config
+  proj1: DenseGeneral
+  proj2: DenseGeneral
+
+  def __init__(self, config: Config, *, rngs: nnx.Rngs = None):
+    self.config = config
+    self.proj1 = DenseGeneral(
+        in_features_shape=config.d_model_for_audio,
+        out_features_shape=config.d_model_for_audio,
+        use_bias=True,
+        dtype=config.dtype_mm,
+        weight_dtype=config.weight_dtype,
+        kernel_init=nd_dense_init(1.0, "fan_in", "normal"),
+        rngs=rngs,
+    )
+
+    self.proj2 = DenseGeneral(
+        in_features_shape=config.d_model_for_audio,
+        out_features_shape=config.output_dim_for_audio,
+        use_bias=True,
+        dtype=config.dtype_mm,
+        weight_dtype=config.weight_dtype,
+        kernel_init=nd_dense_init(1.0, "fan_in", "normal"),
+        rngs=rngs,
+    )
+
+  def __call__(self, hidden_states: Array) -> Array:
+    """
+    Args:
+        hidden_states: Encoder output of shape (num_chunks, seq_len, d_model_for_audio)
+
+    Returns:
+        Projected output of shape (num_chunks, seq_len, output_dim_for_audio)
+    """
+    hidden_states = self.proj1(hidden_states)
+    hidden_states = jax.nn.gelu(hidden_states)
+    hidden_states = self.proj2(hidden_states)
+    return hidden_states
+
+
+class Qwen3OmniAudioModel(nnx.Module):
+  """Audio model combining encoder and projector.
+
+  This model orchestrates the encoder (convs + transformer) and projector
+  to process audio features into model embedding space.
+
+  Attributes:
+      config: Config containing model parameters
+      mesh: Mesh, JAX device mesh (used for sharding)
+  """
+
+  def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs = None):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
+
+    self.audio_encoder = Qwen3OmniAudioEncoder(config=self.config, mesh=self.mesh, rngs=self.rngs)
+    self.audio_projector = Qwen3OmniAudioProjector(config=self.config, rngs=self.rngs)
+
+  def __call__(
+      self,
+      audio_features: Array,
+      deterministic: None | bool = False,
+  ) -> Array:
+    """Forward pass combining encoder and projector.
+
+    Args:
+        audio_features: Input audio features of shape (batch_size, num_mel_bins, audio_length)
+        deterministic: Whether to use deterministic mode (disables dropout)
+
+    Returns:
+        Projected audio features of shape (batch_size, seq_len, output_dim_for_audio)
+    """
+    # Apply encoder (convs + transformer)
+    hidden_states = self.audio_encoder(audio_features, deterministic=deterministic)
+    # Apply projector
+    hidden_states = self.audio_projector(hidden_states)
+    return hidden_states
+
+
+def qwen3omni_audioencoder_as_linen(config: Config, mesh: Mesh):
+  """Convert AudioEncoder (convs + transformer layers, no projector) to Linen module."""
+  return nnx_wrappers.to_linen(
+      Qwen3OmniAudioEncoder,
+      config=config,
+      mesh=mesh,
+      name="Qwen3OmniAudioEncoder_0",
+      abstract_init=False,
+      metadata_fn=variable_to_logically_partitioned,
+  )
+
+
+def qwen3omni_audioprojector_as_linen(config: Config, mesh: Mesh):
+  """Convert AudioProjector to Linen module."""
+  return nnx_wrappers.to_linen(
+      Qwen3OmniAudioProjector,
+      config=config,
+      name="Qwen3OmniAudioProjector_0",
+      abstract_init=False,
+      metadata_fn=variable_to_logically_partitioned,
+  )
+
+
 # Vision encoder Linen wrappers
 Qwen3OmniMoeVisionPatchMergerToLinen = nnx_wrappers.to_linen_class(
     Qwen3OmniMoeVisionPatchMerger,
@@ -1694,5 +2046,26 @@ Qwen3NextDecoderLayerToLinen = nnx_wrappers.to_linen_class(
 
 Qwen3NextScannableBlockToLinen = nnx_wrappers.to_linen_class(
     Qwen3NextScannableBlock,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+# Audio encoder Linen wrappers
+Qwen3OmniAudioEncoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioEncoderLayer,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniAudioEncoderToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioEncoder,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniAudioProjectorToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioProjector,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniAudioModelToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioModel,
     base_metadata_fn=max_initializers.variable_to_logically_partitioned,
 )

--- a/src/MaxText/maxtext_utils.py
+++ b/src/MaxText/maxtext_utils.py
@@ -139,6 +139,11 @@ def get_shaped_batch(config):
     )
     shaped_batch["images"] = jax.ShapeDtypeStruct(image_shape, jnp.int32)
     shaped_batch["image_masks"] = jax.ShapeDtypeStruct(image_shape[:2], jnp.int32)
+  if config.use_audio:
+    audio_shape = multimodal_utils.get_dummy_audio_shape_for_init(
+        config.model_name, config=config, batch_size=config.micro_batch_size_to_train_on
+    )
+    shaped_batch["audios"] = jax.ShapeDtypeStruct(audio_shape, jnp.float32)
   return shaped_batch
 
 
@@ -738,11 +743,15 @@ def init_initial_state(model, tx, config, is_training, key):
   image_shape = multimodal_utils.get_dummy_image_shape_for_init(
       config.model_name, batch_size=config.micro_batch_size_to_train_on
   )
+  audio_shape = multimodal_utils.get_dummy_audio_shape_for_init(
+      config.model_name, config=config, batch_size=config.micro_batch_size_to_train_on
+  )
   model_vars = model.init(
       {"params": key, "dropout": key, "aqt": key},
       np.ones(input_shape, dtype=jnp.int32),
       np.ones(input_shape, dtype=jnp.int32),
       encoder_images=np.ones(image_shape, dtype=jnp.int32) if config.use_multimodal else None,
+      encoder_audios=np.ones(audio_shape, dtype=jnp.float32) if config.use_audio else None,
       # nnx_method="no_op",
   )
   if is_training:
@@ -757,12 +766,16 @@ def get_abstract_param(model, config):
   image_shape = multimodal_utils.get_dummy_image_shape_for_init(
       config.model_name, batch_size=config.micro_batch_size_to_train_on
   )
+  audio_shape = multimodal_utils.get_dummy_audio_shape_for_init(
+      config.model_name, config=config, batch_size=config.micro_batch_size_to_train_on
+  )
   abstract_vars = jax.eval_shape(
       model.init,
       {"params": key, "dropout": key, "aqt": key},
       jnp.ones(input_shape, dtype=jnp.int32),
       jnp.ones(input_shape, dtype=jnp.int32),
       encoder_images=np.ones(image_shape, dtype=jnp.int32) if config.use_multimodal else None,
+      encoder_audios=np.ones(audio_shape, dtype=jnp.float32) if config.use_audio else None,
   )
   return abstract_vars
 
@@ -953,12 +966,16 @@ def get_prefill_kv_cache_annotations(model, config, rng, mesh, page_state: None 
     image_shape = multimodal_utils.get_dummy_image_shape_for_init(
         config.model_name, batch_size=config.micro_batch_size_to_train_on
     )
+    audio_shape = multimodal_utils.get_dummy_audio_shape_for_init(
+        config.model_name, config=config, batch_size=config.micro_batch_size_to_train_on
+    )
 
     model_vars = model.init(
         {"params": rng, "dropout": rng, "aqt": rng},
         jnp.ones(input_shape),
         jnp.ones(input_shape),
         encoder_images=jnp.ones(image_shape) if config.use_multimodal else None,
+        encoder_audios=jnp.ones(audio_shape) if config.use_audio else None,
         model_mode=MODEL_MODE_PREFILL,
         slot=0,
         page_state=page_state,
@@ -982,12 +999,16 @@ def get_kv_cache_annotations(model, config, rng, mesh, page_state: None | PageSt
     image_shape = multimodal_utils.get_dummy_image_shape_for_init(
         config.model_name, batch_size=config.micro_batch_size_to_train_on
     )
+    audio_shape = multimodal_utils.get_dummy_audio_shape_for_init(
+        config.model_name, config=config, batch_size=config.micro_batch_size_to_train_on
+    )
 
     model_vars = model.init(
         {"params": rng, "dropout": rng, "aqt": rng},
         jnp.ones(input_shape),
         jnp.ones(input_shape),
         encoder_images=jnp.ones(image_shape) if config.use_multimodal else None,
+        encoder_audios=jnp.ones(audio_shape) if config.use_audio else None,
         model_mode=MODEL_MODE_AUTOREGRESSIVE,
         slot=0,
         page_state=page_state,

--- a/src/MaxText/multimodal_utils.py
+++ b/src/MaxText/multimodal_utils.py
@@ -63,9 +63,11 @@ LLAMA4_TILE_Y_SEPARATOR_TOKEN = 200085  # <|tile_y_separator|>
 LLAMA4_PIXEL_SHUFFLE_RATIO = 0.5  # TODO(hengtaoguo): We should reuse config.pixel_shuffle_ratio_for_vit
 
 # Qwen3OmniMoe-specific processing
-QWEN3_OMNI_IMAGE_TOKEN = 151655
-QWEN3_OMNI_VIDEO_TOKEN = 151656
-QWEN3_OMNI_AUDIO_TOKEN = 151675
+QWEN3_OMNI_VISION_START_TOKEN = 151652  # <|vision_start|>
+QWEN3_OMNI_IMAGE_TOKEN = 151655  # <|image_pad|>
+QWEN3_OMNI_VIDEO_TOKEN = 151656  # <|video_pad|>
+QWEN3_OMNI_AUDIO_START_TOKEN = 151669  # <|audio_start|>
+QWEN3_OMNI_AUDIO_TOKEN = 151675  # <|audio_pad|>
 QWEN3_TEMPORAL_PATCH_SIZE = 2
 QWEN3_OMNI_IMAGE_SIZE = 768
 
@@ -568,6 +570,29 @@ def get_dummy_image_shape_for_init(
   return image_shape
 
 
+def get_dummy_audio_shape_for_init(model_name, config, batch_size=1):
+  """Return the shape of the dummy audio for specific model's initialization.
+
+  Args:
+    model_name: Name of the model
+    config: Model configuration containing audio parameters
+    batch_size: Batch size for the dummy audio
+
+  Returns:
+    Tuple representing audio shape: (batch, num_mel_bins, audio_length)
+    Returns None if audio is not configured
+  """
+  audio_shape = None
+  if model_name.startswith("qwen3-omni"):
+    # Audio shape: (batch, num_mel_bins, audio_length)
+    # audio_length must be divisible by n_window * 2
+    chunk_size = config.n_window_for_audio * 2
+    audio_length = chunk_size * 4  # 4 chunks
+    audio_shape = (batch_size, config.num_mel_bins_for_audio, audio_length)
+
+  return audio_shape
+
+
 def prepare_text_for_image_fusion(texts, model_name, processor_output=None):
   if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
     num_images = processor_output.pixel_values.shape[0] if processor_output else 1
@@ -859,101 +884,486 @@ def _get_new_text_positions(
 
 def merge_mm_embeddings(
     text_embeddings: np.ndarray | jnp.ndarray,
-    vision_embeddings: np.ndarray | jnp.ndarray,
+    multimodal_embeddings: np.ndarray | jnp.ndarray,
     mask,
-    image_masks: np.ndarray | jnp.ndarray | None = None,
+    token_masks: np.ndarray | jnp.ndarray | None = None,
 ) -> np.ndarray | jnp.ndarray:
-  """Merges text and vision embeddings based on a mask.
+  """Merges text and multimodal (vision/audio) embeddings based on a mask.
 
-  This function handles two primary formats for vision embeddings:
-  1. Tiled Format (e.g., Llama4): Vision embeddings are provided as a batch of
+  This function handles two primary formats for multimodal embeddings:
+  1. Tiled Format (e.g., Llama4 vision): Embeddings are provided as a batch of
      images and their tiles, with shape (B * N, T, K, D). These are flattened
-     into a single sequence of vision tokens per batch item.
-  2. Simple Format (e.g., Gemma3): Vision embeddings are provided as
-     (B, N, K, D) and are flattened into a sequence of vision tokens.
+     into a single sequence of tokens per batch item.
+  2. Simple Format (e.g., Gemma3 vision, Qwen3-Omni audio): Embeddings are provided as
+     (B, N, K, D) and are flattened into a sequence of tokens.
 
   Args:
     text_embeddings: (B, S, D) array of text embeddings.
-    vision_embeddings: Vision embeddings in one of two formats:
+    multimodal_embeddings: Multimodal embeddings (vision/audio) in one of two formats:
       - (B * N, T, K, D) for tiled inputs.
       - (B, N, K, D) for simple inputs.
-      (B=batch_size, S=seq_len, D=embedding_dim, N=num_images,
-       T=num_tiles, K=toks_per_image)
+      (B=batch_size, S=seq_len, D=embedding_dim, N=num_images/audio_chunks,
+       T=num_tiles, K=toks_per_image/audio_chunk)
     mask: (B, S) boolean or integer array where non-zero positions
-      indicate where vision embeddings should be placed.
-    image_masks: (Optional) A mask for the vision tokens.
+      indicate where multimodal embeddings should be placed.
+    token_masks: (Optional) A mask for the multimodal tokens.
       - (B * N, T) for tiled inputs, indicating valid tiles.
-      - If None, all vision embeddings are assumed to be valid.
+      - If None, all multimodal embeddings are assumed to be valid.
 
   Returns:
     A (B, S, D) array of merged embeddings.
   """
   # Input Validation and Shape Unpacking
   batch_size, _, d_model = text_embeddings.shape
-  # The number of tokens per image/tile is the second to last dimension.
-  num_toks_per_image = vision_embeddings.shape[-2]
+  # The number of tokens per image/tile/audio_chunk is the second to last dimension.
+  num_toks_per_token = multimodal_embeddings.shape[-2]
 
-  if d_model != vision_embeddings.shape[-1]:
+  if d_model != multimodal_embeddings.shape[-1]:
     raise ValueError(
-        "Embedding dimension mismatch between text and vision embeddings:" f" {d_model} vs {vision_embeddings.shape[-1]}"
+        "Embedding dimension mismatch between text and multimodal embeddings:"
+        f" {d_model} vs {multimodal_embeddings.shape[-1]}"
     )
 
-  # Reshape Vision Embeddings to a unified (B, S_vision, D) format
+  # Reshape Multimodal Embeddings to a unified (B, S_mm, D) format
   # This single reshape robustly handles both documented cases:
   # Case 1: (B * N, T, K, D) -> (B, N*T*K, D)
   # Case 2: (B, N, K, D) -> (B, N*K, D)
-  flat_vision_embeddings = vision_embeddings.reshape(batch_size, -1, d_model)
+  flat_multimodal_embeddings = multimodal_embeddings.reshape(batch_size, -1, d_model)
 
-  # Process Optional Image Masks
-  flat_image_token_masks = None
-  if image_masks is not None:
-    # Handle the tiled case where image_masks batch dimension is (B * N)
-    if image_masks.shape[0] != batch_size:
-      if image_masks.shape[0] % batch_size != 0:
+  # Process Optional Token Masks
+  flat_token_masks_processed = None
+  if token_masks is not None:
+    # Handle the tiled case where token_masks batch dimension is (B * N)
+    if token_masks.shape[0] != batch_size:
+      if token_masks.shape[0] % batch_size != 0:
         raise ValueError(
-            "Batch dimension of image_masks must be a multiple of the text"
-            f" batch size. Got {image_masks.shape[0]} and {batch_size}."
+            "Batch dimension of token_masks must be a multiple of the text"
+            f" batch size. Got {token_masks.shape[0]} and {batch_size}."
         )
       # Reshape from (B * N, T) to (B, N * T)
-      flat_image_tile_masks = image_masks.reshape(batch_size, -1)
+      flat_tile_masks = token_masks.reshape(batch_size, -1)
     else:
-      # This handles cases where image_masks is already (B, ...)
-      flat_image_tile_masks = image_masks.reshape(batch_size, -1)
+      # This handles cases where token_masks is already (B, ...)
+      flat_tile_masks = token_masks.reshape(batch_size, -1)
 
     # Expand the tile-level mask to a token-level mask to match the embeddings.
     # A mask of shape (B, N*T) becomes (B, N*T*K) by repeating each element K times.
-    flat_image_token_masks = jnp.repeat(flat_image_tile_masks, repeats=num_toks_per_image, axis=1)
+    flat_token_masks_processed = jnp.repeat(flat_tile_masks, repeats=num_toks_per_token, axis=1)
 
   # Vmap the inner merge function over the batch dimension
   return jax.vmap(
       _merge_mm_embeddings_inner,  # Assumes this function is defined elsewhere
-      in_axes=(0, 0, 0, None if flat_image_token_masks is None else 0),
-  )(text_embeddings, flat_vision_embeddings, mask, flat_image_token_masks)
+      in_axes=(0, 0, 0, None if flat_token_masks_processed is None else 0),
+  )(text_embeddings, flat_multimodal_embeddings, mask, flat_token_masks_processed)
 
 
 def _merge_mm_embeddings_inner(
-    text_embeddings: jnp.ndarray, vision_embeddings: jnp.ndarray, mask: jnp.ndarray, token_mask: jnp.ndarray | None = None
+    text_embeddings: jnp.ndarray,
+    multimodal_embeddings: jnp.ndarray,
+    mask: jnp.ndarray | None = None,
+    token_mask: jnp.ndarray | None = None,
 ) -> jnp.ndarray:
   """`merge_mm_embeddings` without batch dimension."""
 
   if token_mask is not None:
-    # This logic packs valid vision tokens to the front of the array.
-    # It correctly handles cases where some vision tokens are just padding.
+    # This logic packs valid multimodal tokens to the front of the array.
+    # It correctly handles cases where some multimodal tokens are just padding.
     sort_indices = jnp.argsort(-token_mask)  # Sorts descending, putting 1s first
-    vision_embeddings = vision_embeddings[sort_indices]
+    multimodal_embeddings = multimodal_embeddings[sort_indices]
 
-  # Find positions in the text sequence to place the vision embeddings.
+  # Find positions in the text sequence to place the multimodal embeddings.
   # The `size` argument ensures a fixed shape for JIT compilation.
-  target_pos = jnp.nonzero(mask, size=vision_embeddings.shape[0])
+  target_pos = jnp.nonzero(mask, size=multimodal_embeddings.shape[0])
   target_pos = target_pos[0]  # jnp.nonzero returns a tuple of arrays
 
   # Save the embedding at the first position.
   first_pos_embedding = text_embeddings[0]
 
   # Perform the insertion.
-  merged = text_embeddings.at[target_pos, :].set(vision_embeddings)
+  merged = text_embeddings.at[target_pos, :].set(multimodal_embeddings)
 
   # Restore the first position's embedding, in case it was overwritten.
   merged = merged.at[0].set(first_pos_embedding)
 
   return merged
+
+
+# ==============================================================================
+# Qwen3-Omni Multimodal Position ID Utilities
+# ==============================================================================
+def _get_feat_extract_output_lengths(input_lengths: jax.Array) -> jax.Array:
+  """Computes the output length of the audio encoder convolutional layers.
+
+  The audio encoder processes audio in chunks of 100 samples, applying
+  multiple convolutional layers with stride 2. Each full 100-sample chunk
+  produces 13 output tokens, and remaining samples are processed separately.
+
+  Args:
+    input_lengths: Input audio sequence lengths. Shape: (batch,) or scalar.
+
+  Returns:
+    Output sequence lengths after audio encoding. Same shape as input.
+  """
+  input_lengths_leave = input_lengths % 100
+  feat_lengths = (input_lengths_leave - 1) // 2 + 1
+  output_lengths = ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
+  return output_lengths
+
+
+def get_llm_pos_ids_for_vision(
+    start_idx: int | jax.Array,
+    vision_idx: int,
+    spatial_merge_size: int,
+    t_index: jax.Array,
+    grid_hs: jax.Array,
+    grid_ws: jax.Array,
+) -> jax.Array:
+  """Computes 3D position IDs (temporal, height, width) for vision tokens.
+
+  Creates position embeddings for a grid of vision tokens representing an
+  image or video. For each temporal frame, generates a spatial grid of
+  (height, width) positions.
+
+  Args:
+    start_idx: Starting position ID value to add as offset.
+    vision_idx: Index of the current image/video being processed.
+    spatial_merge_size: Number of patches merged spatially (e.g., 2 means 2x2 patches → 1 token).
+    t_index: Temporal position for each frame. Shape: (num_frames,).
+    grid_hs: Height dimensions for all images/videos. Shape: (num_images,).
+    grid_ws: Width dimensions for all images/videos. Shape: (num_images,).
+
+  Returns:
+    3D position IDs with shape (3, num_vision_tokens) where:
+      - dim 0: temporal positions
+      - dim 1: height positions
+      - dim 2: width positions
+
+  Example:
+    If spatial_merge_size=2, grid_h=4, grid_w=4, num_frames=2:
+      - After merge: 2x2 grid per frame
+      - Total tokens: 2 frames x 2 x 2 = 8 tokens
+      - Output shape: (3, 8)
+      - t_index: [0, 0, 0, 0, 50, 50, 50, 50]
+      - h_index: [0, 0, 1, 1, 0, 0, 1, 1]
+      - w_index: [0, 1, 0, 1, 0, 1, 0, 1]
+  """
+  # Calculate effective spatial dimensions after merging patches
+  llm_grid_h = grid_hs[vision_idx] // spatial_merge_size
+  llm_grid_w = grid_ws[vision_idx] // spatial_merge_size
+
+  # Create height indices: [0, 0, ..., 0 (W times), 1, 1, ..., 1 (W times), ...]
+  # Shape: (num_frames, llm_grid_h, 1) -> expand -> (num_frames, llm_grid_h, llm_grid_w) -> flatten
+  h_index = jnp.arange(llm_grid_h).reshape(1, -1, 1).repeat(len(t_index), axis=0).repeat(llm_grid_w, axis=2).flatten()
+
+  # Create width indices: [0, 1, 2, ..., W-1, 0, 1, 2, ..., W-1, ...]
+  # Shape: (num_frames, 1, llm_grid_w) -> expand -> (num_frames, llm_grid_h, llm_grid_w) -> flatten
+  w_index = jnp.arange(llm_grid_w).reshape(1, 1, -1).repeat(len(t_index), axis=0).repeat(llm_grid_h, axis=1).flatten()
+
+  # Create temporal indices: [t0, t0, ..., t0 (HxW times), t1, t1, ..., t1 (HxW times), ...]
+  # Shape: (num_frames, 1) -> expand -> (num_frames, llm_grid_h * llm_grid_w) -> flatten
+  t_index_expanded = t_index.reshape(-1, 1).repeat(llm_grid_h * llm_grid_w, axis=1).flatten()
+
+  # Stack all three dimensions and add starting offset
+  _llm_pos_ids = jnp.stack([t_index_expanded, h_index, w_index])
+  llm_pos_ids = _llm_pos_ids + start_idx
+
+  return llm_pos_ids
+
+
+def get_chunked_index(token_indices: jax.Array, tokens_per_chunk: int, remove_index: int) -> list[tuple[int, int]]:
+  """Splits token index list into chunks based on token value ranges.
+
+  Given a list of monotonically increasing token indices, returns a list of
+  (start, end) index tuples representing slices where token values fall within
+  successive ranges of `tokens_per_chunk`.
+
+  Args:
+    token_indices: Monotonically increasing array of token index values. Shape: (seq_len,).
+    tokens_per_chunk: Chunk size threshold (e.g., 100 means first chunk has values < 100).
+    remove_index: Offset to subtract from token_indices before chunking.
+
+  Returns:
+    List of (start_idx, end_idx) tuples, each representing a chunk.
+
+  Example:
+    token_indices = [5, 10, 52, 105, 150, 250]
+    tokens_per_chunk = 100
+    remove_index = 0
+
+    Result: [(0, 3), (3, 5), (5, 6)]
+      - Chunk 0: indices 0-3 (values 5, 10, 52 are < 100)
+      - Chunk 1: indices 3-5 (values 105, 150 are >= 100 and < 200)
+      - Chunk 2: indices 5-6 (value 250 is >= 200)
+  """
+  chunks = []
+  i = 0
+  start_idx = 0
+  current_chunk = 1
+
+  while i < len(token_indices):
+    if token_indices[i] - remove_index >= current_chunk * tokens_per_chunk:
+      chunks.append((start_idx, i))
+      start_idx = i
+      current_chunk += 1
+    i += 1
+
+  # Append final chunk
+  chunks.append((start_idx, len(token_indices)))
+
+  return chunks
+
+
+def get_rope_index(
+    input_ids: jax.Array,
+    image_grid_thw: jax.Array | None = None,
+    video_grid_thw: jax.Array | None = None,
+    attention_mask: jax.Array | None = None,
+    use_audio_in_video: bool = False,
+    audio_lengths: jax.Array | None = None,
+    second_per_grids: jax.Array | None = None,
+    spatial_merge_size: int = 2,
+    position_id_per_seconds: int = 25,
+) -> tuple[jax.Array, jax.Array]:
+  """Calculate 3D RoPE position indices for multimodal sequences.
+
+  This function computes position IDs that encode both sequential (text) and
+  spatial-temporal (vision/audio) structure for Qwen3-Omni multimodal inputs.
+
+  For pure text sequences:
+    - All 3 dimensions receive the same sequential positions: [0, 1, 2, 3, 4]
+
+  For multimodal sequences with vision:
+    - Vision tokens get 3D positions (temporal, height, width)
+    - Text tokens continue sequentially from max(vision_pos) + 1
+    - Example with video (3 temporal patches, 2x2 spatial):
+        Vision temporal: [0, 0, 0, 0, 50, 50, 50, 50, 100, 100, 100, 100]
+        Vision height:   [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+        Vision width:    [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+        Text positions:  [101, 102, 103, 104, 105]
+
+  Args:
+    input_ids: Input token IDs. Shape: (batch, seq_len).
+    image_grid_thw: Image dimensions (temporal, height, width). Shape: (num_images, 3).
+    video_grid_thw: Video dimensions (temporal, height, width). Shape: (num_videos, 3).
+    attention_mask: Padding mask (1 = real token, 0 = padding). Shape: (batch, seq_len).
+    use_audio_in_video: If True, audio tokens are interleaved with video tokens.
+    audio_lengths: Audio sequence lengths. Shape: (num_audios,).
+    second_per_grids: Time interval per temporal grid (for videos). Shape: (num_videos,).
+    spatial_merge_size: Number of patches merged spatially (e.g., 2 for 2x2→1).
+    position_id_per_seconds: Temporal granularity (tokens per second, typically 25).
+
+  Returns:
+    A tuple of:
+      - position_ids: 3D position IDs. Shape: (3, batch, seq_len).
+      - mrope_position_deltas: Position offset for each sequence. Shape: (batch, 1).
+
+  Raises:
+    ValueError: If multimodal tokens are present but grid info is missing.
+  """
+  batch_size, seq_len = input_ids.shape
+
+  # Handle text-only case (no multimodal content)
+  if image_grid_thw is None and video_grid_thw is None:
+    if attention_mask is None:
+      attention_mask = jnp.ones_like(input_ids)
+
+    # Create sequential 1D positions
+    position_ids = jnp.cumsum(attention_mask.astype(jnp.float32), axis=-1) - 1
+    position_ids = jnp.where(attention_mask == 0, 1.0, position_ids)
+
+    # Expand to 3D (same value in all dimensions for text-only)
+    position_ids = jnp.broadcast_to(position_ids[jnp.newaxis, :, :], (3, batch_size, seq_len))
+
+    # Calculate deltas for each sequence
+    max_position_ids = jnp.max(position_ids, axis=(0, 2), keepdims=True).transpose(1, 0, 2)  # (batch, 1, 1)
+    mrope_position_deltas = max_position_ids.squeeze(-1) + 1 - jnp.sum(attention_mask, axis=-1, keepdims=True)
+
+    return position_ids, mrope_position_deltas
+
+  # Multimodal case: process each sequence in batch
+  if attention_mask is None:
+    attention_mask = jnp.ones_like(input_ids)
+
+  attention_mask_bool = attention_mask == 1
+  position_ids = jnp.zeros((3, batch_size, seq_len), dtype=jnp.float32)
+  mrope_position_deltas = []
+
+  # Process each sequence in the batch
+  for i in range(batch_size):
+    # Get valid tokens (non-padding)
+    valid_input_ids = input_ids[i][attention_mask_bool[i]]
+
+    # Count multimodal elements in this sequence
+    vision_start_indices = jnp.where(valid_input_ids == QWEN3_OMNI_VISION_START_TOKEN)[0]
+    vision_tokens = valid_input_ids[vision_start_indices + 1] if len(vision_start_indices) > 0 else jnp.array([])
+
+    audio_nums = jnp.sum(valid_input_ids == QWEN3_OMNI_AUDIO_START_TOKEN).item()
+    image_nums = jnp.sum(vision_tokens == QWEN3_OMNI_IMAGE_TOKEN).item() if len(vision_tokens) > 0 else 0
+    video_nums = (
+        (
+            jnp.sum(vision_tokens == QWEN3_OMNI_AUDIO_START_TOKEN).item()
+            if use_audio_in_video
+            else jnp.sum(vision_tokens == QWEN3_OMNI_VIDEO_TOKEN).item()
+        )
+        if len(vision_tokens) > 0
+        else 0
+    )
+
+    input_tokens = valid_input_ids.tolist()
+    llm_pos_ids_list = []
+    st = 0
+    remain_images = image_nums
+    remain_videos = video_nums
+    remain_audios = audio_nums
+    image_idx = 0
+    video_idx = 0
+    audio_idx = 0
+
+    multimodal_nums = image_nums + audio_nums if use_audio_in_video else image_nums + video_nums + audio_nums
+
+    # Process each multimodal element
+    for _ in range(multimodal_nums):
+      st_idx = llm_pos_ids_list[-1].max().item() + 1 if len(llm_pos_ids_list) > 0 else 0
+
+      # Find next vision or audio start token
+      if (QWEN3_OMNI_IMAGE_TOKEN in input_tokens or QWEN3_OMNI_VIDEO_TOKEN in input_tokens) and (
+          remain_videos > 0 or remain_images > 0
+      ):
+        try:
+          ed_vision_start = input_tokens.index(QWEN3_OMNI_VISION_START_TOKEN, st)
+        except ValueError:
+          ed_vision_start = len(input_tokens) + 1
+      else:
+        ed_vision_start = len(input_tokens) + 1
+
+      if QWEN3_OMNI_AUDIO_TOKEN in input_tokens and remain_audios > 0:
+        try:
+          ed_audio_start = input_tokens.index(QWEN3_OMNI_AUDIO_START_TOKEN, st)
+        except ValueError:
+          ed_audio_start = len(input_tokens) + 1
+      else:
+        ed_audio_start = len(input_tokens) + 1
+
+      min_ed = min(ed_vision_start, ed_audio_start)
+
+      # Add text tokens before multimodal element
+      text_len = min_ed - st
+      if text_len > 0:
+        text_pos = jnp.arange(text_len).reshape(1, -1).repeat(3, axis=0) + st_idx
+        llm_pos_ids_list.append(text_pos)
+        st_idx += text_len
+
+      # Determine BOS/EOS token lengths
+      if min_ed == ed_vision_start and ed_vision_start + 1 == ed_audio_start:
+        bos_len, eos_len = 2, 2  # Audio in video
+      else:
+        bos_len, eos_len = 1, 1
+
+      # Add BOS token(s)
+      bos_pos = jnp.arange(bos_len).reshape(1, -1).repeat(3, axis=0) + st_idx
+      llm_pos_ids_list.append(bos_pos)
+      st_idx += bos_len
+
+      # Process modality-specific content
+      # Audio Only
+      if min_ed == ed_audio_start:
+        audio_len = _get_feat_extract_output_lengths(audio_lengths[audio_idx]).item()
+        audio_pos = jnp.arange(audio_len).reshape(1, -1).repeat(3, axis=0) + st_idx
+        llm_pos_ids_list.append(audio_pos)
+
+        st += int(text_len + bos_len + audio_len + eos_len)
+        audio_idx += 1
+        remain_audios -= 1
+
+      # Image Only
+      elif min_ed == ed_vision_start and input_tokens[ed_vision_start + 1] == QWEN3_OMNI_IMAGE_TOKEN:
+        grid_t = image_grid_thw[image_idx, 0].item()
+        grid_hs = image_grid_thw[:, 1]
+        grid_ws = image_grid_thw[:, 2]
+        t_index = jnp.arange(grid_t, dtype=jnp.float32) * 1 * position_id_per_seconds
+
+        image_pos = get_llm_pos_ids_for_vision(st_idx, image_idx, spatial_merge_size, t_index, grid_hs, grid_ws)
+        llm_pos_ids_list.append(image_pos)
+
+        image_len = int(jnp.prod(image_grid_thw[image_idx]).item() // (spatial_merge_size**2))
+        st += int(text_len + bos_len + image_len + eos_len)
+        image_idx += 1
+        remain_images -= 1
+
+      # Video Only
+      elif min_ed == ed_vision_start and input_tokens[ed_vision_start + 1] == QWEN3_OMNI_VIDEO_TOKEN:
+        grid_t = video_grid_thw[video_idx, 0].item()
+        grid_hs = video_grid_thw[:, 1]
+        grid_ws = video_grid_thw[:, 2]
+        t_index = jnp.arange(grid_t, dtype=jnp.float32) * second_per_grids[video_idx].item() * position_id_per_seconds
+
+        video_pos = get_llm_pos_ids_for_vision(st_idx, video_idx, spatial_merge_size, t_index, grid_hs, grid_ws)
+        llm_pos_ids_list.append(video_pos)
+
+        video_len = int(jnp.prod(video_grid_thw[video_idx]).item() // (spatial_merge_size**2))
+        st += int(text_len + bos_len + video_len + eos_len)
+        video_idx += 1
+        remain_videos -= 1
+
+      # Audio in Video (interleaved)
+      elif min_ed == ed_vision_start and ed_vision_start + 1 == ed_audio_start:
+        audio_len = _get_feat_extract_output_lengths(audio_lengths[audio_idx]).item()
+        audio_llm_pos_ids = jnp.arange(audio_len).reshape(1, -1).repeat(3, axis=0) + st_idx
+
+        grid_t = video_grid_thw[video_idx, 0].item()
+        grid_hs = video_grid_thw[:, 1]
+        grid_ws = video_grid_thw[:, 2]
+        t_index = jnp.arange(grid_t, dtype=jnp.float32) * second_per_grids[video_idx].item() * position_id_per_seconds
+
+        video_llm_pos_ids = get_llm_pos_ids_for_vision(st_idx, video_idx, spatial_merge_size, t_index, grid_hs, grid_ws)
+
+        # Interleave audio and video based on temporal ordering
+        video_data_index = 0
+        audio_data_index = 0
+        while video_data_index < video_llm_pos_ids.shape[1] and audio_data_index < audio_llm_pos_ids.shape[1]:
+          if video_llm_pos_ids[0, video_data_index] <= audio_llm_pos_ids[0, audio_data_index]:
+            llm_pos_ids_list.append(video_llm_pos_ids[:, video_data_index : video_data_index + 1])
+            video_data_index += 1
+          else:
+            llm_pos_ids_list.append(audio_llm_pos_ids[:, audio_data_index : audio_data_index + 1])
+            audio_data_index += 1
+
+        # Append remaining tokens
+        if video_data_index < video_llm_pos_ids.shape[1]:
+          llm_pos_ids_list.append(video_llm_pos_ids[:, video_data_index:])
+        if audio_data_index < audio_llm_pos_ids.shape[1]:
+          llm_pos_ids_list.append(audio_llm_pos_ids[:, audio_data_index:])
+
+        video_len = int(jnp.prod(video_grid_thw[video_idx]).item() // (spatial_merge_size**2))
+        st += int(text_len + bos_len + audio_len + video_len + eos_len)
+
+        audio_idx += 1
+        video_idx += 1
+        remain_videos -= 1
+        remain_audios -= 1
+
+      # Add EOS token(s)
+      st_idx = llm_pos_ids_list[-1].max().item() + 1 if len(llm_pos_ids_list) > 0 else 0
+      eos_pos = jnp.arange(eos_len).reshape(1, -1).repeat(3, axis=0) + st_idx
+      llm_pos_ids_list.append(eos_pos)
+
+    # Add any remaining text tokens
+    if st < len(input_tokens):
+      st_idx = llm_pos_ids_list[-1].max().item() + 1 if len(llm_pos_ids_list) > 0 else 0
+      text_len = len(input_tokens) - st
+      remaining_text_pos = jnp.arange(text_len).reshape(1, -1).repeat(3, axis=0) + st_idx
+      llm_pos_ids_list.append(remaining_text_pos)
+
+    # Concatenate all position IDs for this sequence
+    llm_positions = jnp.concatenate(llm_pos_ids_list, axis=1)
+
+    # Place into position_ids tensor at valid positions
+    valid_positions = jnp.where(attention_mask_bool[i])[0]
+    position_ids = position_ids.at[:, i, valid_positions].set(llm_positions)
+
+    # Calculate delta for this sequence
+    mrope_position_deltas.append(llm_positions.max().item() + 1 - len(valid_input_ids))
+
+  mrope_position_deltas = jnp.array(mrope_position_deltas).reshape(batch_size, 1)
+
+  return position_ids, mrope_position_deltas

--- a/src/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -687,7 +687,17 @@ qwen3_omni_30b_a3b_config = transformers.Qwen3OmniMoeConfig(
         "text_config": {
             "num_hidden_layers": 48,
             "num_experts": 128,
-        }
+        },
+        "audio_config": {
+            "encoder_layers": 32,
+            "d_model": 1280,
+            "encoder_attention_heads": 20,
+        },
+        "vision_config": {
+            "depth": 27,
+            "num_heads": 16,
+            "hidden_size": 1152,
+        },
     },
 )
 

--- a/tests/check_qwen3_omni_audio_vs_reference.py
+++ b/tests/check_qwen3_omni_audio_vs_reference.py
@@ -1,0 +1,489 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Qwen3-Omni audio encoder comparing MaxText implementation against reference."""
+
+import unittest
+import os
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import torch
+import torch.nn.functional as F
+from flax import nnx
+from jax.sharding import Mesh
+
+from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+    Qwen3OmniMoeAudioAttention as TorchQwen3OmniMoeAudioAttention,
+    Qwen3OmniMoeAudioEncoderLayer as TorchQwen3OmniMoeAudioEncoderLayer,
+    SinusoidsPositionEmbedding as TorchSinusoidsPositionEmbedding,
+    Qwen3OmniMoeAudioEncoder as TorchQwen3OmniMoeAudioEncoder,
+)
+from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import (
+    Qwen3OmniMoeAudioEncoderConfig,
+)
+
+from MaxText.layers.qwen3 import (
+    Qwen3OmniAudioEncoderLayer,
+    Qwen3OmniAudioEncoder,
+    Qwen3OmniAudioModel,
+)
+from MaxText.layers.embeddings import SinusoidsPositionEmbedding
+from MaxText.layers.attentions import Attention
+from MaxText import common_types
+from MaxText import pyconfig
+
+from multimodal_test_utils import (
+    copy_attention_weights_to_maxtext,
+    copy_audio_model,
+    copy_maxtext_audio_encoder_weights,
+    copy_maxtext_encoder_layer_weights,
+    create_block_diagonal_attention_mask,
+    create_random_jax_torch,
+    assert_all_close_jax_torch,
+)
+
+
+base_config_path = os.path.join(os.path.dirname(__file__), "..", "src", "MaxText", "configs", "base.yml")
+jax_audio_config = pyconfig.initialize(
+    ["", base_config_path],
+    model_name="qwen3-omni-30b-a3b",
+    attention="dot_product",
+    attention_type="full",
+    dropout_rate=0.0,
+    dtype="float32",
+    weight_dtype="float32",
+    float32_logits=True,
+)
+
+torch_audio_encoder_config = Qwen3OmniMoeAudioEncoderConfig(
+    d_model=jax_audio_config.d_model_for_audio,
+    encoder_attention_heads=jax_audio_config.encoder_attention_heads_for_audio,
+    encoder_ffn_dim=jax_audio_config.encoder_ffn_dim_for_audio,
+    encoder_layers=jax_audio_config.encoder_layers_for_audio,
+    attention_dropout=jax_audio_config.attention_dropout_for_audio,
+    dropout=0.0,
+    activation_dropout=0.0,
+    activation_function="gelu",
+    num_mel_bins=jax_audio_config.num_mel_bins_for_audio,
+    max_source_positions=jax_audio_config.max_source_positions_for_audio,
+    scale_embedding=True,
+    n_window=jax_audio_config.n_window_for_audio,
+    n_window_infer=jax_audio_config.n_window_infer_for_audio,
+    conv_chunksize=jax_audio_config.conv_chunksize_for_audio,
+    downsample_hidden_size=jax_audio_config.downsample_hidden_size_for_audio,
+    output_dim=jax_audio_config.output_dim_for_audio,
+    torch_dtype=torch.float32,
+    weight_dtype=torch.float32,
+)
+torch_audio_encoder_config._attn_implementation = "eager"  # pylint: disable=protected-access
+
+torch.set_grad_enabled(False)
+
+
+class TestMaxTextAttentionVsPyTorch(unittest.TestCase):
+  """Test that MaxText's Attention module matches PyTorch's audio attention implementation."""
+
+  def setUp(self):
+    self.batch_size = 1
+    self.seq_length = 16
+    self.config = jax_audio_config
+    self.embed_dim = self.config.d_model_for_audio
+    self.num_heads = self.config.encoder_attention_heads_for_audio
+    self.head_dim = self.embed_dim // self.num_heads
+    np.random.seed(42)
+    torch.manual_seed(42)
+    self.mesh = Mesh(np.array(jax.devices()[:1]), axis_names=("data",))
+
+  def test_attention_output_matches_torch(self):
+    """Test that MaxText Attention produces same output as PyTorch attention."""
+    torch_config = torch_audio_encoder_config
+    torch_model = TorchQwen3OmniMoeAudioAttention(torch_config)
+    torch_model.eval()
+
+    # Create input - PyTorch expects (seq_length, channels), MaxText expects (batch, seq, channels)
+    jax_hidden_states_2d, torch_hidden_states = create_random_jax_torch(self.seq_length, self.embed_dim)
+    jax_hidden_states = jax_hidden_states_2d[jnp.newaxis, :, :]  # Add batch dimension for MaxText
+
+    # Create cu_seqlens for PyTorch (cumulative sequence lengths)
+    cu_seqlens = torch.tensor([0, self.seq_length], dtype=torch.long)
+
+    jax_attn = Attention(
+        config=self.config,
+        num_query_heads=self.num_heads,
+        num_kv_heads=self.num_heads,
+        head_dim=self.head_dim,
+        max_target_length=self.config.max_source_positions_for_audio,
+        attention_kernel="dot_product",
+        inputs_q_shape=(
+            self.config.per_device_batch_size,
+            self.seq_length,
+            self.embed_dim,
+        ),
+        inputs_kv_shape=(
+            self.config.per_device_batch_size,
+            self.seq_length,
+            self.embed_dim,
+        ),
+        float32_qk_product=self.config.float32_qk_product,
+        float32_logits=self.config.float32_logits,
+        dtype=self.config.dtype_mm,
+        weight_dtype=self.config.weight_dtype,
+        mesh=self.mesh,
+        dropout_rate=0.0,
+        name="test_attention",
+        attention_type=common_types.AttentionType.FULL,
+        is_nope_layer=True,
+        use_bias_in_projections=True,
+        use_qk_norm=False,
+        query_pre_attn_scalar=1 / math.sqrt(self.head_dim),
+        model_mode=common_types.MODEL_MODE_TRAIN,
+        rngs=nnx.Rngs(42),
+    )
+
+    copy_attention_weights_to_maxtext(torch_model, jax_attn)
+    torch_output = torch_model(torch_hidden_states, cu_seqlens=cu_seqlens)
+
+    jax_output, _ = jax_attn(inputs_q=jax_hidden_states, inputs_kv=jax_hidden_states, deterministic=True)
+
+    # Both should be (seq, embed) after removing batch dimensions
+    jax_output_2d = jax_output[0]  # (batch, seq, embed) -> (seq, embed)
+    # PyTorch returns (batch, seq, embed), squeeze to remove batch dimension
+    torch_output_2d = torch_output.squeeze(0)  # (1, seq, embed) -> (seq, embed)
+
+    assert_all_close_jax_torch(
+        jax_output_2d,
+        torch_output_2d,
+        rtol=1e-5,
+        atol=5e-3,
+        error_msg="Attention outputs differ",
+    )
+
+
+class TestAudioEncoderLayer(unittest.TestCase):
+  """Test MaxText AudioEncoderLayer against PyTorch implementation."""
+
+  def setUp(self):
+    self.config = jax_audio_config
+    self.torch_config = torch_audio_encoder_config
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+    devices = jax.devices()
+    self.mesh = Mesh(np.array(devices[:1]), axis_names=("data",))
+
+  def _test_encoder_layer_with_batch_size(self, batch_size):
+    """Helper function to test encoder layer with a given batch size."""
+
+    torch_layer = TorchQwen3OmniMoeAudioEncoderLayer(self.torch_config)
+    torch_layer.eval()
+
+    maxtext_layer = Qwen3OmniAudioEncoderLayer(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+
+    # Copy weights from PyTorch to MaxText
+    copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer)
+
+    # Create test input
+    seq_len = 12  # After conv layers
+    hidden_size = self.config.d_model_for_audio
+
+    jax_input, torch_input_3d = create_random_jax_torch(batch_size, seq_len, hidden_size)
+
+    # PyTorch forward pass - expects 2D input (total_seq_len, hidden_dim) with cu_seqlens
+    torch_input_2d = torch_input_3d.reshape(-1, hidden_size)
+
+    # Create cu_seqlens for PyTorch (cumulative sequence lengths for each batch)
+    # For batch_size=2, seq_len=12: [0, 12, 24] indicates two sequences of length 12 each
+    cu_seqlens = torch.tensor([i * seq_len for i in range(batch_size + 1)], dtype=torch.int32)
+
+    attention_mask = create_block_diagonal_attention_mask(cu_seqlens, torch_input_2d.dtype)
+
+    torch_output_1d = torch_layer(torch_input_2d, cu_seqlens=cu_seqlens, attention_mask=attention_mask)[0]
+    torch_output = torch_output_1d.reshape(batch_size, seq_len, hidden_size)
+
+    jax_output = maxtext_layer(jax_input, deterministic=True)
+
+    assert_all_close_jax_torch(
+        jax_output,
+        torch_output,
+        rtol=1e-5,
+        atol=5e-3,
+        error_msg="AudioEncoderLayer outputs differ",
+    )
+
+  def test_encoder_layer_matches_torch_batch_1(self):
+    """Test that MaxText AudioEncoderLayer matches PyTorch with batch_size=1."""
+    self._test_encoder_layer_with_batch_size(batch_size=1)
+
+  def test_encoder_layer_matches_torch_batch_2(self):
+    """Test that MaxText AudioEncoderLayer matches PyTorch with batch_size=2."""
+    self._test_encoder_layer_with_batch_size(batch_size=2)
+
+  def test_encoder_layer_is_jittable(self):
+    """Test that encoder layer can be JIT compiled."""
+    with self.mesh:
+      jax_layer = Qwen3OmniAudioEncoderLayer(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+
+    @nnx.jit
+    def forward(layer, x):
+      return layer(x, deterministic=True)
+
+    batch_size = 2
+    seq_len = 12
+    hidden_size = self.config.d_model_for_audio
+
+    hidden_states = jnp.ones((batch_size, seq_len, hidden_size))
+    output = forward(jax_layer, hidden_states)
+
+    self.assertEqual(output.shape, (batch_size, seq_len, hidden_size))
+
+
+class TestSinusoidsPositionEmbedding(unittest.TestCase):
+  """Tests for SinusoidsPositionEmbedding implementation."""
+
+  def setUp(self):
+    self.length = 100
+    self.channels = 512
+    self.max_timescale = 10000.0
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+  def test_positional_embedding_matches_torch(self):
+    torch_model = TorchSinusoidsPositionEmbedding(self.length, self.channels, self.max_timescale)
+    jax_model = SinusoidsPositionEmbedding(self.length, self.channels, self.max_timescale, cast_as_fprop_dtype=False)
+
+    # Test full sequence
+    torch_output = torch_model(self.length)
+    jax_output = jax_model(self.length)
+
+    assert_all_close_jax_torch(
+        jax_output,
+        torch_output,
+        rtol=1e-5,
+        atol=3e-4,
+        error_msg="Positional embedding outputs differ",
+    )
+
+  def test_positional_embedding_is_jittable(self):
+    model = SinusoidsPositionEmbedding(self.length, self.channels, self.max_timescale)
+
+    @nnx.jit(static_argnames=["seqlen"])
+    def forward(model, seqlen):
+      return model(seqlen)
+
+    output = forward(model, seqlen=self.length)
+    self.assertEqual(output.shape, (self.length, self.channels))
+
+
+class TestAudioEncoder(unittest.TestCase):
+  """Test AudioEncoder (convs + transformer, no projector) against PyTorch implementation."""
+
+  def setUp(self):
+    self.config = jax_audio_config
+    self.torch_config = torch_audio_encoder_config
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+    devices = jax.devices()
+    self.mesh = Mesh(np.array(devices[:1]), axis_names=("data",))
+
+  def test_audio_encoder_matches_torch(self):
+    """Test that MaxText AudioEncoder matches PyTorch encoder (convs + transformer + layernorm, before projector)."""
+    torch_model = TorchQwen3OmniMoeAudioEncoder(self.torch_config)
+    torch_model.eval()
+
+    maxtext_encoder = Qwen3OmniAudioEncoder(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+
+    copy_maxtext_audio_encoder_weights(torch_model, maxtext_encoder, self.config)
+
+    batch_size = 1
+    num_mel_bins = self.config.num_mel_bins_for_audio
+    audio_length = 200  # n_window=50, chunk_size=100, gives 2 chunks
+
+    jax_audio_features, torch_audio_features_3d = create_random_jax_torch(batch_size, num_mel_bins, audio_length)
+
+    # PyTorch forward (manually run convs + transformer encoder without projector)
+    torch_audio_features = torch_audio_features_3d[0]
+
+    # Run through PyTorch convs + positional + encoder
+    chunk_size = self.torch_config.n_window * 2
+    num_chunks = audio_length // chunk_size
+    chunk_lengths = torch.tensor([chunk_size] * num_chunks, dtype=torch.long)
+    chunk_list = torch_audio_features.T.split(chunk_lengths.tolist(), dim=0)
+    torch_padded_feature = torch.nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
+    torch_padded_feature = torch_padded_feature.unsqueeze(1)
+
+    torch_conv1 = F.gelu(torch_model.conv2d1(torch_padded_feature))
+    torch_conv2 = F.gelu(torch_model.conv2d2(torch_conv1))
+    torch_conv3 = F.gelu(torch_model.conv2d3(torch_conv2))
+
+    b, c, f, t = torch_conv3.size()
+    torch_conv_out = torch_model.conv_out(torch_conv3.permute(0, 3, 1, 2).contiguous().view(b, t, c * f))
+
+    torch_pos_emb = (
+        torch_model.positional_embedding.positional_embedding[: torch_conv_out.shape[1], :]
+        .unsqueeze(0)
+        .to(torch_conv_out.dtype)
+    )
+    torch_after_pos = torch_conv_out + torch_pos_emb
+
+    # Run through encoder layers + layernorm (but not projector)
+    # Process all chunks together
+    seq_len_per_chunk = torch_after_pos.shape[1]
+    cu_seqlens = torch.tensor([i * seq_len_per_chunk for i in range(num_chunks + 1)], dtype=torch.int32)
+    attention_mask = create_block_diagonal_attention_mask(cu_seqlens, torch_after_pos.dtype)
+
+    # Flatten: (num_chunks, seq_len_per_chunk, hidden) -> (num_chunks*seq_len_per_chunk, hidden)
+    hidden_state = torch_after_pos.reshape(-1, torch_after_pos.shape[-1])
+    for layer in torch_model.layers:
+      hidden_state = layer(hidden_state, cu_seqlens=cu_seqlens, attention_mask=attention_mask)[0]
+    hidden_state = torch_model.ln_post(hidden_state)
+
+    # Reshape back: (num_chunks*seq_len_per_chunk, hidden) -> (batch=1, num_chunks*seq_len_per_chunk, hidden)
+    torch_output = hidden_state.reshape(1, num_chunks * seq_len_per_chunk, -1)
+
+    # MaxText forward
+    jax_output = maxtext_encoder(jax_audio_features, deterministic=True)
+
+    assert_all_close_jax_torch(
+        jax_output,
+        torch_output,
+        rtol=1e-3,
+        atol=0.1,
+        error_msg="AudioEncoder outputs differ",
+    )
+
+
+class TestAudioModel(unittest.TestCase):
+  """Test full AudioModel end-to-end against PyTorch implementation."""
+
+  def setUp(self):
+    self.config = jax_audio_config
+    self.torch_config = torch_audio_encoder_config
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+    devices = jax.devices()
+    self.mesh = Mesh(np.array(devices[:1]), axis_names=("data",))
+
+  def test_audio_model_end_to_end(self):
+    """Test full AudioModel pipeline against PyTorch."""
+    torch_model = TorchQwen3OmniMoeAudioEncoder(self.torch_config)
+    torch_model.eval()
+
+    maxtext_model = Qwen3OmniAudioModel(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+    copy_audio_model(torch_model, maxtext_model, self.config)
+
+    batch_size = 1
+    num_mel_bins = self.config.num_mel_bins_for_audio
+    audio_length = 200  # With n_window=50, chunk_size=100, gives 2 chunks
+
+    jax_audio_features, torch_audio_features_3d = create_random_jax_torch(batch_size, num_mel_bins, audio_length)
+    audio_lengths_np = np.array([audio_length], dtype=np.int64)
+
+    torch_audio_features = torch_audio_features_3d[0]
+    torch_audio_lengths = torch.from_numpy(audio_lengths_np)
+
+    torch_output = torch_model(input_features=torch_audio_features, feature_lens=torch_audio_lengths)
+    torch_output_tensor = torch_output.last_hidden_state
+
+    jax_output = maxtext_model(
+        audio_features=jax_audio_features,
+        deterministic=True,
+    )
+
+    assert_all_close_jax_torch(
+        jax_output[0],
+        torch_output_tensor,
+        rtol=1e-3,
+        atol=0.02,
+        error_msg="AudioModel outputs differ",
+    )
+
+  def test_audio_model_intermediates(self):
+    """Debug intermediate outputs to verify each stage matches PyTorch."""
+    torch_model = TorchQwen3OmniMoeAudioEncoder(self.torch_config)
+    torch_model.eval()
+
+    maxtext_model = Qwen3OmniAudioModel(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+    copy_audio_model(torch_model, maxtext_model, self.config)
+
+    batch_size = 1
+    num_mel_bins = self.config.num_mel_bins_for_audio
+    audio_length = 100
+
+    jax_audio_features, torch_audio_features_3d = create_random_jax_torch(batch_size, num_mel_bins, audio_length)
+    torch_audio_features = torch_audio_features_3d[0]
+
+    # PyTorch forward
+    chunk_size = self.torch_config.n_window * 2
+    num_chunks = audio_length // chunk_size
+    chunk_lengths = torch.tensor([chunk_size] * num_chunks, dtype=torch.long)
+    chunk_list = torch_audio_features.T.split(chunk_lengths.tolist(), dim=0)
+    torch_padded_feature = torch.nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
+    torch_padded_feature = torch_padded_feature.unsqueeze(1)
+
+    torch_conv1 = F.gelu(torch_model.conv2d1(torch_padded_feature))
+    torch_conv2 = F.gelu(torch_model.conv2d2(torch_conv1))
+    torch_conv3 = F.gelu(torch_model.conv2d3(torch_conv2))
+
+    b, c, f, t = torch_conv3.size()
+    torch_conv_out = torch_model.conv_out(torch_conv3.permute(0, 3, 1, 2).contiguous().view(b, t, c * f))
+
+    torch_pos_emb = (
+        torch_model.positional_embedding.positional_embedding[: torch_conv_out.shape[1], :]
+        .unsqueeze(0)
+        .to(torch_conv_out.dtype)
+    )
+    torch_after_pos = torch_conv_out + torch_pos_emb
+
+    # JAX forward
+    jax_audio_chunks = jax_audio_features.reshape(batch_size, num_mel_bins, num_chunks, chunk_size)
+    jax_audio_chunks = jax_audio_chunks.transpose(0, 2, 1, 3).reshape(batch_size * num_chunks, num_mel_bins, chunk_size)
+    jax_hidden = jax_audio_chunks[:, :, :, jnp.newaxis]
+
+    jax_conv1 = jax.nn.gelu(maxtext_model.audio_encoder.conv2d1(jax_hidden))
+    jax_conv2 = jax.nn.gelu(maxtext_model.audio_encoder.conv2d2(jax_conv1))
+    jax_conv3 = jax.nn.gelu(maxtext_model.audio_encoder.conv2d3(jax_conv2))
+
+    bc, f_jax, t_jax, c_jax = jax_conv3.shape
+    jax_conv_out = maxtext_model.audio_encoder.conv_out(jax_conv3.transpose(0, 2, 3, 1).reshape(bc, t_jax, c_jax * f_jax))
+
+    seq_len_per_chunk = jax_conv_out.shape[1]
+    jax_pos_emb = maxtext_model.audio_encoder.positional_embedding(seq_len_per_chunk)
+    jax_pos_emb = jnp.broadcast_to(
+        jax_pos_emb[None, :, :], (batch_size * num_chunks, seq_len_per_chunk, self.config.d_model_for_audio)
+    )
+    jax_after_pos = jax_conv_out + jax_pos_emb
+
+    # Verify all stages match
+    assert_all_close_jax_torch(
+        jax_conv1[0], torch_conv1.permute(0, 2, 3, 1)[0], rtol=1e-4, atol=1e-3, error_msg="Conv1 differs"
+    )
+    assert_all_close_jax_torch(
+        jax_conv2[0], torch_conv2.permute(0, 2, 3, 1)[0], rtol=1e-4, atol=1e-3, error_msg="Conv2 differs"
+    )
+    assert_all_close_jax_torch(
+        jax_conv3[0], torch_conv3.permute(0, 2, 3, 1)[0], rtol=1e-4, atol=1e-3, error_msg="Conv3 differs"
+    )
+    assert_all_close_jax_torch(jax_conv_out[0], torch_conv_out[0], rtol=1e-4, atol=1e-3, error_msg="Conv out differs")
+    assert_all_close_jax_torch(
+        jax_after_pos[0], torch_after_pos[0], rtol=1e-4, atol=1e-3, error_msg="After pos emb differs"
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

- Add audio encoder support for qwen3
* classes such as `AudioEncoder` and `Qwen3OmniAudioEncoder`
* added the `use_audio` flag to the configuration.
* various audio specific flags

- added merging of audio tokens for qwen3
- added support in maxengine and maxtext_utils
- added support in decode.py

# Tests

tests/check_qwen3_omni_audio_vs_reference.py

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
