### PR TITLE
Add pypi release automation workflow

### DIFF
--- a/.github/workflows/build_and_test_maxtext.yml
+++ b/.github/workflows/build_and_test_maxtext.yml
@@ -18,6 +18,7 @@ name: MaxText Package Tests
 
 on:
   pull_request:
+  workflow_call:
   workflow_dispatch:
   schedule:
     # Run the job every 4 hours

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,0 +1,61 @@
+# Copyright 2025 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow will build, test and automatically release MaxText package to PyPI using Trusted Publishing (OIDC).
+
+name: Publish MaxText to PyPI
+
+# Triggers when a new "release" is published in the GitHub UI
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+jobs:
+  release_approval:
+    name: Approve Release
+    runs-on: ubuntu-latest
+    # "release" environment is configured in MaxText repository settings.
+    # This environment requires manual approval before proceeding to the next job.
+    environment: release
+    steps:
+    - name: Acknowledge Approval
+      run: echo "Release approved, proceeding to build, test and publish MaxText package."
+
+  build_and_test_maxtext_package:
+    name: Build and Test MaxText Package
+    needs: [release_approval]
+    uses: ./.github/workflows/build_and_test_maxtext.yml
+      
+  publish_maxtext_package_to_pypi:
+    name: Publish MaxText package to PyPI
+    needs: [build_and_test_maxtext_package]
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - name: Download MaxText wheel
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      with:
+        name: maxtext-wheel
+        path: dist/
+    - name: Publish MaxText wheel to PyPI
+      # Official action for PyPI Trusted Publishing
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: dist/


### PR DESCRIPTION
# Description

* Add workflow to automatically release MaxText to PyPI when release tag is created.
* Package will be published to PyPI only after approvals.

# Tests

Tested by publishing package to testpypi
```
uv venv --python 3.12 --seed ~/test_pypi
source ~/test_pypi/bin/activate

uv pip install --index-url https://test.pypi.org/simple --extra-index-url https://pypi.org/simple/ test-sjsurbhi[tpu]==0.1.1 --resolution=lowest

python3 -m MaxText.train MaxText/configs/sft.yml run_name=2025-12-18-$TEST_MODE base_output_directory=$OUTPUT_PATH model_name=llama3.1-8b load_parameters_path=$MODEL_CKPT_PATH hf_access_token=$HF_TOKEN tokenizer_path=meta-llama/Llama-3.1-8B-Instruct steps=2
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
