### PR TITLE
Add P.UNCONSTRAINED condition in remove size one mesh axis 

### DIFF
--- a/src/MaxText/sharding.py
+++ b/src/MaxText/sharding.py
@@ -85,7 +85,7 @@ def remove_size_one_mesh_axis(spec, mesh):
     return None
   new_spec = []  # type: ignore
   for s in spec:
-    if s is None:
+    if s is None or s == P.UNCONSTRAINED:
       new_spec.append(s)  # type: ignore
     elif isinstance(s, tuple):
       new_spec.append(tuple(i for i in s if mesh.shape[i] != 1))


### PR DESCRIPTION
# Description

For `MaxText.sharding.remove_size_one_mesh_axis` function we always assume the given partition spec exists in mesh, but using `jax.sharding.PartitionSpec.UNCONSTRAINED` violates this setting. This PR fixes this connor case to avoid possible bugs (mostly using pipeline parallelism + `debug_sharding=True`).

# Tests

Before change: https://paste.googleplex.com/6298233649364992

After change: https://paste.googleplex.com/6317784340496384

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
