### PR TITLE
Add attn_logits_soft_cap to LlamaDecoderLayer

### DIFF
--- a/src/MaxText/layers/llama2.py
+++ b/src/MaxText/layers/llama2.py
@@ -101,6 +101,7 @@ class LlamaDecoderLayer(nnx.Module):
         use_ragged_attention=config.use_ragged_attention,
         ragged_block_size=config.ragged_block_size,
         model_mode=model_mode,
+        attn_logits_soft_cap=config.attn_logits_soft_cap,
         rngs=rngs,
     )
 


### PR DESCRIPTION
Passes the `attn_logits_soft_cap` configuration to the attention layer in LlamaDecoderLayer.

# Description
Llama 3.1 405b training encountered NaN loss issue when using max_logit_estimate.

To use max_logit_estimate for tokamax splash attention kernel, we need `attn_logits_soft_cap` passed to the attention layer to cap the logit in the splash attention kernel.

FIXES: b/478017227

# Tests

I've launched a run yesterday with soft cap = 20 and max logit estimate = 30: https://cloudlogging.app.goo.gl/7Nh5GU6nvxJvtqRm9

The loss kept valid until the workloads stopped at step 254 (due to the cluster issue), the final loss is about 5.1 and the latest eval loss is about 5.8.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
