### PR TITLE
Set local_devices from CUDA_VISIBLE_DEVICES in initialize_jax_for_gpu

### DIFF
--- a/tests/unit/max_utils_test.py
+++ b/tests/unit/max_utils_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Tests for the common Max Utils """
+"""Tests for the common Max Utils"""
+import os
 import sys
 import unittest
 import time
 import pytest
+
 
 import jax
 from jax import numpy as jnp
@@ -30,6 +32,7 @@ from MaxText import pyconfig
 from maxtext.utils import max_utils
 from maxtext.utils.train_utils import setup_train_loop
 from tests.utils.test_helpers import get_test_config_path
+from unittest import mock
 
 
 class MaxUtilsSummaryStats(unittest.TestCase):
@@ -166,6 +169,74 @@ class UnscanTest(unittest.TestCase):
     # Check that the original state is unchanged.
     self.assertIn("layers", state.params["params"]["decoder"])
     self.assertNotIn("layers_0", state.params["params"]["decoder"])
+
+
+class TestGpuDistributedInitialization(unittest.TestCase):
+  """Tests using CUDA_VISIBLE_DEVICES to control which GPUs are used in jax.distributed.initialize."""
+
+  @mock.patch.dict(
+      os.environ,
+      {
+          "JAX_COORDINATOR_IP": "10.0.0.1",
+          "JAX_COORDINATOR_PORT": "1234",
+          "NNODES": "1",
+          "NODE_RANK": "0",
+          "CUDA_VISIBLE_DEVICES": "0,2,3",  # Simulating Slurm/orchestrator assignment
+      },
+  )
+  @mock.patch("jax.distributed.initialize")
+  @mock.patch("jax.devices")
+  @mock.patch("maxtext.utils.max_logging.log")
+  def test_initialize_jax_for_gpu_valid_devices(self, _mock_log, _mock_devices, mock_init):
+    """Verifies that a comma-separated string of IDs is correctly parsed."""
+    raw_keys = {"jax_distributed_initialization_timeout": 300}
+    max_utils.initialize_jax_for_gpu(raw_keys)
+    # Check that local_device_ids was passed correctly as a list of integers
+    _, kwargs = mock_init.call_args
+    self.assertEqual(kwargs["local_device_ids"], [0, 2, 3])
+    self.assertEqual(kwargs["coordinator_address"], "10.0.0.1:1234")
+
+  @mock.patch.dict(
+      os.environ,
+      {
+          "JAX_COORDINATOR_IP": "10.0.0.1",
+          "JAX_COORDINATOR_PORT": "1234",
+          "NNODES": "1",
+          "NODE_RANK": "0",
+          "CUDA_VISIBLE_DEVICES": "GPU-8f2e3072-...",  # Invalid format for integer parsing
+      },
+  )
+  @mock.patch("jax.distributed.initialize")
+  @mock.patch("jax.devices")
+  @mock.patch("maxtext.utils.max_logging.log")
+  def test_initialize_jax_for_gpu_invalid_devices(self, _mock_log, mock_devices, mock_init):
+    """Verifies fallback behavior when parsing fails (e.g., UUIDs)."""
+    raw_keys = {"jax_distributed_initialization_timeout": 300}
+    max_utils.initialize_jax_for_gpu(raw_keys)
+    # Check that it falls back to None (JAX auto-detection default) on error
+    _, kwargs = mock_init.call_args
+    self.assertIsNone(kwargs.get("local_device_ids"))
+    self.assertEqual(kwargs["coordinator_address"], "10.0.0.1:1234")
+
+  @mock.patch.dict(
+      os.environ,
+      {
+          "JAX_COORDINATOR_IP": "10.0.0.1",
+          "JAX_COORDINATOR_PORT": "1234",
+          "NNODES": "1",
+          "NODE_RANK": "0",
+      },
+  )
+  @mock.patch("jax.distributed.initialize")
+  @mock.patch("jax.devices")
+  @mock.patch("maxtext.utils.max_logging.log")
+  def test_initialize_jax_for_gpu_no_devices(self, _mock_log, mock_devices, mock_init):
+    """Verifies that no error occurs when CUDA_VISIBLE_DEVICES is not set"""
+    raw_keys = {"jax_distributed_initialization_timeout": 300}
+    max_utils.initialize_jax_for_gpu(raw_keys)
+    _, kwargs = mock_init.call_args
+    self.assertIsNone(kwargs.get("local_device_ids"))
+    self.assertEqual(kwargs["coordinator_address"], "10.0.0.1:1234")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

When running in Slurm, jax.init_distributed.initialize only attaches to one GPU unless local_device_ids is passed.
This PR uses the standard CUDA_VISIBLE_DEVICES environment variable to set local_device_ids,
falling back to the default behavior if CUDA_VISIBLE_DEVICES is None or cannot be parsed.

We have been using this internally at AMD for some time.

This change will not affect TPUs in any way.

FIXES: #865 


# Tests

Run a job in Slurm on a machine with multiple GPUs with and without CUDA_VISIBLE_DEVICES set

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
