### PR TITLE
Implement Warmup-Stable-Decay (WSD) Learning Rate Schedule

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -607,7 +607,7 @@ grain_file_type: 'arrayrecord' # arrayrecord or parquet
 grain_packing_type: 'first_fit' # 'first_fit' or 'concat_then_split'. See details of the corresponding module in https://google-grain.readthedocs.io/en/latest/grain.experimental.html
 grain_worker_count: 1 # Set to -1 to enable auto-tuning: automatically determines optimal worker count. See https://google-grain.readthedocs.io/en/latest/_autosummary/grain.experimental.pick_performance_config.html
 grain_per_worker_buffer_size: 1
-# num_threads and prefetch_buffer_size are per-worker per-dataset. 
+# num_threads and prefetch_buffer_size are per-worker per-dataset.
 # When using array_records, they are used in ReadOptions (https://google-grain.readthedocs.io/en/latest/tutorials/data_loader_tutorial.html#per-worker-readoptions)
 # The default value matches that in the Grain package. If mixing multiple data sources, consider lowering these values to reduce memory usage.
 # When using parquet, grain_num_threads is the number of files to read and interleave in parallel
@@ -635,15 +635,28 @@ skip_jax_distributed_system: False # If True we will not initialize the jax dist
 # However when run on google internal TPUs the coordination service is started automatically
 # and we should set this to True so we won't try to initialize a second time manually.
 
-# We take inspiration from Llama2's learning rate (LR) schedule, see https://arxiv.org/pdf/2307.09288.pdf section 2.2
-# Learning rate schedule has either two or three parts:
+# Learning rate schedule structure depends on lr_schedule_type:
+#
+# Cosine schedule (lr_schedule_type='cosine'):
+# Inspired by Llama2's learning rate schedule, see https://arxiv.org/pdf/2307.09288.pdf section 2.2
 # 1) Linear warmup from 0 to [learning_rate] over steps 0 to [learning_rate_schedule_steps * warmup_steps_fraction]
-# 2) Cosine decay from [learning_rate] to [learning_rate * cosine_learning_rate_final_fraction] from warmup to learning_rate_schedule_steps
-# 3) Constant learning rate of 0 from learning_rate_schedule_steps to steps.
+# 2) Cosine decay from [learning_rate] to [learning_rate * learning_rate_final_fraction] until learning_rate_schedule_steps
+# 3) Constant learning rate of 0 from learning_rate_schedule_steps to steps (if steps > learning_rate_schedule_steps)
+#
+# WSD schedule (lr_schedule_type='wsd', Warmup-Stable-Decay):
+# 1) Linear warmup from 0 to [learning_rate] over steps 0 to [learning_rate_schedule_steps * warmup_steps_fraction]
+# 2) Stable phase at [learning_rate] for the majority of training
+# 3) Decay from [learning_rate] to [learning_rate * learning_rate_final_fraction] over [learning_rate_schedule_steps * wsd_decay_steps_fraction] steps
+#    The decay can be either linear or cosine based on wsd_decay_style
+# 4) Constant learning rate of 0 from learning_rate_schedule_steps to steps (if steps > learning_rate_schedule_steps)
+#
 # The zero learning rate section can be used to more accurately measure the fully trained model's performance.
 learning_rate: 3.e-5
-cosine_learning_rate_final_fraction: 0.1
-warmup_steps_fraction: 0.1
+lr_schedule_type: 'cosine'  # Options: 'cosine' or 'wsd'
+learning_rate_final_fraction: 0.1  # Final LR as fraction of peak LR (applies to both cosine and WSD schedules)
+wsd_decay_steps_fraction: 0.1  # Fraction of learning_rate_schedule_steps used for decay phase in WSD (e.g., 0.1 = 10%)
+wsd_decay_style: 'linear'  # Decay style for WSD schedule: 'linear' or 'cosine'
+warmup_steps_fraction: 0.1  # Fraction of learning_rate_schedule_steps used for warmup phase (applies to both schedules)
 learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.
 # However you may choose a longer schedule (learning_rate_schedule_steps > steps), in which case the training will end before
 # dropping fully down. Or you may choose a shorter schedule, where the unspecified steps will have a learning rate of 0.


### PR DESCRIPTION
# Description

This PR implements the Warmup-Stable-Decay (WSD) learning rate schedule as a configurable option alongside the existing Cosine schedule. This allows users to choose between the standard cosine decay and a schedule that maintains a stable peak learning rate for the majority of training before a rapid decay.

Additionally, this implementation introduces a `wsd_decay_style` parameter, giving users the flexibility to choose the decay profile (linear or cosine) for the final annealing phase.

**Details and Context:**
- **Why:** The WSD schedule is a widely adopted training strategy where the learning rate warms up, stays constant (stable) to maximize training throughput, and then decays rapidly to converge. Separating the stable and decay phases allows for "infinite" training horizons and flexible checkpointing.
- **Implementation:**
    - **Configuration (`src/MaxText/configs/base.yml`):**
        - Added `lr_schedule_type` (options: `'cosine'`, `'wsd'`).
        - Added WSD-specific parameters: `wsd_learning_rate_final_fraction`, `wsd_decay_steps_fraction`.
        - Added `wsd_decay_style`: Supports `'linear'` (default, standard for WSD) or `'cosine'` decay for the final phase.
    - **Types (`src/MaxText/configs/types.py`):**
        - Added `LearningRateScheduleType` and `WsdDecayStyle` Enums.
        - Updated the `Optimizer` class to include validation for these new fields.
    - **Logic (`src/MaxText/maxtext_utils.py`):**
        - Refactored `create_learning_rate_schedule` to switch between Cosine and WSD logic.
        - Implemented WSD construction: `Linear Warmup` -> `Constant Stable` -> `Decay`.
        - The decay phase dynamically selects between `optax.linear_schedule` and a custom cosine schedule based on `wsd_decay_style`.
        - Added validation to ensure `warmup_steps_fraction + wsd_decay_steps_fraction <= 1.0`.

# Tests

I have added a comprehensive test suite, `TestLearningRateSchedules`, in `tests/maxtext_utils_test.py`.

- **Unit Tests:**
    - **Cosine Schedule:** Verified standard behavior (Warmup -> Cosine Decay).
    - **WSD Schedule:** Verified the 3-phase structure (Warmup -> Stable -> Decay) for **both** `linear` and `cosine` decay styles.
    - Checked that the learning rate hits the correct peak, stable values, and final fraction values.
- **Edge Cases:** Verified that invalid configurations (e.g., sum of fractions > 1.0) raise a `ValueError`.

To reproduce/test:
```bash
python3 -m unittest tests/maxtext_utils_test.py

```

Fixes: #2882 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).