### PR TITLE
Remove unused VLLM import from train_rl & rename install_tunix_vllm_requirement.sh

### DIFF
--- a/docs/tutorials/posttraining/rl.md
+++ b/docs/tutorials/posttraining/rl.md
@@ -54,7 +54,7 @@ Next, run the following bash script to get all the necessary installations insid
 This will take few minutes. Follow along the installation logs and look out for any issues!
 
 ```
-bash ~/maxtext/src/MaxText/examples/install_tunix_vllm_requirement.sh
+bash tools/setup/setup_post_training_requirements.sh
 ```
 
 Primarily, it installs `vllm-tpu` which is [vllm](https://github.com/vllm-project/vllm) and [tpu-inference](https://github.com/vllm-project/tpu-inference) and thereby providing TPU inference for vLLM, with unified JAX and PyTorch support.

--- a/src/MaxText/examples/sft_train_and_evaluate.py
+++ b/src/MaxText/examples/sft_train_and_evaluate.py
@@ -21,8 +21,11 @@ The primary goal is to demonstrate the end-to-end process of:
 
 ## Example command to run on single-host TPU:
 ```
-# Install dependencies in virtual environment
-bash setup.sh && bash src/MaxText/examples/install_tunix_vllm_requirement.sh
+# Install dependencies in virtual environment:
+# https://maxtext.readthedocs.io/en/latest/install_maxtext.html#from-pypi-recommended
+
+# Install post-training dependencies in virtual environment:
+bash tools/setup/setup_post_training_requirements.sh
 
 # Environment configurations
 export RUN_NAME=$(date +%Y-%m-%d-%H-%M-%S)

--- a/src/MaxText/rl/train_rl.py
+++ b/src/MaxText/rl/train_rl.py
@@ -64,7 +64,6 @@ from tunix.rl import rl_cluster as rl_cluster_lib
 from tunix.rl.rollout import base_rollout
 from tunix.rl.grpo.grpo_learner import GrpoConfig, GrpoLearner
 from tunix.sft import metrics_logger, profiler
-from vllm.outputs import PoolingRequestOutput  # pylint: disable=unused-import
 
 # for vLLM we can skip JAX precompilation with this flag, it makes startup faster
 os.environ["SKIP_JAX_PRECOMPILE"] = "1"

--- a/tools/setup/setup_post_training_requirements.sh
+++ b/tools/setup/setup_post_training_requirements.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script installs the dependencies for running GRPO with MaxText+Tunix+vLLM on TPUs
+# This script installs the dependencies for running post-training with MaxText+Tunix+vLLM on TPUs
 
 set -e
 set -x


### PR DESCRIPTION
# Description

This PR solves two issues:
1. Error thrown by `from vllm.outputs import PoolingRequestOutput` when installing vllm from Github head. This import is unused and should be safe to remove. Logs of error thrown: https://cloudlogging.app.goo.gl/Lgm3CJ1pLX7k38927 and https://cloudlogging.app.goo.gl/7tB8RDcK9NVfX8yc9
2. Rename `install_tunix_vllm_requirement.sh` to `setup_post_training_requirements.sh` and move it out of `examples` folder. Also, update the documentation.

# Tests
Tested locally on v5p-8 and on pathways cluster

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
