### PR TITLE
Add prompt preprocessing and token placeholders for Omni

### DIFF
--- a/benchmarks/api_server/maxtext_generator.py
+++ b/benchmarks/api_server/maxtext_generator.py
@@ -505,15 +505,13 @@ class MaxTextGenerator:
           num_images=1,
       )
       processor_output = mm_processor.preprocess_mm_data(self.config)
-      prefill_length -= mm_processor.get_image_offsets(self.config.model_name, processor_output=processor_output)
+      prefill_length -= mm_processor.get_image_offsets(config=self.config, processor_output=processor_output)
       images = processor_output.pixel_values
 
     tokens, true_length = self.tokenizer.encode(text, is_bos=not self.has_chat_template, prefill_lengths=[prefill_length])
     if self.config.use_multimodal and image_path:
-      tokens = mm_processor.prepare_text_for_image_fusion(
-          tokens, model_name=self.config.model_name, processor_output=processor_output
-      )
-      true_length += mm_processor.get_image_offsets(self.config.model_name, processor_output=processor_output)
+      tokens = mm_processor.prepare_text_for_image_fusion(tokens, config=self.config, processor_output=processor_output)
+      true_length += mm_processor.get_image_offsets(config=self.config, processor_output=processor_output)
 
     return tokens, true_length, images
 

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -992,9 +992,11 @@ dtype_mm: "float32"  # Data type for multimodal model's vision encoder
 remat_policy_for_vit: "minimal"  # Remat policy for multimodal model's vision encoder. Check `remat_policy` for options.
 image_size_for_vit: 896 # Default for Gemma3, and should be overwritten by model's config
 image_path: "" # Local image path used for decoding, can be multiple paths separated by comma, exp "/path/image1.jpg,/path/image2.jpg"
-image_placeholder: "<|image|>"
 video_path: "" # Local video path used for decoding, can be multiple paths separated by comma, exp "/path/video1.mp4,/path/video2.mp4"
 audio_path: "" # Local audio path used for decoding, can be multiple paths separated by comma, exp "/path/audio1.wav,/path/audio2.wav"
+image_placeholder: "<|image|>"
+video_placeholder: "<|video|>"
+audio_placeholder: "<|audio|>"
 use_audio_in_video: False
 posemb_type_for_vit: "learn"
 # max_num_images_per_example only applies for training when your image column is a list of images.

--- a/src/maxtext/configs/models/qwen3-omni-30b-a3b.yml
+++ b/src/maxtext/configs/models/qwen3-omni-30b-a3b.yml
@@ -77,4 +77,4 @@ max_sample_len_for_audio: 10000
 # MRoPE Settings (Multi-dimensional RoPE for multimodal)
 use_mrope: true
 mrope_section: [24, 20, 20]
-position_id_per_seconds: 25
+position_id_per_seconds: 13

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1457,6 +1457,8 @@ class MultimodalGeneral(BaseModel):
   )
   video_path: PathStr = Field("", description="Path to a video for decoding.")
   audio_path: PathStr = Field("", description="Path to an audio file for decoding.")
+  video_placeholder: str = Field("<|video|>", description="Placeholder string for video in text prompts.")
+  audio_placeholder: str = Field("<|audio|>", description="Placeholder string for audio in text prompts.")
   use_audio_in_video: bool = Field(False, description="Extract and use audio from video files.")
   use_mrope: bool = Field(False, description="Enable Multi-dimensional RoPE for Qwen3-Omni models.")
   mrope_section: list[int] = Field([24, 20, 20], description="Dimensions for temporal, height, width in MRoPE.")

--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -126,7 +126,7 @@ def vision_sft_preprocessing_pipeline(
   )
   dataset = dataset.map(
       input_pipeline_utils.prepare_text_for_image_fusion,
-      fn_kwargs={"column_name": text_columns[0], "model_name": config.model_name},
+      fn_kwargs={"column_name": text_columns[0], "config": config},
   )
 
   dataset = input_pipeline_utils.HFDataSource(

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -115,10 +115,10 @@ def pre_process_image_sft(example, image_column, model_name):
   return example
 
 
-def prepare_text_for_image_fusion(example, column_name, model_name):
+def prepare_text_for_image_fusion(example, column_name, config):
   """prepare text for image fusion for multimodal SFT"""
   example[column_name] = mm_processor.prepare_text_for_image_fusion(
-      example[column_name], model_name, processor_output=example["images"]
+      tokens=example[column_name], config=config, processor_output=example["images"]
   )
   return example
 

--- a/tests/unit/multimodal_utils_test.py
+++ b/tests/unit/multimodal_utils_test.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 """ Tests for the common MaxText utilities """
+import os
 import unittest
 import numpy as np
 
+from MaxText import pyconfig
+from MaxText.globals import MAXTEXT_REPO_ROOT
 from maxtext.multimodal import processor as mm_processor
 from maxtext.multimodal import utils as mm_utils
 from maxtext.multimodal import processor_gemma3
@@ -195,8 +198,12 @@ class TestLlama4PostProcessing(unittest.TestCase):
         pixel_values=dummy_pixel_values,
         aspect_ratios=dummy_aspect_ratios,
     )
-
-    image_offsets = mm_processor.get_image_offsets(model_name=self.model_name, processor_output=processor_output)
+    base_config_path = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "base.yml")
+    config = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="llama4-17b-16e",
+    )
+    image_offsets = mm_processor.get_image_offsets(config=config, processor_output=processor_output)
     post_processed_tokens = processor_llama4.add_extra_tokens_for_images_llama4(dummy_tokens, processor_output)
     self.assertEqual(post_processed_tokens.shape[0], dummy_tokens.shape[0] + image_offsets)
 


### PR DESCRIPTION
# Description

**Collaborate with original author**: @eitanporat at [PR #2731](https://github.com/AI-Hypercomputer/maxtext/pull/2731).

- Add `reformat_prompt_qwen3_omni` for prompt template.
- Add `get_mm_offsets_qwen3_omni` to compute multimodal token lengths.
- Update `prepare_text_for_image_fusion`, accepting `config` so it allows more complicated placeholder formatting by using model-specific config fields.

# Tests

Follow up in e2e tests in https://github.com/AI-Hypercomputer/maxtext/pull/2729

Added two more test asserts in `qwen3_omni_layers_test.py`:
- Check the formatted prompts are the same.
- Check the tokenized IDs are the same (with multimodal placeholder paddings inside).

```
python -m pytest tests/unit/qwen3_omni_layers_test.py::TestQwen3OmniPreprocessing::test_preprocess_mm_data -vv -s
```

Prompt (with placeholders): https://paste.googleplex.com/6444051776798720
Tokenized prompt (with placeholders): https://diff.googleplex.com/#key=v8U2Vrap2cyR

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
