### PR TITLE
Fixes for CI breakage

### DIFF
--- a/tools/setup/setup.sh
+++ b/tools/setup/setup.sh
@@ -268,7 +268,7 @@ elif [[ $MODE == "nightly" ]]; then
         fi
         # Install Transformer Engine
         export NVTE_FRAMEWORK=jax
-        python3 -m uv pip install https://github.com/NVIDIA/TransformerEngine/archive/9d031f.zip
+        python3 -m uv pip install 'transformer-engine[jax]'
     elif [[ $DEVICE == "tpu" ]]; then
         echo "Installing nightly tensorboard plugin profile"
         python3 -m uv pip install tbp-nightly --upgrade


### PR DESCRIPTION
# Description

First attempt: see if transformer-engine is the issue. Attempt to upgrade it from the June version to the two-week old version.

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
