### PR TITLE
Add doc-only change detection to skip tests

### DIFF
--- a/.github/workflows/build_and_test_maxtext.yml
+++ b/.github/workflows/build_and_test_maxtext.yml
@@ -37,7 +37,44 @@ concurrency:
 permissions:
   contents: read
 jobs:
+  doc_only_check:
+    name: Check for Documentation-Only Changes
+    runs-on: ubuntu-latest
+    outputs:
+      skip_tests: ${{ steps.check.outputs.skip_tests }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check if only documentation changed
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Not a pull request, running all tests"
+            echo "skip_tests=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          git fetch origin ${{ github.base_ref }}
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No files changed"
+            echo "skip_tests=false" >> $GITHUB_OUTPUT
+          elif echo "$CHANGED_FILES" | grep -v -E '\.(md|ipynb)$' > /dev/null; then
+            echo "Non-documentation files changed, running tests"
+            echo "skip_tests=false" >> $GITHUB_OUTPUT
+          else
+            echo "Only documentation (.md|ipynb) files changed, skipping tests"
+            echo "skip_tests=true" >> $GITHUB_OUTPUT
+          fi
+
   build_and_upload_maxtext_package:
+    needs: doc_only_check
+    if: needs.doc_only_check.outputs.skip_tests != 'true'
     uses: ./.github/workflows/build_package.yml
     with:
       device_type: tpu
@@ -176,6 +213,38 @@ jobs:
       tf_force_gpu_allow_growth: true
       container_resource_option: "--shm-size 2g --runtime=nvidia --gpus all --privileged"
       is_scheduled_run: ${{ github.event_name == 'schedule' }}
+
+  all_tests_passed:
+    name: All Required Tests Passed
+    needs: [doc_only_check, build_and_upload_maxtext_package, maxtext_cpu_unit_tests, maxtext_tpu_unit_tests, maxtext_tpu_integration_tests, maxtext_tpu_pathways_unit_tests, maxtext_tpu_pathways_integration_tests, maxtext_gpu_unit_tests, maxtext_gpu_integration_tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          # If doc-only, all tests should be skipped
+          if [ "${{ needs.doc_only_check.outputs.skip_tests }}" == "true" ]; then
+            echo "Documentation-only changes detected, tests were skipped"
+            exit 0
+          fi
+
+          # Otherwise, check that build and all tests passed or were skipped
+          echo "Build result: ${{ needs.build_and_upload_maxtext_package.result }}"
+          echo "CPU tests: ${{ needs.maxtext_cpu_unit_tests.result }}"
+          echo "TPU tests: ${{ needs.maxtext_tpu_unit_tests.result }}"
+          echo "TPU integration: ${{ needs.maxtext_tpu_integration_tests.result }}"
+          echo "TPU pathways: ${{ needs.maxtext_tpu_pathways_unit_tests.result }}"
+          echo "TPU pathways integration: ${{ needs.maxtext_tpu_pathways_integration_tests.result }}"
+          echo "GPU tests: ${{ needs.maxtext_gpu_unit_tests.result }}"
+          echo "GPU integration: ${{ needs.maxtext_gpu_integration_tests.result }}"
+
+          # Fail only if any job failed or was cancelled (skipped is OK)
+          if [ "${{ contains(needs.*.result, 'failure') }}" == "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]; then
+            echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi
+
+          echo "All required tests passed successfully"
 
   notify_failure:
     name: Notify failed build # creates an issue or modifies last open existing issue for failed build


### PR DESCRIPTION
# Description
- Add `doc_only_check` job to detect when only `.md|ipynb` files are modified (Later, you can skip more file types such as `jpg|png|mp4` if needed):
  - If `skip_tests==true`: Skip the build process and all unit tests.
  - If `skip_tests==false`: Execute all remaining build process and unit tests like before.


- Add `all_tests_passed` to aggregate build and all unit tests status. Later in GitHub branch protection rule, we only check this test. Benefits of doing so:
  - Clear intent: Single "gate" that represents overall health
  - Future-proof: Add/remove/rename test jobs without updating branch protection
 

# Tests

Skip test (doc-only): https://screenshot.googleplex.com/ANutL8W8zpaRP5e
Non-skip test (success): https://screenshot.googleplex.com/BKxyPkxUgAYZvxR
Non-skip test (failure): https://screenshot.googleplex.com/4JU7AtHVWpJ7SMT
Non-skip test (cancel): https://screenshot.googleplex.com/8om8PyDT3vSxJd3

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
