### PR TITLE
Update run_maxtext_via_xpk.md to fix path to docker image build scripts

### DIFF
--- a/docs/run_maxtext/run_maxtext_via_xpk.md
+++ b/docs/run_maxtext/run_maxtext_via_xpk.md
@@ -129,13 +129,13 @@ pip install xpk
     -   **For TPUs:**
 
         ```
-        bash docker_build_dependency_image.sh DEVICE=tpu MODE=stable
+        bash dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable
         ```
 
     -   **For GPUs:**
 
         ```
-        bash docker_build_dependency_image.sh DEVICE=gpu MODE=stable
+        bash dependencies/scripts/docker_build_dependency_image.sh DEVICE=gpu MODE=stable
         ```
 
 * * * * *


### PR DESCRIPTION
# Description

Update to the new location of docker image build

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
