### PR TITLE
Disable a flaky test

### DIFF
--- a/tests/grain_data_processing_test.py
+++ b/tests/grain_data_processing_test.py
@@ -226,6 +226,10 @@ class GrainArrayRecordAutoTuneTest(GrainArrayRecordProcessingTest):
   def test_batch_determinism(self):
     super().test_batch_determinism()
 
+  @pytest.mark.skip(reason="Flaky test - see b/475255774.")
+  def test_for_loop_repeatable(self):
+    super().test_for_loop_repeatable()
+
 
 class GrainArrayRecordBestFitPackingTest(GrainArrayRecordProcessingTest):
   """Test grain data processing with best_fit packing strategy."""


### PR DESCRIPTION
# Description

Disable grain_data_processing_test.py::GrainArrayRecordAutoTuneTest::test_for_loop_repeatable due to flakiness. Fix is tracked in b/475255774.

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
