### PR TITLE
Add fractional batch size search for MaxText estimator

### DIFF
--- a/docs/guides/optimization/benchmark_and_performance.md
+++ b/docs/guides/optimization/benchmark_and_performance.md
@@ -61,6 +61,128 @@ To use a custom policy, set `remat_policy` to `custom` and specify the layers in
 - `device`: The activation remains on the TPU device.
 - `Remat`: Rematerialization is performed during the backward pass.
 
+**Automatic remat policy search with the Estimator**
+
+Finding the optimal remat policy and batch size manually can be time-consuming. MaxText provides an **Estimator** tool (`estimator.py`) that automates this search using [Ahead-of-Time (AOT) compilation](../monitoring_and_debugging/features_and_diagnostics.md#ahead-of-time-compilation-aot). It leverages `train_compile` to test whether a given configuration causes an Out-Of-Memory (OOM) error *without* requiring the target hardware.
+
+The estimator supports two modes:
+
+1. **Search both batch size and remat policy** (when `per_device_batch_size` is *not* provided): It finds the Pareto frontier of batch size vs. remat policy by iterating through policies from full remat to full device, using binary search for the largest non-OOM batch size at each step.
+2. **Search remat policy only** (when `per_device_batch_size` *is* provided): It finds the least aggressive (fastest) remat policy that fits in memory for the given fixed batch size.
+
+*Mode 1 example: Search both batch size and remat policy (Llama 3.1 405B on tpu7x-1024)*
+
+```bash
+python -m maxtext.utils.estimator \
+  maxtext/configs/base.yml \
+  compile_topology=tpu7x-1024 \
+  compile_topology_num_slices=1 \
+  model_name=llama3.1-405b \
+  max_target_length=32768 \
+  ici_context_parallelism=8 \
+  ici_fsdp_parallelism=-1 \
+  log_config=False \
+  write_estimator_result=False
+```
+
+*Mode 2 example: Search best remat policy for a fixed batch size (DeepSeek3 671B on v5p-1024)*
+
+```bash
+python3 -m maxtext.utils.estimator maxtext/configs/base.yml \
+  model_name=deepseek3-671b \
+  compile_topology=v5p-1024 \
+  compile_topology_num_slices=1 \
+  ici_fsdp_parallelism=512 \
+  per_device_batch_size=2.0 \
+  dtype=bfloat16 \
+  weight_dtype=float32 \
+  max_target_length=8192 \
+  log_config=False \
+  write_estimator_result=False \
+  decoder_layer_input=offload
+```
+
+Key options:
+
+- `write_estimator_result=True`: Writes runnable training commands to `remat_commands_from_estimator.txt`.
+- `write_estimator_result=False` (default): Prints results to stdout only.
+- You can pin specific tensor remat actions (e.g., `context=offload`) to constrain the search space.
+
+*Advanced example: Search remat policy with XLA tuning flags (DeepSeek3 671B on tpu7x-512)*
+
+For production workloads you often want to combine the estimator with XLA compiler tuning flags for SparseCore offloading, latency-hiding scheduling, and other optimizations. Set these via `LIBTPU_INIT_ARGS` before invoking the estimator:
+
+```bash
+export LIBTPU_INIT_ARGS=" \
+  --xla_tpu_dvfs_p_state=7 \
+  --xla_tpu_scoped_vmem_limit_kib=65536 \
+  --xla_tpu_bf16_emission_mode=NATIVE_EMISSION \
+  --xla_tpu_enable_sparse_core_reduce_scatter_v2=true \
+  --xla_tpu_enable_sparse_core_collective_offload_all_gather=true \
+  --xla_tpu_enable_sparse_core_collective_offload_2d_all_gather=true \
+  --xla_tpu_enable_all_gather_offload_tracing=true \
+  --xla_tpu_use_tc_device_shape_on_sc=True \
+  --xla_sc_disable_megacore_partitioning=True \
+  --xla_tpu_enable_async_collective_fusion_fuse_all_gather=false \
+  --xla_enable_async_all_gather=true \
+  --xla_tpu_prefer_async_allgather_to_allreduce=true \
+  --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true \
+  --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true \
+  --xla_tpu_enable_sparse_core_collective_offload_3d_all_gather=true \
+  --xla_tpu_use_single_sparse_core_for_all_gather_offload=true \
+  --xla_tpu_enable_concurrent_sparse_core_offloading=true \
+  --xla_tpu_aggressive_opt_barrier_removal=true \
+  --xla_tpu_enable_offloading_gather_to_sparsecore=true \
+  --xla_tpu_sparse_core_all_gather_latency_multiplier=1 \
+  --xla_tpu_sparse_core_reduce_scatter_latency_multiplier=3 \
+  --xla_tpu_enable_sparse_core_collective_aggregator=true \
+  --xla_tpu_enable_latency_hiding_layer_scheduler=true \
+  --xla_tpu_scheduler_percent_shared_memory_limit=150 \
+  --xla_tpu_enable_layer_scheduler_for_dependent_collectives=true \
+  --xla_tpu_enable_sparse_core_collective_offload_nd_reduce_scatter=true \
+  --xla_tpu_pcie_bandwidth_multiplier=0.03 \
+  --xla_tpu_enable_sparse_core_offload_queuing_in_lhs=true \
+  --xla_tpu_enable_multi_compute_overlap_in_layer_scheduler=false \
+  --xla_tpu_enable_3d_reduce_scatter_decomposer=false "
+
+python3 -m maxtext.utils.estimator maxtext/configs/base.yml \
+  compile_topology=tpu7x-512 \
+  compile_topology_num_slices=1 \
+  run_name=${WORKLOAD_NAME} \
+  skip_jax_distributed_system=true \
+  dtype=bfloat16 \
+  per_device_batch_size=4.0 \
+  model_name=deepseek3-671b \
+  remat_policy=custom \
+  decoder_layer_input=device \
+  mu_dtype=bfloat16 \
+  grad_dtype=bfloat16 \
+  ici_fsdp_parallelism=128 \
+  ici_expert_parallelism=4 \
+  dataset_type=synthetic \
+  dataset_path=gs://max-datasets-rogue \
+  opt_type=adamw \
+  steps=20 \
+  sa_use_fused_bwd_kernel=true \
+  use_max_logit_estimate=-1 \
+  cost_estimate_flops_fwd=5000000000000 \
+  cost_estimate_flops_bwd=5000000000000 \
+  float32_weight_sum=False \
+  megablox=true \
+  sparse_matmul=true \
+  use_tokamax_gmm=false \
+  use_tokamax_splash=true \
+  max_target_length=4096 \
+  use_random_routing=true \
+  use_ring_of_experts=true \
+  use_ragged_sort=true \
+  tokenizer_path=assets/tokenizer.mistral-v3 \
+  base_output_directory=${BASE_OUTPUT_DIR} \
+  merge_gating_gmm=false
+```
+
+This example fixes `per_device_batch_size=4.0` so the estimator runs in **Mode 2** (policy-only search), finding the least aggressive remat policy that fits the DeepSeek3 671B model on a tpu7x-512 pod. The XLA flags enable SparseCore collective offloading and latency-hiding scheduling, which affect compilation memory layout and thus the OOM boundary.
+
 ### Low precision training
 
 MaxText supports quantization via QWIX. To enable this, set `use_qwix_quantization=true`.

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -948,6 +948,9 @@ compiled_trainstep_file: "" # Name of saved serialized compiled train_step, e.g.
 compile_topology: '' # Target hardware version, e.g. 'v5e-256'
 compile_topology_num_slices: -1 # Number of target slices, set to a positive integer.
 
+# MaxText Estimator configs
+write_estimator_result: False
+
 decode_sampling_strategy: "greedy" # decode_sampling_strategy should be one of greedy, weighted, nucleus, topk, or composite(top_k -> top_p -> weighted temperature)
 decode_sampling_nucleus_p: -1 # set if you're doing nucleus / top-p
 decode_sampling_top_k: 0 # set if you're doing top-k

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1674,6 +1674,7 @@ class AOT(BaseModel):
   compiled_trainstep_file: PathStr = Field("", description="Name of saved serialized compiled train_step.")
   compile_topology: str = Field("", description="Target hardware version, e.g. 'v5e-256'.")
   compile_topology_num_slices: int = Field(-1, description="Number of target slices.")
+  write_estimator_result: bool = Field(False, description="Write estimator.py results in a separate file.")
 
 
 class DevelopmentAndDebugging(BaseModel):

--- a/src/maxtext/trainers/pre_train/train_compile.py
+++ b/src/maxtext/trainers/pre_train/train_compile.py
@@ -61,12 +61,9 @@ Transformer = models.transformer_as_linen
 def validate_config(config):
   """Validates the config is is setup correctly to compile, returning a useful error message if not."""
   assert config.compile_topology != "", (
-      "You must pass your desired target hardware in compile_topology, e.g."
-      " compile_topology=v5e-256"
+      "You must pass your desired target hardware in compile_topology, e.g." " compile_topology=v5e-256"
   )
-  assert (
-      config.compile_topology_num_slices > 0
-  ), "You must set compile_topology_num_slices to a positive integer"
+  assert config.compile_topology_num_slices > 0, "You must set compile_topology_num_slices to a positive integer"
 
 
 def get_topology_mesh(config):
@@ -78,18 +75,12 @@ def get_topology_mesh(config):
         num_slices=config.compile_topology_num_slices,
     ).devices
   else:
-    target_hardware = accelerator_to_spec_map.get_system_characteristics(
-        config.compile_topology
-    )
+    target_hardware = accelerator_to_spec_map.get_system_characteristics(config.compile_topology)
     if target_hardware.platform == "gpu":
       # Disable sharded autotuning. This is an optimization to distribute
       # autotuning across the fleet, but can cause hangs with AoT compilation.
-      os.environ["XLA_FLAGS"] = (
-          os.environ.get("XLA_FLAGS", "") + " --xla_gpu_shard_autotuning=false"
-      )
-      jax.config.update(
-          "mock_num_gpu_processes", config.compile_topology_num_slices
-      )
+      os.environ["XLA_FLAGS"] = os.environ.get("XLA_FLAGS", "") + " --xla_gpu_shard_autotuning=false"
+      jax.config.update("mock_num_gpu_processes", config.compile_topology_num_slices)
       topology_devices = jax.devices()
     else:
       topology_devices = get_topology_desc(
@@ -104,14 +95,8 @@ def get_topology_mesh(config):
       "jax_remove_size_one_mesh_axis_from_type",
       config.remove_size_one_mesh_axis_from_type,
   )
-  topology_device_mesh = maxtext_utils.create_device_mesh(
-      config, topology_devices
-  )
-  mesh_axis_type = (
-      AxisType.Explicit
-      if config.shard_mode == ShardMode.EXPLICIT
-      else AxisType.Auto
-  )
+  topology_device_mesh = maxtext_utils.create_device_mesh(config, topology_devices)
+  mesh_axis_type = AxisType.Explicit if config.shard_mode == ShardMode.EXPLICIT else AxisType.Auto
   topology_mesh = Mesh(
       topology_device_mesh,
       config.mesh_axes,
@@ -129,9 +114,7 @@ def _collect_nnx_activation_shardings(create_model_fn, config, mesh):
   input_shape = (config.micro_batch_size_to_train_on, config.max_target_length)
   abstract_input = jax.ShapeDtypeStruct(input_shape, jnp.int32)
 
-  def _nnx_forward(
-      decoder_input_tokens, decoder_positions, decoder_segment_ids
-  ):
+  def _nnx_forward(decoder_input_tokens, decoder_positions, decoder_segment_ids):
     model_instance = create_model_fn()
     return model_instance(
         decoder_input_tokens=decoder_input_tokens,
@@ -140,9 +123,7 @@ def _collect_nnx_activation_shardings(create_model_fn, config, mesh):
         enable_dropout=False,
     )
 
-  with jax.set_mesh(mesh), nn_partitioning.axis_rules(
-      config.logical_axis_rules
-  ):
+  with jax.set_mesh(mesh), nn_partitioning.axis_rules(config.logical_axis_rules):
     jax.eval_shape(_nnx_forward, abstract_input, abstract_input, abstract_input)
 
 
@@ -151,13 +132,9 @@ def get_shaped_inputs(topology_mesh, config):
   # Construct the model and optimizer to get shaped versions of the state
   quant = quantizations.configure_quantization(config)
   if config.pure_nnx:
-    _create_model_partial, model = (
-        model_creation_utils.create_nnx_abstract_model(config, topology_mesh)
-    )
+    _create_model_partial, model = model_creation_utils.create_nnx_abstract_model(config, topology_mesh)
   else:
-    model = Transformer(
-        config, topology_mesh, quant=quant, model_mode=MODEL_MODE_TRAIN
-    )
+    model = Transformer(config, topology_mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
   # The learning_rate_schedule is baked into the compiled object.
   learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(config)
   # pass in model for muon
@@ -176,20 +153,14 @@ def get_shaped_inputs(topology_mesh, config):
 
     init_state_fn = create_train_state_fn
   else:
-    init_state_fn = functools.partial(
-        maxtext_utils.init_initial_state, model, tx, config, True, example_rng
-    )
+    init_state_fn = functools.partial(maxtext_utils.init_initial_state, model, tx, config, True, example_rng)
 
   # Shaped state
-  abstract_state, _, state_mesh_shardings = maxtext_utils.get_abstract_state(
-      config, topology_mesh, init_state_fn, True
-  )
+  abstract_state, _, state_mesh_shardings = maxtext_utils.get_abstract_state(config, topology_mesh, init_state_fn, True)
 
   if config.pure_nnx:
     # NNX doesn't use Linen logical annotations; derive PartitionSpecs from the physical shardings.
-    logical_annotations = maxtext_utils_nnx.get_partition_spec_nnx(
-        state_mesh_shardings
-    )
+    logical_annotations = maxtext_utils_nnx.get_partition_spec_nnx(state_mesh_shardings)
     # For NNX, get_functional_train_with_signature expects the graphdef (static structure),
     # not the raw model — mirroring how the training loop does nnx.split(train_state).
     with nn_partitioning.axis_rules(config.logical_axis_rules):
@@ -198,9 +169,7 @@ def get_shaped_inputs(topology_mesh, config):
     model = graphdef
   else:
     # unsharded logical annotations
-    logical_annotations = maxtext_utils.get_logical_annotations(
-        config, topology_mesh, init_state_fn
-    )
+    logical_annotations = maxtext_utils.get_logical_annotations(config, topology_mesh, init_state_fn)
 
   # Shaped batch
   shaped_batch = maxtext_utils.get_shaped_batch(config)
@@ -217,9 +186,7 @@ def get_shaped_inputs(topology_mesh, config):
   # Collect NNX activation shardings via an abstract forward pass (must run
   # after get_abstract_state, which only traces __init__).
   if config.debug_sharding and config.pure_nnx:
-    _collect_nnx_activation_shardings(
-        _create_model_partial, config, topology_mesh
-    )
+    _collect_nnx_activation_shardings(_create_model_partial, config, topology_mesh)
 
   return (
       shaped_train_args,
@@ -256,9 +223,7 @@ def jit_and_compile(
     maxtext_utils.maybe_dump_jaxpr(config, jitted, func_input_args)
     lowered = jitted.lower(*func_input_args, **func_input_kwargs)
   # Import libtpu flags as compiler options. Defaults to empty dict if string is empty.
-  compiler_options = max_utils.parse_libtpu_flags_to_dict(
-      config.compile_xla_flags
-  )
+  compiler_options = max_utils.parse_libtpu_flags_to_dict(config.compile_xla_flags)
   compiled = lowered.compile(compiler_options=compiler_options)
   return compiled
 
@@ -293,18 +258,12 @@ def is_oom(argv: Sequence[str]) -> bool:
   ) = get_shaped_inputs(topology_mesh, config)
 
   # Update params_shardings when shard_optimizer_over_data is enabled (Zero-1)
-  params_shardings, state_mesh_shardings = (
-      sharding.maybe_update_params_sharding_with_opt(
-          config, state_mesh_shardings
-      )
-  )
+  params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
 
   # When ZeRO-1 is enabled, we need to use the original params_shardings for input shardings
   # but keep the updated state_mesh_shardings for the optimizer state
   if config.shard_optimizer_over_data:
-    input_state_mesh_shardings = state_mesh_shardings.replace(
-        params=params_shardings
-    )
+    input_state_mesh_shardings = state_mesh_shardings.replace(params=params_shardings)
   else:
     input_state_mesh_shardings = state_mesh_shardings
 
@@ -344,6 +303,7 @@ def is_oom(argv: Sequence[str]) -> bool:
   except Exception as e:
     # return true if OOM error happens
     # OOM error looks like
+    # Check failed: entries[i] <= std::numeric_limits<uint32_t>::max()
     # jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED: Allocation ...
     # jax.errors.JaxRuntimeError: INTERNAL: RET_CHECK failure ...
     message = str(e).lower()
@@ -355,8 +315,7 @@ def is_oom(argv: Sequence[str]) -> bool:
 def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["LIBTPU_INIT_ARGS"] = (
-      os.environ.get("LIBTPU_INIT_ARGS", "")
-      + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
+      os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
   )
   print("Starting train_compile.py...", flush=True)
 
@@ -381,18 +340,12 @@ def main(argv: Sequence[str]) -> None:
   ) = get_shaped_inputs(topology_mesh, config)
 
   # Update params_shardings when shard_optimizer_over_data is enabled (Zero-1)
-  params_shardings, state_mesh_shardings = (
-      sharding.maybe_update_params_sharding_with_opt(
-          config, state_mesh_shardings
-      )
-  )
+  params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
 
   # When ZeRO-1 is enabled, we need to use the original params_shardings for input shardings
   # but keep the updated state_mesh_shardings for the optimizer state
   if config.shard_optimizer_over_data:
-    input_state_mesh_shardings = state_mesh_shardings.replace(
-        params=params_shardings
-    )
+    input_state_mesh_shardings = state_mesh_shardings.replace(params=params_shardings)
   else:
     input_state_mesh_shardings = state_mesh_shardings
 
@@ -401,21 +354,15 @@ def main(argv: Sequence[str]) -> None:
   if config.enable_diloco:
     # Build abstract DiLoCo state and shardings for AOT compilation
     abstract_state = shaped_train_args[0]
-    diloco_state, state_mesh_shardings, inner_state_shardings = (
-        diloco.build_abstract_diloco_state(
-            config, abstract_state, state_mesh_shardings, topology_mesh
-        )
+    diloco_state, state_mesh_shardings, inner_state_shardings = diloco.build_abstract_diloco_state(
+        config, abstract_state, state_mesh_shardings, topology_mesh
     )
     # For NNX, shaped_train_args has 2 elements (state, batch) — no rng; pass None for prng.
-    shaped_rng_arg = (
-        shaped_train_args[2] if len(shaped_train_args) > 2 else None
-    )
+    shaped_rng_arg = shaped_train_args[2] if len(shaped_train_args) > 2 else None
     shaped_train_args = (diloco_state, shaped_train_args[1], shaped_rng_arg)
 
     # Wrap train_step with diloco
-    train_step_partial = functools.partial(
-        train.train_step, model, config, inner_state_shardings, params_shardings
-    )
+    train_step_partial = functools.partial(train.train_step, model, config, inner_state_shardings, params_shardings)
     train_step_fn = diloco.build_diloco_train_step(config, train_step_partial)
 
     # For DiLoCo, the train_step_fn is already fully wrapped and takes (state, batch, prng)
@@ -480,10 +427,7 @@ def main(argv: Sequence[str]) -> None:
   if config.compiled_trainstep_file != "":
     print("Saving compiled object...")
     save_compiled(compiled, config.compiled_trainstep_file)
-    print(
-        "Successfully saved compiled object as"
-        f" {config.compiled_trainstep_file}"
-    )
+    print("Successfully saved compiled object as" f" {config.compiled_trainstep_file}")
   print("Finished train_compile.py successfully!", flush=True)
   print(f"Cost analysis: {compiled.cost_analysis()}")
   print(f"Memory analysis: {compiled.memory_analysis()}")

--- a/src/maxtext/utils/estimator.py
+++ b/src/maxtext/utils/estimator.py
@@ -38,9 +38,66 @@ from typing import Sequence
 from absl import app
 import time
 import jax
+from enum import IntEnum
 
 from maxtext.configs import pyconfig
 from maxtext.trainers.pre_train import train_compile
+
+
+class Action(IntEnum):
+  REMAT = 0
+  OFFLOAD = 1
+  DEVICE = 2
+
+
+class RematPolicy:
+  """RematPolicy representing different remat policy combinations"""
+
+  def __init__(self, tensor_names: list[str], tensors: dict | None = None, initial_level: Action = Action.REMAT):
+    self.tensors = {name: initial_level for name in tensor_names} if tensors is None else tensors
+    self.tensor_order = tensor_names
+
+  @property
+  def to_dict(self) -> dict[str, str]:
+    """Convert internal action to strings for MaxText"""
+    mapping = {0: "remat", 1: "offload", 2: "device"}
+    return {k: mapping[v.value] if isinstance(v, Action) else mapping[v] for k, v in self.tensors.items()}
+
+  def next_policy(self):
+    """
+    Moves from Remat -> Offload -> Device.
+    Iterates through tensors in priority order to increase memory but reduce time usage
+    TODO: it is not necessary offload is strictly better than remat. We simplify the order
+    here. We need to update this logic for better time-memory modeling purpose.
+    """
+    new_policy = RematPolicy(tensor_names=self.tensor_order, tensors=self.tensors.copy())
+
+    # Search for the first tensor that can be moved to a more compute-efficient state
+    # reverse tensor order to on-device high AI later
+    for action_to_check in [Action.OFFLOAD, Action.DEVICE]:
+      for name in reversed(self.tensor_order):
+        if new_policy.tensors[name] < action_to_check:
+          new_policy.tensors[name] = action_to_check
+          return new_policy
+    return None
+
+  def previous_policy(self):
+    """
+    Moves from Device -> Offload -> Remat.
+    Iterates through tensors in priority order to reduce memory but increase time usage
+    """
+    new_policy = RematPolicy(tensor_names=self.tensor_order, tensors=self.tensors.copy())
+
+    # Search for the first tensor that can be moved to a more memory-efficient state
+    for action_to_check in [Action.OFFLOAD, Action.REMAT]:
+      for name in self.tensor_order:
+        if new_policy.tensors[name] > action_to_check:
+          new_policy.tensors[name] = action_to_check
+          return new_policy
+    return None
+
+  def __repr__(self):
+    return str(self.to_dict)
 
 
 def generate_priority_list(config, provided_tensor_names):
@@ -110,61 +167,34 @@ def tensor_score(tensor_name: str, config) -> tuple:
   return tensor_score_map[tensor_name]
 
 
-def build_full_device_policy(tensor_names) -> dict[str, str]:
-  """
-  Builds a minimal rematerialization policy with all tensors on device.
+def find_pdb_scalar(config):
+  """Calculates the scaling factor to normalize the Per-Device Batch (PDB) size.
+
+  In distributed training, the batch size is divided across various mesh axes.
+  When using non-batch-based sharding (like Tensor Parallelism), the raw
+  per-device batch size can become a fractional value.
+
+  This function identifies those non-batch axes (e.g., 'tensor') and calculates
+  a multiplier. This scalar represents the value by which a fractional per-device
+  batch size must be multiplied to result in an integer value, ensuring
+  compatibility with memory and compute estimation logic.
 
   Args:
-    config: The model configuration.
+    config: The configuration object containing 'mesh_axes' and the
+      corresponding 'ici_{axis}_parallelism' values.
 
   Returns:
-    The initial policy dictionary.
+    float: The aggregate parallelism degree of all non-data/non-FSDP axes,
+      serving as the integer-normalization constant for the PDB.
   """
-  return {key: "device" for key in tensor_names}
+  pdb_scalar = 1.0
+  for mesh_axis in config.mesh_axes:
+    if mesh_axis not in ("data", "fsdp", "fsdp_transpose", "expert", "stage"):
+      pdb_scalar *= getattr(config, f"ici_{mesh_axis}_parallelism")
+  return pdb_scalar
 
 
-def build_full_remat_policy(tensor_names) -> dict[str, str]:
-  """
-  Builds a full rematerialization policy with all tensors set to remat.
-
-  Args:
-    config: The model configuration.
-
-  Returns:
-    The full remat policy dictionary.
-  """
-  return {key: "remat" for key in tensor_names}
-
-
-def next_policy(policy: dict) -> dict[str, str] | None:
-  """
-  Generates the next rematerialization policy in the sequence.
-
-  This function iterates through the policy and changes the first tensor it
-  finds with a ``device`` value to ``offload``, or the first ``offload`` to
-  ``remat``. If all tensors are already set to ``remat``, it returns None.
-
-  Args:
-    policy: The current policy dictionary.
-
-  Returns:
-    The next policy dictionary, or None if the search is complete.
-  """
-  if "device" not in policy.values() and "offload" not in policy.values():
-    return None
-  tensor_in_device = "device" in policy.values()
-  new_policy = policy.copy()
-  for key, value in new_policy.items():
-    if tensor_in_device and value == "device":
-      new_policy[key] = "offload"
-      return new_policy
-    if not tensor_in_device and value == "offload":
-      new_policy[key] = "remat"
-      return new_policy
-  return None
-
-
-def largest_batch_size(base_argv, policy, min_pdb, max_pdb=64) -> int:
+def largest_batch_size(base_argv, policy, min_pdb=None, max_pdb=32.0, pdb_scalar=1.0) -> float:
   """
   Finds the largest possible ``per_device_batch_size`` (pdb) that does not cause
   an OOM error.
@@ -173,44 +203,60 @@ def largest_batch_size(base_argv, policy, min_pdb, max_pdb=64) -> int:
   range to efficiently find the optimal batch size.
 
   Args:
-    policy: The rematerialization policy dictionary.
-    min_pdb: The minimum ``per_device_batch_size`` to test.
-    max_pdb: The maximum ``per_device_batch_size`` to test.
+    base_argv: The base command-line arguments.
+    policy: The rematerialization policy.
+    min_pdb: The minimum per_device_batch_size to test.
+    max_pdb: The maximum per_device_batch_size to test.
+    pdb_scalar: The scalar for fractional batch size normalization.
 
   Returns:
     The largest ``per_device_batch_size`` within the range that does not result
     in an OOM error.
   """
+  if pdb_scalar == 0.0:
+    raise ValueError("pdb_scalar cannot be value zero.")
+
+  # Apply default before validation so min_pdb is never None during comparison
+  min_pdb = 1.0 / pdb_scalar if min_pdb is None else min_pdb
+
+  if min_pdb <= 0.0 or max_pdb < min_pdb:
+    raise ValueError(f"Abnormal {min_pdb=} or {max_pdb=} values.")
+
   print(f"Starting binary search for the largest batch size between {min_pdb} and {max_pdb}.")
+
+  if min_pdb == max_pdb:
+    oom_res = is_oom(base_argv, policy, min_pdb)
+    return min_pdb if not oom_res else min_pdb - 1 / pdb_scalar
 
   if is_oom(base_argv, policy, min_pdb):
     print(f"OOM at minimum batch size {min_pdb}.")
-    return min_pdb - 1
+    return min_pdb - 1 / pdb_scalar
   if not is_oom(base_argv, policy, max_pdb):
     print(f"No OOM at maximum batch size {max_pdb}.")
     return max_pdb
 
-  low, high, result = min_pdb, max_pdb, min_pdb
+  low, high, result = int(min_pdb * pdb_scalar), int(max_pdb * pdb_scalar), int(min_pdb * pdb_scalar)
   while low <= high:
     mid = (low + high) // 2
     if mid < min_pdb:
       low = mid + 1
       continue
 
-    if not is_oom(base_argv, policy, mid):
+    if not is_oom(base_argv, policy, mid / pdb_scalar):
       result = mid
       low = mid + 1
     else:
       high = mid - 1
-  return result
+  return result / pdb_scalar
 
 
-def is_oom(base_argv, policy: dict, pdb: int) -> bool:
+def is_oom(base_argv, policy: RematPolicy, pdb: float) -> bool:
   """
   Checks if the given policy and batch size cause an OOM error.
 
   Args:
-    policy: The rematerialization policy dictionary.
+    base_argv: The base command-line arguments.
+    policy: The rematerialization policy.
     pdb: The per_device_batch_size.
 
   Returns:
@@ -251,14 +297,14 @@ def search_policy_only(
     tensor_names,
     base_argv,
     pdb,
-    init_policy: dict = None,
-) -> dict:
+    init_policy: RematPolicy = None,
+) -> RematPolicy:
   """
   Finds the "lightest" remat policy that fits in memory for a *fixed* batch size.
 
-  It starts with an initial policy (e.g., no remat) and iteratively adds
-  more tensors to rematerialize (`next_policy`) until it no longer
-  causes an Out-Of-Memory (OOM) error.
+  Starting from an initial policy (defaulting to full device / no remat), this
+  function iteratively moves to more memory-efficient policies via
+  ``previous_policy()`` until it finds one that does *not* cause an OOM error.
 
   Args:
     tensor_names: Prioritized list of all tensor names available for remat.
@@ -268,71 +314,103 @@ def search_policy_only(
       ``full_device_policy`` (no remat).
 
   Returns:
-    The first rematerialization policy that did *not* OOM.
+    The first (least aggressive) rematerialization policy that fits in memory.
 
   Raises:
     ValueError: If even a full remat policy causes an OOM for the given batch size.
   """
   # Sanity check: If full remat OOMs, this batch size is impossible.
-  full_remat_policy = build_full_remat_policy(tensor_names)
+  full_remat_policy = RematPolicy(tensor_names=tensor_names, initial_level=Action.REMAT)
   if is_oom(base_argv, full_remat_policy, pdb):
     raise ValueError(f"Given batch size {pdb} leads to OOM even with full remat.")
 
   # Start with the lightest policy (e.g., no remat fully on device)
-  policy = build_full_device_policy(tensor_names) if init_policy is None else init_policy
-  pre_policy = None  # To track the last policy that *did not* OOM
+  policy = RematPolicy(tensor_names=tensor_names, initial_level=Action.DEVICE) if init_policy is None else init_policy
 
   # Iteratively reduce memory usage until it fits
   while is_oom(base_argv, policy, pdb):
-    pre_policy = policy
-    policy = next_policy(policy)
+    policy = policy.previous_policy()
 
   # Return the first policy that *fit* (did not OOM).
-  return pre_policy
+  return policy
 
 
 def search(
     tensor_names,
     base_argv,
-    init_policy: dict = None,
-    max_pdb: int = 256,
-) -> list[tuple[int, dict]]:
+    min_pdb: float | None = None,
+    max_pdb: float = 64.0,
+    init_policy: RematPolicy = None,
+    pdb_scalar: float = 1.0,
+) -> list[tuple[float, dict]]:
   """
   Performs the core search algorithm to find the Pareto frontier points.
 
   Args:
-    config: The model configuration.
-    max_pdb: The maximum ``per_device_batch_size`` to test.
+    tensor_names: Priority list of tensors.
+    base_argv: base arguments for training.
+    min_pdb: minimal pdb value from full device policy.
+    max_pdb: maximal pdb value from full remat policy.
+    init_policy: The initial remat policy to start searching from.
+    pdb_scalar: batch scalar enabling fractional batch size search.
 
   Returns:
     A list of tuples, where each tuple contains a batch size and its
-    corresponding rematerialization policy.
+    corresponding rematerialization policy dict.
   """
   output_lst = []
-  policy = build_full_device_policy(tensor_names) if init_policy is None else init_policy
-  pdb = 1
+  policy = RematPolicy(tensor_names=tensor_names, initial_level=Action.REMAT) if init_policy is None else init_policy
+  min_pdb = 1 / pdb_scalar if min_pdb is None else min_pdb
+  pdb = max_pdb
   while policy is not None:
-    pdb = largest_batch_size(base_argv, policy, min_pdb=pdb, max_pdb=max_pdb)
+    pdb = largest_batch_size(base_argv, policy, min_pdb=min_pdb, max_pdb=pdb, pdb_scalar=pdb_scalar)
     if pdb > 0:
-      output_lst.append((pdb, policy))
-    policy = next_policy(policy)
+      output_lst.append((pdb, policy.to_dict))
+
+    policy = policy.next_policy()
+    if pdb < min_pdb:
+      print(f"The value of {pdb=} hits {min_pdb=}. Stop iterating policies.")
+      break
   return output_lst
 
 
-def generate_remat_config(policy: dict) -> tuple:
-  """Generate remat-related configs"""
-  return ("remat_policy=custom",) + tuple(f"{key}={value}" for key, value in policy.items())
+def generate_remat_config(policy) -> tuple:
+  """Generate remat-related configs from a RematPolicy or a dict."""
+  if isinstance(policy, RematPolicy):
+    policy_dict = policy.to_dict
+  else:
+    policy_dict = policy
+  return ("remat_policy=custom",) + tuple(f"{key}={value}" for key, value in policy_dict.items())
 
 
-def generate_pdb_config(pdb: int):
+def generate_pdb_config(pdb: float):
   """Generate batch size configs"""
   return (f"per_device_batch_size={pdb}",)
 
 
-def build_argv(base_argv, remat_policy: dict, pdb: int) -> tuple[str, ...]:
-  """Builds the argument vector for train_compile."""
+def build_argv(base_argv, remat_policy, pdb: float) -> tuple[str, ...]:
+  """Builds the argument vector for train_compile.
+
+  Args:
+    base_argv: The base command-line arguments.
+    remat_policy: A RematPolicy object or a dict mapping tensor names to actions.
+    pdb: The per_device_batch_size.
+
+  Returns:
+    A tuple of argument strings.
+  """
   remat_args = generate_remat_config(remat_policy)
   pdb_args = generate_pdb_config(pdb)
+
+  # Check if decoder_layer_input is already specified in base_argv
+  has_layer_input_config = any(
+      arg is not None and ("decoder_layer_input=device" in arg or "decoder_layer_input=offload" in arg)
+      for arg in base_argv
+  )
+
+  # If not specified, append the default offload setting to remat_args
+  if not has_layer_input_config:
+    remat_args += ("decoder_layer_input=device",)
   return base_argv + pdb_args + remat_args
 
 
@@ -370,14 +448,14 @@ def find_batch_size(base_argv):
     base_argv: The tuple of command-line arguments.
 
   Returns:
-    A tuple of (bool, int or None)
+    A tuple of (bool, float or None)
 
     * ``(True, batch_size)`` if ``per_device_batch_size=...`` was found.
     * ``(False, None)`` if it was not found.
   """
   pdb_provided, pdb_str = get_parameter_value(base_argv, prefix="per_device_batch_size=")
 
-  return pdb_provided, int(pdb_str) if pdb_provided else None
+  return pdb_provided, float(pdb_str) if pdb_provided else None
 
 
 def find_remat_policy_tensor_names(base_argv):
@@ -431,17 +509,16 @@ def main(argv_list: Sequence[str]) -> None:
   provided_tensor_names = find_remat_policy_tensor_names(base_argv)
 
   # Load the base MaxText configuration from the provided args
-  # (Assuming pyconfig and train_compile are imported)
   with open(os.devnull, "w") as devnull:  # pylint: disable=unspecified-encoding
     with contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(devnull):
       config = pyconfig.initialize(base_argv)
   train_compile.validate_config(config)
+  pdb_scalar = find_pdb_scalar(config)
 
   # Get the prioritized list of tensors to try rematerializing
   tensor_names = generate_priority_list(config, provided_tensor_names)
   # Define the two extremes: all remat vs. no remat
-  full_remat_policy = build_full_remat_policy(tensor_names)
-  full_device_policy = build_full_device_policy(tensor_names)
+  full_remat_policy = RematPolicy(tensor_names=tensor_names, initial_level=Action.REMAT)
 
   start_time = time.time()
   suggested_list = []
@@ -449,30 +526,48 @@ def main(argv_list: Sequence[str]) -> None:
   if pdb_provided:
     # MODE 1: Batch size is fixed, just find the best policy.
     print(f"Batch size provided ({pdb}). Searching for best policy...")
-    best_policy = search_policy_only(tensor_names, base_argv, pdb=pdb, init_policy=full_device_policy)
-    suggested_list = [(pdb, best_policy)]
+    best_policy = search_policy_only(tensor_names, base_argv, pdb=pdb)
+    # Store as (pdb, dict) for consistency with Mode 2
+    suggested_list = [(pdb, best_policy.to_dict)]
   else:
     # MODE 2: No batch size. Search for both batch size and policy.
     print("No batch size provided. Searching for max batch size and policies...")
     # First, find the absolute max batch size that fits *even with full remat*
-    max_pdb = largest_batch_size(base_argv, full_remat_policy, min_pdb=1)
+    max_pdb = largest_batch_size(base_argv, full_remat_policy, min_pdb=1.0 / pdb_scalar, pdb_scalar=pdb_scalar)
 
-    # Now, search for combinations, starting from no-remat up to max_pdb
-    suggested_list = search(tensor_names, base_argv, init_policy=full_device_policy, max_pdb=max_pdb)
+    # Now, search for combinations, starting from full-remat up to min_pdb
+    suggested_list.extend(
+        search(
+            tensor_names,
+            base_argv,
+            min_pdb=1.0 / pdb_scalar,
+            max_pdb=max_pdb,
+            init_policy=full_remat_policy,
+            pdb_scalar=pdb_scalar,
+        )
+    )
 
   end_time = time.time()
   print(f"\nSearch completed in {end_time - start_time:.2f} seconds.")
 
   output_filename = "remat_commands_from_estimator.txt"
-  print(f"Writing {len(suggested_list)} suggested command(s) to {output_filename}...")
 
-  with open(output_filename, "w", encoding="utf-8") as f:
+  # Only open the file and print the status if the config allows writing
+  if config.write_estimator_result:
+    print(f"Writing {len(suggested_list)} suggested command(s) to {output_filename}...")
+
+    with open(output_filename, "w", encoding="utf-8") as f:
+      for pdb_result, policy_result in suggested_list:
+        # Build the full, runnable command string
+        final_argv = build_argv(base_argv[1:], policy_result, pdb_result)
+        command = "python -m maxtext.trainers.pre_train.train " + " ".join(final_argv)
+
+        f.write(command + "\n")
+        print(f"  - Found valid combo: pdb={pdb_result}, policy={policy_result}")
+
+    print("Done.")
+  else:
     for pdb_result, policy_result in suggested_list:
-      # Build the full, runnable command string
-      final_argv = build_argv(base_argv[1:], policy_result, pdb_result)
-      command = "python -m maxtext.trainers.pre_train.train " + " ".join(final_argv)
-
-      f.write(command + "\n")
       print(f"  - Found valid combo: pdb={pdb_result}, policy={policy_result}")
 
   print("Done.")

--- a/tests/integration/estimator_test.py
+++ b/tests/integration/estimator_test.py
@@ -1,0 +1,115 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+E2E integration tests for the MaxText estimator.
+
+These tests exercise the estimator against a real (small) model compilation
+to verify the search_policy_only and is_oom functions work end-to-end.
+The tests use a small default model (global_parameter_scale=1) to stay fast.
+"""
+
+import unittest
+import pytest
+import jax
+
+from tests.utils.test_helpers import get_test_config_path
+from maxtext.utils.estimator import (
+    Action,
+    RematPolicy,
+    is_oom,
+    search_policy_only,
+)
+
+
+@pytest.mark.skip_on_tpu7x
+class EstimatorE2ETest(unittest.TestCase):
+  """E2E tests for the estimator search logic."""
+
+  def get_device_user_facing_name(self):
+    """Gets TPU device user facing name to generate correct AOT arguments."""
+    devices = jax.devices()
+    if not devices or "tpu" not in devices[0].platform.lower():
+      pytest.skip("This test requires a TPU environment.")
+
+    num_devices = len(devices)
+    device_kind = devices[0].device_kind
+    device_info = {
+        "TPU v4": ("v4", 2 * num_devices),
+        "TPU v5 lite": ("v5e", num_devices),
+        "TPU v5": ("v5p", 2 * num_devices),
+        "TPU v6": ("v6e", num_devices),
+    }
+
+    prefix, topology_devices = next((v for k, v in device_info.items() if k in device_kind), (None, None))
+    if prefix is None:
+      raise ValueError(f"Unsupported TPU device kind for estimator test: {device_kind}")
+
+    return f"{prefix}-{topology_devices}"
+
+  def _make_base_argv(self, extra_args=None):
+    """Build the base argv tuple for a small default model."""
+    topology = self.get_device_user_facing_name()
+    args = [
+        None,
+        get_test_config_path(),
+        f"compile_topology={topology}",
+        "compile_topology_num_slices=1",
+        "global_parameter_scale=1",
+        "per_device_batch_size=2",
+        "max_target_length=128",
+        "dataset_type=synthetic",
+        "enable_checkpointing=False",
+        "write_estimator_result=False",
+        "log_config=False",
+    ]
+    if extra_args:
+      args.extend(extra_args)
+    return tuple(args)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_is_oom_returns_bool(self):
+    """Verify is_oom returns a boolean for a small model with full remat."""
+    base_argv = self._make_base_argv()
+    tensor_names = ["context", "query_proj", "key_proj", "value_proj", "mlpwi_0", "mlpwi_1", "mlpwo", "out_proj"]
+    policy = RematPolicy(tensor_names=tensor_names, initial_level=Action.REMAT)
+
+    jax.clear_caches()
+    result = is_oom(base_argv, policy, pdb=2.0)
+
+    self.assertIsInstance(result, bool)
+    # A small model with full remat and small batch should NOT OOM
+    self.assertFalse(result, "Small model with full remat and pdb=2 should not OOM")
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  def test_search_policy_only_small_model(self):
+    """E2E: search_policy_only returns a valid policy for a small model."""
+    base_argv = self._make_base_argv()
+    tensor_names = ["context", "query_proj", "key_proj", "value_proj", "mlpwi_0", "mlpwi_1", "mlpwo", "out_proj"]
+
+    jax.clear_caches()
+    result = search_policy_only(tensor_names, base_argv, pdb=2.0)
+
+    # Should return a RematPolicy
+    self.assertIsInstance(result, RematPolicy)
+
+    # The result's to_dict should have all expected tensor names
+    result_dict = result.to_dict
+    for name in tensor_names:
+      self.assertIn(name, result_dict)
+      self.assertIn(result_dict[name], ("remat", "offload", "device"))
+
+    print(f"Estimator found policy: {result_dict}")

--- a/tests/unit/estimator_test.py
+++ b/tests/unit/estimator_test.py
@@ -1,0 +1,380 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+These tests verify the proper functioning of MaxText estimator.
+"""
+
+import unittest
+import pytest
+from unittest.mock import MagicMock, patch
+import os
+
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.estimator import (
+    Action,
+    RematPolicy,
+    largest_batch_size,
+    generate_priority_list,
+    find_pdb_scalar,
+    build_argv,
+    get_parameter_value,
+    find_batch_size,
+    find_remat_policy_tensor_names,
+    generate_remat_config,
+    generate_pdb_config,
+    search,
+    search_policy_only,
+)
+
+
+class TestRematEstimator(unittest.TestCase):
+  """Tests for the MaxText estimator functions."""
+
+  def setUp(self):
+    """Set up standard test variables."""
+    self.tensor_names = ["context", "mlpwo"]
+    self.base_argv = (None, os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"))
+
+  @pytest.mark.cpu_only
+  def test_policy_to_dict_conversion(self):
+    """Verify the Action enum correctly maps to MaxText string flags."""
+    policy = RematPolicy(self.tensor_names, initial_level=Action.REMAT)
+    d = policy.to_dict
+    self.assertEqual(d["context"], "remat")
+
+    policy.tensors["context"] = Action.DEVICE
+    self.assertEqual(policy.to_dict["context"], "device")
+
+  @pytest.mark.cpu_only
+  def test_next_policy_logic(self):
+    """
+    Verify that next_policy moves through actions incrementally
+    and respects the reversed priority order.
+    """
+    # Start at full remat
+    policy = RematPolicy(self.tensor_names, initial_level=Action.REMAT)
+
+    # mlpwo should be updated
+    next_p = policy.next_policy()
+    self.assertIsNotNone(next_p)
+    self.assertEqual(next_p.tensors["mlpwo"], Action.OFFLOAD)
+    self.assertEqual(next_p.tensors["context"], Action.REMAT)
+
+    # previous_policy should reverse the result from next_policy
+    same_p = next_p.previous_policy()
+    self.assertEqual(same_p.tensors["mlpwo"], Action.REMAT)
+
+  @pytest.mark.cpu_only
+  def test_policy_terminal_state(self):
+    """Verify next_policy returns None when no more upgrades are possible."""
+    policy = RematPolicy(self.tensor_names, initial_level=Action.DEVICE)
+    self.assertIsNone(policy.next_policy())
+
+  @pytest.mark.cpu_only
+  def test_previous_policy_terminal_state(self):
+    """Verify previous_policy returns None when no more downgrades are possible."""
+    policy = RematPolicy(self.tensor_names, initial_level=Action.REMAT)
+    self.assertIsNone(policy.previous_policy())
+
+  @pytest.mark.cpu_only
+  def test_find_pdb_scalar(self):
+    """Verify pdb_scalar ignores data/fsdp axes and multiplies parallelism axes."""
+    mock_config = MagicMock()
+    mock_config.mesh_axes = ["data", "tensor", "expert"]
+    mock_config.ici_tensor_parallelism = 4
+    mock_config.ici_expert_parallelism = 8  # Should be ignored per your logic
+
+    scalar = find_pdb_scalar(mock_config)
+    # Per your code: if mesh_axis not in ("data", "fsdp", ... "expert")
+    # Only "tensor" is left -> scalar should be 4.0
+    self.assertEqual(scalar, 4.0)
+
+  @pytest.mark.cpu_only
+  @patch("maxtext.utils.estimator.is_oom")
+  def test_largest_batch_size_binary_search(self, mock_is_oom):
+    """
+    Simulate OOM checks to ensure binary search finds the exact boundary.
+    Scenario: Fits at pdb=4, OOMs at pdb=5.
+    """
+
+    def oom_side_effect(argv, policy, pdb):
+      return pdb >= 5.0  # OOM if batch size is 5 or higher
+
+    mock_is_oom.side_effect = oom_side_effect
+
+    policy = RematPolicy(self.tensor_names)
+    # Search between 1 and 8
+    result = largest_batch_size(self.base_argv, policy, min_pdb=1.0, max_pdb=8.0, pdb_scalar=1.0)
+    self.assertEqual(result, 4.0)
+
+  @pytest.mark.cpu_only
+  @patch("maxtext.utils.estimator.is_oom")
+  def test_largest_batch_size_min_equals_max_no_oom(self, mock_is_oom):
+    """When min_pdb == max_pdb and it does NOT OOM, return that batch size."""
+    mock_is_oom.return_value = False
+    policy = RematPolicy(self.tensor_names)
+    result = largest_batch_size(self.base_argv, policy, min_pdb=4.0, max_pdb=4.0, pdb_scalar=1.0)
+    self.assertEqual(result, 4.0)
+
+  @pytest.mark.cpu_only
+  @patch("maxtext.utils.estimator.is_oom")
+  def test_largest_batch_size_min_equals_max_oom(self, mock_is_oom):
+    """When min_pdb == max_pdb and it DOES OOM, return below min."""
+    mock_is_oom.return_value = True
+    policy = RematPolicy(self.tensor_names)
+    result = largest_batch_size(self.base_argv, policy, min_pdb=4.0, max_pdb=4.0, pdb_scalar=1.0)
+    self.assertEqual(result, 3.0)
+
+  @pytest.mark.cpu_only
+  def test_largest_batch_size_zero_scalar(self):
+    """Verify ValueError is raised when pdb_scalar is zero."""
+    policy = RematPolicy(self.tensor_names)
+    with self.assertRaises(ValueError):
+      largest_batch_size(self.base_argv, policy, min_pdb=1.0, max_pdb=8.0, pdb_scalar=0.0)
+
+  @pytest.mark.cpu_only
+  def test_largest_batch_size_invalid_range(self):
+    """Verify ValueError when max_pdb < min_pdb."""
+    policy = RematPolicy(self.tensor_names)
+    with self.assertRaises(ValueError):
+      largest_batch_size(self.base_argv, policy, min_pdb=8.0, max_pdb=4.0, pdb_scalar=1.0)
+
+  @pytest.mark.cpu_only
+  @patch("maxtext.utils.estimator.is_oom")
+  def test_largest_batch_size_default_min_pdb(self, mock_is_oom):
+    """Verify min_pdb defaults to 1/pdb_scalar when None."""
+    mock_is_oom.return_value = False  # Never OOM
+    policy = RematPolicy(self.tensor_names)
+    result = largest_batch_size(self.base_argv, policy, min_pdb=None, max_pdb=8.0, pdb_scalar=4.0)
+    # min_pdb defaults to 1/4 = 0.25; since no OOM at max, result should be 8.0
+    self.assertEqual(result, 8.0)
+
+  @pytest.mark.cpu_only
+  def test_build_argv_default_layer_input(self):
+    """Ensure decoder_layer_input=device is added if not present."""
+    policy = RematPolicy(["context"], initial_level=Action.REMAT)
+    argv = build_argv(self.base_argv[1:], policy, pdb=2)
+
+    self.assertIn("decoder_layer_input=device", argv)
+    self.assertIn("per_device_batch_size=2", argv)
+    self.assertIn("context=remat", argv)
+
+  @pytest.mark.cpu_only
+  def test_build_argv_with_existing_layer_input(self):
+    """Ensure decoder_layer_input is NOT added when already present."""
+    base = self.base_argv[1:] + ("decoder_layer_input=offload",)
+    policy = RematPolicy(["context"], initial_level=Action.REMAT)
+    argv = build_argv(base, policy, pdb=2)
+
+    # Should have exactly one decoder_layer_input
+    count = sum(1 for a in argv if "decoder_layer_input" in a)
+    self.assertEqual(count, 1)
+    self.assertIn("decoder_layer_input=offload", argv)
+
+  @pytest.mark.cpu_only
+  def test_build_argv_with_dict_policy(self):
+    """Ensure build_argv works with a dict policy (as stored in Mode 2 results)."""
+    policy_dict = {"context": "remat", "mlpwo": "offload"}
+    argv = build_argv(self.base_argv[1:], policy_dict, pdb=4)
+
+    self.assertIn("remat_policy=custom", argv)
+    self.assertIn("context=remat", argv)
+    self.assertIn("mlpwo=offload", argv)
+    self.assertIn("per_device_batch_size=4", argv)
+
+  @pytest.mark.cpu_only
+  def test_priority_list_generation(self):
+    """Test that generate_priority_list pulls the correct key from config."""
+    mock_config = MagicMock()
+    mock_config.fused_mlp = True
+    mock_config.mlp_activations = [1, 2]  # Length 2
+    mock_config.emb_dim = 1024
+    mock_config.mlp_dim = 4096
+    mock_config.head_dim = 64
+    mock_config.num_query_heads = 16
+    mock_config.num_kv_heads = 16
+    mock_config.max_target_length = 2048
+
+    # Tensors for (True, 2): ["context", "qkv_proj", "mlpwi_0", "mlpwi_1", "mlpwo", "out_proj"]
+    plist = generate_priority_list(mock_config, provided_tensor_names=["context"])
+
+    self.assertNotIn("context", plist)
+    self.assertIn("mlpwi_0", plist)
+    self.assertIn("mlpwi_1", plist)
+
+  @pytest.mark.cpu_only
+  def test_get_parameter_value_found(self):
+    """Verify get_parameter_value finds a matching prefix."""
+    config = ("foo=bar", "per_device_batch_size=4", "baz=qux")
+    found, value = get_parameter_value(config, "per_device_batch_size=")
+    self.assertTrue(found)
+    self.assertEqual(value, "4")
+
+  @pytest.mark.cpu_only
+  def test_get_parameter_value_not_found(self):
+    """Verify get_parameter_value returns (False, None) when not found."""
+    config = ("foo=bar", "baz=qux")
+    found, value = get_parameter_value(config, "per_device_batch_size=")
+    self.assertFalse(found)
+    self.assertIsNone(value)
+
+  @pytest.mark.cpu_only
+  def test_find_batch_size_provided(self):
+    """Verify find_batch_size returns the batch size when present."""
+    argv = ("base.yml", "per_device_batch_size=2.5", "model_name=llama")
+    provided, pdb = find_batch_size(argv)
+    self.assertTrue(provided)
+    self.assertEqual(pdb, 2.5)
+
+  @pytest.mark.cpu_only
+  def test_find_batch_size_not_provided(self):
+    """Verify find_batch_size returns (False, None) when not present."""
+    argv = ("base.yml", "model_name=llama")
+    provided, pdb = find_batch_size(argv)
+    self.assertFalse(provided)
+    self.assertIsNone(pdb)
+
+  @pytest.mark.cpu_only
+  def test_find_remat_policy_tensor_names(self):
+    """Verify tensor names are detected from argv."""
+    argv = ("base.yml", "context=offload", "mlpwo=remat", "model_name=llama")
+    result = find_remat_policy_tensor_names(argv)
+    self.assertIn("context", result)
+    self.assertIn("mlpwo", result)
+    self.assertNotIn("query_proj", result)
+
+  @pytest.mark.cpu_only
+  def test_find_remat_policy_tensor_names_none(self):
+    """Verify empty list when no tensor names in argv."""
+    argv = ("base.yml", "model_name=llama")
+    result = find_remat_policy_tensor_names(argv)
+    self.assertEqual(result, [])
+
+  @pytest.mark.cpu_only
+  def test_generate_remat_config_from_policy(self):
+    """Verify generate_remat_config works with a RematPolicy object."""
+    policy = RematPolicy(["context", "mlpwo"], initial_level=Action.REMAT)
+    config = generate_remat_config(policy)
+    self.assertIn("remat_policy=custom", config)
+    self.assertIn("context=remat", config)
+    self.assertIn("mlpwo=remat", config)
+
+  @pytest.mark.cpu_only
+  def test_generate_remat_config_from_dict(self):
+    """Verify generate_remat_config works with a dict."""
+    policy_dict = {"context": "offload", "mlpwo": "device"}
+    config = generate_remat_config(policy_dict)
+    self.assertIn("remat_policy=custom", config)
+    self.assertIn("context=offload", config)
+    self.assertIn("mlpwo=device", config)
+
+  @pytest.mark.cpu_only
+  def test_generate_pdb_config(self):
+    """Verify generate_pdb_config returns the expected tuple."""
+    result = generate_pdb_config(4.0)
+    self.assertEqual(result, ("per_device_batch_size=4.0",))
+
+  @pytest.mark.cpu_only
+  @patch("maxtext.utils.estimator.is_oom")
+  def test_search_policy_only_finds_fitting_policy(self, mock_is_oom):
+    """Verify search_policy_only returns the first non-OOM policy."""
+    tensor_names = ["context", "mlpwo"]
+
+    # Simulate: full device OOMs, one step back (previous_policy) fits
+    call_count = [0]
+
+    def oom_side_effect(argv, policy, pdb):
+      call_count[0] += 1
+      if call_count[0] == 1:
+        # First call: sanity check with full remat -> does NOT OOM
+        return False
+      if call_count[0] == 2:
+        # Second call: full device policy -> OOMs
+        return True
+      if call_count[0] == 3:
+        # Third call: one step back -> OOMs
+        return True
+      # Fourth call onwards: fits
+      return False
+
+    mock_is_oom.side_effect = oom_side_effect
+
+    result = search_policy_only(tensor_names, self.base_argv, pdb=4.0)
+    # Result should be a RematPolicy that fits
+    self.assertIsInstance(result, RematPolicy)
+
+  @pytest.mark.cpu_only
+  @patch("maxtext.utils.estimator.is_oom")
+  def test_search_policy_only_raises_on_impossible_batch(self, mock_is_oom):
+    """Verify search_policy_only raises ValueError when full remat OOMs."""
+    mock_is_oom.return_value = True  # Everything OOMs
+
+    with self.assertRaises(ValueError):
+      search_policy_only(self.tensor_names, self.base_argv, pdb=999.0)
+
+  @pytest.mark.cpu_only
+  @patch("maxtext.utils.estimator.is_oom")
+  def test_search_returns_pareto_frontier(self, mock_is_oom):
+    """Verify search returns a list of (pdb, dict) tuples."""
+
+    def oom_side_effect(argv, policy, pdb):
+      # OOM at pdb >= 5
+      return pdb >= 5.0
+
+    mock_is_oom.side_effect = oom_side_effect
+
+    results = search(
+        self.tensor_names,
+        self.base_argv,
+        min_pdb=1.0,
+        max_pdb=8.0,
+        pdb_scalar=1.0,
+    )
+    # Should have at least one result
+    self.assertGreater(len(results), 0)
+    for pdb, policy_dict in results:
+      self.assertIsInstance(pdb, float)
+      self.assertIsInstance(policy_dict, dict)
+      # pdb should be > 0 (valid)
+      self.assertGreater(pdb, 0)
+
+  @pytest.mark.cpu_only
+  def test_next_previous_policy_full_traversal(self):
+    """Verify we can traverse from full remat to full device and back."""
+    names = ["a", "b"]
+    policy = RematPolicy(names, initial_level=Action.REMAT)
+    visited = [policy.to_dict]
+
+    # Traverse forward
+    current = policy
+    while True:
+      nxt = current.next_policy()
+      if nxt is None:
+        break
+      visited.append(nxt.to_dict)
+      current = nxt
+
+    # Final state should be full device
+    self.assertEqual(current.to_dict, {"a": "device", "b": "device"})
+
+    # Traverse backward
+    while True:
+      prev = current.previous_policy()
+      if prev is None:
+        break
+      current = prev
+
+    # Should be back at full remat
+    self.assertEqual(current.to_dict, {"a": "remat", "b": "remat"})


### PR DESCRIPTION
# Description

This PR introduces **fractional batch size search** to the MaxText estimator and refactors the internal policy management logic to be more robust and maintainable. These changes allow the estimator to find optimal batch sizes using non-batch-based sharding (e.g., tensor parallelism, context parallelism) that results in fractional per-device batch sizes.

### Key Changes

#### 1. Estimator Refactoring
*   **Structured Policy Management**: Introduced the `RematPolicy` class and `Action` enum (`REMAT`, `OFFLOAD`, `DEVICE`) to replace dictionary-based policy manipulation.
*   **Policy Transitions**: Implemented `next_policy()` and `previous_policy()` methods within `RematPolicy` to handle transitions between memory-efficient and compute-efficient states more cleanly.

#### 2. Fractional Batch Size Support
*   **Normalization Constant**: Added `find_pdb_scalar()` to calculate a multiplier based on non-data/non-FSDP mesh axes.
*   **Updated Binary Search**: Modified `largest_batch_size` to use the `pdb_scalar` during its search, ensuring compatibility with memory and compute estimation logic while finding fractional boundaries.

#### 3. Configuration & Output
*   **Configurable Output**: Added the `write_estimator_result` flag to control whether the estimator writes its findings to a separate file (`remat_commands_from_estimator.txt`).
*   **Default Behavior**: Updated `build_argv` to ensure `decoder_layer_input=device` is appended by default if not otherwise specified.

#### 4. Testing
*   **New Test Suite**: Added `tests/estimator_test.py` providing comprehensive coverage for the new `RematPolicy` logic, `pdb_scalar` calculation, and the binary search boundary finding.

### Impact
*   **Higher Accuracy**: The estimator can now find the absolute maximum batch size for complex topologies where per-device batch sizes are not integers.
*   **Better Code Quality**: Moving to a class-based policy representation makes the search algorithm easier to reason about and extend.

FIXES: [b/460511589](https://buganizer.corp.google.com/issues/460511589)

# Tests

## Test 1: search both batch sizes and remat policies (llama3.1-405b on tpu7x-1024)

Command
```bash
python -m maxtext.utils.estimator \
maxtext/configs/base.yml \
compile_topology=tpu7x-1024 \
compile_topology_num_slices=1 \
model_name=llama3.1-405b \
max_target_length=32768 \
ici_context_parallelism=8 \
ici_fsdp_parallelism=-1 \
log_config=False \
write_estimator_result=False
```

Output recommendation:
```
Search completed in 647.53 seconds.
  - Found valid combo: pdb=0.25, policy={'mlpwo': 'remat', 'context': 'remat', 'mlpwi_0': 'remat', 'mlpwi_1': 'remat', 'query_proj': 'remat', 'out_proj': 'remat', 'key_proj': 'remat', 'value_proj': 'remat'}
  - Found valid combo: pdb=0.25, policy={'mlpwo': 'remat', 'context': 'remat', 'mlpwi_0': 'remat', 'mlpwi_1': 'remat', 'query_proj': 'remat', 'out_proj': 'remat', 'key_proj': 'remat', 'value_proj': 'offload'}
  - Found valid combo: pdb=0.25, policy={'mlpwo': 'remat', 'context': 'remat', 'mlpwi_0': 'remat', 'mlpwi_1': 'remat', 'query_proj': 'remat', 'out_proj': 'remat', 'key_proj': 'offload', 'value_proj': 'offload'}
  - Found valid combo: pdb=0.25, policy={'mlpwo': 'remat', 'context': 'remat', 'mlpwi_0': 'remat', 'mlpwi_1': 'remat', 'query_proj': 'remat', 'out_proj': 'offload', 'key_proj': 'offload', 'value_proj': 'offload'}
  - Found valid combo: pdb=0.25, policy={'mlpwo': 'remat', 'context': 'remat', 'mlpwi_0': 'remat', 'mlpwi_1': 'remat', 'query_proj': 'offload', 'out_proj': 'offload', 'key_proj': 'offload', 'value_proj': 'offload'}
  - Found valid combo: pdb=0.125, policy={'mlpwo': 'remat', 'context': 'remat', 'mlpwi_0': 'remat', 'mlpwi_1': 'offload', 'query_proj': 'offload', 'out_proj': 'offload', 'key_proj': 'offload', 'value_proj': 'offload'}
  - Found valid combo: pdb=0.125, policy={'mlpwo': 'remat', 'context': 'remat', 'mlpwi_0': 'offload', 'mlpwi_1': 'offload', 'query_proj': 'offload', 'out_proj': 'offload', 'key_proj': 'offload', 'value_proj': 'offload'}
  - Found valid combo: pdb=0.125, policy={'mlpwo': 'remat', 'context': 'offload', 'mlpwi_0': 'offload', 'mlpwi_1': 'offload', 'query_proj': 'offload', 'out_proj': 'offload', 'key_proj': 'offload', 'value_proj': 'offload'}
  - Found valid combo: pdb=0.125, policy={'mlpwo': 'offload', 'context': 'offload', 'mlpwi_0': 'offload', 'mlpwi_1': 'offload', 'query_proj': 'offload', 'out_proj': 'offload', 'key_proj': 'offload', 'value_proj': 'offload'}
  - Found valid combo: pdb=0.125, policy={'mlpwo': 'offload', 'context': 'offload', 'mlpwi_0': 'offload', 'mlpwi_1': 'offload', 'query_proj': 'offload', 'out_proj': 'offload', 'key_proj': 'offload', 'value_proj': 'device'}
  - Found valid combo: pdb=0.125, policy={'mlpwo': 'offload', 'context': 'offload', 'mlpwi_0': 'offload', 'mlpwi_1': 'offload', 'query_proj': 'offload', 'out_proj': 'offload', 'key_proj': 'device', 'value_proj': 'device'}
  - Found valid combo: pdb=0.125, policy={'mlpwo': 'offload', 'context': 'offload', 'mlpwi_0': 'offload', 'mlpwi_1': 'offload', 'query_proj': 'offload', 'out_proj': 'device', 'key_proj': 'device', 'value_proj': 'device'}
Done.
```

Full output: [log](https://paste.googleplex.com/5391599288844288)

## Test 2: search best remat policies given fixed batch size (deepseek3-671b on v5p-1024)

```bash
python3 -m maxtext.utils.estimator maxtext/configs/base.yml \
model_name=deepseek3-671b \
compile_topology=v5p-1024 \
compile_topology_num_slices=1 \
ici_fsdp_parallelism=512 \
per_device_batch_size=2.0 \
dtype=bfloat16 \
weight_dtype=float32 \
scan_layers=True \
sparse_matmul=True \
use_custom_sort_vjp=False \
use_tokamax_splash=True \
use_tokamax_gmm=True \
sa_use_fused_bwd_kernel=False \
max_target_length=8192 \
sa_block_q=1024 \
sa_block_kv=1024 \
sa_block_kv_compute=1024 \
sa_block_q_dkv=1024 \
sa_block_kv_dkv=1024 \
sa_block_kv_dkv_compute=1024 \
sa_block_q_dq=1024 \
sa_block_kv_dq=1024 \
log_config=False \
write_estimator_result=False \
decoder_layer_input=offload
```

Output recommendation:
```
Search completed in 468.94 seconds.
  - Found valid combo: pdb=2.0, policy={'mlpwo': 'remat', 'out_proj': 'remat', 'context': 'remat', 'mlpwi_0': 'remat', 'mlpwi_1': 'remat', 'query_proj': 'offload', 'key_proj': 'offload', 'value_proj': 'offload'}
Done.
```

Full output: [log](https://paste.googleplex.com/4595367549206528)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
