### PR TITLE
Qwen3-Omni Checkpoint Mapping

### DIFF
--- a/src/MaxText/layers/encoders.py
+++ b/src/MaxText/layers/encoders.py
@@ -64,7 +64,14 @@ class VisionEncoder(nnx.Module):
   def __call__(self, input_images, deterministic=False):
     # vision encoder output, frozen params in many cases
     encoder = getattr(self, self.encoder_name)
-    embeddings = encoder(input_images, deterministic=deterministic)
+    encoder_output = encoder(input_images, deterministic=deterministic)
+
+    deep_feats = None
+    if isinstance(encoder_output, tuple):
+      embeddings = encoder_output[0]
+      deep_feats = encoder_output[1]
+    else:
+      embeddings = encoder_output
 
     if self.config.freeze_vision_encoder_params:
       embeddings = jax.lax.stop_gradient(embeddings)
@@ -73,7 +80,7 @@ class VisionEncoder(nnx.Module):
     projector = getattr(self, self.projector_name)
     embeddings = projector(embeddings)
 
-    return embeddings
+    return embeddings, deep_feats
 
 
 class AudioEncoder(nnx.Module):

--- a/src/MaxText/layers/models.py
+++ b/src/MaxText/layers/models.py
@@ -154,7 +154,8 @@ class TransformerLinenPure(nn.Module):
     audio_embeddings = None
 
     if self.config.use_multimodal and encoder_images is not None:
-      image_embeddings = self.vision_encoder(input_images=encoder_images, deterministic=not enable_dropout)
+      # qwen3-omni-30b-a3b returns deep features from the vision encoder.
+      image_embeddings, _ = self.vision_encoder(input_images=encoder_images, deterministic=not enable_dropout)
       bidirectional_mask = mm_processor.get_bidirectional_mask_vision(self.config, decoder_input_tokens)
 
     if self.config.use_multimodal and encoder_audios is not None and self.audio_encoder is not None:
@@ -459,7 +460,7 @@ class Transformer(nnx.Module):
     bidirectional_mask = None
     image_embeddings = None
     if self.config.use_multimodal and encoder_images is not None:
-      image_embeddings = self.vision_encoder(input_images=encoder_images, deterministic=not enable_dropout)
+      image_embeddings, _ = self.vision_encoder(input_images=encoder_images, deterministic=not enable_dropout)
       bidirectional_mask = mm_processor.get_bidirectional_mask_vision(self.config, decoder_input_tokens)
 
     audio_embeddings = None

--- a/src/MaxText/utils/ckpt_conversion/utils/utils.py
+++ b/src/MaxText/utils/ckpt_conversion/utils/utils.py
@@ -939,7 +939,7 @@ def get_hf_model(model_id: str, token: str):
   if model_id in ["Qwen/Qwen3-Omni-30B-A3B-Instruct"]:
     from transformers import Qwen3OmniMoeForConditionalGeneration  # pylint: disable=import-outside-toplevel
 
-    model_class = Qwen3OmniMoeForConditionalGeneration.from_pretrained
+    model_class = Qwen3OmniMoeForConditionalGeneration
   else:
     model_class = AutoModelForCausalLM
 


### PR DESCRIPTION
Original author @eitanporat in https://github.com/AI-Hypercomputer/maxtext/pull/2728
# Description

Checkpoint conversion mapping from hf

# Tests

- Converted HF weights to orbax checkpoint. 
- Tested regressions on other multimodal models by running SFT using tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh (did not run jetstream/generation).
- Logs: https://paste.googleplex.com/5213472762757120

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
