### PR TITLE
Include test_assets from GCS in tpu/gpu dockerfiles

### DIFF
--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -102,6 +102,7 @@ jobs:
       dockerfile: ${{ matrix.dockerfile }}
       maxtext_sha: ${{ needs.setup.outputs.maxtext_sha }}
       image_date: ${{ needs.setup.outputs.image_date }}
+      base_image: gcr.io/tpu-prod-env-multipod/maxtext_jax_stable:${{ needs.setup.outputs.image_date }}
       is_post_training: true
 
   gpu-pre-training:

--- a/.github/workflows/build_and_push_docker_image.yml
+++ b/.github/workflows/build_and_push_docker_image.yml
@@ -37,6 +37,10 @@ on:
       image_date:
         required: true
         type: string
+      base_image:
+        required: false
+        type: string
+        default: ''
       is_post_training:
         required: false
         type: boolean
@@ -114,7 +118,8 @@ jobs:
             MODE=${{ inputs.build_mode }}
             JAX_VERSION=NONE
             LIBTPU_VERSION=NONE
-            BASEIMAGE=gcr.io/tpu-prod-env-multipod/maxtext_jax_stable:${{ inputs.image_date }}
+            INCLUDE_TEST_ASSETS=true
+            ${{ inputs.base_image != '' && format('BASEIMAGE={0}', inputs.base_image) || '' }}
 
       - name: Add tags to Docker image
         if: steps.check.outputs.should_run == 'true'

--- a/dependencies/dockerfiles/maxtext_gpu_dependencies.Dockerfile
+++ b/dependencies/dockerfiles/maxtext_gpu_dependencies.Dockerfile
@@ -58,5 +58,14 @@ RUN --mount=type=cache,target=/root/.cache/pip bash /deps/tools/setup/setup.sh M
 # Now copy the remaining code (source files that may change frequently)
 COPY . .
 
+# Download test assets from GCS if building image with test assets
+ARG INCLUDE_TEST_ASSETS=false
+RUN if [ "$INCLUDE_TEST_ASSETS" = "true" ]; then \
+        echo "Downloading test assets from GCS..."; \
+        if ! gcloud storage cp -r gs://maxtext-test-assets/* "${MAXTEXT_TEST_ASSETS_ROOT}"; then \
+        echo "WARNING: Failed to download test assets from GCS. These files are only used for end-to-end tests; you may not have access to the bucket."; \
+        fi; \
+    fi
+
 # Install (editable) MaxText
 RUN test -f '/tmp/venv_created' && "$(tail -n1 /tmp/venv_created)"/bin/activate ; pip install --no-dependencies -e .

--- a/dependencies/dockerfiles/maxtext_tpu_dependencies.Dockerfile
+++ b/dependencies/dockerfiles/maxtext_tpu_dependencies.Dockerfile
@@ -55,5 +55,14 @@ RUN --mount=type=cache,target=/root/.cache/pip bash /deps/tools/setup/setup.sh M
 # Now copy the remaining code (source files that may change frequently)
 COPY . .
 
+# Download test assets from GCS if building image with test assets
+ARG INCLUDE_TEST_ASSETS=false
+RUN if [ "$INCLUDE_TEST_ASSETS" = "true" ]; then \
+        echo "Downloading test assets from GCS..."; \
+        if ! gcloud storage cp -r gs://maxtext-test-assets/* "${MAXTEXT_TEST_ASSETS_ROOT}"; then \
+        echo "WARNING: Failed to download test assets from GCS. These files are only used for end-to-end tests; you may not have access to the bucket."; \
+        fi; \
+    fi
+
 # Install (editable) MaxText
 RUN test -f '/tmp/venv_created' && "$(tail -n1 /tmp/venv_created)"/bin/activate ; pip install --no-dependencies -e .


### PR DESCRIPTION
# Description

* Include `test_assets` from GCS in TPU/GPU docker images build nightly

FIXES: b/471848644

# Tests

https://github.com/AI-Hypercomputer/maxtext/actions/runs/20602930239/job/59172412583

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
