### PR TITLE
Update loss free & loss control load balance

### DIFF
--- a/docs/reference/core_concepts/moe_configuration.md
+++ b/docs/reference/core_concepts/moe_configuration.md
@@ -59,6 +59,8 @@ Dropping:
 
 `routed_bias`: If enabled, adds a learnable bias term to the gate logits to facilitate load balancing.
 
+`routed_bias_update_rate`: Defines the update rate to routed bias term above. Applicable only to the DeepSeek decoder block.
+
 `routed_score_func`: Defines the scoring function for the router.
 
 `routed_scaling_factor`: A scalar multiplier applied to the expert weights.

--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -177,7 +177,7 @@ num_experts_per_tok: 1
 megablox: true
 sparse_matmul: true
 capacity_factor: -1.0 # a factor to decide expert capacity for token dropping, and no dropping by default
-load_balance_loss_weight: 0.01 # weight for the load balance loss
+load_balance_loss_weight: 0.0 # weight for the load balance loss
 use_random_routing: false # whether to use random routing for debug/test purpose
 use_custom_sort_vjp: true # whether to use a custom sort vjp for sparse matmul ops
 use_ring_of_experts: false # whether to use ring of experts for sparse matmul expert parallelism
@@ -224,6 +224,7 @@ shared_experts: 1
 routed_scaling_factor: 1.0 # scaling factor for routing scores
 routed_score_func: "" # scoring function for routing
 routed_bias: False # a flag if a learnable bias is added for routing
+routed_bias_update_rate: 0.0 # a flag indicate the update rate applied to the router bias term
 mlp_bias: False # a flag if a learnable bias is added for MLP matmul
 n_routing_groups: -1 # number of groups for routing, disabled by default
 topk_routing_group: -1 # number of top groups to route inputs. For EP,

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -552,7 +552,7 @@ class MoEGeneral(BaseModel):
   num_experts: PositiveInt = Field(1, description="The total number of experts in each MoE layer.")
   num_experts_per_tok: PositiveInt = Field(1, description="The number of experts to route each token to.")
   capacity_factor: float = Field(-1.0, description="Expert capacity factor. If < 0, no token dropping.")
-  load_balance_loss_weight: NonNegativeFloat = Field(0.01, description="Weight for the load balancing auxiliary loss.")
+  load_balance_loss_weight: NonNegativeFloat = Field(0.0, description="Weight for the load balancing auxiliary loss.")
   use_custom_sort_vjp: bool = Field(True, description="Whether to use a custom sort VJP for sparse matmul ops.")
   use_ring_of_experts: bool = Field(
       False,
@@ -639,6 +639,7 @@ class DeepSeekMoE(BaseModel):
   routed_scaling_factor: float = Field(1.0, description="Scaling factor for routing scores.")
   routed_score_func: str = Field("", description="Scoring function for routing (e.g., 'softmax', 'sigmoid').")
   routed_bias: bool = Field(False, description="Whether to add a bias term for routing.")
+  routed_bias_update_rate: float = Field(0.0, description="Update rate applied to the router bias term.")
   mlp_bias: bool = Field(False, description="Whether to add a learnable bias for MLP matmul.")
   n_routing_groups: int = Field(-1, description="Number of groups for routing, disabled by default.")
   topk_routing_group: int = Field(-1, description="Number of top groups to route inputs to.")
@@ -2043,6 +2044,8 @@ class MaxTextConfig(
           )
       if self.decoder_block == DecoderBlockType.GPT_OSS and not self.sparse_matmul and self.capacity_factor != -1:
         raise ValueError("GPT-OSS MoE only supports dropless (capacity_factor=-1) with dense matmul.")
+      if self.routed_bias and self.routed_bias_update_rate > 0.0 and self.decoder_block != DecoderBlockType.DEEPSEEK:
+        raise ValueError("Loss-free load balancing is only supported for the DeepSeek decoder block.")
     if self.use_multimodal:
       valid_mm_models = (
           "gemma3-4b",

--- a/src/MaxText/layers/gpt_oss.py
+++ b/src/MaxText/layers/gpt_oss.py
@@ -182,7 +182,7 @@ class GptOssDecoderLayer(nnx.Module):
     )
 
     load_balance_loss = None
-    mlp_lnx, load_balance_loss = self.GptOssMlp(hidden_states)
+    mlp_lnx, load_balance_loss, _ = self.GptOssMlp(hidden_states)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
 
     layer_output = mlp_lnx + intermediate_inputs
@@ -193,7 +193,7 @@ class GptOssDecoderLayer(nnx.Module):
         ("activation_batch", "activation_norm_length", "activation_embed"),
     )
 
-    if load_balance_loss is not None:
+    if cfg.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
       self.sow("intermediates", "moe_lb_loss", load_balance_loss)
 
     if cfg.record_internal_nn_metrics:

--- a/src/MaxText/layers/llama4.py
+++ b/src/MaxText/layers/llama4.py
@@ -484,8 +484,9 @@ class Llama4DecoderLayer(nnx.Module):
     hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
     hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
 
+    load_balance_loss = None
     if self.is_moe_layer:
-      mlp_lnx = self.moe_block(hidden_states)
+      mlp_lnx, load_balance_loss, _ = self.moe_block(hidden_states)
     else:
       mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
@@ -493,6 +494,9 @@ class Llama4DecoderLayer(nnx.Module):
     layer_output = mlp_lnx + intermediate_inputs
     layer_output = self.dropout(layer_output, deterministic=deterministic)
     layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+
+    if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
+      self.sow("intermediates", "moe_lb_loss", load_balance_loss)
 
     if cfg.record_internal_nn_metrics:
       self.sow("intermediates", "activation_mean", jnp.mean(layer_output))

--- a/src/MaxText/layers/mixtral.py
+++ b/src/MaxText/layers/mixtral.py
@@ -172,14 +172,14 @@ class MixtralDecoderLayer(nnx.Module):
     # NOTE: the naming mismatch here is to ensure reverse compatibility with existing checkpoints.
     # The `name` represents the weight name in JAX/checkpoints and so the class name
     # is just for readability.
-    mlp_lnx, load_balance_loss = self.MoeBlock_0(hidden_states)
+    mlp_lnx, load_balance_loss, _ = self.MoeBlock_0(hidden_states)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
 
     layer_output = mlp_lnx + intermediate_inputs
     layer_output = self.dropout(layer_output, deterministic=deterministic)
     layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
 
-    if load_balance_loss is not None:
+    if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
       self.sow("intermediates", "moe_lb_loss", load_balance_loss)
 
     if self.config.record_internal_nn_metrics:

--- a/src/MaxText/train.py
+++ b/src/MaxText/train.py
@@ -190,13 +190,19 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
     mtp_loss = calculate_mtp_loss(intermediate_outputs, config)
     loss += mtp_loss
 
-  # get moe load balance loss
+  # get MoE load balance loss
   moe_lb_loss = 0.0
   if config.num_experts > 1:
     nested_key = ("intermediates", "decoder", "layers", "moe_lb_loss")
     total_moe_lb_loss = maxtext_utils.get_nested_value(intermediate_outputs, nested_key, 0.0)
     moe_lb_loss = jnp.mean(jnp.array(total_moe_lb_loss))
     loss += moe_lb_loss
+
+  # get MoE routed bias term updates
+  moe_bias_updates = None
+  if config.routed_bias and config.routed_bias_update_rate > 0.0:
+    nested_key = ("intermediates", "decoder", "moe_layers", "moe_bias_updates")
+    moe_bias_updates = maxtext_utils.get_nested_value(intermediate_outputs, nested_key, None)
 
   # Add the model's primary output to the intermediates dict so it can be used
   # by the acceptance rate calculation in eval_step.
@@ -207,6 +213,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
       "total_loss": total_loss,
       "total_weights": total_weights,
       "moe_lb_loss": moe_lb_loss,
+      "moe_bias_updates": moe_bias_updates,
       "mtp_loss": mtp_loss,
   }
   return loss, aux
@@ -272,6 +279,7 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
   intermediate_outputs = aux["intermediate_outputs"]
   total_weights = aux["total_weights"]
   moe_lb_loss = aux["moe_lb_loss"]
+  moe_bias_updates = aux["moe_bias_updates"]
   mtp_loss = aux["mtp_loss"]
 
   if config.gradient_clipping_threshold > 0:
@@ -303,6 +311,14 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
         )
     )
   new_state = state.apply_gradients(grads=grads)
+
+  # Apply updates for Auxiliary-Loss-Free load balancing for DeepSeek family
+  if config.routed_bias and config.routed_bias_update_rate > 0.0 and moe_bias_updates is not None:
+    target_path = ("params", "decoder", "moe_layers", "DeepSeekMoeBlock_0", "MoeBlock_0", "gate", "bias")
+    # Flax 'sow' returns a tuple, so we take the first element [0].
+    # Updates the shape to be aligned with state.
+    moe_bias_updates = jnp.array(moe_bias_updates[0]).transpose()
+    new_state = maxtext_utils.update_state_param(new_state, target_path, moe_bias_updates)
 
   scalar_metrics = {
       "learning/loss": loss,


### PR DESCRIPTION
# Description

Please see this [screenshot](https://screenshot.googleplex.com/8N88e9LAmjAZLuo) for high-level pseudo-code, b/461812380.

* Add `routed_bias_update_rate` config to indicate the speed of bias term updates
* Add helper function `calculate_load_balance_updates()` and pass it via `sow` to param updates.  
* Add helper function `update_state_param()` to update or replace the param values.
* Enable **optional** loss control load balance mechanism in other MoE models, like DeepSeek, GPT-OSS, and Llama4 family. We have enabled them in Mixtral & Qwen3 family already.

# Tests
* Expect runner tests are green to catch any compile issue
* Add unit tests for `calculate_load_balance_updates()` and `update_state_param()` functions
* Functional tests:
  * Only DeepSeek models support loss free case, expected - [test](https://paste.googleplex.com/4603411184091136)
  * Optionally support loss control case for MoE models - [test](https://paste.googleplex.com/5112262668976128)
* Performance check before vs. after to run DeepSeek v2 on synthetic dataset `per_device_batch_size=4, max_target_length=4096`

```
# before the change on Main
I1228 23:27:36.115740 140683853757568 metric_logger.py:180] completed step: 14, seconds: 2.557, TFLOP/s/device: 105.114, Tokens/s/device: 6406.837, total_weights: 65536, loss: 10.739

# after the change with this commit 
I1228 23:23:18.459741 140009441311872 metric_logger.py:180] completed step: 14, seconds: 2.557, TFLOP/s/device: 105.124, Tokens/s/device: 6407.436, total_weights: 65536, loss: 10.739
```

* Tested locally to verify the bias update as expectation - [full logs](https://paste.googleplex.com/5411290761789440#l=1974)

Two expected behaviors:
1) before_the_change + bias_updates = after_the_change (expect slight delta for very small values). For instance, -0.000450134 - 0.0005  = -0.000950134 ~= -0.00094986 with reasonable tolerance (|-0.000950134+0.00094986| = 0.000000274).
2) after_the_change in previous layer = bias in next layer

```
before the change: [[-0.000450134]
 [-0.000457764]
 [-0.000537872]
 [0.000463486]
 [0.000480652]
 ...

after the change: [[-0.00094986]
 [-0.000957489]
 [-0.0010376]
 [0.000965118]
 [0.000984192]
...

bias_updates: [-0.0005 -0.0005 -0.0005  0.0005  0.0005 ...]

bias: [-0.00094986 -0.000957489 -0.0010376 0.000965118 0.000984192...
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
