### PR TITLE
UT: add UT for RL and Update Docs for RL single host

### DIFF
--- a/src/MaxText/rl/utils_rl.py
+++ b/src/MaxText/rl/utils_rl.py
@@ -237,7 +237,9 @@ def check_answer(prompts, completions, answer, tmvp_config, **kargs):
 
 def get_match_numbers_regex(tmvp_config):
   """Returns a compiled regex to extract the answer from a completion."""
-  match_numbers = re.compile(rf"{tmvp_config.solution_start_token}.*?([\d\.]{{1,}})", flags=re.MULTILINE | re.DOTALL)
+  match_numbers = re.compile(
+      rf"{tmvp_config.solution_start_token}.*?([-+]?[\d\.,]{{1,}})", flags=re.MULTILINE | re.DOTALL
+  )
   if tmvp_config.debug.rl:
     match_numbers.findall(f"{tmvp_config.solution_start_token}  0.34  {tmvp_config.solution_end_token}")
   return match_numbers

--- a/tests/unit/evaluate_rl_test.py
+++ b/tests/unit/evaluate_rl_test.py
@@ -1,0 +1,498 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for RL evaluation functions."""
+
+# import pytest
+import unittest
+from unittest.mock import MagicMock, patch
+
+from MaxText.rl.evaluate_rl import score_responses
+from MaxText.rl.evaluate_rl import generate_responses
+from MaxText.rl.evaluate_rl import evaluate
+
+
+class MockDebugConfig:
+  """Mock debug configuration."""
+
+  def __init__(self, rl=False):
+    self.rl = rl
+
+
+class MockTMVPConfig:
+  """Mock TMVP configuration for testing evaluation functions."""
+
+  def __init__(
+      self,
+      reasoning_start_token="<think>",
+      reasoning_end_token="</think>",
+      solution_start_token="<answer>",
+      solution_end_token="</answer>",
+      debug_rl=False,
+  ):
+    self.reasoning_start_token = reasoning_start_token
+    self.reasoning_end_token = reasoning_end_token
+    self.solution_start_token = solution_start_token
+    self.solution_end_token = solution_end_token
+    self.debug = MockDebugConfig(debug_rl)
+
+
+class TestScoreResponses(unittest.TestCase):
+  """Tests for score_responses function."""
+
+  def test_exact_correct_answer(self):
+    """Test scoring when answer is exactly correct."""
+
+    config = MockTMVPConfig()
+    question = "What is 2+2?"
+    responses = ["<think>2+2=4</think><answer>4</answer>"]
+    answer = "4"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertTrue(is_correct)
+    self.assertTrue(is_partially_correct)
+    self.assertTrue(has_correct_format)
+
+  def test_partially_correct_answer(self):
+    """Test scoring when answer is within 10% of correct."""
+
+    config = MockTMVPConfig()
+    question = "What is 100+0?"
+    responses = ["<think>Approximately 100</think><answer>95</answer>"]
+    answer = "100"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertFalse(is_correct)
+    self.assertTrue(is_partially_correct)  # 95/100 = 0.95, within 0.9-1.1
+    self.assertTrue(has_correct_format)
+
+  def test_incorrect_answer(self):
+    """Test scoring when answer is incorrect."""
+
+    config = MockTMVPConfig()
+    question = "What is 50+50?"
+    responses = ["<think>Let me calculate</think><answer>50</answer>"]
+    answer = "100"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertFalse(is_correct)
+    self.assertFalse(is_partially_correct)  # 50/100 = 0.5, outside range
+    self.assertTrue(has_correct_format)
+
+  def test_correct_format_wrong_answer(self):
+    """Test scoring with correct format but wrong answer."""
+
+    config = MockTMVPConfig()
+    question = "What is 10+10?"
+    responses = ["<think>Thinking...</think><answer>5</answer>"]
+    answer = "20"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertFalse(is_correct)
+    self.assertFalse(is_partially_correct)
+    self.assertTrue(has_correct_format)
+
+  def test_incorrect_format(self):
+    """Test scoring when format is incorrect."""
+
+    config = MockTMVPConfig()
+    question = "What is 2+2?"
+    responses = ["The answer is 4"]  # Missing format tokens
+    answer = "4"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertFalse(is_correct)
+    self.assertFalse(is_partially_correct)
+    self.assertFalse(has_correct_format)
+
+  def test_multiple_responses_finds_correct(self):
+    """Test that multiple responses are checked and correct one found."""
+
+    config = MockTMVPConfig()
+    question = "What is 5+5?"
+    responses = [
+        "Wrong answer",  # No format, wrong
+        "<think>Thinking</think><answer>8</answer>",  # Format but wrong
+        "<think>5+5=10</think><answer>10</answer>",  # Correct!
+    ]
+    answer = "10"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertTrue(is_correct)
+    self.assertTrue(is_partially_correct)
+    self.assertTrue(has_correct_format)
+
+  def test_answer_with_currency_symbol(self):
+    """Test scoring handles currency symbols in answer."""
+
+    config = MockTMVPConfig()
+    question = "What is the price?"
+    responses = ["<think>Calculating</think><answer>$100</answer>"]
+    answer = "$100"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertTrue(is_correct)
+    self.assertTrue(is_partially_correct)
+    self.assertTrue(has_correct_format)
+
+  def test_answer_with_comma(self):
+    """Test scoring handles commas in numbers."""
+
+    config = MockTMVPConfig()
+    question = "What is 1000+234?"
+    responses = ["<think>Adding</think><answer>1,234</answer>"]
+    answer = "1,234"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertTrue(is_correct)
+    self.assertTrue(is_partially_correct)
+    self.assertTrue(has_correct_format)
+
+  def test_non_numeric_answer_handling(self):
+    """Test scoring handles non-numeric extracted values gracefully."""
+
+    config = MockTMVPConfig()
+    question = "What is the result?"
+    responses = ["<think>Thinking</think><answer>hello</answer>"]
+    answer = "42"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertFalse(is_correct)
+    self.assertFalse(is_partially_correct)
+    self.assertTrue(has_correct_format)
+
+  def test_empty_responses_list(self):
+    """Test scoring with empty responses list."""
+
+    config = MockTMVPConfig()
+    question = "What is 2+2?"
+    responses = []
+    answer = "4"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertFalse(is_correct)
+    self.assertFalse(is_partially_correct)
+    self.assertFalse(has_correct_format)
+
+  def test_custom_tokens(self):
+    """Test scoring with custom reasoning/answer tokens."""
+
+    config = MockTMVPConfig(
+        reasoning_start_token="<THINK>",
+        reasoning_end_token="</THINK>",
+        solution_start_token="<AND>",
+        solution_end_token="</AND>",
+    )
+    question = "What is 3+3?"
+    responses = ["<THINK>3+3=6</THINK><AND>6</AND>"]
+    answer = "6"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertTrue(is_correct)
+    self.assertTrue(is_partially_correct)
+    self.assertTrue(has_correct_format)
+
+  def test_negative_numbers(self):
+    """Test scoring with negative numbers."""
+
+    config = MockTMVPConfig()
+    question = "What is 5-10?"
+    responses = ["<think>5-10=-5</think><answer>-5</answer>"]
+    answer = "-5"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertTrue(is_correct)
+    self.assertTrue(is_partially_correct)
+    self.assertTrue(has_correct_format)
+
+  def test_decimal_numbers(self):
+    """Test scoring with decimal numbers."""
+
+    config = MockTMVPConfig()
+    question = "What is 1/4?"
+    responses = ["<think>1/4=0.25</think><answer>0.25</answer>"]
+    answer = "0.25"
+
+    is_correct, is_partially_correct, has_correct_format = score_responses(config, question, responses, answer)
+
+    self.assertTrue(is_correct)
+    self.assertTrue(is_partially_correct)
+    self.assertTrue(has_correct_format)
+
+
+class TestGenerateResponses(unittest.TestCase):
+  """Tests for generate_responses function."""
+
+  def test_generate_responses_single_pass(self):
+    """Test generating responses with single pass."""
+
+    config = MagicMock()
+    config.max_target_length = 512
+    config.max_prefill_predict_length = 128
+    config.eval_sampling_strategy = "greedy"  ## can be "greedy", "standard", or "liberal"
+    config.generation_configs = {
+        "greedy": {
+            "eval_temperature": 0.01,
+            "eval_top_k": 1,
+            "eval_top_p": 1.0,
+        }
+    }
+    config.debug = MockDebugConfig(rl=False)
+
+    mock_rl_cluster = MagicMock()
+    mock_response = MagicMock()
+    mock_response.text = ["Response 1", "Response 2"]
+    mock_rl_cluster.rollout.generate.return_value = mock_response
+
+    prompts = ["Prompt 1", "Prompt 2"]
+
+    responses = generate_responses(
+        tmvp_config=config,
+        prompts=prompts,
+        rl_cluster=mock_rl_cluster,
+        num_passes=1,
+    )
+
+    self.assertEqual(len(responses), 2)
+    self.assertEqual(responses[0], ["Response 1"])
+    self.assertEqual(responses[1], ["Response 2"])
+
+  def test_generate_responses_multiple_passes(self):
+    """Test generating responses with multiple passes."""
+
+    config = MagicMock()
+    config.max_target_length = 512
+    config.max_prefill_predict_length = 128
+    config.eval_sampling_strategy = "default"
+    config.generation_configs = {
+        "default": {
+            "eval_temperature": 0.7,
+            "eval_top_k": 50,
+            "eval_top_p": 0.9,
+        }
+    }
+    config.debug = MockDebugConfig(rl=False)
+
+    mock_rl_cluster = MagicMock()
+    mock_response_1 = MagicMock()
+    mock_response_1.text = ["Pass1-R1", "Pass1-R2"]
+    mock_response_2 = MagicMock()
+    mock_response_2.text = ["Pass2-R1", "Pass2-R2"]
+    mock_rl_cluster.rollout.generate.side_effect = [
+        mock_response_1,
+        mock_response_2,
+    ]
+
+    prompts = ["Prompt 1", "Prompt 2"]
+
+    responses = generate_responses(
+        tmvp_config=config,
+        prompts=prompts,
+        rl_cluster=mock_rl_cluster,
+        num_passes=2,
+    )
+
+    self.assertEqual(len(responses), 2)
+    self.assertEqual(responses[0], ["Pass1-R1", "Pass2-R1"])
+    self.assertEqual(responses[1], ["Pass1-R2", "Pass2-R2"])
+
+
+class TestEvaluate(unittest.TestCase):
+  """Tests for evaluate function."""
+
+  @patch("MaxText.rl.evaluate_rl.generate_responses")
+  def test_evaluate_perfect_accuracy(self, mock_generate):
+    """Test evaluate with perfect accuracy."""
+
+    config = MockTMVPConfig()
+
+    # Mock dataset with one batch
+    mock_batch = {
+        "answer": ["4", "10"],
+        "question": ["2+2?", "5+5?"],
+        "prompts": ["Prompt1", "Prompt2"],
+    }
+    mock_dataset = [mock_batch]
+
+    # Mock generate_responses to return correct formatted answers
+    mock_generate.return_value = [
+        ["<think>2+2=4</think><answer>4</answer>"],
+        ["<think>5+5=10</think><answer>10</answer>"],
+    ]
+
+    mock_rl_cluster = MagicMock()
+
+    (corr, total, accuracy, partial_accuracy, format_accuracy), _ = evaluate(
+        tmvp_config=config,
+        dataset=mock_dataset,
+        rl_cluster=mock_rl_cluster,
+        num_passes=1,
+    )
+
+    self.assertEqual(corr, 2)
+    self.assertEqual(total, 2)
+    self.assertEqual(accuracy, 100.0)
+    self.assertEqual(partial_accuracy, 100.0)
+    self.assertEqual(format_accuracy, 100.0)
+
+  @patch("MaxText.rl.evaluate_rl.generate_responses")
+  def test_evaluate_partial_accuracy(self, mock_generate):
+    """Test evaluate with partial accuracy."""
+
+    config = MockTMVPConfig()
+
+    mock_batch = {
+        "answer": ["4", "10"],
+        "question": ["2+2?", "5+5?"],
+        "prompts": ["Prompt1", "Prompt2"],
+    }
+    mock_dataset = [mock_batch]
+
+    # First is correct, second is wrong
+    mock_generate.return_value = [
+        ["<think>Correct</think><answer>4</answer>"],
+        ["<think>Wrong</think><answer>5</answer>"],  # Wrong answer
+    ]
+
+    mock_rl_cluster = MagicMock()
+
+    (corr, total, accuracy, partial_accuracy, format_accuracy), _ = evaluate(
+        tmvp_config=config,
+        dataset=mock_dataset,
+        rl_cluster=mock_rl_cluster,
+        num_passes=1,
+    )
+
+    self.assertEqual(corr, 1)
+    self.assertEqual(total, 2)
+    self.assertEqual(accuracy, 50.0)
+    self.assertEqual(partial_accuracy, 50.0)
+    self.assertEqual(format_accuracy, 100.0)
+
+  @patch("MaxText.rl.evaluate_rl.generate_responses")
+  def test_evaluate_with_format_errors(self, mock_generate):
+    """Test evaluate with format errors."""
+
+    config = MockTMVPConfig()
+
+    mock_batch = {
+        "answer": ["4"],
+        "question": ["2+2?"],
+        "prompts": ["Prompt1"],
+    }
+    mock_dataset = [mock_batch]
+
+    # Missing format tokens
+    mock_generate.return_value = [
+        ["The answer is 4"],  # No format tokens
+    ]
+
+    mock_rl_cluster = MagicMock()
+
+    (corr, total, accuracy, partial_accuracy, format_accuracy), _ = evaluate(
+        tmvp_config=config,
+        dataset=mock_dataset,
+        rl_cluster=mock_rl_cluster,
+        num_passes=1,
+    )
+
+    self.assertEqual(corr, 0)
+    self.assertEqual(total, 1)
+    self.assertEqual(accuracy, 0.0)
+    self.assertEqual(partial_accuracy, 0.0)
+    self.assertEqual(format_accuracy, 0.0)
+
+  @patch("MaxText.rl.evaluate_rl.generate_responses")
+  def test_evaluate_make_lst_correct(self, mock_generate):
+    """Test evaluate returns list of correct responses when corr_lst=True."""
+
+    config = MockTMVPConfig()
+
+    mock_batch = {
+        "answer": ["4", "10"],
+        "question": ["2+2?", "5+5?"],
+        "prompts": ["Prompt1", "Prompt2"],
+    }
+    mock_dataset = [mock_batch]
+
+    mock_generate.return_value = [
+        ["<think>Correct</think><answer>4</answer>"],
+        ["<think>Wrong</think><answer>5</answer>"],
+    ]
+
+    mock_rl_cluster = MagicMock()
+
+    _, response_lst = evaluate(
+        tmvp_config=config,
+        dataset=mock_dataset,
+        rl_cluster=mock_rl_cluster,
+        num_passes=1,
+        corr_lst=True,
+        make_lst=True,
+    )
+
+    # Should only contain correct response
+    self.assertEqual(len(response_lst), 1)
+    self.assertEqual(response_lst[0][0], "2+2?")  # question
+    self.assertEqual(response_lst[0][1], "4")  # answer
+
+  @patch("MaxText.rl.evaluate_rl.generate_responses")
+  def test_evaluate_make_lst_incorrect(self, mock_generate):
+    """Test evaluate returns list of incorrect responses when corr_lst=False."""
+
+    config = MockTMVPConfig()
+
+    mock_batch = {
+        "answer": ["4", "10"],
+        "question": ["2+2?", "5+5?"],
+        "prompts": ["Prompt1", "Prompt2"],
+    }
+    mock_dataset = [mock_batch]
+
+    mock_generate.return_value = [
+        ["<think>Correct</think><answer>4</answer>"],
+        ["<think>Wrong</think><answer>5</answer>"],
+    ]
+
+    mock_rl_cluster = MagicMock()
+
+    _, response_lst = evaluate(
+        tmvp_config=config,
+        dataset=mock_dataset,
+        rl_cluster=mock_rl_cluster,
+        num_passes=1,
+        corr_lst=False,
+        make_lst=True,
+    )
+
+    # Should only contain incorrect response
+    self.assertEqual(len(response_lst), 1)
+    self.assertEqual(response_lst[0][0], "5+5?")  # question
+    self.assertEqual(response_lst[0][1], "10")  # answer
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/utils_rl_test.py
+++ b/tests/unit/utils_rl_test.py
@@ -1,0 +1,516 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for RL utility functions."""
+
+# import pytest
+import unittest
+from unittest.mock import MagicMock
+
+from MaxText.rl import utils_rl
+
+
+class MockDebugConfig:
+  """Mock debug configuration."""
+
+  def __init__(self, rl=False):
+    self.rl = rl
+
+
+class MockTMVPConfig:
+  """Mock TMVP configuration for testing reward functions."""
+
+  def __init__(
+      self,
+      reasoning_start_token="<think>",
+      reasoning_end_token="</think>",
+      solution_start_token="<answer>",
+      solution_end_token="</answer>",
+      reward_exact_format_match=3.0,  # aligned with rl.yml
+      reward_white_space_format_match=1.5,
+      reward_partial_format_match=0.5,
+      reward_ratio_guess_to_answer_high=0.5,
+      reward_ratio_guess_to_answer_low=0.25,
+      penalty_incorrect_format=-0.5,
+      penalty_incorrect_answer=-1.0,
+      dataset_name="gsm8k",  # TODO support DAPO
+      debug_rl=False,
+  ):
+    self.reasoning_start_token = reasoning_start_token
+    self.reasoning_end_token = reasoning_end_token
+    self.solution_start_token = solution_start_token
+    self.solution_end_token = solution_end_token
+    self.reward_exact_format_match = reward_exact_format_match
+    self.reward_partial_format_match = reward_partial_format_match
+    self.penalty_incorrect_format = penalty_incorrect_format
+    self.reward_white_space_format_match = reward_white_space_format_match
+    self.reward_ratio_guess_to_answer_high = reward_ratio_guess_to_answer_high
+    self.reward_ratio_guess_to_answer_low = reward_ratio_guess_to_answer_low
+    self.penalty_incorrect_answer = penalty_incorrect_answer
+    self.dataset_name = dataset_name
+    self.debug = MockDebugConfig(debug_rl)
+
+
+class TestExtractHashAnswer(unittest.TestCase):
+  """Tests for extract_hash_answer function."""
+
+  def test_extract_hash_answer_with_valid_hash(self):
+    """Test extraction with valid #### delimiter."""
+    text = "The calculation is 2+2=4. #### 4"
+    result = utils_rl.extract_hash_answer(text)
+    self.assertEqual(result, "4")
+
+  def test_extract_hash_answer_with_spaces(self):
+    """Test extraction handles trailing/leading spaces."""
+    text = "Some reasoning here. ####   42  "
+    result = utils_rl.extract_hash_answer(text)
+    self.assertEqual(result, "42")
+
+  def test_extract_hash_answer_without_hash(self):
+    """Test extraction returns None when no #### delimiter."""
+    text = "No hash delimiter in this text"
+    result = utils_rl.extract_hash_answer(text)
+    self.assertIsNone(result)
+
+  def test_extract_hash_answer_with_multiple_hashes(self):
+    """Test extraction with multiple #### delimiters takes first split."""
+    text = "Step 1 #### answer1 #### answer2"
+    result = utils_rl.extract_hash_answer(text)
+    self.assertEqual(result, "answer1")
+
+  def test_extract_hash_answer_with_negative_number(self):
+    """Test extraction with negative number."""
+    text = "The answer is #### -5"
+    result = utils_rl.extract_hash_answer(text)
+    self.assertEqual(result, "-5")
+
+
+class TestGetMatchFormatRegex(unittest.TestCase):
+  """Tests for get_match_format_regex function."""
+
+  def test_regex_matches_correct_format(self):
+    """Test regex matches properly formatted completion."""
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_format_regex(config)
+
+    completion = "<think>Let me think about this</think><answer>42</answer>"
+    match = regex.search(completion)
+    self.assertIsNotNone(match)
+    self.assertEqual(match.group(1), "42")
+
+  def test_regex_matches_with_whitespace(self):
+    """Test regex handles leading/trailing whitespace."""
+
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_format_regex(config)
+
+    completion = "  <think>Reasoning</think><answer>100</answer>  "
+    match = regex.search(completion)
+    self.assertIsNotNone(match)
+    self.assertEqual(match.group(1), "100")
+
+  def test_regex_matches_multiline_reasoning(self):
+    """Test regex handles multiline reasoning."""
+
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_format_regex(config)
+
+    completion = "<think>Line 1\nLine 2\nLine 3</think><answer>yes</answer>"
+    match = regex.search(completion)
+    self.assertIsNotNone(match)
+    self.assertEqual(match.group(1), "yes")
+
+  def test_regex_does_not_match_missing_reasoning(self):
+    """Test regex doesn't match when reasoning section is missing."""
+
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_format_regex(config)
+
+    completion = "<answer>42</answer>"
+    match = regex.search(completion)
+    self.assertIsNone(match)
+
+  def test_regex_does_not_match_missing_answer(self):
+    """Test regex doesn't match when answer section is missing."""
+
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_format_regex(config)
+
+    completion = "<think>Some reasoning</think>"
+    match = regex.search(completion)
+    self.assertIsNone(match)
+
+  def test_regex_with_custom_tokens(self):
+    """Test regex works with custom tokens."""
+
+    config = MockTMVPConfig(
+        reasoning_start_token="<REASON>",
+        reasoning_end_token="</REASON>",
+        solution_start_token="<SOLUTION>",
+        solution_end_token="</SOLUTION>",
+    )
+    regex = utils_rl.get_match_format_regex(config)
+
+    completion = "<REASON>Thinking...</REASON><SOLUTION>answer</SOLUTION>"
+    match = regex.search(completion)
+    self.assertIsNotNone(match)
+    self.assertEqual(match.group(1), "answer")
+
+
+class TestMatchFormatExactly(unittest.TestCase):
+  """Tests for match_format_exactly function."""
+
+  def test_exact_format_match_gives_reward(self):
+    """Test exact format match returns reward."""
+
+    config = MockTMVPConfig(reward_exact_format_match=2.0)
+    prompts = ["What is 2+2?"]
+    completions = ["<think>2+2=4</think><answer>4</answer>"]
+
+    scores = utils_rl.match_format_exactly(prompts, completions, config)
+    self.assertEqual(scores, [2.0])
+
+  def test_incorrect_format_gives_zero(self):
+    """Test incorrect format returns zero."""
+
+    config = MockTMVPConfig(reward_exact_format_match=2.0)
+    prompts = ["What is 2+2?"]
+    completions = ["The answer is 4"]
+
+    scores = utils_rl.match_format_exactly(prompts, completions, config)
+    self.assertEqual(scores, [0])
+
+  def test_multiple_completions(self):
+    """Test scoring multiple completions."""
+
+    config = MockTMVPConfig(reward_exact_format_match=2.0)
+    prompts = ["Q1", "Q2", "Q3"]
+    completions = [
+        "<think>Thinking</think><answer>1</answer>",  # Matches
+        "Just an answer: 2",  # Doesn't match
+        "<think>More thinking</think><answer>3</answer>",  # Matches
+    ]
+
+    scores = utils_rl.match_format_exactly(prompts, completions, config)
+    self.assertEqual(scores, [2.0, 0, 2.0])
+
+
+class TestMatchFormatApproximately(unittest.TestCase):
+  """Tests for match_format_approximately function."""
+
+  def test_all_tokens_present_once(self):
+    """Test reward when all tokens appear exactly once."""
+
+    config = MockTMVPConfig(
+        reward_partial_format_match=0.5,
+        penalty_incorrect_format=-0.5,
+    )
+    completions = ["<think>Thinking</think><answer>42</answer>"]
+
+    scores = utils_rl.match_format_approximately([], completions, config)
+    # 4 tokens * 0.5 = 2.0
+    self.assertEqual(scores, [2.0])
+
+  def test_missing_tokens_penalized(self):
+    """Test penalty when tokens are missing."""
+
+    config = MockTMVPConfig(
+        reward_partial_format_match=0.5,
+        penalty_incorrect_format=-0.5,
+    )
+    completions = ["Just plain text without any tokens"]
+
+    scores = utils_rl.match_format_approximately([], completions, config)
+    # 4 tokens * -0.5 = -2.0
+    self.assertEqual(scores, [-2.0])
+
+  def test_duplicate_tokens_penalized(self):
+    """Test penalty when tokens appear multiple times."""
+
+    config = MockTMVPConfig(
+        reward_partial_format_match=0.5,
+        penalty_incorrect_format=-0.5,
+    )
+    completions = ["<think>First</think><think>Second</think><answer>42</answer>"]
+
+    scores = utils_rl.match_format_approximately([], completions, config)
+    # <think>: 2 times -> -0.5, </think>: 2 times -> -0.5
+    # <answer>: 1 time -> 0.5, </answer>: 1 time -> 0.5
+    self.assertEqual(scores, [0.0])
+
+  def test_partial_tokens_mixed_rewards(self):
+    """Test mixed rewards for partial token presence."""
+
+    config = MockTMVPConfig(
+        reward_partial_format_match=0.5,
+        penalty_incorrect_format=-0.5,
+    )
+    completions = ["<think>Thinking</think>"]  # Missing answer tokens
+
+    scores = utils_rl.match_format_approximately([], completions, config)
+    # <think>: 1 -> 0.5, </think>: 1 -> 0.5
+    # <answer>: 0 -> -0.5, </answer>: 0 -> -0.5
+    self.assertEqual(scores, [0.0])
+
+
+class TestCheckAnswer(unittest.TestCase):
+  """Tests for check_answer function."""
+
+  def test_exact_answer_match(self):
+    """Test exact answer match gets full reward."""
+
+    config = MockTMVPConfig(reward_exact_format_match=2.0)
+    completions = ["<think>2+2=4</think><answer>4</answer>"]
+    answers = ["4"]
+
+    scores = utils_rl.check_answer([], completions, answers, config)
+    self.assertEqual(scores, [2.0])
+
+  def test_whitespace_answer_match(self):
+    """Test answer match with whitespace differences."""
+
+    config = MockTMVPConfig(
+        reward_exact_format_match=2.0,
+        reward_white_space_format_match=1.5,
+    )
+    completions = ["<think>Thinking</think><answer> 42 </answer>"]
+    answers = ["42"]
+
+    scores = utils_rl.check_answer([], completions, answers, config)
+    self.assertEqual(scores, [1.5])
+
+  def test_ratio_answer_high_reward(self):
+    """Test answer within 10% gets high ratio reward."""
+
+    config = MockTMVPConfig(
+        reward_ratio_guess_to_answer_high=1.0,
+        reward_ratio_guess_to_answer_low=0.5,
+    )
+    completions = ["<think>Approx</think><answer>95</answer>"]
+    answers = ["100"]  # 95/100 = 0.95, within 0.9-1.1
+
+    scores = utils_rl.check_answer([], completions, answers, config)
+    self.assertEqual(scores, [1.0])
+
+  def test_ratio_answer_low_reward(self):
+    """Test answer within 20% but not 10% gets low ratio reward."""
+
+    config = MockTMVPConfig(
+        reward_ratio_guess_to_answer_high=1.0,
+        reward_ratio_guess_to_answer_low=0.5,
+    )
+    completions = ["<think>Approx</think><answer>85</answer>"]
+    answers = ["100"]  # 85/100 = 0.85, within 0.8-1.2 but not 0.9-1.1
+
+    scores = utils_rl.check_answer([], completions, answers, config)
+    self.assertEqual(scores, [0.5])
+
+  def test_wrong_answer_penalized(self):
+    """Test wrong answer gets penalty."""
+
+    config = MockTMVPConfig(penalty_incorrect_answer=-1.0)
+    completions = ["<think>Wrong</think><answer>50</answer>"]
+    answers = ["100"]  # 50/100 = 0.5, outside all ranges
+
+    scores = utils_rl.check_answer([], completions, answers, config)
+    self.assertEqual(scores, [-1.0])
+
+  def test_no_answer_extracted(self):
+    """Test zero score when answer cannot be extracted."""
+
+    config = MockTMVPConfig()
+    completions = ["No proper format here"]
+    answers = ["42"]
+    scores = utils_rl.check_answer([], completions, answers, config)
+    self.assertEqual(scores, [0])
+
+  def test_non_numeric_answer_penalized(self):
+    """Test non-numeric answer gets format penalty."""
+
+    config = MockTMVPConfig(penalty_incorrect_format=-0.5)
+    completions = ["<think>Thinking</think><answer>not a number</answer>"]
+    answers = ["42"]
+
+    scores = utils_rl.check_answer([], completions, answers, config)
+    self.assertEqual(scores, [-0.5])
+
+
+class TestGetMatchNumbersRegex(unittest.TestCase):
+  """Tests for get_match_numbers_regex function."""
+
+  def test_extracts_integer(self):
+    """Test extraction of integer from answer."""
+
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_numbers_regex(config)
+    text = "<answer>42</answer>"
+    match = regex.search(text)
+    self.assertIsNotNone(match)
+    self.assertEqual(match.group(1), "42")
+
+  def test_extracts_integer_with_comma(self):
+    """Test extraction of negative integer from answer."""
+
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_numbers_regex(config)
+    text = "<answer>1,234</answer>"
+    match = regex.search(text)
+    self.assertIsNotNone(match)
+    self.assertEqual(match.group(1), "1,234")
+
+  def test_extracts_negative_integer(self):
+    """Test extraction of negative integer from answer."""
+
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_numbers_regex(config)
+    text = "<answer>-42</answer>"
+    match = regex.search(text)
+    self.assertIsNotNone(match)
+    self.assertEqual(match.group(1), "-42")
+
+  def test_extracts_decimal(self):
+    """Test extraction of decimal from answer."""
+
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_numbers_regex(config)
+    text = "<answer>3.14159</answer>"
+    match = regex.search(text)
+    self.assertIsNotNone(match)
+    self.assertEqual(match.group(1), "3.14159")
+
+  def test_extracts_number_with_text(self):
+    """Test extraction of number from text with surrounding words."""
+
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_numbers_regex(config)
+
+    text = "<answer>The answer is 123 dollars</answer>"
+    match = regex.search(text)
+    self.assertIsNotNone(match)
+    self.assertEqual(match.group(1), "123")
+
+  def test_no_number_in_answer(self):
+    """Test no match when answer contains no number."""
+
+    config = MockTMVPConfig()
+    regex = utils_rl.get_match_numbers_regex(config)
+    text = "<answer>no numbers here</answer>"
+    match = regex.search(text)
+    self.assertIsNone(match)
+
+
+class TestCheckNumbers(unittest.TestCase):
+  """Tests for check_numbers function."""
+
+  def test_exact_number_match(self):
+    """Test exact number match gets reward."""
+
+    config = MockTMVPConfig()
+    completions = ["<answer>42</answer>"]
+    answers = ["42"]
+
+    scores = utils_rl.check_numbers([], completions, answers, config, question=["Q"])
+    self.assertEqual(scores, [1.5])
+
+  def test_number_mismatch(self):
+    """Test number mismatch gets zero."""
+
+    config = MockTMVPConfig()
+    completions = ["<answer>10</answer>"]
+    answers = ["42"]
+
+    scores = utils_rl.check_numbers([], completions, answers, config, question=["Q"])
+    self.assertEqual(scores, [0.0])
+
+  def test_no_number_extracted(self):
+    """Test zero when no number can be extracted."""
+
+    config = MockTMVPConfig()
+    completions = ["No answer tag here"]
+    answers = ["42"]
+
+    scores = utils_rl.check_numbers([], completions, answers, config, question=["Q"])
+    self.assertEqual(scores, [0])
+
+  def test_float_comparison(self):
+    """Test float number comparison."""
+
+    config = MockTMVPConfig()
+    completions = ["<answer>3.5</answer>"]
+    answers = ["3.5"]
+
+    scores = utils_rl.check_numbers([], completions, answers, config, question=["Q"])
+    self.assertEqual(scores, [1.5])
+
+  def test_invalid_answer_format(self):
+    """Test zero when answer is not a valid number."""
+
+    config = MockTMVPConfig()
+    completions = ["<answer>42</answer>"]
+    answers = ["not a number"]
+
+    scores = utils_rl.check_numbers([], completions, answers, config, question=["Q"])
+    self.assertEqual(scores, [0])
+
+
+class TestGetOptimizer(unittest.TestCase):
+  """Tests for get_optimizer function."""
+
+  def test_get_optimizer_without_gradient_clipping(self):
+    """Test optimizer creation without gradient clipping."""
+
+    config = MagicMock()
+    config.learning_rate = 1e-4
+    config.warmup_steps_fraction = 0.1
+    config.adam_b1 = 0.9
+    config.adam_b2 = 0.999
+    config.adam_weight_decay = 0.01
+    config.gradient_clipping_threshold = 0  # No clipping
+
+    optimizer = utils_rl.get_optimizer(config, max_train_steps=1000)
+    self.assertIsNotNone(optimizer)
+
+  def test_get_optimizer_with_gradient_clipping(self):
+    """Test optimizer creation with gradient clipping."""
+
+    config = MagicMock()
+    config.learning_rate = 1e-4
+    config.warmup_steps_fraction = 0.1
+    config.adam_b1 = 0.9
+    config.adam_b2 = 0.999
+    config.adam_weight_decay = 0.01
+    config.gradient_clipping_threshold = 1.0  # With clipping
+
+    optimizer = utils_rl.get_optimizer(config, max_train_steps=1000)
+    self.assertIsNotNone(optimizer)
+
+  def test_get_optimizer_warmup_steps(self):
+    """Test optimizer warmup steps calculation."""
+
+    config = MagicMock()
+    config.learning_rate = 1e-4
+    config.warmup_steps_fraction = 0.2
+    config.adam_b1 = 0.9
+    config.adam_b2 = 0.999
+    config.adam_weight_decay = 0.01
+    config.gradient_clipping_threshold = 0
+
+    max_train_steps = 1000
+    optimizer = utils_rl.get_optimizer(config, max_train_steps=max_train_steps)
+    self.assertIsNotNone(optimizer)
+    # Warmup steps should be 0.2 * 1000 = 200
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

Add UT for rl, fix a potential issue of regex patten match in utils_rl.py
Update Docs for post-training RL single host

# Tests

Add Unit test cases (evaluate_rl.py 20 cases, utils_rl.py 39 cases)
Using below cmd line to run unit test specifically
```
 python3 -m pytest tests/unit/evaluate_rl_test.py
 python3 -m pytest tests/unit/utils_rl_test.py
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
