### PR TITLE
Fix Pydantic validation error for Vertex Tensorboard args

### DIFF
--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -1,5 +1,5 @@
 # Copyright 2023–2025 Google LLC
-#
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -1302,8 +1302,8 @@ class Tensorboard(BaseModel):
 
   enable_tensorboard: bool = Field(True, description="Enable Tensorboard logging.")
   use_vertex_tensorboard: bool = Field(False, description="Set to True for GCE, False if running via XPK.")
-  vertex_tensorboard_project: str = Field("", description="GCP project for Vertex AI Tensorboard.")
-  vertex_tensorboard_region: str = Field("", description="Region for Vertex AI Tensorboard.")
+  vertex_tensorboard_project: Optional[str] = Field("", description="GCP project for Vertex AI Tensorboard.")
+  vertex_tensorboard_region: Optional[str] = Field("", description="Region for Vertex AI Tensorboard.")
 
 
 class MultimodalGeneral(BaseModel):


### PR DESCRIPTION
# Description

When running MaxText benchmarks, `use_vertex_tensorboard` and `vertex_tensorboard_project` may be converted to  `None`. The `MaxTextConfig` Pydantic model currently enforces strict string types, causing a `ValidationError` (Input should be a valid string).

This change updates the config definition to `Optional[str]`. This allows the fields to accept `None` during validation.

[Error Log](https://paste.googleplex.com/5325865821011968)

# Tests

```python3 -m benchmarks.benchmark_runner on-device --base_output_directory gs://maxtext-test/ --run_name="test-run" --num_steps=5```

[Logs](https://paste.googleplex.com/4641388157337600)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
