### PR TITLE
Update tflops calc for qwen3 next & GatedDeltaNet

### DIFF
--- a/src/MaxText/configs/models/qwen3-next-80b-a3b.yml
+++ b/src/MaxText/configs/models/qwen3-next-80b-a3b.yml
@@ -31,6 +31,7 @@ normalization_layer_epsilon: 1.0e-6
 base_mlp_dim: 512
 base_moe_mlp_dim: 512
 num_experts: 512
+shared_experts: 1
 num_experts_per_tok: 10
 norm_topk_prob: True
 

--- a/tests/unit/flop_calculation_test.py
+++ b/tests/unit/flop_calculation_test.py
@@ -98,6 +98,150 @@ class FlopCalculation(unittest.TestCase):
 
     return attention_flops / 1e12  # return tflops
 
+  def compute_qwen3_next_attention_flops_per_device(self, kwargs: dict) -> float:
+    """
+    Computes the total training TFLOPs per device for a Qwen3-Next model.
+    Only counts the attention mechanism operations (non-weights).
+    """
+    B = kwargs["per_device_batch_size"]
+    S = kwargs["max_target_length"]
+    N = kwargs["base_num_decoder_layers"]
+    cycle_interval = kwargs["inhomogeneous_layer_cycle_interval"]
+
+    # Layer counts
+    num_full_layers = N // cycle_interval
+    num_linear_layers = N - num_full_layers
+
+    # 1. Full Attention FLOPs (Causal)
+    D_head = kwargs["head_dim"]
+    H_q = kwargs["base_num_query_heads"]
+    # 2 for QK^T and SV, 3 for fwd+bwd.
+    # Note: maxtext_utils divides by 2 for causal masking.
+    # Formula: 2 * 3 * B * S^2 * H * D
+    full_attn_flops = 2 * 3 * num_full_layers * B * (S**2) * H_q * D_head
+
+    # 2. Linear Attention (Gated Delta Net) FLOPs
+    H_v = kwargs["gdn_num_value_heads"]
+    D_k = kwargs["gdn_key_head_dim"]
+    D_v = kwargs["gdn_value_head_dim"]
+    C = kwargs["gdn_chunk_size"]
+
+    # Formulas from maxtext_utils.calculate_gated_delta_net_flops_per_device
+    flops_intra = 2 * B * S * H_v * C * (2 * D_k + D_v) + (B * H_v * S * C**2)
+    flops_inter = (2 * B * S * H_v * C * (D_k + D_v)) + (6 * B * S * H_v * D_k * D_v)
+
+    # 3 for fwd+bwd
+    linear_attn_flops = 3 * num_linear_layers * (flops_intra + flops_inter)
+
+    return (full_attn_flops + linear_attn_flops) / 1e12
+
+  @pytest.mark.cpu_only
+  def test_qwen3_next_flops(self):
+    """Test Qwen3-Next Flops calculation"""
+    kwargs = {
+        "model_name": "qwen3-next-80b-a3b",
+        "override_model_config": True,
+        "per_device_batch_size": 1,
+        "max_target_length": 4096,
+        "decoder_block": "qwen3_next",
+        "gradient_accumulation_steps": 1,
+        "skip_jax_distributed_system": True,
+        # Core Architectural Parameters
+        "base_emb_dim": 2048,
+        "base_num_decoder_layers": 48,
+        "base_num_query_heads": 16,
+        "base_num_kv_heads": 2,
+        "head_dim": 256,
+        "vocab_size": 151936,
+        # MoE Parameters
+        "base_mlp_dim": 512,  # Note: maxtext_utils uses moe_mlp_dim for calculations
+        "base_moe_mlp_dim": 512,
+        "num_experts": 512,
+        "num_experts_per_tok": 10,
+        "mlp_activations": ["silu", "linear"],
+        # Qwen3-Next Specific Parameters
+        "inhomogeneous_layer_cycle_interval": 4,
+        "gdn_conv_kernel_dim": 4,
+        "gdn_key_head_dim": 128,
+        "gdn_value_head_dim": 128,
+        "gdn_num_key_heads": 16,
+        "gdn_num_value_heads": 32,
+        "gdn_chunk_size": 64,
+    }
+
+    # 1. Calculate Attention TFLOPs
+    attention_tflops = self.compute_qwen3_next_attention_flops_per_device(kwargs)
+
+    # 2. Calculate Learnable Weight Active Params
+    # Config Shortcuts
+    emb_dim = kwargs["base_emb_dim"]
+    vocab = kwargs["vocab_size"]
+    N = kwargs["base_num_decoder_layers"]
+
+    # MoE Active Params (per layer)
+    # FFN uses SwiGLU (3 matrices), Qwen3-Next has 1 shared + N routed experts
+    # Params = Gate + Shared + Routed
+    # Gate: emb_dim * num_experts
+    # Expert: 3 * emb_dim * moe_mlp_dim
+    moe_mlp_dim = kwargs["base_moe_mlp_dim"]
+    num_experts = kwargs["num_experts"]
+    num_routed = kwargs["num_experts_per_tok"]
+
+    params_moe_layer = (
+        (emb_dim * num_experts) + (3 * emb_dim * moe_mlp_dim * 1) + (3 * emb_dim * moe_mlp_dim * num_routed)
+    )
+
+    # Full Attention Params (per full layer)
+    Hq = kwargs["base_num_query_heads"]
+    Hkv = kwargs["base_num_kv_heads"]
+    Hd = kwargs["head_dim"]
+    # Q, K, V, Out projections
+    params_full_attn = (emb_dim * (Hq + 2 * Hkv) * Hd) + (Hq * Hd * emb_dim)
+
+    # GDN Linear Attention Params (per linear layer)
+    Hk_g = kwargs["gdn_num_key_heads"]
+    Hv_g = kwargs["gdn_num_value_heads"]
+    Dk_g = kwargs["gdn_key_head_dim"]
+    Dv_g = kwargs["gdn_value_head_dim"]
+    K_conv = kwargs["gdn_conv_kernel_dim"]
+
+    K_dim = Hk_g * Dk_g
+    V_dim = Hv_g * Dv_g
+
+    # Projections: qkvz (in->2K+2V), ba (in->2Hv), out (V->in)
+    params_gdn_proj = (emb_dim * (2 * K_dim + 2 * V_dim)) + (emb_dim * 2 * Hv_g) + (V_dim * emb_dim)
+    # Conv: depthwise on 2K+V
+    params_gdn_conv = (2 * K_dim + V_dim) * K_conv
+
+    params_gdn_layer = params_gdn_proj + params_gdn_conv
+
+    # Total Active Params
+    # 12 Full Layers, 36 Linear Layers
+    num_full = N // kwargs["inhomogeneous_layer_cycle_interval"]
+    num_linear = N - num_full
+
+    total_active_params = (
+        (vocab * emb_dim)
+        + (num_full * (params_full_attn + params_moe_layer))
+        + (num_linear * (params_gdn_layer + params_moe_layer))
+    )
+
+    # Weight TFLOPs = 6 * B * S * P
+    B = kwargs["per_device_batch_size"]
+    S = kwargs["max_target_length"]
+    weight_tflops = 6 * B * S * total_active_params / 1e12
+
+    golden_tflops = weight_tflops + attention_tflops
+
+    # Run Calculation
+    cfg = pyconfig.initialize(
+        [None, os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")],
+        **kwargs,
+    )
+    calculated_tflops, _, _ = calculate_tflops_training_per_device(cfg)
+
+    self.assertFlopsAlmostEqual(calculated_tflops, golden_tflops)
+
   @pytest.mark.cpu_only
   def test_llama2_7b_flops(self):
     """Test Llama2 7b Flops calculation with default parameters"""


### PR DESCRIPTION
# Description

### PR Title: Enable TFLOPs Calculation for Qwen3-Next

### Description
This PR implements the TFLOPs calculation logic for the Qwen3-Next architecture. Qwen3-Next utilizes a hybrid design containing both standard full attention layers and linear attention (Gated Delta Net) layers, alongside a Mixture-of-Experts (MoE) structure. This update ensures training TFLOPs are accurately reported for this model family.

### Key Changes

**1. TFLOPs Calculation Logic (`src/MaxText/maxtext_utils.py`)**
* **Added `calculate_gated_delta_net_flops_per_device`**: Implemented logic to calculate FLOPs for the Linear Attention layers, breaking down operations into:
    * **Projections**: QKVZ, BA, and Output projections.
    * **Convolution**: Depthwise convolutions on the key/value/gate states.
    * **Core Attention**: Intra-chunk and inter-chunk recurrent state operations.
* **Updated `calculate_tflops_training_per_device`**:
    * Added a specific branch for `DecoderBlockType.QWEN3_NEXT`.
    * Logic now calculates the number of "full attention" layers vs. "linear attention" layers based on the `inhomogeneous_layer_cycle_interval`.
    * Combines FLOPs from embeddings, MoE FFNs (routed + shared), full causal attention, and linear attention.
* **Updated FFN Helpers**: Verified `calculate_routed_and_shared_ffn_tflops_per_device` and `get_dense_moe_layers` explicitly support `QWEN3_NEXT`.

**2. Unit Tests (`tests/unit/flop_calculation_test.py`)**
* **Added `test_qwen3_next_flops`**: A new unit test that verifies the implementation against a "golden" manual calculation for the 80B model configuration.
* **Added `compute_qwen3_next_attention_flops_per_device`**: A helper function to compute the expected attention-specific FLOPs for the test assertion.

**3. Config Updates (`src/MaxText/configs/models/qwen3-next-80b-a3b.yml`)**
* Added `shared_experts: 1` to the model configuration to ensure correct parameter counting in the FFN FLOPs calculation.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/477291633

# Tests



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
