### PR TITLE
Fix fsdp2d ds logical rule

### DIFF
--- a/src/MaxText/configs/models/deepseek3-671b-2dfsdp.yml
+++ b/src/MaxText/configs/models/deepseek3-671b-2dfsdp.yml
@@ -61,6 +61,8 @@ data_sharding: [['data', 'fsdp', 'fsdp_transpose', 'expert', 'context']]
 logical_axis_rules: [
     ['activation_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert', 'context']],
     ['activation_kv_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert', 'context']],
+    ['activation_embed_and_logits_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
+    ['activation_norm_length', ['context']],
     ['activation_heads', []],
     ['embed', ['fsdp']],
     ['embed_no_exp', ['fsdp']],


### PR DESCRIPTION
# Description

Current logical rule of fsdp2 deepseek does not support properly sharded batch data, which generates from `MaxText.sharding.get_input_data_sharding`. This PR adds logical rules and making sure input data are properly sharded.

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
