### PR TITLE
Fix the AddLabel workflow permission issue

### DIFF
--- a/.github/workflows/AddLabel.yml
+++ b/.github/workflows/AddLabel.yml
@@ -22,22 +22,34 @@ on:
   pull_request_review:
   pull_request_review_comment:
   workflow_dispatch:
+    inputs:
+      pull_number:
+        description: 'The Pull Request number to process manually'
+        required: true
+        type: string
 
 jobs:
   AddPullReady:
     permissions:
       checks: read
       pull-requests: write
+      issues: write
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/github-script@v7
         with:
           script: |
+            const token_status = await github.rest.rateLimit.get();
+            console.log("X-OAuth-Scopes:", token_status.headers['x-oauth-scopes']);
             const owner = "google"
             const repo = "maxtext"
             let pull_number = -1
-            if (context.payload.pull_request !== undefined) {
+            if (context.payload.inputs && context.payload.inputs.pull_number) {
+              pull_number = parseInt(context.payload.inputs.pull_number)
+              console.log(`Manual trigger for PR #${pull_number}`)
+            } else if (context.payload.pull_request !== undefined) {
               pull_number = context.payload.pull_request.number
             } else if (context.payload.workflow_run !== undefined) {
               if (context.payload.workflow_run.pull_requests.length === 0) {


### PR DESCRIPTION
# Description

Fix the AddLabel workflow permission issue, and also allow the action to be run manually by giving the pull request number.

This is the failed AddLabel run [example](https://github.com/AI-Hypercomputer/maxtext/actions/runs/20582113556/job/59111600555?pr=2880)

# Tests

None

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
