### PR TITLE
Add HF datasest name

### DIFF
--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -587,7 +587,9 @@ eval_dataset_name: 'c4/en:3.0.1'
 train_split: 'train'
 eval_split: 'validation'
 # for HuggingFace input pipeline (dataset_type=hf)
+# Check definition at https://github.com/huggingface/datasets/blob/0feb65dd8733191dd2d1e74215b422fc5939a56a/src/datasets/load.py#L1338-L1408
 hf_path: ''
+hf_name: ''
 hf_data_dir: ''
 hf_train_files: ''
 hf_eval_split: ''

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -919,7 +919,8 @@ class TfdsDataset(BaseModel):
 class HfDataset(BaseModel):
   """Configuration specific to HuggingFace datasets."""
 
-  hf_path: str = Field("", description="Path or name of the Hugging Face dataset.")
+  hf_path: str = Field("", description="Path of the Hugging Face dataset.")
+  hf_name: str = Field("", description="Name of the Hugging Face dataset.")
   hf_data_dir: PathStr = Field("", description="Data directory for the HF dataset.")
   hf_train_files: Optional[str] = Field(None, description="Files for the HF training split.")
   hf_eval_split: str = Field("", description="Name of the HF evaluation split.")

--- a/src/MaxText/input_pipeline/_hf_data_processing.py
+++ b/src/MaxText/input_pipeline/_hf_data_processing.py
@@ -352,6 +352,7 @@ def make_hf_train_iterator(
   """Load, preprocess dataset and return iterators"""
   train_ds = datasets.load_dataset(
       config.hf_path,
+      name=config.hf_name,
       data_dir=config.hf_data_dir,
       data_files=config.hf_train_files,
       split=config.train_split,
@@ -404,6 +405,7 @@ def make_hf_eval_iterator(
   """Make Hugging Face evaluation iterator. Load and preprocess eval dataset: and return iterator."""
   eval_ds = datasets.load_dataset(
       config.hf_path,
+      name=config.hf_name,
       data_dir=config.hf_data_dir,
       data_files=config.hf_eval_files,
       split=config.hf_eval_split,


### PR DESCRIPTION
# Description

Add HF datasest name

Context: I was trying to use HF dataset `HuggingFaceFW/fineweb-edu` ([link](https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu)), and it was not able to find the right path ([link](https://screenshot.googleplex.com/7Bxaecc9NNmuzMS)). It turns out that we are missing optional `name` config. So adding this config, it can be loaded correctly ([link](https://screenshot.googleplex.com/5iLwVchmWqUChiJ)).

HF recommended usage:

```
from datasets import load_dataset
# use name="sample-10BT" to use the 10BT sample
fw = load_dataset("HuggingFaceFW/fineweb-edu", name="CC-MAIN-2024-10", split="train", streaming=True)
```

# Tests

Tests in description.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
