### PR TITLE
Fix Codecov Coverage Issue

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+# .coveragerc
+
+[run]
+source = MaxText
+branch = True
+omit =
+    tests/*
+    .venv/*
+
+[paths]
+source =
+    src/MaxText
+    */site-packages/MaxText
+
+[report]
+show_missing = True

--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -121,13 +121,18 @@ jobs:
             -m "${FINAL_PYTEST_MARKER}" \
             --durations=0 \
             --deselect "tests/tokenizer_test.py::TokenizerTest::test_detokenize" \
-            --cov=src/MaxText \
+            --cov=MaxText \
             --cov-report=xml \
+            --cov-report=term \
             $SPLIT_ARGS
+        env:
+          PYTHONPATH: "${{ github.workspace }}/src"
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
           # If scheduled, upload to BOTH flags. If PR, upload ONLY to regular.
-          flags: ${{ inputs.is_scheduled_run == 'true' && 'scheduled' || 'regular' }}
+          flags: ${{ inputs.is_scheduled_run == 'true' && 'regular,scheduled' || 'regular' }}
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,7 +29,8 @@ codecov:
 # By default file names in the coverage report will have their path in the file system, which in our
 # runners would be /__w/maxtext/maxtext/src/MaxText/* but Codecov expects src/MaxText/* so we need to fix the path
 fixes:
-  - ".*/maxtext/src/::src/"
+  # - ".*/maxtext/src/::src/"
+  - "/github/workspace/::"
 ignore:
   - "src/MaxText/assets"
   - "src/MaxText/configs"


### PR DESCRIPTION
# Description

Codecov shows coverage is 0, so this PR is used to fix the issue.

# Tests

We add a sample math_utils code and test to check the results. 
[CodeCov branch report](https://app.codecov.io/gh/AI-Hypercomputer/maxtext/tree/Shuang-cnt%2Fmaxtext%3Acodecov_dummy?trend=all%20time)

[CodeCov PR report](https://app.codecov.io/gh/AI-Hypercomputer/maxtext/pull/2934)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
