### PR TITLE
Only log config once

### DIFF
--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -201,12 +201,6 @@ def initialize(argv: list[str], **kwargs) -> HyperParameters:
   """Initializes the configuration by loading YAML files, and applying CLI, env, and kwarg overrides."""
   pydantic_config = initialize_pydantic(argv, **kwargs)
   config = HyperParameters(pydantic_config)
-
-  if config.log_config:
-    for k, v in sorted(config.get_keys().items()):
-      if k != "hf_access_token":
-        logger.info("Config param %s: %s", k, v)
-
   return config
 
 


### PR DESCRIPTION
# Description

Previously the config was being printed twice. Once in pyconfig method `initialize` and once in method `initialize_pydantic`. The `initialize` method calls `initialize_pydantic`, so we keep only the print in that inner method

# Tests

Ran a maxtext command, saw config only printed once after this change.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
