### PR TITLE
use prod diagon instances

### DIFF
--- a/src/MaxText/managed_mldiagnostics.py
+++ b/src/MaxText/managed_mldiagnostics.py
@@ -72,5 +72,4 @@ class ManagedMLDiagnostics:
         gcs_path=config.managed_mldiagnostics_dir,
         # TODO: b/455623960 - Remove the following once multi-region and prod support are enabled.
         region="us-central1",
-        environment="autopush",  # Default would be "prod" for formal launch.
     )


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

Creating a PR addressing rolled back part that is not impacting dependency graph.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
