### PR TITLE
Pydantic `class TrainContext` for train functions (replacing old 11-arity function)

### DIFF
--- a/src/MaxText/elastic_train.py
+++ b/src/MaxText/elastic_train.py
@@ -115,19 +115,15 @@ def elastic_handler(
     checkpoint_manager.close()
 
   with jax.default_device(elastic_manager.default_device):
-    (
-        init_rng,
-        checkpoint_manager,
-        state_mesh_shardings,
-        model,
-        mesh,
-        learning_rate_schedule,
-        data_iterator,
-        _,
-        _,
-        _,
-        state,
-    ) = setup_train_loop(config, recorder, elastic_manager.good_devices)
+    ctx = setup_train_loop(config, recorder, elastic_manager.good_devices)
+    init_rng = ctx.init_rng
+    checkpoint_manager = ctx.checkpoint_manager
+    state_mesh_shardings = ctx.state_mesh_shardings
+    model = ctx.model
+    mesh = ctx.mesh
+    learning_rate_schedule = ctx.learning_rate_schedule
+    data_iterator = ctx.data_iterator
+    state = ctx.state
 
     p_train_step, _ = train_utils.jit_train_and_eval_step(config, model, mesh, state, state_mesh_shardings, train_step)
 
@@ -171,19 +167,15 @@ def elastic_handler(
 
 def train_loop(config, elastic_manager, recorder, state=None):
   """Main Training loop."""
-  (
-      init_rng,
-      checkpoint_manager,
-      state_mesh_shardings,
-      model,
-      mesh,
-      learning_rate_schedule,
-      data_iterator,
-      _,
-      _,
-      _,
-      state,
-  ) = setup_train_loop(config, recorder)
+  ctx = setup_train_loop(config, recorder)
+  init_rng = ctx.init_rng
+  checkpoint_manager = ctx.checkpoint_manager
+  state_mesh_shardings = ctx.state_mesh_shardings
+  model = ctx.model
+  mesh = ctx.mesh
+  learning_rate_schedule = ctx.learning_rate_schedule
+  data_iterator = ctx.data_iterator
+  state = ctx.state
 
   p_train_step, _ = train_utils.jit_train_and_eval_step(config, model, mesh, state, state_mesh_shardings, train_step)
   with jax.set_mesh(mesh), nn_partitioning.axis_rules(config.logical_axis_rules):

--- a/src/MaxText/sft_trainer.py
+++ b/src/MaxText/sft_trainer.py
@@ -58,19 +58,16 @@ def train_loop(config, recorder, state=None):
   if not config.use_sft:
     raise TypeError("Set use_sft to True to run Supervised Fine Tuning.")
 
-  (
-      init_rng,
-      checkpoint_manager,
-      state_mesh_shardings,
-      model,
-      mesh,
-      learning_rate_schedule,
-      data_iterator,
-      _,
-      _,
-      eval_data_iterator,
-      state,
-  ) = setup_train_loop(config, recorder)
+  ctx = setup_train_loop(config, recorder)
+  init_rng = ctx.init_rng
+  checkpoint_manager = ctx.checkpoint_manager
+  state_mesh_shardings = ctx.state_mesh_shardings
+  model = ctx.model
+  mesh = ctx.mesh
+  learning_rate_schedule = ctx.learning_rate_schedule
+  data_iterator = ctx.data_iterator
+  eval_data_iterator = ctx.eval_data_iterator
+  state = ctx.state
 
   params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
 

--- a/tests/max_utils_test.py
+++ b/tests/max_utils_test.py
@@ -130,7 +130,8 @@ class UnscanTest(unittest.TestCase):
     # Initialize a configuration for an 8B model.
     config = self.init_pyconfig()
 
-    _, _, sharding, _, mesh, *_, state = setup_train_loop(config, None)
+    ctx = setup_train_loop(config, None)
+    sharding, mesh, state = ctx.state_mesh_shardings, ctx.mesh, ctx.state
 
     scan_axis = config.param_scan_axis
     num_layers = config.base_num_decoder_layers

--- a/tools/gcs_benchmarks/standalone_dataloader.py
+++ b/tools/gcs_benchmarks/standalone_dataloader.py
@@ -38,8 +38,9 @@ def data_load_loop(config, state=None):
   """Main data loader loop.
   Loads batches of data for each training step.
   """
-  _, _, _, _, mesh, _, data_iterator, _, _, _, state = setup_train_loop(config, recorder=None)
-  data_loader = DataLoader(config, mesh, data_iterator, None)
+  ctx = setup_train_loop(config, recorder=None)
+  state = ctx.state
+  data_loader = DataLoader(config, ctx.mesh, ctx.data_iterator, None)
 
   example_batch = None
 


### PR DESCRIPTION
# Description

A large number of arguments for a function is a code smell. Additionally, usage of Pydantic enables future interesting use-cases like providing all the parameters in, e.g., REST APIs, SQL models, CLIs. And reused across the codebase without duplication. By centralising it to the `class`, it also enables future extensibility and refactoring.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
N/A

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).