### PR TITLE
Update the Ironwood offloading description

### DIFF
--- a/benchmarks/xla_flags_library.py
+++ b/benchmarks/xla_flags_library.py
@@ -77,6 +77,10 @@ ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS = (
 
 
 # Enable SparseCore All Gather (1D), Reduce Scatter (1D) and All Reduce (ND)
+# On Ironwood, by default:
+# xla_tpu_enable_sparse_core_collective_offload_all_gather as True
+# xla_tpu_enable_sparse_core_collective_offload_reduce_scatter as True
+# xla_tpu_enable_sparse_core_collective_offload_all_reduce as True
 ENABLE_SPARSECORE_OFFLOADING_FOR_RS_AG_AR = (
     " --xla_tpu_enable_async_collective_fusion_fuse_all_gather=false"
     " --xla_tpu_enable_async_collective_fusion_fuse_all_reduce=false"
@@ -91,6 +95,8 @@ ENABLE_SPARSECORE_OFFLOADING_FOR_RS_AG_AR = (
 
 # Enable SparseCore Reduce Scatter (SC RS)
 # Either one of CF or SC can be enabled at a time.
+# On Ironwood, by default:
+# xla_tpu_enable_sparse_core_collective_offload_reduce_scatter as True
 ENABLE_SPARSECORE_OFFLOADING_FOR_REDUCE_SCATTER = (
     " --xla_tpu_enable_async_collective_fusion_fuse_reduce_scatter=false"
     " --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true"
@@ -99,6 +105,8 @@ ENABLE_SPARSECORE_OFFLOADING_FOR_REDUCE_SCATTER = (
 
 # Enable SparseCore All Gather (SC AG).
 # Either one of CF or SC can be enabled at a time.
+# On Ironwood, by default:
+# xla_tpu_enable_sparse_core_collective_offload_all_gather as True
 ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_GATHER = (
     " --xla_tpu_enable_async_collective_fusion_fuse_all_gather=false"
     " --xla_tpu_enable_sparse_core_collective_offload_all_gather=true"
@@ -109,6 +117,8 @@ ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_GATHER = (
 # Either one of CF or SC can be enabled at a time.
 # This is useful for reducing the gradient reduction all-reduce time with
 # overlapping with compute during that time.
+# On Ironwood, by default:
+# xla_tpu_enable_sparse_core_collective_offload_all_reduce as True
 ENABLE_SPARSECORE_OFFLOADING_FOR_ALL_REDUCE = (
     " --xla_tpu_enable_async_collective_fusion_fuse_all_reduce=false"
     " --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true"


### PR DESCRIPTION
# Description

Harini reached out and pointed out those `xla_tpu_enable_sparse_core_collective_offload*` flags are enabled by default on Ironwood, not like v6e or v5p (I also cross checked in this [doc](https://docs.google.com/spreadsheets/d/1Acrivw1KoN_FudAYUGLwkPWs4AcS8FPdupmZIy0U9zU/edit?gid=0#gid=0)). Reword the document a little bit and recommend customers to tune flags if needed.

```
# Original:
Enable SparseCore offloading for collectives: By setting the appropriate [XLA flags](https://github.com/AI-Hypercomputer/maxtext/blob/ed517cf80d9aa81f76e236c5516dacebfe39e96d/benchmarks/xla_flags_library.py#L70-L116), you can offload collective operations (like All-Reduce, All-Gather, etc.) to the SparseCores. These operations then run in parallel with the TensorCore computations, effectively hiding communication latency and improving Model Flop Utilization (MFU).

# Updated:
Leverage SparseCore offloading: By default, collective operations (like All-Reduce, All-Gather, etc.) are offloaded to SparseCore, allowing them to run in parallel with TensorCore computations. This effectively hides communication latency and improving Model Flop Utilization (MFU). Also, you can maximize throughput tuning those [XLA flags](https://github.com/AI-Hypercomputer/maxtext/blob/ed517cf80d9aa81f76e236c5516dacebfe39e96d/benchmarks/xla_flags_library.py#L70-L116).
```

Also **format** change to pass the `mdformat` check.

# Tests

Manual check

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
