### PR TITLE
Vision Encoder NNX migration

### DIFF
--- a/src/MaxText/layers/models.py
+++ b/src/MaxText/layers/models.py
@@ -32,7 +32,7 @@ from MaxText import max_utils
 from MaxText.layers import nnx_wrappers
 from MaxText.layers.decoders import Decoder
 from MaxText.layers.embeddings import Embed, embed_as_linen
-from MaxText.layers.encoders import VisionEncoder
+from MaxText.layers.encoders import VisionEncoder, vision_encoder_as_linen
 from MaxText.layers.quantizations import AqtQuantization as Quant
 from MaxText.layers.multi_token_prediction import MultiTokenPredictionBlock
 from MaxText.sharding import all_gather_over_fsdp
@@ -85,7 +85,7 @@ class TransformerLinenPure(nn.Module):
         config=cfg,
         mesh=self.mesh,
     )
-    self.vision_encoder = VisionEncoder(config=cfg, mesh=mesh) if cfg.use_multimodal else None
+    self.vision_encoder = vision_encoder_as_linen(config=cfg, mesh=mesh) if cfg.use_multimodal else None
     self.decoder = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
     # If MTP is enabled via config, set up the MTP block.
     if self.config.mtp_num_layers > 0:
@@ -304,7 +304,7 @@ class Transformer(nnx.Module):
         config=cfg,
         rngs=rngs,
     )
-    self.vision_encoder = VisionEncoder(config=cfg, mesh=mesh) if cfg.use_multimodal else None
+    self.vision_encoder = VisionEncoder(config=cfg, mesh=mesh, rngs=rngs) if cfg.use_multimodal else None
 
     decoder_linen = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
     self.decoder = nnx_wrappers.ToNNX(decoder_linen, rngs=rngs)

--- a/tests/integration_tests/vision_encoder_test.py
+++ b/tests/integration_tests/vision_encoder_test.py
@@ -84,7 +84,7 @@ class VisionEncoderEmbeddingTest(unittest.TestCase):
     input_images = images[jnp.newaxis, jnp.newaxis, ...]  # pytype: disable=unsupported-operands
 
     # Initialize only the vision encoder part and extract the corresponding params
-    vision_encoder_model = models.VisionEncoder(config)
+    vision_encoder_model = models.VisionEncoder(config, engine.mesh, rngs=engine.rng)
     vision_encoder_params = params["params"]["vision_encoder"]
 
     # Apply the vision encoder to get the image embeddings


### PR DESCRIPTION
# Description

Migrating VisionEncoder class to NNX without changing checkpoint tree hierachy.

# Tests

Decode:
- Gemma3 (unchanged):
```
# command
python -m MaxText.decode MaxText/configs/base.yml model_name=gemma3-4b tokenizer_path=google/gemma-3-4b-it tokenizer_type=huggingface hf_access_token=<your_hf_token> load_parameters_path=gs://maxtext-gemma/unified/gemma3/4b/unscanned/2025-08-09-01-17/0/items per_device_batch_size=1 run_name=ht_test max_prefill_predict_length=272 max_target_length=300 steps=1 async_checkpointing=false scan_layers=false use_multimodal=true prompt=\'Describe\ image\ \<start_of_image\>\' image_path=\'src/MaxText/test_assets/test_image.jpg\' attention=\'dot_product\'

# result 
Input `<start_of_turn>user
Describe image <start_of_image><end_of_turn>
<start_of_turn>model
` -> `Here’s a description of the image:

**Overall Impression:** The image is a bright, expansive view of Seattle, Washington. It captures`
```
- Llama4: [log](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22v5p-128-bodaborg-europe-west4-b%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22hengtaoguo-2025-12-03-06-16-44-slice-job-0-0-%22%20severity%3E%3DDEFAULT;storageScope=project;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev), unchanged outputs comparing to https://github.com/AI-Hypercomputer/maxtext/pull/2269.

SFT (no changes in peak memory usage):
```
python -m MaxText.sft_trainer MaxText/configs/sft-vision-chartqa.yml model_name=gemma3-4b tokenizer_path=google/gemma-3-4b-it tokenizer_type=huggingface hf_access_token=<your_token> load_parameters_path=gs://maxtext-gemma/unified/gemma3/4b/unscanned/2025-08-09-01-17/0/items base_output_directory=gs://hengtaoguo-maxtext-logs/sft/gemma3 per_device_batch_size=1 run_name=ht_test max_prefill_predict_length=512 max_target_length=1024 steps=20 async_checkpointing=false scan_layers=false image_path=\'src/MaxText/test_assets/test_image.jpg\' attention=\'dot_product\' dataset_type=hf hf_path=parquet hf_train_files=gs://aireenmei-multipod/dataset/hf/chartqa/train-\* sharding_tolerance=0.05 checkpoint_period=1000
```
Before NNX: [logs](https://paste.googleplex.com/5171710296981504) (0.469s/step), [profile](https://xprof.corp.google.com/overview_page/hengtaoguo-2648912527487774322)
After NNX: [logs](https://paste.googleplex.com/5406273224966144) (0.469s/step), [profile](https://xprof.corp.google.com/overview_page/hengtaoguo-15847770981277357990)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
