### PR TITLE
Fix missing `hf_eval_split` option in test_convergence_1b_params.sh

### DIFF
--- a/end_to_end/tpu/test_convergence_1b_params.sh
+++ b/end_to_end/tpu/test_convergence_1b_params.sh
@@ -52,6 +52,7 @@ then
     gsutil cp -r gs://maxtext-dataset/hf/llama2-tokenizer "${MAXTEXT_ASSETS_ROOT:-${MAXTEXT_PKG_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/MaxText/assets}}"
     CMD_DATA=" hf_path=parquet tokenizer_path=${MAXTEXT_ASSETS_ROOT:-${MAXTEXT_PKG_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/MaxText/assets}}/llama2-tokenizer \
         hf_train_files=$DATASET_PATH/hf/c4/c4-train-*.parquet \
+        hf_eval_split=train \
         hf_eval_files=$DATASET_PATH/hf/c4/c4-validation-*.parquet "
 fi
 


### PR DESCRIPTION
# Description

The `hf_eval_split` must be set when running `end_to_end/tpu/test_convergence_1b_params.sh`, otherwise it will throw `ValueError: Bad split: . Available splits: ['train']`.

[Error Log](https://paste.googleplex.com/5037131359715328#l=1126)

# Tests

```~/xpk/xpk.py workload create --cluster=bodaborg-v6e-256-lcscld-c --workload=maxtext-convergence-hf-v6e-2569caf0631 --command='set -xue;export M_RUN_NAME=maxtext-convergence-hf-v6e-256-2026-01-05-06-36-59;bash end_to_end/tpu/test_convergence_1b_params.sh OUTPUT_PATH=gs://ml-auto-solutions/output/maxtext/stable/automated/2026-01-05 DATASET_PATH=gs://max-datasets-rogue LOSS_THRESHOLD=2.7 STEPS=500 PER_DEVICE_BATCH_SIZE=2.0 DATASET_TYPE=hf' --device-type=v6e-256 --num-slices=1 --docker-image=gcr.io/tpu-prod-env-multipod/maxtext_base_image:hf --project=tpu-prod-env-one-vm --zone=southamerica-west1-a --env GCS_OUTPUT=gs://ml-auto-solutions/output/unowned/maxtext-convergence-hf-v6e-256-2026-01-05-06-37-20/ --skip-validation```

[Log](https://paste.googleplex.com/4759413221097472)
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
