### PR TITLE
Support FP8 in batch split config

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -211,6 +211,9 @@ wo_tile_fwd_buffer_count: 2
 wo_tile_dlhs_buffer_count: 2
 wo_tile_drhs_buffer_count: 2
 
+wi_combine_scopes: False
+wo_combine_scopes: False
+
 norm_topk_prob: false # boolean to enable the top-k probability normalization. qwen3-specific normalization of router weights.
 
 # how the expert axis is used to shard attention weights and activations

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -679,6 +679,9 @@ class MoEKernels(BaseModel):
   wo_tile_dlhs_buffer_count: int = Field(2, description="bwd pass dlhs tiling buffer count in GMM for wo.")
   wo_tile_drhs_buffer_count: int = Field(2, description="bwd pass drhs tiling buffer count in GMM for wo.")
 
+  wi_combine_scopes: bool = Field(False, description="whether to use combine_scopes features for tgmm for wi.")
+  wo_combine_scopes: bool = Field(False, description="whether to use combine_scopes features for tgmm for wo.")
+
 
 class DeepSeekMoE(BaseModel):
   """Configuration specific to DeepSeek-style MoE layers."""


### PR DESCRIPTION
# Description

This update enables FP8 quantization support for DeepSeek batch split configurations.

When quantization is active, the following changes apply:

* Kernel Quantization: gmm kernels allow FP8 recipes (defined via the MaxText command line) in both forward and backward passes.

* `gmm` Weight All-Gathers: gmm weight all-gathers are now quantized along non-expert, non-tensor, and non-tensor_transpose axes.

Note: Quantization for dispatch all-gathers is currently out of scope and will be implemented in a follow-up PR.

# Tests

* Verification: Validated via end-to-end (e2e) perf and convergence benchmarks.

* Coverage: Unit tests will be added in a subsequent update.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
