### PR TITLE
fix bug when unpickling config object

### DIFF
--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -165,8 +165,11 @@ class HyperParameters:
 
   def __getattr__(self, attr: str) -> Any:
     """Provides attribute-style access to the final configuration dictionary."""
-    if attr in self._flat_config:
-      return self._flat_config[attr]
+    # Use object.__getattribute__ to avoid recursion when accessing _flat_config
+    # This is necessary for proper pickling/unpickling support
+    flat_config = object.__getattribute__(self, "_flat_config")
+    if attr in flat_config:
+      return flat_config[attr]
     raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'")
 
   def __setattr__(self, attr: str, value: Any) -> None:


### PR DESCRIPTION
# Description

When using Pathways with colocated python, we need to pass the dataset construction and preprocessing functions as serializable objects to colocated python. We see this error https://b.corp.google.com/issues/466407361#comment14 when unpickling config object 

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: https://b.corp.google.com/issues/466407361#comment14

# Tests
Tested on v5e-32 cluster, log: https://cloudlogging.app.goo.gl/rMpm6UY6aJnJ6efg6

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
