### PR TITLE
Skip MHC gmm tests for GPU

### DIFF
--- a/tests/unit/mhc_test.py
+++ b/tests/unit/mhc_test.py
@@ -16,6 +16,7 @@
 
 import os.path
 import unittest
+import pytest
 
 from flax import nnx
 from flax.linen import partitioning as nn_partitioning
@@ -118,6 +119,8 @@ class TestMHC(unittest.TestCase):
         ),
     )
 
+  # Skip GPU due to NotImplementedError: dynamic grid bounds not supported in the Triton backend
+  @pytest.mark.tpu_only
   def test_moe_layer_output_shape(self):
     with nn_partitioning.axis_rules(self.config.logical_axis_rules):
       module = mhc.ManifoldConstrainedHyperConnections(self.config, self.dim, self.mesh, self.rngs)


### PR DESCRIPTION
# Description

Skip MHC gmm tests for GPU for now, due to the error `NotImplementedError: dynamic grid bounds not supported in the Triton backend` ([link](https://screenshot.googleplex.com/9bCzkfiY56sPPEf)).

# Tests

Expect all runners are green.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
