### PR TITLE
Fix build-docs CI workflow

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ autodoc_mock_imports = [
     "cloud_tpu_diagnostics",
     "google_cloud_mldiagnostics",
     "jetstream",
+    "librosa",
     "ml_goodput_measurement",
     "pathwaysutils",
     "safetensors",
@@ -178,6 +179,7 @@ def run_apidoc(_):
       os.path.join(MAXTEXT_REPO_ROOT, "src", "MaxText", "scratch_code"),
       os.path.join(MAXTEXT_REPO_ROOT, "src", "MaxText", "utils", "ckpt_conversion"),
       os.path.join(MAXTEXT_REPO_ROOT, "src", "MaxText", "rl"),
+      os.path.join(MAXTEXT_REPO_ROOT, "src", "MaxText", "multimodal_utils.py"),
   ]
 
   # Run the command and check for errors

--- a/docs/tutorials/posttraining/sft.md
+++ b/docs/tutorials/posttraining/sft.md
@@ -15,6 +15,7 @@
  -->
 
 # SFT on single-host TPUs
+
 Supervised fine-tuning (SFT) is a process where a pre-trained large language model is fine-tuned on a labeled dataset to adapt the model to perform better on specific tasks.
 
 This tutorial demonstrates step-by-step instructions for setting up the environment and then training the model on a Hugging Face dataset using SFT.
@@ -64,9 +65,11 @@ export TRAIN_DATA_COLUMNS=<data columns to train on> # e.g., ['messages']
 ```
 
 ## Get your model checkpoint
+
 This section explains how to prepare your model checkpoint for use with MaxText. You have two options: using an existing MaxText checkpoint or converting a Hugging Face checkpoint.
 
 ### Option 1: Using an existing MaxText checkpoint
+
 If you already have a MaxText-compatible model checkpoint, simply set the following environment variable and move on to the next section.
 
 ```sh
@@ -74,6 +77,7 @@ export PRE_TRAINED_MODEL_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs:
 ```
 
 ### Option 2: Converting a Hugging Face checkpoint
+
 If your model checkpoint is from Hugging Face, you need to run a conversion script to make it MaxText-compatible.
 
 1. **Set the Output Path:** First, define where the converted MaxText checkpoint will be saved. For example:
@@ -101,6 +105,7 @@ export PRE_TRAINED_MODEL_CKPT_PATH=${PRE_TRAINED_MODEL_CKPT_DIRECTORY}/0/items
 ```
 
 ## Run SFT on Hugging Face Dataset
+
 Now you are ready to run SFT using the following command:
 
 ```sh
@@ -118,4 +123,5 @@ python3 -m MaxText.sft.sft_trainer src/MaxText/configs/sft.yml \
     train_data_columns=${TRAIN_DATA_COLUMNS} \
     profiler=xplane
 ```
+
 Your fine-tuned model checkpoints will be saved here: `$BASE_OUTPUT_DIRECTORY/$RUN_NAME/checkpoints`.

--- a/src/MaxText/maxengine.py
+++ b/src/MaxText/maxengine.py
@@ -15,7 +15,7 @@
 """Implementation of Engine API for MaxText."""
 
 from collections import defaultdict
-from typing import Any, Callable
+from typing import Any, Callable, Union
 import functools
 import os.path
 import uuid
@@ -102,7 +102,7 @@ class MaxEngine(engine_api.Engine):
   JetStream efficient serving infrastructure.
   """
 
-  def __init__(self, config: Any, devices: config_lib.Devices | None = None):
+  def __init__(self, config: Any, devices: Union[config_lib.Devices, None] = None):
     self.config = config
 
     # Mesh definition

--- a/src/MaxText/multimodal/utils.py
+++ b/src/MaxText/multimodal/utils.py
@@ -27,7 +27,7 @@ from PIL import Image
 class PreprocessorOutput:
   """Holds the output of an image preprocessor.
 
-  Attributes:
+  Args:
     pixel_values: A JAX array containing the processed image pixel data.
                   The shape and format depend on the specific model and
                   preprocessing steps (e.g., [H, W, C] for Gemma3 or


### PR DESCRIPTION
# Description

This PR solves several issues introduced by [PR](https://github.com/AI-Hypercomputer/maxtext/pull/2049).

1. `TypeError: unsupported operand type(s) for |: 'Devices' and 'NoneType'`

In `maxengine.py`, the MaxEngine class defines its constructor as:
```
def __init__(self, config: Any, devices: config_lib.Devices | None = None):
```

In the documentation build configuration (docs/conf.py), the jetstream package is listed in `autodoc_mock_imports`. When a package is mocked, its attributes (like `config_lib.Devices`) become dummy Mock objects rather than actual types.
While Python 3.12 supports the | operator for type unions (e.g., int | None), it does not support using | with mock objects. When Sphinx attempts to import the module to generate documentation, it evaluates the type hint, tries to perform MockObject | None, and fails with the TypeError because the mock doesn't know how to handle the OR (|) operator.

2. `librosa` not found
```
ModuleNotFoundError: No module named 'librosa'
```

The `qwen3_omni_processor` require librosa, but this package is not installed in the docs environment. librosa is not mocked in conf.py, so the import fails completely.

3. The class `PreprocessorOutput` is defined in both `src/MaxText/multimodal_utils.py` and `src/MaxText/multimodal/utils.py` with nearly identical docstrings.

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
