### PR TITLE
Remove unsafe_rbg from post training

### DIFF
--- a/docs/tutorials/grpo.md
+++ b/docs/tutorials/grpo.md
@@ -31,6 +31,8 @@ recommend creating the virtual environment outside the `maxtext` directory.
 
 ## vLLM and tpu-inference installations
 
+### From PyPI releases
+
 Next, run the following bash script to get all the necessary installations inside the virtual environment (for e.g., `maxtext_venv`).
 This will take few minutes. Follow along the installation logs and look out for any issues!
 
@@ -40,6 +42,9 @@ bash ~/maxtext/src/MaxText/examples/install_tunix_vllm_requirement.sh
 
 Primarily, it installs `vllm-tpu` which is [vllm](https://github.com/vllm-project/vllm) and [tpu-inference](https://github.com/vllm-project/tpu-inference) and thereby providing TPU inference for vLLM, with unified JAX and PyTorch support.
 
+### From Github
+
+You can also locally git clone [tunix](https://github.com/google/tunix) and install using the instructions [here](https://github.com/google/tunix?tab=readme-ov-file#installation). Similarly install [vllm](https://github.com/vllm-project/vllm) and [tpu-inference](https://github.com/vllm-project/tpu-inference) from source following the instructions [here](https://docs.vllm.ai/projects/tpu/en/latest/getting_started/installation/#install-from-source)
 
 ## Run GRPO
 

--- a/src/MaxText/rl/train_rl.py
+++ b/src/MaxText/rl/train_rl.py
@@ -460,12 +460,7 @@ def main(argv: Sequence[str]) -> None:
     argv: Command-line arguments.
   """
   pathwaysutils.initialize()
-  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
-  if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
-    os.environ["LIBTPU_INIT_ARGS"] = (
-        os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
-    )
 
   max_utils.print_system_information()
   trainer_config, sampler_config, trainer_devices, sampler_devices = setup_configs_and_devices(argv)

--- a/src/MaxText/sft/sft_trainer.py
+++ b/src/MaxText/sft/sft_trainer.py
@@ -184,12 +184,7 @@ def main(argv: Sequence[str]) -> None:
     argv: Command-line arguments.
   """
   pathwaysutils.initialize()
-  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
-  if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
-    os.environ["LIBTPU_INIT_ARGS"] = (
-        os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
-    )
 
   mt_config = pyconfig.initialize(argv)
   max_utils.print_system_information()


### PR DESCRIPTION
# Description

Remove unsafe rng from post training trainer scripts which is causing vllm to generate incorrectly.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/454124128

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Ran locally `train_rl.py` on v5p-8

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
