### PR TITLE
[src/MaxText/pyconfig.py] Remove `base_config` at end of its usage to avoid ValueError and or warnings being leveled

### DIFF
--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -102,6 +102,9 @@ def _prepare_for_pydantic(raw_keys: dict[str, Any]) -> dict[str, Any]:
   pydantic_kwargs = {}
   valid_fields = types.MaxTextConfig.model_fields.keys()
 
+  if "base_config" in raw_keys:
+    del raw_keys["base_config"]
+
   for key, value in raw_keys.items():
     if key not in valid_fields:
       logger.warning("Ignoring invalid/unsupported field from YAML/CLI: %s", repr(key))


### PR DESCRIPTION
# Description

Remove `base_config` at end of its usage to avoid ValueError and or warnings being leveled

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
