### PR TITLE
support openmath split

### DIFF
--- a/dependencies/dockerfiles/maxtext_post_training_dependencies.Dockerfile
+++ b/dependencies/dockerfiles/maxtext_post_training_dependencies.Dockerfile
@@ -35,6 +35,8 @@ RUN pip install vllm-tpu
 
 RUN pip install --no-deps qwix==0.1.4
 
+RUN pip install math-verify==0.9.0
+
 RUN if [ "$MODE" = "post-training-experimental" ]; then \
     pip uninstall -y jax jaxlib libtpu && \
     pip install --pre -U jax jaxlib -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ && \

--- a/dependencies/dockerfiles/maxtext_post_training_local_dependencies.Dockerfile
+++ b/dependencies/dockerfiles/maxtext_post_training_local_dependencies.Dockerfile
@@ -40,6 +40,8 @@ RUN pip install -e /tpu-inference --no-cache-dir
 
 RUN pip install --no-deps qwix==0.1.4
 
+RUN pip install math-verify==0.9.0
+
 RUN if [ "$MODE" = "post-training-experimental" ]; then \
     echo "MODE=post-training-experimental: Re-installing JAX/libtpu"; \
     pip uninstall -y jax jaxlib libtpu && \


### PR DESCRIPTION
# Description

Joint work by @A9isha and @hengtaoguo with the following changes:

1.  support `nvidia/OpenMathInstruct-2`  and `open-r1/DAPO-Math-17k-Processed` datasets
2. update evaluate and rewards to address the complications of the new dataset
3. use `math_verify` library for math expressions comparison


*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Ran on 1xv5p-128, one for trainer and two for sampler, and also 1xvrp-128

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
