### PR TITLE
Update attention layer for Gemma3 ViT

### DIFF
--- a/src/MaxText/layers/gemma3.py
+++ b/src/MaxText/layers/gemma3.py
@@ -382,7 +382,7 @@ class MlpBlockViT(nnx.Module):
         matmul_precision=self.config.matmul_precision,
         rngs=self.rngs,
     )
-    self.Dropout_0 = nnx.Dropout(rate=self.config.dropout_rate)
+    self.Dropout_0 = Dropout(rate=self.config.dropout_rate, rngs=self.rngs)
     self.Dense_1 = DenseGeneral(
         in_features_shape=self.config.intermediate_size_for_vit,
         out_features_shape=self.config.hidden_size_for_vit,
@@ -452,12 +452,12 @@ class Encoder1DBlock(nnx.Module):
         config=self.config,
         rngs=self.rngs,
     )
-    self.Dropout_0 = nnx.Dropout(self.config.dropout_rate, rngs=self.rngs)
+    self.Dropout_0 = Dropout(rate=self.config.dropout_rate, rngs=self.rngs)
 
   def __call__(self, x: jax.Array, deterministic: bool = False) -> jax.Array:
     y = self.LayerNorm_0(x)
 
-    y = self.MultiHeadDotProductAttention_0(inputs_q=y, inputs_kv=y, deterministic=deterministic)
+    y, _ = self.MultiHeadDotProductAttention_0(inputs_q=y, inputs_kv=y, deterministic=deterministic)
     y = self.Dropout_0(y, deterministic=deterministic)
     x = x + y
 
@@ -634,7 +634,7 @@ class Gemma3VisionEncoderLayer(nnx.Module):
         width=self.config.hidden_size_for_vit,
         dtype=self.config.dtype_mm,
     )
-    self.Dropout_0 = nnx.Dropout(self.config.dropout_rate, rngs=self.rngs)
+    self.Dropout_0 = Dropout(rate=self.config.dropout_rate, rngs=self.rngs)
     self.Transformer = Encoder(
         config=self.config,
         mesh=self.mesh,


### PR DESCRIPTION
# Description

- Following https://github.com/AI-Hypercomputer/maxtext/pull/2616, the `attention` module now returns a tuple `out, kv_cache` instead of `out`. This PR updates the output of Gemma3 ViT attention layer.
- Update from `nnx.Dropout` to `linears.Dropout`.

# Tests

Tested by decode forward pass.
```
python -m MaxText.decode MaxText/configs/base.yml model_name=gemma3-4b tokenizer_type=huggingface tokenizer_path=google/gemma-3-4b-it load_parameters_path=gs://maxtext-gemma/unified/gemma3/4b/unscanned/2025-08-09-01-17/0/items per_device_batch_size=1 run_name=ht_test max_prefill_predict_length=272 max_target_length=372 steps=1 async_checkpointing=false scan_layers=false use_multimodal=true prompt=\'Describe\ image\ \<start_of_image\>\' image_path=\'/home/hengtaoguo_google_com/projects/maxtext/src/MaxText/test_assets/test_image.jpg\' attention=\'dot_product\' hf_access_token=xxx
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
