### PR TITLE
feat: update knowledge distillation tutorial for using vllm with Qwen model

### DIFF
--- a/docs/tutorials/posttraining/knowledge_distillation.md
+++ b/docs/tutorials/posttraining/knowledge_distillation.md
@@ -17,160 +17,186 @@
 # Knowledge distillation
 
 ## Overview
+
 Knowledge Distillation is a compression technique that transfers knowledge from a larger (teacher) model to a smaller (student) model. This allows the smaller model to achieve performance levels closer to the larger one, but with significantly fewer parameters and computational resources.
 
-This guide focuses on **response-based knowledge distillation**, a technique where the student model is trained to replicate the outputs and behaviors of the teacher model. Within response-based knowledge distillation, two primary methods are often employed:
+This tutorial focuses on **response-based knowledge distillation**, a technique where the student model is trained to replicate the outputs and behaviors of the teacher model. Within response-based knowledge distillation, two primary methods are often employed:
 
-1.  **Offline Distillation (Dataset Generation):**
-    *   The pre-trained teacher model first generates a new dataset of input-output pairs.
-    *   The student model is then trained on this teacher-generated dataset using standard fine-tuning techniques.
+1. **Offline Distillation (Dataset Generation):**
 
-2.  **Online Distillation (Logit Matching):**
-    *   During the training process, both the teacher model (which is typically frozen) and the student model process the same input data simultaneously.
-    *   The student model is trained by minimizing a loss function that encourages its output logits to match the logits produced by the teacher model for the same inputs.
+   - The pre-trained teacher model (running in vLLM) generates a new dataset of input-output pairs.
+   - The student model is then trained on this teacher-generated dataset using standard fine-tuning techniques in MaxText.
+
+1. **Online Distillation (Logit Matching):**
+
+   - During the training process, both the teacher model (which is typically frozen) and the student model process the same input data simultaneously.
+   - The student model is trained by minimizing a loss function that encourages its output logits to match the logits produced by the teacher model for the same inputs.
 
 ## Running Offline Distillation with MaxText
 
-The following recipe demonstrates the process of offline distillation using **Deepseek2-16b** as the teacher model and **Llama2-7b** as the student model. Since this recipe fine-tunes the student model using Supervised Fine-Tuning (SFT), it's crucial to use the conversational variant for both the teacher and student models. Here’s a step-by-step guide:
+The following recipe demonstrates the process of offline distillation using **Qwen/Qwen3-32B** as the teacher model and **Llama-3.1-8B** as the student model. Since this recipe fine-tunes the student model using Supervised Fine-Tuning (SFT), it's crucial to use the conversational variant for both the teacher and student models. Here's a step-by-step tutorial:
 
 ### Prerequisites
 
 #### a. Setup environment variables
 
 ```bash
-export HF_TOKEN = <Hugging Face access token>
-export BASE_DIRECTORY = <Directory to store distillation results>
-export HF_REPO_NAME = <Hugging Face repository name to store teacher-generated dataset>
-export USERNAME_OR_ORG = <Owner of Hugging Face repository>
-export RUN_NAME = <unique name for the run>
+export HF_TOKEN=<your-hf-token> # e.g., hf_BA6...
+export RUN_NAME=<your-run-name> # e.g., distill-20260115
 ```
 
 #### b. Install dependencies
 
-```sh
-git clone https://github.com/AI-Hypercomputer/maxtext.git
-python3 -m venv ~/venv-maxtext
-source ~/venv-maxtext/bin/activate
-python3 -m pip install uv
-cd maxtext
-uv pip install -r dependencies/requirements/requirements.txt
-```
+To install MaxText and its dependencies for post-training (including vLLM for the teacher), run the following:
 
-### 1. Obtain and prepare the teacher model
+1. Follow the [MaxText installation instructions](https://maxtext.readthedocs.io/en/latest/install_maxtext.html#install-maxtext).
 
-#### a. Download model from Hugging Face
+1. Install the additional dependencies for post-training:
 
 ```bash
-huggingface-cli login  # Provide your Hugging Face token
-huggingface-cli download deepseek-ai/DeepSeek-V2-Lite-Chat --repo-type model --local-dir ~/deepseek2-16b-chat
+bash tools/setup/setup_post_training_requirements.sh
 ```
 
-#### b. Convert checkpoint to MaxText format
-MaxText requires checkpoints to be in a specific format. You'll need to convert the downloaded Hugging Face checkpoints to a MaxText-compatible checkpoint.
+#### c. Setup storage with Hyperdisk
+
+To store large models and datasets, attach a Hyperdisk to your TPU VM. Refer to the [Google Cloud Hyperdisk documentation](https://cloud.google.com/compute/docs/disks/add-hyperdisk) and [TPU VM management](https://cloud.google.com/tpu/docs/managing-tpus-tpu-vm) for detailed instructions.
+
+First, create a Hyperdisk:
 
 ```bash
-# Get unscanned checkpoint for efficient decoding
-JAX_PLATFORMS=cpu \
-python3 -m MaxText.utils.ckpt_scripts.convert_deepseek_family_unscanned_ckpt \
-  --base_model_path ~/deepseek2-16b-chat \
-  --maxtext_model_path ${BASE_DIRECTORY}/deepseek2-16-chat/unscanned \
-  --model_size deepseek2-16b
+export ZONE=<your-tpu-zone>  # e.g., us-central1-a
+export TPU_VM_NAME=<your-tpu-vm-name>
+export DISK_NAME=<your-disk-name>  # e.g., my-hyperdisk
+export DISK_SIZE=<disk-size>  # e.g., 500GB
+
+gcloud compute disks create ${DISK_NAME} \
+  --size=${DISK_SIZE} \
+  --type=hyperdisk-balanced \
+  --zone=${ZONE}
 ```
 
-### 2. Obtain and prepare the student model
-
-#### a. Download model from Hugging Face
+Then, attach the disk to your TPU VM:
 
 ```bash
-huggingface-cli download meta-llama/Llama-2-7b-chat-hf --repo-type model --local-dir ~/llama2-7b-chat
+gcloud compute instances attach-disk ${TPU_VM_NAME} \
+  --disk=${DISK_NAME} \
+  --zone=${ZONE}
 ```
 
-#### b. Convert checkpoint to MaxText format
-MaxText requires checkpoints to be in a specific format. You'll need to convert the downloaded Hugging Face checkpoints to a MaxText-compatible checkpoint.
+Inside the TPU VM, format and mount the disk (if not already mounted):
 
 ```bash
-# Get scanned checkpoint for fine-tuning
-JAX_PLATFORMS=cpu \
-python3 -m MaxText.utils.ckpt_scripts.llama_or_mistral_ckpt \
-  --base-model-path ~/llama2-7b-chat \
-  --maxtext-model-path ${BASE_DIRECTORY}/llama2-7b-chat/scanned \
-  --model-size llama2-7b
+# Assuming the disk is /dev/sdb, check with lsblk
+sudo mkfs.ext4 /dev/sdb
+sudo mkdir -p /mnt/hyperdisk
+sudo mount /dev/sdb /mnt/hyperdisk
 ```
 
-### 3. Generate dataset using the teacher model
-Once the teacher model's checkpoint is in the MaxText format, you can run inference to generate the dataset that will be used to fine-tune the student model.
-
-### 3.a. Run the JetStream server
-
-Example command to run JetStream server on `v4-8`:
+Update the BASE_DIRECTORY to point to the mounted disk and create the directory:
 
 ```bash
-python3 -m MaxText.maxengine_server src/MaxText/configs/base.yml \
-  tokenizer_path=deepseek-ai/DeepSeek-V2-Lite-chat tokenizer_type=huggingface \
-  load_parameters_path=${BASE_DIRECTORY}/deepseek2-16-chat/unscanned/0/items \
-  model_name=deepseek2-16b \
-  per_device_batch_size=10 ici_tensor_parallelism=4 \
-  max_target_length=2048 max_prefill_predict_length=64 \
-  hf_access_token=$HF_TOKEN \
-  scan_layers=False \
-  multi_sampling=True decode_sampling_strategy=weighted
+export BASE_NAME=<your-base-directory>  # e.g., knowledge-distillation
+export BASE_DIRECTORY=/mnt/hyperdisk/${BASE_NAME}
+mkdir -p ${BASE_DIRECTORY}
 ```
 
-Set `multi_sampling` to `True` to generate multiple independent completions per prompt.
+> **Note:** This tutorial uses a mounted Hyperdisk for performance and reproducibility, because writing large model files and many small I/O operations directly to `gs://` can be significantly slower.
 
+### Obtain and prepare the teacher model
 
-### 3.b. Generate dataset using JetStream server
-In a new tab in your terminal, run the following command to generate dataset from teacher model. Note that this is an example command to run on `v4-8`:
+For the teacher model, we will use **vLLM** to run inference. vLLM can load Hugging Face checkpoints directly, so **no conversion to MaxText format is needed** for the teacher. Ensure the teacher model is supported on TPU vLLM (refer to the [vLLM TPU recommended models](https://docs.vllm.ai/projects/tpu/en/latest/recommended_models_features/#text-only-models) for the latest list).
+
+You can simply download the model from Hugging Face to your local directory:
 
 ```bash
-python3 -m MaxText.generate_distillation_data \
-  --tokenizer-path deepseek-ai/DeepSeek-V2-Lite-chat \
-  --dataset-path HuggingFaceH4/ultrachat_200k --data-split train_sft \
+huggingface-cli login --token $HF_TOKEN
+huggingface-cli download Qwen/Qwen3-32B --repo-type model --local-dir ${BASE_DIRECTORY}/qwen3-32b
+```
+
+### Obtain and prepare the student model
+
+The student model will be trained in MaxText, which uses the Orbax checkpointing format. You will download the Hugging Face weights to your mounted bucket and convert them for training.
+
+#### Convert checkpoint to MaxText format
+
+The following command downloads the Hugging Face weights and converts them to the MaxText format.
+
+**Note:** This conversion script requires PyTorch.
+
+```bash
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+```
+
+```bash
+# Set the checkpoint directory
+export PRE_TRAINED_MODEL_CKPT_DIRECTORY=${BASE_DIRECTORY}/llama3.1-8b-ckpt
+
+# Convert to MaxText format
+python3 -m MaxText.utils.ckpt_conversion.to_maxtext src/MaxText/configs/base.yml \
+    model_name=llama3.1-8b \
+    hf_access_token=${HF_TOKEN} \
+    base_output_directory=${PRE_TRAINED_MODEL_CKPT_DIRECTORY} \
+    scan_layers=True skip_jax_distributed_system=True
+```
+
+### Generate dataset using vLLM (Teacher Step)
+
+Use the provided script `generate_distillation_data_vllm.py` to generate the dataset from the teacher model. This script writes a Parquet dataset compatible with MaxText SFT.
+
+Run the generation script:
+
+```bash
+export OUTPUT_DATASET=${BASE_DIRECTORY}/datasets/distillation_data.parquet
+
+python3 -m tools.data_generation.generate_distillation_data_vllm \
+  --dataset-path HuggingFaceH4/ultrachat_200k \
+  --data-split train_sft \
   --data-columns messages \
-  --max-prefill-length 64 --max-target-length 2048 \
   --hf-access-token $HF_TOKEN \
-  --use-chat-template --remove-local-dataset-files \
-  --num-generations 2 --batch-size 1024 --num-batches 200 \
-  upload-to-hf --hf-repo-id ${HF_REPO_NAME}
+  --teacher-model ${BASE_DIRECTORY}/qwen3-32b \
+  --use-chat-template \
+  --num-prompts 5120 \
+  --num-generations 2 \
+  --output-file ${OUTPUT_DATASET}
+
 ```
 
-When `multi_sampling=True` (Step 3.a), the `--num-generations` parameter specifies the number of distinct completions to generate per prompt. The `--batch-size` parameter controls how many prompts are processed per batch, and `--num-batches` defines how many such batches to run. The total number of prompt-completion pairs generated is approximately `num_batches * batch_size * num_generations`.
+### Fine-tune the student model using Supervised Fine Tuning (SFT)
 
-For example, with `--batch-size 1024`, `--num-generations 2`, and `--num-batches 200`, this would yield `200 * 1024 * 2 = 409,600` prompt-completion pairs.
-
-It's important to note that some prompts may be filtered out by pre-processing logic before inference. If the prompt sequences are longer than `max-prefill-length`, then those prompts will be filtered out in pre-processing stage.
-
-Additionally, the generated dataset can be uploaded to either Hugging Face or Google Cloud Storage (GCS). To upload to Hugging Face, use the `upload-to-hf --hf-repo-id <hf_repo_name>` flags. To upload to GCS, use the `upload-to-gcs --gcs-bucket <gcs bucket name> --gcs-data-path <path in gcs bucket>` flags.
-
-### 4. Fine-tune the student model using Supervised Fine Tuning (SFT)
 You can now fine-tune your smaller student model using supervised fine-tuning technique in MaxText.
 
-### 4.a. Fine-tune the student model using dataset generated in Step 3
+#### Fine-tune the student model using the generated dataset
 
-Example command to run fine-tuning on v4-8:
+Example command to run fine-tuning on a TPU v6e-8:
 
 ```bash
-python3 -m MaxText.sft_trainer src/MaxText/configs/sft.yml \
+python3 -m MaxText.sft.sft_trainer src/MaxText/configs/sft.yml \
   run_name=${RUN_NAME} \
-  base_output_directory=${BASE_DIRECTORY}/distillation/deepseek2-16b-distill-llama2-7b \
-  tokenizer_path=meta-llama/Llama-2-7b-chat-hf tokenizer_type=huggingface \
-  hf_path=${USERNAME_OR_ORG}/${HF_REPO_NAME} \
-  train_split='train' train_data_columns=['prompt','completion'] \
-  load_parameters_path=${BASE_DIRECTORY}/llama2-7b-chat/scanned/0/items \
-  model_name=llama2-7b \
-  per_device_batch_size=2 ici_expert_parallelism=-1 ici_fsdp_parallelism=4 \
+  base_output_directory=${BASE_DIRECTORY}/distillation/qwen3-32b-distill-llama3.1-8b \
+  tokenizer_path=meta-llama/Llama-3.1-8B-Instruct tokenizer_type=huggingface \
+  dataset_type=hf \
+  hf_path=parquet \
+  hf_train_files=${OUTPUT_DATASET} \
+  train_split='train' \
+  train_data_columns=['messages'] \
+  load_parameters_path=${PRE_TRAINED_MODEL_CKPT_DIRECTORY}/0/items \
+  model_name=llama3.1-8b \
+  per_device_batch_size=2 \
+  steps=200 \
+  ici_expert_parallelism=-1 ici_fsdp_parallelism=4 \
   max_target_length=2048 \
-  hf_access_token=$HF_TOKEN
+  hf_access_token=$HF_TOKEN \
+  profiler=xplane
 ```
 
-### 4.b. **[OPTIONAL]** Fine-tune the student model using the original dataset
+#### **[OPTIONAL]** Fine-tune the student model using the original dataset
 
 The checkpoint from the student model's fine-tuning (on the teacher-generated dataset) can be used for a subsequent fine-tuning stage. In this step, the student model is fine-tuned on the original dataset that was initially provided to the teacher model for generating the dataset.
 
 ```bash
 # Get the latest checkpoint for fine-tuned student model
-CHECKPOINTS_PATH=${BASE_DIRECTORY}/distillation/deepseek2-16b-distill-llama2-7b/${RUN_NAME}/checkpoints
-checkpoints=$(gcloud storage ls $CHECKPOINTS_PATH)
+CHECKPOINTS_PATH=${BASE_DIRECTORY}/distillation/qwen3-32b-distill-llama3.1-8b/${RUN_NAME}/checkpoints
+checkpoints=$(ls $CHECKPOINTS_PATH)
 integer_dirs=()
 for dir in $checkpoints; do
   dir_name=$(basename "$dir")
@@ -180,18 +206,23 @@ for dir in $checkpoints; do
 done
 sorted_dirs=($(printf '%s\n' "${integer_dirs[@]}" | sort -n))
 largest_dir="${sorted_dirs[-1]}"
-FINE_TUNED_MODEL_CKPT_PATH=${CHECKPOINTS_PATH}/${largest_dir}/items
+FINE_TUNED_MODEL_CKPT_PATH=${CHECKPOINTS_PATH}/${largest_dir}/model_params
 
 # Fine-tune student model on original dataset
-python3 -m MaxText.sft_trainer src/MaxText/configs/sft.yml \
-  run_name=${RUN_NAME} \
-  base_output_directory=${BASE_DIRECTORY}/distillation/deepseek2-16b-distill-llama2-7b \
-  tokenizer_path=meta-llama/Llama-2-7b-chat-hf tokenizer_type=huggingface \
+python3 -m MaxText.sft.sft_trainer src/MaxText/configs/sft.yml \
+  run_name=${RUN_NAME}_stage2 \
+  base_output_directory=${BASE_DIRECTORY}/distillation/qwen3-32b-distill-llama3.1-8b \
+  tokenizer_path=meta-llama/Llama-3.1-8B-Instruct tokenizer_type=huggingface \
+  dataset_type=hf \
   hf_path='HuggingFaceH4/ultrachat_200k' \
-  train_split='train_sft' train_data_columns=['messages'] \
+  train_split='train_sft' \
+  train_data_columns=['messages'] \
   load_parameters_path=${FINE_TUNED_MODEL_CKPT_PATH} \
-  model_name=llama2-7b \
-  per_device_batch_size=2 ici_expert_parallelism=-1 ici_fsdp_parallelism=4 \
+  model_name=llama3.1-8b \
+  per_device_batch_size=2 \
+  steps=200 \
+  ici_expert_parallelism=-1 ici_fsdp_parallelism=4 \
   max_target_length=2048 \
-  hf_access_token=$HF_TOKEN
+  hf_access_token=$HF_TOKEN \
+  profiler=xplane
 ```

--- a/tools/data_generation/generate_distillation_data_vllm.py
+++ b/tools/data_generation/generate_distillation_data_vllm.py
@@ -1,0 +1,197 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This script executes the data generation step for Response-based Knowledge Distillation.
+Knowledge Distillation is a compression technique that transfers knowledge
+from a larger (teacher) model to a smaller (student) model.
+The script runs inference on a teacher model using vLLM to create output samples.
+This generated dataset can be used to fine-tune a student model.
+
+Example command:
+  python3 -m tools.data_generation.generate_distillation_data_vllm \
+      --dataset-path HuggingFaceH4/ultrachat_200k \
+      --data-split train_sft \
+      --data-columns messages \
+      --hf-access-token $HF_TOKEN \
+      --teacher-model ${BASE_DIRECTORY}/qwen3-32b \
+      --use-chat-template \
+      --num-prompts 5120 \
+      --output-file ${BASE_DIRECTORY}/datasets/distillation_data.parquet
+
+This processes 5120 prompts, generating the specified number of samples per prompt.
+Some prompts may be filtered out if prompt tokens are longer than `max-prefill-length`.
+`max-target-length` is the max length of prompt tokens and expected completion tokens.
+"""
+
+import argparse
+import os
+from vllm import LLM, SamplingParams
+from datasets import load_dataset, Dataset
+import transformers
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Generate distillation data using vLLM.")
+  parser.add_argument(
+      "--dataset-path",
+      type=str,
+      default="HuggingFaceH4/ultrachat_200k",
+      help="Path to Hugging Face dataset.",
+  )
+  parser.add_argument("--data-split", type=str, default="train_sft", help="Subset of data to load.")
+  parser.add_argument(
+      "--data-columns",
+      nargs="+",
+      default=["messages"],
+      help="Columns names that contain relevant data.",
+  )
+  parser.add_argument(
+      "--hf-access-token",
+      type=str,
+      required=True,
+      help="Access token for Hugging Face.",
+  )
+  parser.add_argument(
+      "--use-chat-template",
+      action="store_true",
+      help="Enable tokenizer to apply a chat template.",
+  )
+  parser.add_argument("--max-prefill-length", type=int, default=256, help="The maximum prompt length.")
+  parser.add_argument(
+      "--max-target-length",
+      type=int,
+      default=2048,
+      help="The maximum prompt length plus the output completion length.",
+  )
+  parser.add_argument(
+      "--num-generations",
+      type=int,
+      default=1,
+      help="Number of samples to generate per prompt.",
+  )
+  parser.add_argument(
+      "--num-prompts",
+      type=int,
+      default=5120,
+      help="Number of prompts to process.",
+  )
+  parser.add_argument(
+      "--output-file",
+      type=str,
+      default=os.path.join(os.environ.get("BASE_DIRECTORY", "."), "datasets", "distillation_data.parquet"),
+      help="Output Parquet file path.",
+  )
+  parser.add_argument(
+      "--teacher-model",
+      type=str,
+      default=os.path.join(os.environ.get("BASE_DIRECTORY", "."), "qwen3-32b"),
+      help="Local path to downloaded teacher model.",
+  )
+  parser.add_argument("--tp-size", type=int, default=4, help="Number of TPU chips.")
+  parser.add_argument("--max-model-len", type=int, default=4096, help="Maximum model length.")
+  parser.add_argument("--max-new-tokens", type=int, default=512, help="Maximum new tokens to generate.")
+  parser.add_argument(
+      "--max-num-batched-tokens",
+      type=int,
+      default=2048,
+      help="Maximum number of batched tokens.",
+  )
+  parser.add_argument("--max-num-seqs", type=int, default=256, help="Maximum number of sequences.")
+  parser.add_argument(
+      "--gpu-memory-utilization",
+      type=float,
+      default=0.98,
+      help="GPU memory utilization.",
+  )
+
+  config = parser.parse_args()
+
+  # --- Configuration ---
+  TEACHER_MODEL = config.teacher_model
+  DATASET_NAME = config.dataset_path
+  DATASET_SPLIT = config.data_split
+  PROMPT_COLUMN = config.data_columns[0] if config.data_columns else "messages"
+  OUTPUT_FILE = config.output_file
+  TP_SIZE = config.tp_size
+  MAX_MODEL_LEN = config.max_model_len
+  MAX_NEW_TOKENS = config.max_new_tokens
+  MAX_NUM_BATCHED_TOKENS = config.max_num_batched_tokens
+  MAX_NUM_SEQS = config.max_num_seqs
+  GPU_MEMORY_UTILIZATION = config.gpu_memory_utilization
+  NUM_PROMPTS = config.num_prompts
+  NUM_GENERATIONS = config.num_generations
+  # ---------------------
+
+  def apply_chat_template(example, tokenizer, prompt_column):
+    messages = example[prompt_column]
+    prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    return {"formatted_prompt": prompt}
+
+  print(f"Loading dataset {DATASET_NAME} ({DATASET_SPLIT})...")
+  dataset = load_dataset(DATASET_NAME, split=DATASET_SPLIT)
+
+  # Limit dataset for tutorial
+  dataset = dataset.select(range(min(len(dataset), NUM_PROMPTS)))
+
+  print(f"Loading tokenizer {TEACHER_MODEL}...")
+  tokenizer = transformers.AutoTokenizer.from_pretrained(TEACHER_MODEL)
+
+  if config.use_chat_template:
+    print("Formatting prompts...")
+    dataset = dataset.map(
+        lambda x: apply_chat_template(x, tokenizer, PROMPT_COLUMN),
+        desc="Applying chat template",
+    )
+    prompts = dataset["formatted_prompt"]
+  else:
+    prompts = dataset[PROMPT_COLUMN]
+
+  print(f"Initializing vLLM with model {TEACHER_MODEL}...")
+  llm = LLM(
+      model=TEACHER_MODEL,
+      max_model_len=MAX_MODEL_LEN,
+      tensor_parallel_size=TP_SIZE,
+      max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
+      max_num_seqs=MAX_NUM_SEQS,
+      gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
+      enforce_eager=False,
+  )
+
+  sampling_params = SamplingParams(
+      temperature=1.0,
+      top_p=1.0,
+      max_tokens=MAX_NEW_TOKENS,
+      n=NUM_GENERATIONS,
+  )
+
+  print("Running inference...")
+  outputs = llm.generate(prompts, sampling_params)
+
+  # Collect results and save directly to Parquet.
+  results = []
+  for output, original_item in zip(outputs, dataset):
+    for completion in output.outputs:
+      msgs = list(original_item[PROMPT_COLUMN])
+      msgs.append({"role": "assistant", "content": completion.text})
+      results.append({"messages": msgs})
+
+  os.makedirs(os.path.dirname(OUTPUT_FILE), exist_ok=True)
+  print(f"Saving results to {OUTPUT_FILE} (Parquet)")
+  ds = Dataset.from_list(results)
+  ds.to_parquet(OUTPUT_FILE)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
# Description

This pull request significantly updates and modernizes the knowledge distillation tutorial for MaxText, aligning it with current best practices and tooling. The guide now uses Qwen3-32B as the teacher model (via vLLM) and Llama-3.1-8B as the student, streamlines the setup with Hyperdisk storage, and provides new scripts and commands for dataset generation and fine-tuning. The instructions have been clarified, unnecessary conversion steps removed for the teacher, and the fine-tuning process updated for the latest MaxText and vLLM workflows.

# Tests

Manually triggered the distillation pipeline and monitored the execution flow step-by-step. Confirmed that the training loop finished and resources were released. 
<img width="500" height="350" alt="image" src="https://github.com/user-attachments/assets/9e9173e3-96b1-41cc-91e3-b62b6fad3a90" />


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
