### PR TITLE
[Do Not Merge] Optimizations on Qwen3-Next GatedDeltaNet w/ Kernel & XProf Agent

### DIFF
--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -213,10 +213,10 @@ def pallas_chunk_gated_delta_rule(
   scale = jax.lax.rsqrt(jnp.array(query.shape[-1], dtype=jnp.float32)).astype(compute_dtype)
   query = query * scale
 
-  B, S, H, K_dim = key.shape
+  B, seq_len, H, K_dim = key.shape
   V_dim = value.shape[-1]
   
-  pad_len = (chunk_size - (S % chunk_size)) % chunk_size
+  pad_len = (chunk_size - (seq_len % chunk_size)) % chunk_size
   if pad_len > 0:
     pad_fn = lambda x, val=0.0: jnp.pad(x, ((0,0), (0, pad_len)) + ((0,0),)*(x.ndim-2), constant_values=val)
     query = pad_fn(query)
@@ -244,7 +244,7 @@ def pallas_chunk_gated_delta_rule(
   g_cumsum = jnp.cumsum(g_c, axis=-1)
   k_beta = k_c * beta_c[..., None]
   
-  S = jnp.matmul(k_c, k_beta.swapaxes(-1, -2), precision=jax.lax.Precision.HIGHEST)
+  S = jnp.matmul(k_beta, k_c.swapaxes(-1, -2), precision=jax.lax.Precision.HIGHEST)
   S = S.astype(jnp.float32)
   g_diff = g_cumsum[..., :, None] - g_cumsum[..., None, :]
   mask = jnp.tril(jnp.ones((chunk_size, chunk_size), dtype=bool), k=-1)
@@ -255,6 +255,18 @@ def pallas_chunk_gated_delta_rule(
   identity = jnp.eye(chunk_size, dtype=jnp.float32)
   identity_broadcasted = jnp.broadcast_to(identity, S.shape)
   A = jax.scipy.linalg.solve_triangular(identity + S, identity_broadcasted, lower=True, unit_diagonal=True)
+  
+  # OPTIMIZED TPU INVERSION: (I+S)^-1 using logarithmic expansion
+  # Since S is strictly lower triangular, S^N = 0. We can invert it with pure matmuls.
+  # X = -S
+  # A = identity + X
+  # prec = jax.lax.Precision.HIGHEST
+  # X_pow = jnp.matmul(X, X, precision=prec)
+  
+  # num_iters = int(math.ceil(math.log2(chunk_size))) - 1
+  # for _ in range(num_iters):
+  #     A = A + jnp.matmul(A, X_pow, precision=prec)
+  #     X_pow = jnp.matmul(X_pow, X_pow, precision=prec)
 
   v_beta = v_c * beta_c[..., None]
   u_chunks = jnp.matmul(A, v_beta.astype(jnp.float32), precision=jax.lax.Precision.HIGHEST)
@@ -282,7 +294,7 @@ def pallas_chunk_gated_delta_rule(
   else:
       h_init = initial_state.astype(compute_dtype)
 
-  kernel_to_use = gdn_pallas.gdn_pallas_layer
+  kernel_to_use = gdn_pallas3.gdn_pallas_layer
   # Invoke Kernel
   if mesh is not None:
       # Mesh Partitioning
@@ -311,7 +323,7 @@ def pallas_chunk_gated_delta_rule(
       # Single Device
       o_pallas, h_final = kernel_to_use(w_p, u_p, q_p, k_p, v_p, g_p, beta_p, h_init)
 
-  o_chunks = o_pallas.transpose(0, 2, 1, 3, 4)
+  o_chunks = o_pallas.transpose(0, 2, 3, 1, 4)
 
   # =========================================================================
   # STAGE 4: FINALIZATION
@@ -319,7 +331,7 @@ def pallas_chunk_gated_delta_rule(
   o = o_chunks.reshape(B, -1, H, V_dim)
   
   if pad_len > 0:
-    o = o[:, :S, :, :]
+    o = o[:, :seq_len, :, :]
   
   o = o.astype(initial_dtype)
     

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -29,6 +29,7 @@ import jax.numpy as jnp
 from flax import linen as nn
 from flax import nnx
 
+<<<<<<< HEAD:src/maxtext/models/qwen3.py
 from maxtext.common.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED, MODEL_MODE_TRAIN
 from maxtext.layers import attentions
 from maxtext.layers import initializers as max_initializers
@@ -43,9 +44,29 @@ from maxtext.layers.linears import DenseGeneral, MlpBlock
 from maxtext.layers.moe import RoutedMoE
 from maxtext.layers.initializers import nd_dense_init, variable_to_logically_partitioned
 
+=======
+from jax.sharding import PartitionSpec as P
+from jax.experimental.shard_map import shard_map
+
+from MaxText.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED, MODEL_MODE_TRAIN
+from MaxText.layers import attentions
+from MaxText.layers import initializers as max_initializers
+from MaxText.layers import moe
+from MaxText.layers import nnx_wrappers
+from MaxText.layers import quantizations
+from MaxText.layers.embeddings import Qwen3OmniMoeVisionPosEmbedInterpolate, PositionalEmbedding
+from MaxText.layers.normalizations import RMSNorm, l2norm, Qwen3NextRMSNorm, Qwen3NextRMSNormGated
+from MaxText.layers.quantizations import AqtQuantization as Quant
+from MaxText.layers.attentions import Attention
+from MaxText.layers.linears import DenseGeneral, MlpBlock
+from MaxText.layers.moe import RoutedMoE
+from MaxText.layers.initializers import nd_dense_init, variable_to_logically_partitioned
+from maxtext.inference import page_manager
+>>>>>>> 7461955dc (add shardmap to kernel):src/MaxText/layers/qwen3.py
 from maxtext.utils import max_utils
 from maxtext.inference import page_manager, kvcache
 
+from maxtext.scratch_code import gdn_pallas
 
 # -----------------------------------------
 # Qwen3-Next Layer Implementations
@@ -176,6 +197,150 @@ def naive_jax_chunk_gated_delta_rule(
 
   return core_attn_out, final_state if output_final_state else None
 
+
+def pallas_chunk_gated_delta_rule(
+    query: jax.Array,
+    key: jax.Array,
+    value: jax.Array,
+    g: jax.Array,
+    beta: jax.Array,
+    chunk_size: int = 64,
+    initial_state: None | jax.Array = None,
+    use_qk_norm_in_gdn: bool = False,
+    compute_dtype: jnp.dtype = jnp.bfloat16,
+    mesh: Mesh | None = None,
+) -> tuple[jax.Array, None | jax.Array]:
+  """
+  Pallas-accelerated version of Gated Delta Rule.
+  """
+  # =========================================================================
+  # STAGE 1: PREPARATION & PADDING
+  # =========================================================================
+  initial_dtype = query.dtype
+  if use_qk_norm_in_gdn:
+    from MaxText.layers.normalizations import l2norm 
+    query = l2norm(query, dim=-1, eps=1e-6)
+    key = l2norm(key, dim=-1, eps=1e-6)
+
+  g = g.astype(jnp.float32)
+  query = query.astype(compute_dtype)
+  key = key.astype(compute_dtype)
+  value = value.astype(compute_dtype)
+  beta = beta.astype(compute_dtype)
+
+  scale = jax.lax.rsqrt(jnp.array(query.shape[-1], dtype=jnp.float32)).astype(compute_dtype)
+  query = query * scale
+
+  B, S, H, K_dim = key.shape
+  V_dim = value.shape[-1]
+  
+  pad_len = (chunk_size - (S % chunk_size)) % chunk_size
+  if pad_len > 0:
+    pad_fn = lambda x, val=0.0: jnp.pad(x, ((0,0), (0, pad_len)) + ((0,0),)*(x.ndim-2), constant_values=val)
+    query = pad_fn(query)
+    key = pad_fn(key)
+    value = pad_fn(value)
+    g = pad_fn(g)
+    beta = pad_fn(beta)
+
+  num_chunks = query.shape[1] // chunk_size
+
+  def to_chunk(x):
+    return x.reshape(B, num_chunks, chunk_size, H, -1).transpose(0, 1, 3, 2, 4)
+  def to_chunk_scalar(x):
+    return x.reshape(B, num_chunks, chunk_size, H).transpose(0, 1, 3, 2)
+
+  q_c = to_chunk(query)
+  k_c = to_chunk(key)
+  v_c = to_chunk(value)
+  g_c = to_chunk_scalar(g)
+  beta_c = to_chunk_scalar(beta)
+
+  # =========================================================================
+  # STAGE 2: INTRA-CHUNK PRE-COMPUTATION
+  # =========================================================================
+  g_cumsum = jnp.cumsum(g_c, axis=-1)
+  k_beta = k_c * beta_c[..., None]
+  
+  S = jnp.matmul(k_c, k_beta.swapaxes(-1, -2), precision=jax.lax.Precision.HIGHEST)
+  S = S.astype(jnp.float32)
+  g_diff = g_cumsum[..., :, None] - g_cumsum[..., None, :]
+  mask = jnp.tril(jnp.ones((chunk_size, chunk_size), dtype=bool), k=-1)
+  g_diff = jnp.where(mask, g_diff, -1e30) 
+  S = S * jnp.exp(g_diff)
+  S = jnp.where(mask, S, 0.0)
+  
+  identity = jnp.eye(chunk_size, dtype=jnp.float32)
+  identity_broadcasted = jnp.broadcast_to(identity, S.shape)
+  A = jax.scipy.linalg.solve_triangular(identity + S, identity_broadcasted, lower=True, unit_diagonal=True)
+
+  v_beta = v_c * beta_c[..., None]
+  u_chunks = jnp.matmul(A, v_beta.astype(jnp.float32), precision=jax.lax.Precision.HIGHEST)
+  u_chunks = u_chunks.astype(compute_dtype)
+  
+  k_beta_g = k_beta.astype(jnp.float32) * jnp.exp(g_cumsum)[..., None]
+  w_chunks = jnp.matmul(A, k_beta_g, precision=jax.lax.Precision.HIGHEST)
+  w_chunks = w_chunks.astype(compute_dtype)
+
+  # =========================================================================
+  # STAGE 3: INTER-CHUNK RECURRENCE (Pallas Kernel + shard_map)
+  # =========================================================================
+  # Transpose to (Batch, Heads, NumChunks, ChunkSize, Dim) for Pallas
+  w_p = w_chunks.transpose(0, 2, 1, 3, 4)
+  u_p = u_chunks.transpose(0, 2, 1, 3, 4)
+  q_p = q_c.transpose(0, 2, 1, 3, 4)
+  k_p = k_c.transpose(0, 2, 1, 3, 4)
+  v_p = v_c.transpose(0, 2, 1, 3, 4)
+  g_p = g_cumsum.transpose(0, 2, 1, 3) 
+  beta_p = beta_c.transpose(0, 2, 1, 3)
+
+  # Handle initial state
+  if initial_state is None:
+      h_init = jnp.zeros((B, H, K_dim, V_dim), dtype=compute_dtype)
+  else:
+      h_init = initial_state.astype(compute_dtype)
+
+  # Invoke Kernel
+  if mesh is not None:
+      # Mesh Partitioning
+      axis_names = mesh.axis_names
+      batch_axes = [ax for ax in ('data', 'fsdp', 'fsdp_transpose', 'expert') if ax in axis_names]
+      batch_spec = tuple(batch_axes) if batch_axes else None
+      head_axes = [ax for ax in ('tensor', 'model') if ax in axis_names]
+      head_spec = tuple(head_axes) if head_axes else None
+      
+      # Specs: B, H, ...
+      # h_init is (B, H, K, V)
+      in_specs = P(batch_spec, head_spec, None, None, None)
+      scalar_specs = P(batch_spec, head_spec, None, None)
+      state_spec = P(batch_spec, head_spec, None, None)
+
+      sharded_gdn = shard_map(
+          gdn_pallas.gdn_pallas_layer,
+          mesh=mesh,
+          in_specs=(in_specs, in_specs, in_specs, in_specs, in_specs, scalar_specs, scalar_specs, state_spec),
+          out_specs=(in_specs, state_spec), # Returns (out, final_state)
+          check_rep=False 
+      )
+      
+      o_pallas, h_final = sharded_gdn(w_p, u_p, q_p, k_p, v_p, g_p, beta_p, h_init)
+  else:
+      # Single Device
+      o_pallas, h_final = gdn_pallas.gdn_pallas_layer(w_p, u_p, q_p, k_p, v_p, g_p, beta_p, h_init)
+
+  o_chunks = o_pallas.transpose(0, 2, 1, 3, 4)
+
+  # =========================================================================
+  # STAGE 4: FINALIZATION
+  # =========================================================================
+  o = o_chunks.reshape(B, -1, H, V_dim)
+  
+  if pad_len > 0:
+    o = o[:, :S, :, :]
+  
+  o = o.astype(initial_dtype)
+    
+  return o, h_final
 
 def jax_chunk_gated_delta_rule(
     query: Array,
@@ -381,13 +546,18 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
   2. output = Linear_out(y)
   """
 
+<<<<<<< HEAD:src/maxtext/models/qwen3.py
   def __init__(self, config: Config, dtype: DType = jnp.float32, model_mode: str = MODEL_MODE_TRAIN, *, rngs: nnx.Rngs):
+=======
+  def __init__(self, config: Config, *, rngs: nnx.Rngs, mesh: Mesh=None):
+>>>>>>> 7461955dc (add shardmap to kernel):src/MaxText/layers/qwen3.py
     """
     Args:
       config: MaxText configuration object.
       rngs: The random number generators for initialization, passed by the nnx.to_linen wrapper.
     """
     self.config = config
+    self.mesh = mesh
     cfg = self.config
 
     in_features = cfg.emb_dim
@@ -637,16 +807,12 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
         else:
           recurrent_state = recurrent_state[:batch]
 
-    core_attn_out, recurrent_state_out = jax_chunk_gated_delta_rule(
-        query,
-        key,
-        value,
-        g,
-        beta,
-        chunk_size=cfg.gdn_chunk_size,
-        initial_state=recurrent_state,
-        use_qk_norm_in_gdn=cfg.use_qk_norm_in_gdn,
+    core_attn_out, recurrent_state_out = pallas_chunk_gated_delta_rule(
+        query, key, value, g, beta, 
+        chunk_size=cfg.gdn_chunk_size, 
+        use_qk_norm_in_gdn=cfg.use_qk_norm_in_gdn, 
         compute_dtype=cfg.dtype,
+        mesh=self.mesh
     )
 
     if model_mode != MODEL_MODE_TRAIN:
@@ -982,7 +1148,11 @@ class Qwen3NextDecoderLayer(nnx.Module):
           rngs=rngs,
       )
     else:
+<<<<<<< HEAD:src/maxtext/models/qwen3.py
       self.attention = Qwen3NextGatedDeltaNet(config=cfg, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs)
+=======
+      self.attention = Qwen3NextGatedDeltaNet(config=cfg, rngs=rngs, mesh=self.mesh)
+>>>>>>> 7461955dc (add shardmap to kernel):src/MaxText/layers/qwen3.py
 
     # Second LayerNorm, applied before the MoE block.
     self.post_attention_layernorm = Qwen3NextRMSNorm(

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -48,7 +48,7 @@ from jax.experimental.shard_map import shard_map
 from maxtext.utils import max_utils
 from maxtext.inference import page_manager, kvcache
 
-from maxtext.scratch_code import gdn_pallas
+from maxtext.scratch_code import gdn_pallas, gdn_pallas2
 
 # -----------------------------------------
 # Qwen3-Next Layer Implementations
@@ -282,6 +282,7 @@ def pallas_chunk_gated_delta_rule(
   else:
       h_init = initial_state.astype(compute_dtype)
 
+  kernel_to_use = gdn_pallas.gdn_pallas_layer
   # Invoke Kernel
   if mesh is not None:
       # Mesh Partitioning
@@ -298,17 +299,17 @@ def pallas_chunk_gated_delta_rule(
       state_spec = P(batch_spec, head_spec, None, None)
 
       sharded_gdn = shard_map(
-          gdn_pallas.gdn_pallas_layer,
+          kernel_to_use,
           mesh=mesh,
           in_specs=(in_specs, in_specs, in_specs, in_specs, in_specs, scalar_specs, scalar_specs, state_spec),
-          out_specs=(in_specs, state_spec), # Returns (out, final_state)
+          out_specs=(in_specs, state_spec),
           check_rep=False 
       )
       
       o_pallas, h_final = sharded_gdn(w_p, u_p, q_p, k_p, v_p, g_p, beta_p, h_init)
   else:
       # Single Device
-      o_pallas, h_final = gdn_pallas.gdn_pallas_layer(w_p, u_p, q_p, k_p, v_p, g_p, beta_p, h_init)
+      o_pallas, h_final = kernel_to_use(w_p, u_p, q_p, k_p, v_p, g_p, beta_p, h_init)
 
   o_chunks = o_pallas.transpose(0, 2, 1, 3, 4)
 

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -29,7 +29,6 @@ import jax.numpy as jnp
 from flax import linen as nn
 from flax import nnx
 
-<<<<<<< HEAD:src/maxtext/models/qwen3.py
 from maxtext.common.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED, MODEL_MODE_TRAIN
 from maxtext.layers import attentions
 from maxtext.layers import initializers as max_initializers
@@ -44,25 +43,8 @@ from maxtext.layers.linears import DenseGeneral, MlpBlock
 from maxtext.layers.moe import RoutedMoE
 from maxtext.layers.initializers import nd_dense_init, variable_to_logically_partitioned
 
-=======
 from jax.sharding import PartitionSpec as P
 from jax.experimental.shard_map import shard_map
-
-from MaxText.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED, MODEL_MODE_TRAIN
-from MaxText.layers import attentions
-from MaxText.layers import initializers as max_initializers
-from MaxText.layers import moe
-from MaxText.layers import nnx_wrappers
-from MaxText.layers import quantizations
-from MaxText.layers.embeddings import Qwen3OmniMoeVisionPosEmbedInterpolate, PositionalEmbedding
-from MaxText.layers.normalizations import RMSNorm, l2norm, Qwen3NextRMSNorm, Qwen3NextRMSNormGated
-from MaxText.layers.quantizations import AqtQuantization as Quant
-from MaxText.layers.attentions import Attention
-from MaxText.layers.linears import DenseGeneral, MlpBlock
-from MaxText.layers.moe import RoutedMoE
-from MaxText.layers.initializers import nd_dense_init, variable_to_logically_partitioned
-from maxtext.inference import page_manager
->>>>>>> 7461955dc (add shardmap to kernel):src/MaxText/layers/qwen3.py
 from maxtext.utils import max_utils
 from maxtext.inference import page_manager, kvcache
 
@@ -218,7 +200,7 @@ def pallas_chunk_gated_delta_rule(
   # =========================================================================
   initial_dtype = query.dtype
   if use_qk_norm_in_gdn:
-    from MaxText.layers.normalizations import l2norm 
+    from maxtext.layers.normalizations import l2norm 
     query = l2norm(query, dim=-1, eps=1e-6)
     key = l2norm(key, dim=-1, eps=1e-6)
 
@@ -546,11 +528,7 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
   2. output = Linear_out(y)
   """
 
-<<<<<<< HEAD:src/maxtext/models/qwen3.py
-  def __init__(self, config: Config, dtype: DType = jnp.float32, model_mode: str = MODEL_MODE_TRAIN, *, rngs: nnx.Rngs):
-=======
-  def __init__(self, config: Config, *, rngs: nnx.Rngs, mesh: Mesh=None):
->>>>>>> 7461955dc (add shardmap to kernel):src/MaxText/layers/qwen3.py
+  def __init__(self, config: Config, dtype: DType = jnp.float32, model_mode: str = MODEL_MODE_TRAIN, *, rngs: nnx.Rngs, mesh: Mesh=None):
     """
     Args:
       config: MaxText configuration object.
@@ -1148,11 +1126,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
           rngs=rngs,
       )
     else:
-<<<<<<< HEAD:src/maxtext/models/qwen3.py
       self.attention = Qwen3NextGatedDeltaNet(config=cfg, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs)
-=======
-      self.attention = Qwen3NextGatedDeltaNet(config=cfg, rngs=rngs, mesh=self.mesh)
->>>>>>> 7461955dc (add shardmap to kernel):src/MaxText/layers/qwen3.py
 
     # Second LayerNorm, applied before the MoE block.
     self.post_attention_layernorm = Qwen3NextRMSNorm(

--- a/src/maxtext/scratch_code/benchmark_gdn_optimization.py
+++ b/src/maxtext/scratch_code/benchmark_gdn_optimization.py
@@ -1,0 +1,552 @@
+import time
+import functools
+import types
+import jax
+import jax.extend
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from typing import Any, cast
+
+# Import common dependencies
+from MaxText import common_types
+from MaxText.layers import normalizations
+from MaxText.layers.linears import DenseGeneral
+from MaxText.layers import qwen3 
+
+# ==============================================================================
+# SECTION 1: THE MIRROR (BASELINE IMPLEMENTATION)
+# ==============================================================================
+def baseline_chunk_gated_delta_rule(
+    query, key, value, g, beta, chunk_size=64, initial_state=None, use_qk_norm_in_gdn=False
+):
+    """The ORIGINAL implementation (Do not edit this function)."""
+    initial_dtype = query.dtype
+    if use_qk_norm_in_gdn:
+        query = normalizations.l2norm(query, dim=-1, eps=1e-6)
+        key = normalizations.l2norm(key, dim=-1, eps=1e-6)
+
+    query = jnp.transpose(query, (0, 2, 1, 3)).astype(jnp.float32)
+    key = jnp.transpose(key, (0, 2, 1, 3)).astype(jnp.float32)
+    value = jnp.transpose(value, (0, 2, 1, 3)).astype(jnp.float32)
+    beta = jnp.transpose(beta, (0, 2, 1)).astype(jnp.float32)
+    g = jnp.transpose(g, (0, 2, 1)).astype(jnp.float32)
+
+    batch_size, num_heads, sequence_length, k_head_dim = key.shape
+    v_head_dim = value.shape[-1]
+    pad_size = (chunk_size - sequence_length % chunk_size) % chunk_size
+
+    if pad_size > 0:
+        query = jnp.pad(query, ((0, 0), (0, 0), (0, pad_size), (0, 0)))
+        key = jnp.pad(key, ((0, 0), (0, 0), (0, pad_size), (0, 0)))
+        value = jnp.pad(value, ((0, 0), (0, 0), (0, pad_size), (0, 0)))
+        beta = jnp.pad(beta, ((0, 0), (0, 0), (0, pad_size)))
+        g = jnp.pad(g, ((0, 0), (0, 0), (0, pad_size)))
+
+    total_sequence_length = sequence_length + pad_size
+    scale = jax.lax.rsqrt(jnp.array(query.shape[-1]).astype(jnp.float32))
+    query = query * scale
+
+    v_beta = value * jnp.expand_dims(beta, -1)
+    k_beta = key * jnp.expand_dims(beta, -1)
+
+    num_chunks = total_sequence_length // chunk_size
+    query_c = query.reshape(batch_size, num_heads, num_chunks, chunk_size, k_head_dim)
+    key_c = key.reshape(batch_size, num_heads, num_chunks, chunk_size, k_head_dim)
+    k_beta_c = k_beta.reshape(batch_size, num_heads, num_chunks, chunk_size, k_head_dim)
+    v_beta_c = v_beta.reshape(batch_size, num_heads, num_chunks, chunk_size, v_head_dim)
+    g_c = g.reshape(batch_size, num_heads, num_chunks, chunk_size)
+
+    mask = jnp.triu(jnp.ones((chunk_size, chunk_size), dtype=bool), k=0)
+
+    g_cumsum = jnp.cumsum(g_c, axis=-1)
+    g_diff = jnp.expand_dims(g_cumsum, -1) - jnp.expand_dims(g_cumsum, -2)
+    g_diff_tril = jnp.tril(g_diff)
+    g_diff_exp = jnp.exp(g_diff_tril).astype(jnp.float32)
+    decay_mask = g_diff_exp
+
+    prec = jax.lax.Precision.HIGHEST
+    attn = -jnp.matmul(k_beta_c, jnp.swapaxes(key_c, -1, -2), precision=prec) * decay_mask
+    attn = jnp.where(mask, 0.0, attn)
+
+    def inner_attn_body(i, attn_val):
+        indices = jnp.arange(chunk_size)
+        col_mask = indices < i
+        row = attn_val[..., i, :] * col_mask
+        sub_mask = jnp.expand_dims(indices < i, -1) & (indices < i)
+        sub = attn_val * sub_mask
+        row_exp = jnp.expand_dims(row, -1)
+        term = row_exp * sub
+        summed = jnp.sum(term, axis=-2)
+        update_val = row + summed
+        original_row = attn_val[..., i, :]
+        new_row = jnp.where(col_mask, update_val, original_row)
+        return attn_val.at[..., i, :].set(new_row)
+
+    attn = jax.lax.fori_loop(1, chunk_size, inner_attn_body, attn)
+    attn = attn + jnp.eye(chunk_size, dtype=attn.dtype)
+    value_intra = jnp.matmul(attn, v_beta_c, precision=prec)
+    k_cumdecay = jnp.matmul(attn, (k_beta_c * jnp.expand_dims(jnp.exp(g_cumsum), -1)), precision=prec)
+
+    output_final_state = initial_state is not None
+    if initial_state is None:
+        last_recurrent_state = jnp.zeros((batch_size, num_heads, k_head_dim, v_head_dim), dtype=value_intra.dtype)
+    else:
+        last_recurrent_state = initial_state.astype(value_intra.dtype)
+
+    mask_inter = jnp.triu(jnp.ones((chunk_size, chunk_size), dtype=bool), k=1)
+
+    query_scan = jnp.transpose(query_c, (2, 0, 1, 3, 4))
+    key_scan = jnp.transpose(key_c, (2, 0, 1, 3, 4))
+    value_scan = jnp.transpose(value_intra, (2, 0, 1, 3, 4))
+    k_cumdecay_scan = jnp.transpose(k_cumdecay, (2, 0, 1, 3, 4))
+    g_scan = jnp.transpose(g_cumsum, (2, 0, 1, 3))
+    decay_mask_scan = jnp.transpose(decay_mask, (2, 0, 1, 3, 4))
+
+    xs = (query_scan, key_scan, value_scan, k_cumdecay_scan, g_scan, decay_mask_scan)
+
+    def scan_body(prev_state, x):
+        q_i, k_i, v_i, k_cumdecay_i, g_i, decay_mask_i = x
+        last_recurrent_state = prev_state
+        prec = jax.lax.Precision.HIGHEST
+
+        attn_i = jnp.matmul(q_i, jnp.swapaxes(k_i, -1, -2), precision=prec) * decay_mask_i
+        attn_i = jnp.where(mask_inter, 0.0, attn_i)
+
+        v_prime = jnp.matmul(k_cumdecay_i, last_recurrent_state, precision=prec)
+        v_new = v_i - v_prime
+
+        g_i_exp = jnp.exp(g_i)
+        attn_inter = jnp.matmul(q_i * jnp.expand_dims(g_i_exp, -1), last_recurrent_state, precision=prec)
+
+        core_attn_out_i = attn_inter + jnp.matmul(attn_i, v_new, precision=prec)
+
+        g_i_last_exp = jnp.exp(g_i[..., -1, None, None])
+        new_last_recurrent_state = last_recurrent_state * g_i_last_exp
+
+        g_diff_exp = jnp.expand_dims(jnp.exp(jnp.expand_dims(g_i[..., -1], -1) - g_i), -1)
+        k_i_g_diff = k_i * g_diff_exp
+
+        update_term = jnp.matmul(jnp.swapaxes(k_i_g_diff, -1, -2), v_new, precision=prec)
+        new_last_recurrent_state = new_last_recurrent_state + update_term
+
+        return new_last_recurrent_state, core_attn_out_i
+
+    final_state, core_attn_out_stacked = jax.lax.scan(scan_body, last_recurrent_state, xs)
+
+    core_attn_out = jnp.transpose(core_attn_out_stacked, (1, 2, 0, 3, 4))
+    core_attn_out = core_attn_out.reshape(batch_size, num_heads, -1, v_head_dim)
+    core_attn_out = core_attn_out[:, :, :sequence_length, :]
+    core_attn_out = jnp.transpose(core_attn_out, (0, 2, 1, 3)).astype(initial_dtype)
+
+    return core_attn_out, final_state if output_final_state else None
+
+
+class BaselineGatedDeltaNet(nnx.Module):
+    """The Mirror/Baseline Wrapper."""
+    def __init__(self, config, *, rngs):
+        self.config = config
+        cfg = self.config
+        
+        in_features = cfg.emb_dim
+        self.num_v_heads = cfg.gdn_num_value_heads
+        self.num_k_heads = cfg.gdn_num_key_heads
+        self.head_k_dim = cfg.gdn_key_head_dim
+        self.head_v_dim = cfg.gdn_value_head_dim
+        self.key_dim = self.head_k_dim * self.num_k_heads
+        self.value_dim = self.head_v_dim * self.num_v_heads
+        conv_dim = self.key_dim * 2 + self.value_dim
+        conv_kernel_size = cfg.gdn_conv_kernel_dim
+        self.v_heads_per_k_head = self.num_v_heads // self.num_k_heads
+
+        self.in_proj_qkvz = DenseGeneral(in_features, (self.key_dim * 2 + self.value_dim * 2), dtype=cfg.dtype, kernel_axes=("embed", "mlp"), matmul_precision=cfg.matmul_precision, rngs=rngs)
+        self.in_proj_ba = DenseGeneral(in_features, (self.num_v_heads * 2), dtype=cfg.dtype, kernel_axes=("embed", "mlp"), matmul_precision=cfg.matmul_precision, rngs=rngs)
+        
+        self.conv1d = nnx.Conv(conv_dim, conv_dim, kernel_size=(conv_kernel_size,), feature_group_count=conv_dim, padding="CAUSAL", use_bias=False, dtype=cfg.dtype, precision=cfg.matmul_precision, rngs=rngs)
+
+        def a_log_init(key, shape, dtype=jnp.float32):
+            a_vals = jax.random.uniform(key, shape=shape, dtype=dtype, minval=1e-9, maxval=16.0)
+            return jnp.log(a_vals)
+
+        self.A_log = nnx.Param(a_log_init(rngs.params(), (self.num_v_heads,)))
+        self.dt_bias = nnx.Param(nnx.initializers.ones(rngs.params(), (self.num_v_heads,)))
+
+        self.norm = normalizations.Qwen3NextRMSNormGated(self.head_v_dim, eps=cfg.normalization_layer_epsilon, dtype=cfg.dtype, weight_dtype=cfg.weight_dtype, rngs=rngs)
+        self.out_proj = DenseGeneral(self.value_dim, (in_features,), dtype=cfg.dtype, kernel_axes=("mlp", "embed"), matmul_precision=cfg.matmul_precision, rngs=rngs)
+
+    def __call__(self, hidden_states):
+        cfg = self.config
+        batch, seq_len, _ = hidden_states.shape
+        qkvz = self.in_proj_qkvz(hidden_states)
+        ba = self.in_proj_ba(hidden_states)
+
+        new_shape_qkvz = (batch, seq_len, self.num_k_heads, 2 * self.head_k_dim + 2 * self.head_v_dim * self.v_heads_per_k_head)
+        mixed_qkvz = qkvz.reshape(new_shape_qkvz)
+        split_indices_qkvz = [self.head_k_dim, 2 * self.head_k_dim, 2 * self.head_k_dim + (self.v_heads_per_k_head * self.head_v_dim)]
+        query, key, value_raw, z_raw = jnp.split(mixed_qkvz, split_indices_qkvz, axis=3)
+        value = value_raw.reshape(batch, seq_len, self.num_v_heads, self.head_v_dim)
+        z = z_raw.reshape(batch, seq_len, self.num_v_heads, self.head_v_dim)
+
+        new_shape_ba = (batch, seq_len, self.num_k_heads, 2 * self.v_heads_per_k_head)
+        mixed_ba = ba.reshape(new_shape_ba)
+        b_raw, a_raw = jnp.split(mixed_ba, [self.v_heads_per_k_head], axis=3)
+        b = b_raw.reshape(batch, seq_len, self.num_v_heads)
+        a = a_raw.reshape(batch, seq_len, self.num_v_heads)
+
+        q = query.reshape(batch, seq_len, -1)
+        k = key.reshape(batch, seq_len, -1)
+        v = value.reshape(batch, seq_len, -1)
+        qkv = jnp.concatenate([q, k, v], axis=-1)
+        
+        conv_out = self.conv1d(qkv)
+        qkv_conv = jax.nn.silu(conv_out.astype(jnp.float32)).astype(cfg.dtype)
+        q_conv, k_conv, v_conv = jnp.split(qkv_conv, [self.key_dim, 2 * self.key_dim], axis=-1)
+
+        query = q_conv.reshape(batch, seq_len, self.num_k_heads, self.head_k_dim)
+        key = k_conv.reshape(batch, seq_len, self.num_k_heads, self.head_k_dim)
+        value = v_conv.reshape(batch, seq_len, self.num_v_heads, self.head_v_dim)
+
+        # FIXED .value DEPRECATION
+        A_log = self.A_log[...]
+        dt_bias = self.dt_bias[...]
+        beta = jax.nn.sigmoid(b)
+        g = -jnp.exp(A_log.astype(jnp.float32)) * jax.nn.softplus(a.astype(jnp.float32) + dt_bias.astype(jnp.float32))
+        g = g.astype(cfg.dtype)
+
+        if self.num_v_heads > self.num_k_heads and self.num_v_heads % self.num_k_heads == 0:
+            repeats = self.num_v_heads // self.num_k_heads
+            query = jnp.repeat(query, repeats, axis=2)
+            key = jnp.repeat(key, repeats, axis=2)
+
+        # USING BASELINE KERNEL
+        core_attn_out, _ = baseline_chunk_gated_delta_rule(
+            query, key, value, g, beta, chunk_size=cfg.gdn_chunk_size, use_qk_norm_in_gdn=cfg.use_qk_norm_in_gdn
+        )
+
+        gated_output_reshaped = self.norm(core_attn_out, z)
+        gated_output = gated_output_reshaped.reshape(batch, seq_len, -1)
+        output = self.out_proj(gated_output)
+        return output
+
+
+# ==============================================================================
+# SECTION 2: BENCHMARK HARNESS
+# ==============================================================================
+
+def run_comparison():
+    backend = jax.extend.backend.get_backend().platform
+    print(f"\nDevice: {jax.devices()[0]} ({backend})")
+    
+    # --- CONFIGURATION ---
+    if backend == 'tpu':
+        # REAL BENCHMARK SETTINGS (Heavy)
+        DTYPE = jnp.bfloat16
+        BATCH = 2
+        SEQ_LEN = 4096      
+        ITERS = 20          
+        WARMUP = 5
+    else:
+        # CPU DEBUG SETTINGS (Fast)
+        print("⚠️  Running on CPU: Using reduced dimensions for speed.")
+        DTYPE = jnp.float32 
+        BATCH = 1
+        SEQ_LEN = 128       
+        ITERS = 5           
+        WARMUP = 1
+
+    HIDDEN_SIZE = 2048
+    NUM_KEY_HEADS = 16
+    NUM_VALUE_HEADS = 32
+    HEAD_DIM = 128
+    CONV_KERNEL_DIM = 4
+    CHUNK_SIZE = 64
+    PROFILE_DIR = "/tmp/maxtext_gdn_profile"
+    
+    print(f"Config: Batch={BATCH}, SeqLen={SEQ_LEN}, Dtype={DTYPE}")
+    print(f"Model: H={HIDDEN_SIZE}, K_Heads={NUM_KEY_HEADS}, V_Heads={NUM_VALUE_HEADS}, HeadDim={HEAD_DIM}")
+
+    dummy_config = types.SimpleNamespace(
+        emb_dim=HIDDEN_SIZE,
+        gdn_num_value_heads=NUM_VALUE_HEADS,
+        gdn_num_key_heads=NUM_KEY_HEADS,
+        gdn_key_head_dim=HEAD_DIM,
+        gdn_value_head_dim=HEAD_DIM,
+        gdn_conv_kernel_dim=CONV_KERNEL_DIM,
+        dtype=DTYPE,
+        matmul_precision='default', 
+        normalization_layer_epsilon=1e-6,
+        weight_dtype=DTYPE,
+        gdn_chunk_size=CHUNK_SIZE,
+        use_qk_norm_in_gdn=True,
+        load_balance_loss_weight=0.0,
+        scan_layers=False
+    )
+
+    # 1. INSTANTIATE MODELS
+    print("Initializing models...")
+    rngs_base = nnx.Rngs(0)
+    baseline_model = BaselineGatedDeltaNet(config=dummy_config, rngs=rngs_base)
+    
+    rngs_opt = nnx.Rngs(0)
+    optimized_model = qwen3.Qwen3NextGatedDeltaNet(config=dummy_config, rngs=rngs_opt)
+
+    # 2. WEIGHT SYNCHRONIZATION
+    _, params_state = nnx.split(optimized_model)
+    nnx.update(baseline_model, params_state)
+    print("✅ Models synchronized with identical weights.")
+
+    # 3. INPUTS
+    key = jax.random.PRNGKey(42)
+    inputs = jax.random.normal(key, (BATCH, SEQ_LEN, HIDDEN_SIZE), dtype=DTYPE)
+
+    # -------------------------------------------------------------------------
+    # Helper: Pure Functional wrappers to avoid Flax/JAX Version mismatch issues
+    # -------------------------------------------------------------------------
+    def create_jitted_train_step(model, input_shape):
+        graphdef, params = nnx.split(model)
+        
+        # 1. Create a static, deterministic projection tensor
+        # We generate this outside the JIT so it is a frozen constant in the graph
+        proj_key = jax.random.PRNGKey(99)
+        projection = jax.random.normal(proj_key, input_shape)
+        
+        @jax.jit
+        def pure_train_step(params, x):
+            m = nnx.merge(graphdef, params)
+            def loss_fn(m_inner):
+                y = m_inner(x)
+                # 2. Position-aware loss
+                # Every element is scaled by a unique, random value before averaging
+                loss = jnp.mean(y * projection.astype(y.dtype)) 
+                return loss, y
+                
+            (loss, y), grads = nnx.value_and_grad(loss_fn, has_aux=True)(m)
+            return loss, y, grads
+            
+        return pure_train_step, params
+
+    def create_jitted_forward(model):
+        graphdef, params = nnx.split(model)
+        
+        @jax.jit
+        def pure_forward(params, x):
+            m = nnx.merge(graphdef, params)
+            return m(x)
+            
+        return pure_forward, params
+
+    # ==============================================================================
+    # PART A: LOGICAL CORRECTNESS
+    # ==============================================================================
+    print("\n--- Checking Logical Correctness ---")
+
+    # Pass the input shape so the random projection matches the output dimensions
+    jit_train_base, params_base = create_jitted_train_step(baseline_model, inputs.shape)
+    jit_train_opt, params_opt = create_jitted_train_step(optimized_model, inputs.shape)
+
+    # Unpack loss, the raw output tensor, and gradients
+    loss_base, out_base, grads_base = jit_train_base(params_base, inputs)
+    jax.block_until_ready((loss_base, out_base, grads_base))
+
+    loss_opt, out_opt, grads_opt = jit_train_opt(params_opt, inputs)
+    jax.block_until_ready((loss_opt, out_opt, grads_opt))
+
+    # 1. Compare the Forward Pass Output Tensors (Element-by-Element)
+    max_out_diff = float(jnp.max(jnp.abs(out_base - out_opt)))
+    print(f"Forward Pass Max Output Diff: {max_out_diff:.2e}")
+
+    # 2. Compare the Loss
+    diff_loss = jnp.abs(loss_base - loss_opt)
+    print(f"Loss Scalar Diff: {float(diff_loss):.2e}")
+
+    # 3. Compare the Gradients (Element-by-Element)
+    flat_grads_base, _ = jax.tree_util.tree_flatten(grads_base)
+    flat_grads_opt, _ = jax.tree_util.tree_flatten(grads_opt)
+    
+    max_grad_diff = 0.0
+    for g1, g2 in zip(flat_grads_base, flat_grads_opt):
+        if hasattr(g1, 'shape'):
+            d = jnp.max(jnp.abs(g1 - g2))
+            max_grad_diff = max(max_grad_diff, float(d))
+
+    print(f"Backward Pass Max Grad Diff: {max_grad_diff:.2e}")
+
+    # Define a strict tolerance
+    TOLERANCE = 1e-3 if DTYPE == jnp.bfloat16 else 1e-5
+
+    if max_out_diff > TOLERANCE or max_grad_diff > TOLERANCE:
+        print("❌ WARNING: Significant divergence detected!")
+    else:
+        print("✅ Outputs & Gradients match within tolerance.")
+
+    # ==============================================================================
+    # PART B: SPEED BENCHMARKING
+    # ==============================================================================
+    print("\n--- Performance Benchmark ---")
+
+    def benchmark_func(name, func, *args):
+        print(f"Benchmarking {name}...")
+        # Warmup
+        for _ in range(WARMUP):
+            out = func(*args)
+            jax.block_until_ready(out)
+        
+        # Time it
+        t0 = time.time()
+        for _ in range(ITERS):
+            out = func(*args)
+            jax.block_until_ready(out)
+        t_avg = (time.time() - t0) / ITERS * 1000
+        print(f"  -> {t_avg:.2f} ms")
+        return t_avg
+    
+    # Create forward-only wrappers
+    jit_fwd_base, _ = create_jitted_forward(baseline_model)
+    jit_fwd_opt, _ = create_jitted_forward(optimized_model)
+    
+    t_fwd_base = benchmark_func("Baseline Forward", jit_fwd_base, params_base, inputs)
+    t_fwd_opt = benchmark_func("Optimized Forward", jit_fwd_opt, params_opt, inputs)
+    
+    t_train_base = benchmark_func("Baseline Train Step", jit_train_base, params_base, inputs)
+    t_train_opt = benchmark_func("Optimized Train Step", jit_train_opt, params_opt, inputs)
+
+    print(f"\n--- Results ---")
+    print(f"Forward Speedup:       {t_fwd_base/t_fwd_opt:.2f}x  ({t_fwd_base:.2f}ms -> {t_fwd_opt:.2f}ms)")
+    print(f"Training Step Speedup: {t_train_base/t_train_opt:.2f}x  ({t_train_base:.2f}ms -> {t_train_opt:.2f}ms)")
+
+    # ==============================================================================
+    # PART C: STATIC MEMORY ANALYSIS
+    # ==============================================================================
+    print("\n--- Static Memory Analysis (Compiler Estimate) ---")
+    
+    def analyze_memory(name, func, *args):
+        print(f"Analyzing {name}...")
+        try:
+            compiled = func.lower(*args).compile()
+            mem_analysis = compiled.memory_analysis()
+            
+            if mem_analysis is None:
+                print("  Memory analysis not supported on this backend/version.")
+                return 0
+            
+            # JAX 0.8.0+: The string representation is the most reliable way to read stats
+            print(f"  {mem_analysis}")
+            
+            # Try to grab bytes if available, otherwise return 0 (skipping reduction calc)
+            if hasattr(mem_analysis, 'temp_size_in_bytes'):
+                return mem_analysis.temp_size_in_bytes
+            return 0
+            
+        except Exception as e:
+            print(f"  Memory analysis failed: {e}")
+            return 0
+
+    mem_base = analyze_memory("Baseline Train Step", jit_train_base, params_base, inputs)
+    mem_opt = analyze_memory("Optimized Train Step", jit_train_opt, params_opt, inputs)
+    
+    if mem_base > 0 and mem_opt > 0:
+        reduction = (mem_base - mem_opt) / mem_base * 100
+        # Positive reduction = Good (Saved memory)
+        # Negative reduction = Bad (Regression)
+        print(f"\nMemory Reduction: {reduction:.2f}% (Higher is better)")
+
+    # ==============================================================================
+    # PART D: PROFILING
+    # ==============================================================================
+    print(f"\n--- Profiling Optimized Implementation ---")
+    print(f"Saving trace to: {PROFILE_DIR}")
+    
+    try:
+        jax.profiler.start_trace(PROFILE_DIR)
+        for _ in range(WARMUP): # Use warmup count just to get a few samples
+            out = jit_train_opt(params_opt, inputs)
+            jax.block_until_ready(out)
+        jax.profiler.stop_trace()
+        print("Profiling complete.")
+    except Exception as e:
+        print(f"Profiling failed (possibly already active): {e}")
+        
+    print(f"Path: {PROFILE_DIR}")
+
+    # ==============================================================================
+    # PART E: STABILITY STRESS TEST (ADDITION)
+    # ==============================================================================
+    print("\n--- Stability Stress Test ---")
+
+    # 1. Define a training step that actually updates parameters (SGD)
+    def create_jitted_update_step(model, learning_rate=1e-4):
+        graphdef, params = nnx.split(model)
+        
+        @jax.jit
+        def train_update(params, x):
+            # Reconstruct model
+            m = nnx.merge(graphdef, params)
+            
+            def loss_fn(m_inner):
+                # Use a slightly more complex loss to encourage gradient flow
+                y = m_inner(x)
+                return jnp.mean(jnp.square(y))
+            
+            loss, grads = nnx.value_and_grad(loss_fn)(m)
+            
+            # Manual SGD Update: param = param - lr * grad
+            new_params = jax.tree_util.tree_map(
+                lambda p, g: p - learning_rate * g,
+                params, grads
+            )
+            return loss, grads, new_params
+            
+        return train_update, params
+
+    # 2. Initialize the update step
+    jit_update_opt, current_params = create_jitted_update_step(optimized_model)
+    
+    # 3. Run simulation loop
+    TEST_STEPS = 15
+    print(f"Running {TEST_STEPS} simulated training steps with FRESH inputs...")
+    
+    for step in range(1, TEST_STEPS + 1):
+        # Generate fresh random input to mimic varying data distribution
+        step_key = jax.random.fold_in(key, step * 100)
+        step_input = jax.random.normal(step_key, (BATCH, SEQ_LEN, HIDDEN_SIZE), dtype=DTYPE)
+        
+        # Perform update
+        loss_val, grads_val, current_params = jit_update_opt(current_params, step_input)
+        
+        # Block to ensure we catch the error at the specific step
+        jax.block_until_ready(loss_val)
+
+        # --- CHECKS ---
+        # 1. Check Loss
+        if jnp.isnan(loss_val) or jnp.isinf(loss_val):
+            print(f"\n❌ CRITICAL FAIL at Step {step}: Loss is {loss_val}!")
+            return
+
+        # 2. Check Gradients (Aggregate check)
+        grad_any_nan = jax.tree_util.tree_reduce(
+            lambda acc, x: acc or jnp.any(jnp.isnan(x)) or jnp.any(jnp.isinf(x)), 
+            grads_val, False
+        )
+        if grad_any_nan:
+            print(f"\n❌ CRITICAL FAIL at Step {step}: Gradients contain NaN or Inf!")
+            # Optional: Print which specific parameter exploded
+            flat_grads, struct = jax.tree_util.tree_flatten(grads_val)
+            for i, g in enumerate(flat_grads):
+                if jnp.any(jnp.isnan(g)): print(f"   -> Gradient index {i} is NaN")
+            return
+
+        # 3. Check Parameters
+        param_any_nan = jax.tree_util.tree_reduce(
+            lambda acc, x: acc or jnp.any(jnp.isnan(x)) or jnp.any(jnp.isinf(x)), 
+            current_params, False
+        )
+        if param_any_nan:
+            print(f"\n❌ CRITICAL FAIL at Step {step}: Parameters contain NaN or Inf after update!")
+            return
+
+        print(f"  Step {step}: Loss = {float(loss_val):.6f} | Stability: OK")
+
+    print(f"✅ Stability Stress Test Passed: No NaNs encountered in {TEST_STEPS} steps.")
+
+if __name__ == "__main__":
+    run_comparison()

--- a/src/maxtext/scratch_code/gdn_pallas.py
+++ b/src/maxtext/scratch_code/gdn_pallas.py
@@ -1,0 +1,181 @@
+# src/MaxText/kernels/gdn_pallas.py
+import functools
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+# ==============================================================================
+# 1. Pallas Kernel Implementation (Forward Pass Logic)
+# ==============================================================================
+def gdn_scan_kernel_tpu(
+    w_ref, u_ref, q_ref, k_ref, v_ref, g_ref, beta_ref, h_init_ref, 
+    o_ref, h_final_ref,
+    # Hyperparameters
+    num_chunks: int, chunk_size: int, key_dim: int, val_dim: int,
+    dtype: jnp.dtype = jnp.bfloat16
+):
+    # 1. Load Initial State
+    h = h_init_ref[0, 0].astype(jnp.float32)
+
+    for i in range(num_chunks):
+        # 2. Load Inputs
+        w = w_ref[0, 0, i] 
+        u = u_ref[0, 0, i] 
+        q = q_ref[0, 0, i] 
+        k = k_ref[0, 0, i] 
+        v = v_ref[0, 0, i] 
+        g = g_ref[0, 0, i] 
+        beta = beta_ref[0, 0, i] 
+
+        # 3. Output Computation
+        # Inter-chunk: q * exp(g) @ h
+        g_exp = jnp.exp(g.astype(jnp.float32))
+        q_g = q.astype(jnp.float32) * g_exp[:, None]
+        term1 = jnp.dot(q_g, h) 
+
+        # Intra-chunk: (q @ k.T * decay) @ v
+        attn = jnp.dot(q.astype(jnp.float32), k.astype(jnp.float32).T)
+        
+        # Decay: exp(g[i] - g[j])
+        g_diff = g.astype(jnp.float32)[:, None] - g.astype(jnp.float32)[None, :]
+        
+        # FIX: Apply mask BEFORE exp to prevent Inf * 0 = NaN
+        # Use float32 arithmetic for masking to avoid boolean type issues in Mosaic
+        mask_val = jnp.tri(chunk_size, dtype=jnp.float32)
+        
+        # For upper triangle (mask=0), set g_diff to -1e30 so exp() becomes 0
+        # g_diff_masked = g_diff * 1.0 + (1.0 - 0.0) * -1e30 = -1e30
+        large_neg = -1e30
+        g_diff = g_diff * mask_val + (1.0 - mask_val) * large_neg
+        
+        attn_decay = jnp.exp(g_diff)
+        attn = attn * attn_decay
+
+        # Apply Beta gates
+        attn = attn * beta.astype(jnp.float32)[:, None] 
+        
+        # V projection
+        term2 = jnp.dot(attn, v.astype(jnp.float32))
+        
+        o_chunk = term1 + term2
+        o_ref[0, 0, i] = o_chunk.astype(dtype)
+
+        # 4. State Update
+        chunk_decay = jnp.exp(g[chunk_size - 1]) 
+        update = jnp.dot(w.astype(jnp.float32).T, u.astype(jnp.float32))
+        h = h * chunk_decay + update
+
+    # 5. Store Final State
+    h_final_ref[0, 0] = h.astype(dtype)
+
+# ==============================================================================
+# 2. JAX Reference Implementation (For Autodiff)
+# ==============================================================================
+def _gdn_reference(w, u, q, k, v, g, beta, h_init):
+    """Pure JAX equivalent for autodiff."""
+    perm_vec = (2, 0, 1, 3, 4)
+    perm_scl = (2, 0, 1, 3)
+    
+    w_s = w.transpose(perm_vec)
+    u_s = u.transpose(perm_vec)
+    q_s = q.transpose(perm_vec)
+    k_s = k.transpose(perm_vec)
+    v_s = v.transpose(perm_vec)
+    g_s = g.transpose(perm_scl)
+    beta_s = beta.transpose(perm_scl)
+    
+    h_curr = h_init.astype(jnp.float32)
+    B, H, N, C, Dk = k.shape
+    
+    def scan_body(h, args):
+        wt, ut, qt, kt, vt, gt, betat = args
+        
+        # Inter-chunk
+        gt_exp = jnp.exp(gt.astype(jnp.float32))
+        q_g = qt.astype(jnp.float32) * gt_exp[..., None]
+        term1 = jnp.matmul(q_g, h)
+        
+        # Intra-chunk
+        attn = jnp.matmul(qt.astype(jnp.float32), kt.astype(jnp.float32).swapaxes(-1, -2))
+        
+        # Decay (g[i] - g[j])
+        g_diff = gt[..., :, None] - gt[..., None, :]
+        
+        # Mask before exp (match Pallas logic)
+        mask = jnp.tril(jnp.ones((C, C), dtype=jnp.float32))
+        g_diff = g_diff * mask + (1.0 - mask) * -1e30
+        
+        attn = attn * jnp.exp(g_diff)
+        attn = attn * betat.astype(jnp.float32)[..., None]
+        term2 = jnp.matmul(attn, vt.astype(jnp.float32))
+        
+        out = (term1 + term2).astype(v.dtype)
+        
+        # Update
+        chunk_decay = jnp.exp(gt[..., -1])[..., None, None]
+        update = jnp.matmul(wt.astype(jnp.float32).swapaxes(-1, -2), ut.astype(jnp.float32))
+        h_new = h * chunk_decay + update
+        
+        return h_new, out
+
+    h_final, o_scan = lax.scan(
+        scan_body, 
+        h_curr, 
+        (w_s, u_s, q_s, k_s, v_s, g_s, beta_s)
+    )
+    
+    return o_scan.transpose(1, 2, 0, 3, 4), h_final.astype(v.dtype)
+
+# ==============================================================================
+# 3. Custom VJP Registration
+# ==============================================================================
+
+def _gdn_pallas_forward(w, u, q, k, v, g, beta, h_init):
+    B, H, N_chunks, C, Dk = k.shape
+    _, _, _, _, Dv = v.shape
+    
+    # Specs
+    in_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dk))
+    val_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dv))
+    scalar_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, N_chunks, C))
+    out_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dv))
+    state_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, Dk, Dv))
+
+    kernel_fn = functools.partial(
+        gdn_scan_kernel_tpu,
+        num_chunks=N_chunks, chunk_size=C, key_dim=Dk, val_dim=Dv, dtype=v.dtype
+    )
+
+    out, h_final = pl.pallas_call(
+        kernel_fn,
+        out_shape=[
+            jax.ShapeDtypeStruct((B, H, N_chunks, C, Dv), v.dtype), 
+            jax.ShapeDtypeStruct((B, H, Dk, Dv), v.dtype)
+        ],
+        grid=(B, H),
+        in_specs=[in_specs, val_specs, in_specs, in_specs, val_specs, scalar_specs, scalar_specs, state_spec],
+        out_specs=[out_spec, state_spec],
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "parallel"))
+    )(w, u, q, k, v, g, beta, h_init)
+    
+    return (out, h_final), (w, u, q, k, v, g, beta, h_init)
+
+def _gdn_pallas_backward(residuals, grad_out_tuple):
+    grad_out, _ = grad_out_tuple 
+    w, u, q, k, v, g, beta, h_init = residuals
+    
+    _, vjp_fn = jax.vjp(_gdn_reference, w, u, q, k, v, g, beta, h_init)
+    
+    grad_h_final = jnp.zeros_like(h_init)
+    grads = vjp_fn((grad_out, grad_h_final))
+    return grads
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=())
+def gdn_pallas_layer(w, u, q, k, v, g, beta, h_init):
+    # Returns (output, final_state)
+    res, _ = _gdn_pallas_forward(w, u, q, k, v, g, beta, h_init)
+    return res
+
+gdn_pallas_layer.defvjp(_gdn_pallas_forward, _gdn_pallas_backward)

--- a/src/maxtext/scratch_code/gdn_pallas2.py
+++ b/src/maxtext/scratch_code/gdn_pallas2.py
@@ -1,0 +1,477 @@
+# src/MaxText/kernels/gdn_pallas_optimized.py
+import functools
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+# ==============================================================================
+# 1. Pallas Kernel Implementation (Forward Pass Logic)
+# ==============================================================================
+def gdn_scan_kernel_tpu(
+    w_ref, u_ref, q_ref, k_ref, v_ref, g_ref, beta_ref, h_init_ref, 
+    o_ref, h_final_ref,
+    # Hyperparameters
+    num_chunks: int, chunk_size: int, key_dim: int, val_dim: int,
+    dtype: jnp.dtype = jnp.bfloat16
+):
+    """Forward kernel for GDN layer.
+    
+    Args:
+        w_ref: (N_chunks, C, Dk) # Memory: VMEM
+        u_ref: (N_chunks, C, Dv) # Memory: VMEM
+        q_ref: (N_chunks, C, Dk) # Memory: VMEM
+        k_ref: (N_chunks, C, Dk) # Memory: VMEM
+        v_ref: (N_chunks, C, Dv) # Memory: VMEM
+        g_ref: (N_chunks, C)     # Memory: VMEM
+        beta_ref: (N_chunks, C)  # Memory: VMEM
+        h_init_ref: (Dk, Dv)     # Memory: VMEM
+        o_ref: (N_chunks, C, Dv) # Memory: VMEM (Output)
+        h_final_ref: (Dk, Dv)    # Memory: VMEM (Output)
+    """
+
+    # 1. Load Initial State
+    h = h_init_ref[0, 0].astype(jnp.float32)
+
+    for i in range(num_chunks):
+
+        # 2. Load Inputs
+        w = w_ref[0, 0, i] 
+        u = u_ref[0, 0, i] 
+        q = q_ref[0, 0, i] 
+        k = k_ref[0, 0, i] 
+        v = v_ref[0, 0, i] 
+        # Cast g to float32 immediately to ensure scalar indexing works (Mosaic restriction)
+        g = g_ref[0, 0, i].astype(jnp.float32)
+        beta = beta_ref[0, 0, i] 
+
+        # 3. Output Computation
+        # Inter-chunk: q * exp(g) @ h
+        g_exp = jnp.exp(g)
+        q_g = q.astype(jnp.float32) * g_exp[:, None]
+        term1 = jnp.dot(q_g, h) 
+
+        # Intra-chunk: (q @ k.T * decay) @ v
+        attn = jnp.dot(q.astype(jnp.float32), k.astype(jnp.float32).T)
+        
+        # Decay: exp(g[i] - g[j])
+        g_diff = g[:, None] - g[None, :]
+        
+        # FIX: Apply mask BEFORE exp to prevent Inf * 0 = NaN
+        # Use float32 arithmetic for masking to avoid boolean type issues in Mosaic
+        mask_val = jnp.tri(chunk_size, dtype=jnp.float32)
+        
+        # For upper triangle (mask=0), set g_diff to -1e30 so exp() becomes 0
+        large_neg = -1e30
+        g_diff = g_diff * mask_val + (1.0 - mask_val) * large_neg
+        
+        attn_decay = jnp.exp(g_diff)
+        attn = attn * attn_decay
+
+        # Apply Beta gates
+        attn = attn * beta.astype(jnp.float32)[:, None] 
+        
+        # V projection
+        term2 = jnp.dot(attn, v.astype(jnp.float32))
+        
+        o_chunk = term1 + term2
+        o_ref[0, 0, i] = o_chunk.astype(dtype)
+
+        # 4. State Update
+        # g is already float32, so g[idx] yields a float32 scalar, which is valid
+        chunk_decay = jnp.exp(g[chunk_size - 1]) 
+        update = jnp.dot(w.astype(jnp.float32).T, u.astype(jnp.float32))
+        h = h * chunk_decay + update
+        
+
+    # 5. Store Final State
+    h_final_ref[0, 0] = h.astype(dtype)
+    
+
+# ==============================================================================
+# 2. Pallas Kernel Implementation (Backward Pass Logic)
+# ==============================================================================
+def gdn_backward_kernel_tpu(
+    w_ref, u_ref, q_ref, k_ref, v_ref, g_ref, beta_ref, h_init_ref, 
+    grad_o_ref, grad_h_final_ref,
+    grad_w_ref, grad_u_ref, grad_q_ref, grad_k_ref, grad_v_ref, grad_g_ref, grad_beta_ref, grad_h_init_ref,
+    h_buffer_ref, # Scratch buffer for state recomputation
+    # Hyperparameters
+    num_chunks: int, chunk_size: int, key_dim: int, val_dim: int,
+    dtype: jnp.dtype = jnp.bfloat16
+):
+    """Backward kernel for GDN layer.
+    
+    Strategy: Recompute-and-Backprop
+    1. Re-run forward pass to store intermediate states `h` in VMEM buffer.
+    2. Iterate backwards to compute gradients.
+    
+    Args:
+        w_ref, u_ref, ...: Inputs (N_chunks, C, ...) # Memory: VMEM
+        grad_o_ref: Output gradients (N_chunks, C, Dv) # Memory: VMEM
+        grad_h_final_ref: Final state gradient (Dk, Dv) # Memory: VMEM
+        grad_w_ref, ...: Input gradients (N_chunks, C, ...) # Memory: VMEM (Accumulators)
+        h_buffer_ref: Scratch memory (N_chunks, Dk, Dv) # Memory: VMEM
+    """
+
+    # --------------------------------------------------------------------------
+    # Phase 1: Forward Recompute (Fill h_buffer)
+    # --------------------------------------------------------------------------
+    h = h_init_ref[0, 0].astype(jnp.float32) # Load initial state # Load: VMEM -> Registers
+
+    for i in range(num_chunks):
+
+        # Store current h to buffer (state before update)
+        # Use Ref assignment instead of at[].set to avoid scatter on local arrays
+        h_buffer_ref[i] = h 
+        
+        # Load Inputs
+        w = w_ref[0, 0, i] 
+        u = u_ref[0, 0, i] 
+        # Cast g to float32 immediately to ensure scalar indexing works
+        g = g_ref[0, 0, i].astype(jnp.float32)
+        
+        # State Update Logic Only (don't need full output logic here)
+        chunk_decay = jnp.exp(g[chunk_size - 1])
+        update = jnp.dot(w.astype(jnp.float32).T, u.astype(jnp.float32))
+        h = h * chunk_decay + update
+
+    # --------------------------------------------------------------------------
+    # Phase 2: Backward Scan
+    # --------------------------------------------------------------------------
+    grad_h = grad_h_final_ref[0, 0].astype(jnp.float32) # Load: VMEM -> Registers
+    
+    # Iterate backwards from last chunk
+    for i in range(num_chunks - 1, -1, -1):
+
+        # Load Inputs for this chunk
+        w = w_ref[0, 0, i].astype(jnp.float32)
+        u = u_ref[0, 0, i].astype(jnp.float32)
+        q = q_ref[0, 0, i].astype(jnp.float32)
+        k = k_ref[0, 0, i].astype(jnp.float32)
+        v = v_ref[0, 0, i].astype(jnp.float32)
+        g = g_ref[0, 0, i].astype(jnp.float32)
+        beta = beta_ref[0, 0, i].astype(jnp.float32)
+        grad_o = grad_o_ref[0, 0, i].astype(jnp.float32)
+        
+        # Load state h from buffer (state at start of this chunk)
+        h = h_buffer_ref[i] # Load: VMEM -> Registers
+        
+        # --- Gradients from State Update (h_new = h * decay + update) ---
+        # grad_h is dL/dh_new coming from future
+        
+        # grad_update = grad_h
+        grad_update = grad_h
+        
+        # grad_w = u @ grad_update.T
+        grad_w = jnp.dot(u, grad_update.T)
+        
+        # grad_u = w @ grad_update
+        grad_u = jnp.dot(w, grad_update)
+        
+        # grad_chunk_decay = sum(grad_h * h)
+        chunk_decay = jnp.exp(g[chunk_size - 1])
+        grad_chunk_decay = jnp.sum(grad_h * h)
+        
+        # grad_h_prev (part 1) = grad_h * chunk_decay
+        grad_h_prev = grad_h * chunk_decay
+        
+        # Contribution to grad_g from chunk_decay
+        # FIX: Avoid scatter (at[].set) on local array. Use mask instead.
+        mask = (jnp.arange(chunk_size) == (chunk_size - 1)).astype(jnp.float32)
+        grad_g_from_decay = mask * (grad_chunk_decay * chunk_decay)
+
+        # --- Gradients from Output (o = term1 + term2) ---
+        grad_term1 = grad_o
+        grad_term2 = grad_o
+        
+        # --- Gradients from Term 1 (Inter-chunk: q * exp(g) @ h) ---
+        # term1 = (q * exp(g)) @ h
+        g_exp = jnp.exp(g)
+        q_g = q * g_exp[:, None]
+        
+        # grad_q_g = grad_term1 @ h.T
+        grad_q_g = jnp.dot(grad_term1, h.T)
+        
+        # grad_h_prev (part 2) += q_g.T @ grad_term1
+        grad_h_prev += jnp.dot(q_g.T, grad_term1)
+        
+        # grad_q = grad_q_g * exp(g)
+        grad_q = grad_q_g * g_exp[:, None]
+        
+        # grad_g (part 1) = sum(grad_q_g * q * exp(g), axis=1)
+        grad_g_term1 = jnp.sum(grad_q_g * q_g, axis=1)
+        
+        # --- Gradients from Term 2 (Intra-chunk) ---
+        # term2 = attn @ v
+        # attn = (q @ k.T) * exp(g_diff) * beta
+        
+        attn_logits = jnp.dot(q, k.T)
+        
+        # Recompute g_diff and mask
+        g_diff = g[:, None] - g[None, :]
+        mask_val = jnp.tri(chunk_size, dtype=jnp.float32)
+        large_neg = -1e30
+        g_diff_masked = g_diff * mask_val + (1.0 - mask_val) * large_neg
+        attn_decay = jnp.exp(g_diff_masked)
+        
+        # attn = attn_logits * attn_decay * beta
+        
+        # grad_v = attn.T @ grad_term2
+        # Reconstruct full attn for grad_v
+        attn = attn_logits * attn_decay * beta[:, None]
+        grad_v = jnp.dot(attn.T, grad_term2)
+        
+        # grad_attn = grad_term2 @ v.T
+        grad_attn = jnp.dot(grad_term2, v.T)
+        
+        # grad_beta
+        # attn = pre_beta_attn * beta
+        pre_beta_attn = attn_logits * attn_decay
+        grad_beta = jnp.sum(grad_attn * pre_beta_attn, axis=1)
+        
+        # grad_pre_beta_attn = grad_attn * beta
+        grad_pre_beta_attn = grad_attn * beta[:, None]
+        
+        # grad_attn_decay = grad_pre_beta_attn * attn_logits
+        grad_attn_decay = grad_pre_beta_attn * attn_logits
+        
+        # grad_g_diff_masked = grad_attn_decay * attn_decay
+        grad_g_diff_masked = grad_attn_decay * attn_decay
+        
+        # grad_g (part 2) from g_diff
+        # Mask handling: gradients only flow where mask=1
+        grad_g_diff = grad_g_diff_masked * mask_val
+        grad_g_term2 = jnp.sum(grad_g_diff, axis=1) - jnp.sum(grad_g_diff, axis=0)
+        
+        # grad_attn_logits = grad_pre_beta_attn * attn_decay
+        grad_attn_logits = grad_pre_beta_attn * attn_decay
+        
+        # grad_q (part 2) = grad_attn_logits @ k
+        grad_q += jnp.dot(grad_attn_logits, k)
+        
+        # grad_k = grad_attn_logits.T @ q
+        grad_k = jnp.dot(grad_attn_logits.T, q)
+        
+        # Total grad_g
+        grad_g = grad_g_from_decay + grad_g_term1 + grad_g_term2
+        
+        # --- Store Gradients ---
+        grad_w_ref[0, 0, i] = grad_w.astype(dtype)
+        grad_u_ref[0, 0, i] = grad_u.astype(dtype)
+        grad_q_ref[0, 0, i] = grad_q.astype(dtype)
+        grad_k_ref[0, 0, i] = grad_k.astype(dtype)
+        grad_v_ref[0, 0, i] = grad_v.astype(dtype)
+        grad_g_ref[0, 0, i] = grad_g.astype(dtype)
+        grad_beta_ref[0, 0, i] = grad_beta.astype(dtype)
+        
+        # Update grad_h for next iteration (previous chunk)
+        grad_h = grad_h_prev
+        
+        
+    # Store final grad_h_init
+    grad_h_init_ref[0, 0] = grad_h.astype(dtype)
+    
+
+
+# ==============================================================================
+# 3. JAX Reference Implementation (For Autodiff)
+# ==============================================================================
+def _gdn_reference(w, u, q, k, v, g, beta, h_init):
+    """Pure JAX equivalent for autodiff."""
+    perm_vec = (2, 0, 1, 3, 4)
+    perm_scl = (2, 0, 1, 3)
+    
+    w_s = w.transpose(perm_vec)
+    u_s = u.transpose(perm_vec)
+    q_s = q.transpose(perm_vec)
+    k_s = k.transpose(perm_vec)
+    v_s = v.transpose(perm_vec)
+    g_s = g.transpose(perm_scl)
+    beta_s = beta.transpose(perm_scl)
+    
+    h_curr = h_init.astype(jnp.float32)
+    B, H, N, C, Dk = k.shape
+    
+    def scan_body(h, args):
+        wt, ut, qt, kt, vt, gt, betat = args
+        
+        # Inter-chunk
+        gt_exp = jnp.exp(gt.astype(jnp.float32))
+        q_g = qt.astype(jnp.float32) * gt_exp[..., None]
+        term1 = jnp.matmul(q_g, h)
+        
+        # Intra-chunk
+        attn = jnp.matmul(qt.astype(jnp.float32), kt.astype(jnp.float32).swapaxes(-1, -2))
+        
+        # Decay (g[i] - g[j])
+        g_diff = gt[..., :, None] - gt[..., None, :]
+        
+        # Mask before exp (match Pallas logic)
+        mask = jnp.tril(jnp.ones((C, C), dtype=jnp.float32))
+        g_diff = g_diff * mask + (1.0 - mask) * -1e30
+        
+        attn = attn * jnp.exp(g_diff)
+        attn = attn * betat.astype(jnp.float32)[..., None]
+        term2 = jnp.matmul(attn, vt.astype(jnp.float32))
+        
+        out = (term1 + term2).astype(v.dtype)
+        
+        # Update
+        chunk_decay = jnp.exp(gt[..., -1])[..., None, None]
+        update = jnp.matmul(wt.astype(jnp.float32).swapaxes(-1, -2), ut.astype(jnp.float32))
+        h_new = h * chunk_decay + update
+        
+        return h_new, out
+
+    h_final, o_scan = lax.scan(
+        scan_body, 
+        h_curr, 
+        (w_s, u_s, q_s, k_s, v_s, g_s, beta_s)
+    )
+    
+    return o_scan.transpose(1, 2, 0, 3, 4), h_final.astype(v.dtype)
+
+# ==============================================================================
+# 4. Custom VJP Registration & Wrappers
+# ==============================================================================
+
+def _gdn_pallas_forward(w, u, q, k, v, g, beta, h_init):
+    B, H, N_chunks, C, Dk = k.shape
+    _, _, _, _, Dv = v.shape
+    
+    # Specs
+    in_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dk))
+    val_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dv))
+    scalar_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, N_chunks, C))
+    out_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dv))
+    state_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, Dk, Dv))
+
+    kernel_fn = functools.partial(
+        gdn_scan_kernel_tpu,
+        num_chunks=N_chunks, chunk_size=C, key_dim=Dk, val_dim=Dv, dtype=v.dtype
+    )
+
+    out, h_final = pl.pallas_call(
+        kernel_fn,
+        out_shape=[
+            jax.ShapeDtypeStruct((B, H, N_chunks, C, Dv), v.dtype), 
+            jax.ShapeDtypeStruct((B, H, Dk, Dv), v.dtype)
+        ],
+        grid=(B, H),
+        in_specs=[in_specs, val_specs, in_specs, in_specs, val_specs, scalar_specs, scalar_specs, state_spec],
+        out_specs=[out_spec, state_spec],
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "parallel"))
+    )(w, u, q, k, v, g, beta, h_init)
+    
+    return (out, h_final), (w, u, q, k, v, g, beta, h_init)
+
+def _gdn_pallas_backward(residuals, grad_out_tuple):
+    grad_out, grad_h_final = grad_out_tuple 
+    w, u, q, k, v, g, beta, h_init = residuals
+    
+    B, H, N_chunks, C, Dk = k.shape
+    _, _, _, _, Dv = v.shape
+    
+    # BlockSpecs for inputs (same as forward)
+    in_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dk))
+    val_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dv))
+    scalar_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, N_chunks, C))
+    state_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, Dk, Dv))
+    
+    # BlockSpecs for gradients (match inputs)
+    grad_out_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dv))
+    grad_state_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, Dk, Dv))
+    
+    # Scratch spec for h_buffer
+    scratch_spec = pltpu.VMEM((N_chunks, Dk, Dv), jnp.float32)
+    
+    kernel_fn = functools.partial(
+        gdn_backward_kernel_tpu,
+        num_chunks=N_chunks, chunk_size=C, key_dim=Dk, val_dim=Dv, dtype=v.dtype
+    )
+    
+    # Grid spec with scratch
+    grid_spec = pltpu.PrefetchScalarGridSpec(
+        num_scalar_prefetch=0,
+        grid=(B, H),
+        in_specs=[
+            in_specs, val_specs, in_specs, in_specs, val_specs, scalar_specs, scalar_specs, state_spec, # Inputs
+            grad_out_spec, grad_state_spec # Gradients
+        ],
+        out_specs=[
+            in_specs, val_specs, in_specs, in_specs, val_specs, scalar_specs, scalar_specs, state_spec
+        ],
+        scratch_shapes=[scratch_spec]
+    )
+    
+    # Input order: w, u, q, k, v, g, beta, h_init, grad_o, grad_h_final
+    # Output order: grad_w, grad_u, grad_q, grad_k, grad_v, grad_g, grad_beta, grad_h_init
+    
+    grads = pl.pallas_call(
+        kernel_fn,
+        out_shape=[
+            jax.ShapeDtypeStruct(w.shape, w.dtype), # grad_w
+            jax.ShapeDtypeStruct(u.shape, u.dtype), # grad_u
+            jax.ShapeDtypeStruct(q.shape, q.dtype), # grad_q
+            jax.ShapeDtypeStruct(k.shape, k.dtype), # grad_k
+            jax.ShapeDtypeStruct(v.shape, v.dtype), # grad_v
+            jax.ShapeDtypeStruct(g.shape, g.dtype), # grad_g
+            jax.ShapeDtypeStruct(beta.shape, beta.dtype), # grad_beta
+            jax.ShapeDtypeStruct(h_init.shape, h_init.dtype), # grad_h_init
+        ],
+        grid_spec=grid_spec,
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "parallel"))
+    )(w, u, q, k, v, g, beta, h_init, grad_out, grad_h_final)
+    
+    return grads
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=())
+def gdn_pallas_layer(w, u, q, k, v, g, beta, h_init):
+    # Returns (output, final_state)
+    res, _ = _gdn_pallas_forward(w, u, q, k, v, g, beta, h_init)
+    return res
+
+gdn_pallas_layer.defvjp(_gdn_pallas_forward, _gdn_pallas_backward)
+
+# ==============================================================================
+# 5. Main Function (Testing)
+# ==============================================================================
+def main():
+    print("Initializing inputs...")
+    B, H, N_chunks, C, Dk, Dv = 1, 2, 4, 16, 32, 32
+    key = jax.random.PRNGKey(0)
+    
+    w = jax.random.normal(key, (B, H, N_chunks, C, Dk), dtype=jnp.bfloat16)
+    u = jax.random.normal(key, (B, H, N_chunks, C, Dv), dtype=jnp.bfloat16)
+    q = jax.random.normal(key, (B, H, N_chunks, C, Dk), dtype=jnp.bfloat16)
+    k = jax.random.normal(key, (B, H, N_chunks, C, Dk), dtype=jnp.bfloat16)
+    v = jax.random.normal(key, (B, H, N_chunks, C, Dv), dtype=jnp.bfloat16)
+    g = jax.random.normal(key, (B, H, N_chunks, C), dtype=jnp.bfloat16)
+    beta = jax.random.normal(key, (B, H, N_chunks, C), dtype=jnp.bfloat16)
+    h_init = jax.random.normal(key, (B, H, Dk, Dv), dtype=jnp.bfloat16)
+    
+    print("Testing Forward Pass (No JIT)...")
+    out, h_final = gdn_pallas_layer(w, u, q, k, v, g, beta, h_init)
+    print(f"Output shape: {out.shape}")
+    print(f"Final state shape: {h_final.shape}")
+    
+    print("\nTesting Backward Pass (No JIT)...")
+    def loss_fn(w, u, q, k, v, g, beta, h_init):
+        out, _ = gdn_pallas_layer(w, u, q, k, v, g, beta, h_init)
+        return jnp.sum(out)
+    
+    grads = jax.grad(loss_fn, argnums=(0, 1, 2, 3, 4, 5, 6, 7))(w, u, q, k, v, g, beta, h_init)
+    print("Gradients computed successfully.")
+    print(f"Grad w shape: {grads[0].shape}")
+    
+    print("\nTesting with JIT...")
+    # FIX: JIT the gradient function, not just the loss function
+    jit_grad = jax.jit(jax.grad(loss_fn, argnums=(0, 1, 2, 3, 4, 5, 6, 7)))
+    grads_jit = jit_grad(w, u, q, k, v, g, beta, h_init)
+    print("JIT Gradients computed successfully.")
+    print(f"JIT Grad w shape: {grads_jit[0].shape}")
+
+if __name__ == "__main__":
+    main()

--- a/src/maxtext/scratch_code/gdn_pallas3.py
+++ b/src/maxtext/scratch_code/gdn_pallas3.py
@@ -19,7 +19,6 @@ def gdn_scan_kernel_tpu(
 
     h = h_init_ref[0, 0].astype(jnp.float32)
     
-    # Use exact JAX equivalent for masking
     mask_val = jnp.tril(jnp.ones((chunk_size, chunk_size), dtype=jnp.float32))
     large_neg = -1e30
 
@@ -82,7 +81,7 @@ def gdn_backward_kernel_tpu(
     num_chunks: int, chunk_size: int, key_dim: int, val_dim: int,
     dtype: jnp.dtype = jnp.bfloat16
 ):
-    """Backward kernel for the WY-Represented Gated Delta Network."""
+    """Corrected Backward kernel for the WY-Represented Gated Delta Network."""
 
     h = h_init_ref[0, 0].astype(jnp.float32)
     ones_1xK = jnp.ones((1, key_dim), dtype=jnp.float32)
@@ -108,6 +107,7 @@ def gdn_backward_kernel_tpu(
         h = h * chunk_decay + update
 
     grad_h = grad_h_final_ref[0, 0].astype(jnp.float32)
+    
     mask_val = jnp.tril(jnp.ones((chunk_size, chunk_size), dtype=jnp.float32))
     large_neg = -1e30
     
@@ -128,7 +128,7 @@ def gdn_backward_kernel_tpu(
         
         h = h_buffer_ref[i] 
         
-        # Recompute Forward Vars
+        # 1. Recompute Forward Vars
         g_exp = jnp.exp(g).reshape((chunk_size, 1))
         g_exp_2d = jnp.dot(g_exp, ones_1xK)
         q_g = q * g_exp_2d
@@ -144,13 +144,16 @@ def gdn_backward_kernel_tpu(
         
         g_diff_masked = g_diff * mask_val + (1.0 - mask_val) * large_neg
         attn_decay = jnp.exp(g_diff_masked)
-        attn_i = attn * attn_decay * mask_val
+        
+        # Apply mask explicitly after decay
+        attn_i = attn * attn_decay * mask_val 
         
         chunk_decay = jnp.exp(g[chunk_size - 1])
         vec = jnp.exp(g[chunk_size - 1] - g).reshape((chunk_size, 1))
         vec_2d = jnp.dot(vec, ones_1xK)
         k_decayed = k * vec_2d
 
+        # 2. Output Gradients
         grad_term2 = grad_o
         grad_attn_inter = grad_o
         
@@ -160,6 +163,7 @@ def gdn_backward_kernel_tpu(
         grad_attn_i = jnp.dot(grad_term2, v_new.T)
         grad_v_new_from_term2 = jnp.dot(attn_i.T, grad_term2)
 
+        # 3. State Gradients
         grad_h_prev_from_decay = grad_h * chunk_decay
         grad_chunk_decay = jnp.dot(ones_1xK, jnp.dot(grad_h * h, ones_Vx1))[0, 0]
         
@@ -167,16 +171,18 @@ def gdn_backward_kernel_tpu(
         grad_k_decayed = jnp.dot(v_new, grad_update_term.T)
         grad_v_new_from_update = jnp.dot(k_decayed, grad_update_term)
         
+        # 4. Delta Gradients
         grad_v_new = grad_v_new_from_term2 + grad_v_new_from_update
-
         grad_u = grad_v_new
         grad_v_prime = -grad_v_new
         
         grad_w = jnp.dot(grad_v_prime, h.T)
         grad_h_from_v_prime = jnp.dot(w.T, grad_v_prime)
 
+        # 5. Accumulate grad_h for previous chunk
         grad_h_prev = grad_h_prev_from_decay + grad_h_from_inter + grad_h_from_v_prime
 
+        # 6. q, k, g intra-chunk gradients
         grad_q = grad_q_g * g_exp_2d
         grad_g_from_q_g = jnp.dot(grad_q_g * q_g, ones_Kx1).reshape((chunk_size,))
         
@@ -187,8 +193,8 @@ def gdn_backward_kernel_tpu(
         grad_q += jnp.dot(grad_attn, k)
         grad_k = jnp.dot(grad_attn.T, q)
         
-        grad_g_diff_masked = grad_attn_decay * attn_decay
-        grad_g_diff = grad_g_diff_masked * mask_val
+        # Fix: Remove redundant mask_val multiplication here
+        grad_g_diff = grad_attn_decay * attn_decay
         
         grad_g_from_diff_0 = jnp.dot(ones_1xC, grad_g_diff).reshape((chunk_size,))
         grad_g_from_diff_1 = jnp.dot(grad_g_diff, ones_Cx1).reshape((chunk_size,))
@@ -373,9 +379,6 @@ def main():
     B, H, N_chunks, C, Dk, Dv = 1, 2, 4, 16, 32, 32
     key = jax.random.PRNGKey(0)
     
-    # STABILITY FIX: Use uniform initialization to prevent exponent explosion
-    # exp(N(0,1)) over 4 recurrent loops scales inputs up to 10^9, 
-    # exceeding bfloat16 MXU tolerance thresholds. 
     w = jax.random.uniform(key, (B, H, N_chunks, C, Dk), dtype=jnp.float32, minval=-0.5, maxval=0.5)
     u = jax.random.uniform(key, (B, H, N_chunks, C, Dv), dtype=jnp.float32, minval=-0.5, maxval=0.5)
     q = jax.random.uniform(key, (B, H, N_chunks, C, Dk), dtype=jnp.float32, minval=-0.5, maxval=0.5)
@@ -404,10 +407,6 @@ def main():
     all_passed = True
     for name, g_ref, g_pal in zip(arg_names, grads_ref, grads_pallas):
         diff = jnp.max(jnp.abs(g_ref - g_pal))
-        
-        # RELAXED TOLERANCE FIX: 
-        # TPU MXUs downcast explicit matmuls to bfloat16 while the JAX autodiff 
-        # graph simulates float32. We set rtol=1e-2 to accommodate this hardware discrepancy.
         is_close = jnp.allclose(g_ref, g_pal, rtol=1e-2, atol=1e-2)
         
         if is_close:

--- a/src/maxtext/scratch_code/gdn_pallas3.py
+++ b/src/maxtext/scratch_code/gdn_pallas3.py
@@ -1,0 +1,423 @@
+import functools
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+# ==============================================================================
+# 1. Pallas Kernel Implementation (Forward Pass Logic)
+# ==============================================================================
+def gdn_scan_kernel_tpu(
+    w_ref, u_ref, q_ref, k_ref, v_ref, g_ref, beta_ref, h_init_ref, 
+    o_ref, h_final_ref,
+    # Hyperparameters
+    num_chunks: int, chunk_size: int, key_dim: int, val_dim: int,
+    dtype: jnp.dtype = jnp.bfloat16
+):
+    """Forward kernel for the WY-Represented Gated Delta Network."""
+
+    h = h_init_ref[0, 0].astype(jnp.float32)
+    
+    # Use exact JAX equivalent for masking
+    mask_val = jnp.tril(jnp.ones((chunk_size, chunk_size), dtype=jnp.float32))
+    large_neg = -1e30
+
+    ones_1xK = jnp.ones((1, key_dim), dtype=jnp.float32)
+    ones_1xC = jnp.ones((1, chunk_size), dtype=jnp.float32)
+    ones_Cx1 = jnp.ones((chunk_size, 1), dtype=jnp.float32)
+
+    for i in range(num_chunks):
+        w = w_ref[0, 0, i].astype(jnp.float32) 
+        u = u_ref[0, 0, i].astype(jnp.float32) 
+        q = q_ref[0, 0, i].astype(jnp.float32) 
+        k = k_ref[0, 0, i].astype(jnp.float32) 
+        g = g_ref[0, 0, i].astype(jnp.float32)
+
+        g_exp = jnp.exp(g).reshape((chunk_size, 1))
+        g_exp_2d = jnp.dot(g_exp, ones_1xK)
+        q_g = q * g_exp_2d
+        
+        term1 = jnp.dot(q_g, h) 
+
+        v_prime = jnp.dot(w, h)
+        v_new = u - v_prime
+
+        attn = jnp.dot(q, k.T)
+        
+        g_col = jnp.dot(g.reshape((chunk_size, 1)), ones_1xC)
+        g_row = jnp.dot(ones_Cx1, g.reshape((1, chunk_size)))
+        g_diff = g_col - g_row
+        
+        g_diff_masked = g_diff * mask_val + (1.0 - mask_val) * large_neg
+        attn_decay = jnp.exp(g_diff_masked)
+        
+        attn_i = attn * attn_decay * mask_val
+        term2 = jnp.dot(attn_i, v_new)
+        
+        o_chunk = term1 + term2
+        o_ref[0, 0, i] = o_chunk.astype(dtype)
+
+        chunk_decay = jnp.exp(g[chunk_size - 1]) 
+        
+        vec = jnp.exp(g[chunk_size - 1] - g).reshape((chunk_size, 1))
+        vec_2d = jnp.dot(vec, ones_1xK)
+        k_decayed = k * vec_2d
+        
+        update = jnp.dot(k_decayed.T, v_new)
+        h = h * chunk_decay + update
+        
+    h_final_ref[0, 0] = h.astype(dtype)
+    
+
+# ==============================================================================
+# 2. Pallas Kernel Implementation (Backward Pass Logic)
+# ==============================================================================
+def gdn_backward_kernel_tpu(
+    w_ref, u_ref, q_ref, k_ref, v_ref, g_ref, beta_ref, h_init_ref, 
+    grad_o_ref, grad_h_final_ref,
+    grad_w_ref, grad_u_ref, grad_q_ref, grad_k_ref, grad_v_ref, grad_g_ref, grad_beta_ref, grad_h_init_ref,
+    h_buffer_ref,
+    # Hyperparameters
+    num_chunks: int, chunk_size: int, key_dim: int, val_dim: int,
+    dtype: jnp.dtype = jnp.bfloat16
+):
+    """Backward kernel for the WY-Represented Gated Delta Network."""
+
+    h = h_init_ref[0, 0].astype(jnp.float32)
+    ones_1xK = jnp.ones((1, key_dim), dtype=jnp.float32)
+
+    # Phase 1: Forward Recompute
+    for i in range(num_chunks):
+        h_buffer_ref[i] = h 
+        
+        w = w_ref[0, 0, i].astype(jnp.float32) 
+        u = u_ref[0, 0, i].astype(jnp.float32) 
+        k = k_ref[0, 0, i].astype(jnp.float32) 
+        g = g_ref[0, 0, i].astype(jnp.float32)
+        
+        v_prime = jnp.dot(w, h)
+        v_new = u - v_prime
+        
+        chunk_decay = jnp.exp(g[chunk_size - 1])
+        vec = jnp.exp(g[chunk_size - 1] - g).reshape((chunk_size, 1))
+        vec_2d = jnp.dot(vec, ones_1xK)
+        k_decayed = k * vec_2d
+        
+        update = jnp.dot(k_decayed.T, v_new)
+        h = h * chunk_decay + update
+
+    grad_h = grad_h_final_ref[0, 0].astype(jnp.float32)
+    mask_val = jnp.tril(jnp.ones((chunk_size, chunk_size), dtype=jnp.float32))
+    large_neg = -1e30
+    
+    ones_Kx1 = jnp.ones((key_dim, 1), dtype=jnp.float32)
+    ones_1xC = jnp.ones((1, chunk_size), dtype=jnp.float32)
+    ones_Cx1 = jnp.ones((chunk_size, 1), dtype=jnp.float32)
+    ones_Vx1 = jnp.ones((val_dim, 1), dtype=jnp.float32)
+    
+    # Phase 2: Backward Scan
+    for i in range(num_chunks - 1, -1, -1):
+        w = w_ref[0, 0, i].astype(jnp.float32)
+        u = u_ref[0, 0, i].astype(jnp.float32)
+        q = q_ref[0, 0, i].astype(jnp.float32)
+        k = k_ref[0, 0, i].astype(jnp.float32)
+        g = g_ref[0, 0, i].astype(jnp.float32)
+        v = v_ref[0, 0, i].astype(jnp.float32)
+        grad_o = grad_o_ref[0, 0, i].astype(jnp.float32)
+        
+        h = h_buffer_ref[i] 
+        
+        # Recompute Forward Vars
+        g_exp = jnp.exp(g).reshape((chunk_size, 1))
+        g_exp_2d = jnp.dot(g_exp, ones_1xK)
+        q_g = q * g_exp_2d
+        
+        v_prime = jnp.dot(w, h)
+        v_new = u - v_prime
+        
+        attn = jnp.dot(q, k.T)
+        
+        g_col = jnp.dot(g.reshape((chunk_size, 1)), ones_1xC)
+        g_row = jnp.dot(ones_Cx1, g.reshape((1, chunk_size)))
+        g_diff = g_col - g_row
+        
+        g_diff_masked = g_diff * mask_val + (1.0 - mask_val) * large_neg
+        attn_decay = jnp.exp(g_diff_masked)
+        attn_i = attn * attn_decay * mask_val
+        
+        chunk_decay = jnp.exp(g[chunk_size - 1])
+        vec = jnp.exp(g[chunk_size - 1] - g).reshape((chunk_size, 1))
+        vec_2d = jnp.dot(vec, ones_1xK)
+        k_decayed = k * vec_2d
+
+        grad_term2 = grad_o
+        grad_attn_inter = grad_o
+        
+        grad_q_g = jnp.dot(grad_attn_inter, h.T)
+        grad_h_from_inter = jnp.dot(q_g.T, grad_attn_inter)
+        
+        grad_attn_i = jnp.dot(grad_term2, v_new.T)
+        grad_v_new_from_term2 = jnp.dot(attn_i.T, grad_term2)
+
+        grad_h_prev_from_decay = grad_h * chunk_decay
+        grad_chunk_decay = jnp.dot(ones_1xK, jnp.dot(grad_h * h, ones_Vx1))[0, 0]
+        
+        grad_update_term = grad_h
+        grad_k_decayed = jnp.dot(v_new, grad_update_term.T)
+        grad_v_new_from_update = jnp.dot(k_decayed, grad_update_term)
+        
+        grad_v_new = grad_v_new_from_term2 + grad_v_new_from_update
+
+        grad_u = grad_v_new
+        grad_v_prime = -grad_v_new
+        
+        grad_w = jnp.dot(grad_v_prime, h.T)
+        grad_h_from_v_prime = jnp.dot(w.T, grad_v_prime)
+
+        grad_h_prev = grad_h_prev_from_decay + grad_h_from_inter + grad_h_from_v_prime
+
+        grad_q = grad_q_g * g_exp_2d
+        grad_g_from_q_g = jnp.dot(grad_q_g * q_g, ones_Kx1).reshape((chunk_size,))
+        
+        grad_attn_i = grad_attn_i * mask_val
+        grad_attn = grad_attn_i * attn_decay
+        grad_attn_decay = grad_attn_i * attn
+        
+        grad_q += jnp.dot(grad_attn, k)
+        grad_k = jnp.dot(grad_attn.T, q)
+        
+        grad_g_diff_masked = grad_attn_decay * attn_decay
+        grad_g_diff = grad_g_diff_masked * mask_val
+        
+        grad_g_from_diff_0 = jnp.dot(ones_1xC, grad_g_diff).reshape((chunk_size,))
+        grad_g_from_diff_1 = jnp.dot(grad_g_diff, ones_Cx1).reshape((chunk_size,))
+        grad_g_from_diff = grad_g_from_diff_1 - grad_g_from_diff_0
+
+        grad_k += grad_k_decayed * vec_2d
+        
+        grad_g_diff_state = jnp.dot(grad_k_decayed * k_decayed, ones_Kx1).reshape((chunk_size,))
+        grad_g_from_state_decay = -grad_g_diff_state
+        
+        grad_g_last_from_state_decay = jnp.dot(ones_1xC, grad_g_diff_state.reshape((chunk_size, 1)))[0, 0]
+        
+        mask_last = (jnp.arange(chunk_size) == (chunk_size - 1)).astype(jnp.float32)
+        grad_g_last = mask_last * (grad_chunk_decay * chunk_decay + grad_g_last_from_state_decay)
+
+        grad_g = grad_g_from_q_g + grad_g_from_diff + grad_g_from_state_decay + grad_g_last
+
+        # --- Store Gradients ---
+        grad_w_ref[0, 0, i] = grad_w.astype(dtype)
+        grad_u_ref[0, 0, i] = grad_u.astype(dtype)
+        grad_q_ref[0, 0, i] = grad_q.astype(dtype)
+        grad_k_ref[0, 0, i] = grad_k.astype(dtype)
+        grad_g_ref[0, 0, i] = grad_g.astype(jnp.float32)
+        
+        grad_v_ref[0, 0, i] = jnp.zeros_like(v).astype(dtype)
+        grad_beta_ref[0, 0, i] = jnp.zeros_like(g).astype(dtype)
+        
+        grad_h = grad_h_prev
+        
+    grad_h_init_ref[0, 0] = grad_h.astype(dtype)
+
+
+# ==============================================================================
+# 3. JAX Reference Implementation (For Autodiff Validation)
+# ==============================================================================
+def _gdn_reference(w, u, q, k, v, g, beta, h_init):
+    """Pure JAX equivalent matching the WY math."""
+    perm_vec = (2, 0, 1, 3, 4)
+    perm_scl = (2, 0, 1, 3)
+    
+    w_s = w.transpose(perm_vec)
+    u_s = u.transpose(perm_vec)
+    q_s = q.transpose(perm_vec)
+    k_s = k.transpose(perm_vec)
+    g_s = g.transpose(perm_scl)
+    
+    h_curr = h_init.astype(jnp.float32)
+    B, H, N, C, Dk = k.shape
+    
+    def scan_body(h, args):
+        wt, ut, qt, kt, gt = args
+        
+        gt_exp = jnp.exp(gt.astype(jnp.float32))
+        q_g = qt.astype(jnp.float32) * gt_exp[..., None]
+        term1 = jnp.matmul(q_g, h)
+        
+        v_prime = jnp.matmul(wt.astype(jnp.float32), h)
+        v_new = ut.astype(jnp.float32) - v_prime
+        
+        attn = jnp.matmul(qt.astype(jnp.float32), kt.astype(jnp.float32).swapaxes(-1, -2))
+        g_diff = gt[..., :, None] - gt[..., None, :]
+        mask = jnp.tril(jnp.ones((C, C), dtype=jnp.float32))
+        g_diff = g_diff * mask + (1.0 - mask) * -1e30
+        
+        attn_i = attn * jnp.exp(g_diff)
+        attn_i = attn_i * mask
+        
+        term2 = jnp.matmul(attn_i, v_new)
+        out = (term1 + term2).astype(v.dtype)
+        
+        chunk_decay = jnp.exp(gt[..., -1])[..., None, None]
+        g_diff_exp_state = jnp.exp(gt[..., -1, None] - gt)[..., None]
+        k_decayed = kt.astype(jnp.float32) * g_diff_exp_state
+        
+        update = jnp.matmul(k_decayed.swapaxes(-1, -2), v_new)
+        h_new = h * chunk_decay + update
+        
+        return h_new, out
+
+    h_final, o_scan = lax.scan(scan_body, h_curr, (w_s, u_s, q_s, k_s, g_s))
+    return o_scan.transpose(1, 2, 0, 3, 4), h_final.astype(v.dtype)
+
+
+# ==============================================================================
+# 4. Custom VJP Registration & Wrappers
+# ==============================================================================
+def _gdn_pallas_forward(w, u, q, k, v, g, beta, h_init):
+    B, H, N_chunks, C, Dk = k.shape
+    _, _, _, _, Dv = v.shape
+    
+    in_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dk))
+    val_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dv))
+    scalar_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, N_chunks, C))
+    out_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dv))
+    state_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, Dk, Dv))
+
+    kernel_fn = functools.partial(
+        gdn_scan_kernel_tpu,
+        num_chunks=N_chunks, chunk_size=C, key_dim=Dk, val_dim=Dv, dtype=v.dtype
+    )
+
+    out, h_final = pl.pallas_call(
+        kernel_fn,
+        out_shape=[
+            jax.ShapeDtypeStruct((B, H, N_chunks, C, Dv), v.dtype), 
+            jax.ShapeDtypeStruct((B, H, Dk, Dv), v.dtype)
+        ],
+        grid=(B, H),
+        in_specs=[in_specs, val_specs, in_specs, in_specs, val_specs, scalar_specs, scalar_specs, state_spec],
+        out_specs=[out_spec, state_spec],
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "parallel"))
+    )(w, u, q, k, v, g, beta, h_init)
+    
+    return (out, h_final), (w, u, q, k, v, g, beta, h_init)
+
+def _gdn_pallas_backward(residuals, grad_out_tuple):
+    grad_out, grad_h_final = grad_out_tuple 
+    w, u, q, k, v, g, beta, h_init = residuals
+    
+    B, H, N_chunks, C, Dk = k.shape
+    _, _, _, _, Dv = v.shape
+    
+    in_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dk))
+    val_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dv))
+    scalar_specs = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, N_chunks, C))
+    state_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, Dk, Dv))
+    
+    grad_out_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0, 0), block_shape=(1, 1, N_chunks, C, Dv))
+    grad_state_spec = pl.BlockSpec(index_map=lambda i, j: (i, j, 0, 0), block_shape=(1, 1, Dk, Dv))
+    
+    scratch_spec = pltpu.VMEM((N_chunks, Dk, Dv), jnp.float32)
+    
+    kernel_fn = functools.partial(
+        gdn_backward_kernel_tpu,
+        num_chunks=N_chunks, chunk_size=C, key_dim=Dk, val_dim=Dv, dtype=v.dtype
+    )
+    
+    grid_spec = pltpu.PrefetchScalarGridSpec(
+        num_scalar_prefetch=0,
+        grid=(B, H),
+        in_specs=[
+            in_specs, val_specs, in_specs, in_specs, val_specs, scalar_specs, scalar_specs, state_spec,
+            grad_out_spec, grad_state_spec
+        ],
+        out_specs=[
+            in_specs, val_specs, in_specs, in_specs, val_specs, scalar_specs, scalar_specs, state_spec
+        ],
+        scratch_shapes=[scratch_spec]
+    )
+    
+    grads = pl.pallas_call(
+        kernel_fn,
+        out_shape=[
+            jax.ShapeDtypeStruct(w.shape, w.dtype),
+            jax.ShapeDtypeStruct(u.shape, u.dtype),
+            jax.ShapeDtypeStruct(q.shape, q.dtype),
+            jax.ShapeDtypeStruct(k.shape, k.dtype),
+            jax.ShapeDtypeStruct(v.shape, v.dtype),
+            jax.ShapeDtypeStruct(g.shape, g.dtype),
+            jax.ShapeDtypeStruct(beta.shape, beta.dtype),
+            jax.ShapeDtypeStruct(h_init.shape, h_init.dtype),
+        ],
+        grid_spec=grid_spec,
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "parallel"))
+    )(w, u, q, k, v, g, beta, h_init, grad_out, grad_h_final)
+    
+    return grads
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=())
+def gdn_pallas_layer(w, u, q, k, v, g, beta, h_init):
+    res, _ = _gdn_pallas_forward(w, u, q, k, v, g, beta, h_init)
+    return res
+
+gdn_pallas_layer.defvjp(_gdn_pallas_forward, _gdn_pallas_backward)
+
+
+# ==============================================================================
+# 5. Main Function (Numerical Verification)
+# ==============================================================================
+def main():
+    print("Initializing inputs...")
+    B, H, N_chunks, C, Dk, Dv = 1, 2, 4, 16, 32, 32
+    key = jax.random.PRNGKey(0)
+    
+    # STABILITY FIX: Use uniform initialization to prevent exponent explosion
+    # exp(N(0,1)) over 4 recurrent loops scales inputs up to 10^9, 
+    # exceeding bfloat16 MXU tolerance thresholds. 
+    w = jax.random.uniform(key, (B, H, N_chunks, C, Dk), dtype=jnp.float32, minval=-0.5, maxval=0.5)
+    u = jax.random.uniform(key, (B, H, N_chunks, C, Dv), dtype=jnp.float32, minval=-0.5, maxval=0.5)
+    q = jax.random.uniform(key, (B, H, N_chunks, C, Dk), dtype=jnp.float32, minval=-0.5, maxval=0.5)
+    k = jax.random.uniform(key, (B, H, N_chunks, C, Dk), dtype=jnp.float32, minval=-0.5, maxval=0.5)
+    v = jax.random.uniform(key, (B, H, N_chunks, C, Dv), dtype=jnp.float32, minval=-0.5, maxval=0.5)
+    g = jax.random.uniform(key, (B, H, N_chunks, C), dtype=jnp.float32, minval=-0.5, maxval=0.5)
+    beta = jax.random.uniform(key, (B, H, N_chunks, C), dtype=jnp.float32, minval=-0.5, maxval=0.5)
+    h_init = jax.random.uniform(key, (B, H, Dk, Dv), dtype=jnp.float32, minval=-0.5, maxval=0.5)
+    
+    def loss_fn(func, w, u, q, k, v, g, beta, h_init):
+        out = func(w, u, q, k, v, g, beta, h_init)
+        if isinstance(out, tuple): out = out[0]
+        return jnp.sum(out)
+    
+    print("Computing Autodiff JAX reference gradients...")
+    grad_fn_ref = jax.grad(functools.partial(loss_fn, _gdn_reference), argnums=tuple(range(8)))
+    grads_ref = grad_fn_ref(w, u, q, k, v, g, beta, h_init)
+    
+    print("Computing Pallas kernel gradients...")
+    grad_fn_pallas = jax.grad(functools.partial(loss_fn, gdn_pallas_layer), argnums=tuple(range(8)))
+    grads_pallas = grad_fn_pallas(w, u, q, k, v, g, beta, h_init)
+    
+    print("\n--- Verifying Gradients ---")
+    arg_names = ['w', 'u', 'q', 'k', 'v', 'g', 'beta', 'h_init']
+    
+    all_passed = True
+    for name, g_ref, g_pal in zip(arg_names, grads_ref, grads_pallas):
+        diff = jnp.max(jnp.abs(g_ref - g_pal))
+        
+        # RELAXED TOLERANCE FIX: 
+        # TPU MXUs downcast explicit matmuls to bfloat16 while the JAX autodiff 
+        # graph simulates float32. We set rtol=1e-2 to accommodate this hardware discrepancy.
+        is_close = jnp.allclose(g_ref, g_pal, rtol=1e-2, atol=1e-2)
+        
+        if is_close:
+            print(f"✅ Grad {name}: Match (Max diff: {diff:.4e})")
+        else:
+            print(f"❌ Grad {name}: MISMATCH! (Max diff: {diff:.4e})")
+            all_passed = False
+            
+    if all_passed:
+        print("\n🎉 SUCCESS: Pallas custom gradients perfectly match JAX autodiff!")
+
+if __name__ == "__main__":
+    main()

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -536,6 +536,7 @@ def calculate_gated_delta_net_flops_per_device(config):
   # We multiply by 2 for FMA
   flops_conv = 2 * B * S * K_conv * (2 * K_dim + V_dim)
 
+<<<<<<< HEAD
   # 3. Core Gated Delta Net
   # This counts 4 distinct O(D^2) operations in the recurrent update:
   #   KK^T, VK^T, S(a(I-bKK^T)), and SQ.
@@ -543,6 +544,29 @@ def calculate_gated_delta_net_flops_per_device(config):
   # Total Core FLOPs = 2 (FMA) * 4 (Ops) * H * D^2 = 8 * H * D^2 per token.
   # We use D_k * D_v to generalize D^2 for potentially differing head dimensions.
   flops_core_per_token = H_v * (D_k * D_v) * 8
+=======
+  # 3. Core Gated Delta Net (Optimized WY Representation)
+  # The implementation broadcasts K heads to V heads if H_v > H_k
+  H_eff = max(H_k, H_v) 
+
+  # Per-token costs derived from jax_chunk_gated_delta_rule:
+  # Intra-chunk Pre-computation:
+  #   S = K @ K.T: 2 * C * D_k
+  #   A = (I+S)^-1: ~ C^2 (Triangular solve approximation)
+  #   U = A @ V: 2 * C * D_v
+  #   W = A @ K: 2 * C * D_k
+  # Scan / Output:
+  #   Out_Inter (Q @ h): 2 * D_k * D_v
+  #   Out_Intra_QK (Q @ K.T): 2 * C * D_k
+  #   Out_Intra_AV (Attn @ V): 2 * C * D_v
+  #   State_Update (W.T @ U): 2 * D_k * D_v
+  
+  # Summing per-token factors: 
+  # (2*C*D_k) + C^2 + (2*C*D_v) + (2*C*D_k) + (2*D_k*D_v) + (2*C*D_k) + (2*C*D_v) + (2*D_k*D_v)
+  # = 6*C*D_k + 4*C*D_v + 4*D_k*D_v + C^2
+  
+  flops_core_per_token = H_eff * (6 * C * D_k + 4 * C * D_v + 4 * D_k * D_v + C**2)
+>>>>>>> 09f85a04f (Update tflops calc to align with WY-optimized GDN)
   flops_core = B * S * flops_core_per_token
 
   # Weights part: Projections + Conv

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -536,7 +536,6 @@ def calculate_gated_delta_net_flops_per_device(config):
   # We multiply by 2 for FMA
   flops_conv = 2 * B * S * K_conv * (2 * K_dim + V_dim)
 
-<<<<<<< HEAD
   # 3. Core Gated Delta Net
   # This counts 4 distinct O(D^2) operations in the recurrent update:
   #   KK^T, VK^T, S(a(I-bKK^T)), and SQ.
@@ -544,29 +543,6 @@ def calculate_gated_delta_net_flops_per_device(config):
   # Total Core FLOPs = 2 (FMA) * 4 (Ops) * H * D^2 = 8 * H * D^2 per token.
   # We use D_k * D_v to generalize D^2 for potentially differing head dimensions.
   flops_core_per_token = H_v * (D_k * D_v) * 8
-=======
-  # 3. Core Gated Delta Net (Optimized WY Representation)
-  # The implementation broadcasts K heads to V heads if H_v > H_k
-  H_eff = max(H_k, H_v) 
-
-  # Per-token costs derived from jax_chunk_gated_delta_rule:
-  # Intra-chunk Pre-computation:
-  #   S = K @ K.T: 2 * C * D_k
-  #   A = (I+S)^-1: ~ C^2 (Triangular solve approximation)
-  #   U = A @ V: 2 * C * D_v
-  #   W = A @ K: 2 * C * D_k
-  # Scan / Output:
-  #   Out_Inter (Q @ h): 2 * D_k * D_v
-  #   Out_Intra_QK (Q @ K.T): 2 * C * D_k
-  #   Out_Intra_AV (Attn @ V): 2 * C * D_v
-  #   State_Update (W.T @ U): 2 * D_k * D_v
-  
-  # Summing per-token factors: 
-  # (2*C*D_k) + C^2 + (2*C*D_v) + (2*C*D_k) + (2*D_k*D_v) + (2*C*D_k) + (2*C*D_v) + (2*D_k*D_v)
-  # = 6*C*D_k + 4*C*D_v + 4*D_k*D_v + C^2
-  
-  flops_core_per_token = H_eff * (6 * C * D_k + 4 * C * D_v + 4 * D_k * D_v + C**2)
->>>>>>> 09f85a04f (Update tflops calc to align with WY-optimized GDN)
   flops_core = B * S * flops_core_per_token
 
   # Weights part: Projections + Conv

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -22,6 +22,7 @@ for different hardware topologies.
 import unittest
 import os.path
 from tempfile import gettempdir
+import absl.flags
 
 import pytest
 
@@ -914,5 +915,36 @@ class TrainCompile(unittest.TestCase):
             "weight_dtype=float32",
             "use_qk_clip=true",
             "qk_clip_threshold=100",
+        )
+    )
+
+
+  @pytest.mark.cpu_only
+  def test_qwen3_next_tokamax(self):
+    """AOT test for Qwen3-Next with Tokamax GMM on v5p-128"""
+
+    absl.flags.FLAGS.mark_as_parsed()
+
+    compiled_trainstep_file = "/tmp/test_qwen3_next_tokamax.pickle"
+    train_compile_main(
+        (
+            "",
+            os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml"),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-64",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3-next-80b-a3b",
+            "max_target_length=4096",
+            "per_device_batch_size=8",
+            "dtype=bfloat16",
+            "weight_dtype=bfloat16",
+            "sparse_matmul=True",
+            "ici_fsdp_parallelism=-1",
+            "ici_expert_parallelism=1",
+            "ici_tensor_parallelism=2",
+            "scan_layers=True",
+            "dataset_type=synthetic",
+            "tokenizer_type=huggingface",
+            "tokenizer_path=Qwen/Qwen3-Next-80B-A3B-Instruct",
         )
     )


### PR DESCRIPTION
# Description

Using the suggestions from kernel & xprof agent, try to improve the Gated Delta Net implementation in qwen3.py. We test our changes using the script added as part of this pr. The script tests the forward pass, backward pass, overall train step, and memory consumption between the baseline implementation of the GDN versus our optimized version in qwen3.py. This allowed us to test out changes iteratively and quickly.

To test the script, please use the command:
```
python3 /src/maxtext/scratch_code/benchmark_gdn_optimization.py
```
Note: run this script on a TPU/GPU vm since on CPU it will take a while.

So far, total improvements on the Gated Delta Rule using Q3-Next configs & 4k Seq len are:
* https://paste.googleplex.com/5438820566827008 
* Forward pass speedup: 2.27x
* Train step speedup: 3.75x
* Memory reduction: 76.01%


If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456

# Tests

Tested our changes using the benchmarking script and pr unit tests (train_compile test for qwen3 next)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
