### PR TITLE
Fix SFT + GA (gradient accumulation)

### DIFF
--- a/src/MaxText/sft_trainer.py
+++ b/src/MaxText/sft_trainer.py
@@ -35,6 +35,7 @@ from MaxText import maxtext_utils
 from MaxText import profiler
 from MaxText import pyconfig
 from MaxText import train_utils
+from MaxText import sharding
 from MaxText.data_loader import DataLoader
 from MaxText.metric_logger import MetricLogger
 from MaxText.train import (
@@ -71,8 +72,10 @@ def train_loop(config, recorder, state=None):
       state,
   ) = setup_train_loop(config, recorder)
 
+  params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
+
   p_train_step, p_eval_step = train_utils.jit_train_and_eval_step(
-      config, model, mesh, state, state_mesh_shardings, train_step, eval_step, eval_data_iterator
+      config, model, mesh, state, state_mesh_shardings, train_step, eval_step, eval_data_iterator, params_shardings
   )
 
   with jax.set_mesh(mesh), nn_partitioning.axis_rules(config.logical_axis_rules):


### PR DESCRIPTION
# Description

Fixes an issue where gradient accumulation + sft would fail due to missing param sharding

FIXES: b/472309528


# Tests

Added a unit test (integration test) for sft + ga

Manually tested via 

python3 -m MaxText.sft_trainer MaxText/configs/base.yml run_name=mattdavidow-train-base base_output_directory=$output_dir dataset_path=$dataset steps=5 enable_checkpointing=False enable_goodput_recording=False use_sft=True gradient_accumulation_steps=5

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
