### PR TITLE
Add sidebar toggle to landing page

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,6 +1,6 @@
 /* Base file modifications */
-body:has(.hero) .bd-sidebar-primary,
-body:has(.hero) .sidebar-toggle,
+/* body:has(.hero) .bd-sidebar-primary,
+body:has(.hero) .sidebar-toggle, */
 body:has(.hero) .bd-sidebar-secondary {
     display: none !important;
 }
@@ -38,7 +38,6 @@ body:has(.hero) .bd-article > section > h1 {
 
     body:has(.hero) .header-article-items,
     body:has(.hero) .doc-body > section {
-        max-width: 80% !important;
         align-self: center;
         width: -moz-available;
         width: -webkit-fill-available;
@@ -156,6 +155,7 @@ body:has(.hero) .bd-article > section > h1 {
     gap: 24px;
     padding-inline: 60px;
     margin-top: 20px;
+    max-width: 80%;
 }
 
 .text-body {


### PR DESCRIPTION
# Description
Adds a sidebar toggle to the landing page, so that the main docs menu is also optionally visible there.

# Tests

Local docs build looks like this, when the sidebar is toggled:

<img width="3736" height="1976" alt="2025-12-16_16-13" src="https://github.com/user-attachments/assets/5524310a-f4aa-4b42-97eb-caa6cbcaa5f4" />


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
