### PR TITLE
RemoteIterator skip iter ckpt

### DIFF
--- a/src/MaxText/multihost_dataloading.py
+++ b/src/MaxText/multihost_dataloading.py
@@ -230,9 +230,14 @@ class RemoteIterator:
         raise ValueError("Type error: dataloader should be either tf.data.Dataset or grain.DataLoader.")
       return dummy_array
 
-    out = jax.device_get(init(self.dummy_array))
-    if out is not None:
-      max_logging.log(f"RemoteIterator initiated. Test output: {out}")
+    max_logging.log("Initiating RemoteIterator")
+    try:
+      out = jax.device_get(init(self.dummy_array))
+      if out is not None:
+        max_logging.log(f"RemoteIterator initiated. Test output: {out}")
+    except Exception as e:
+      max_logging.log(f"RemoteIterator init FAILED with error: {type(e).__name__}: {e}")
+      raise
 
   def __iter__(self):
     return self


### PR DESCRIPTION
# Description
Checkpointing Grain iterator when using RemoteIterator (for Pathways+colocated python) is not properly implemented yet. Causing this error: https://b.corp.google.com/issues/466407361#comment20. This PR skips data_iterator checkpointing to unblock testing the data loading part of Grain pipeline. Checkpointing model weights is not impacted. Will fix the checkpointing implementation later.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: https://b.corp.google.com/issues/466407361#comment20

# Tests
Tested on v5e-32 and verified checkpointing only model weights work [log](https://cloudlogging.app.goo.gl/LervpReUwdXKoPtE7)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
