### PR TITLE
Doc warnings are not errors

### DIFF
--- a/.github/workflows/check_docs_build.yml
+++ b/.github/workflows/check_docs_build.yml
@@ -34,7 +34,7 @@ jobs:
           . $GITHUB_WORKSPACE/venv/bin/activate
           uv pip install -e . --no-deps
           uv pip install torch
-          sphinx-build -W -b html docs docs/_build/html
+          sphinx-build -b html docs docs/_build/html
         env:
           JAX_PLATFORMS: cpu
           CUDA_VISIBLE_DEVICES: ""


### PR DESCRIPTION
# Description

Remove `-W` recognizing warnings as errors for doc build.

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
