### PR TITLE
Deprecate custom_wheels mode

### DIFF
--- a/RESTRUCTURE.md
+++ b/RESTRUCTURE.md
@@ -27,7 +27,6 @@ comments, or questions by creating a new
 ├── README.md
 ├── dependencies/
 │   ├── dockerfiles/
-│   │   ├── maxtext_custom_wheels.Dockerfile
 │   │   ├── maxtext_tpu_dependencies.Dockerfile
 │   │   ├── maxtext_gpu_dependencies.Dockerfile
 │   │   └── maxtext_runner.Dockerfile

--- a/dependencies/dockerfiles/maxtext_custom_wheels.Dockerfile
+++ b/dependencies/dockerfiles/maxtext_custom_wheels.Dockerfile
@@ -1,6 +1,0 @@
-ARG BASEIMAGE=maxtext_base_image
-FROM $BASEIMAGE
-
-# Requires wheels be in /deps. This means any custom wheels should be placed
-# in the maxtext directory.
-RUN python3 -m pip install --force-reinstall /deps/*.whl

--- a/dependencies/scripts/docker_build_dependency_image.sh
+++ b/dependencies/scripts/docker_build_dependency_image.sh
@@ -96,18 +96,18 @@ if [[ -z ${JAX_VERSION+x} ]] ; then
 fi
 if [[ -z ${MODE} ]]; then
   export MODE=stable
-# TODO: Remove 'custom_wheels' mode support when tpu-recipes migration is complete.
-elif [[ ${MODE} == "custom_wheels" ]]; then
-  export WORKFLOW=custom-wheels
-  export MODE=nightly
 fi
 if [[ -z ${DEVICE} ]]; then
   export DEVICE=tpu
+fi
+if [[ -z ${WORKFLOW} ]]; then
+  export WORKFLOW=pre-training
 fi
 
 # Create docker build arguments array
 docker_build_args=(
   "DEVICE=${DEVICE}"
+  "WORKFLOW=${WORKFLOW}"
   "MODE=${MODE}"
   "JAX_VERSION=${JAX_VERSION}"
 )
@@ -171,12 +171,6 @@ build_tpu_image() {
   # Handle post-training workflow if specified
   if [[ ${WORKFLOW} == "post-training" || ${WORKFLOW} == "post-training-experimental" ]]; then
     build_post_training_image
-  fi
-
-  # TODO: Remove 'custom_wheels' mode support when tpu-recipes migration is complete.
-  if [[ ${WORKFLOW} == "custom-wheels" ]]; then
-    echo "Building custom wheels dependencies."
-    run_docker_build "$MAXTEXT_REPO_ROOT/dependencies/dockerfiles/maxtext_custom_wheels.Dockerfile" "BASEIMAGE=${LOCAL_IMAGE_NAME}"
   fi
 }
 


### PR DESCRIPTION
# Description

* Deprecate `MODE=custom_wheels` from `docker_build_dependency_image.sh`

# Tests

Tested locally by building docker images for stable/nightly

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
