### PR TITLE
Fix gradient accumulation in post training sft

### DIFF
--- a/src/MaxText/configs/sft-vision-chartqa.yml
+++ b/src/MaxText/configs/sft-vision-chartqa.yml
@@ -15,6 +15,7 @@
 base_config: "base.yml"
 
 use_sft: True
+use_tunix_gradient_accumulation: True
 use_multimodal: True
 # For vision, the prompt contains image, we only train on completion tokens
 sft_train_on_completion_only: True

--- a/src/MaxText/configs/sft-vision-slidevqa.yml
+++ b/src/MaxText/configs/sft-vision-slidevqa.yml
@@ -15,6 +15,7 @@
 base_config: "base.yml"
 
 use_sft: True
+use_tunix_gradient_accumulation: True
 use_multimodal: True
 # For vision, the prompt contains image, we only train on completion tokens
 sft_train_on_completion_only: True

--- a/src/MaxText/configs/sft.yml
+++ b/src/MaxText/configs/sft.yml
@@ -15,6 +15,7 @@
 base_config: "base.yml"
 
 use_sft: True
+use_tunix_gradient_accumulation: True
 # sft_train_on_completion_only=False trains on both prompt and completion tokens; trains only on completion tokens otherwise
 sft_train_on_completion_only: True
 packing: True

--- a/src/MaxText/configs/types.py
+++ b/src/MaxText/configs/types.py
@@ -1056,6 +1056,10 @@ class Optimizer(BaseModel):
   gradient_accumulation_steps: PositiveInt = Field(
       1, description="Number of steps to accumulate gradients before updating."
   )
+  use_tunix_gradient_accumulation: bool = Field(
+      False,
+      description="Whether to use the Tunix implementation for gradient accumulation.",
+  )
   gradient_clipping_threshold: NonNegativeFloat = Field(
       1.0, description="The threshold for gradient clipping. 0 disables clipping."
   )

--- a/src/MaxText/sft_trainer.py
+++ b/src/MaxText/sft_trainer.py
@@ -165,7 +165,7 @@ def main(argv: Sequence[str]) -> None:
     os.environ["LIBTPU_INIT_ARGS"] = (
         os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
     )
-  config = pyconfig.initialize(argv)
+  config = pyconfig.initialize(argv, use_tunix_gradient_accumulation=False)
   jax.config.update("jax_use_shardy_partitioner", config.shardy)
   max_utils.print_system_information()
   train_utils.validate_train_config(config)

--- a/src/MaxText/train.py
+++ b/src/MaxText/train.py
@@ -179,9 +179,13 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
   # Zero1+GA to reduce communication overhead.
   # EPS was used to avoid division by zero, but it's not needed when gradient
   # accumulation is enabled since there's no division.
-  if config.gradient_accumulation_steps > 1:
+  if config.gradient_accumulation_steps > 1 and not config.use_tunix_gradient_accumulation:
     loss = total_loss
   else:
+    # When using Tunix gradient accumulation, we revert to standard normalization.
+    # Unlike the manual accumulation path above, Tunix (via optax.MultiSteps) expects
+    # a normalized loss for each step. It handles the accumulation state
+    # updates and scaling internally.
     loss = total_loss / (total_weights + EPS)
 
   # Calculate and Add MTP Loss


### PR DESCRIPTION
# Description

FIXES: b/478823561

This PR resolves discrepancies in loss calculation and training step counts when running SFT with gradient accumulation enabled. Currently, `MaxText.sft.sft_trainer` (which uses the Tunix trainer) exhibits breaking behavior when gradient accumulation is turned on, diverging significantly from the native implementation in `MaxText.sft_trainer`. This change aligns the Tunix-based SFT logic to match the native behavior.

## Problem Statement

- Loss Disparity: When GA is enabled, MaxText-Tunix observed a massive loss scale disparity compared to the native implementation. This occurs because MaxText-Tunix uses the same loss_fn as the native implementation. The native logic explicitly skips dividing by total_weights inside the function (deferring normalization to a later stage [here](https://github.com/AI-Hypercomputer/maxtext/pull/3040/changes#diff-4956f1016541609a6ae02b50cc212b3ba30cffc67e40d929e85dffaa0ce82baeR174-R178)). Consequently, Tunix inherited this behavior and failed to normalize the loss, resulting in broken calculations and inflated values. 

![pr_fix_vs_original_vs_native](https://github.com/user-attachments/assets/ac21fd24-57c1-4cc9-a3df-a8e527bb473a)

- Step Count Mismatch: While MaxText-Native handles micro-batching internally by reshaping the full global batch, Tunix relies on the input pipeline to provide pre-sized micro-batches. Without this adjustment, Tunix was ingesting full global batches at every step, resulting in incorrect epoch calculations and causing the run to terminate prematurely compared to the native implementation.

## Changes
- Introduced a new configuration `use_tunix`
  -  Determine whether gradient accumulation (GA) is performed through the Tunix implementation.

- Modified the loss function
  - Aligned Tunix loss calculation with native behavior. these changes are backward-compatible and will not affect existing native GA implementations.

- Pre-sliced batches in data preprocessing
  - Ensures that when using Tunix GA, the chunk size is correctly calculated during the data preparation stage.

- Add Tunix SFT integration test for gradient accumulation loss verification [here](https://github.com/AI-Hypercomputer/maxtext/pull/3040/changes#diff-7173b581a58bb895b89d15af0c2474889d2f969215b014053b0d5f2bd475019fR159-R224)


# Tests
## End2End
```
python3 -m MaxText.sft.sft_trainer \
    src/MaxText/configs/sft.yml \
    run_name=$RUN_NAME \
    base_output_directory=..../qwen3-4b \
    model_name=qwen3-4b \
    load_parameters_path=..../qwen3-4b/0/items \
    tokenizer_path=Qwen/qwen3-4b \
    steps=$train_step \
    profiler=xplane \
    hf_path=arrow \
    dataset_type=hf \
    train_split=train \
    hf_train_files=..../data-00000-of-00001.arrow \
    hf_eval_files=..../data-00000-of-00001.arrow \
    per_device_batch_size=4 \
    gradient_accumulation_steps=4 \
    max_target_length=1024 \
    learning_rate=1.3e-5 \
    warmup_steps_fraction=0.05 \
    data_shuffle_seed=42 \
    gradient_clipping_threshold=1 \
    learning_rate_final_fraction=0 \
    weight_dtype=bfloat16
```
After applying the changes, the loss graphs of both versions are now almost identical.

![graph_2026-01-29_15-52-15](https://github.com/user-attachments/assets/9f48828a-0acb-4056-b1ae-713817f45217)

## Integration Test
```
python -m unittest tests.integration.gradient_accumulation_test.GradientAccumulationTest.test_tunix_sft_grad_accumulate_same_loss
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
