### PR TITLE
Add concat_then_split packing in Grain pipeline

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -597,6 +597,7 @@ grain_train_files: ''
 grain_eval_files: ''
 grain_train_mixture_config_path: '' # Path to a JSON file specifying the mixture weights for Grain training data.
 grain_file_type: 'arrayrecord' # arrayrecord or parquet
+grain_packing_type: 'first_fit' # 'first_fit' or 'concat_then_split'. See details of the corresponding module in https://google-grain.readthedocs.io/en/latest/grain.experimental.html
 grain_worker_count: 1 # Set to -1 to enable auto-tuning: automatically determines optimal worker count. See https://google-grain.readthedocs.io/en/latest/_autosummary/grain.experimental.pick_performance_config.html
 grain_per_worker_buffer_size: 1
 # num_threads and prefetch_buffer_size are per-worker per-dataset. 

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -852,6 +852,10 @@ class DatasetGeneral(BaseModel):
       True,
       description="Whether to pack multiple short examples into a single sequence.",
   )
+  grain_packing_type: Literal["first_fit", "concat_then_split"] = Field(
+      "first_fit",
+      description="Packing type when using Grain pipeline. 'first_fit' or 'concat_then_split'.",
+  )
   max_segments_per_seq: int = Field(
       32,
       description="Maximum number of segments that can be packed into a single sequence.",

--- a/src/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/src/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -17,6 +17,7 @@
 import dataclasses
 import warnings
 from threading import current_thread
+from typing import Any
 import datasets
 from datasets.distributed import split_dataset_by_node
 import grain.python as grain
@@ -387,6 +388,28 @@ class NormalizeFeatures(grain.MapTransform):
       return {col: element[col].numpy()[0].decode() for col in self.column_names}
     else:
       return {col: element[col].numpy() for col in self.column_names}
+
+
+@dataclasses.dataclass
+class KeepFeatures(grain.MapTransform):
+  """Keep only specified features in the dataset element.
+
+  This transform filters the input dictionary, retaining only the keys
+  that are present in `feature_names`.
+  """
+
+  def __init__(self, feature_names: list[str]):
+    """Initializes the KeepFeatures transform.
+
+    Args:
+      feature_names: A list of strings, where each string is the name of a
+        feature to be kept in the dataset element.
+    """
+    self.feature_names = feature_names
+
+  def map(self, element: dict[str, Any]) -> dict[str, Any]:
+    """Applies the feature filtering to the input element."""
+    return {k: v for k, v in element.items() if k in self.feature_names}
 
 
 @dataclasses.dataclass

--- a/tests/grain_data_processing_test.py
+++ b/tests/grain_data_processing_test.py
@@ -198,6 +198,7 @@ class GrainArrayRecordAutoTuneTest(GrainArrayRecordProcessingTest):
         data_sharding=["data"],
         base_output_directory="gs://max-experiments/",
         dataset_type="grain",
+        grain_ram_budget_mb=512,
         grain_train_files=os.path.join(
             temp_dir, "gcsfuse", "array-record", "c4", "en", "3.0.1", "c4-train.array_record*"
         ),


### PR DESCRIPTION
# Description
b/452438529
See grain docs for the two packing types: [first_fit](https://google-grain.readthedocs.io/en/latest/_autosummary/grain.experimental.FirstFitPackIterDataset.html#grain.experimental.FirstFitPackIterDataset), [concat_then_split](https://google-grain.readthedocs.io/en/latest/_autosummary/grain.experimental.ConcatThenSplitIterDataset.html#grain.experimental.ConcatThenSplitIterDataset) 

# Tests
Manually tested both packing methods on v5p

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
