### PR TITLE
Fix Gpt3 MultiHeadAttention out projection dimension

### DIFF
--- a/src/MaxText/layers/gpt3.py
+++ b/src/MaxText/layers/gpt3.py
@@ -246,7 +246,7 @@ class Gpt3MultiHeadAttention(nnx.Module):
       self.key = self.create_projection_layer(feature_dim, (self.num_heads, self.head_dim), ("embed", "heads", "kv"))
       self.value = self.create_projection_layer(feature_dim, (self.num_heads, self.head_dim), ("embed", "heads", "kv"))
     self.out = self.create_projection_layer(
-        (self.num_heads, self.head_dim), self.num_heads * self.head_dim, ("heads", "kv", "embed"), axis=(-2, -1)
+        (self.num_heads, self.head_dim), feature_dim[-1], ("heads", "kv", "embed"), axis=(-2, -1)
     )
     self.attention_op = AttentionOp(
         config=config,


### PR DESCRIPTION
# Description

The output dimension of the output projection in the Gpt3 MultiHeadAttention layer is mistakenly set to `self.num_heads * self.head_dim`; it should be `config.emb_dim`.

# Tests

```
python3 -m MaxText.train  MaxText/configs/base.yml run_name=gpt3-train-run base_output_directory=gs://maxtext-test/train_gpt3/13/ model_name=gpt3-6b dataset_type=synthetic steps=10
```
[Logs: base_emb_dim=3584](https://paste.googleplex.com/4872277281865728)
[Logs: base_emb_dim=3584 base_mlp_dim=3584](https://paste.googleplex.com/5124818204753920)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
