### PR TITLE
Print activation pspec

### DIFF
--- a/src/MaxText/data_loader.py
+++ b/src/MaxText/data_loader.py
@@ -20,7 +20,7 @@ import jax.numpy as jnp
 from jax.experimental import checkify
 
 from MaxText import exceptions
-from MaxText.sharding import get_input_data_sharding, maybe_shard_with_name
+from MaxText.sharding import get_input_data_sharding
 from MaxText.utils.goodput_utils import (
     GoodputEvent,
     maybe_record_goodput,
@@ -70,10 +70,9 @@ class DataLoader:
 
   def load_next_batch(self, *args, **kwargs):
     """Loads the next batch with sharding hint"""
-    return maybe_shard_with_name(
+    return jax.device_put(
         self.load_next_batch_pre_sharding(),
         self.input_data_shardings,
-        self.config.shard_mode,
     )
 
   def check_example_batch(self):
@@ -154,7 +153,7 @@ class RampUpDataLoader(DataLoader):
       self.buffer_start = slice_end
       output = jax.tree.map(_slice, self.batch_buffer)
     self.rampup_active = rampup_manager.update()
-    return maybe_shard_with_name(output, self.input_data_shardings, self.config.shard_mode)
+    return jax.device_put(output, self.input_data_shardings)
 
 
 def create_dataloader(config, mesh, data_iterator, goodput_recorder, rampup_manager):

--- a/src/MaxText/gradient_accumulation.py
+++ b/src/MaxText/gradient_accumulation.py
@@ -65,7 +65,7 @@ def gradient_accumulation_loss_and_grad(
 
   def _maybe_shard_with_name(inputs, sharding_names):
     """Wrapper of maybe_shard_with_name with fixed shard_mode"""
-    return maybe_shard_with_name(inputs, sharding_names, config.shard_mode)
+    return maybe_shard_with_name(inputs, sharding_names, config.shard_mode, debug_sharding=config.debug_sharding)
 
   # For more efficient DP/ZeRO-1 + GA
   if config.shard_mode == ShardMode.EXPLICIT and config.ici_data_parallelism > 1:

--- a/src/MaxText/layers/attention_op.py
+++ b/src/MaxText/layers/attention_op.py
@@ -1198,17 +1198,10 @@ class AttentionOp(nnx.Module):
         segment_axis_names_splash_kernel = self._logical_to_mesh_axes((Q_LENGTH,))
       else:
         segment_axis_names_splash_kernel = self._logical_to_mesh_axes((Q_LENGTH_NO_EXP,))
-    elif (
-        self.config.use_jax_splash
-        and self.config.expert_shard_attention_option == EP_AS_FSDP
-    ):
+    elif self.config.use_jax_splash and self.config.expert_shard_attention_option == EP_AS_FSDP:
       if self.config.use_max_logit_estimate > 0:
-        sa_config = dataclasses.replace(
-            sa_config, max_logit_const=self.config.use_max_logit_estimate
-        )
-      segment_axis_names_splash_kernel = nn.logical_to_mesh_axes((
-          Q_LENGTH_NO_EXP,
-      ))
+        sa_config = dataclasses.replace(sa_config, max_logit_const=self.config.use_max_logit_estimate)
+      segment_axis_names_splash_kernel = nn.logical_to_mesh_axes((Q_LENGTH_NO_EXP,))
     else:
       # Create multi-head mask
       multi_head_mask = splash_attention_mask.MultiHeadMask(masks=(mask,) * query.shape[1])
@@ -1327,7 +1320,13 @@ class AttentionOp(nnx.Module):
       if pspec is None:
         return None
       sharding = NamedSharding(self.mesh, pspec)
-      return maybe_shard_with_name(inputs, sharding, shard_mode=self.config.shard_mode)
+      return maybe_shard_with_name(
+          inputs,
+          sharding,
+          shard_mode=self.config.shard_mode,
+          debug_sharding=self.config.debug_sharding,
+          extra_stack_level=1,
+      )
 
     query = _maybe_shard_with_pspec(query, axis_names_q)
     key = _maybe_shard_with_pspec(key, axis_names_kv)

--- a/src/MaxText/layers/attentions.py
+++ b/src/MaxText/layers/attentions.py
@@ -525,6 +525,7 @@ class Attention(nnx.Module):
         maybe_shard_with_logical,
         mesh=mesh,
         shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
     )
 
   def _init_projections(self, inputs_q_shape: Tuple, inputs_kv_shape: Tuple) -> None:

--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -98,6 +98,7 @@ class DecoderLayer(nn.Module):
         sharding.maybe_shard_with_logical,
         mesh=mesh,
         shard_mode=cfg.shard_mode,
+        debug_sharding=cfg.debug_sharding,
     )
 
     if self.model_mode == MODEL_MODE_PREFILL:

--- a/src/MaxText/layers/deepseek.py
+++ b/src/MaxText/layers/deepseek.py
@@ -129,7 +129,11 @@ class DeepSeekGenericLayer(nnx.Module):
 
   def with_logical_constraint(self, x):
     return maybe_shard_with_logical(
-        x, logical_axes=self.logical_axis_names, mesh=self.mesh, shard_mode=self.config.shard_mode
+        x,
+        logical_axes=self.logical_axis_names,
+        mesh=self.mesh,
+        shard_mode=self.config.shard_mode,
+        debug_sharding=self.config.debug_sharding,
     )
 
   def dropout_op(self, x, deterministic):

--- a/src/MaxText/layers/deepseek_batchsplit.py
+++ b/src/MaxText/layers/deepseek_batchsplit.py
@@ -179,7 +179,7 @@ class DeepSeekBatchSplitGenericLayer(nnx.Module):
   def with_logical_constraint(self, x):
     return maybe_shard_with_logical(
       x, logical_axes=self.logical_axis_names,
-      mesh=self.mesh, shard_mode=self.config.shard_mode
+      mesh=self.mesh, shard_mode=self.config.shard_mode, debug_sharding=self.config.debug_sharding,
     )
 
   def pre_attention_norm_op(self, x):

--- a/src/MaxText/layers/linears.py
+++ b/src/MaxText/layers/linears.py
@@ -459,6 +459,7 @@ class MlpBlock(nnx.Module):
         maybe_shard_with_logical,
         mesh=mesh,
         shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
     )
 
   def get_norm_layer(self, num_features: int):

--- a/src/MaxText/layers/llama2.py
+++ b/src/MaxText/layers/llama2.py
@@ -134,6 +134,7 @@ class LlamaDecoderLayer(nnx.Module):
         maybe_shard_with_logical,
         mesh=self.mesh,
         shard_mode=config.shard_mode,
+        debug_sharding=config.debug_sharding,
     )
 
   def __call__(

--- a/src/MaxText/layers/moe.py
+++ b/src/MaxText/layers/moe.py
@@ -444,7 +444,13 @@ class RoutedMoE(nnx.Module):
       self.wo_bias = None
 
   def _maybe_shard_with_logical(self, inputs, logical_name):
-    return maybe_shard_with_logical(inputs, logical_name, mesh=self.mesh, shard_mode=self.config.shard_mode)
+    return maybe_shard_with_logical(
+        inputs,
+        logical_name,
+        mesh=self.mesh,
+        shard_mode=self.config.shard_mode,
+        debug_sharding=self.config.debug_sharding,
+    )
 
   def _logical_to_mesh_axes(self, logical_name):
     return logical_to_mesh_axes(logical_name, mesh=self.mesh, rules=self.config.logical_axis_rules)

--- a/src/MaxText/layers/pipeline.py
+++ b/src/MaxText/layers/pipeline.py
@@ -133,11 +133,17 @@ class Pipeline(nn.Module):
         shard_mode=self.config.shard_mode,
         mesh=self.mesh,
         rules=self.config.logical_axis_rules,
+        debug_sharding=self.config.debug_sharding,
     )
 
   def _maybe_shard_with_name(self, inputs, sharding_name):
     """Wrapper of maybe_shard_with_name"""
-    return maybe_shard_with_name(inputs, sharding_name, shard_mode=self.config.shard_mode)
+    return maybe_shard_with_name(
+        inputs,
+        sharding_name,
+        shard_mode=self.config.shard_mode,
+        debug_sharding=self.config.debug_sharding,
+    )
 
   def init_states(self, inputs):
     """Initialize components of state: state_io, shift, circular_storage and circular_storage_mover

--- a/src/MaxText/max_logging.py
+++ b/src/MaxText/max_logging.py
@@ -27,9 +27,9 @@ def debug(user_str):
   logging.debug(user_str, stacklevel=2)
 
 
-def info(user_str):
+def info(user_str, stacklevel=2):
   """Logs a message at the INFO level."""
-  logging.info(user_str, stacklevel=2)
+  logging.info(user_str, stacklevel=stacklevel)
 
 
 def warning(user_str):

--- a/src/MaxText/maxtext_utils.py
+++ b/src/MaxText/maxtext_utils.py
@@ -1179,4 +1179,4 @@ def print_state_mesh_shardings_params(state, state_sharding, mesh):
     path_str = "/".join(str(p.key) for p in path)
     shape = jax.typeof(leaf_val)
     pspec = sharding.remove_size_one_mesh_axis(leaf_sharding.spec, mesh)
-    print(f"{path_str:.<80} {shape} {pspec}", flush=True)
+    max_logging.log(f"{path_str:.<80} {shape} {tuple(pspec)}")

--- a/src/MaxText/vocabulary_tiling.py
+++ b/src/MaxText/vocabulary_tiling.py
@@ -88,7 +88,9 @@ def vocab_tiling_linen_loss(
       ("activation_embed_and_logits_batch_sequence", "activation_vocab"),
   )
 
-  _maybe_shard_with_name = functools.partial(maybe_shard_with_name, shard_mode=config.shard_mode)
+  _maybe_shard_with_name = functools.partial(
+      maybe_shard_with_name, shard_mode=config.shard_mode, debug_sharding=config.debug_sharding
+  )
 
   def _reshape(inputs, out_shape, out_sharding):
     reshape_out_sharding = out_sharding if config.shard_mode == ShardMode.EXPLICIT else None


### PR DESCRIPTION
# Description

This PR improves the observability of sharding constraints in MaxText. When `debug_sharding=True`, the system now logs the JAX type (shape and dtype) and physical partitions for both model weights and activations (with sharding hints). This information is critical for developers designing or debugging complex logical sharding rules. This PR specifically implements the following features:

* **Call-Site Attribution:** Uses `stacklevel` to track and report the exact line number in the model code (e.g., `llama2.py`, `attention_mla.py`) where a sharding constraint is applied, rather than simply reporting the utility function's location.
* **Support for Core Utilities:** Integrated directly into `MaxText.sharding.maybe_shard_with_name` and `MaxText.sharding.maybe_shard_with_logical` (activations won't get printed if using `jax.lax.with_sharding_constraint` or `linen.with_logical_constraint` unfortunately).
* **Trace De-duplication:** Implements a global cache mechanism to prevent log flooding.

In MaxText, JAX tracing occurs three times:
1. **Model Initialization:** Triggered during `train_utils.setup_train_loop` to discover parameter shapes and shardings.
2. **Performance Analysis:** Triggered during `.lower().compile()` to generate the HLO graph for TFLOPs and memory analysis.
3. **First-Step Execution:** The final JIT trace when the first concrete data batch is passed to the compiled train step.

To avoid printing identical sharding information at least three times per tensor, this PR introduces a caching mechanism in `sharding.py`. It stores unique combinations of tensor types and physical partitions, ensuring each unique sharding event is logged exactly once during the first discovery pass.

# Tests

```
alias smoke_train='python3 -m MaxText.train MaxText/configs/base.yml run_name=ncheng-train-base base_output_directory=gs://chengnuojin-maxtext-logs/smoke_train dataset_path=gs://max-datasets-rogue steps=10 log_config=False enable_checkpointing=False enable_goodput_recording=False'
```

Validated on **v5p-8** with `jax==0.8.1`.

## Test 1: DeepSeek-V3 FSDP+EP
**Command:**
`smoke_train debug_sharding=true model_name=deepseek3-test per_device_batch_size=1 ici_expert_parallelism=2`

**Output:** [https://paste.googleplex.com/5196232098185216](https://paste.googleplex.com/5196232098185216)

## Test 2: Llama2-7B FSDP+CP
**Command:**
`smoke_train model_name=llama2-7b per_device_batch_size=1 ici_context_parallelism=2 dataset_type=synthetic debug_sharding=true` 

**Output:** [https://paste.googleplex.com/575225772546464576](https://paste.googleplex.com/5752257725464576)

## Test 3: Default model + Vocab tiling FSDP
**Command:**
`smoke_train debug_sharding=true num_vocab_tiling=4`

**Output:** [https://paste.googleplex.com/4637754698891264](https://paste.googleplex.com/4637754698891264)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
