### PR TITLE
[src/MaxText/configs/types.py] Error loudly on invalid keys ; Add missing `base_config` meta field ; [src/MaxText/pyconfig.py] Enable pydantic to be constructed in public API ; [tests/configs_value_test.py] Test `ValueError` is raised

### DIFF
--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -223,6 +223,10 @@ type ModelName = Literal[
 class RunInfo(BaseModel):
   """Configuration for the overall run, model identity, and logging."""
 
+  base_config: None | str = Field(
+      None,
+      description="Base config to inherit from. This is a meta-field and is consumed by the config loading system.",
+  )
   run_name: str = Field(
       "",
       description="The name of the run. Checkpoints will be stored under this name.",

--- a/tests/configs_value_test.py
+++ b/tests/configs_value_test.py
@@ -23,6 +23,7 @@ import pydantic
 from MaxText import pyconfig
 from MaxText.configs import types
 from MaxText.globals import MAXTEXT_REPO_ROOT
+from MaxText.pyconfig import initialize_pydantic
 
 # Path to the base.yml config. This assumes that `pytest` is run from the project root.
 _BASE_CONFIG_PATH = os.path.join(MAXTEXT_REPO_ROOT, "src", "MaxText", "configs", "base.yml")
@@ -130,6 +131,18 @@ class ConfigTest(unittest.TestCase):
     ]
     config = pyconfig.initialize(argv)
     self.assertEqual(config.tokenizer_type, "tiktoken")
+
+  def test_initialize_pydantic_bad_keys(self):
+    """Test that `pydantic.ValidationError` is raised on keys not in MaxTextConfig"""
+    with self.assertRaises(ValueError):
+      initialize_pydantic(
+          [
+              "",
+              _BASE_CONFIG_PATH,
+              "tokenizer_path=assets/tokenizer_llama3.tiktoken",
+              "NOT_A_VALID_KEY=test",
+          ]
+      )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Now that the pydantic PR has been merged for a while, we can be reasonably confident fields are properly defined. This also adds one missing field.

# Tests

CI and conversations at the whole-team meeting

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).