### PR TITLE
Fix HLO Dump

### DIFF
--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -202,7 +202,6 @@ def initialize(argv: list[str], **kwargs) -> HyperParameters:
   config_path = resolve_config_path(argv[1])
   base_yml_config = _load_config(config_path)
 
-
   # 2. Get overrides from CLI and kwargs
   cli_cfg = omegaconf.OmegaConf.from_cli(argv[2:])
   kwargs_cfg = omegaconf.OmegaConf.create(kwargs)
@@ -299,7 +298,6 @@ def initialize(argv: list[str], **kwargs) -> HyperParameters:
 
     compilation_cache.set_cache_dir(os.path.expanduser(pydantic_kwargs["jax_cache_dir"]))
 
-  jax.distributed.initialize()
   validate_and_set_hlo_dump_defaults(pydantic_kwargs)
 
   pydantic_config = types.MaxTextConfig(**pydantic_kwargs)

--- a/src/MaxText/pyconfig_deprecated.py
+++ b/src/MaxText/pyconfig_deprecated.py
@@ -977,7 +977,6 @@ def set_mu_dtype(raw_keys):
 
 
 def validate_and_set_hlo_dump_defaults(raw_keys):
-  breakpoint()
   if not raw_keys["dump_hlo"]:
     return raw_keys
   if os.environ.get("XLA_FLAGS") and raw_keys["dump_hlo_xla_flags"]:


### PR DESCRIPTION
# Description

Dumping HLO has been broken since our pydantic migration, the function to set HLO dump XLA_FLAGS was missed. This PR adds back the function to set XLA_FLAGS to dump HLO.

If the change fixes a bug or a Github issue, please include a link, e.g.,:

# Tests
TODO: Add unit test for dump_hlo


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
