### PR TITLE
Remove size one spec axis for MaxText sharding

### DIFF
--- a/src/MaxText/inference/paged_attention.py
+++ b/src/MaxText/inference/paged_attention.py
@@ -30,6 +30,7 @@ from flax import nnx
 
 from MaxText.inference import page_manager
 from MaxText.inference import paged_attention_kernel_v2
+from MaxText.sharding import logical_to_mesh_axes
 from MaxText.common_types import Array, DType, AxisNames, BATCH, LENGTH, HEAD, D_KV, MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
 from MaxText.layers.initializers import variable_to_logically_partitioned
 
@@ -322,8 +323,8 @@ class PagedAttentionOp(nnx.Module):
       page_state: page_manager.PageState,
   ) -> Array:
     """Apply Paged Attention v1 in decode only."""
-    kv_pages_pspec = nn.logical_to_mesh_axes(("paged_kv_heads", None, None, None))
-    q_pspec = nn.logical_to_mesh_axes((None, None, "paged_kv_heads", None))
+    kv_pages_pspec = logical_to_mesh_axes(("paged_kv_heads", None, None, None), self.mesh)
+    q_pspec = logical_to_mesh_axes((None, None, "paged_kv_heads", None), self.mesh)
 
     @functools.partial(
         jax.shard_map,

--- a/src/MaxText/layers/attention_mla.py
+++ b/src/MaxText/layers/attention_mla.py
@@ -21,7 +21,6 @@ from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh, NamedSharding
 import jax.numpy as jnp
 
-from flax import linen as nn
 from flax import nnx
 
 from MaxText.common_types import (
@@ -56,6 +55,7 @@ from MaxText.inference import kvcache
 from MaxText.inference import page_manager
 from MaxText.inference import paged_attention
 from MaxText.inference.kvcache import KVQuant
+from MaxText.sharding import create_sharding
 from MaxText.layers import nnx_wrappers
 from MaxText.layers.attentions import Attention
 from MaxText.layers.initializers import nd_dense_init, NdInitializer, variable_to_logically_partitioned
@@ -515,8 +515,8 @@ class MLA(Attention):
     else:
       query_logical_name = self.query_axis_names
       wqa_logical_name = (KV_BATCH, LENGTH_NO_EXP, Q_LORA_UP_PROJ)
-    query_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(query_logical_name))
-    wqa_out_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(wqa_logical_name))
+    query_sharding = create_sharding(self.mesh, query_logical_name)
+    wqa_out_sharding = create_sharding(self.mesh, wqa_logical_name)
     # Set softmax scaling.
     self.qk_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
     self.softmax_scale = self.qk_head_dim**-0.5
@@ -555,7 +555,7 @@ class MLA(Attention):
       key_logical_name = self.key_axis_names
       value_logical_name = self.value_axis_names
 
-    wkva_out_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(key_logical_name))
+    wkva_out_sharding = create_sharding(self.mesh, key_logical_name)
     kv_out = self.wkv_b(low_rank_main, out_sharding=wkva_out_sharding)
 
     # Split kv_out into key_nope and value parts.
@@ -664,7 +664,7 @@ class MLA(Attention):
       wka_logical_name = (KV_BATCH_NO_EXP, LENGTH, KV_LORA_UP_PROJ)
     else:
       wka_logical_name = (KV_BATCH, LENGTH_NO_EXP, KV_LORA_UP_PROJ)
-    wkva_out_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(wka_logical_name))
+    wkva_out_sharding = create_sharding(self.mesh, wka_logical_name)
     low_rank = self.wkv_a(inputs, out_sharding=wkva_out_sharding)
     low_rank_main, low_rank_rope = jnp.split(low_rank, [self.kv_lora_rank], axis=-1)
     low_rank_main = self.kv_norm(low_rank_main)
@@ -759,7 +759,7 @@ class MLA(Attention):
     else:
       out = self._maybe_shard_with_logical(out, self.out_axis_names)
 
-    out_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(out_logical_name))
+    out_sharding = create_sharding(self.mesh, out_logical_name)
     out = self.out_projection(out, out_sharding=out_sharding)
     out = checkpoint_name(out, "out_proj")
     return out, kv_cache

--- a/src/MaxText/layers/attentions.py
+++ b/src/MaxText/layers/attentions.py
@@ -23,7 +23,7 @@ from jax.sharding import Mesh, NamedSharding
 import jax
 import jax.numpy as jnp
 
-from flax import nnx, linen as nn
+from flax import nnx
 
 from MaxText.common_types import (
     DecoderBlockType,
@@ -53,7 +53,7 @@ from MaxText.common_types import (
     EP_AS_CONTEXT,
     AttentionType,
 )
-from MaxText.sharding import maybe_shard_with_logical
+from MaxText.sharding import maybe_shard_with_logical, create_sharding
 from MaxText.inference import kvcache
 from MaxText.inference import page_manager
 from MaxText.inference import paged_attention
@@ -1003,7 +1003,7 @@ class Attention(nnx.Module):
 
     inputs_q = self._maybe_shard_with_logical(inputs_q, input_axis_names)
     inputs_kv = self._maybe_shard_with_logical(inputs_kv, input_axis_names)
-    qkv_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(input_axis_names))
+    qkv_sharding = create_sharding(self.mesh, input_axis_names)
 
     # apply projection.
     if self.config.fused_qkv:

--- a/src/MaxText/layers/deepseek.py
+++ b/src/MaxText/layers/deepseek.py
@@ -19,7 +19,7 @@
 from functools import partial
 
 from jax.ad_checkpoint import checkpoint_name
-from jax.sharding import Mesh, NamedSharding
+from jax.sharding import Mesh
 import jax.numpy as jnp
 
 from flax import linen as nn
@@ -32,7 +32,7 @@ from MaxText.layers.normalizations import rms_norm
 from MaxText.layers import moe
 from MaxText.layers import quantizations
 from MaxText.layers.quantizations import AqtQuantization as Quant
-from MaxText.sharding import maybe_shard_with_logical
+from MaxText.sharding import maybe_shard_with_logical, create_sharding
 from MaxText.inference import page_manager
 from MaxText.common_types import MODEL_MODE_PREFILL
 
@@ -75,7 +75,7 @@ def self_attention_with_norm(
       mesh=mesh,
       shard_mode=cfg.shard_mode,
   )
-  lnx_sharding = NamedSharding(mesh, nn.logical_to_mesh_axes(logical_axis_names))
+  lnx_sharding = create_sharding(mesh, logical_axis_names)
   lnx = _maybe_shard_with_logical(lnx, logical_axis_names)
 
   attention_layer = attention_mla.mla_as_linen(
@@ -189,8 +189,8 @@ class DeepSeekDenseLayer(nn.Module):
       inputs = inputs[0]
 
     _maybe_shard_with_logical = partial(maybe_shard_with_logical, mesh=self.mesh, shard_mode=self.config.shard_mode)
-    lnx_out_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(logical_axis_names))
-    mlp_intermediate_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(mlp_logical_axis_names))
+    lnx_out_sharding = create_sharding(self.mesh, logical_axis_names)
+    mlp_intermediate_sharding = create_sharding(self.mesh, mlp_logical_axis_names)
     inputs = _maybe_shard_with_logical(inputs, logical_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 
@@ -273,8 +273,8 @@ class DeepSeekMoELayer(nn.Module):
       inputs = inputs[0]
 
     _maybe_shard_with_logical = partial(maybe_shard_with_logical, mesh=self.mesh, shard_mode=self.config.shard_mode)
-    lnx_out_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(logical_axis_names))
-    lnx_intermediate_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(mlp_logical_axis_names))
+    lnx_out_sharding = create_sharding(self.mesh, logical_axis_names)
+    lnx_intermediate_sharding = create_sharding(self.mesh, mlp_logical_axis_names)
     inputs = _maybe_shard_with_logical(inputs, logical_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 

--- a/src/MaxText/layers/moe.py
+++ b/src/MaxText/layers/moe.py
@@ -23,7 +23,6 @@ from typing import Iterable, Optional, Tuple, Union
 
 from aqt.jax.v2 import aqt_tensor as aqt
 from flax import nnx
-import flax.linen as nn
 import jax
 from jax import ad_checkpoint as adc
 from jax.experimental import xla_metadata
@@ -33,8 +32,9 @@ from MaxText import common_types as ctypes
 from MaxText import max_logging
 from MaxText import max_utils
 from MaxText.common_types import ShardMode
-from MaxText.sharding import maybe_shard_with_logical
+from MaxText.sharding import maybe_shard_with_logical, create_sharding
 from MaxText.kernels import megablox as mblx
+from MaxText.sharding import logical_to_mesh_axes
 from MaxText.layers import attentions, linears, nnx_wrappers, quantizations
 from MaxText.layers.initializers import NdInitializer, default_bias_init, nd_dense_init, variable_to_logically_partitioned
 import numpy as np
@@ -246,7 +246,7 @@ class GateLogit(nnx.Module):
 
     contract_ind = tuple(range(0, len(norm_axis)))
     output_sharding = (
-        NamedSharding(self.mesh, nn.logical_to_mesh_axes(("activation_batch_no_exp", "activation_length_no_exp", None)))
+        create_sharding(self.mesh, ("activation_batch_no_exp", "activation_length_no_exp", None))
         if self.shard_mode == ShardMode.EXPLICIT
         else None
     )
@@ -417,6 +417,9 @@ class RoutedMoE(nnx.Module):
 
   def _maybe_shard_with_logical(self, inputs, logical_name):
     return maybe_shard_with_logical(inputs, logical_name, mesh=self.mesh, shard_mode=self.config.shard_mode)
+
+  def _logical_to_mesh_axes(self, logical_name):
+    return logical_to_mesh_axes(logical_name, mesh=self.mesh, rules=self.config.logical_axis_rules)
 
   def get_expert_parallelism_size(self):
     return self.mesh.shape.get("expert", 1)
@@ -941,19 +944,21 @@ class RoutedMoE(nnx.Module):
       batch_logical_axis = "activation_batch_no_exp"
 
     if self.get_tensor_transpose_parallelism_size() > 1:
-      input_partition_pspec = nn.logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", "activation_embed"))
-      w0_bias_pspec = nn.logical_to_mesh_axes(("exp", None))
-      w1_bias_pspec = nn.logical_to_mesh_axes(("exp", None))
-      wo_bias_pspec = nn.logical_to_mesh_axes(("exp", "activation_embed"))
+      input_partition_pspec = self._logical_to_mesh_axes(
+          (batch_logical_axis, "activation_norm_length", "activation_embed")
+      )
+      w0_bias_pspec = self._logical_to_mesh_axes(("exp", None))
+      w1_bias_pspec = self._logical_to_mesh_axes(("exp", None))
+      wo_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_embed"))
     else:
-      input_partition_pspec = nn.logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
-      w0_bias_pspec = nn.logical_to_mesh_axes(("exp", "activation_mlp"))
-      w1_bias_pspec = nn.logical_to_mesh_axes(("exp", "activation_mlp"))
-      wo_bias_pspec = nn.logical_to_mesh_axes(("exp", "activation_embed"))
+      input_partition_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
+      w0_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_mlp"))
+      w1_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_mlp"))
+      wo_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_embed"))
 
-    gate_logits_pspec = nn.logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
+    gate_logits_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
     if self.config.model_name.startswith("deepseek3"):
-      pre_bias_logits_pspec = nn.logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
+      pre_bias_logits_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
     else:
       # pre_bias_logits is None for non-DeepSeek v3 models
       pre_bias_logits_pspec = None
@@ -965,19 +970,19 @@ class RoutedMoE(nnx.Module):
       quantization_rule = qpl.get_current_rule("gmm")
       if quantization_rule and quantization_rule.weight_calibration_method.startswith("fixed"):
         # special sharding when using static scaling for weights in quantization with fsdp_shard_on_exp
-        w0_pspec = nn.logical_to_mesh_axes(self.wi_kernel_axes)
-        w1_pspec = nn.logical_to_mesh_axes(self.wi_kernel_axes)
-        wo_pspec = nn.logical_to_mesh_axes(self.wo_kernel_axes)
+        w0_pspec = self._logical_to_mesh_axes(self.wi_kernel_axes)
+        w1_pspec = self._logical_to_mesh_axes(self.wi_kernel_axes)
+        wo_pspec = self._logical_to_mesh_axes(self.wo_kernel_axes)
         weight_gather = True
       else:
         # special sharding for dsv3 to remove overhead between gmm/AG
-        w0_pspec = nn.logical_to_mesh_axes(("embed_tensor_transpose", None, "mlp_no_fsdp"))
-        w1_pspec = nn.logical_to_mesh_axes(("embed_tensor_transpose", None, "mlp_no_fsdp"))
-        wo_pspec = nn.logical_to_mesh_axes(("embed_tensor_transpose", "mlp_no_fsdp", None))
+        w0_pspec = self._logical_to_mesh_axes(("embed_tensor_transpose", None, "mlp_no_fsdp"))
+        w1_pspec = self._logical_to_mesh_axes(("embed_tensor_transpose", None, "mlp_no_fsdp"))
+        wo_pspec = self._logical_to_mesh_axes(("embed_tensor_transpose", "mlp_no_fsdp", None))
     else:
-      w0_pspec = nn.logical_to_mesh_axes(("exp", "embed_tensor_transpose", "mlp_no_fsdp"))
-      w1_pspec = nn.logical_to_mesh_axes(("exp", "embed_tensor_transpose", "mlp_no_fsdp"))
-      wo_pspec = nn.logical_to_mesh_axes(("exp", "mlp_no_fsdp", "embed_tensor_transpose"))
+      w0_pspec = self._logical_to_mesh_axes(("exp", "embed_tensor_transpose", "mlp_no_fsdp"))
+      w1_pspec = self._logical_to_mesh_axes(("exp", "embed_tensor_transpose", "mlp_no_fsdp"))
+      wo_pspec = self._logical_to_mesh_axes(("exp", "mlp_no_fsdp", "embed_tensor_transpose"))
     if isinstance(w0_kernel, aqt.QTensor):
       w0_pspec = aqt.partition_spec(w0_pspec, (1,), w0_kernel.dtype, use_bias=False)
     if isinstance(w1_kernel, aqt.QTensor):
@@ -1000,7 +1005,7 @@ class RoutedMoE(nnx.Module):
             wo_bias_pspec,
             None,
         ),
-        out_specs=(nn.logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", "activation_embed"))),
+        out_specs=(self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", "activation_embed"))),
         check_vma=False,
     )
     def wrapper(x, logits, pre_bias_logits, w0, w1, wo, w0_bias, w1_bias, wo_bias, rngs):
@@ -1305,10 +1310,7 @@ class RoutedMoE(nnx.Module):
         indices,
     )
     weight_sharding = (
-        NamedSharding(
-            self.mesh,
-            nn.logical_to_mesh_axes(("activation_batch_no_exp", "activation_length_no_exp", None)),
-        )
+        create_sharding(self.mesh, ("activation_batch_no_exp", "activation_length_no_exp", None))
         if self.config.shard_mode == ShardMode.EXPLICIT
         else None
     )

--- a/src/MaxText/sharding.py
+++ b/src/MaxText/sharding.py
@@ -30,7 +30,7 @@ from MaxText.common_types import ShardMode
 
 def get_input_data_sharding(config, mesh):
   """Get the input data sharding for the model"""
-  return nn.logical_to_mesh_sharding(P(*config.input_data_sharding_logical_axes), mesh, config.logical_axis_rules)
+  return create_sharding(mesh, config.input_data_sharding_logical_axes, rules=config.logical_axis_rules)
 
 
 def maybe_shard_with_name(inputs, named_sharding, shard_mode):
@@ -46,14 +46,46 @@ def maybe_shard_with_name(inputs, named_sharding, shard_mode):
     return jax.lax.with_sharding_constraint(inputs, named_sharding)
 
 
-def maybe_shard_with_logical(inputs, logical_axes, mesh, shard_mode):
+def maybe_shard_with_logical(inputs, logical_axes, mesh, shard_mode, rules=None):
   """
   A wrapper of maybe_shard_with_name when logical axes are inputs
   """
   if inputs is None:
     return None
-  named_sharding = NamedSharding(mesh, nn.logical_to_mesh_axes(logical_axes))
+  named_sharding = create_sharding(mesh, logical_axes, rules=rules)
   return maybe_shard_with_name(inputs, named_sharding, shard_mode)
+
+
+def remove_size_one_mesh_axis(spec, mesh):
+  """
+  Removes mesh axes from a PartitionSpec (P) where the axis size is 1.
+
+  This is a common optimization to simplify sharding by excluding redundant axes.
+  Function originally from jax._src.core:
+  https://github.com/jax-ml/jax/blob/main/jax/_src/core.py
+  """
+  if spec is None:
+    return None
+  new_spec = []  # type: ignore
+  for s in spec:
+    if s is None:
+      new_spec.append(s)  # type: ignore
+    elif isinstance(s, tuple):
+      new_spec.append(tuple(i for i in s if mesh.shape[i] != 1))
+    else:
+      new_spec.append(None if mesh.shape[s] == 1 else s)  # type: ignore
+  return P(*new_spec, unreduced=spec.unreduced, reduced=spec.reduced)
+
+
+def logical_to_mesh_axes(logical_names, mesh, rules=None):
+  """Remove size one mesh axes given logical names."""
+  tensor_spec = nn.logical_to_mesh_axes(logical_names, rules=rules)
+  return remove_size_one_mesh_axis(tensor_spec, mesh)
+
+
+def create_sharding(mesh, logical_names, rules=None):
+  """Create NamedSharding with given logical names."""
+  return NamedSharding(mesh, logical_to_mesh_axes(logical_names, mesh, rules=rules))
 
 
 def get_mesh_axes_used_by_tensor_spec(tensor_sharding_spec):

--- a/src/MaxText/vocabulary_tiling.py
+++ b/src/MaxText/vocabulary_tiling.py
@@ -21,7 +21,11 @@ from flax import linen as nn
 import jax
 import jax.numpy as jnp
 from MaxText import max_utils
-from MaxText.sharding import maybe_shard_with_name, all_gather_over_fsdp
+from MaxText.sharding import (
+    maybe_shard_with_name,
+    all_gather_over_fsdp,
+    create_sharding,
+)
 from MaxText.common_types import ShardMode
 
 
@@ -55,27 +59,33 @@ def vocab_tiling_linen_loss(
   deterministic = not config.enable_dropout if is_train else True
 
   param_spec = nn.get_partition_spec(params)
-  hidden_spec = jax.sharding.NamedSharding(
+  hidden_spec = create_sharding(
       model.mesh,
-      nn.logical_to_mesh_axes(("activation_embed_and_logits_batch", "activation_length_no_exp", "activation_embed")),
+      ("activation_embed_and_logits_batch", "activation_length_no_exp", "activation_embed"),
   )
-  label_spec = jax.sharding.NamedSharding(
-      model.mesh, nn.logical_to_mesh_axes(("activation_embed_and_logits_batch", "activation_length_no_exp"))
+  label_spec = create_sharding(
+      model.mesh,
+      ("activation_embed_and_logits_batch", "activation_length_no_exp"),
   )
-  reshaped_hidden_spec = jax.sharding.NamedSharding(
-      model.mesh, nn.logical_to_mesh_axes(("num_tile", "activation_embed_and_logits_batch_sequence", "activation_embed"))
+  reshaped_hidden_spec = create_sharding(
+      model.mesh,
+      ("num_tile", "activation_embed_and_logits_batch_sequence", "activation_embed"),
   )
-  reshaped_data_spec = jax.sharding.NamedSharding(
-      model.mesh, nn.logical_to_mesh_axes(("num_tile", "activation_embed_and_logits_batch_sequence"))
+  reshaped_data_spec = create_sharding(
+      model.mesh,
+      ("num_tile", "activation_embed_and_logits_batch_sequence"),
   )
-  chunked_hidden_spec = jax.sharding.NamedSharding(
-      model.mesh, nn.logical_to_mesh_axes(("activation_embed_and_logits_batch_sequence", "activation_embed"))
+  chunked_hidden_spec = create_sharding(
+      model.mesh,
+      ("activation_embed_and_logits_batch_sequence", "activation_embed"),
   )
-  chunked_data_spec = jax.sharding.NamedSharding(
-      model.mesh, nn.logical_to_mesh_axes(("activation_embed_and_logits_batch_sequence",))
+  chunked_data_spec = create_sharding(
+      model.mesh,
+      ("activation_embed_and_logits_batch_sequence",),
   )
-  chunked_logits_spec = jax.sharding.NamedSharding(
-      model.mesh, nn.logical_to_mesh_axes(("activation_embed_and_logits_batch_sequence", "activation_vocab"))
+  chunked_logits_spec = create_sharding(
+      model.mesh,
+      ("activation_embed_and_logits_batch_sequence", "activation_vocab"),
   )
 
   _maybe_shard_with_name = functools.partial(maybe_shard_with_name, shard_mode=config.shard_mode)


### PR DESCRIPTION
### Description

This PR addresses issues related to redundant partition axes of size one in sharding specifications. These redundant axes can be misleading, complicate debugging, and have caused confusion with `jax.lax.pvary`. They also prevent the use of `check_vma=True` in `jax.shard_map`.

For example, if we only use FSDP (`ici_fsdp_parallelism=-1`), the sharding specification for an activation tensor would be:

**Before this PR:**
```python
> flax.linen.logical_to_mesh_axes(("activation_batch", "activation_length", "activation_embed"), rules)
> P(('data', 'fsdp', 'fsdp_transpose', 'expert'), ('sequence', 'context', 'expert'), ('tensor', 'tensor_transpose'))
```

**After this PR:**
```python
> MaxText.sharding.logical_to_mesh_axes(("activation_batch", "activation_length", "activation_embed"), mesh, rules)
> P("fsdp", None, None)
```

To solve this, this PR introduces two new utility functions in `MaxText.sharding`:
1. `logical_to_mesh_axes`: This function is a wrapper around `linen.logical_to_mesh_axes` that also removes mesh axes of size one from the resulting PartitionSpec. This simplifies the sharding specification and avoids potential issues with JAX APIs.
2. `create_sharding`: This function simplifies the creation of `NamedSharding` objects by combining the mesh and logical axis names into a single call.

The PR then refactors the existing codebase to use these new utility functions, replacing direct calls to `linen.logical_to_mesh_axes` and manual creation of `NamedSharding` objects.

# Tests

This PR includes targeted testing to validate the fix for the TP issue with MoE models in b/460216386 and b/458796896. The following tests confirm that the sharding strategy now works correctly with `ici_tensor_parallelism=2`.

| Model | Test Command | Log |
| :--- | :--- | :--- |
| **Deepseek3-test** | `smoke_train model_name=deepseek3-test per_device_batch_size=1 shard_mode=auto ici_tensor_parallelism=2 use_tokamax_gmm=true` | [View Log](https://paste.googleplex.com/5716110378926080) |
| **GPT-OSS-20b** (single layer) | `smoke_train model_name=gpt-oss-20b per_device_batch_size=1 shard_mode=auto ici_tensor_parallelism=2 use_tokamax_gmm=true` | [View Log](https://paste.googleplex.com/5275592662581248) |

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
