### PR TITLE
Switch from pytest-split to pytest-xdist for parallel test execution.

### DIFF
--- a/.github/workflows/run_tests_internal.yml
+++ b/.github/workflows/run_tests_internal.yml
@@ -79,6 +79,7 @@ jobs:
             FINAL_PYTEST_MARKER="${{ inputs.pytest_marker }} and not scheduled_only"
           fi
           python3 -m pip install -e . --no-dependencies
-          [ "${{ inputs.total_workers }}" -gt 1 ] && python3 -m pip install --quiet pytest-split && SPLIT_ARGS="--splits ${{ inputs.total_workers }} --group ${{ inputs.worker_group }}" || SPLIT_ARGS=""
+          [ "${{ inputs.total_workers }}" -gt 1 ] && python3 -m pip install --quiet pytest-xdist && XDIST_ARGS="-n ${{ inputs.total_workers }} --dist=load" || XDIST_ARGS=""
           export LIBTPU_INIT_ARGS='--xla_tpu_scoped_vmem_limit_kib=65536'
-          python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" --durations=0 $SPLIT_ARGS
+          export JAX_ENABLE_X64="$JAXCI_ENABLE_X64"
+          python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" --durations=0 $XDIST_ARGS


### PR DESCRIPTION
Previously, CPU tests are distributed across multiple workers using pytest-split, which assigns the same number of tests to each worker. However, since the runtime of tests is different, some workers end up finishing fast and stand idle while others take a long time, so we're not utilizing the workers fully. This change replaces the use of pytest-split with pytest-xdist which dynamically assigns work to workers.

# Tests

CI change, tested on CI.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
