### PR TITLE
Add Qwen3 Audio Encoder

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,7 +18,7 @@ addopts =
     --ignore=tests/unit/moba_vs_reference_test.py
     --ignore=tests/unit/offline_engine_test.py
     --ignore=tests/unit/profiler_test.py
-    --ignore=tests/unit/qwen3_embedding_vs_reference_test.py
+    --ignore=tests/unit/qwen3_omni_layers_test.py
     --ignore=tests/unit/qwen3_next_vs_reference_test.py
 markers =
     tpu_only: marks tests to be run on TPUs only

--- a/src/MaxText/configs/base.yml
+++ b/src/MaxText/configs/base.yml
@@ -942,7 +942,9 @@ temperature_tuning: False
 
 # Multimodal flags
 use_multimodal: False
+use_audio: False
 freeze_vision_encoder_params: True
+freeze_audio_encoder_params: True
 dtype_mm: "float32"  # Data type for multimodal model's vision encoder
 remat_policy_for_vit: "minimal"  # Remat policy for multimodal model's vision encoder. Check `remat_policy` for options.
 image_size_for_vit: 896 # Default for Gemma3, and should be overwritten by model's config
@@ -980,7 +982,27 @@ temporal_patch_size_for_vit: 2
 num_position_embeddings_for_vit: 1024
 deepstack_visual_indexes_for_vit: []
 
-# Subslice shape in the form of "x,y,z" when using pathways (single controller).
+### Audio encoder configs (Qwen3-OmniMoe)
+d_model_for_audio: 256
+encoder_attention_heads_for_audio: 4
+encoder_ffn_dim_for_audio: 512
+encoder_layers_for_audio: 2
+attention_dropout_for_audio: 0.0
+activation_dropout_for_audio: 0.0
+activation_function_for_audio: "gelu"
+num_mel_bins_for_audio: 128
+max_source_positions_for_audio: 1500
+scale_embedding_for_audio: True
+n_window_for_audio: 50
+n_window_infer_for_audio: 800
+conv_chunksize_for_audio: 500
+downsample_hidden_size_for_audio: 256
+output_dim_for_audio: 512
+num_conv_layers_for_audio: 3
+max_timescale_for_audio: 10000.0
+max_sample_len_for_audio: 10000
+
+# Subslice shape in the form of "x,y,z" when using pathways (single controller). 
 # Example: "8,8" to use a 8x8 subgrid (64 chips) of a full pod (16x16) of trillium.
 subslice_shape: ""
 

--- a/src/MaxText/configs/models/qwen3-omni-30b-a3b.yml
+++ b/src/MaxText/configs/models/qwen3-omni-30b-a3b.yml
@@ -56,3 +56,21 @@ num_position_embeddings_for_vit: 2304
 deepstack_visual_indexes_for_vit: [8, 16, 24]
 
 use_multimodal: true
+use_audio: true
+# Audio Encoder Configuration (need to set use_audio=true to enable)
+# Based on https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
+d_model_for_audio: 1280
+encoder_layers_for_audio: 32
+encoder_attention_heads_for_audio: 20
+encoder_ffn_dim_for_audio: 5120
+max_source_positions_for_audio: 1500
+num_mel_bins_for_audio: 128
+downsample_hidden_size_for_audio: 480
+output_dim_for_audio: 2048
+attention_dropout_for_audio: 0.0
+n_window_for_audio: 50
+n_window_infer_for_audio: 400
+conv_chunksize_for_audio: 500
+num_conv_layers_for_audio: 3
+max_timescale_for_audio: 10000.0
+max_sample_len_for_audio: 10000

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -1360,6 +1360,8 @@ class MultimodalGeneral(BaseModel):
 
   use_multimodal: bool = Field(False, description="Enable multimodal capabilities.")
   freeze_vision_encoder_params: bool = Field(True, description="Freeze the parameters of the vision encoder.")
+  freeze_audio_encoder_params: bool = Field(True, description="Freeze the parameters of the audio encoder.")
+  use_audio: bool = Field(False, description="Enable audio encoder for multimodal models.")
   image_size_for_vit: int = Field(896, description="Input image size for the Vision Transformer.")
   image_path: PathStr = Field("", description="Path to an image for decoding.")
   image_placeholder: str = Field("<|image|>", description="Placeholder string for images in text prompts.")
@@ -1406,6 +1408,29 @@ class VisionProjector(BaseModel):
   projector_output_dim_for_vit: int = Field(4096, description="Output dimension for the vision projector.")
   pixel_shuffle_ratio_for_vit: float = Field(0.5, description="Pixel shuffle ratio for the Vision Transformer.")
   projector_dropout_for_vit: float = Field(0.0, description="Dropout rate for the vision projector.")
+
+
+class AudioEncoder(BaseModel):
+  """Configuration for the Audio Encoder in a multimodal model."""
+
+  d_model_for_audio: int = Field(256, description="Model dimension for the audio encoder.")
+  encoder_attention_heads_for_audio: int = Field(4, description="Number of attention heads in the audio encoder.")
+  encoder_ffn_dim_for_audio: int = Field(512, description="Feed-forward network dimension for the audio encoder.")
+  encoder_layers_for_audio: int = Field(2, description="Number of encoder layers for audio.")
+  attention_dropout_for_audio: float = Field(0.0, description="Attention dropout rate for audio encoder.")
+  activation_dropout_for_audio: float = Field(0.0, description="Activation dropout rate for audio encoder.")
+  activation_function_for_audio: str = Field("gelu", description="Activation function for audio encoder.")
+  num_mel_bins_for_audio: int = Field(128, description="Number of mel-frequency bins for audio input.")
+  max_source_positions_for_audio: int = Field(1500, description="Maximum source positions for audio encoder.")
+  scale_embedding_for_audio: bool = Field(True, description="Whether to scale embeddings in audio encoder.")
+  n_window_for_audio: int = Field(50, description="Window size for audio processing.")
+  n_window_infer_for_audio: int = Field(800, description="Window size for audio inference.")
+  conv_chunksize_for_audio: int = Field(500, description="Chunk size for convolutional layers in audio encoder.")
+  downsample_hidden_size_for_audio: int = Field(256, description="Hidden size for downsampling in audio encoder.")
+  output_dim_for_audio: int = Field(512, description="Output dimension for audio encoder.")
+  num_conv_layers_for_audio: int = Field(3, description="Number of convolutional layers in audio encoder.")
+  max_timescale_for_audio: float = Field(10000.0, description="Maximum timescale for audio positional encoding.")
+  max_sample_len_for_audio: int = Field(10000, description="Maximum sample length for audio input.")
 
 
 class Debug(BaseModel):
@@ -1722,6 +1747,7 @@ class MaxTextConfig(
     MultimodalGeneral,
     VisionTower,
     VisionProjector,
+    AudioEncoder,
     # Derived
     DerivedValues,
 ):

--- a/src/MaxText/decode.py
+++ b/src/MaxText/decode.py
@@ -152,6 +152,8 @@ def main(argv: Sequence[str]) -> None:
           padded_tokens=tokens,
           images=processor_outputs.pixel_values if config.use_multimodal else None,
           image_masks=processor_outputs.pixel_mask if config.use_multimodal and "llama4" in config.model_name else None,
+          audio_values=processor_outputs.audio_values if config.use_audio else None,
+          audio_masks=processor_outputs.audio_mask if config.use_audio else None,
           true_length=true_length,
           rng=rng_prefill,
           slot=i,

--- a/src/MaxText/layers/embeddings.py
+++ b/src/MaxText/layers/embeddings.py
@@ -898,50 +898,114 @@ class YarnRotaryEmbedding(nnx.Module):
     return output
 
 
-def positional_embedding_as_linen(*, embedding_dims: int, max_wavelength: int = _MAX_WAVELENGTH):
+def positional_embedding_as_linen(
+    *,
+    embedding_dims: int,
+    max_wavelength: int = _MAX_WAVELENGTH,
+    cast_as_fprop_dtype: bool = False,
+    fprop_dtype: DType = jnp.bfloat16,
+):
   """Initializes the PositionalEmbedding module and returns it as a Linen module.
 
   Args:
     embedding_dims: The dimension of the embeddings.
     max_wavelength: The maximum wavelength for the sinusoidal positional embeddings.
+    cast_as_fprop_dtype: Whether to cast output to fprop_dtype.
+    fprop_dtype: The dtype of the output when cast_as_fprop_dtype is True.
   """
   return nnx_wrappers.to_linen(
       PositionalEmbedding,
       embedding_dims=embedding_dims,
       max_wavelength=max_wavelength,
+      cast_as_fprop_dtype=cast_as_fprop_dtype,
+      fprop_dtype=fprop_dtype,
       metadata_fn=variable_to_logically_partitioned,
   )
 
 
 @dataclasses.dataclass(repr=False)
 class PositionalEmbedding(nnx.Module):
-  """A layer that adds sinusoidal positional embeddings to the input."""
+  """Sinusoidal positional embeddings supporting both uniform and per-batch positions.
+
+  This module computes sinusoidal positional embeddings and supports two use cases:
+
+  1. Uniform positions across batch: All batch elements share the same position sequence.
+     Pass position as 1D array (seq_len,) or None for sequential [0,1,2,...].
+     Returns (seq_len, embedding_dims), caller broadcasts to batch.
+     Example: pos_emb = layer(seq_len)  # Sequential positions
+              pos_emb = layer(seq_len, position_1d)  # Custom 1D positions
+
+  2. Per-batch positions (packed sequences): Each batch element has different positions.
+     Pass position as 2D array (batch, seq_len).
+     Returns (batch, seq_len, embedding_dims).
+     Example: pos_emb = layer(seq_len, position_2d)
+
+  As a side effect, the uniform case is more efficient since sin/cos are computed once
+  and broadcasted, rather than per batch element.
+  """
 
   #: The dimension of the embeddings.
   embedding_dims: int
   #: The maximum wavelength for the sinusoidal positional embeddings.
   max_wavelength: int = _MAX_WAVELENGTH
-
+  #: Whether to cast output to fprop_dtype.
+  cast_as_fprop_dtype: bool = False
+  #: The dtype of the output when cast_as_fprop_dtype is True.
+  fprop_dtype: DType = jnp.bfloat16
   #: RNG state passed in by nnx.bridge.to_linen, not used in this module.
   rngs: nnx.Rngs = None  # Not used in PositionalEmbedding but passed in by nnx.bridge.to_linen
 
-  def __call__(
-      self,  # pytype: disable=signature-mismatch  # overriding-parameter-count-checks
-      input_embedding: jax.Array,
-      position: jax.Array,
-  ) -> jax.Array:
+  def _compute_embeddings(self, position: Array) -> Array:
+    """Compute sinusoidal embeddings for given positions.
+
+    Args:
+      position: Either (seq_len,) for efficient path or (batch, seq_len) for full path.
+
+    Returns:
+      Embeddings of shape (seq_len, embedding_dims) or (batch, seq_len, embedding_dims).
+    """
     num_timescales = self.embedding_dims // 2
     log_timescale_increment = jnp.log(float(self.max_wavelength)) / jnp.maximum(
         jnp.asarray(num_timescales, dtype=jnp.float32) - 1, 1
     )
     inv_timescales = jnp.exp(jnp.arange(num_timescales, dtype=jnp.float32) * -log_timescale_increment)
-    position = position[:, :, jnp.newaxis]
-    inv_timescales = inv_timescales[jnp.newaxis, jnp.newaxis, :]
-    scaled_time = position * inv_timescales
+
+    if position.ndim == 1:
+      # use the same position for the whole batch when position is (seq_len,)
+      scaled_time = position[:, jnp.newaxis] * inv_timescales[jnp.newaxis, :]
+    else:
+      # when position is (batch, seq_len)
+      position = position[:, :, jnp.newaxis]
+      inv_timescales = inv_timescales[jnp.newaxis, jnp.newaxis, :]
+      scaled_time = position * inv_timescales
+
     signal = jnp.concatenate([jnp.sin(scaled_time), jnp.cos(scaled_time)], axis=-1)
-    # signal = jnp.pad(signal, [[0, jnp.mod(self.embedding_dims, 2)]])
-    position_embedding = signal.astype(jnp.float32)
-    return input_embedding + position_embedding
+
+    if self.cast_as_fprop_dtype:
+      return signal.astype(self.fprop_dtype)
+    else:
+      return signal.astype(jnp.float32)
+
+  def __call__(
+      self,
+      seq_len: int,
+      position: Array | None = None,
+  ) -> Array:
+    """Compute positional embeddings.
+
+    Args:
+      seq_len: Sequence length for computing embeddings.
+      position: Optional position array. If None, uses sequential [0,1,2,...].
+        Shape can be (seq_len,) or (batch, seq_len) for packed sequences.
+
+    Returns:
+      Positional embeddings of shape (seq_len, embedding_dims) or
+      (batch, seq_len, embedding_dims) if position has batch dimension.
+    """
+    if position is None:
+      position = jnp.arange(seq_len, dtype=jnp.float32)
+
+    return self._compute_embeddings(position)
 
 
 def llama_vision_rotary_embedding_as_linen(

--- a/src/MaxText/layers/models.py
+++ b/src/MaxText/layers/models.py
@@ -32,7 +32,7 @@ from MaxText import max_utils
 from MaxText.layers import nnx_wrappers
 from MaxText.layers.decoders import Decoder
 from MaxText.layers.embeddings import Embed, embed_as_linen
-from MaxText.layers.encoders import VisionEncoder, vision_encoder_as_linen
+from MaxText.layers.encoders import VisionEncoder, vision_encoder_as_linen, AudioEncoder, audio_encoder_as_linen
 from MaxText.layers.quantizations import AqtQuantization as Quant
 from MaxText.layers.multi_token_prediction import multi_token_prediction_block_as_linen
 
@@ -85,6 +85,7 @@ class TransformerLinenPure(nn.Module):
         mesh=self.mesh,
     )
     self.vision_encoder = vision_encoder_as_linen(config=cfg, mesh=mesh) if cfg.use_multimodal else None
+    self.audio_encoder = audio_encoder_as_linen(config=cfg, mesh=mesh) if cfg.use_audio else None
     self.decoder = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
     # If MTP is enabled via config, set up the MTP block.
     if self.config.mtp_num_layers > 0:
@@ -121,6 +122,7 @@ class TransformerLinenPure(nn.Module):
       decoder_segment_ids=None,
       encoder_images: None | jnp.ndarray = None,
       encoder_image_masks: None | jnp.ndarray = None,
+      encoder_audios: None | jnp.ndarray = None,
       enable_dropout=True,
       model_mode=MODEL_MODE_TRAIN,
       previous_chunk=None,
@@ -149,6 +151,8 @@ class TransformerLinenPure(nn.Module):
 
     bidirectional_mask = None
     image_embeddings = None
+    audio_embeddings = None
+
     if self.config.use_multimodal and encoder_images is not None:
       image_embeddings = self.vision_encoder(input_images=encoder_images, deterministic=not enable_dropout)
 
@@ -157,7 +161,18 @@ class TransformerLinenPure(nn.Module):
       elif self.config.decoder_block == DecoderBlockType.LLAMA4:
         bidirectional_mask = decoder_input_tokens == multimodal_utils.LLAMA4_PATCH_TOKEN
       elif self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
-        bidirectional_mask = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN
+        # Create bidirectional_mask for vision/video token merging
+        bidirectional_mask = (decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN) | (
+            decoder_input_tokens == multimodal_utils.QWEN3_OMNI_VIDEO_TOKEN
+        )
+        # Create image/video mask for deepstack visual embedding injection
+    if self.config.use_multimodal and encoder_audios is not None and self.audio_encoder is not None:
+      audio_embeddings = self.audio_encoder(input_audio=encoder_audios, deterministic=not enable_dropout)
+
+    # Create audio mask for placeholder tokens (qwen3-omni models)
+    audio_masks = None
+    if audio_embeddings is not None and self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
+      audio_masks = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_AUDIO_TOKEN
 
     logits, hidden_state, kv_caches = self.decoder(
         shared_embedding=self.shared_embedding,
@@ -172,6 +187,8 @@ class TransformerLinenPure(nn.Module):
         bidirectional_mask=bidirectional_mask,
         image_embeddings=image_embeddings,
         image_masks=encoder_image_masks,
+        audio_embeddings=audio_embeddings,
+        audio_masks=audio_masks,
         kv_caches=kv_caches,
         attention_metadata=attention_metadata,
     )
@@ -316,6 +333,7 @@ class Transformer(nnx.Module):
         rngs=rngs,
     )
     self.vision_encoder = VisionEncoder(config=cfg, mesh=mesh, rngs=rngs) if cfg.use_multimodal else None
+    self.audio_encoder = AudioEncoder(config=cfg, mesh=mesh, rngs=rngs) if cfg.use_audio else None
 
     decoder_linen = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
     self.decoder = nnx_wrappers.ToNNX(decoder_linen, rngs=rngs)
@@ -404,6 +422,7 @@ class Transformer(nnx.Module):
       cache=None,
       encoder_images: jax.Array | None = None,
       encoder_image_masks: jax.Array | None = None,
+      encoder_audios: jax.Array | None = None,
       enable_dropout=True,
       model_mode=MODEL_MODE_TRAIN,
       previous_chunk=None,
@@ -456,7 +475,18 @@ class Transformer(nnx.Module):
       elif self.config.decoder_block == DecoderBlockType.LLAMA4:
         bidirectional_mask = decoder_input_tokens == multimodal_utils.LLAMA4_PATCH_TOKEN
       elif self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
-        bidirectional_mask = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN
+        bidirectional_mask = (decoder_input_tokens == multimodal_utils.QWEN3_OMNI_IMAGE_TOKEN) | (
+            decoder_input_tokens == multimodal_utils.QWEN3_OMNI_VIDEO_TOKEN
+        )
+
+    audio_embeddings = None
+    if self.config.use_multimodal and encoder_audios is not None and self.audio_encoder is not None:
+      audio_embeddings = self.audio_encoder(input_audio=encoder_audios, deterministic=not enable_dropout)
+
+    # Create audio mask for placeholder tokens (qwen3-omni models)
+    audio_masks = None
+    if audio_embeddings is not None and self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
+      audio_masks = decoder_input_tokens == multimodal_utils.QWEN3_OMNI_AUDIO_TOKEN
 
     logits, hidden_state, kv_caches = self.decoder(
         shared_embedding=self.token_embedder,
@@ -471,6 +501,8 @@ class Transformer(nnx.Module):
         bidirectional_mask=bidirectional_mask,
         image_embeddings=image_embeddings,
         image_masks=encoder_image_masks,
+        audio_embeddings=audio_embeddings,
+        audio_masks=audio_masks,
         kv_caches=kv_caches,
         attention_metadata=attention_metadata,
     )

--- a/src/MaxText/layers/qwen3.py
+++ b/src/MaxText/layers/qwen3.py
@@ -17,6 +17,7 @@
 # pylint: disable=no-name-in-module
 
 from typing import Any, cast
+import math
 
 import jax
 import jax.nn
@@ -28,22 +29,20 @@ from flax import linen as nn
 from flax import nnx
 
 from MaxText import max_utils
-from MaxText.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED
+from MaxText.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED, MODEL_MODE_TRAIN
 from MaxText.layers import attentions
 from MaxText.layers import initializers as max_initializers
-from MaxText.layers import linears
 from MaxText.layers import moe
 from MaxText.layers import nnx_wrappers
 from MaxText.layers import quantizations
-from MaxText.layers.embeddings import Qwen3OmniMoeVisionPosEmbedInterpolate
+from MaxText.layers.embeddings import Qwen3OmniMoeVisionPosEmbedInterpolate, PositionalEmbedding
 from MaxText.layers.normalizations import RMSNorm, l2norm, Qwen3NextRMSNorm, Qwen3NextRMSNormGated
 from MaxText.layers.quantizations import AqtQuantization as Quant
 from MaxText.inference import page_manager
 from MaxText.layers.attentions import Attention
 from MaxText.layers.linears import DenseGeneral, MlpBlock
 from MaxText.layers.moe import RoutedMoE
-
-
+from MaxText.layers.initializers import nd_dense_init, variable_to_logically_partitioned
 # -----------------------------------------
 # Qwen3-Next Layer Implementations
 # -----------------------------------------
@@ -306,15 +305,13 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
   2. output = Linear_out(y)
   """
 
-  def __init__(self, config: Config, dtype: DType = jnp.float32, *, rngs: nnx.Rngs):
+  def __init__(self, config: Config, *, rngs: nnx.Rngs):
     """
     Args:
       config: MaxText configuration object.
-      dtype: The datatype of the computation.
       rngs: The random number generators for initialization, passed by the nnx.to_linen wrapper.
     """
     self.config = config
-    self.dtype = dtype
     cfg = self.config
 
     in_features = cfg.emb_dim
@@ -329,7 +326,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     self.v_heads_per_k_head = self.num_v_heads // self.num_k_heads
 
     # Submodule instantiations
-    self.in_proj_qkvz = linears.DenseGeneral(
+    self.in_proj_qkvz = DenseGeneral(
         in_features_shape=in_features,
         out_features_shape=(self.key_dim * 2 + self.value_dim * 2),
         dtype=cfg.dtype,
@@ -337,7 +334,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         matmul_precision=cfg.matmul_precision,
         rngs=rngs,
     )
-    self.in_proj_ba = linears.DenseGeneral(
+    self.in_proj_ba = DenseGeneral(
         in_features_shape=in_features,
         out_features_shape=(self.num_v_heads * 2),
         dtype=cfg.dtype,
@@ -374,7 +371,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         weight_dtype=cfg.weight_dtype,
         rngs=rngs,
     )
-    self.out_proj = linears.DenseGeneral(
+    self.out_proj = DenseGeneral(
         in_features_shape=self.value_dim,
         out_features_shape=(in_features,),
         dtype=cfg.dtype,
@@ -645,7 +642,7 @@ class Qwen3NextSparseMoeBlock(nnx.Module):
     )
 
     # 2. Instantiate and apply the shared expert.
-    self.shared_expert = linears.MlpBlock(
+    self.shared_expert = MlpBlock(
         config=cfg,
         mesh=mesh,
         in_features=cfg.emb_dim,
@@ -660,13 +657,14 @@ class Qwen3NextSparseMoeBlock(nnx.Module):
     )
 
     # 3. Instantiate and apply the gate for the shared expert.
-    self.shared_expert_gate = linears.DenseGeneral(
+    self.shared_expert_gate = DenseGeneral(
         in_features_shape=cfg.emb_dim,
         out_features_shape=1,
         use_bias=False,  # Qwen3-Next shared_expert_gate does not have a bias
         dtype=cfg.dtype,
         kernel_init=max_initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
         kernel_axes=("embed", "vocab"),
+        matmul_precision=cfg.matmul_precision,
         rngs=rngs,
     )
 
@@ -831,7 +829,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
           rngs=rngs,
       )
     else:
-      self.attention = Qwen3NextGatedDeltaNet(config=cfg, dtype=cfg.dtype, rngs=rngs)
+      self.attention = Qwen3NextGatedDeltaNet(config=cfg, rngs=rngs)
 
     # Second LayerNorm, applied before the MoE block.
     self.post_attention_layernorm = Qwen3NextRMSNorm(
@@ -1365,6 +1363,7 @@ class Qwen3OmniMoeVisionPatchEmbed(nnx.Module):
   def __init__(
       self,
       config: Config,
+      # Default to float32 for numerical stability in 3D convolutions on image/video inputs
       dtype: DType = jnp.float32,
       weight_dtype: DType = jnp.float32,
       rngs: nnx.Rngs = None,
@@ -1373,8 +1372,8 @@ class Qwen3OmniMoeVisionPatchEmbed(nnx.Module):
 
     Args:
         config: Config containing model parameters
-        dtype: Data type for computation
-        weight_dtype: Data type for weights
+        dtype: Data type for computation (defaults to float32 for numerical stability)
+        weight_dtype: Data type for weights (defaults to float32 for numerical stability)
         rngs: RNG state for initialization
     """
     self.config = config
@@ -1706,6 +1705,326 @@ def qwen3omni_visionprojector_as_linen(config: Config, mesh: Mesh) -> nn.Module:
   )
 
 
+class Qwen3OmniAudioEncoderLayer(nnx.Module):
+  """Transformer encoder layer for audio model."""
+
+  def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs = None):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
+
+    self.hidden_states_shape = (
+        self.config.per_device_batch_size,
+        self.config.max_source_positions_for_audio,
+        self.config.d_model_for_audio,
+    )
+
+    self.input_layer_norm = nnx.LayerNorm(
+        num_features=self.config.d_model_for_audio,
+        epsilon=1e-5,
+        dtype=self.config.dtype_mm,
+        rngs=self.rngs,
+    )
+
+    self.self_attention_audio = Attention(
+        config=self.config,
+        num_query_heads=self.config.encoder_attention_heads_for_audio,
+        num_kv_heads=self.config.encoder_attention_heads_for_audio,
+        head_dim=self.config.d_model_for_audio // self.config.encoder_attention_heads_for_audio,
+        max_target_length=self.config.max_source_positions_for_audio,
+        attention_kernel="dot_product",
+        inputs_q_shape=self.hidden_states_shape,
+        inputs_kv_shape=self.hidden_states_shape,
+        float32_qk_product=self.config.float32_qk_product,
+        float32_logits=self.config.float32_logits,
+        dtype=self.config.dtype_mm,
+        weight_dtype=self.config.weight_dtype,
+        mesh=self.mesh,
+        dropout_rate=self.config.attention_dropout_for_audio,
+        name="self_attention_audio",
+        attention_type=AttentionType.FULL,
+        is_nope_layer=True,  # No rotary position embeddings for audio
+        use_bias_in_projections=True,
+        use_qk_norm=False,
+        query_pre_attn_scalar=1
+        / math.sqrt(self.config.d_model_for_audio // self.config.encoder_attention_heads_for_audio),
+        model_mode=MODEL_MODE_TRAIN,
+        rngs=self.rngs,
+    )
+
+    self.post_attention_layer_norm = nnx.LayerNorm(
+        num_features=self.config.d_model_for_audio,
+        epsilon=1e-5,
+        dtype=self.config.dtype_mm,
+        rngs=self.rngs,
+    )
+
+    self.AudioMLP = MlpBlock(
+        config=self.config,
+        mesh=self.mesh,
+        in_features=self.config.d_model_for_audio,
+        intermediate_dim=self.config.encoder_ffn_dim_for_audio,
+        activations=("gelu",),  # Single GELU activation
+        kernel_init=max_initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        intermediate_dropout_rate=0.0,  # No dropout to match AudioMLP
+        dtype=self.config.dtype_mm,
+        weight_dtype=self.config.weight_dtype,
+        use_bias=True,  # AudioMLP uses bias
+        use_pre_norm=False,  # Norm is handled outside
+        quant=None,  # No quantization
+        model_mode=None,  # Not needed for encoder
+        rngs=rngs,
+    )
+
+  def __call__(
+      self,
+      hidden_states: Array,
+      deterministic: bool = False,
+  ):
+    """Apply transformer encoder layer to audio hidden states.
+
+    Args:
+        hidden_states: Input tensor of shape (batch, seq_len, d_model_for_audio)
+        deterministic: Whether to use deterministic mode (disable dropout)
+
+    Returns:
+        Output tensor of shape (batch, seq_len, d_model_for_audio)
+    """
+    residual = hidden_states
+    hidden_states = self.input_layer_norm(hidden_states)
+    hidden_states, _ = self.self_attention_audio(
+        inputs_q=hidden_states,
+        inputs_kv=hidden_states,
+        deterministic=deterministic,
+    )
+    hidden_states = residual + hidden_states
+    residual = hidden_states
+    hidden_states = self.post_attention_layer_norm(hidden_states)
+    hidden_states = self.AudioMLP(hidden_states)
+    hidden_states = residual + hidden_states
+    return hidden_states
+
+
+class Qwen3OmniAudioEncoder(nnx.Module):
+  """Full audio encoder with convs, positional embeddings, and transformer layers.
+
+  Attributes:
+      config: Config containing model parameters
+      mesh: Mesh, JAX device mesh (used for sharding)
+  """
+
+  def __init__(self, config: Config, mesh: Mesh, *, rngs: nnx.Rngs = None):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
+
+    self.positional_embedding = PositionalEmbedding(
+        embedding_dims=self.config.d_model_for_audio,
+        max_wavelength=self.config.max_timescale_for_audio,
+        cast_as_fprop_dtype=True,
+        fprop_dtype=self.config.dtype_mm,
+    )
+
+    self.layernorm_post = nnx.LayerNorm(
+        num_features=self.config.d_model_for_audio,
+        epsilon=1e-5,
+        dtype=self.config.dtype_mm,
+        rngs=self.rngs,
+    )
+
+    # Convolutional downsampling layers
+    self.conv2d1 = nnx.Conv(
+        in_features=1,
+        out_features=self.config.downsample_hidden_size_for_audio,
+        kernel_size=(3, 3),
+        strides=(2, 2),
+        padding=((1, 1), (1, 1)),
+        use_bias=True,
+        dtype=self.config.dtype_mm,
+        param_dtype=self.config.weight_dtype,
+        precision=self.config.matmul_precision,
+        rngs=self.rngs,
+    )
+
+    self.conv2d2 = nnx.Conv(
+        in_features=self.config.downsample_hidden_size_for_audio,
+        out_features=self.config.downsample_hidden_size_for_audio,
+        kernel_size=(3, 3),
+        strides=(2, 2),
+        padding=((1, 1), (1, 1)),
+        use_bias=True,
+        dtype=self.config.dtype_mm,
+        param_dtype=self.config.weight_dtype,
+        precision=self.config.matmul_precision,
+        rngs=self.rngs,
+    )
+
+    self.conv2d3 = nnx.Conv(
+        in_features=self.config.downsample_hidden_size_for_audio,
+        out_features=self.config.downsample_hidden_size_for_audio,
+        kernel_size=(3, 3),
+        strides=(2, 2),
+        padding=((1, 1), (1, 1)),
+        use_bias=True,
+        dtype=self.config.dtype_mm,
+        param_dtype=self.config.weight_dtype,
+        precision=self.config.matmul_precision,
+        rngs=self.rngs,
+    )
+
+    conv_out_dim = self.config.downsample_hidden_size_for_audio * (
+        (((self.config.num_mel_bins_for_audio + 1) // 2 + 1) // 2 + 1) // 2
+    )
+    self.conv_out = DenseGeneral(
+        in_features_shape=conv_out_dim,
+        out_features_shape=self.config.d_model_for_audio,
+        use_bias=False,
+        dtype=self.config.dtype_mm,
+        weight_dtype=self.config.weight_dtype,
+        kernel_init=nd_dense_init(1.0, "fan_in", "normal"),
+        matmul_precision=self.config.matmul_precision,
+        rngs=self.rngs,
+    )
+
+    # Transformer encoder layers
+    for lyr in range(self.config.encoder_layers_for_audio):
+      layer_name = f"layers_{lyr}"
+      layer = Qwen3OmniAudioEncoderLayer(
+          config=self.config,
+          mesh=self.mesh,
+          rngs=self.rngs,
+      )
+      setattr(self, layer_name, layer)
+
+  def __call__(
+      self,
+      audio_features: Array,
+      deterministic: bool = False,
+  ):
+    """Process audio features through convs + transformer encoder.
+
+    Args:
+        audio_features: Input of shape (batch, num_mel_bins, audio_length)
+        deterministic: Whether to use deterministic mode
+
+    Returns:
+        Encoded features of shape (batch, seq_len, d_model_for_audio)
+    """
+    batch_size, num_mel_bins, audio_length = audio_features.shape
+    chunk_size = self.config.n_window_for_audio * 2
+
+    # Reshape to chunks
+    num_chunks = audio_length // chunk_size
+    audio_chunks = audio_features.reshape(batch_size, num_mel_bins, num_chunks, chunk_size)
+    audio_chunks = audio_chunks.transpose(0, 2, 1, 3)
+    audio_chunks = audio_chunks.reshape(batch_size * num_chunks, num_mel_bins, chunk_size)
+
+    # Add channel dimension
+    hidden_states = audio_chunks[:, :, :, jnp.newaxis]
+
+    # Apply convolutional layers
+    hidden_states = self.conv2d1(hidden_states)
+    hidden_states = jax.nn.gelu(hidden_states)
+    hidden_states = self.conv2d2(hidden_states)
+    hidden_states = jax.nn.gelu(hidden_states)
+    hidden_states = self.conv2d3(hidden_states)
+    hidden_states = jax.nn.gelu(hidden_states)
+
+    # Reshape conv output
+    bc, f, t, c = hidden_states.shape
+    hidden_states = hidden_states.transpose(0, 2, 3, 1)
+    hidden_states = hidden_states.reshape(bc, t, c * f)
+    hidden_states = self.conv_out(hidden_states)
+
+    # Add positional embeddings
+    seq_len_per_chunk = hidden_states.shape[1]
+    pos_emb = self.positional_embedding(seq_len_per_chunk)
+    pos_emb = jnp.broadcast_to(
+        pos_emb[None, :, :], (batch_size * num_chunks, seq_len_per_chunk, self.config.d_model_for_audio)
+    )
+    hidden_states = hidden_states + pos_emb
+
+    # Apply transformer encoder layers
+    for lyr in range(self.config.encoder_layers_for_audio):
+      layer_name = f"layers_{lyr}"
+      layer = getattr(self, layer_name)
+      hidden_states = layer(
+          hidden_states,
+          deterministic=deterministic,
+      )
+
+    hidden_states = self.layernorm_post(hidden_states)
+
+    # Reshape back: (batch*chunks, seq_len_per_chunk, d_model) -> (batch, chunks*seq_len_per_chunk, d_model)
+    hidden_states = hidden_states.reshape(batch_size, num_chunks * seq_len_per_chunk, self.config.d_model_for_audio)
+
+    return hidden_states
+
+
+class Qwen3OmniAudioProjector(nnx.Module):
+  """Projection layer that converts audio encoder output to model embedding space."""
+
+  def __init__(self, config: Config, *, rngs: nnx.Rngs = None):
+    self.config = config
+    self.proj1 = DenseGeneral(
+        in_features_shape=config.d_model_for_audio,
+        out_features_shape=config.d_model_for_audio,
+        use_bias=True,
+        dtype=config.dtype_mm,
+        weight_dtype=config.weight_dtype,
+        kernel_init=nd_dense_init(1.0, "fan_in", "normal"),
+        matmul_precision=config.matmul_precision,
+        rngs=rngs,
+    )
+
+    self.proj2 = DenseGeneral(
+        in_features_shape=config.d_model_for_audio,
+        out_features_shape=config.output_dim_for_audio,
+        use_bias=True,
+        dtype=config.dtype_mm,
+        weight_dtype=config.weight_dtype,
+        kernel_init=nd_dense_init(1.0, "fan_in", "normal"),
+        matmul_precision=config.matmul_precision,
+        rngs=rngs,
+    )
+
+  def __call__(self, hidden_states: Array) -> Array:
+    """
+    Args:
+        hidden_states: Encoder output of shape (num_chunks, seq_len, d_model_for_audio)
+
+    Returns:
+        Projected output of shape (num_chunks, seq_len, output_dim_for_audio)
+    """
+    hidden_states = self.proj1(hidden_states)
+    hidden_states = jax.nn.gelu(hidden_states)
+    hidden_states = self.proj2(hidden_states)
+    return hidden_states
+
+
+def qwen3omni_audioencoder_as_linen(config: Config, mesh: Mesh):
+  """Convert AudioEncoder (convs + transformer layers, no projector) to Linen module."""
+  return nnx_wrappers.to_linen(
+      Qwen3OmniAudioEncoder,
+      config=config,
+      mesh=mesh,
+      name="Qwen3OmniAudioEncoder_0",
+      abstract_init=False,
+      metadata_fn=variable_to_logically_partitioned,
+  )
+
+
+def qwen3omni_audioprojector_as_linen(config: Config, mesh: Mesh):
+  """Convert AudioProjector to Linen module."""
+  return nnx_wrappers.to_linen(
+      Qwen3OmniAudioProjector,
+      config=config,
+      name="Qwen3OmniAudioProjector_0",
+      abstract_init=False,
+      metadata_fn=variable_to_logically_partitioned,
+  )
+
+
 # Vision encoder Linen wrappers
 Qwen3OmniMoeVisionPatchMergerToLinen = nnx_wrappers.to_linen_class(
     Qwen3OmniMoeVisionPatchMerger,
@@ -1759,5 +2078,21 @@ Qwen3NextDecoderLayerToLinen = nnx_wrappers.to_linen_class(
 
 Qwen3NextScannableBlockToLinen = nnx_wrappers.to_linen_class(
     Qwen3NextScannableBlock,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+# Audio encoder Linen wrappers
+Qwen3OmniAudioEncoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioEncoderLayer,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniAudioEncoderToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioEncoder,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+Qwen3OmniAudioProjectorToLinen = nnx_wrappers.to_linen_class(
+    Qwen3OmniAudioProjector,
     base_metadata_fn=max_initializers.variable_to_logically_partitioned,
 )

--- a/src/MaxText/maxengine.py
+++ b/src/MaxText/maxengine.py
@@ -327,6 +327,9 @@ class MaxEngine(engine_api.Engine):
       image_shape = multimodal_utils.get_dummy_image_shape_for_init(
           self.config.model_name, batch_size=self.config.micro_batch_size_to_train_on
       )
+      audio_shape = multimodal_utils.get_dummy_audio_shape_for_init(
+          self.config.model_name, config=self.config, batch_size=self.config.micro_batch_size_to_train_on
+      )
       return self.model.apply(
           _p | {"aqt": {}},
           jnp.ones((1, self.config.max_prefill_predict_length), dtype=jnp.int32),
@@ -336,6 +339,7 @@ class MaxEngine(engine_api.Engine):
           encoder_image_masks=jnp.ones(image_shape[:2], dtype=jnp.int32)
           if self.config.use_multimodal and "llama4" in self.config.model_name
           else None,
+          encoder_audios=jnp.ones(audio_shape, dtype=jnp.float32) if self.config.use_audio else None,
           decoder_segment_ids=jnp.zeros((1, self.config.max_prefill_predict_length), dtype=jnp.int32),
           enable_dropout=False,
           model_mode=MODEL_MODE_PREFILL,
@@ -410,6 +414,8 @@ class MaxEngine(engine_api.Engine):
       padded_tokens: jax.Array,
       images: jax.Array | None = None,
       image_masks: jax.Array | None = None,
+      audio_values: jax.Array | None = None,
+      audio_masks: jax.Array | None = None,
       true_length: int,
       sampler: Callable[[Any], Any] | None = None,  # pylint: disable=unused-argument
       rng: PRNGKeyType | None = None,
@@ -435,6 +441,9 @@ class MaxEngine(engine_api.Engine):
         tokens of a previously processed chunk. Used for chunked prefilling.
       padded_tokens: The input token sequence, padded to a fixed length.
       images: Optional input images for multimodal models.
+      image_masks: Optional image masks for multimodal models with tiled images.
+      audio_values: Optional input audio for multimodal models.
+      audio_masks: Optional audio masks for multimodal models (currently unused).
       true_length: The actual length of `padded_tokens` before padding.
       sampler: A callable for custom sampling logic (currently unused).
       rng: JAX random number generator key for sampling.
@@ -497,6 +506,7 @@ class MaxEngine(engine_api.Engine):
           positions,
           encoder_images=images,
           encoder_image_masks=image_masks,
+          encoder_audios=audio_values,
           decoder_segment_ids=sequence_indicator,
           enable_dropout=False,
           model_mode=MODEL_MODE_PREFILL,
@@ -572,6 +582,8 @@ class MaxEngine(engine_api.Engine):
       padded_tokens: jax.Array,
       images: jax.Array | None = None,
       image_masks: jax.Array | None = None,
+      audio_values: jax.Array | None = None,
+      audio_masks: jax.Array | None = None,
       true_length: int,
       sampler: Callable[[Any], Any] | None = None,  # pylint: disable=unused-argument
       rng: PRNGKeyType | None = None,
@@ -605,6 +617,8 @@ class MaxEngine(engine_api.Engine):
         padded_tokens=padded_tokens,
         images=images,
         image_masks=image_masks,
+        audio_values=audio_values,
+        audio_masks=audio_masks,
         sampler=sampler,
         true_length=true_length,
         page_state=self.page_state,  # Pass current page state
@@ -1540,11 +1554,18 @@ class MaxEngine(engine_api.Engine):
           ),
           dtype=jnp.int32,
       )
+      dummy_audio = jnp.ones(
+          multimodal_utils.get_dummy_audio_shape_for_init(
+              self.config.model_name, config=self.config, batch_size=self.config.micro_batch_size_to_train_on
+          ),
+          dtype=jnp.float32,
+      )
       _, cache = self.model.apply(
           abstract_params,
           x,
           x,
           encoder_images=dummy_image if self.config.use_multimodal else None,
+          encoder_audios=dummy_audio if self.config.use_audio else None,
           enable_dropout=False,
           model_mode=MODEL_MODE_AUTOREGRESSIVE,
           rngs={"params": rng},

--- a/src/MaxText/multimodal/utils.py
+++ b/src/MaxText/multimodal/utils.py
@@ -25,7 +25,7 @@ from PIL import Image
 
 @dataclass
 class PreprocessorOutput:
-  """Holds the output of an image preprocessor.
+  """Holds the output of a multimodal preprocessor.
 
   Attributes:
     pixel_values: A JAX array containing the processed image pixel data.
@@ -38,12 +38,18 @@ class PreprocessorOutput:
                    the aspect ratio [ratio_h, ratio_w] of the processed image(s).
                    This is particularly relevant for models like Llama4 that handle
                    images by tiling.
+    num_images: Number of images in the output.
+    audio_values: An optional array containing processed audio features.
+    audio_mask: An optional array indicating valid audio segments.
   """
 
   pixel_values: None | np.ndarray = None
   pixel_mask: None | np.ndarray = None
   aspect_ratios: None | np.ndarray = None
   num_images: int = 0
+  # Audio attributes.
+  audio_values: None | np.ndarray = None
+  audio_mask: None | np.ndarray = None
 
 
 def load_image_from_path(image_path):

--- a/src/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -687,7 +687,17 @@ qwen3_omni_30b_a3b_config = transformers.Qwen3OmniMoeConfig(
         "text_config": {
             "num_hidden_layers": 48,
             "num_experts": 128,
-        }
+        },
+        "audio_config": {
+            "encoder_layers": 32,
+            "d_model": 1280,
+            "encoder_attention_heads": 20,
+        },
+        "vision_config": {
+            "depth": 27,
+            "num_heads": 16,
+            "hidden_size": 1152,
+        },
     },
 )
 

--- a/tests/unit/qwen3_next_vs_reference_test.py
+++ b/tests/unit/qwen3_next_vs_reference_test.py
@@ -1030,7 +1030,7 @@ class TestQwen3Next(unittest.TestCase):
       expected_output = pt_model(hidden_states_pt)
 
     # 2. Setup JAX model and map weights
-    jax_model = qwen3.Qwen3NextGatedDeltaNet(config=self.cfg, dtype=jnp.float32, rngs=self.nnx_rngs)
+    jax_model = qwen3.Qwen3NextGatedDeltaNet(config=self.cfg, rngs=self.nnx_rngs)
 
     conv1d_weight_pt = pt_model.conv1d.weight.detach().numpy()
     # Transpose PT (out, in/groups, kw) -> JAX (kw, in/groups, out)

--- a/tests/unit/qwen3_omni_layers_test.py
+++ b/tests/unit/qwen3_omni_layers_test.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for Qwen3 Omni Moe Vision Encoder layers."""
+"""Tests for Qwen3 Omni layers comparing MaxText implementation against PyTorch reference.
 
+This module tests both vision and audio encoder components.
+"""
+
+import math
 import os
 import unittest
 
@@ -21,24 +25,40 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import torch
+import torch.nn.functional as F
 from flax import nnx
 from jax.sharding import Mesh
-from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import Qwen3OmniMoeVisionEncoderConfig
+
+# Vision encoder imports from transformers
+from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import (
+    Qwen3OmniMoeAudioEncoderConfig,
+    Qwen3OmniMoeVisionEncoderConfig,
+)
 from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+    Qwen3OmniMoeAudioAttention as TorchQwen3OmniMoeAudioAttention,
+    Qwen3OmniMoeAudioEncoder as TorchQwen3OmniMoeAudioEncoder,
+    Qwen3OmniMoeAudioEncoderLayer as TorchQwen3OmniMoeAudioEncoderLayer,
     Qwen3OmniMoeVisionEncoder as TorchQwen3OmniMoeVisionEncoder,
     Qwen3OmniMoeVisionMLP as TorchQwen3OmniMoeVisionMLP,
     Qwen3OmniMoeVisionPatchEmbed as TorchQwen3OmniMoeVisionPatchEmbed,
     Qwen3OmniMoeVisionPatchMerger as TorchQwen3OmniMoeVisionPatchMerger,
+    SinusoidsPositionEmbedding as TorchSinusoidsPositionEmbedding,
     apply_rotary_pos_emb_vision,
 )
 
+from MaxText import common_types
 from MaxText import pyconfig
 from MaxText.globals import MAXTEXT_REPO_ROOT
+from MaxText.layers.attentions import Attention
 from MaxText.layers.embeddings import (
+    PositionalEmbedding,
     Qwen3OmniMoeVisionPosEmbedInterpolate as JaxQwen3OmniMoeVisionPosEmbedInterpolate,
     Qwen3OmniMoeVisionRotaryEmbedding as JaxQwen3OmniMoeVisionRotaryEmbedding,
 )
+from MaxText.layers.encoders import AudioEncoder
 from MaxText.layers.qwen3 import (
+    Qwen3OmniAudioEncoder,
+    Qwen3OmniAudioEncoderLayer,
     Qwen3OmniMoeVisionAttention as JaxQwen3OmniMoeVisionAttention,
     Qwen3OmniMoeVisionEncoder as JaxQwen3OmniMoeVisionEncoder,
     Qwen3OmniMoeVisionMLP as JaxQwen3OmniMoeVisionMLP,
@@ -50,22 +70,27 @@ from MaxText.multimodal import preprocessor
 from tests.utils.multimodal_test_utils import (
     assert_all_close_jax_torch,
     copy_attention_weights_to_maxtext,
+    copy_audio_projector_weights,
+    copy_maxtext_audio_encoder_weights,
+    copy_maxtext_encoder_layer_weights,
     copy_mlp_weights,
     copy_patch_embed_weights,
     copy_patch_merger_weights,
     copy_vision_encoder_weights,
+    create_block_diagonal_attention_mask,
     create_random_jax_torch,
     split_into_patches,
 )
 
-
+# Initialize config once for all tests
 base_config_path = os.path.join(MAXTEXT_REPO_ROOT, "src", "MaxText", "configs", "base.yml")
-jax_vision_config = pyconfig.initialize(
+jax_config = pyconfig.initialize(
     ["", base_config_path],
     model_name="qwen3-omni-30b-a3b",
     attention="dot_product",
     attention_type="full",
     matmul_precision="highest",
+    dropout_rate=0.0,
     dtype="float32",
     dtype_mm="float32",
     weight_dtype="float32",
@@ -73,27 +98,51 @@ jax_vision_config = pyconfig.initialize(
     float32_qk_product=True,
 )
 
+# PyTorch vision encoder config
 torch_vision_config = Qwen3OmniMoeVisionEncoderConfig(
-    hidden_size=jax_vision_config.hidden_size_for_vit,
-    num_heads=jax_vision_config.num_attention_heads_for_vit,
-    intermediate_size=jax_vision_config.intermediate_size_for_vit,
-    spatial_merge_size=jax_vision_config.spatial_merge_size_for_vit,
-    depth=jax_vision_config.num_hidden_layers_for_vit,
-    rope_theta=jax_vision_config.rope_theta_for_vit,
-    patch_size=jax_vision_config.patch_size_for_vit,
-    temporal_patch_size=jax_vision_config.temporal_patch_size_for_vit,
-    in_channels=jax_vision_config.num_channels_for_vit,
-    num_position_embeddings=jax_vision_config.num_position_embeddings_for_vit,
-    out_hidden_size=jax_vision_config.out_hidden_size_for_vit,
-    deepstack_visual_indexes=list(jax_vision_config.deepstack_visual_indexes_for_vit),
+    hidden_size=jax_config.hidden_size_for_vit,
+    num_heads=jax_config.num_attention_heads_for_vit,
+    intermediate_size=jax_config.intermediate_size_for_vit,
+    spatial_merge_size=jax_config.spatial_merge_size_for_vit,
+    depth=jax_config.num_hidden_layers_for_vit,
+    rope_theta=jax_config.rope_theta_for_vit,
+    patch_size=jax_config.patch_size_for_vit,
+    temporal_patch_size=jax_config.temporal_patch_size_for_vit,
+    in_channels=jax_config.num_channels_for_vit,
+    num_position_embeddings=jax_config.num_position_embeddings_for_vit,
+    out_hidden_size=jax_config.out_hidden_size_for_vit,
+    deepstack_visual_indexes=list(jax_config.deepstack_visual_indexes_for_vit),
     hidden_act="gelu_pytorch_tanh",
 )
 torch_vision_config._attn_implementation = "eager"  # pylint: disable=protected-access
 
+# PyTorch audio encoder config
+torch_audio_encoder_config = Qwen3OmniMoeAudioEncoderConfig(
+    d_model=jax_config.d_model_for_audio,
+    encoder_attention_heads=jax_config.encoder_attention_heads_for_audio,
+    encoder_ffn_dim=jax_config.encoder_ffn_dim_for_audio,
+    encoder_layers=jax_config.encoder_layers_for_audio,
+    attention_dropout=jax_config.attention_dropout_for_audio,
+    dropout=0.0,
+    activation_dropout=0.0,
+    activation_function="gelu",
+    num_mel_bins=jax_config.num_mel_bins_for_audio,
+    max_source_positions=jax_config.max_source_positions_for_audio,
+    scale_embedding=True,
+    n_window=jax_config.n_window_for_audio,
+    n_window_infer=jax_config.n_window_infer_for_audio,
+    conv_chunksize=jax_config.conv_chunksize_for_audio,
+    downsample_hidden_size=jax_config.downsample_hidden_size_for_audio,
+    output_dim=jax_config.output_dim_for_audio,
+    torch_dtype=torch.float32,
+    weight_dtype=torch.float32,
+)
+torch_audio_encoder_config._attn_implementation = "eager"  # pylint: disable=protected-access
+
 torch.set_grad_enabled(False)
 
 
-def create_torch_encoder():
+def create_torch_vision_encoder():
   """Create and configure PyTorch vision encoder."""
   encoder = TorchQwen3OmniMoeVisionEncoder(torch_vision_config)
   encoder.eval()
@@ -106,11 +155,16 @@ def setup_test_seeds():
   torch.manual_seed(42)
 
 
+# =============================================================================
+# Vision Encoder Tests
+# =============================================================================
+
+
 class BaseVisionTestCase(unittest.TestCase):
   """Base class for vision tests with common setup."""
 
   def setUp(self):
-    self.config = jax_vision_config
+    self.config = jax_config
     setup_test_seeds()
 
 
@@ -134,7 +188,7 @@ class TestQwen3OmniMoeVisionAttention(BaseVisionTestCaseWithMesh):
 
   def test_attention_output_matches_torch(self):
     """Test that JAX vision attention output matches PyTorch implementation."""
-    torch_encoder = create_torch_encoder()
+    torch_encoder = create_torch_vision_encoder()
     torch_model = torch_encoder.blocks[0].attn
 
     jax_model = JaxQwen3OmniMoeVisionAttention(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(42))
@@ -350,7 +404,7 @@ class TestQwen3OmniMoeVisionRotaryEmbedding(BaseVisionTestCase):
         fprop_dtype=jnp.float32,
         rngs=nnx.Rngs(42),
     )
-    self.torch_encoder = create_torch_encoder()
+    self.torch_encoder = create_torch_vision_encoder()
 
   def _create_jax_rotary_model(self):
     """Helper to create JAX rotary embedding model."""
@@ -430,7 +484,7 @@ class TestQwen3OmniMoeVisionPosEmbedInterpolate(BaseVisionTestCase):
         dtype=jnp.float32,
         rngs=nnx.Rngs(42),
     )
-    self.torch_encoder = create_torch_encoder()
+    self.torch_encoder = create_torch_vision_encoder()
     torch_pos_embed_weight = self.torch_encoder.pos_embed.weight.detach().cpu().numpy()
     self.jax_model.pos_embed.value = jnp.array(torch_pos_embed_weight)
 
@@ -468,7 +522,7 @@ class TestQwen3OmniMoeVisionEncoderEndToEnd(BaseVisionTestCaseWithMesh):
 
   def test_vision_encoder_single_image(self):
     """Test full vision encoder with single image matches PyTorch."""
-    torch_encoder = create_torch_encoder()
+    torch_encoder = create_torch_vision_encoder()
 
     jax_encoder = JaxQwen3OmniMoeVisionEncoder(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(42))
     jax_projector = JaxQwen3OmniMoeVisionProjector(config=self.config, rngs=nnx.Rngs(43))
@@ -526,7 +580,7 @@ class TestQwen3OmniMoeVisionEncoderEndToEnd(BaseVisionTestCaseWithMesh):
       )
 
 
-class TextQwen3OmniPreprocessing(unittest.TestCase):
+class TestQwen3OmniPreprocessing(unittest.TestCase):
   """Test MaxText Qwen3 Omni preprocessor against HuggingFace reference."""
 
   def setUp(self):
@@ -594,6 +648,404 @@ class TextQwen3OmniPreprocessing(unittest.TestCase):
         np.array(hf_processor_outputs["input_features"]).astype(np.float32),
         rtol=1e-2,
         atol=1e-2,
+    )
+
+
+# =============================================================================
+# Audio Encoder Tests
+# =============================================================================
+
+
+class TestMaxTextAudioAttentionVsPyTorch(unittest.TestCase):
+  """Test that MaxText's Attention module matches PyTorch's audio attention implementation."""
+
+  def setUp(self):
+    self.batch_size = 1
+    self.seq_length = 16
+    self.config = jax_config
+    self.embed_dim = self.config.d_model_for_audio
+    self.num_heads = self.config.encoder_attention_heads_for_audio
+    self.head_dim = self.embed_dim // self.num_heads
+    np.random.seed(42)
+    torch.manual_seed(42)
+    self.mesh = Mesh(np.array(jax.devices()[:1]), axis_names=("data",))
+
+  def test_attention_output_matches_torch(self):
+    """Test that MaxText Attention produces same output as PyTorch attention."""
+    torch_config = torch_audio_encoder_config
+    torch_model = TorchQwen3OmniMoeAudioAttention(torch_config)
+    torch_model.eval()
+
+    # Create input - PyTorch expects (seq_length, channels), MaxText expects (batch, seq, channels)
+    jax_hidden_states_2d, torch_hidden_states = create_random_jax_torch(self.seq_length, self.embed_dim)
+    jax_hidden_states = jax_hidden_states_2d[jnp.newaxis, :, :]  # Add batch dimension for MaxText
+
+    # Create cu_seqlens for PyTorch (cumulative sequence lengths)
+    cu_seqlens = torch.tensor([0, self.seq_length], dtype=torch.long)
+
+    jax_attn = Attention(
+        config=self.config,
+        num_query_heads=self.num_heads,
+        num_kv_heads=self.num_heads,
+        head_dim=self.head_dim,
+        max_target_length=self.config.max_source_positions_for_audio,
+        attention_kernel="dot_product",
+        inputs_q_shape=(
+            self.config.per_device_batch_size,
+            self.seq_length,
+            self.embed_dim,
+        ),
+        inputs_kv_shape=(
+            self.config.per_device_batch_size,
+            self.seq_length,
+            self.embed_dim,
+        ),
+        float32_qk_product=self.config.float32_qk_product,
+        float32_logits=self.config.float32_logits,
+        dtype=self.config.dtype_mm,
+        weight_dtype=self.config.weight_dtype,
+        mesh=self.mesh,
+        dropout_rate=0.0,
+        name="test_attention",
+        attention_type=common_types.AttentionType.FULL,
+        is_nope_layer=True,
+        use_bias_in_projections=True,
+        use_qk_norm=False,
+        query_pre_attn_scalar=1 / math.sqrt(self.head_dim),
+        model_mode=common_types.MODEL_MODE_TRAIN,
+        rngs=nnx.Rngs(42),
+    )
+
+    copy_attention_weights_to_maxtext(torch_model, jax_attn)
+    torch_output = torch_model(torch_hidden_states, cu_seqlens=cu_seqlens)
+
+    jax_output, _ = jax_attn(inputs_q=jax_hidden_states, inputs_kv=jax_hidden_states, deterministic=True)
+
+    # Both should be (seq, embed) after removing batch dimensions
+    jax_output_2d = jax_output[0]  # (batch, seq, embed) -> (seq, embed)
+    # PyTorch returns (batch, seq, embed), squeeze to remove batch dimension
+    torch_output_2d = torch_output.squeeze(0)  # (1, seq, embed) -> (seq, embed)
+
+    assert_all_close_jax_torch(
+        jax_output_2d,
+        torch_output_2d,
+        rtol=1e-5,
+        atol=5e-3,
+        error_msg="Attention outputs differ",
+    )
+
+
+class TestAudioEncoderLayer(unittest.TestCase):
+  """Test MaxText AudioEncoderLayer against PyTorch implementation."""
+
+  def setUp(self):
+    self.config = jax_config
+    self.torch_config = torch_audio_encoder_config
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+    devices = jax.devices()
+    self.mesh = Mesh(np.array(devices[:1]), axis_names=("data",))
+
+  def _test_encoder_layer_with_batch_size(self, batch_size):
+    """Helper function to test encoder layer with a given batch size."""
+
+    torch_layer = TorchQwen3OmniMoeAudioEncoderLayer(self.torch_config)
+    torch_layer.eval()
+
+    maxtext_layer = Qwen3OmniAudioEncoderLayer(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+
+    # Copy weights from PyTorch to MaxText
+    copy_maxtext_encoder_layer_weights(torch_layer, maxtext_layer)
+
+    # Create test input
+    seq_len = 12  # After conv layers
+    hidden_size = self.config.d_model_for_audio
+
+    jax_input, torch_input_3d = create_random_jax_torch(batch_size, seq_len, hidden_size)
+
+    # PyTorch forward pass - expects 2D input (total_seq_len, hidden_dim) with cu_seqlens
+    torch_input_2d = torch_input_3d.reshape(-1, hidden_size)
+
+    # Create cu_seqlens for PyTorch (cumulative sequence lengths for each batch)
+    # For batch_size=2, seq_len=12: [0, 12, 24] indicates two sequences of length 12 each
+    cu_seqlens = torch.tensor([i * seq_len for i in range(batch_size + 1)], dtype=torch.int32)
+
+    attention_mask = create_block_diagonal_attention_mask(cu_seqlens, torch_input_2d.dtype)
+
+    torch_output_1d = torch_layer(torch_input_2d, cu_seqlens=cu_seqlens, attention_mask=attention_mask)[0]
+    torch_output = torch_output_1d.reshape(batch_size, seq_len, hidden_size)
+
+    jax_output = maxtext_layer(jax_input, deterministic=True)
+
+    assert_all_close_jax_torch(
+        jax_output,
+        torch_output,
+        rtol=1e-5,
+        atol=5e-3,
+        error_msg="AudioEncoderLayer outputs differ",
+    )
+
+  def test_encoder_layer_matches_torch_batch_1(self):
+    """Test that MaxText AudioEncoderLayer matches PyTorch with batch_size=1."""
+    self._test_encoder_layer_with_batch_size(batch_size=1)
+
+  def test_encoder_layer_matches_torch_batch_2(self):
+    """Test that MaxText AudioEncoderLayer matches PyTorch with batch_size=2."""
+    self._test_encoder_layer_with_batch_size(batch_size=2)
+
+  def test_encoder_layer_is_jittable(self):
+    """Test that encoder layer can be JIT compiled."""
+    with self.mesh:
+      jax_layer = Qwen3OmniAudioEncoderLayer(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+
+    @nnx.jit
+    def forward(layer, x):
+      return layer(x, deterministic=True)
+
+    batch_size = 2
+    seq_len = 12
+    hidden_size = self.config.d_model_for_audio
+
+    hidden_states = jnp.ones((batch_size, seq_len, hidden_size))
+    output = forward(jax_layer, hidden_states)
+
+    self.assertEqual(output.shape, (batch_size, seq_len, hidden_size))
+
+
+class TestPositionalEmbedding(unittest.TestCase):
+  """Tests for PositionalEmbedding implementation."""
+
+  def setUp(self):
+    self.length = 100
+    self.channels = 512
+    self.max_timescale = 10000.0
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+  def test_positional_embedding_matches_torch(self):
+    torch_model = TorchSinusoidsPositionEmbedding(self.length, self.channels, self.max_timescale)
+    jax_model = PositionalEmbedding(
+        embedding_dims=self.channels, max_wavelength=self.max_timescale, cast_as_fprop_dtype=False
+    )
+
+    # Test full sequence
+    torch_output = torch_model(self.length)
+    jax_output = jax_model(self.length)
+
+    assert_all_close_jax_torch(
+        jax_output,
+        torch_output,
+        rtol=1e-5,
+        atol=3e-4,
+        error_msg="Positional embedding outputs differ",
+    )
+
+  def test_positional_embedding_is_jittable(self):
+    model = PositionalEmbedding(embedding_dims=self.channels, max_wavelength=self.max_timescale)
+
+    @nnx.jit(static_argnames=["seqlen"])
+    def forward(model, seqlen):
+      return model(seqlen)
+
+    output = forward(model, seqlen=self.length)
+    self.assertEqual(output.shape, (self.length, self.channels))
+
+
+class TestAudioEncoder(unittest.TestCase):
+  """Test AudioEncoder (convs + transformer, no projector) against PyTorch implementation."""
+
+  def setUp(self):
+    self.config = jax_config
+    self.torch_config = torch_audio_encoder_config
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+    devices = jax.devices()
+    self.mesh = Mesh(np.array(devices[:1]), axis_names=("data",))
+
+  def test_audio_encoder_matches_torch(self):
+    """Test that MaxText AudioEncoder matches PyTorch encoder (convs + transformer + layernorm, before projector)."""
+    torch_model = TorchQwen3OmniMoeAudioEncoder(self.torch_config)
+    torch_model.eval()
+
+    maxtext_encoder = Qwen3OmniAudioEncoder(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+
+    copy_maxtext_audio_encoder_weights(torch_model, maxtext_encoder, self.config)
+
+    batch_size = 1
+    num_mel_bins = self.config.num_mel_bins_for_audio
+    audio_length = 200  # n_window=50, chunk_size=100, gives 2 chunks
+
+    jax_audio_features, torch_audio_features_3d = create_random_jax_torch(batch_size, num_mel_bins, audio_length)
+
+    # PyTorch forward (manually run convs + transformer encoder without projector)
+    torch_audio_features = torch_audio_features_3d[0]
+
+    # Run through PyTorch convs + positional + encoder
+    chunk_size = self.torch_config.n_window * 2
+    num_chunks = audio_length // chunk_size
+    chunk_lengths = torch.tensor([chunk_size] * num_chunks, dtype=torch.long)
+    chunk_list = torch_audio_features.T.split(chunk_lengths.tolist(), dim=0)
+    torch_padded_feature = torch.nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
+    torch_padded_feature = torch_padded_feature.unsqueeze(1)
+
+    torch_conv1 = F.gelu(torch_model.conv2d1(torch_padded_feature))
+    torch_conv2 = F.gelu(torch_model.conv2d2(torch_conv1))
+    torch_conv3 = F.gelu(torch_model.conv2d3(torch_conv2))
+
+    b, c, f, t = torch_conv3.size()
+    torch_conv_out = torch_model.conv_out(torch_conv3.permute(0, 3, 1, 2).contiguous().view(b, t, c * f))
+
+    torch_pos_emb = (
+        torch_model.positional_embedding.positional_embedding[: torch_conv_out.shape[1], :]
+        .unsqueeze(0)
+        .to(torch_conv_out.dtype)
+    )
+    torch_after_pos = torch_conv_out + torch_pos_emb
+
+    # Run through encoder layers + layernorm (but not projector)
+    # Process all chunks together
+    seq_len_per_chunk = torch_after_pos.shape[1]
+    cu_seqlens = torch.tensor([i * seq_len_per_chunk for i in range(num_chunks + 1)], dtype=torch.int32)
+    attention_mask = create_block_diagonal_attention_mask(cu_seqlens, torch_after_pos.dtype)
+
+    # Flatten: (num_chunks, seq_len_per_chunk, hidden) -> (num_chunks*seq_len_per_chunk, hidden)
+    hidden_state = torch_after_pos.reshape(-1, torch_after_pos.shape[-1])
+    for layer in torch_model.layers:
+      hidden_state = layer(hidden_state, cu_seqlens=cu_seqlens, attention_mask=attention_mask)[0]
+    hidden_state = torch_model.ln_post(hidden_state)
+
+    # Reshape back: (num_chunks*seq_len_per_chunk, hidden) -> (batch=1, num_chunks*seq_len_per_chunk, hidden)
+    torch_output = hidden_state.reshape(1, num_chunks * seq_len_per_chunk, -1)
+
+    # MaxText forward
+    jax_output = maxtext_encoder(jax_audio_features, deterministic=True)
+
+    assert_all_close_jax_torch(
+        jax_output,
+        torch_output,
+        rtol=1e-3,
+        atol=0.1,
+        error_msg="AudioEncoder outputs differ",
+    )
+
+
+class TestAudioModel(unittest.TestCase):
+  """Test full AudioModel end-to-end against PyTorch implementation."""
+
+  def setUp(self):
+    self.config = jax_config
+    self.torch_config = torch_audio_encoder_config
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+    devices = jax.devices()
+    self.mesh = Mesh(np.array(devices[:1]), axis_names=("data",))
+
+  def test_audio_model_end_to_end(self):
+    """Test full AudioModel pipeline against PyTorch."""
+    torch_model = TorchQwen3OmniMoeAudioEncoder(self.torch_config)
+    torch_model.eval()
+
+    maxtext_model = AudioEncoder(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+    encoder = getattr(maxtext_model, maxtext_model.encoder_name)
+    projector = getattr(maxtext_model, maxtext_model.projector_name)
+    copy_maxtext_audio_encoder_weights(torch_model, encoder, self.config)
+    copy_audio_projector_weights(torch_model, projector)
+
+    batch_size = 1
+    num_mel_bins = self.config.num_mel_bins_for_audio
+    audio_length = 200  # With n_window=50, chunk_size=100, gives 2 chunks
+
+    jax_audio_features, torch_audio_features_3d = create_random_jax_torch(batch_size, num_mel_bins, audio_length)
+    audio_lengths_np = np.array([audio_length], dtype=np.int64)
+
+    torch_audio_features = torch_audio_features_3d[0]
+    torch_audio_lengths = torch.from_numpy(audio_lengths_np)
+
+    torch_output = torch_model(input_features=torch_audio_features, feature_lens=torch_audio_lengths)
+    torch_output_tensor = torch_output.last_hidden_state
+
+    jax_output = maxtext_model(jax_audio_features, deterministic=True)
+
+    assert_all_close_jax_torch(
+        jax_output[0],
+        torch_output_tensor,
+        rtol=1e-3,
+        atol=0.02,
+        error_msg="AudioModel outputs differ",
+    )
+
+  def test_audio_model_intermediates(self):
+    """Debug intermediate outputs to verify each stage matches PyTorch."""
+    torch_model = TorchQwen3OmniMoeAudioEncoder(self.torch_config)
+    torch_model.eval()
+
+    audio_encoder = Qwen3OmniAudioEncoder(config=self.config, mesh=self.mesh, rngs=nnx.Rngs(0))
+    copy_maxtext_audio_encoder_weights(torch_model, audio_encoder, self.config)
+
+    batch_size = 1
+    num_mel_bins = self.config.num_mel_bins_for_audio
+    audio_length = 100
+
+    jax_audio_features, torch_audio_features_3d = create_random_jax_torch(batch_size, num_mel_bins, audio_length)
+    torch_audio_features = torch_audio_features_3d[0]
+
+    # PyTorch forward
+    chunk_size = self.torch_config.n_window * 2
+    num_chunks = audio_length // chunk_size
+    chunk_lengths = torch.tensor([chunk_size] * num_chunks, dtype=torch.long)
+    chunk_list = torch_audio_features.T.split(chunk_lengths.tolist(), dim=0)
+    torch_padded_feature = torch.nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
+    torch_padded_feature = torch_padded_feature.unsqueeze(1)
+
+    torch_conv1 = F.gelu(torch_model.conv2d1(torch_padded_feature))
+    torch_conv2 = F.gelu(torch_model.conv2d2(torch_conv1))
+    torch_conv3 = F.gelu(torch_model.conv2d3(torch_conv2))
+
+    b, c, f, t = torch_conv3.size()
+    torch_conv_out = torch_model.conv_out(torch_conv3.permute(0, 3, 1, 2).contiguous().view(b, t, c * f))
+
+    torch_pos_emb = (
+        torch_model.positional_embedding.positional_embedding[: torch_conv_out.shape[1], :]
+        .unsqueeze(0)
+        .to(torch_conv_out.dtype)
+    )
+    torch_after_pos = torch_conv_out + torch_pos_emb
+
+    # JAX forward
+    jax_audio_chunks = jax_audio_features.reshape(batch_size, num_mel_bins, num_chunks, chunk_size)
+    jax_audio_chunks = jax_audio_chunks.transpose(0, 2, 1, 3).reshape(batch_size * num_chunks, num_mel_bins, chunk_size)
+    jax_hidden = jax_audio_chunks[:, :, :, jnp.newaxis]
+
+    jax_conv1 = jax.nn.gelu(audio_encoder.conv2d1(jax_hidden))
+    jax_conv2 = jax.nn.gelu(audio_encoder.conv2d2(jax_conv1))
+    jax_conv3 = jax.nn.gelu(audio_encoder.conv2d3(jax_conv2))
+
+    bc, f_jax, t_jax, c_jax = jax_conv3.shape
+    jax_conv_out = audio_encoder.conv_out(jax_conv3.transpose(0, 2, 3, 1).reshape(bc, t_jax, c_jax * f_jax))
+
+    seq_len_per_chunk = jax_conv_out.shape[1]
+    jax_pos_emb = audio_encoder.positional_embedding(seq_len_per_chunk)
+    jax_pos_emb = jnp.broadcast_to(
+        jax_pos_emb[None, :, :], (batch_size * num_chunks, seq_len_per_chunk, self.config.d_model_for_audio)
+    )
+    jax_after_pos = jax_conv_out + jax_pos_emb
+
+    # Verify all stages match
+    assert_all_close_jax_torch(
+        jax_conv1[0], torch_conv1.permute(0, 2, 3, 1)[0], rtol=1e-4, atol=1e-3, error_msg="Conv1 differs"
+    )
+    assert_all_close_jax_torch(
+        jax_conv2[0], torch_conv2.permute(0, 2, 3, 1)[0], rtol=1e-4, atol=1e-3, error_msg="Conv2 differs"
+    )
+    assert_all_close_jax_torch(
+        jax_conv3[0], torch_conv3.permute(0, 2, 3, 1)[0], rtol=1e-4, atol=1e-3, error_msg="Conv3 differs"
+    )
+    assert_all_close_jax_torch(jax_conv_out[0], torch_conv_out[0], rtol=1e-4, atol=1e-3, error_msg="Conv out differs")
+    assert_all_close_jax_torch(
+        jax_after_pos[0], torch_after_pos[0], rtol=1e-4, atol=1e-3, error_msg="After pos emb differs"
     )
 
 


### PR DESCRIPTION
# Description

Original author @eitanporat in https://github.com/AI-Hypercomputer/maxtext/pull/2726

Revise according to the original PR comments:
* rename flags for consistency and clean up usage
* make AudioEncoder an NNX module
* remove SinusoidsPositionEmbedding, replaced with expanded existing PositionalEmbedding module
* remove Qwen3OmniAudioModel in qwen3.py since we use the AudioEncoder class in decoder.py instead
* add precision related flags

# Tests
tests/check_qwen3_omni_audio_vs_reference.py all pass


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
