### PR TITLE
Fix the LIBTPU_INIT_ARGS logging issue

### DIFF
--- a/src/MaxText/metric_logger.py
+++ b/src/MaxText/metric_logger.py
@@ -273,7 +273,7 @@ class MetricLogger:
     self.metadata[MetadataKey.PER_DEVICE_TOKENS] = maxtext_utils.calculate_tokens_training_per_device(self.config)
     max_logging.log(f"number parameters: {num_model_parameters/1e9:.3f} billion")
     max_utils.add_text_to_summary_writer("num_model_parameters", str(num_model_parameters), self.writer)
-    max_utils.add_text_to_summary_writer("libtpu_init_args", os.environ["LIBTPU_INIT_ARGS"], self.writer)
+    max_utils.add_text_to_summary_writer("libtpu_init_args", os.getenv("LIBTPU_INIT_ARGS", ""), self.writer)
     maxtext_utils.add_config_to_summary_writer(self.config, self.writer)
 
   def get_performance_metric_queue(self, config):


### PR DESCRIPTION
# Description
Fix the following error when the LIBTPU_INIT_ARGS env is not set
```
  File "/deps/src/MaxText/metric_logger.py", line 276, in write_setup_info_to_tensorboard
    max_utils.add_text_to_summary_writer("libtpu_init_args", os.environ["LIBTPU_INIT_ARGS"], self.writer)
                                                             ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 714, in __getitem__
KeyError: 'LIBTPU_INIT_ARGS'
```

# Tests

Tested following [the doc](https://maxtext.readthedocs.io/en/latest/tutorials/posttraining/sft_on_multi_host.html#sft-with-pathways)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
