### PR TITLE
Roll back set mesh context manager in sft train

### DIFF
--- a/src/MaxText/rl/train_rl.py
+++ b/src/MaxText/rl/train_rl.py
@@ -94,7 +94,7 @@ def get_maxtext_model(config, devices=None):
   # load_parameters_path=/path/to/your/output/directory/0/items
   """
   model, mesh = model_creation_utils.create_nnx_model(config, devices=devices)
-  with jax.set_mesh(mesh):
+  with mesh:
     use_no_op_mappings = "maxtext_config" in config.vllm_additional_config
     tunix_model = TunixMaxTextAdapter(base_model=model, use_no_op_mappings=use_no_op_mappings)
     tunix_model.config = None

--- a/src/MaxText/sft/sft_trainer.py
+++ b/src/MaxText/sft/sft_trainer.py
@@ -160,7 +160,7 @@ def setup_trainer_state(mt_config, goodput_recorder=None):
 
 def train_model(mt_config, trainer, mesh):
   """Runs the SFT training loop in Tunix."""
-  with jax.set_mesh(mesh), nn_partitioning.axis_rules(mt_config.logical_axis_rules):
+  with mesh, nn_partitioning.axis_rules(mt_config.logical_axis_rules):
     trainer.train(trainer.data_hooks.train_data_iterator, trainer.data_hooks.eval_data_iterator)
   return trainer
 


### PR DESCRIPTION
# Description

It has been reported that `jax.set_mesh(mesh)` changes device order and leads to following error 

```
ValueError: Received incompatible devices for jitted computation. Got argument args[0] of slice with shape float32[4096] and device ids [0] on platform TPU and jit's context mesh with device ids [0, 1, 2, 3, 7, 6, 5, 4] on platform TPU
```

This PR reverts the usage of `jax.set_mesh` context manager. However, `with mesh` will soon be deprecated in JAX.

# Tests

Regular maxtext tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
