### PR TITLE
Fix codecov to upload to separate flags for PR vs scheduled runs

### DIFF
--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -133,6 +133,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          # If scheduled, upload to BOTH flags. If PR, upload ONLY to regular.
-          flags: ${{ inputs.is_scheduled_run == 'true' && 'regular,scheduled' || 'regular' }}
+          # If scheduled, upload to scheduled flag only. If PR, upload to regular flag only.
+          flags: ${{ inputs.is_scheduled_run == 'true' && 'scheduled' || 'regular' }}
           verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 # MaxText Codecov Configuration
-# 
+#
 # We use a two-flag scheme ('regular' and 'scheduled') to handle our tiered test suite.
-# 'carryforward' is enabled because Pull Requests only run a subset of tests (excluding 'scheduled_only').
-# Without it, PRs would show a significant coverage drop as they would 'overwrite' the full-suite results.
+# 'carryforward' is enabled because each flag is only updated by its respective run type.
 #
 # Scheme:
-# - 'regular': Updated by every PR. Used to evaluate 'patch' (new code) coverage.
-# - 'scheduled': Updated by scheduled full runs. Used to anchor 'project' (total health) coverage.
+# - 'regular': Updated ONLY by PRs (subset of tests, excluding 'scheduled_only'). Used for 'patch' coverage.
+# - 'scheduled': Updated ONLY by scheduled runs (all tests including 'scheduled_only'). Used for 'project' coverage.
 # During PRs, the 'scheduled' flag is carried forward from the last full run on 'main' to keep the score stable.
+# During scheduled runs, the 'regular' flag is carried forward from the last PR.
 
 # Exclude non-source code, deprecated and experimental folders from coverage tracking
 codecov: 
@@ -43,10 +43,10 @@ ignore:
 
 
 flags:
-  # Updated on every PR and during every scheduled run (contains a subset of tests).
+  # Updated ONLY by PRs (contains subset of tests, excluding scheduled_only).
   regular:
     carryforward: true
-  # Updated ONLY during scheduled runs (contains all tests).
+  # Updated ONLY by scheduled runs (contains all tests including scheduled_only).
   scheduled:
     carryforward: true
 


### PR DESCRIPTION
# Description
Scheduled runs now upload only to 'scheduled' flag instead of both 'regular,scheduled'. This ensures the flags reflect their respective test suites: regular (PR subset) vs scheduled (full suite including scheduled_only tests).

# Tests
N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
