### PR TITLE
Make the workflows more robust

### DIFF
--- a/.github/workflows/AddLabel.yml
+++ b/.github/workflows/AddLabel.yml
@@ -101,11 +101,24 @@ jobs:
               process.exit()
             }
             for (const checkRun of checkRuns.data.check_runs) {
-              if (checkRun.name.endsWith(context.job)) continue
-              if (checkRun.conclusion !== "success") {
-                console.log("Not adding pull ready because " + checkRun.name + " has not passed yet: " + checkRun.html_url)
-                process.exit()
+              if (checkRun.name.endsWith(context.job)) continue  # Ignore the current job
+              const maintenanceJobs = [
+                "notify_success_and_close",
+                "notify_failure",
+              ];
+              const isMaintenanceJob = maintenanceJobs.some(job => checkRun.name.includes(job));
+
+              // It must be 'success', OR it can be 'skipped' if it's a maintenance job
+              if (checkRun.conclusion === "success") {
+                continue;
               }
+              if (checkRun.conclusion === "skipped" && isMaintenanceJob) {
+                console.log(`Ignoring skipped maintenance job: ${checkRun.name}`);
+                continue;
+              }
+              // If it's anything else (failure, cancelled, in_progress, or a skipped core test)
+              console.log("Not adding pull ready because " + checkRun.name + " status is " + checkRun.conclusion + ": " + checkRun.html_url);
+              process.exit();
             }
             console.log("Adding pull ready label because the PR is approved AND all the check runs have passed")
             await github.rest.issues.addLabels({


### PR DESCRIPTION
# Description

AddPullReady
    Ignore the global maintenance jobs when checking job status.
    The maintenance jobs are designed to be run by cron jobs, so they are often
    skipped during PR or manual run. This will cause the AddPullReady job failure.


# Tests

Run the workflows to test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
