### PR TITLE
Add flops calculation for DeepSeek v3.2

### DIFF
--- a/src/MaxText/layers/attention_mla.py
+++ b/src/MaxText/layers/attention_mla.py
@@ -226,7 +226,7 @@ class Indexer(nnx.Module):
       2. K = RoPE(Norm(Wk @ X))
       3. Logits = ReLU(Q @ K.T)                      # Pairwise similarity
       4. Head_Weights = (W_proj @ X) * scale         # Dynamic head importance, scale for stability
-      5. Score = Sum_head(Logits * Head_Weights)     # Aggregate heads
+      5. Score = Logits @ Head_Weights               # Aggregate heads
       6. Indices = ArgTopk(Score)
 
     Args:
@@ -281,7 +281,7 @@ class Indexer(nnx.Module):
     # Weights scaling affect index_score, but does not affect topk_indices. Keep scaling for numerical stability.
     # https://github.com/deepseek-ai/DeepSeek-V3.2-Exp/blob/87e509a2e5a100d221c97df52c6e8be7835f0057/inference/model.py#L478-L480
     weights = weights * (self.n_heads**-0.5) * self.softmax_scale
-    # Weighted sum over head: sum_h(logits * weights)
+    # Aggregate head-wise logits: logits @ weights
     index_score = jnp.einsum("btsh, bth -> bts", logits, weights, precision=self.config.matmul_precision)  # [b, t, s]
 
     # Apply attention mask before TopK

--- a/src/MaxText/maxtext_utils.py
+++ b/src/MaxText/maxtext_utils.py
@@ -319,11 +319,86 @@ def calculate_llama4_attention_tflops(config):
   return attention_tflops
 
 
+def calculate_indexer_mask_ratio(index_topk, max_target_length):
+  """
+  Calculates the sparse-to-dense ratio for Indexer TFLOPs.
+
+  The indexer evaluates all previous tokens in a causal manner until it hits
+  the Top-K limit.
+
+  Visual Representation (T=8, K=4):
+  Key (S) ->
+  Q1 [X . . . . . . .]  <- 1 token scored
+  Q2 [X X . . . . . .]  <- 2 tokens scored
+  Q3 [X X X . . . . .]  <- 3 tokens scored
+  Q4 [X X X X . . . .]  <- 4 tokens scored (K limit reached)
+  Q5 [X X X . X . . .]  <- 4 tokens scored
+  Q6 [X X . X . X . .]  <- 4 tokens scored
+  Q7 [X . X X . . X .]  <- 4 tokens scored
+  Q8 [X X . X . . . X]  <- 4 tokens scored
+
+  For MFU calculation:
+
+  Visual Representation (T=8, K=4):
+  Key (S) ->
+  Q1 [X . . . . . . .]  <- 1 token scored
+  Q2 [X X . . . . . .]  <- 2 tokens scored
+  Q3 [X X X . . . . .]  <- 3 tokens scored
+  Q4 [X X X X . . . .]  <- 4 tokens scored (K limit reached)
+  Q5 [X X X X . . . .]  <- 4 tokens scored
+  Q6 [X X X X . . . .]  <- 4 tokens scored
+  Q7 [X X X X . . . .]  <- 4 tokens scored
+  Q8 [X X X X . . . .]  <- 4 tokens scored
+
+  Mathematical Calculation:
+  - Triangle (Phase 1: 1 to K): K^2 / 2
+  - Rectangle (Phase 2: K+1 to T): (T - K) * K
+  - Total Active Area = TK - K^2 / 2
+  - Dense Area = T^2
+
+  Ratio = (TK - 0.5*K^2) / T^2  =>  (K/T) - 0.5*(K/T)^2
+  """
+
+  T = float(max_target_length)
+  K = float(index_topk)
+
+  ratio = K / T
+  mask_multiplier = ratio - (0.5 * ratio**2)
+  return mask_multiplier
+
+
+def calculate_indexer_tflops_per_device(config):
+  """Calculates TFLOPs for the DeepSeek Lightning Indexer (handles causal reduction)."""
+  batch_len = config.per_device_batch_size * config.max_target_length
+
+  # 1. Calculate projections flops
+  # Query: [batch, seq, q_lora_rank] @ [q_lora_rank, index_n_heads, index_head_dim]
+  q_flops = 2 * batch_len * config.q_lora_rank * config.index_n_heads * config.index_head_dim
+  # Key: [batch, seq, emb_dim] @ [emb_dim, index_head_dim]
+  k_flops = 2 * batch_len * config.emb_dim * config.index_head_dim
+  # Head weight: [batch, seq, emb_dim] @ [emb_dim, index_n_heads]
+  head_weight_flops = 2 * batch_len * config.emb_dim * config.index_n_heads
+  proj_flops = q_flops + k_flops + head_weight_flops
+
+  # 2. Calculate index score flops
+  # QK product [batch, seq, index_n_heads, index_head_dim] @ [batch, seq, index_head_dim]
+  # --> [batch, seq, seq, index_n_heads]
+  qk_product_flops = 2 * batch_len * config.max_target_length * config.index_n_heads * config.index_head_dim
+  # Aggregate heads [batch, seq, seq, index_n_heads] @ [batch, seq, index_n_heads]
+  head_reduction_flops = 2 * batch_len * config.max_target_length * config.index_n_heads
+  # Apply causal mask: Divide by 2 to account for triangular interactions
+  # The mask restricts the indexer's search space prior to Top-K filtering
+  scoring_flops = (qk_product_flops + head_reduction_flops) / 2
+
+  return proj_flops, scoring_flops
+
+
 def calculate_mla_tflops_per_device(config):
-  """Calculate Multi-Head Latent Attention TFLOP"""
+  """Calculate Multi-Head Latent Attention TFLOP (handles causal reduction)"""
   batch_len = config.per_device_batch_size * config.max_target_length
   qk_head_dim_sum = config.qk_nope_head_dim + config.qk_rope_head_dim
-  # calculate mla query projection
+
+  # 1. calculate mla query projection
   if config.q_lora_rank == 0:
     q_flops = 2 * batch_len * config.emb_dim * config.num_query_heads * qk_head_dim_sum
   else:
@@ -333,7 +408,8 @@ def calculate_mla_tflops_per_device(config):
         * batch_len
         * (config.emb_dim * config.q_lora_rank + config.q_lora_rank * config.num_query_heads * qk_head_dim_sum)
     )
-  # calculate mla kv projection with down and up flops
+
+  # 2. calculate mla kv projection
   kv_flops = (
       2
       * batch_len
@@ -344,9 +420,31 @@ def calculate_mla_tflops_per_device(config):
   )
   qkv_flops = q_flops + kv_flops
 
-  attention_flops = (
-      2 * batch_len * config.max_target_length * config.num_query_heads * (qk_head_dim_sum + config.v_head_dim)
-  )
+  # 3. calculate attention
+  if config.use_sparse_indexer and config.max_target_length > config.index_topk:
+    # get indexer flops
+    indexer_proj_flops, indexer_scoring_flops = calculate_indexer_tflops_per_device(config)
+    qkv_flops += indexer_proj_flops
+
+    # calculate the proportion of the T x T causal matrix that the Indexer actually explores
+    # this follows the area: (TK - 0.5*K^2) / T^2 (T: max_target_length, K: index_topk)
+    multiplier = calculate_indexer_mask_ratio(config.index_topk, config.max_target_length)
+    attention_flops = (
+        2
+        * batch_len
+        * config.max_target_length
+        * config.num_query_heads
+        * (qk_head_dim_sum + config.v_head_dim)
+        * multiplier
+    )
+    attention_flops += indexer_scoring_flops
+  else:
+    # standard MLA & max_target_length <= index_topk in sparse indexer
+    # in both cases, the indexer is bypassed as the causal mask remains the efficient representation
+    attention_flops = (
+        2 * batch_len * config.max_target_length * config.num_query_heads * (qk_head_dim_sum + config.v_head_dim)
+    )
+    attention_flops = attention_flops / 2
   projection_flops = 2 * batch_len * config.emb_dim * config.num_query_heads * config.v_head_dim
   return qkv_flops, attention_flops, projection_flops
 
@@ -546,7 +644,7 @@ def calculate_tflops_training_per_device(config, log=True):
 
   # Attention flops
   if config.attention_type == "mla":
-    qkv_flops, noncausal_attention_flops, projection_flops = calculate_mla_tflops_per_device(config)
+    qkv_flops, causal_attention_flops, projection_flops = calculate_mla_tflops_per_device(config)
   else:
     qkv_flops = (
         2
@@ -568,11 +666,11 @@ def calculate_tflops_training_per_device(config, log=True):
         * config.head_dim
     )
 
-  # Divide attention flops by 2 due to causal mask
-  # References:
-  # NVIDIA/Megatron-LM (2025 March): https://github.com/NVIDIA/Megatron-LM/blob/250b79415dcc4b660521273c87f15334c804eeae/megatron/training/training.py#L361-L362
-  # NVIDIA/NeMo (2025 April): https://github.com/NVIDIA/NeMo/blob/ba4d6d116463de512ff0cfc14641aa6cf4577a42/nemo/utils/flops_formulas.py#L259-L272
-  causal_attention_flops = noncausal_attention_flops / 2
+    # Divide attention flops by 2 due to causal mask
+    # References:
+    # NVIDIA/Megatron-LM (2025 March): https://github.com/NVIDIA/Megatron-LM/blob/250b79415dcc4b660521273c87f15334c804eeae/megatron/training/training.py#L361-L362
+    # NVIDIA/NeMo (2025 April): https://github.com/NVIDIA/NeMo/blob/ba4d6d116463de512ff0cfc14641aa6cf4577a42/nemo/utils/flops_formulas.py#L259-L272
+    causal_attention_flops = noncausal_attention_flops / 2
 
   # Embedding flops
   embedding_flops = 2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.vocab_size


### PR DESCRIPTION
# Description

Add flops calculation for DeepSeek v3.2, and this PR depends on [this change](https://github.com/AI-Hypercomputer/maxtext/pull/2933)

* Add indexer flops helper function
* Add option to combine indexer flops inside of MLA
* Added a unit test to **rough** estimate tflops

# Tests

* Tested DS v2-16b, no impact

```
# Before the change
Per train step:
 Total TFLOPs: 593.27 
 split as 81.24% learnable weight flops and 18.76% attention flops
before the change: 593.272422531072

# After the change
Per train step:
 Total TFLOPs: 593.27 
 split as 81.24% learnable weight flops and 18.76% attention flops
after change: 593.272422531072
```

* Tested DS v3.2, with indexer (expected)
```
# Enable this feature
Per train step:
 Total TFLOPs: 4162.71 
 split as 88.50% learnable weight flops and 11.50% attention flops
enable use_sparse_indexer: 4162.71

# Disable this feature like v3
Per train step:
 Total TFLOPs: 4103.37 
 split as 87.74% learnable weight flops and 12.26% attention flops
disable use_sparse_indexer: 4103.370952409088
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
