### PR TITLE
fix: remove --2a886c8_chip_config_name flag in sparsecore offloading

### DIFF
--- a/benchmarks/xla_flags_library.py
+++ b/benchmarks/xla_flags_library.py
@@ -72,7 +72,6 @@ ENABLE_SPARSECORE_OFFLOADING_BASE_FLAGS = (
     " --xla_sc_enable_instruction_fusion=false"
     " --xla_sc_disjoint_spmem=false"
     " --xla_sc_disable_megacore_partitioning=true"
-    " --2a886c8_chip_config_name=megachip_tccontrol"
 )
 
 


### PR DESCRIPTION
# Description

The flag is unsupported in libtpu versions greater than 0.0.24. Since our current environment uses v0.0.30+, the flag is obsolete.
Confirmed with rishabhbaghel@google.com that this flag is not in use across our stack.

FIXES: b/474511786


# Tests

[Training with the `--2a886c8_chip_config_name` flag](https://paste.googleplex.com/6223870442995712)
[Training without the `--2a886c8_chip_config_name` flag](https://paste.googleplex.com/5880293158420480)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
