### PR TITLE
Onboard Mixtral to bidirectional conversion

### DIFF
--- a/src/MaxText/experimental/agent/ckpt_conversion_agent/README.md
+++ b/src/MaxText/experimental/agent/ckpt_conversion_agent/README.md
@@ -1,5 +1,5 @@
 # Checkpoint conversion agent 
-The agent is used to automate the model-specific mappings of checkpoint conversion.  It is designed to cooperate with the new checkpoint conversion [framework](https://github.com/AI-Hypercomputer/maxtext/tree/main/MaxText/utils/ckpt_conversion).
+The agent is used to automate the model-specific mappings of checkpoint conversion.  It is designed to cooperate with the new checkpoint conversion [framework](https://github.com/AI-Hypercomputer/maxtext/tree/main/src/MaxText/utils/ckpt_conversion).
 
 ## Quick starts
 To begin, you'll need:
@@ -16,7 +16,7 @@ pip install -q -U "google-genai>=1.0.0"
 
 ## 1. Prepare the context file
 
-The agent requires context files about the target and source model's parameter names and tensor shapes. You can generate them using the [`save_param.py`](ckpt_conversion/utils/save_param.py) script. The output directory defined by `config.base_output_directory`. The default is `src/MaxText/experimental/agent/ckpt_conversion_agent/context/<model_name>` folder.
+The agent requires context files about the target and source model's parameter names and tensor shapes. You can generate them using the [`save_param.py`](../ckpt_conversion_agent/utils/save_param.py) script. The output directory defined by `config.base_output_directory`. The default is `src/MaxText/experimental/agent/ckpt_conversion_agent/context/<model_name>` folder.
 ```bash
 python3 -m MaxText.experimental.agent.ckpt_conversion_agent.utils.save_param src/MaxText/configs/base.yml \
   per_device_batch_size=1 run_name=param_<model_name> model_name=<model_name> scan_layers=false \

--- a/src/MaxText/utils/ckpt_conversion/README.md
+++ b/src/MaxText/utils/ckpt_conversion/README.md
@@ -9,6 +9,7 @@ The following models are supported:
 - Gemma2 (2B, 9B, 27B).
 - Gemma3 multimodal (4B, 12B, 27B).
 - Qwen3 (0.6B, 4B, 8B, 14B, 32B).
+- Mixtral (8x7B, 8x22B).
 
 ## Prerequisites
 - Hugging Face requires Pytorch.

--- a/src/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -691,6 +691,69 @@ qwen3_omni_30b_a3b_config = transformers.Qwen3OmniMoeConfig(
     },
 )
 
+
+# from https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1/blob/main/config.json
+mixtral_8x7b_dict = {
+    "architectures": ["MixtralForCausalLM"],
+    "attention_dropout": 0.0,
+    "bos_token_id": 1,
+    "eos_token_id": 2,
+    "hidden_act": "silu",
+    "hidden_size": 4096,
+    "initializer_range": 0.02,
+    "intermediate_size": 14336,
+    "max_position_embeddings": 32768,
+    "model_type": "mixtral",
+    "num_attention_heads": 32,
+    "num_experts_per_tok": 2,
+    "num_hidden_layers": 32,
+    "num_key_value_heads": 8,
+    "num_local_experts": 8,
+    "output_router_logits": False,
+    "rms_norm_eps": 1e-05,
+    "rope_theta": 1000000.0,
+    "router_aux_loss_coef": 0.02,
+    "sliding_window": None,
+    "tie_word_embeddings": False,
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.36.0.dev0",
+    "use_cache": True,
+    "vocab_size": 32000,
+}
+mixtral_8x7b_config = transformers.MixtralConfig(**mixtral_8x7b_dict)
+
+
+# from https://huggingface.co/mistralai/Mixtral-8x22B-Instruct-v0.1/blob/main/config.json
+mixtral_8x22b_dict = {
+    "architectures": ["MixtralForCausalLM"],
+    "attention_dropout": 0.0,
+    "bos_token_id": 1,
+    "eos_token_id": 2,
+    "hidden_act": "silu",
+    "hidden_size": 6144,
+    "initializer_range": 0.02,
+    "intermediate_size": 16384,
+    "max_position_embeddings": 65536,
+    "model_type": "mixtral",
+    "num_attention_heads": 48,
+    "num_experts_per_tok": 2,
+    "num_hidden_layers": 56,
+    "num_key_value_heads": 8,
+    "num_local_experts": 8,
+    "output_router_logits": False,
+    "rms_norm_eps": 1e-05,
+    "rope_theta": 1000000.0,
+    "router_aux_loss_coef": 0.001,
+    "sliding_window": None,
+    "tie_word_embeddings": False,
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.38.0",
+    "use_cache": True,
+    "vocab_size": 32768,
+}
+mixtral_8x22b_config = transformers.MixtralConfig(**mixtral_8x22b_dict)
+
+
 # {maxtext model name: hf model config}
 HF_MODEL_CONFIGS = {
     "gemma2-2b": gemma2_2b_config,
@@ -716,4 +779,6 @@ HF_MODEL_CONFIGS = {
     "gpt-oss-20b": gpt_oss_20b_config,
     "gpt-oss-120b": gpt_oss_120b_config,
     "qwen3-omni-30b-a3b": qwen3_omni_30b_a3b_config,
+    "mixtral-8x7b": mixtral_8x7b_config,
+    "mixtral-8x22b": mixtral_8x22b_config,
 }

--- a/src/MaxText/utils/ckpt_conversion/utils/hf_shape.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/hf_shape.py
@@ -581,6 +581,77 @@ def LLAMA31_HF_WEIGHTS_TO_SHAPE(config):
   return mapping
 
 
+def MIXTRAL_HF_WEIGHTS_TO_SHAPE(config):
+  """
+  Returns a mapping of Hugging Face parameter names to their tensor shapes.
+
+  Args:
+      config (dict): The model configuration dictionary.
+
+  Returns:
+      A dictionary mapping Hugging Face parameter paths to their tensor shapes.
+  """
+  shapes = {}
+
+  # Embedding and LM Head
+  shapes["model.embed_tokens.weight"] = [config["vocab_size"], config["hidden_size"]]
+  shapes["lm_head.weight"] = [config["vocab_size"], config["hidden_size"]]
+
+  # Final LayerNorm
+  shapes["model.norm.weight"] = [config["hidden_size"]]
+
+  # Calculated dimensions
+  head_dim = config["hidden_size"] // config["num_attention_heads"]
+  kv_dim = config["num_key_value_heads"] * head_dim
+
+  # Decoder Layers
+  for i in range(config["num_hidden_layers"]):
+    # Attention Projections
+    shapes[f"model.layers.{i}.self_attn.q_proj.weight"] = [
+        config["hidden_size"],
+        config["hidden_size"],
+    ]
+    shapes[f"model.layers.{i}.self_attn.k_proj.weight"] = [
+        kv_dim,
+        config["hidden_size"],
+    ]
+    shapes[f"model.layers.{i}.self_attn.v_proj.weight"] = [
+        kv_dim,
+        config["hidden_size"],
+    ]
+    shapes[f"model.layers.{i}.self_attn.o_proj.weight"] = [
+        config["hidden_size"],
+        config["hidden_size"],
+    ]
+
+    # LayerNorms
+    shapes[f"model.layers.{i}.input_layernorm.weight"] = [config["hidden_size"]]
+    shapes[f"model.layers.{i}.post_attention_layernorm.weight"] = [config["hidden_size"]]
+
+    # MOE Gate
+    shapes[f"model.layers.{i}.block_sparse_moe.gate.weight"] = [
+        config["num_local_experts"],
+        config["hidden_size"],
+    ]
+
+    # MOE Experts
+    for j in range(config["num_local_experts"]):
+      shapes[f"model.layers.{i}.block_sparse_moe.experts.{j}.w1.weight"] = [
+          config["intermediate_size"],
+          config["hidden_size"],
+      ]
+      shapes[f"model.layers.{i}.block_sparse_moe.experts.{j}.w2.weight"] = [
+          config["hidden_size"],
+          config["intermediate_size"],
+      ]
+      shapes[f"model.layers.{i}.block_sparse_moe.experts.{j}.w3.weight"] = [
+          config["intermediate_size"],
+          config["hidden_size"],
+      ]
+
+  return shapes
+
+
 # {maxtext model name: {hf weight name: hf shape}}
 HF_SHAPE = {
     "gemma2-2b": GEMMA2_HF_WEIGHTS_TO_SHAPE,
@@ -604,4 +675,6 @@ HF_SHAPE = {
     "deepseek3-671b": DEEPSEEK_HF_WEIGHTS_TO_SHAPE,
     "gpt-oss-20b": GPT_OSS_HF_WEIGHTS_TO_SHAPE,
     "gpt-oss-120b": GPT_OSS_HF_WEIGHTS_TO_SHAPE,
+    "mixtral-8x7b": MIXTRAL_HF_WEIGHTS_TO_SHAPE,
+    "mixtral-8x22b": MIXTRAL_HF_WEIGHTS_TO_SHAPE,
 }

--- a/src/MaxText/utils/ckpt_conversion/utils/utils.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/utils.py
@@ -76,6 +76,8 @@ HF_IDS = {
     "gpt-oss-20b": "openai/gpt-oss-20b",
     "gpt-oss-120b": "openai/gpt-oss-120b",
     "qwen3-omni-30b-a3b": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+    "mixtral-8x7b": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "mixtral-8x22b": "mistralai/Mixtral-8x22B-Instruct-v0.1",
 }
 
 
@@ -195,7 +197,10 @@ def process_maxtext_param(
 
   # Case 3 or 4: The source tensor is stacked on a single axis.
   # We determine if it's an unscanned MoE (expert axis) or standard scanned (layer axis).
-  is_unscanned_moe = "moe_block" in maxtext_param_key and any(
+  # `w` is needed for weights, and except for gate.
+  # Gate values are stack in layers only, but weights are stack in both expert and layer.
+  moe_block_list = ["moe_block", "MoeBlock_0-w"]
+  is_unscanned_moe = any(block in maxtext_param_key for block in moe_block_list) and any(
       f"_{i}-" in maxtext_param_key for i in range(maxtext_config.base_num_decoder_layers)
   )
 

--- a/tests/forward_pass_logit_checker.py
+++ b/tests/forward_pass_logit_checker.py
@@ -380,7 +380,8 @@ def main(config, test_args):  # pylint: disable=W0621
       raise ValueError("run_hf_model requires hf_model_path")
     hf_model = AutoModelForCausalLM.from_pretrained(test_args.hf_model_path, dtype=torch.bfloat16)
     tokenizer = AutoTokenizer.from_pretrained(test_args.hf_model_path)
-    if "Llama-3.1" in test_args.hf_model_path:
+    pad_token_models = ["Llama-3.1", "Mixtral-8x"]
+    if any(model in test_args.hf_model_path for model in pad_token_models):
       tokenizer.pad_token = tokenizer.eos_token
 
     init_rng = jax.random.PRNGKey(config.init_weights_seed)


### PR DESCRIPTION
# Description

Onboard Mixtral to bidirectional conversion, b/452391836.
* Add mappings, include `MIXTRAL_HF_WEIGHTS_TO_SHAPE`, `MIXTRAL_MAXTEXT_TO_HF_PARAM_MAPPING`, and `MIXTRAL_MAXTEXT_TO_HF_PARAM_HOOK_FN`.
* Other small fixes

# Tests

Mainly tested smaller model 8x7B:

* Unscan
  * **HF --> MaxText** - threshold aligned with [script](https://github.com/AI-Hypercomputer/maxtext/blob/56a7fd8f7618901edc93121a5e9bb3a9919ee623/end_to_end/tpu/mixtral/8x7b/2_test_mixtral.sh#L42) with extra `max_kl_div=0.015`: [test](https://paste.googleplex.com/4828500219527168)
  * **MaxText --> HF** - use above checkpoint and converted back with `rtol=1e-2, atol=1e-2`: [test](https://paste.googleplex.com/5684908511068160)
* Scan
  * **HF --> MaxText** - load checkpoint in SFT: [test](https://screenshot.googleplex.com/6etbzHQxeRoRfKn), logits verification with extra `max_kl_div=0.015` [test](https://paste.googleplex.com/5709549396951040)
  * **MaxText --> HF** - use above checkpoint and converted back with `rtol=1e-2, atol=1e-2`: [test](https://paste.googleplex.com/6530292762411008)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
