### PR TITLE
Fix the type of micro_batch_size

### DIFF
--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -1368,7 +1368,7 @@ class RLDataset(BaseModel):
   num_batches: int = Field(4, description="Number of batches for RL training.")
   num_test_batches: int = Field(5, description="Number of batches for RL evaluation.")
   train_fraction: float = Field(1.0, description="Fraction of the dataset to be used for training.")
-  micro_batch_size: float = Field(-1, description="Micro batch size for rollout and training.")
+  micro_batch_size: int = Field(-1, description="Micro batch size for rollout and training.")
 
 
 class RLEvaluation(BaseModel):


### PR DESCRIPTION
# Description

Fix the type of micro_batch_size

# Tests

Manually tested. Without the change, the float number would cause problems in Tunix.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
