### PR TITLE
Onboard Olmo3 config and decoder layer

### DIFF
--- a/src/MaxText/common_types.py
+++ b/src/MaxText/common_types.py
@@ -100,6 +100,7 @@ class DecoderBlockType(enum.Enum):
   SIMPLE = "simple"
   SIMPLE_MLP = "simple_mlp"
   LLAMA4 = "llama4"
+  OLMO3 = "olmo3"
 
 
 class AttentionType(enum.Enum):

--- a/src/MaxText/configs/models/olmo3_32b.yml
+++ b/src/MaxText/configs/models/olmo3_32b.yml
@@ -1,0 +1,51 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AllenAI OLMo 3 32B Configuration
+# https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/main/config.json
+
+model_name: "olmo3_32b"
+decoder_block: "olmo3"
+
+# Model Dimensions
+base_emb_dim: 5120
+base_num_query_heads: 40
+base_num_kv_heads: 8
+base_mlp_dim: 27648
+base_num_decoder_layers: 64
+head_dim: 128
+
+# Activations & Normalization
+mlp_activations: ["silu", "linear"]
+normalization_layer_epsilon: 1.e-6
+use_qk_norm: True
+
+# Attention
+# Layers 0,1,2 use sliding window 4096. Layer 3 uses global. Repeats.
+sliding_window_size: 4096
+inhomogeneous_layer_cycle_interval: 4
+
+# RoPE (YaRN)
+rope_type: "yarn"
+rope_max_timescale: 500000 # rope_theta
+rope_factor: 8.0 # factor so 0.1 * ln(rope_factor) + 1.0 = 1.2079441541679836
+original_max_position_embeddings: 8192
+beta_fast: 32.0
+beta_slow: 1.0
+max_position_embeddings: 65536
+rope_attention_scaling: True
+
+# Embeddings
+vocab_size: 100278
+logits_via_embedding: False

--- a/src/MaxText/configs/models/olmo3_7b.yml
+++ b/src/MaxText/configs/models/olmo3_7b.yml
@@ -1,0 +1,51 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AllenAI OLMo 3 7B Configuration
+# https://huggingface.co/allenai/Olmo-3-7B-Instruct
+
+model_name: "olmo3_7b"
+decoder_block: "olmo3"
+
+# Model Dimensions
+base_emb_dim: 4096
+base_num_query_heads: 32
+base_num_kv_heads: 32
+base_mlp_dim: 11008
+base_num_decoder_layers: 32
+head_dim: 128
+
+# Activations & Normalization
+mlp_activations: ["silu", "linear"] # SwiGLU
+normalization_layer_epsilon: 1.e-6
+use_qk_norm: True
+
+# Attention
+# Layers 0,1,2 use sliding window 4096. Layer 3 uses global. Repeats.
+sliding_window_size: 4096
+inhomogeneous_layer_cycle_interval: 4
+
+# RoPE
+rope_type: "yarn"
+rope_max_timescale: 500000 # rope_theta
+rope_factor: 8.0 # factor so 0.1 * ln(rope_factor) + 1.0 = 1.2079441541679836
+original_max_position_embeddings: 8192
+beta_fast: 32.0
+beta_slow: 1.0
+max_position_embeddings: 65536
+rope_attention_scaling: True
+
+# Embeddings
+vocab_size: 100278
+logits_via_embedding: False

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -236,6 +236,8 @@ ModelName = Literal[
     "gpt-oss-120b",
     "llama4-17b-16e",
     "llama4-17b-128e",
+    "olmo3_7b",
+    "olmo3_32b",
 ]
 
 

--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -59,6 +59,7 @@ from MaxText.layers import (
     mixtral,
     qwen3,
     simple_layer,
+    olmo3,
 )
 
 # ------------------------------------------------------------------------------
@@ -430,6 +431,9 @@ class Decoder(nn.Module):
         return [simple_layer.SimpleMlpDecoderLayerToLinen]
       case DecoderBlockType.LLAMA4:
         return [llama4.Llama4ScannableBlockToLinen] if self.config.scan_layers else [llama4.Llama4DecoderLayerToLinen]
+      case DecoderBlockType.OLMO3:
+        return [olmo3.Olmo3ScannableBlockToLinen] if self.config.scan_layers else [olmo3.Olmo3DecoderLayerToLinen]
+
       case _:
         # Default case to handle any unknown decoder block types.
         raise ValueError(f"Incorrect decoder_block name {self.config.decoder_block.value=}")
@@ -479,6 +483,7 @@ class Decoder(nn.Module):
         DecoderBlockType.SIMPLE,
         DecoderBlockType.SIMPLE_MLP,
         DecoderBlockType.LLAMA4,
+        DecoderBlockType.OLMO3,
     ):
       return functools.partial(rms_norm, num_features=num_features, shard_mode=self.config.shard_mode)
     elif self.config.decoder_block == DecoderBlockType.GPT3:

--- a/src/MaxText/layers/olmo3.py
+++ b/src/MaxText/layers/olmo3.py
@@ -1,0 +1,295 @@
+"""
+Copyright 2023-2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Decoder layer definition for Olmo 3 models."""
+# pylint: disable=arguments-differ
+# pylint: disable=no-name-in-module
+
+
+from typing import Optional
+
+from jax.ad_checkpoint import checkpoint_name
+from jax.sharding import Mesh
+import jax.numpy as jnp
+
+from flax import linen as nn
+from flax import nnx
+
+from MaxText.common_types import AttentionType
+from MaxText.layers import initializers
+from MaxText.layers import attentions
+from MaxText.layers import models
+from MaxText.layers import quantizations
+from MaxText.layers.attentions import Attention
+from MaxText.layers.quantizations import AqtQuantization as Quant
+from MaxText.layers.normalizations import RMSNorm
+from MaxText import max_utils
+from MaxText.layers import nnx_wrappers
+from MaxText.layers.linears import MlpBlock
+
+
+# -----------------------------------------
+# The Decoder Layer for Olmo3 models
+# -----------------------------------------
+
+OLMO3_ATTENTION_PATTERN = (
+    attentions.AttentionType.LOCAL_SLIDING,
+    attentions.AttentionType.LOCAL_SLIDING,
+    attentions.AttentionType.LOCAL_SLIDING,
+    attentions.AttentionType.GLOBAL,
+)
+
+
+def get_attention_type(layer_id):
+  """Get attention type based on layer ID."""
+  layer_id %= len(OLMO3_ATTENTION_PATTERN)
+  return OLMO3_ATTENTION_PATTERN[layer_id]
+
+
+class Olmo3DecoderLayer(nnx.Module):
+  """Transformer decoder layer that attends to the encoder."""
+
+  def __init__(
+      self,
+      config: models.Config,
+      mesh: Mesh,
+      model_mode: str,
+      attention_type: AttentionType,
+      quant: Optional[Quant] = None,
+      rngs: nnx.Rngs = None,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.attention_type = attention_type
+    self.quant = quant
+
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
+
+    self.post_self_attention_layer_norm = RMSNorm(
+        num_features=dummy_inputs_shape[-1],
+        dtype=config.dtype,
+        weight_dtype=jnp.float32,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=rngs,
+    )
+
+    self.post_mlp_layer_norm = RMSNorm(
+        num_features=dummy_inputs_shape[-1],
+        dtype=config.dtype,
+        weight_dtype=jnp.float32,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=rngs,
+    )
+
+    # Self-attention block
+    self.attention = Attention(
+        config=config,
+        num_query_heads=config.num_query_heads,
+        num_kv_heads=config.num_kv_heads,
+        head_dim=config.head_dim,
+        max_target_length=config.max_target_length,
+        max_prefill_predict_length=config.max_prefill_predict_length,
+        attention_kernel=config.attention,
+        inputs_q_shape=dummy_inputs_shape,
+        inputs_kv_shape=dummy_inputs_shape,
+        mesh=mesh,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        dropout_rate=config.dropout_rate,
+        quant=self.quant,
+        kv_quant=quantizations.configure_kv_quant(config),
+        use_bias_in_projections=config.attention_bias,
+        attention_type=self.attention_type,
+        sliding_window_size=config.sliding_window_size,
+        query_pre_attn_scalar=(config.head_dim**-0.5),
+        model_mode=model_mode,
+        use_qk_norm=config.use_qk_norm,
+        rngs=rngs,
+    )
+
+    self.mlp = MlpBlock(
+        in_features=config.emb_dim,
+        intermediate_dim=config.mlp_dim,
+        activations=config.mlp_activations,
+        intermediate_dropout_rate=config.dropout_rate,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        config=config,
+        mesh=mesh,
+        quant=quant,
+        model_mode=model_mode,
+        rngs=rngs,
+    )
+
+  def __call__(
+      self,
+      inputs,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      previous_chunk=None,
+      page_state=None,
+      slot=None,
+      kv_cache=None,
+      attention_metadata=None,
+  ):
+    cfg = self.config
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
+
+    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
+
+    attention_lnx, kv_cache = self.attention(
+        inputs,
+        inputs,
+        decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        deterministic=deterministic,
+        model_mode=model_mode,
+        kv_cache=kv_cache,
+        attention_metadata=attention_metadata,
+    )
+
+    attention_lnx = nn.with_logical_constraint(
+        attention_lnx, ("activation_batch", "activation_norm_length", "activation_embed")
+    )
+
+    # Normalize stream before addition
+    attention_lnx = self.post_self_attention_layer_norm(attention_lnx)
+    attention_lnx = nn.with_logical_constraint(
+        attention_lnx, ("activation_batch", "activation_norm_length", "activation_embed")
+    )
+
+    intermediate_inputs = inputs + attention_lnx
+
+    # Fully Connected
+    mlp_lnx = self.mlp(intermediate_inputs)
+    mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+
+    # Normalize stream before addition
+    mlp_lnx = self.post_mlp_layer_norm(mlp_lnx)
+    mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+
+    layer_output = mlp_lnx + intermediate_inputs
+    layer_output = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(layer_output, deterministic=deterministic)
+
+    layer_output = nn.with_logical_constraint(
+        layer_output,
+        ("activation_batch", "activation_norm_length", "activation_embed"),
+    )
+
+    if cfg.record_internal_nn_metrics:
+      self.sow("intermediates", "activation_mean", jnp.mean(layer_output))
+      self.sow("intermediates", "activation_stdev", jnp.std(layer_output))
+      self.sow(
+          "intermediates",
+          "activation_fraction_zero",
+          jnp.sum(layer_output == 0) / jnp.size(layer_output),
+      )
+
+    if cfg.scan_layers:
+      return layer_output, None
+    else:
+      return layer_output, kv_cache
+
+
+Olmo3DecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Olmo3DecoderLayer,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)
+
+
+class Olmo3ScannableBlock(nnx.Module):
+  """A repeatable block of Olmo 3 decoder layers.
+
+    This block applies multiple decoder layers sequentially, using the attention
+    pattern defined by OLMO3_ATTENTION_PATTERN. It's designed to be
+    used with `nn.scan` for efficient compilation.
+
+  Attributes:
+    config: Config, MaxText model config
+    mesh: Mesh, JAX device mesh (used for sharding)
+    num_of_layers: int, number of decoder layers in the block
+    quant: Optional[Quant], quantization config
+  """
+
+  def __init__(
+      self,
+      config: models.Config,
+      mesh: Mesh,
+      model_mode: str,
+      quant: Optional[Quant] = None,
+      rngs: nnx.Rngs = None,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.quant = quant
+    for layer_id in range(config.inhomogeneous_layer_cycle_interval):
+      attention_type = get_attention_type(layer_id)
+      layer_name = f"layers_{layer_id}"
+      layer = Olmo3DecoderLayer(
+          config=config,
+          mesh=mesh,
+          model_mode=model_mode,
+          attention_type=attention_type,
+          quant=self.quant,
+          rngs=rngs,
+      )
+      setattr(self, layer_name, layer)
+
+  def __call__(
+      self,
+      inputs,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+  ):
+    cfg = self.config
+
+    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
+    y = inputs
+    for layer_id in range(cfg.inhomogeneous_layer_cycle_interval):
+      layer_name = f"layers_{layer_id}"
+      layer = getattr(self, layer_name)
+      y = layer(
+          y,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+      )
+      if cfg.scan_layers:
+        y = y[0]
+    if cfg.scan_layers:
+      return y, None
+    else:
+      return y
+
+
+Olmo3ScannableBlockToLinen = nnx_wrappers.to_linen_class(
+    Olmo3ScannableBlock,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -796,3 +796,20 @@ class TrainCompile(unittest.TestCase):
             "topk_routing_group=-1",
         )
     )
+
+  @pytest.mark.cpu_only
+  def test_olmo3_7b(self):
+    """AOT test for Olmo3 7B implementation"""
+    compiled_trainstep_file = "/tmp/test_olmo3_7b"
+    train_compile_main(
+        (
+            "",
+            os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "model_name=olmo3_7b",
+            "per_device_batch_size=1",
+            "scan_layers=True",
+        )
+    )


### PR DESCRIPTION
# Description

Onboard Olmo3 -7b and 32b configs and decoder layer.
* The pattern is similar to GPT-OSS and Gemma with interleaved attention
* I didn't select Olmo3.1 (latest) as I only found official [Olmo3.1-32b-instruct](https://huggingface.co/allenai/Olmo-3.1-32B-Instruct), but not Olmo3.1-7b. But we could onboard other [variants](https://screenshot.googleplex.com/5pBcZNsmB4PSriH) with RL of 7B if want. To simplify, so onboard Olmo3 for alignment. Let me know your thoughts.
* [Reference](https://github.com/allenai/OLMo-core/tree/6674dafa55c423859d6a567f472c8d7c07e344a7/src/scripts/train/OLMo3) of official implementation. OLMo-3 is built directly on the OLMo-2 architecture, it inherits this "reordered" (Post-Norm style with slight difference) normalization ([link](https://github.com/allenai/OLMo-core/blob/6674dafa55c423859d6a567f472c8d7c07e344a7/src/olmo_core/nn/transformer/config.py#L922)). It applies for both attention and mlp modules ([link](https://github.com/allenai/OLMo-core/blob/6674dafa55c423859d6a567f472c8d7c07e344a7/src/olmo_core/nn/transformer/block.py#L289)).

Next: we will need to work on checkpoint and verify logits.

# Tests

Expect added test to be green.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
