### PR TITLE
add markdown linting as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,10 @@ repos:
           - '--pyink-indentation=2'
           - '--line-length=122'
           - '--check'
+
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.22
+    hooks:
+      - id: mdformat
+        additional_dependencies: [mdformat-myst, mdformat-ruff]
+        files: (docs/.)


### PR DESCRIPTION
# Description

Add a pre-commit hook to lint markdown files in the `docs/` folder, thus it will only run on files changed in a particular commit.
Linting all docs, via `$ pre-commit run --all-files`, generates a ~1kLOC patch, which is not including here. Can add it now if desired.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
