### PR TITLE
Improve max_logging to use absl logging.

### DIFF
--- a/src/MaxText/max_logging.py
+++ b/src/MaxText/max_logging.py
@@ -12,8 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Stub for logging utilities. Right now just meant to avoid raw prints."""
+"""Logging utilities."""
+from absl import logging
 
 
 def log(user_str):
-  print(user_str, flush=True)
+  """Logs a message at the INFO level."""
+  # Note, stacklevel=2 makes the log show the caller of this function.
+  logging.info(user_str, stacklevel=2)
+
+
+def debug(user_str):
+  """Logs a message at the DEBUG level."""
+  logging.debug(user_str, stacklevel=2)
+
+
+def info(user_str):
+  """Logs a message at the INFO level."""
+  logging.info(user_str, stacklevel=2)
+
+
+def warning(user_str):
+  """Logs a message at the WARNING level."""
+  logging.warning(user_str, stacklevel=2)
+
+
+def error(user_str):
+  """Logs a message at the ERROR level."""
+  logging.error(user_str, stacklevel=2)


### PR DESCRIPTION
# Description

I noticed `max_logging` was simply calling `print` under the hood, which lacks a lot of useful context like caller line number, logging severity and more. This PR updates max_logging to use absl logging instead. The `log` method is preserved for backwards compatibility.

# Tests

Regular MaxText tests.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
