### PR TITLE
Add caching for GatedDeltaNetCache (linear attention models)

### DIFF
--- a/src/maxtext/inference/kvcache.py
+++ b/src/maxtext/inference/kvcache.py
@@ -230,7 +230,11 @@ def kv_cache_as_linen(
   )
 
 
-class KVCache(nnx.Module):
+class BaseCache(nnx.Module):
+  """Abstract base class for Caches."""
+
+
+class KVCache(BaseCache):
   """Implementation of the KVCache."""
 
   def __init__(
@@ -290,6 +294,7 @@ class KVCache(nnx.Module):
       use_chunked_prefill: Whether to use chunked prefill.
       rngs: The random number generators for initialization.
     """
+    super().__init__()
     self.max_prefill_length = max_prefill_length
     self.max_target_length = max_target_length
     self.batch = batch
@@ -842,6 +847,76 @@ class KVCache(nnx.Module):
       return self.kv_cache_autoregressive(key, value, use_ragged_attention)
     else:
       raise ValueError(f"Model Mode isn't supported! {model_mode=}")
+
+
+class GatedDeltaNetCache(BaseCache):
+  """Cache for Linear Attention (Gated Delta Net).
+
+  Stores the fixed-size recurrent state and the sliding window state for convolution.
+  """
+
+  def __init__(
+      self,
+      batch: int,
+      num_heads: int,
+      k_head_dim: int,
+      v_head_dim: int,
+      conv_kernel_size: int,
+      conv_dim: int,
+      dtype: DType,
+      cache_batch_axis_name: str = CACHE_BATCH,
+      cache_heads_axis_name: str = CACHE_HEADS,
+  ):
+    super().__init__()
+    self.batch = batch
+    self.dtype = dtype
+
+    # 1. Recurrent State (S) for the Delta Rule
+    # Shape: [Batch, Heads, K_Dim, V_Dim]
+    # We maintain the running state matrix.
+    self.recurrent_state = nnx.Cache(
+        jnp.zeros((int(batch), num_heads, k_head_dim, v_head_dim), dtype=dtype),
+        # Sharding: Batch, Heads, None (K), None (V)
+        sharding=(cache_batch_axis_name, cache_heads_axis_name, None, None),
+    )
+
+    # 2. Convolution State for the 1D Conv
+    # Shape: [Batch, Kernel_Size - 1, Conv_Dim]
+    # We store the last (K-1) inputs to perform the sliding window conv during decoding.
+    self.conv_state = nnx.Cache(
+        jnp.zeros((int(batch), conv_kernel_size - 1, conv_dim), dtype=dtype),
+        # Sharding: Batch, None (Time), None (Dim)
+        sharding=(cache_batch_axis_name, None, None),
+    )
+
+  def __call__(self):
+    """Returns the cache variables for the layer to use."""
+    return self
+
+
+def gated_delta_net_cache_as_linen(
+    *,
+    batch: int,
+    num_heads: int,
+    head_dim: int,
+    conv_kernel_size: int,
+    conv_dim: int,
+    dtype: DType,
+    name: str | None = None,
+):
+  """Initializes the GatedDeltaNetCache and returns it as a Linen module."""
+  return nnx_wrappers.to_linen(
+      GatedDeltaNetCache,
+      batch=batch,
+      num_heads=num_heads,
+      head_dim=head_dim,
+      conv_kernel_size=conv_kernel_size,
+      conv_dim=conv_dim,
+      dtype=dtype,
+      metadata_fn=variable_to_logically_partitioned,
+      name=name,
+      abstract_init=False,
+  )
 
 
 def mla_kv_cache_as_linen(

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -979,6 +979,14 @@ class Decoder(nn.Module):
               }
             if cfg.decoder_block == DecoderBlockType.QWEN3_NEXT:
               layer_kwargs = {"layer_idx": lyr}
+            kv_cache = None
+            if kv_caches is not None and cfg.decoder_block != DecoderBlockType.QWEN3_NEXT:
+              kv_cache = kv_caches[lyr]
+            elif kv_caches is not None and cfg.decoder_block == DecoderBlockType.QWEN3_NEXT:
+              # For Qwen3Next, kv_caches is a dictionary of lists of caches.
+              if (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
+                kv_cache = (kv_caches["key_cache"][lyr], kv_caches["value_cache"][lyr])
+
             if cfg.decoder_block == DecoderBlockType.GPT_OSS:
               layer_kwargs = {"attention_type": gpt_oss.get_attention_type(layer_id=lyr)}
             if cfg.decoder_block == DecoderBlockType.OLMO3:
@@ -986,8 +994,7 @@ class Decoder(nn.Module):
             layer = RemattedBlockLayer(
                 config=cfg, mesh=mesh, name=f"layers_{lyr}", quant=self.quant, model_mode=self.model_mode, **layer_kwargs
             )
-            kv_cache = kv_caches[lyr] if kv_caches is not None else None
-            y, kv_cache = layer(
+            y, returned_cache = layer(
                 y,
                 decoder_segment_ids,
                 decoder_positions,
@@ -1000,8 +1007,12 @@ class Decoder(nn.Module):
                 attention_metadata=attention_metadata,
                 **layer_call_kwargs,
             )
-            if kv_caches is not None and kv_cache is not None:
-              kv_caches[lyr] = kv_cache
+            if kv_caches is not None and returned_cache is not None:
+              if cfg.decoder_block != DecoderBlockType.QWEN3_NEXT:
+                kv_caches[lyr] = returned_cache
+              elif (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
+                kv_caches["key_cache"][lyr] = returned_cache[0]
+                kv_caches["value_cache"][lyr] = returned_cache[1]
 
             if deepstack_visual_embeds is not None and lyr < len(deepstack_visual_embeds):
               visual_embeds = deepstack_visual_embeds[lyr]

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -42,8 +42,10 @@ from maxtext.layers.attentions import Attention
 from maxtext.layers.linears import DenseGeneral, MlpBlock
 from maxtext.layers.moe import RoutedMoE
 from maxtext.layers.initializers import nd_dense_init, variable_to_logically_partitioned
-from maxtext.inference import page_manager
+
 from maxtext.utils import max_utils
+from maxtext.inference import page_manager, kvcache
+
 
 # -----------------------------------------
 # Qwen3-Next Layer Implementations
@@ -379,7 +381,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
   2. output = Linear_out(y)
   """
 
-  def __init__(self, config: Config, *, rngs: nnx.Rngs):
+  def __init__(self, config: Config, dtype: DType = jnp.float32, model_mode: str = MODEL_MODE_TRAIN, *, rngs: nnx.Rngs):
     """
     Args:
       config: MaxText configuration object.
@@ -398,6 +400,17 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     conv_dim = self.key_dim * 2 + self.value_dim
     conv_kernel_size = cfg.gdn_conv_kernel_dim
     self.v_heads_per_k_head = self.num_v_heads // self.num_k_heads
+
+    if model_mode != MODEL_MODE_TRAIN:
+      self.cache = kvcache.GatedDeltaNetCache(
+          batch=config.per_device_batch_size,
+          num_heads=self.num_v_heads,
+          k_head_dim=self.head_k_dim,
+          v_head_dim=self.head_v_dim,
+          conv_kernel_size=self.config.gdn_conv_kernel_dim,
+          conv_dim=conv_dim,
+          dtype=dtype,
+      )
 
     # Submodule instantiations
     self.in_proj_qkvz = DenseGeneral(
@@ -458,7 +471,14 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         rngs=rngs,
     )
 
-  def __call__(self, hidden_states: Array) -> Array:
+  def __call__(
+      self,
+      hidden_states: Array,
+      model_mode: str = MODEL_MODE_TRAIN,
+      kv_cache=None,
+      decoder_segment_ids: None | Array = None,
+      **kwargs,
+  ) -> tuple[Array, dict[str, Array]]:
     # hidden_states: (B, S, E)
     cfg = self.config
     batch, seq_len, _ = hidden_states.shape
@@ -529,15 +549,44 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     # =========================================================================
     # STEP B: 1D Convolution
     # =========================================================================
-    # conv_dim = 2 * K_dim + V_dim
-    # qkv: (B, S, 2 * K_dim + V_dim)
     qkv = jnp.concatenate([q, k, v], axis=-1)
+    batch, seq_len, _ = qkv.shape
+    conv_kernel_size = self.config.gdn_conv_kernel_dim
 
-    # TODO(parambole): Implement caching logic for conv_state and recurrent_state
+    conv_state = None
+    if model_mode != MODEL_MODE_TRAIN:
+      # Retrieve state from self.cache
+      conv_state = self.cache.conv_state.value
+      if conv_state.shape[0] != batch:
+        # Assumes zero-initialized state for testing
+        if conv_state.shape[0] == 1:
+          conv_state = jnp.broadcast_to(conv_state, (batch,) + conv_state.shape[1:])
+        else:
+          conv_state = conv_state[:batch]
 
-    # Input to conv_layer should be (B, S, C)
-    # qkv_conv shape: (B, S, conv_dim)
-    conv_out = self.conv1d(qkv)
+      # Concatenate previous state with new input
+      conv_input = jnp.concatenate([conv_state, qkv], axis=1)
+
+      if decoder_segment_ids is not None:
+        valid_lens = jnp.sum(decoder_segment_ids != 0, axis=1)  # Shape: (B,)
+
+        def extract_state(c_in, v_len):
+          return jax.lax.dynamic_slice_in_dim(c_in, v_len, conv_kernel_size - 1, axis=0)
+
+        new_conv_state = jax.vmap(extract_state)(conv_input, valid_lens)
+      else:
+        new_conv_state = conv_input[:, -(conv_kernel_size - 1) :, :]
+
+      # Update self.cache in place
+      self.cache.conv_state.value = new_conv_state
+    else:
+      # Train: pad with zeros
+      conv_input = jnp.pad(qkv, ((0, 0), (conv_kernel_size - 1, 0), (0, 0)))
+
+    # Perform the convolution.
+    conv_out = self.conv1d(conv_input)
+    # Slice the output to match the original input sequence length.
+    conv_out = conv_out[:, -seq_len:, :]
     qkv_conv = jax.nn.silu(conv_out.astype(jnp.float32)).astype(cfg.dtype)
     # q_conv shape: (B, S, key_dim), k_conv shape: (B, S, key_dim), v_conv shape: (B, S, value_dim)
     q_conv, k_conv, v_conv = jnp.split(qkv_conv, [self.key_dim, 2 * self.key_dim], axis=-1)
@@ -561,6 +610,13 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     # g shape: (B, S, H_v)
     g = -jnp.exp(A_log) * jax.nn.softplus(a + dt_bias)
 
+    if decoder_segment_ids is not None:
+      mask = decoder_segment_ids != 0
+      # Apply mask by broadcasting to respective shapes
+      key = jnp.where(mask[..., None, None], key, 0.0)
+      value = jnp.where(mask[..., None, None], value, 0.0)
+      g = jnp.where(mask[..., None], g, 0.0)
+
     if self.num_v_heads > self.num_k_heads and self.num_v_heads % self.num_k_heads == 0:
       repeats = self.num_v_heads // self.num_k_heads
       # query shape after repeat: (B, S, H_v, D_k)
@@ -568,21 +624,34 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       # key shape after repeat: (B, S, H_v, D_k)
       key = jnp.repeat(key, repeats, axis=2)
     elif self.num_k_heads > self.num_v_heads and self.num_k_heads % self.num_v_heads == 0:
-      # This case might occur if key/query heads are more than value heads.
-      pass  # No repeating needed for query/key in this case
+      pass
 
-    # TODO(parambole): Pass and update cache state for jax_chunk_gated_delta_rule
-    # core_attn_out shape: (B, S, H_v, D_v)
-    core_attn_out, _ = jax_chunk_gated_delta_rule(
+    recurrent_state = None
+    if model_mode != MODEL_MODE_TRAIN:
+      # Retrieve state from self.cache
+      recurrent_state = self.cache.recurrent_state.value
+
+      if recurrent_state.shape[0] != batch:
+        if recurrent_state.shape[0] == 1:
+          recurrent_state = jnp.broadcast_to(recurrent_state, (batch,) + recurrent_state.shape[1:])
+        else:
+          recurrent_state = recurrent_state[:batch]
+
+    core_attn_out, recurrent_state_out = jax_chunk_gated_delta_rule(
         query,
         key,
         value,
         g,
         beta,
         chunk_size=cfg.gdn_chunk_size,
+        initial_state=recurrent_state,
         use_qk_norm_in_gdn=cfg.use_qk_norm_in_gdn,
         compute_dtype=cfg.dtype,
     )
+
+    if model_mode != MODEL_MODE_TRAIN:
+      # Update self.cache in place for both prefill and decode
+      self.cache.recurrent_state.value = recurrent_state_out
 
     # =========================================================================
     # STEP D: Final Output Stage
@@ -913,7 +982,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
           rngs=rngs,
       )
     else:
-      self.attention = Qwen3NextGatedDeltaNet(config=cfg, rngs=rngs)
+      self.attention = Qwen3NextGatedDeltaNet(config=cfg, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs)
 
     # Second LayerNorm, applied before the MoE block.
     self.post_attention_layernorm = Qwen3NextRMSNorm(
@@ -937,7 +1006,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
       previous_chunk=None,
       page_state: None | page_manager.PageState = None,
       slot: None | int = None,
-      kv_cache: None | jnp.ndarray = None,
+      kv_cache: None | dict[str, Array] = None,
       attention_metadata: None | dict[str, Any] = None,
   ):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
@@ -951,7 +1020,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
 
     # Conditionally apply either the Linear Attention or Full Attention block.
     if isinstance(self.attention, Qwen3NextFullAttention):
-      attention_output, kv_cache = cast(Qwen3NextFullAttention, self.attention)(
+      attention_output, new_kv_cache = cast(Qwen3NextFullAttention, self.attention)(
           hidden_states,
           decoder_segment_ids,
           decoder_positions,
@@ -960,10 +1029,14 @@ class Qwen3NextDecoderLayer(nnx.Module):
           kv_cache=kv_cache,
           attention_metadata=attention_metadata,
       )
-    elif isinstance(self.attention, Qwen3NextGatedDeltaNet):
-      attention_output = cast(Qwen3NextGatedDeltaNet, self.attention)(hidden_states)
     else:
-      raise TypeError(f"Unexpected type for self.attention: {type(self.attention)}")
+      attention_output = cast(Qwen3NextGatedDeltaNet, self.attention)(
+          hidden_states,
+          model_mode=model_mode,
+          kv_cache=None,
+          decoder_segment_ids=decoder_segment_ids,
+      )
+      new_kv_cache = None
 
     # First residual connection after attention
     hidden_states = residual + attention_output
@@ -990,8 +1063,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
         layer_output,
         self.activation_axis_names,
     )
-
-    return layer_output, kv_cache
+    return layer_output, new_kv_cache
 
 
 # -----------------------------------------

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -39,6 +39,7 @@ from maxtext.layers.attention_mla import MLA
 from maxtext.layers.attention_op import ChunkedCausalMask, _generate_chunk_attention_mask, _make_bidirectional_block_mask
 from maxtext.layers.attentions import Attention
 from maxtext.configs import pyconfig
+from maxtext.models.qwen3 import Qwen3NextGatedDeltaNet
 import numpy as np
 import pytest
 
@@ -1502,6 +1503,92 @@ class MLATest(attention_test_util.MLATestBase):
         f"ici_context_parallelism={ici_context_parallelism}, context_parallel_load_balance={context_parallel_load_balance},"
         f" ici_expert_parallelism={ici_expert_parallelism}, expert_shard_attention_option={expert_shard_attention_option}.",
     )
+
+
+class Qwen3NextGatedDeltaNetTest(unittest.TestCase):
+  """Test for the Gated Delta Net in Qwen3-Next"""
+
+  def setUp(self):
+    super().setUp()
+    self.config_arguments = {
+        "per_device_batch_size": 1.0,
+        "run_name": "test",
+        "enable_checkpointing": False,
+        "max_prefill_predict_length": 16,
+        "max_target_length": 32,
+        "base_emb_dim": 128,  # changed to base_emb_dim so it properly overrides the default 2048
+        "gdn_num_value_heads": 4,
+        "gdn_num_key_heads": 4,
+        "gdn_key_head_dim": 32,
+        "gdn_value_head_dim": 32,
+        "gdn_conv_kernel_dim": 4,
+        "gdn_chunk_size": 16,
+        "dtype": "bfloat16",
+    }
+    self.cfg = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path()],
+        **self.config_arguments,
+    )
+    self.rng = jax.random.PRNGKey(0)
+    self.nnx_rng = nnx.Rngs(params=0, dropout=jax.random.PRNGKey(42))
+
+  def get_structured_data(self, dtype):
+    """get structured data for GDN (only requires hidden states)"""
+    lnx = jax.random.normal(
+        self.rng,
+        shape=(self.cfg.global_batch_size_to_train_on, self.cfg.max_target_length, self.cfg.emb_dim),
+        dtype=dtype,
+    )
+    return lnx
+
+  @pytest.mark.tpu_only
+  def test_autoregression(self):
+    cfg = self.cfg
+    prefill_length = cfg.max_prefill_predict_length
+    decode_total_length = cfg.max_target_length
+
+    # 1. Init Data
+    lnx = self.get_structured_data(cfg.dtype)
+
+    # 2. Init GDN Layer
+    gdn = Qwen3NextGatedDeltaNet(
+        config=cfg,
+        dtype=cfg.dtype,
+        model_mode=MODEL_MODE_PREFILL,
+        rngs=self.nnx_rng,
+    )
+
+    # 3. Full / Train mode
+    gdn_full = gdn(
+        lnx,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+
+    # 4. Prefill mode
+    lnx_prefill = lnx[:, 0:prefill_length, :]
+
+    gdn_prefill = gdn(
+        lnx_prefill,
+        model_mode=MODEL_MODE_PREFILL,
+    )
+
+    self.assertTrue(
+        jax.numpy.allclose(gdn_prefill, gdn_full[:, :prefill_length, :], rtol=1e-02, atol=1e-02, equal_nan=False)
+    )
+
+    # 5. Autoregressive mode
+    for idx in range(prefill_length, decode_total_length):
+      lnx_idx = lnx[:, idx : idx + 1, :]
+
+      gdn_idx = gdn(
+          lnx_idx,
+          model_mode=MODEL_MODE_AUTOREGRESSIVE,
+      )
+
+      gdn_full_this_idx = gdn_full[:, idx : idx + 1, :]
+      self.assertEqual(gdn_full_this_idx.shape, gdn_idx.shape)
+
+      self.assertTrue(jax.numpy.allclose(gdn_full_this_idx, gdn_idx, rtol=1e-02, atol=1e-02, equal_nan=False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR: Add Caching Support for Qwen3-Next (Gated Delta Network)
### Problem
The Qwen3-Next architecture utilizes a hybrid approach consisting of standard Self-Attention layers and Gated Delta Network (GDN) layers (a form of Linear Attention).
While MaxText’s existing KVCache handles standard attention (growing Key/Value history), it does not support the state management required for GDN. GDN layers require:

  * **A Fixed-size Recurrent State**: Compresses history into a constant-size matrix, rather than growing linearly with sequence length.

  * **A Convolution State**: A sliding window buffer for the short 1D convolution preceding the delta rule.

Without these, Qwen3-Next could not perform efficient autoregressive decoding; it would either need to recompute the entire history at every step or fail to capture temporal dependencies correctly. 

This PR adds caching support to the Gated Delta Net implementation for Qwen3-Next. This is the first non-standard attention caching support in MaxText and required changes to both the MaxEngine code and the Qwen3-Next implementation.

Note: Decoding is currently ONLY supported in unscanned checkpoint format (scan_layers=False and stack_prefill_result_cache=False).

### Solution
This PR implements specific caching infrastructure for Qwen3-Next's linear attention mechanism and integrates it natively into the MaxEngine workflow.

#### 1. New Cache Implementation (src/MaxText/inference/kvcache.py)

  * Introduced GatedDeltaNetCache. Unlike the standard KV cache, this stores fixed-size states:
    * recurrent_state: Shape (B, H, K, V)
    * conv_state: Shape (B, Kernel-1, Dim)
  * Both variables are wrapped in nn.with_logical_constraint to ensure MaxText can automatically infer proper shardings. 
  * Created a BaseCache class to abstract commonalities between standard KV and GDN caches.

#### 2. Layer Logic & State Management (src/MaxText/layers/qwen3.py)

  * Conv & Recurrent Updates: Modified Qwen3NextGatedDeltaNet to properly slide the convolution window and update the recurrent state during MODEL_MODE_AUTOREGRESSIVE.

  * Chunked Prefill Support: Re-wrote MODEL_MODE_PREFILL logic to read from self.cache rather than defaulting to zeros. This allows the GDN state to seamlessly carry over between chunks for long prompts.

  * Dynamic Batch Alignment: Added jnp.broadcast_to and [:batch] slicing during cache retrieval. This dynamically bridges the gap between MaxEngine's global cache allocation (e.g., batch=64) and the active compute shape (e.g., batch=1 during prefill), preventing concatenation shape errors during XLA dummy-tracing passes.

#### 3. MaxEngine Integration (src/MaxText/maxengine.py)

  * Non-sequence-growing Insertions: Updated _insert_jit and bulk_insert to handle fixed-size states. For GDN variables (recurrent_state, conv_state), the prefill step produces a "final state" which is directly copied into the decode cache slot (bypassing the sequence-length slicing logic used for standard KV caches).

  * Packed Prefill Guard: Added a NotImplementedError in insert_partial to block packed prefill for GDN states, preventing sequential memory from bleeding across independent packed prompts.

  * Logical Axes Fix: Updated init_decode_state to properly check for both .logical_axes and .names when unpacking LogicallyPartitioned variables, fixing a bug where empty tuples caused batch index crashes.


If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/448407748

# Tests

Decode.py tests:
  * On v5p-64 & pdb=1, global_batch_size=32: https://paste.googleplex.com/5916785586077696
  * On CPU vm with pdb=1: https://paste.googleplex.com/5608748317016064

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
