### PR TITLE
Adding Support for Attention Sinks to vLLM Code Path.

### DIFF
--- a/src/MaxText/layers/attentions.py
+++ b/src/MaxText/layers/attentions.py
@@ -915,9 +915,6 @@ class Attention(nnx.Module):
           "vLLM RPA attention ops require the vllm-tpu package. Please install it with `pip install vllm-tpu`."
       ) from e
 
-    if self.config.attention_sink:
-      raise NotImplementedError("Attention sink is not supported in MaxText vLLM RPA attention.")
-
     if rpa_kv_cache is None or rpa_metadata is None:
       raise ValueError("kv_cache and attention_metadata must be provided when using vLLM.")
 
@@ -925,7 +922,12 @@ class Attention(nnx.Module):
     key = key.reshape(-1, key.shape[2], key.shape[3])
     value = value.reshape(-1, value.shape[2], value.shape[3])
 
-    attention_chunk_size = self.config.chunk_attn_window_size if self.config.chunk_attn_window_size > 0 else None
+    if self.config.sliding_window_size > 0:
+      attention_chunk_size = self.config.sliding_window_size
+    else:
+      # Chunked attention currently not used in vLLM RPA.
+      attention_chunk_size = None
+
     q_scale, k_scale, v_scale = None, None, None
 
     md = rpa_metadata
@@ -940,7 +942,7 @@ class Attention(nnx.Module):
         md.block_tables,
         md.query_start_loc,
         md.request_distribution,
-        None,
+        self.sinks.astype(jnp.float32) if self.sinks is not None else None,
         1.0,
         attention_chunk_size,
         q_scale,


### PR DESCRIPTION
# Description

This PR introduces support for attention sinks in the MaxText on vLLM codepath. This introduces support for the GPT-OSS family of models.

# Tests

Tested locally on v6e-4 with the following command:

```
  python3 -m MaxText.vllm_decode \
    --model_name gpt-oss-20b \
    --hf_model_name openai/gpt-oss-20b \
    --hf_config_path src/MaxText/integration/vllm/maxtext_vllm_adapter \
    --load_parameters_path $CHECKPOINT_PATH \
    --ici_tensor_parallelism 4 \
    --gpu_memory_utilization 0.5 \
    --prompt "Suggest some famous landmarks in London."
```

**Output:**

```
Prompt: 'Suggest some famous landmarks in London.', Generated text: "\n\nLondon is home to a wealth of iconic landmarks that reflect its rich history and vibrant culture. Here are some of the most famous:\n\n1. **The Tower of London** - A historic castle on the north bank of the River Thames, known for its role as a royal palace, prison, and treasury.\n2. **Buckingham Palace** - The London residence and administrative headquarters of the monarch of the United Kingdom.\n3. **The British Museum** - One of the world's best museums, famous for its vast collection of art and antiquities from around the world.\n4. **The Houses of Parliament and Big Ben** - The iconic clock tower and the seat of the UK Parliament.\n5. **The London Eye** - A giant Ferris wheel on the South Bank of the River Thames, offering panoramic views of the city.\n6. **St. Paul’s Cathedral** - Known for its magnificent dome and historic significance.\n7. **The Shard** - The tallest building in the UK, offering spectacular views from its viewing platform.\n8. **The Tate Modern** - A leading contemporary art museum.\n9. **The National Gallery** - Home to a collection of paintings, sculpture, and prints.\n10. **The National Gallery** - The National Gallery** - Home to a collection of paintings, sculpture, and prints.\n\nHere are some of the\n\nHere are some of the\n\nHere are some famous landmarks in London\n\nHere\n\nHere\n\nHere\n\nHere\n\nLondon\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nLondon\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\n1\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nLondon\n\nHere\n\nLondon\n\nHere\n\nHere\n\nLondon\n\nHere\n\nHere\n\nLondon\n\nLondon\n\nHere\n\nLondon\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nand\n\nHere\n\n\n\nHere\n\nand\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\nHere\n\n"
```

**Note:** GPT-OSS uses the harmony tokenizer with a special end token which is not used in vLLM by default. This is why we see repeated characters at the end of the response. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
