### PR TITLE
Support checkpointing TE quantizations with new remat policies

### DIFF
--- a/src/MaxText/layers/quantizations.py
+++ b/src/MaxText/layers/quantizations.py
@@ -807,7 +807,10 @@ class TransformerEngineQuantization(Quantization):
       def generate_quantizer_set(self, postfix: str = ""):
         OVERWRITE_WITH_GRADIENT = "_overwrite_with_gradient"
         return super().generate_quantizer_set(  # pytype: disable=wrong-keyword-args
-            postfix=postfix, variable_collection=OVERWRITE_WITH_GRADIENT, fp8_recipe=fp8_recipe
+            postfix=postfix,
+            variable_collection=OVERWRITE_WITH_GRADIENT, 
+            quantization_checkpoint_name="quantization",
+            fp8_recipe=fp8_recipe
         )
 
       @nn.compact


### PR DESCRIPTION
# Description

This PR allows us to avoid rematerializing TransformerEngine (TE) quantizations. TE supports fused kernels that compute both the forward and backward layouts in a single kernel, however, these are only useful if we are saving the alternate layouts for the backward.

This PR introduces two new remat policies, `minimal_with_quantization` and `minimal_with_context_and_quantization` which extend the existing policies with additional support for checkpointing TE quantizations.

# Tests

Tested locally with E2E workloads and confirmed the quantization operations were saved and not rematerialized with these policies enabled.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
