### PR TITLE
Set check_vma true for moe sparse matmul

### DIFF
--- a/src/MaxText/gradient_accumulation.py
+++ b/src/MaxText/gradient_accumulation.py
@@ -68,7 +68,7 @@ def gradient_accumulation_loss_and_grad(
     return maybe_shard_with_name(inputs, sharding_names, config.shard_mode, debug_sharding=config.debug_sharding)
 
   # For more efficient DP/ZeRO-1 + GA
-  if config.shard_mode == ShardMode.EXPLICIT and config.ici_data_parallelism > 1:
+  if config.shard_mode == ShardMode.EXPLICIT and model.mesh.shape.get("data", 1) > 1:
     ga_params_shardings = jax.tree.map(update_sharding_for_reduced, params_shardings)
     grad_shardings = jax.tree.map(update_sharding_for_unreduced, params_shardings)
   else:

--- a/src/MaxText/layers/deepseek.py
+++ b/src/MaxText/layers/deepseek.py
@@ -135,7 +135,7 @@ class DeepSeekGenericLayer(nnx.Module):
   def with_logical_constraint(self, x):
     return maybe_shard_with_logical(
         x,
-        logical_axes=self.logical_axis_names,
+        logical_axes=tuple(self.logical_axis_names),
         mesh=self.mesh,
         shard_mode=self.config.shard_mode,
         debug_sharding=self.config.debug_sharding,

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -900,7 +900,7 @@ xprof_e2e_enable_fw_throttle_event: False
 xprof_e2e_enable_fw_power_level_event: False
 xprof_e2e_enable_fw_thermal_event: False
 
-log_config: True # Prints the config (after defaults have been set by pyconfig logic)
+log_config: False # Prints the config (after defaults have been set by pyconfig logic)
 debug_sharding: False # Prints model weights sharding info
 
 # Checkpoint Structured logging

--- a/src/maxtext/kernels/megablox/backend.py
+++ b/src/maxtext/kernels/megablox/backend.py
@@ -298,6 +298,7 @@ LutFn = Callable[[int, int, int], Optional[tuple[int, int, int]]]
         "tiling",
         "transpose_rhs",
         "interpret",
+        "vma_axes",
     ],
 )
 def gmm(
@@ -310,6 +311,7 @@ def gmm(
     existing_out: jnp.ndarray | None = None,
     transpose_rhs: bool = False,
     interpret: bool = False,
+    vma_axes: tuple = tuple(),
 ) -> jnp.ndarray:
   """Compute lhs[sizes[i-1]:sizes[i], :] @ rhs for each group 'i'.
 
@@ -522,7 +524,7 @@ def gmm(
   }
   call_gmm = qpl.pallas_call(
       kernel,
-      out_shape=jax.ShapeDtypeStruct((m, n), preferred_element_type),
+      out_shape=jax.ShapeDtypeStruct((m, n), preferred_element_type, vma=set(vma_axes)),
       grid_spec=pltpu.PrefetchScalarGridSpec(
           num_scalar_prefetch=2,
           in_specs=[
@@ -565,6 +567,7 @@ def gmm(
         "tiling",
         "num_actual_groups",
         "interpret",
+        "vma_axes",
     ],
 )
 def tgmm(
@@ -577,6 +580,7 @@ def tgmm(
     num_actual_groups: int | None = None,
     existing_out: jnp.ndarray | None = None,
     interpret: bool = False,
+    vma_axes: tuple = tuple(),
 ) -> jnp.ndarray:
   """Compute lhs[:, sizes[i-1]:sizes[i]] @ rhs[sizes[i-1]:sizes[i], :].
 
@@ -775,7 +779,7 @@ def tgmm(
   }
   call_gmm = qpl.pallas_call(
       kernel,
-      out_shape=jax.ShapeDtypeStruct((num_actual_groups, k, n), preferred_element_type),
+      out_shape=jax.ShapeDtypeStruct((num_actual_groups, k, n), preferred_element_type, vma=set()),
       grid_spec=pltpu.PrefetchScalarGridSpec(
           num_scalar_prefetch=2,
           in_specs=[


### PR DESCRIPTION
# Description

This PR enables `check_vma=True` for the sparse_matmul shard_map, and remove some unnecessaary `psum`, which are backward transpose of `jax.lax.pvary`, see [jax doc](https://docs.jax.dev/en/latest/notebooks/shard_map.html#tracking-how-values-vary-over-manual-mesh-axes-and-check-vma-true).

This PR currently only supports pure FSDP + megablox kernel.

**Following tests are outdated.**
# Performance Improvements

## Test Case 1: Deepseek-test(small) + ZeRO1 + GA

-   **Metric:** Step Time
-   **Result:** Reduced from 1457ms to 1435ms.
-   **MFU Increase:** ~1.5%
-   **Profiles:**
    -   Before: [xprof](https://xprof.corp.google.com/trace_viewer/chengnuojin-18312303074822168464)
    -   After: [xprof](https://xprof.corp.google.com/trace_viewer/chengnuojin-10810411337773861470)

## Test Case 2: Deepseek3-test Model

-   **Metric:** Step Time
-   **Result:** Reduced from 2238ms to 2091ms.
-   **MFU Increase:** ~7%
-   **Profiles:**
    -   Before: [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-17146079934836311003) ([Screenshot](https://screenshot.googleplex.com/6iZjTTGGSTQqB43))
    -   After: [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-6629947290290786597) ([Screenshot](https://screenshot.googleplex.com/BvDegPPbUXFBefr))

## Test Case 3: Deepseek2-16b on v5p-32 Cluster

-   **Metric:** Step Time
-   **Result:** Reduced from 17045ms to 16808ms.
-   **Improvement:** ~1.41% reduction in step time.
-   **Details:**
    -   **Before:**
        -   [Command](https://paste.googleplex.com/5596131901964288)
        -   [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-1991790803143815425)
        -   [Log](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22chengnuojin-v5p-32%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fjobset_sigs_k8s_io%2Fjobset-name%3D%22chengnuojin-ds-test-7284%22%20severity%3E%3DDEFAULT;storageScope=project;cursorTimestamp=2025-11-25T01:14:01.341851828Z?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)
    -   **After:**
        -   [Command](https://paste.googleplex.com/5968974305165312)
        -   [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-17266140903991301648)
        -   [Log](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22chengnuojin-v5p-32%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fjobset_sigs_k8s_io%2Fjobset-name%3D%22chengnuojin-ds-test-19123%22%20severity%3E%3DDEFAULT;storageScope=project;cursorTimestamp=2025-11-25T01:06:11.057727613Z;duration=PT15M?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)


## Test Case 4: Deepseek3-671b on tpu7x-512

-   **Metric:** MFU
-   **Improvement:** ~17% improvement
-   **Details:**
    -   **Before:**
        -   [Command](https://paste.googleplex.com/6232936603058176)
        -  [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-9798723056134418605)
        -   [Log](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22bodaborg-tpu7x-512%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22ncheng-ds671b-test-251125-0448-slice-job-0-0-%22%20severity%3E%3DDEFAULT;storageScope=project;cursorTimestamp=2025-11-25T04:51:56.605987296Z;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)
    -   **After:**
        -   [Command](https://paste.googleplex.com/5513656517394432)
        -  [xprof](http://xprof.corp.google.com/trace_viewer/chengnuojin-14107488120419685899)
        -   [Log](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22bodaborg-tpu7x-512%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22ncheng-ds671b-test-251125-0452-slice-job-0-0-%22%20severity%3E%3DDEFAULT;storageScope=project;cursorTimestamp=2025-11-25T05:35:28.162069104Z;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
