### PR TITLE
Add support for more datasets for rl

### DIFF
--- a/src/MaxText/configs/rl.yml
+++ b/src/MaxText/configs/rl.yml
@@ -92,7 +92,7 @@ enable_tunix_perf_metrics: False
 batch_size: 1
 # Increase `batch_size` and `MAX_STEPS` for better results.
 # num_batches: 3738
-num_batches: 4  # 200
+num_batches: 4
 # A batch can be split into multiple micro batches for memory management
 # and/or async sampling and training.
 micro_batch_size: -1
@@ -171,7 +171,8 @@ skip_jax_distributed_system: True
 
 # # TODO(@mazumdera): fix this
 # Dataset Configuration
-dataset_name: 'gsm8k'
+dataset_name: 'gsm8k' # huggingface:open-r1/DAPO-Math-17k-Processed
+eval_dataset_name: 'gsm8k' # huggingface:BytedTsinghua-SIA/AIME-2024
 train_split: 'train'
 eval_split: 'test'
 tokenizer_type: 'huggingface'

--- a/src/MaxText/rl/utils_rl.py
+++ b/src/MaxText/rl/utils_rl.py
@@ -19,6 +19,65 @@ import optax
 from MaxText import max_logging
 
 
+# Constants for normalization
+SUBSTITUTIONS = [
+    ("an ", ""),
+    ("a ", ""),
+    (".$", "$"),
+    ("\\$", ""),
+    (r"\ ", ""),
+    (" ", ""),
+    ("mbox", "text"),
+    (",\\text{and}", ","),
+    ("\\text{and}", ","),
+    ("\\text{m}", "\\text{}"),
+]
+
+REMOVED_EXPRESSIONS = [
+    "square",
+    "ways",
+    "integers",
+    "dollars",
+    "mph",
+    "inches",
+    "hours",
+    "km",
+    "units",
+    "\\ldots",
+    "sue",
+    "points",
+    "feet",
+    "minutes",
+    "digits",
+    "cents",
+    "degrees",
+    "cm",
+    "gm",
+    "pounds",
+    "meters",
+    "meals",
+    "edges",
+    "students",
+    "childrentickets",
+    "multiples",
+    "\\text{s}",
+    "\\text{.}",
+    "\\text{\ns}",
+    "\\text{}^2",
+    "\\text{}^3",
+    "\\text{\n}",
+    "\\text{}",
+    r"\mathrm{th}",
+    r"^\circ",
+    r"^{\circ}",
+    r"\;",
+    r",\!",
+    "{,}",
+    '"',
+    "\\dots",
+]
+
+
 # Let's define a RegEx for checking whether the format matches.
 #
 def get_match_format_regex(tmvp_config):
@@ -90,6 +149,47 @@ def match_format_approximately(prompts, completions, tmvp_config, **kargs):
   return scores
 
 
+def normalize_final_answer(final_answer: str) -> str:
+  """Normalize a final answer to a quantitative reasoning question.
+
+  Args:
+      final_answer: The answer string to normalize
+
+  Returns:
+      Normalized answer string
+  """
+  final_answer = final_answer.split("=")[-1]
+
+  # Apply substitutions and removals
+  for before, after in SUBSTITUTIONS:
+    final_answer = final_answer.replace(before, after)
+  for expr in REMOVED_EXPRESSIONS:
+    final_answer = final_answer.replace(expr, "")
+
+  # Extract and normalize LaTeX math
+  final_answer = re.sub(r"(.*?)(\$)(.*?)(\$)(.*)", "$\\3$", final_answer)
+  final_answer = re.sub(r"(\\text\{)(.*?)(\})", "\\2", final_answer)
+  final_answer = re.sub(r"(\\textbf\{)(.*?)(\})", "\\2", final_answer)
+  final_answer = re.sub(r"(\\overline\{)(.*?)(\})", "\\2", final_answer)
+  final_answer = re.sub(r"(\\boxed\{)(.*)(\})", "\\2", final_answer)
+
+  # Normalize shorthand TeX:
+  #  \fracab -> \frac{a}{b}
+  #  \frac{abc}{bef} -> \frac{abc}{bef}
+  #  \fracabc -> \frac{a}{b}c
+  #  \sqrta -> \sqrt{a}
+  #  \sqrtab -> sqrt{a}b
+  final_answer = re.sub(r"(frac)([^{])(.)", "frac{\\2}{\\3}", final_answer)
+  final_answer = re.sub(r"(sqrt)([^{])", "sqrt{\\2}", final_answer)
+  final_answer = final_answer.replace("$", "")
+
+  # Normalize numbers
+  if final_answer.replace(",", "").isdigit():
+    final_answer = final_answer.replace(",", "")
+
+  return final_answer.strip()
+
+
 def check_answer(prompts, completions, answer, tmvp_config, **kargs):
   """
   Reward the model if the answer is correct. A reward is also given if the answer
@@ -105,6 +205,9 @@ def check_answer(prompts, completions, answer, tmvp_config, **kargs):
     if guess is None:
       scores.append(0)
       continue
+    if "DAPO" in tmvp_config.dataset_name:
+      guess = normalize_final_answer(guess)
+      true_answer = normalize_final_answer(true_answer)
     # Correct answer gets tmvp_config.reward_exact_format_match points!
     if guess == true_answer:
       score += tmvp_config.reward_exact_format_match
@@ -207,3 +310,68 @@ def get_optimizer(tmvp_config, max_train_steps):
         optimizer,
     )
   return optimizer
+
+
+def process_data(dataset_name, model_tokenizer, template_config, tmvp_config, x):
+  """Function to process input dataset"""
+
+  def _to_str(val):
+    if isinstance(val, bytes):
+      return val.decode("utf-8")
+    return str(val)
+
+  # Handle DAPO dataset schema
+  # originally (prompt is a list, answer is in reward_model)
+  # https://huggingface.co/datasets/BytedTsinghua-SIA/DAPO-Math-17k/viewer/default/train?row=0
+  # but using https://huggingface.co/datasets/open-r1/DAPO-Math-17k-Processed/viewer/all/train?row=1
+  # so question is prompt and answer is solution
+
+  question = x.get("question", x.get("prompt"))
+  answer = x.get("answer")
+  if answer is None and "solution" in x:
+    answer = x["solution"]
+
+  # Handle OpenMathInstruct-2
+  if "problem" in x:
+    question = x["problem"]
+  if "expected_answer" in x:
+    answer = x["expected_answer"]
+
+  # Handle AIME-2024
+  if "extra_info" in x and isinstance(x["extra_info"], dict) and "raw_problem" in x["extra_info"]:
+    question = x["extra_info"]["raw_problem"]
+
+  if "reward_model" in x and isinstance(x["reward_model"], dict) and "ground_truth" in x["reward_model"]:
+    answer = x["reward_model"]["ground_truth"]
+
+  question = _to_str(question)
+  answer = _to_str(answer)
+
+  if dataset_name == "gsm8k":
+    answer = extract_hash_answer(answer)
+
+  return {
+      # passed to model forward pass
+      "prompts": model_tokenizer.apply_chat_template(
+          [
+              {
+                  "role": "user",
+                  "content": template_config["TEMPLATE"].format(
+                      system_prompt=template_config["SYSTEM_PROMPT"].format(
+                          reasoning_start_token=tmvp_config.reasoning_start_token,
+                          reasoning_end_token=tmvp_config.reasoning_end_token,
+                          solution_start_token=tmvp_config.solution_start_token,
+                          solution_end_token=tmvp_config.solution_end_token,
+                      ),
+                      question=question,
+                  ),
+              },
+          ],
+          tokenize=False,
+          add_generation_prompt=True,
+      ),
+      # passed to reward functions
+      "question": question,
+      # passed to reward functions
+      "answer": answer,
+  }


### PR DESCRIPTION
# Description

This PR adds the following support:

1. Adding support for various datasets from huggingface beyond gsm8k such as `open-r1/DAPO-Math-17k-Processed`, `BytedTsinghua-SIA/AIME-2024`, `nvidia/OpenMathInstruct-2`
2. Also, supporting separate evaluation datasets, because previously we only supported using `gsm8k` for both training and evaluation
3.  Adding support to read parquet files for partial dataset reads where the splits are defined by slices of the dataset. This becomes important for large datasets like `nvidia/OpenMathInstruct-2` which has 14M rows.

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Ran the following commands locally:

```
# using the default gsm8k for train and eval
python3 -m src.MaxText.rl.train_rl src/MaxText/configs/rl.yml   model_name=llama3.1-8b   tokenizer_path=meta-llama/Llama-3.1-8B-Instruct   load_parameters_path=/path/to/checkpoint   run_name=maz-8b-$RANDOM   base_output_directory=/path/to/gcs/directory   hf_access_token=<HF_TOKEN> 

# using new separate datasets for train and eval

python3 -m src.MaxText.rl.train_rl src/MaxText/configs/rl.yml   model_name=llama3.1-8b   tokenizer_path=meta-llama/Llama-3.1-8B-Instruct   load_parameters_path=/path/to/checkpoint   run_name=maz-8b-$RANDOM   base_output_directory=/path/to/gcs/directory   hf_access_token=<HF_TOKEN> dataset_name=huggingface:open-r1/DAPO-Math-17k-Processed eval_dataset_name=huggingface:BytedTsinghua-SIA/AIME-2024 eval_split=train
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
