### PR TITLE
Support system role in hf data processing

### DIFF
--- a/src/MaxText/input_pipeline/_hf_data_processing.py
+++ b/src/MaxText/input_pipeline/_hf_data_processing.py
@@ -31,6 +31,16 @@ from MaxText.input_pipeline import instruction_data_processing
 from MaxText import multihost_dataloading
 
 
+def _get_pad_id(tokenizer):
+  if tokenizer.pad_token_id is not None:
+    pad_id = tokenizer.pad_token_id
+  elif tokenizer.unk_token_id is not None:
+    pad_id = tokenizer.unk_token_id
+  else:
+    pad_id = -1
+  return pad_id
+
+
 def vision_sft_preprocessing_pipeline(
     dataset,
     config,
@@ -89,12 +99,7 @@ def vision_sft_preprocessing_pipeline(
       legacy=False,
       token=config.hf_access_token,
   )
-  if tokenizer.pad_token_id is not None:
-    pad_id = tokenizer.pad_token_id
-  elif tokenizer.unk_token_id is not None:
-    pad_id = tokenizer.unk_token_id
-  else:
-    pad_id = -1
+  pad_id = _get_pad_id(tokenizer)
 
   dataset = dataset.map(
       _input_pipeline_utils.tokenization,
@@ -246,12 +251,7 @@ def preprocessing_pipeline(
   else:
     dataset = dataset.select_columns(data_column_names)
 
-  if tokenizer.pad_token_id is not None:
-    pad_id = tokenizer.pad_token_id
-  elif tokenizer.unk_token_id is not None:
-    pad_id = tokenizer.unk_token_id
-  else:
-    pad_id = -1
+  pad_id = _get_pad_id(tokenizer)
 
   if tokenize:
     dataset = dataset.map(

--- a/tests/unit/sft_data_processing_test.py
+++ b/tests/unit/sft_data_processing_test.py
@@ -13,31 +13,28 @@
 # limitations under the License.
 
 """Data processing tests for SFT."""
-
 import subprocess
 import unittest
 import os.path
-
 import numpy as np
-
 import jax
-
 from jax.sharding import Mesh
 from jax.experimental import mesh_utils
-
 from datasets import Dataset
-
 import transformers
+from parameterized import parameterized_class
 
 from MaxText import pyconfig
 from MaxText.globals import MAXTEXT_PKG_DIR, MAXTEXT_ASSETS_ROOT
 from MaxText.input_pipeline import _hf_data_processing
 from MaxText.input_pipeline import input_pipeline_interface
+from MaxText.input_pipeline._hf_data_processing import _get_pad_id
 
 PROMPT_DATA = [
     [
         {"content": "example one question one", "role": "user"},
         {"content": "example one question two", "role": "user"},
+        {"content": "example one question three", "role": "user"},
     ],
     [
         {"content": "question two", "role": "user"},
@@ -47,6 +44,9 @@ PROMPT_DATA = [
     ],
     [
         {"content": "question four", "role": "user"},
+    ],
+    [
+        {"content": "question five", "role": "user"},
     ],
 ]
 
@@ -54,6 +54,7 @@ COMPLETION_DATA = [
     [
         {"content": "example one answer one", "role": "assistant"},
         {"content": "example one answer two", "role": "assistant"},
+        {"content": "example one answer three", "role": "assistant"},
     ],
     [
         {"content": "answer two", "role": "assistant"},
@@ -64,10 +65,14 @@ COMPLETION_DATA = [
     [
         {"content": "answer four", "role": "assistant"},
     ],
+    [
+        {"content": "answer five", "role": "assistant"},
+    ],
 ]
 
 MESSAGES_DATA = [
     [
+        {"content": "the system prompt", "role": "system"},
         {"content": "example one question one", "role": "user"},
         {"content": "example one answer one", "role": "assistant"},
         {"content": "example one question two", "role": "user"},
@@ -85,10 +90,205 @@ MESSAGES_DATA = [
         {"content": "question four", "role": "user"},
         {"content": "answer four", "role": "assistant"},
     ],
+    [
+        {"content": "question five", "role": "user"},
+        {"content": "answer five", "role": "assistant"},
+    ],
 ]
 
+LLAMA2_DATA = {
+    "tokenizer_path": None,
+    "messages": {
+        "truncated_exp1_inputs": (
+            "<s> [INST] <<SYS>>\nthe system prompt\n<</SYS>>\n\nexample one question one [/INST] "
+            "example one answer one </s>"
+            "<s> [INST] example one question two [/INST] "
+            "example one answer two"
+        ),
+        "truncated_exp1_targets": (
+            "<unk>" * 27 + " " + "example one answer one </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "example one answer two<unk>"
+        ),
+        "truncated_exp1_targets_predictable": (
+            "<unk>" * 27 + " " + "example one answer one </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "example one answer two<unk>"
+        ),
+        "packed_exp2_inputs": (
+            "<s> [INST] question two [/INST] "
+            "answer two </s>"
+            "<s> [INST] question three [/INST] "
+            "answer three </s>"
+            "<s> [INST] question four [/INST] "
+            "answer four </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk>"
+        ),
+        "packed_exp2_targets": (
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer two </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer three </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer four </s><unk><unk><unk><unk><unk><unk><unk><unk><unk>"
+        ),
+        "packed_exp2_targets_predictable": (
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer two </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer three </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer four </s><unk><unk><unk><unk><unk><unk><unk><unk><unk>"
+        ),
+    },
+    "prompt_completion": {
+        "truncated_exp1_inputs": (
+            "<s> [INST] example one question one [/INST] "
+            "example one answer one </s>"
+            "<s> [INST] example one question two [/INST] "
+            "example one answer two </s>"
+            "<s> [INST] example one question three [/INST] "
+            "example one"
+        ),
+        "truncated_exp1_targets": (
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "example one answer one </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "example one answer two </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "example one<unk>"
+        ),
+        "truncated_exp1_targets_predictable": (
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "example one answer one </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "example one answer two </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "example one<unk>"
+        ),
+        "packed_exp2_inputs": (
+            "<s> [INST] question two [/INST] "
+            "answer two </s>"
+            "<s> [INST] question three [/INST]"
+            " answer three </s>"
+            "<s> [INST] question four [/INST]"
+            " answer four </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk>"
+        ),
+        "packed_exp2_targets": (
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer two </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer three </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer four </s><unk><unk><unk><unk><unk><unk><unk><unk><unk>"
+        ),
+        "packed_exp2_targets_predictable": (
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer two </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer three </s>"
+            "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
+            "answer four </s><unk><unk><unk><unk><unk><unk><unk><unk><unk>"
+        ),
+    },
+}
 
+QWEN_DATA = {
+    "tokenizer_path": "Qwen/Qwen3-4B",
+    "messages": {
+        "truncated_exp1_inputs": (
+            "<|im_start|>system\nthe system prompt<|im_end|>\n"
+            "<|im_start|>user\nexample one question one<|im_end|>\n"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
+            "<|im_start|>user\nexample one question two<|im_end|>\n"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer two"
+        ),
+        "truncated_exp1_targets": (
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
+            + "<|endoftext|>" * 9
+            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer two<|endoftext|>"
+        ),
+        "truncated_exp1_targets_predictable": (
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
+            + "<|endoftext|>" * 9
+            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer two<|endoftext|>"
+        ),
+        "packed_exp2_inputs": (
+            "<|im_start|>user\nquestion two<|im_end|>\n"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer two<|im_end|>\n"
+            "<|im_start|>user\nquestion three<|im_end|>\n"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer three<|im_end|>\n" + "!" * 14
+        ),
+        "packed_exp2_targets": (
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer two<|im_end|>\n"
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer three<|im_end|>\n" + "!" * 14 + "<|endoftext|>"
+        ),
+        "packed_exp2_targets_predictable": (
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer two<|im_end|>\n"
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer three<|im_end|>\n" + "<|endoftext|>" * 15
+        ),
+    },
+    "prompt_completion": {
+        "truncated_exp1_inputs": (
+            "<|im_start|>user\nexample one question one<|im_end|>\n"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
+            "<|im_start|>user\nexample one question two<|im_end|>\n"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer two<|im_end|>\n"
+            "<|im_start|>user\nexample one question"
+        ),
+        "truncated_exp1_targets": (
+            "<|endoftext|>" * 8
+            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
+            + "<|endoftext|>" * 9
+            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer two<|im_end|>\n"
+            + "<|endoftext|>" * 7
+        ),
+        "truncated_exp1_targets_predictable": (
+            "<|endoftext|>" * 8
+            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
+            + "<|endoftext|>" * 9
+            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer two<|im_end|>\n"
+            + "<|endoftext|>" * 7
+        ),
+        "packed_exp2_inputs": (
+            "<|im_start|>user\nquestion two<|im_end|>\n"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer two<|im_end|>\n"
+            "<|im_start|>user\nquestion three<|im_end|>\n<|im_start|>assistant\n"
+            "<think>\n\n</think>\n\nanswer three<|im_end|>\n" + "!" * 14
+        ),
+        "packed_exp2_targets": (
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer two<|im_end|>\n"
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer three<|im_end|>\n" + "!" * 14 + "<|endoftext|>"
+        ),
+        "packed_exp2_targets_predictable": (
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer two<|im_end|>\n"
+            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer three<|im_end|>\n" + "<|endoftext|>" * 15
+        ),
+    },
+}
+
+
+@parameterized_class(
+    [
+        {"test_data": LLAMA2_DATA},
+        {"test_data": QWEN_DATA},
+    ]
+)
 class SFTDataProcessingTest(unittest.TestCase):
+  test_data = {}
 
   @classmethod
   def setUpClass(cls):
@@ -107,6 +307,10 @@ class SFTDataProcessingTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
+    tokenizer_path = self.test_data.get("tokenizer_path")
+    if tokenizer_path is None:
+      tokenizer_path = os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer")
+
     self.config = pyconfig.initialize(
         [os.path.join(MAXTEXT_PKG_DIR, "sft_trainer"), os.path.join(MAXTEXT_PKG_DIR, "configs", "sft.yml")],
         per_device_batch_size=2,
@@ -115,12 +319,12 @@ class SFTDataProcessingTest(unittest.TestCase):
         logical_axis_rules=[["batch", "data"]],
         data_sharding=["data"],
         base_output_directory="gs://max-experiments/",
-        tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "llama2-chat-tokenizer"),
+        tokenizer_path=tokenizer_path,
         train_split="train",
         enable_checkpointing=False,
         use_sft=True,
         enable_data_shuffling=False,
-        max_target_length=32,
+        max_target_length=50,
         max_prefill_predict_length=16,
     )
     self.mesh_shape_1d = (len(jax.devices()),)
@@ -165,134 +369,91 @@ class SFTDataProcessingTest(unittest.TestCase):
     )
 
   def test_sft_format_with_messages(self):
+    expected = self.test_data["messages"]
     dataset = Dataset.from_dict({"messages": MESSAGES_DATA * 4})
     data_columns = ["messages"]
     data_iter = self.get_data_iterator(dataset, data_columns)
 
-    # exp1 is longer than max_target_length, testing truncation
-    truncated_exp1_inputs = (
-        "<s> [INST] example one question one [/INST] "
-        "example one answer one </s>"
-        "<s> [INST] example one question two [/INST] "
-        "example one"
-    )
-    truncated_exp1_targets = (
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "example one answer one </s>"
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "example one<unk>"
-    )
-    truncated_exp1_targets_predictable = (
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "example one answer one </s>"
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "example one<unk>"
-    )
-
-    # exp2 is packed from 2nd and 3rd entries, testing packing
-    packed_exp2_inputs = (
-        "<s> [INST] question two [/INST] "
-        "answer two </s>"
-        "<s> [INST] question three [/INST] "
-        "answer three </s><unk><unk><unk><unk>"
-    )
-    packed_exp2_targets = (
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "answer two </s>"
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "answer three </s><unk><unk><unk><unk><unk>"
-    )
-    packed_exp2_targets_predictable = (
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "answer two </s>"
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "answer three </s><unk><unk><unk><unk><unk>"
-    )
-
     batch = next(data_iter)
-    self.assertEqual(self.tokenizer.decode(batch["inputs"][0]), truncated_exp1_inputs)
-    self.assertEqual(self.tokenizer.decode(batch["targets"][0]), truncated_exp1_targets)
+
+    # Check Truncation
+    self.assertEqual(self.tokenizer.decode(batch["inputs"][0]), expected["truncated_exp1_inputs"])
+    self.assertEqual(self.tokenizer.decode(batch["targets"][0]), expected["truncated_exp1_targets"])
     self.assertEqual(
-        self.tokenizer.decode(np.where(batch["inputs_segmentation"][0] > 0, batch["inputs"][0], 0)), truncated_exp1_inputs
+        self.tokenizer.decode(np.where(batch["inputs_segmentation"][0] > 0, batch["inputs"][0], 0)),
+        expected["truncated_exp1_inputs"],
     )
     self.assertEqual(
-        self.tokenizer.decode(np.where(batch["targets_segmentation"][0] > 0, batch["targets"][0], 0)),
-        truncated_exp1_targets_predictable,
+        self.tokenizer.decode(
+            np.where(batch["targets_segmentation"][0] > 0, batch["targets"][0], _get_pad_id(self.tokenizer))
+        ),
+        expected["truncated_exp1_targets"],
     )
-    self.assertEqual(self.tokenizer.decode(batch["inputs"][1]), packed_exp2_inputs)
-    self.assertEqual(self.tokenizer.decode(batch["targets"][1]), packed_exp2_targets)
+
+    # Check Packing
+    self.assertEqual(self.tokenizer.decode(batch["inputs"][1]), expected["packed_exp2_inputs"])
+    self.assertEqual(self.tokenizer.decode(batch["targets"][1]), expected["packed_exp2_targets"])
     self.assertEqual(
-        self.tokenizer.decode(np.where(batch["inputs_segmentation"][1] > 0, batch["inputs"][1], 0)), packed_exp2_inputs
+        self.tokenizer.decode(np.where(batch["inputs_segmentation"][1] > 0, batch["inputs"][1], 0)),
+        expected["packed_exp2_inputs"],
     )
     self.assertEqual(
-        self.tokenizer.decode(np.where(batch["targets_segmentation"][1] > 0, batch["targets"][1], 0)),
-        packed_exp2_targets_predictable,
+        self.tokenizer.decode(
+            np.where(batch["targets_segmentation"][1] > 0, batch["targets"][1], _get_pad_id(self.tokenizer))
+        ),
+        expected["packed_exp2_targets_predictable"],
     )
 
   def test_sft_format_with_prompt_completion(self):
+    expected = self.test_data["prompt_completion"]
+
     dataset = Dataset.from_dict({"prompt": PROMPT_DATA * 4, "completion": COMPLETION_DATA * 4})
     data_columns = ["prompt", "completion"]
     data_iter = self.get_data_iterator(dataset, data_columns)
 
-    # exp1 is longer than max_target_length, testing truncation
-    truncated_exp1_inputs = (
-        "<s> [INST] example one question one [/INST] "
-        "example one answer one </s>"
-        "<s> [INST] example one question two [/INST] "
-        "example one"
-    )
-    truncated_exp1_targets = (
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "example one answer one </s>"
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "example one<unk>"
-    )
-    truncated_exp1_targets_predictable = (
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "example one answer one </s>"
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "example one<unk>"
-    )
-
-    # exp2 is packed from 2nd and 3rd entries, testing packing
-    packed_exp2_inputs = (
-        "<s> [INST] question two [/INST] "
-        "answer two </s>"
-        "<s> [INST] question three [/INST] "
-        "answer three </s><unk><unk><unk><unk>"
-    )
-    packed_exp2_targets = (
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "answer two </s>"
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "answer three </s><unk><unk><unk><unk><unk>"
-    )
-    packed_exp2_targets_predictable = (
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "answer two </s>"
-        "<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk> "
-        "answer three </s><unk><unk><unk><unk><unk>"
-    )
-
     batch = next(data_iter)
-    self.assertEqual(self.tokenizer.decode(batch["inputs"][0]), truncated_exp1_inputs)
-    self.assertEqual(self.tokenizer.decode(batch["targets"][0]), truncated_exp1_targets)
+
+    # Check Truncation
+    self.assertEqual(self.tokenizer.decode(batch["inputs"][0]), expected["truncated_exp1_inputs"])
+    self.assertEqual(self.tokenizer.decode(batch["targets"][0]), expected["truncated_exp1_targets"])
     self.assertEqual(
-        self.tokenizer.decode(np.where(batch["inputs_segmentation"][0] > 0, batch["inputs"][0], 0)), truncated_exp1_inputs
+        self.tokenizer.decode(np.where(batch["inputs_segmentation"][0] > 0, batch["inputs"][0], 0)),
+        expected["truncated_exp1_inputs"],
     )
     self.assertEqual(
-        self.tokenizer.decode(np.where(batch["targets_segmentation"][0] > 0, batch["targets"][0], 0)),
-        truncated_exp1_targets_predictable,
+        self.tokenizer.decode(
+            np.where(batch["targets_segmentation"][0] > 0, batch["targets"][0], _get_pad_id(self.tokenizer))
+        ),
+        expected["truncated_exp1_targets_predictable"],
     )
-    self.assertEqual(self.tokenizer.decode(batch["inputs"][1]), packed_exp2_inputs)
-    self.assertEqual(self.tokenizer.decode(batch["targets"][1]), packed_exp2_targets)
+
+    # Check Packing
+    self.assertEqual(self.tokenizer.decode(batch["inputs"][1]), expected["packed_exp2_inputs"])
+    self.assertEqual(self.tokenizer.decode(batch["targets"][1]), expected["packed_exp2_targets"])
     self.assertEqual(
-        self.tokenizer.decode(np.where(batch["inputs_segmentation"][1] > 0, batch["inputs"][1], 0)), packed_exp2_inputs
+        self.tokenizer.decode(np.where(batch["inputs_segmentation"][1] > 0, batch["inputs"][1], 0)),
+        expected["packed_exp2_inputs"],
     )
     self.assertEqual(
-        self.tokenizer.decode(np.where(batch["targets_segmentation"][1] > 0, batch["targets"][1], 0)),
-        packed_exp2_targets_predictable,
+        self.tokenizer.decode(
+            np.where(batch["targets_segmentation"][1] > 0, batch["targets"][1], _get_pad_id(self.tokenizer))
+        ),
+        expected["packed_exp2_targets_predictable"],
     )
+
+  def test_system_message_not_at_beginning(self):
+    dataset = Dataset.from_dict(
+        {
+            "messages": [
+                [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "system", "content": "You are a helpful assistant."},
+                ]
+            ]
+        }
+    )
+    with self.assertRaisesRegex(ValueError, "System messages must be at index 0"):
+      self.get_data_iterator(dataset, ["messages"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
- Supporting `system` role in hf data processing
- Add test case for Qwen in `sft_data_processing_test.py`
- Refactoring `sft_data_processing_test.py` to support testing multiple tokenizer
- Fix incorrect left shift in targets_segmentation in `shift_and_refine`
   - see more details [here](https://github.com/AI-Hypercomputer/maxtext/pull/2970/files#r2707486614) 

FIXES: b/471740714

# Tests
### Unit test
```
MAXTEXT_PKG_DIR=<xxx>/maxtext/src/MaxText pytest tests/sft_data_processing_test.py
```
### E2E sft
```
python3 -m MaxText.sft.sft_trainer \
   src/MaxText/configs/sft.yml \
    run_name=$(date +%Y-%m-%d-%H-%M-%S) \
    base_output_directory=<xxx> \
    model_name=qwen3-4b \
    load_parameters_path=<xxx>/0/items \
    tokenizer_path=Qwen/Qwen3-4B \
    steps=53 \
    profiler=xplane \
    hf_path=arrow \
    dataset_type=hf \
    train_split=train \
    hf_train_files=<xxx>.arrow \
    hf_eval_files=<xxx>.arrow \
    per_device_batch_size=16 \
    max_target_length=1024 \
    learning_rate=5e-6 \
    warmup_steps_fraction=0.05 \
   data_shuffle_seed=42 \
    gradient_clipping_threshold=1 \
    weight_dtype=bfloat16
```

#### logs
[unpatched gpaste](https://paste.googleplex.com/4921812016300032)
[patched gpaste](https://paste.googleplex.com/4715041083490304)

Step 1 loss drop from `6.100826 ` to `5.839514 `

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
