### PR TITLE
Skip AOT Identify Tests

### DIFF
--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -111,4 +111,4 @@ jobs:
           fi
           # TODO: Fix the skipped tests and remove the deselect flags
           [ "${{ inputs.total_workers }}" -gt 1 ] && .venv/bin/python3 -m pip install --quiet pytest-split && SPLIT_ARGS="--splits ${{ inputs.total_workers }} --group ${{ inputs.worker_group }}" || SPLIT_ARGS=""
-          .venv/bin/python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" --durations=0 --deselect "tests/aot_hlo_identical_test.py::AotHloIdenticalTest::test_default_hlo_match" --deselect "tests/tokenizer_test.py::TokenizerTest::test_detokenize" $SPLIT_ARGS
+          .venv/bin/python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" --durations=0 --deselect "tests/tokenizer_test.py::TokenizerTest::test_detokenize" $SPLIT_ARGS

--- a/.github/workflows/run_tests_internal.yml
+++ b/.github/workflows/run_tests_internal.yml
@@ -81,4 +81,4 @@ jobs:
           python3 -m pip install -e . --no-dependencies
           [ "${{ inputs.total_workers }}" -gt 1 ] && python3 -m pip install --quiet pytest-split && SPLIT_ARGS="--splits ${{ inputs.total_workers }} --group ${{ inputs.worker_group }}" || SPLIT_ARGS=""
           export LIBTPU_INIT_ARGS='--xla_tpu_scoped_vmem_limit_kib=65536'
-          python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" --durations=0 --deselect "tests/aot_hlo_identical_test.py::AotHloIdenticalTest::test_default_hlo_match" $SPLIT_ARGS
+          python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" --durations=0 $SPLIT_ARGS

--- a/tests/aot_hlo_identical_test.py
+++ b/tests/aot_hlo_identical_test.py
@@ -153,16 +153,19 @@ class AotHloIdenticalTest(unittest.TestCase):
     print("AOT Compiled and train HLO files are identical for test {test_name}!")
 
   @pytest.mark.tpu_only
+  @pytest.mark.skip(reason="FileNotFoundError: /tmp/aot_test_dump. Skipped until fixing b/463839714.")
   def test_default_hlo_match(self):
     self.assert_compile_and_real_match_hlo("default_run")
 
   @pytest.mark.tpu_only
   @pytest.mark.scheduled_only
+  @pytest.mark.skip(reason="FileNotFoundError: /tmp/aot_test_dump. Skipped until fixing b/463839714.")
   def test_int8_hlo_match(self):
     self.assert_compile_and_real_match_hlo("int8", "quantization=int8")
 
   @pytest.mark.tpu_only
   @pytest.mark.scheduled_only
+  @pytest.mark.skip(reason="FileNotFoundError: /tmp/aot_test_dump. Skipped until fixing b/463839714.")
   def test_llama2_7b_hlo_match(self):
     self.assert_compile_and_real_match_hlo(
         "llama2-7b",


### PR DESCRIPTION
# Description

Temporarily skip AOT Identification tests with `FileNotFoundError: [Errno 2] No such file or directory: '/tmp/aot_test_dump'` error. Use b/463839714 to track fixes.

# Tests


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
