### PR TITLE
Add input unpacking for tuple inputs in decoder layers

### DIFF
--- a/src/MaxText/layers/deepseek.py
+++ b/src/MaxText/layers/deepseek.py
@@ -171,6 +171,9 @@ class DeepSeekDenseLayer(nn.Module):
       logical_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
     else:
       logical_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, logical_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 
@@ -240,6 +243,10 @@ class DeepSeekMoELayer(nn.Module):
       logical_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
     else:
       logical_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, logical_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 

--- a/src/MaxText/layers/deepseek_batchsplit.py
+++ b/src/MaxText/layers/deepseek_batchsplit.py
@@ -61,6 +61,9 @@ class DeepSeekGenericLayer(nn.Module):
       kv_cache=None,
       attention_metadata=None,
   ):
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     x = self.with_logical_constraint(inputs)
     x = jax.ad_checkpoint.checkpoint_name(x, "decoder_layer_input")
 

--- a/src/MaxText/layers/gemma.py
+++ b/src/MaxText/layers/gemma.py
@@ -132,6 +132,9 @@ class GemmaDecoderLayer(nnx.Module):
       kv_cache=None,
       attention_metadata=None,
   ):
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     # inputs: embedded inputs to the decoder with shape [batch, length, emb_dim]

--- a/src/MaxText/layers/gemma2.py
+++ b/src/MaxText/layers/gemma2.py
@@ -226,6 +226,9 @@ class Gemma2DecoderLayer(nnx.Module):
       kv_cache=None,
       attention_metadata=None,
   ):
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     # inputs: embedded inputs to the decoder with shape [batch, length, emb_dim]

--- a/src/MaxText/layers/gemma3.py
+++ b/src/MaxText/layers/gemma3.py
@@ -193,6 +193,9 @@ class Gemma3DecoderLayer(nnx.Module):
       attention_metadata=None,
   ):
     cfg = self.config
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 

--- a/src/MaxText/layers/gpt3.py
+++ b/src/MaxText/layers/gpt3.py
@@ -430,6 +430,10 @@ class Gpt3DecoderLayer(nnx.Module):
       kv_cache=None,
       attention_metadata=None,
   ):
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
+
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     lnx = self.pre_self_attention_norm(inputs)

--- a/src/MaxText/layers/gpt_oss.py
+++ b/src/MaxText/layers/gpt_oss.py
@@ -149,6 +149,9 @@ class GptOssDecoderLayer(nnx.Module):
       attention_metadata=None,
   ):
     cfg = self.config
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
 
     inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
     inputs = checkpoint_name(inputs, "decoder_layer_input")

--- a/src/MaxText/layers/llama2.py
+++ b/src/MaxText/layers/llama2.py
@@ -152,6 +152,9 @@ class LlamaDecoderLayer(nnx.Module):
   ):
     cfg = self.config
 
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     lnx_sharding = NamedSharding(self.mesh, nn.logical_to_mesh_axes(self.activation_axis_names))

--- a/src/MaxText/layers/llama4.py
+++ b/src/MaxText/layers/llama4.py
@@ -454,6 +454,9 @@ class Llama4DecoderLayer(nnx.Module):
     cfg = self.config
     assert cfg.num_experts >= 1, "Expected the Llama4 config to have `num_experts > 1`."
 
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 

--- a/src/MaxText/layers/mistral.py
+++ b/src/MaxText/layers/mistral.py
@@ -135,9 +135,11 @@ class MistralDecoderLayer(nnx.Module):
       kv_cache=None,
       attention_metadata=None,
   ):
-
     cfg = self.config
 
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
     lnx = self.pre_self_attention_layer_norm(inputs)

--- a/src/MaxText/layers/mixtral.py
+++ b/src/MaxText/layers/mixtral.py
@@ -140,7 +140,9 @@ class MixtralDecoderLayer(nnx.Module):
       kv_cache=None,
       attention_metadata=None,
   ):
-
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
 

--- a/src/MaxText/layers/simple_layer.py
+++ b/src/MaxText/layers/simple_layer.py
@@ -61,6 +61,9 @@ class SimpleDecoderLayer(nnx.Module):
   def __call__(
       self, inputs: jnp.ndarray, positions, segmentation, deterministic, model_mode, previous_chunk=None, page_state=None
   ):
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     if self.config.scan_layers:
       return jnp.dot(inputs, self.weights.astype(inputs.dtype), out_sharding=self.out_sharding), None
     return jnp.dot(inputs, self.weights.astype(inputs.dtype), out_sharding=self.out_sharding)
@@ -124,6 +127,9 @@ class SimpleMlpDecoderLayer(nnx.Module):
       page_state=None,
       slot=0,
   ):
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
     intermediate = jnp.dot(inputs, self.ff_1.astype(inputs.dtype), out_sharding=self.mlp_sharding)
     output = jnp.dot(intermediate, self.ff_2.astype(inputs.dtype), out_sharding=self.activation_sharding)
     if self.config.scan_layers:

--- a/tests/train_smoke_test.py
+++ b/tests/train_smoke_test.py
@@ -53,6 +53,35 @@ class Train(unittest.TestCase):
         ]
     )
 
+  def test_tiny_config_no_scan(self):
+    test_tmpdir = os.environ.get("TEST_TMPDIR")  # pylint: disable=unused-variable
+    train_main(
+        [
+            None,
+            os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"),
+            # pylint: disable=f-string-without-interpolation
+            f"base_output_directory=gs://runner-maxtext-logs",
+            "run_name=runner_test",
+            r"dataset_path=gs://maxtext-dataset",
+            "base_emb_dim=8",
+            "base_num_query_heads=4",
+            "base_num_kv_heads=4",
+            "base_mlp_dim=32",
+            "base_num_decoder_layers=8",
+            "head_dim=128",
+            "per_device_batch_size=2",
+            "max_target_length=1024",
+            "dataset_type=synthetic",
+            "steps=10",
+            "enable_checkpointing=False",
+            rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizer.llama2')}",
+            "enable_goodput_recording=False",
+            "enable_checkpoint_cloud_logger=False",
+            "monitor_goodput=False",
+            "scan_layers=False",
+        ]
+    )
+
   def test_tiny_config_explicit_shardmode(self):
     test_tmpdir = os.environ.get("TEST_TMPDIR")  # pylint: disable=unused-variable
     train_main(


### PR DESCRIPTION
# Description

*This PR finishes the work started by @gagika in #2753. Credits to @gagika for uncovering this regression!*

This PR fixes a regression introduced in a recent commit where decoder layers began returning a tuple `(hidden_states, kv_cache)` even when `scan_layers=False`. This caused failures in `SequentialBlockDecoderLayers` (used in pipeline parallelism) because the subsequent layer would receive a tuple as input instead of a tensor, leading to a `ValueError` in normalization layers.

### Changes
- Added a check at the beginning of the `__call__` method for all Decoder Layer implementations to handle tuple inputs gracefully:
  ```python
  # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
  if isinstance(inputs, tuple):
    inputs = inputs[0]
    
 ### Changes
- Updated Qwen3NextScannableBlock to correctly unpack the (output, kv_cache) tuple inside its scan loop.

If the change fixes a bug:
FIXES: b/462751017

### Affected Models
This fix covers the following model architectures:
* DeepSeek (Dense & MoE)
* Gemma, Gemma 2, Gemma 3
* GPT-3, GPT-OSS
* Llama 2, Llama 4
* Mistral, Mixtral
* Qwen 3 (Dense, MoE, and Next)
* Simple Layer (Testing)

# Tests
internal google3 tests.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
