### PR TITLE
Fix duplicate peak learning rate in warmup schedule

### DIFF
--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -1376,7 +1376,7 @@ def create_learning_rate_schedule(config):
   boundaries = []
 
   if warmup_steps > 0:
-    warmup_schedule = optax.linear_schedule(init_value=0.0, end_value=lr, transition_steps=warmup_steps - 1)
+    warmup_schedule = optax.linear_schedule(init_value=0.0, end_value=lr, transition_steps=warmup_steps)
     pieces.append(warmup_schedule)
     boundaries.append(warmup_steps)
 

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -748,6 +748,11 @@ class TestLearningRateSchedules(unittest.TestCase):
     # Warmup phase: 0 -> peak
     self.assertAlmostEqual(float(schedule_fn(0)), 0.0, places=6)
     self.assertAlmostEqual(float(schedule_fn(warmup_steps)), learning_rate, places=6)
+    # Ensure delta is constant
+    expected_slope = learning_rate / warmup_steps
+    for i in range(1, warmup_steps + 1):
+      current_lr = float(schedule_fn(i))
+      self.assertAlmostEqual(current_lr - float(schedule_fn(i - 1)), expected_slope, places=6)
 
     # Cosine decay phase
     lr_end = schedule_fn(learning_rate_schedule_steps - 1)
@@ -791,6 +796,11 @@ class TestLearningRateSchedules(unittest.TestCase):
       # Warmup phase: 0 -> peak
       self.assertAlmostEqual(float(schedule_fn(0)), 0.0, places=6)
       self.assertAlmostEqual(float(schedule_fn(warmup_steps)), learning_rate, places=6)
+      # Ensure delta is constant
+      expected_slope = learning_rate / warmup_steps
+      for i in range(1, warmup_steps + 1):
+        current_lr = float(schedule_fn(i))
+        self.assertAlmostEqual(current_lr - float(schedule_fn(i - 1)), expected_slope, places=6)
 
       # Stable phase: constant at peak
       self.assertAlmostEqual(float(schedule_fn(warmup_steps + 10)), learning_rate, places=6)


### PR DESCRIPTION
# Description

This bug was introduced by recent changes in this [PR](https://github.com/AI-Hypercomputer/maxtext/pull/2883), which caused the warmup schedule to reach its peak one step early, resulting in a duplicate peak learning rate.

Fixes  b/481934309

```
from MaxText import pyconfig
config = pyconfig.initialize(
        [None, "/mnt/disks/jimmy_workspace/maxtext_dev/maxtext/src/MaxText/configs/base.yml"],
        enable_checkpointing=False,
        learning_rate=1,
        learning_rate_schedule_steps=10,
        steps=12,
        warmup_steps_fraction=0.3,
        lr_schedule_type="cosine",
        learning_rate_final_fraction=0.1,
    )
from maxtext.utils import maxtext_utils
schedule_fn = maxtext_utils.create_learning_rate_schedule(config)
[(i, float(schedule_fn(i))) for i in range(7)]
```
Before
```
[(0, 0.0),
 (1, 0.5),
 (2, 1.0),
 (3, 1.0),
 (4, 0.9397114515304565),
 (5, 0.7749999761581421),
 (6, 0.5499999523162842)]
```
After
```
[(0, 0.0),
 (1, 0.3333333730697632),
 (2, 0.6666666865348816),
 (3, 1.0),
 (4, 0.9397114515304565),
 (5, 0.7749999761581421),
 (6, 0.5499999523162842)]
```
original schedule (git sha d4a259dbbc3a7bf2194ea0a62bd210465e054be6)
```
[(0, 0.0),
 (1, 0.3333333730697632),
 (2, 0.6666666865348816),
 (3, 1.0),
 (4, 0.9554359912872314),
 (5, 0.8305704593658447),
 (6, 0.6501344442367554)]
```



## Changes
- Fix duplicate peak learning rate in warmup schedule
- Add an additional unit test to ensure the delta in the warmup schedule is constant.

# Tests
```
 python -m unittest tests.unit.maxtext_utils_test.TestLearningRateSchedules
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
