### PR TITLE
Update buffer size for EP sharding

### DIFF
--- a/src/MaxText/layers/moe.py
+++ b/src/MaxText/layers/moe.py
@@ -1036,12 +1036,7 @@ class RoutedMoE(nnx.Module):
             # This would result in num_expert_shards * input_size * experts_per_shard assignments. However, if
             # experts_per_shard > num_experts_per_tok we cannot assign more than num_experts_per_tok to all of the inputs.
             max_local_experts_per_tok = min(local_expert_size, self.config.num_experts_per_tok)
-            buffer_size = int(
-                num_expert_parallelism
-                * self.config.per_device_batch_size
-                * self.config.max_target_length
-                * max_local_experts_per_tok
-            )
+            buffer_size = int(num_expert_parallelism * batch_size * sequence_length * max_local_experts_per_tok)
             output_shape = jnp.zeros((buffer_size, self.config.emb_dim), dtype=x.dtype)
 
             x = jax.lax.ragged_all_to_all(

--- a/tests/moe_test.py
+++ b/tests/moe_test.py
@@ -653,6 +653,69 @@ class RoutedMoeTest(unittest.TestCase):
       actual_output, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
       self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
 
+  @pytest.mark.tpu_only
+  def test_megablox_expert_context_parallelism(self):
+    cfg = pyconfig.initialize(
+        [None, os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")],
+        run_name="moe_block_megablox_ep_cp_test",
+        enable_checkpointing=False,
+        model_name="mixtral-8x7b",
+        dtype="bfloat16",
+        megablox=True,
+        sparse_matmul=True,
+        per_device_batch_size=4,
+        ici_context_parallelism=2,
+        ici_expert_parallelism=2,
+        packing=False,
+    )
+
+    rng = jax.random.PRNGKey(2345)
+    rng_model, rng_hidden_states = jax.random.split(rng)
+    device_count = jax.device_count()
+    hidden_states = jax.random.uniform(
+        rng_hidden_states,
+        (int(cfg.per_device_batch_size) * device_count, cfg.max_target_length, cfg.base_emb_dim),
+        dtype=cfg.dtype,
+    )
+
+    devices_array = maxtext_utils.create_device_mesh(cfg)
+    mesh = Mesh(devices_array, cfg.mesh_axes)
+    with nn_partitioning.axis_rules(cfg.logical_axis_rules):
+      variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
+      actual_output, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
+      self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
+
+  @pytest.mark.tpu_only
+  def test_megablox_expert_tensor_parallelism(self):
+    cfg = pyconfig.initialize(
+        [None, os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")],
+        run_name="moe_block_megablox_ep_tp_test",
+        enable_checkpointing=False,
+        model_name="mixtral-8x7b",
+        dtype="bfloat16",
+        megablox=True,
+        sparse_matmul=True,
+        per_device_batch_size=4,
+        ici_tensor_parallelism=2,
+        ici_expert_parallelism=2,
+    )
+
+    rng = jax.random.PRNGKey(2345)
+    rng_model, rng_hidden_states = jax.random.split(rng)
+    device_count = jax.device_count()
+    hidden_states = jax.random.uniform(
+        rng_hidden_states,
+        (int(cfg.per_device_batch_size) * device_count, cfg.max_target_length, cfg.base_emb_dim),
+        dtype=cfg.dtype,
+    )
+
+    devices_array = maxtext_utils.create_device_mesh(cfg)
+    mesh = Mesh(devices_array, cfg.mesh_axes)
+    with nn_partitioning.axis_rules(cfg.logical_axis_rules):
+      variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
+      actual_output, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
+      self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
+
   def test_random_routing(self):
     bs, seq_len, num_experts, num_experts_per_tok = 12, 1024, 8, 2
     rng = jax.random.PRNGKey(0)


### PR DESCRIPTION
# Description

Update buffer size for EP sharding with other sharding combinations, b/454714787


# Tests

* Added unit tests
* Also testsed locally

```
# per_device_batch_size=4  max_target_length=1024

====
EP=4 before:

(Pdb) buffer_size
32768
(Pdb) num_expert_parallelism
4
(Pdb) self.config.per_device_batch_size
4
(Pdb) self.config.max_target_length
1024
(Pdb) max_local_experts_per_tok
2

EP=4 after:

(Pdb) buffer_size
32768
(Pdb) batch_size
4
(Pdb) sequence_length
1024
(Pdb) max_local_experts_per_tok
2
(Pdb) num_expert_parallelism
4

=====
EP=2 TP=2 before:

(Pdb) buffer_size
16384
(Pdb) num_expert_parallelism
2
(Pdb) self.config.per_device_batch_size
4
(Pdb) self.config.max_target_length
1024
(Pdb) max_local_experts_per_tok
2

EP=2 TP=2 after:

(Pdb) buffer_size
32768
(Pdb) num_expert_parallelism
2
(Pdb) batch_size
8
(Pdb) sequence_length
1024
(Pdb) max_local_experts_per_tok
2
======
EP=2 CP=2 before:

(Pdb) buffer_size
16384
(Pdb) num_expert_parallelism
2
(Pdb) self.config.per_device_batch_size
4
(Pdb) self.config.max_target_length
1024
(Pdb) max_local_experts_per_tok
2

EP=2 CP=2 after:

(Pdb) buffer_size
16384
(Pdb) num_expert_parallelism
2
(Pdb) batch_size
8
(Pdb) sequence_length
512
(Pdb) max_local_experts_per_tok
2
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
