### PR TITLE
Adjusted the batch size to enable llama2-70b to run on v5p-128

### DIFF
--- a/benchmarks/maxtext_v5p_model_configs.py
+++ b/benchmarks/maxtext_v5p_model_configs.py
@@ -202,7 +202,7 @@ llama2_70b_v5p_128 = _add_to_model_dictionary(
         model_type="llama2-70b",
         tuning_params={
             "ici_fsdp_parallelism": -1,
-            "per_device_batch_size": 4,
+            "per_device_batch_size": 2,
             "remat_policy": "save_dot_except_mlpwi",
             "max_target_length": 4096,
             "use_iota_embed": True,


### PR DESCRIPTION
# Description

Currently, the benchmark configuration for Llama2-70b training on v5p-128 encounters OOM issue. This PR reduces the batch size to 2 (previously 4) to prevent OOM errors during training.

# Tests

[Training with batch size 4 - OOM](https://paste.googleplex.com/5473134528561152)
[Training with batch size 2 - success](https://paste.googleplex.com/5213696492175360)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
