### PR TITLE
checkpoint utility: shard checkpoint, monitor peak

### DIFF
--- a/docs/guides/checkpointing_solutions/convert_checkpoint.md
+++ b/docs/guides/checkpointing_solutions/convert_checkpoint.md
@@ -90,7 +90,7 @@ python3 -m MaxText.utils.ckpt_conversion.to_maxtext MaxText/configs/base.yml \
 - `checkpoint_storage_use_zarr3`: # Set to True to use zarr3 format (recommended for McJAX); set to False for Pathways.
 - `checkpoint_storage_use_ocdbt`: # Set to True to use OCDBT format (recommended for McJAX); set to False for Pathways.
 - `--lazy_load_tensors` (optional): If `true`, loads Hugging Face weights on-demand to minimize RAM usage. For large models, it is recommended to use the `--lazy_load_tensors=true` flag to reduce memory usage during conversion. For example, converting a Llama3.1-70B model with `--lazy_load_tensors=true` uses around 200GB of RAM and completes in ~10 minutes.
-- `--hf_model_path` (optional): Specifies a local directory containing the model weights. If unspecified, we use the [default Hugging Face repository ID](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/MaxText/utils/ckpt_conversion/utils/utils.py#L58-L85) (e.g., openai/gpt-oss-20b). This is necessary for locally dequantized models like GPT-OSS or DeepSeek.
+- `--hf_model_path` (optional): Specifies a local or remote directory containing the model weights. If unspecified, we use the [default Hugging Face repository ID](https://github.com/AI-Hypercomputer/maxtext/blob/0d909c44391539db4e8cc2a33de9d77a891beb31/src/MaxText/utils/ckpt_conversion/utils/utils.py#L58-L85) (e.g., openai/gpt-oss-20b). This is necessary for locally dequantized models like GPT-OSS or DeepSeek.
 
 Above command will download the Hugging Face model to local machine, convert it to the MaxText format and save it to `${MODEL_CHECKPOINT_DIRECTORY}/0/items`.
 

--- a/src/MaxText/utils/ckpt_conversion/to_maxtext.py
+++ b/src/MaxText/utils/ckpt_conversion/to_maxtext.py
@@ -28,6 +28,10 @@ Key Parameters (to be set in the config file or as command-line overrides):
   lazy_load: (bool) If True, uses an on-demand loading strategy to minimize RAM
              usage during conversion. Recommended if, 2 * model_size (GB) >= system RAM
              Defaults to False.
+  --hf_model_path: (Optional) Specifies a local or remote directory containing the model weights. 
+      If unspecified, we use the default Hugging Face repository ID 
+      (e.g., openai/gpt-oss-20b; see `HF_IDS[model_name]` in `utils/ckpt_conversion/utils`).
+      This is necessary for locally dequantized models like GPT-OSS or DeepSeek. 
 
 Environment Variables:
   HF_AUTH_TOKEN: (Required) HuggingFace authentication token, needed to
@@ -63,64 +67,36 @@ import threading
 from functools import partial
 from typing import Sequence, List, Any, Callable
 import numpy as np
-import jax
-import psutil
-from flax.training import train_state
-import flax.linen as nn
-from transformers import AutoConfig
-from tqdm import tqdm
-from huggingface_hub import hf_hub_download, list_repo_files
-from safetensors import safe_open
 import absl
 
+from transformers import AutoConfig
+from huggingface_hub import hf_hub_download, list_repo_files
+from safetensors import safe_open
+import jax
+import flax.linen as nn
 from orbax.checkpoint import type_handlers
+
 from MaxText import max_logging
 from MaxText import max_utils
 from MaxText import maxtext_utils
 from MaxText import pyconfig
 from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.layers import models, quantizations
+from MaxText.utils.ckpt_scripts.llama_or_mistral_ckpt import save_weights_to_checkpoint
 from MaxText.utils.ckpt_conversion.utils.param_mapping import HOOK_FNS, PARAM_MAPPING
-from MaxText.utils.ckpt_conversion.utils.utils import apply_hook_fns, HF_IDS, print_ram_usage, get_hf_model, validate_and_filter_param_map_keys
+from MaxText.utils.ckpt_conversion.utils.utils import (
+    apply_hook_fns,
+    HF_IDS,
+    get_hf_model,
+    validate_and_filter_param_map_keys,
+    MemoryMonitorTqdm,
+    print_ram_usage,
+    print_peak_memory,
+)
 from maxtext.inference.inference_utils import str2bool
-from maxtext.common import checkpointing
 
-jax.config.update("jax_platform_name", "cpu")
 
 absl.logging.set_verbosity(absl.logging.INFO)  # for max_logging.log
-
-
-class MemoryMonitorTqdm(tqdm):
-  """Custom tqdm class that displays memory usage in the progress bar."""
-
-  def format_meter(
-      self,
-      n,
-      total,
-      elapsed,
-      postfix=None,
-      **extra_kwargs,
-  ):
-    """Override to add memory usage info to the postfix."""
-    # Get memory info
-    memory = psutil.virtual_memory()
-    used_gb = memory.used / (1024**3)
-    total_gb = memory.total / (1024**3)
-    memory_percent = memory.percent
-
-    # Create memory postfix
-    memory_info = f"RAM: {used_gb:.1f}/{total_gb:.1f}GB ({memory_percent:.1f}%)"
-
-    # Add memory info to postfix
-    if postfix:
-      if isinstance(postfix, dict):
-        postfix["memory"] = memory_info
-      else:
-        postfix = f"{postfix}, {memory_info}"
-    else:
-      postfix = memory_info
-
-    return super().format_meter(n=n, total=total, elapsed=elapsed, postfix=postfix, **extra_kwargs)
 
 
 class LazyHFLoader:
@@ -654,20 +630,12 @@ def main(args: Sequence[str], test_args: Sequence[str]) -> None:
   hook_fn_map_mt = HOOK_FNS[model_key](hf_config_obj.to_dict(), config, config.scan_layers, saving_to_hf=False)
   max_logging.log("Parameter mappings and hooks obtained.")
 
-  checkpoint_manager = checkpointing.create_orbax_checkpoint_manager(
-      output_directory,
-      enable_checkpointing=True,
-      use_async=False,  # Synchronous saving for simplicity in conversion script
-      save_interval_steps=1,  # Save at step 0
-      use_ocdbt=config.checkpoint_storage_use_ocdbt,
-      use_zarr3=config.checkpoint_storage_use_zarr3,
-  )
-
   maxtext_abstract_dict, abstract_params_treedef = get_maxtext_model_info(config)
 
   # Weight transformation
   max_logging.log("Starting weight transformation...")
   start = time.time()
+  # Stores MaxText weights: numpy.ndarray
   final_mt_weights = [None] * len(maxtext_abstract_dict)
 
   # Preprocess key
@@ -676,7 +644,7 @@ def main(args: Sequence[str], test_args: Sequence[str]) -> None:
   for mt_param_key_or_keys in MemoryMonitorTqdm(
       filtered_map_keys, desc="Transforming weights", unit="param", leave=True, dynamic_ncols=True
   ):
-    if not use_lazy_load and config.scan_layers:
+    if not use_lazy_load:
       max_logging.log(f"maxtext param: {mt_param_key_or_keys}")
 
     hf_source_keys_or_key = param_map_mt_to_hf.get(mt_param_key_or_keys)
@@ -715,37 +683,34 @@ def main(args: Sequence[str], test_args: Sequence[str]) -> None:
   jax_weights = jax.tree_util.tree_unflatten(abstract_params_treedef, final_mt_weights)
   del final_mt_weights, abstract_params_treedef
 
-  # Create TrainState for saving.
-  final_params_for_state = {"params": jax_weights}
-  final_save_state = train_state.TrainState(step=0, apply_fn=None, params=final_params_for_state, tx=None, opt_state={})
-  del final_params_for_state
-
   print_ram_usage("Before saving")
-  start = time.time()
-  if checkpoint_manager is not None:
-    if use_lazy_load:
-      max_logging.log("Starting checkpoint save (loading weights just-in-time)...")
-    else:
-      max_logging.log("Starting checkpoint save...")
+  if use_lazy_load:
+    max_logging.log("Starting checkpoint save (loading weights just-in-time)...")
+  else:
+    max_logging.log("Starting checkpoint save...")
 
-    if checkpointing.save_checkpoint(checkpoint_manager, 0, final_save_state):
-      max_logging.log("saved a checkpoint at step 0")
-
-    # Upon preemption, exit when and only when all ongoing saves are complete.
-    if checkpoint_manager.reached_preemption(0):
-      checkpoint_manager.wait_until_finished()
-      sys.exit()
+  # Save the converted weights to a MaxText checkpoint.
+  # If simulated_cpu_devices_count > 1, weights are promoted from NumPy to JAX arrays
+  # and sharded across virtual devices.
+  save_weights_to_checkpoint(
+      output_directory,
+      jax_weights,
+      test_args.simulated_cpu_devices_count,
+      config.checkpoint_storage_use_ocdbt,
+      config.checkpoint_storage_use_zarr3,
+  )
 
   print_ram_usage("Program Ends")
   max_logging.log(f"Conversion complete. Checkpoint saved to {output_directory}")
-  max_logging.log(f"Elapse for save: {(time.time() - start) / 60:.2f} min")
   max_logging.log(f"Overall Elapse: {(time.time() - overall_start) / 60:.2f} min")
+  print_peak_memory()
 
 
 if __name__ == "__main__":
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"  # Suppress TensorFlow logging
 
+  # Define local parser
   parser = argparse.ArgumentParser()
   parser.add_argument(
       "--lazy_load_tensors",
@@ -754,13 +719,32 @@ if __name__ == "__main__":
       default=False,
       help="Whether to use lazy loading of HF tensors.",
   )
-  # if not specified, default to MaxText.utils.ckpt_conversion.utils.utils.HF_IDS[model_name]
+  # If not specified, default to MaxText.utils.ckpt_conversion.utils.utils.HF_IDS[model_name]
   parser.add_argument(
       "--hf_model_path", type=str, required=False, default="", help="local path to hf model, or custom remote hf repo"
   )
-  local_args, _ = parser.parse_known_args()
-  model_args = sys.argv
-  to_remove_args = ["--lazy_load_tensors", "--hf_model_path"]
-  for a in to_remove_args:
-    model_args = [s for s in model_args if not s.startswith(a)]
+  # Determines the logical sharding of the output checkpoint by partitioning
+  # weights across virtual XLA devices.
+  # - Even on a single CPU host, JAX can simulate multiple devices (e.g., 16)
+  # - If set to 1, sharding is skipped.
+  # - Sharding is preferred. For downstream loading on TPU pods, this helps prevent OOM and speedup.
+  #
+  # Example: Embedding Layer shape=(151936, 1024)
+  # Case 1: simulated_cpu_devices_count=16 (Sharded)
+  #   sharding: NamedShardingMetadata(shape=[16], ...)
+  #   storage:  chunk_shape=(9496, 1024)  <-- 1/16th of rows per chunk
+  # Case 2: simulated_cpu_devices_count=1 (Monolith)
+  #   sharding: None
+  #   storage:  chunk_shape=(151936, 1024) <-- Full layer in one chunk
+  parser.add_argument("--simulated_cpu_devices_count", type=int, required=False, default=16)
+
+  # Parse local arguments
+  # Parse known args returns the namespace AND the list of remaining arguments
+  local_args, remaining_args = parser.parse_known_args()
+  # Reconstruct model_args (script name + the args MaxText needs)
+  model_args = [sys.argv[0]] + remaining_args
+
+  # Set jax environment
+  jax.config.update("jax_platforms", "cpu")
+  os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={local_args.simulated_cpu_devices_count}"
   main(model_args, local_args)

--- a/src/MaxText/utils/ckpt_scripts/convert_gpt_oss_ckpt.py
+++ b/src/MaxText/utils/ckpt_scripts/convert_gpt_oss_ckpt.py
@@ -27,6 +27,7 @@ import logging
 import os
 import pathlib
 import absl
+import time
 
 os.environ["JAX_PLATFORMS"] = "cpu"
 
@@ -39,6 +40,7 @@ from tqdm import tqdm
 from MaxText import max_logging
 from MaxText.utils.ckpt_scripts.llama_or_mistral_ckpt import save_weights_to_checkpoint
 from MaxText.utils.ckpt_scripts.convert_gpt_oss_unscanned_ckpt import MODEL_PARAMS_DICT, _hf_to_maxtext_mapping, _pt_to_np
+from MaxText.utils.ckpt_conversion.utils.utils import MemoryMonitorTqdm, print_peak_memory
 from maxtext.inference.inference_utils import str2bool
 
 absl.logging.set_verbosity(absl.logging.INFO)  # for max_logging.log
@@ -77,7 +79,7 @@ def _convert_huggingface_to_jax_weights(
   max_logging.log(f"Loading the base model from {base_model_path}")
   ckpt_paths = sorted(pathlib.Path(base_model_path).glob("[!.]*.safetensors"))
   chkpt_vars = {}
-  for i, ckpt_path in enumerate(ckpt_paths):
+  for i, ckpt_path in tqdm(enumerate(ckpt_paths), total=len(ckpt_paths)):
     max_logging.log(f"Loading checkpoint {i+1} of {len(ckpt_paths)} ...")
 
     with safe_open(ckpt_path, framework="pt", device="cpu") as f:
@@ -141,9 +143,9 @@ def _convert_huggingface_to_jax_weights(
 
   logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
 
-  # self attention ###############################################
+  # layer weight: self attention ###############################################
   max_logging.log("Processing self attention")
-  for layer_idx in tqdm(range(base_num_decoder_layers), desc="layers", leave=False):
+  for layer_idx in MemoryMonitorTqdm(range(base_num_decoder_layers), desc="layers", leave=True):
     block_layer_idx, block_idx = divmod(layer_idx, layer_cycle_interval)
     stack_shape = (base_num_decoder_layers // layer_cycle_interval,)
     self_attention = jax_weights["decoder"]["layers"][f"layers_{block_idx}"]["GptOssAttention"]
@@ -212,9 +214,9 @@ def _convert_huggingface_to_jax_weights(
 
   logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
 
-  # layer weight pre and post self attention norm ################
+  # layer weight: pre and post self attention norm ################
   max_logging.log("Processing pre and post self attention norms")
-  for layer_idx in tqdm(range(base_num_decoder_layers), desc="layers", leave=False):
+  for layer_idx in MemoryMonitorTqdm(range(base_num_decoder_layers), desc="layers", leave=True):
     block_layer_idx, block_idx = divmod(layer_idx, layer_cycle_interval)
     stack_shape = (base_num_decoder_layers // layer_cycle_interval,)
     layer_weight = jax_weights["decoder"]["layers"][f"layers_{block_idx}"]
@@ -246,10 +248,10 @@ def _convert_huggingface_to_jax_weights(
 
   logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
 
-  # layer weights ################################################
-  max_logging.log("Processing layer weights")
+  # layer weight: mlp ################################################
+  max_logging.log("Processing mlp weights")
 
-  for layer_idx in tqdm(range(base_num_decoder_layers), desc="layers", leave=False):
+  for layer_idx in MemoryMonitorTqdm(range(base_num_decoder_layers), desc="layers", leave=True):
     block_layer_idx, block_idx = divmod(layer_idx, layer_cycle_interval)
     stack_shape = (base_num_decoder_layers // layer_cycle_interval,)
     mlp_weight = jax_weights["decoder"]["layers"][f"layers_{block_idx}"]["GptOssMlp"]
@@ -337,17 +339,27 @@ if __name__ == "__main__":
   parser.add_argument("--use-zarr3", type=str2bool, required=False, default=True)
   args = parser.parse_args()
 
+  overall_start = time.time()
+
   if args.model_size not in MODEL_PARAMS_DICT:
     raise NotImplementedError(f"Model '{args.model_size}' is not supported.")
 
   os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={args.simulated_cpu_devices_count}"
   base_weights_path = args.maxtext_model_path
 
+  # transform
+  start = time.time()
+  weights = convert_to_jax_weights(args.base_model_path, args.model_size)
+  max_logging.log(f"Elapse for transform: {(time.time() - start) / 60:.2f} min")
+
+  # save
   save_weights_to_checkpoint(
       args.maxtext_model_path,
-      convert_to_jax_weights(args.base_model_path, args.model_size),
+      weights,
       args.simulated_cpu_devices_count,
       args.use_ocdbt,
       args.use_zarr3,
   )
   max_logging.log(f"Successfully saved base_weights to {base_weights_path}.")
+  max_logging.log(f"Overall Elapse: {(time.time() - overall_start) / 60:.2f} min")
+  print_peak_memory()

--- a/src/MaxText/utils/ckpt_scripts/llama_or_mistral_ckpt.py
+++ b/src/MaxText/utils/ckpt_scripts/llama_or_mistral_ckpt.py
@@ -48,6 +48,7 @@ import ml_dtypes
 import psutil
 
 from tqdm import tqdm
+import time
 
 import numpy as np
 
@@ -1631,52 +1632,114 @@ def convert_to_jax_weights(base_model_path: str, model_size: str, huggingface_ck
   return _convert_pytorch_to_jax_weights(base_model_path, model_size, model_params, mem_info)
 
 
-def save_weights_to_checkpoint(
-    maxtext_model_path: str, jax_weights: dict, device_count: int, use_ocdbt: bool, use_zarr3: bool
-):
-  """
-  Function to save jax_weights ready for MaxText to a parameters checkpoint.
+def shard_checkpoint(jax_weights, device_count, mem_info):
+  """Shards the checkpoint weights across the simulated devices.
 
   Args:
-      maxtext_model_path: Path to save the MaxText checkpoint.
-      jax_weights: The JAX model weights to be saved.
-      device_count: The number of simulated devices.
-      use_ocdbt: Whether to use Optimized Checkpoint Database with Transactions.
-      use_zarr3: Whether to use Zarr3 or not.
+    jax_weights: Pytree of model weights (numpy arrays).
+    device_count: The number of simulated devices.
+    mem_info: Process object to track memory usage.
+
+  Returns:
+    Pytree of sharded JAX arrays.
   """
-  mem_info = psutil.Process()
-  logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
-  gc.collect()
+  # Setup mesh & sharding specs
+  if len(jax.devices()) != device_count:
+    max_logging.log(
+        "WARNING: hardware/simulated device mismatch. "
+        f"Actual JAX devices: {len(jax.devices())}, Requested count: {device_count}."
+    )
+  max_logging.log(f"shard weights across {len(jax.devices())} devices")
+  # Pre-define sharding specs
   mesh = jax.sharding.Mesh(jax.devices(), "checkpoint_sharding_axis")
-  s1 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec("checkpoint_sharding_axis"))  # shards first axis
-  s2 = jax.sharding.NamedSharding(
-      mesh, jax.sharding.PartitionSpec(None, "checkpoint_sharding_axis")
-  )  # shards second axis
-  s3 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None))  # no sharding
+  # Sharding along axis 0
+  s1 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec("checkpoint_sharding_axis"))
+  # Sharding along axis 1
+  s2 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None, "checkpoint_sharding_axis"))
+  # No sharding (replicated)
+  s3 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None))
 
   def checkpoint_device_put(arr):
+    """Determines correct sharding spec based on shape and shards the input array.
+
+    Args:
+      arr: A numpy array (or jax array).
+
+    Returns:
+      A sharded jax array.
+    """
+    if not isinstance(arr, (np.ndarray, jax.Array)):
+      # materialize lazy tensor
+      arr = np.array(arr)
+
     if arr.shape[0] % device_count == 0:
-      max_logging.log("sharding first axis")
+      max_logging.log("sharding axis 0")
       return jax.device_put(arr, device=s1)
     elif len(arr.shape) > 1 and arr.shape[1] % device_count == 0:
-      max_logging.log("sharding second axis")
+      max_logging.log("sharding axis 1")
       return jax.device_put(arr, device=s2)
     else:
       max_logging.log("no sharding was possible, replicating")
       return jax.device_put(arr, device=s3)
 
+  # Weight sharding
+  start = time.time()
   # convert all weights to jax.numpy with sharding if applicable
   jax_weights_flat, jax_weights_struct = tree.flatten(jax_weights)
+  del jax_weights
+  gc.collect()
+
   jax_weights_new = []
-  while len(jax_weights_flat) > 0:
-    jax_weight = jax_weights_flat.pop(0)
+  jax_weights_flat.reverse()
+  num_weights = len(jax_weights_flat)
+  for _ in tqdm(range(num_weights)):
+    jax_weight = jax_weights_flat.pop()
     jax_weights_new.append(checkpoint_device_put(jax_weight))
     del jax_weight
     gc.collect()
     logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
 
   jax_weights = tree.unflatten(jax_weights_struct, jax_weights_new)
+  max_logging.log(f"Elapse for checkpoint sharding: {(time.time() - start) / 60:.2f} min")
 
+  return jax_weights
+
+
+def save_weights_to_checkpoint(
+    maxtext_model_path: str,
+    jax_weights: dict,
+    device_count: int,
+    use_ocdbt: bool,
+    use_zarr3: bool,
+):
+  """Saves model weights to a MaxText-compatible checkpoint with optional sharding.
+
+  This function handles the conversion of NumPy weights into sharded JAX arrays
+  across a specified number of simulated devices. If the device count is 1,
+  the sharding and JAX conversion steps are skipped.
+
+  Args:
+      maxtext_model_path: The destination directory or URI for the MaxText checkpoint.
+      jax_weights: A dictionary mapping parameter names to weight arrays (typically NumPy).
+      device_count: The number of simulated devices to shard across. If 1, weights
+          are saved in their original format.
+      use_ocdbt: If True, enables the Optimized Checkpoint Database with Transactions
+          (OCDBT) format for improved metadata handling.
+      use_zarr3: If True, uses the Zarr3 storage format for the underlying array data.
+  """
+  mem_info = psutil.Process()
+  logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
+  gc.collect()
+
+  # Weight sharding
+  if device_count > 1:
+    jax_weights = shard_checkpoint(jax_weights, device_count, mem_info)
+  else:
+    # If number of simulated devices is 1, SKIP sharding and SKIP jax conversion.
+    max_logging.log("Single device: Skip sharding")
+
+  # Save checkpoint
+  start = time.time()
   # dummy configs for the checkpoint_manager
   step_number_to_save_new_ckpt = 0
   enable_checkpointing = True
@@ -1702,6 +1765,8 @@ def save_weights_to_checkpoint(
       max_logging.log(f"saved a checkpoint at step {step_number_to_save_new_ckpt}")
     # Upon preemption, exit when and only when all ongoing saves are complete.
     checkpoint_manager.wait_until_finished()
+
+  max_logging.log(f"Elapse for checkpoint save: {(time.time() - start) / 60:.2f} min")
 
 
 def list_folders_pathlib(directory: str):


### PR DESCRIPTION
# Description

Fix: b/477648456

**Main change**: `to_maxtext.py` add option to shard weights before saving orbax checkpoint. 
- control by `--simulated_cpu_devices_count`, default to 16. That is, shard ckpt across 16 simulated cpu array. Note: This default value follows previous scripts; see below.
  - If set `--simulated_cpu_devices_count=1`, skip sharding
- reuse `save_weights_to_checkpoint` from `MaxText.utils.ckpt_scripts.llama_or_mistral_ckpt`
  - refine `save_weights_to_checkpoint`: add comment, use pop() rather than pop(0), log time for shard and save

**Why?**
- In most of previous conversions scripts, the weights are sharded before saving ([here](https://github.com/AI-Hypercomputer/maxtext/blob/c32eb92cbab2f992879f9a160175e1ec39d1882b/src/MaxText/utils/ckpt_scripts/llama_or_mistral_ckpt.py#L1634-L1676)), mostly with simulated_cpu_devices_count=16 and shard 0th dim
  - See: [llama & mixtral](https://github.com/AI-Hypercomputer/maxtext/blob/e8cbb57670ff7394217828ff11016c161c39a38c/src/MaxText/utils/ckpt_scripts/llama_or_mistral_ckpt.py#L195), [deepseek & kimi](https://github.com/AI-Hypercomputer/maxtext/blob/e8cbb57670ff7394217828ff11016c161c39a38c/src/MaxText/utils/ckpt_scripts/convert_deepseek_family_ckpt.py#L716), as well as [gpt-oss](https://github.com/AI-Hypercomputer/maxtext/blob/e8cbb57670ff7394217828ff11016c161c39a38c/src/MaxText/utils/ckpt_scripts/convert_gpt_oss_ckpt.py#L335), [qwen3-moe](https://github.com/AI-Hypercomputer/maxtext/blob/e8cbb57670ff7394217828ff11016c161c39a38c/src/MaxText/utils/ckpt_scripts/convert_qwen3_moe.py#L290).
- From previous investigation, the main issue of unsharded ckpt is out of RAM on TPU and slow loading speed.
  - b/302192179#comment22: llama2-70b OOM on v5e with 197GB RAM
  - b/326133855#comment5
  - Following https://github.com/AI-Hypercomputer/maxtext/pull/466, from 2024-03.
- In conclusion, checkpoint sharding has been used and tested for a long term. Particularly, all MoEs and largest models (deepseek-671b, kimi-1T) has been converted this way. Therefore, it is a good practice to follow.


**Additional change:**
- print peak memory
- move `MemoryMonitorTqdm` from to_maxtext to utils

# Tests

model: `qwen3-0.6b`

auxiliary script to check checkpoint sharding `check_orbax.py`: https://paste.googleplex.com/4961902692270080

## 1 eager mode, cpu, simulated_cpu_devices_count=16 (default)
```
BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d-%H-%M); \
echo $BASE_OUTPUT_PATH/0/items; \
python -m MaxText.utils.ckpt_conversion.to_maxtext MaxText/configs/base.yml model_name=qwen3-0.6b scan_layers=true \
base_output_directory=$BASE_OUTPUT_PATH hf_access_token=$HF_TOKEN \
hardware=cpu skip_jax_distributed_system=True \
attention=dot_product \
--simulated_cpu_devices_count=16
```

log: https://paste.googleplex.com/6454418499305472
gs://runner-maxtext-logs/2026-01-28-01-19/0/items
INFO:absl:Peak Memory: 6.50 GB

```
INFO:absl:shard weights across 16 devices
  0%|                                                   | 0/13 [00:00<?, ?it/s]
INFO:absl:sharding axis 0
INFO:absl:Elapse for checkpoint sharding: 0.16 min
```

**check sharding**
```
python check_orbax.py gs://runner-maxtext-logs/2026-01-28-01-19/0/items
```
https://paste.googleplex.com/4954491986247680

```
ArrayMetadata :  name=params.params.token_embedder.embedding,  directory=gs://runner-maxtext-logs/2026-01-28-01-19/0/items,  shape=(151936, 1024),  sharding=NamedShardingMetadata(shape=[16], axis_names=['checkpoint_sharding_axis'], axis_types=(Auto,), partition_spec=('checkpoint_sharding_axis',)) device_mesh=DeviceMetadataMesh(mesh=[DeviceMetadata(id=0), DeviceMetadata(id=1), DeviceMetadata(id=2), DeviceMetadata(id=3), DeviceMetadata(id=4), DeviceMetadata(id=5), DeviceMetadata(id=6), DeviceMetadata(id=7), DeviceMetadata(id=8), DeviceMetadata(id=9), DeviceMetadata(id=10), DeviceMetadata(id=11), DeviceMetadata(id=12), DeviceMetadata(id=13), DeviceMetadata(id=14), DeviceMetadata(id=15)]),  dtype=float32,  storage=StorageMetadata(chunk_shape=(9496, 1024), write_shape=(9496, 1024)),
```

## 2 eager mode, cpu, simulated_cpu_devices_count=1 (no shard)
```
BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d-%H-%M); \
echo $BASE_OUTPUT_PATH/0/items; \
python -m MaxText.utils.ckpt_conversion.to_maxtext MaxText/configs/base.yml model_name=qwen3-0.6b scan_layers=true \
base_output_directory=$BASE_OUTPUT_PATH hf_access_token=$HF_TOKEN \
hardware=cpu skip_jax_distributed_system=True \
attention=dot_product \
--simulated_cpu_devices_count=1
```

log: https://paste.googleplex.com/5084079739502592
gs://runner-maxtext-logs/2026-01-28-01-23/0/items
INFO:absl:Peak Memory: 6.72 GB

**check sharding**
```
python check_orbax.py gs://runner-maxtext-logs/2026-01-28-01-23/0/items
```

https://paste.googleplex.com/4528057568329728

```
ArrayMetadata :  name=params.params.token_embedder.embedding,  directory=gs://runner-maxtext-logs/2026-01-28-01-23/0/items,  shape=(151936, 1024),  sharding=None,  dtype=float32,  storage=StorageMetadata(chunk_shape=(151936, 1024), write_shape=None),
```

## 3 lazy mode, cpu, simulated_cpu_devices_count=16 (default)

```
BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d-%H-%M); \
echo $BASE_OUTPUT_PATH/0/items; \
python -m MaxText.utils.ckpt_conversion.to_maxtext MaxText/configs/base.yml model_name=qwen3-0.6b scan_layers=true \
base_output_directory=$BASE_OUTPUT_PATH hf_access_token=$HF_TOKEN \
hardware=cpu skip_jax_distributed_system=True \
attention=dot_product \
--lazy_load_tensors=true --simulated_cpu_devices_count=16
```

log: https://paste.googleplex.com/6152565647605760
gs://runner-maxtext-logs/2026-01-28-01-26/0/items
INFO:absl:Peak Memory: 3.53 GB


**check sharding**
```
python check_orbax.py gs://runner-maxtext-logs/2026-01-28-01-26/0/items
```

https://paste.googleplex.com/6147058778112000

```
ArrayMetadata :  name=params.params.token_embedder.embedding,  directory=gs://runner-maxtext-logs/2026-01-28-01-26/0/items,  shape=(151936, 1024),  sharding=NamedShardingMetadata(shape=[16], axis_names=['checkpoint_sharding_axis'], axis_types=(Auto,), partition_spec=('checkpoint_sharding_axis',)) device_mesh=DeviceMetadataMesh(mesh=[DeviceMetadata(id=0), DeviceMetadata(id=1), DeviceMetadata(id=2), DeviceMetadata(id=3), DeviceMetadata(id=4), DeviceMetadata(id=5), DeviceMetadata(id=6), DeviceMetadata(id=7), DeviceMetadata(id=8), DeviceMetadata(id=9), DeviceMetadata(id=10), DeviceMetadata(id=11), DeviceMetadata(id=12), DeviceMetadata(id=13), DeviceMetadata(id=14), DeviceMetadata(id=15)]),  dtype=bfloat16,  storage=StorageMetadata(chunk_shape=(9496, 1024), write_shape=(9496, 1024)),
```

**Sanity check: TPU v5p-8**
- still works, log: https://paste.googleplex.com/5308140717473792

## 4 lazy mode, cpu, simulated_cpu_devices_count=1 (no shard)
```
BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d-%H-%M); \
echo $BASE_OUTPUT_PATH/0/items; \
python -m MaxText.utils.ckpt_conversion.to_maxtext MaxText/configs/base.yml model_name=qwen3-0.6b scan_layers=true \
base_output_directory=$BASE_OUTPUT_PATH hf_access_token=$HF_TOKEN \
hardware=cpu skip_jax_distributed_system=True \
attention=dot_product \
--lazy_load_tensors=true --simulated_cpu_devices_count=1
```

log: https://paste.googleplex.com/5756578252849152
gs://runner-maxtext-logs/2026-01-28-01-29/0/items
INFO:absl:Peak Memory: 2.95 GB


**check sharding**
```
python check_orbax.py gs://runner-maxtext-logs/2026-01-28-01-29/0/items
```
https://paste.googleplex.com/6370607933554688

```
ArrayMetadata :  name=params.params.token_embedder.embedding,  directory=gs://runner-maxtext-logs/2026-01-28-01-29/0/items,  shape=(151936, 1024),  sharding=None,  dtype=float32,  storage=StorageMetadata(chunk_shape=(151936, 1024), write_shape=None),
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
