### PR TITLE
[src/MaxText/inference/offline_engine.py] Make `OfflineEngine` a fluent interface

### DIFF
--- a/src/MaxText/experimental/rl/grpo_trainer.py
+++ b/src/MaxText/experimental/rl/grpo_trainer.py
@@ -41,6 +41,7 @@ import os
 import functools
 import threading
 
+from copy import deepcopy
 from typing import Sequence, Callable, Iterator
 
 from absl import app
@@ -691,10 +692,9 @@ def train_loop(config, config_inference, recorder, state=None):
 
   data_sharding = sharding.get_input_data_sharding(config, mesh)
 
-  inference_engine = offline_engine.OfflineEngine(
-      config=config_inference,
-      mesh=inference_mesh,
-  )
+  config = deepcopy(config_inference)
+  config.mesh = inference_mesh
+  inference_engine = offline_engine.OfflineEngine(config=config)
   data_buffer = []
   data_buffer_lock = threading.Lock()
 

--- a/tests/grpo_trainer_correctness_test.py
+++ b/tests/grpo_trainer_correctness_test.py
@@ -142,9 +142,8 @@ class GrpoTrainerTest(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(self.config_inference)
     self.mesh = Mesh(devices_array, self.config_inference.mesh_axes)
     self.tokenizer_model.add_special_tokens({"pad_token": "<pad>"})
-    self.inference_engine = offline_engine.OfflineEngine(
-        config=self.config_inference,
-        mesh=self.inference_model.mesh,
+    self.inference_engine = (
+        offline_engine.OfflineEngineBuilder(self.config_inference).set_mesh(self.inference_model.mesh).build()
     )
 
   @pytest.mark.skip(reason="Logit output test fragile, failing on jax upgrade to 0.6.2 - see b/425997645")

--- a/tests/inference/benchmark_offline_engine.py
+++ b/tests/inference/benchmark_offline_engine.py
@@ -31,7 +31,7 @@ import numpy as np
 from MaxText.globals import MAXTEXT_PKG_DIR
 from MaxText import max_logging
 from MaxText import pyconfig
-from MaxText.inference.offline_engine import OfflineEngine, InputData, CompletionOutput
+from MaxText.inference.offline_engine import OfflineEngineBuilder, InputData, CompletionOutput
 
 
 def get_metrics(results: list[CompletionOutput], start_time, end_time):
@@ -97,13 +97,13 @@ def run(
     profile_path="",
 ):
   """Run offline engine"""
-  inference_engine = OfflineEngine(
-      config,
-      params=None,
-      enable_batch_prefill=False,
-      rng=jax.random.PRNGKey(0),
-      eos_ids=[1002],
-      debug=False,
+  inference_engine = (
+      OfflineEngineBuilder(config)
+      .set_params(None)
+      .set_rng(jax.random.PRNGKey(0))
+      .set_eos_ids([1002])
+      .set_debug(False)
+      .build()
   )
   max_logging.log("Starting Warmup")
   _ = [inference_engine.batch_inference(input_data) for _ in range(4)]

--- a/tests/offline_engine_test.py
+++ b/tests/offline_engine_test.py
@@ -21,7 +21,7 @@ import os.path
 import jax
 import jax.numpy as jnp
 import numpy as np
-from MaxText.inference.offline_engine import OfflineEngine, InputData, CompletionOutput
+from MaxText.inference.offline_engine import OfflineEngineBuilder, InputData, CompletionOutput
 from MaxText import pyconfig
 from MaxText.globals import MAXTEXT_PKG_DIR
 
@@ -68,7 +68,17 @@ class OfflineEngineTest(unittest.TestCase):
 
     config = self.cfg
     rng = jax.random.PRNGKey(0)
-    inference_engine = OfflineEngine(config=config, params=None, enable_batch_prefill=False, rng=rng, eos_ids=[])
+    # Use Builder instead of direct init
+    inference_engine = (
+        OfflineEngineBuilder(config)
+        .enable_batch_prefill(max_batch_size=16)  # Just demonstrating usage; test asked for False which is default
+        .set_rng(rng)
+        .set_eos_ids([])
+        .build()
+    )
+    # The test actually wanted enable_batch_prefill=False. To match previous behavior precisely:
+    inference_engine = OfflineEngineBuilder(config).set_rng(rng).set_eos_ids([]).build()
+
     input_lengths = list(range(10, 600, 100))
     input_data = [
         InputData(id=f"input_{i}", tokens=np.arange(length), true_length=length) for i, length in enumerate(input_lengths)
@@ -87,7 +97,7 @@ class OfflineEngineTest(unittest.TestCase):
   def test_multi_sampling(self):
     config = self.cfg
     rng = jax.random.PRNGKey(0)
-    inference_engine = OfflineEngine(config=config, params=None, enable_batch_prefill=False, rng=rng, eos_ids=[])
+    inference_engine = OfflineEngineBuilder(config).set_rng(rng).set_eos_ids([]).build()
     rng1, rng_2 = jax.random.split(rng, 2)
     input_data = [InputData(id=f"input_{i}", tokens=jnp.arange(128), true_length=128) for i in range(4)]
 


### PR DESCRIPTION
# Description

[src/MaxText/inference/offline_engine.py] `OfflineEngine.__init__` takes many configuration flags ( `enable_batch_prefill`, `min_decode_steps`, `prefill_lengths`, `eos_ids`) to configure internal workers and prefill helpers. The setup logic branches based on these flags (e.g., choosing `BatchedPrefillProcessor` vs `PrefillProcessor`) ; [tests/{grpo_trainer_correctness_test.py,inference/benchmark_offline_engine.py,offline_engine_test.py}] Update tests for new fluent interface

TL;DR: Instead of passing a long list of arguments (some mutually exclusive or dependent on flags like `enable_batch_prefill`) directly to `__init__`, we now use a Builder pattern. This validates configuration (e.g. checking `scan_layers` vs `batch_prefill`) before the engine is created.

**Before:**

```python
# Initialization was brittle with many positional/keyword args
engine = OfflineEngine(
    config=self.config,
    params=self.params,
    min_decode_steps=10,
    enable_batch_prefill=True,
    batch_prefill_max_batch_size=16,
    tokenizer=self.tokenizer,
    eos_ids=[100, 101],
    rng=self.rng
)
```

**After:**

```python
# Initialization is now fluent, explicit, and pre-validated
engine = (
    OfflineEngineBuilder(self.config)
    .set_params(self.params)
    .enable_batch_prefill(max_batch_size=16)
    .set_decoding_params(min_steps=10)
    .set_tokenizer(self.tokenizer_path) # Or strictly passing tokenizer instance via builder
    .set_eos_ids([100, 101])
    .set_rng(self.rng)
    .build() # Validation happens here
)
```

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
