### PR TITLE
Add qwen2 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ MaxText aims to provide you with the best OSS models, whether as a reference imp
   * Gemma 2 (2B, 9B, 27B)
   * Gemma 1 (2B, 7B)
 * Alibaba
+  * Qwen 2.5 (7B, 14B)
   * Qwen 3 MoE 2507 (235B, 480B)
   * Qwen 3 MoE (30B, 235B)
   * Qwen 3 Dense (0.6B, 1.7B, 4B, 8B, 14B, 32B)

--- a/docs/guides/checkpointing_solutions/convert_checkpoint.md
+++ b/docs/guides/checkpointing_solutions/convert_checkpoint.md
@@ -11,6 +11,7 @@ The following models are supported:
 | **Gemma2**              | 2B, 9B, 27B            |           √            |            √             |           √            |            √             |
 | **Gemma3** (Multimodal) | 4B, 12B, 27B           |           √            |            √             |           √            |            √             |
 | **Llama3.1**            | 8B, 70B, 450B          |           √            |            √             |           √            |            √             |
+| **Qwen2.5**             | 7B, 14B                |           √            |            √             |           √            |            √             |
 | **Qwen3**               | 0.6B, 4B, 8B, 14B, 32B |           √            |            √             |           √            |            √             |
 | **Qwen3 MoE**           | 30B, 235B, 480B        |           √            |            √             |           √            |            √             |
 | **Mixtral**             | 8x7B, 8x22B            |           √            |            √             |           √            |            √             |

--- a/src/maxtext/checkpoint_conversion/utils/hf_model_configs.py
+++ b/src/maxtext/checkpoint_conversion/utils/hf_model_configs.py
@@ -210,6 +210,41 @@ gemma2_27b_config = transformers.Gemma2Config(
     query_pre_attn_scalar=144,
 )
 
+qwen25_7b_config = transformers.Qwen2Config(
+    vocab_size=152064,
+    hidden_size=3584,
+    intermediate_size=18944,
+    num_hidden_layers=28,
+    num_attention_heads=28,
+    num_key_value_heads=4,
+    hidden_act="silu",
+    max_position_embeddings=32768,
+    initializer_range=0.02,
+    rms_norm_eps=1e-06,
+    use_cache=True,
+    rope_theta=1000000.0,
+    tie_word_embeddings=False,
+    torch_dtype="bfloat16",
+    attention_bias=True,
+)
+
+qwen25_14b_config = transformers.Qwen2Config(
+    vocab_size=152064,
+    hidden_size=5120,
+    intermediate_size=13824,
+    num_hidden_layers=48,
+    num_attention_heads=40,
+    num_key_value_heads=8,
+    hidden_act="silu",
+    max_position_embeddings=32768,
+    rms_norm_eps=1e-06,
+    rope_theta=1000000.0,
+    tie_word_embeddings=False,
+    torch_dtype="bfloat16",
+    attention_bias=True,
+)
+
+
 qwen3_0_6b_config = transformers.Qwen3Config(
     vocab_size=151936,
     hidden_size=1024,
@@ -815,6 +850,8 @@ HF_MODEL_CONFIGS = {
     "gemma3-4b": gemma3_4b_config,
     "gemma3-12b": gemma3_12b_config,
     "gemma3-27b": gemma3_27b_config,
+    "qwen2.5-7b": qwen25_7b_config,
+    "qwen2.5-14b": qwen25_14b_config,
     "qwen3-0.6b": qwen3_0_6b_config,
     "qwen3-4b": qwen3_4b_config,
     "qwen3-4b-thinking-2507": qwen3_4b_config,

--- a/src/maxtext/checkpoint_conversion/utils/hf_shape.py
+++ b/src/maxtext/checkpoint_conversion/utils/hf_shape.py
@@ -529,8 +529,8 @@ def GPT_OSS_HF_WEIGHTS_TO_SHAPE(config):
   return mapping
 
 
-def QWEN3_HF_WEIGHTS_TO_SHAPE(config):
-  """Returns mapping between HuggingFace Qwen3 weights path and the HuggingFace weights shape.
+def QWEN_HF_WEIGHTS_TO_SHAPE(config):
+  """Returns mapping between HuggingFace Qwen weights path and the HuggingFace weights shape.
 
   To check this mapping, dump the huggingface model shapes:
     from transformers import AutoModelForCausalLM
@@ -555,6 +555,7 @@ def QWEN3_HF_WEIGHTS_TO_SHAPE(config):
   head_dim = config.get(
       "head_dim", config["hidden_size"] // config["num_attention_heads"]
   )  # head_dim might not always be present
+  attention_bias = config.get("attention_bias", False)
 
   mapping = {
       "model.embed_tokens.weight": [config["vocab_size"], hidden_size],
@@ -579,6 +580,15 @@ def QWEN3_HF_WEIGHTS_TO_SHAPE(config):
         f"{layer_prefix}.self_attn.q_norm.weight": [head_dim],
         f"{layer_prefix}.self_attn.k_norm.weight": [head_dim],
     }
+
+    if attention_bias:
+      layer_mapping.update(
+          {
+              f"{layer_prefix}.self_attn.q_proj.bias": [num_attention_heads * head_dim],
+              f"{layer_prefix}.self_attn.k_proj.bias": [num_key_value_heads * head_dim],
+              f"{layer_prefix}.self_attn.v_proj.bias": [num_key_value_heads * head_dim],
+          }
+      )
 
     if num_experts > 1:
       # MoE MLP layers
@@ -756,18 +766,20 @@ HF_SHAPE = {
     "gemma3-4b": GEMMA3_HF_WEIGHTS_TO_SHAPE,
     "gemma3-12b": GEMMA3_HF_WEIGHTS_TO_SHAPE,
     "gemma3-27b": GEMMA3_HF_WEIGHTS_TO_SHAPE,
-    "qwen3-0.6b": QWEN3_HF_WEIGHTS_TO_SHAPE,
-    "qwen3-4b": QWEN3_HF_WEIGHTS_TO_SHAPE,
-    "qwen3-4b-thinking-2507": QWEN3_HF_WEIGHTS_TO_SHAPE,
-    "qwen3-8b": QWEN3_HF_WEIGHTS_TO_SHAPE,
-    "qwen3-14b": QWEN3_HF_WEIGHTS_TO_SHAPE,
-    "qwen3-32b": QWEN3_HF_WEIGHTS_TO_SHAPE,
+    "qwen2.5-7b": QWEN_HF_WEIGHTS_TO_SHAPE,
+    "qwen2.5-14b": QWEN_HF_WEIGHTS_TO_SHAPE,
+    "qwen3-0.6b": QWEN_HF_WEIGHTS_TO_SHAPE,
+    "qwen3-4b": QWEN_HF_WEIGHTS_TO_SHAPE,
+    "qwen3-4b-thinking-2507": QWEN_HF_WEIGHTS_TO_SHAPE,
+    "qwen3-8b": QWEN_HF_WEIGHTS_TO_SHAPE,
+    "qwen3-14b": QWEN_HF_WEIGHTS_TO_SHAPE,
+    "qwen3-32b": QWEN_HF_WEIGHTS_TO_SHAPE,
     "llama3.1-8b": LLAMA31_HF_WEIGHTS_TO_SHAPE,
     "llama3.1-70b": LLAMA31_HF_WEIGHTS_TO_SHAPE,
     "llama3.1-405b": LLAMA31_HF_WEIGHTS_TO_SHAPE,
-    "qwen3-30b-a3b": QWEN3_HF_WEIGHTS_TO_SHAPE,
-    "qwen3-235b-a22b": QWEN3_HF_WEIGHTS_TO_SHAPE,
-    "qwen3-480b-a35b": QWEN3_HF_WEIGHTS_TO_SHAPE,
+    "qwen3-30b-a3b": QWEN_HF_WEIGHTS_TO_SHAPE,
+    "qwen3-235b-a22b": QWEN_HF_WEIGHTS_TO_SHAPE,
+    "qwen3-480b-a35b": QWEN_HF_WEIGHTS_TO_SHAPE,
     "deepseek3-671b": DEEPSEEK_HF_WEIGHTS_TO_SHAPE,
     "gpt-oss-20b": GPT_OSS_HF_WEIGHTS_TO_SHAPE,
     "gpt-oss-120b": GPT_OSS_HF_WEIGHTS_TO_SHAPE,

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -587,11 +587,11 @@ def GEMMA2_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False
   return mapping
 
 
-def QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
-  """Returns mapping from MaxText to HuggingFace Qwen3 weight paths.
+def QWEN_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
+  """Returns mapping from MaxText to HuggingFace Qwen weight paths.
 
   This function generates a dictionary that maps parameter names from a MaxText
-  Qwen3 checkpoint to their corresponding names in the Hugging Face format.
+  Qwen checkpoint to their corresponding names in the Hugging Face format.
   It handles both dense and Mixture-of-Experts (MoE) model variants.
 
   Args:
@@ -630,6 +630,15 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False)
             ],
             "params-decoder-layers-self_attention-value-kernel": [
                 f"model.layers.{i}.self_attn.v_proj.weight" for i in range(n_layers)
+            ],
+            "params-decoder-layers-self_attention-query-bias": [
+                f"model.layers.{i}.self_attn.q_proj.bias" for i in range(n_layers)
+            ],
+            "params-decoder-layers-self_attention-key-bias": [
+                f"model.layers.{i}.self_attn.k_proj.bias" for i in range(n_layers)
+            ],
+            "params-decoder-layers-self_attention-value-bias": [
+                f"model.layers.{i}.self_attn.v_proj.bias" for i in range(n_layers)
             ],
             "params-decoder-layers-self_attention-out-kernel": [
                 f"model.layers.{i}.self_attn.o_proj.weight" for i in range(n_layers)
@@ -688,6 +697,9 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False)
               f"params-decoder-layers_{i}-self_attention-key-kernel": f"model.layers.{i}.self_attn.k_proj.weight",
               f"params-decoder-layers_{i}-self_attention-value-kernel": f"model.layers.{i}.self_attn.v_proj.weight",
               f"params-decoder-layers_{i}-self_attention-out-kernel": f"model.layers.{i}.self_attn.o_proj.weight",
+              f"params-decoder-layers_{i}-self_attention-query-bias": f"model.layers.{i}.self_attn.q_proj.bias",
+              f"params-decoder-layers_{i}-self_attention-key-bias": f"model.layers.{i}.self_attn.k_proj.bias",
+              f"params-decoder-layers_{i}-self_attention-value-bias": f"model.layers.{i}.self_attn.v_proj.bias",
               f"params-decoder-layers_{i}-self_attention-query_norm-scale": f"model.layers.{i}.self_attn.q_norm.weight",
               f"params-decoder-layers_{i}-self_attention-key_norm-scale": f"model.layers.{i}.self_attn.k_norm.weight",
               f"params-decoder-layers_{i}-post_self_attention_layer_norm-scale": f"model.layers.{i}.post_attention_layernorm.weight",
@@ -721,8 +733,8 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False)
   return mapping
 
 
-def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
-  """Creates parameter transformation functions for Qwen3.
+def QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
+  """Creates parameter transformation functions for Qwen.
 
   This function provides a dictionary of transformation functions (hooks) for
   converting Qwen3 model parameters between MaxText and Hugging Face formats.
@@ -766,6 +778,15 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False,
     else:
       return input_tensor.T.reshape(target_shape)
 
+  def reshape_bias(input_tensor, target_shape=None):
+    """Reshapes biases between MaxText 2D (heads, dim) and HF 1D (hidden)."""
+    if saving_to_hf:
+      # MaxText [heads, head_dim] -> HF [hidden_dim] (flatten)
+      return input_tensor.reshape(target_shape)
+    else:
+      # HF [hidden_dim] -> MaxText [heads, head_dim]
+      return input_tensor.reshape(target_shape)
+
   mapping = {
       "params-token_embedder-embedding": pad_embedding_layer,
       "params-decoder-logits_dense-kernel": reshape_kernel,
@@ -780,6 +801,11 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False,
       "mlp-wi_1-kernel",
       "mlp-wo-kernel",
   ]
+  bias_hooks = [
+      "self_attention-query-bias",
+      "self_attention-key-bias",
+      "self_attention-value-bias",
+  ]
   moe_kernel_hooks = [
       "moe_block-gate-kernel",
       "moe_block-wi_0-kernel",
@@ -793,6 +819,8 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False,
   if scan_layers:
     for key in kernel_hooks:
       mapping[f"params-decoder-layers-{key}"] = reshape_kernel
+    for key in bias_hooks:
+      mapping[f"params-decoder-layers-{key}"] = reshape_bias
     if num_experts > 1:
       for key in moe_kernel_hooks:
         mapping[f"params-decoder-layers-{key}"] = reshape_kernel
@@ -800,6 +828,8 @@ def QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False,
     for i in range(n_layers):
       for key in kernel_hooks:
         mapping[f"params-decoder-layers_{i}-{key}"] = reshape_kernel
+      for key in bias_hooks:
+        mapping[f"params-decoder-layers_{i}-{key}"] = reshape_bias
       if num_experts > 1:
         for key in moe_kernel_hooks:
           mapping[f"params-decoder-layers_{i}-{key}"] = reshape_kernel
@@ -1376,7 +1406,7 @@ def QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_laye
   # Text mapping with "thinker." prefix, reusing QWEN3-MOE mapping function
   num_experts_text = config["thinker_config"]["text_config"].get("num_experts", 0)
   n_layers_text = config["thinker_config"]["text_config"]["num_hidden_layers"]
-  text_mapping = QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING(
+  text_mapping = QWEN_MAXTEXT_TO_HF_PARAM_MAPPING(
       config={"num_hidden_layers": n_layers_text, "num_experts": num_experts_text},
       maxtext_config=maxtext_config,
       scan_layers=scan_layers,
@@ -1544,7 +1574,7 @@ def QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_laye
   # Text hooks, reusing QWEN3-MOE hook function
   num_experts_text = config["thinker_config"]["text_config"].get("num_experts", 0)
   n_layers_text = config["thinker_config"]["text_config"]["num_hidden_layers"]
-  text_hooks = QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN(
+  text_hooks = QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN(
       config={"num_hidden_layers": n_layers_text, "num_experts": num_experts_text},
       maxtext_config=maxtext_config,
       scan_layers=scan_layers,
@@ -2332,18 +2362,23 @@ PARAM_MAPPING = {
     "gemma3-4b": GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma3-12b": GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma3-27b": GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING,
-    "qwen3-0.6b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
-    "qwen3-4b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
-    "qwen3-4b-thinking-2507": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
-    "qwen3-8b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
-    "qwen3-14b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
-    "qwen3-32b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen2.5-0.5b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen2.5-1.5b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen2.5-3b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen2.5-7b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen2.5-14b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-0.6b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-4b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-4b-thinking-2507": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-8b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-14b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-32b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
     "llama3.1-8b": LLAMA31_MAXTEXT_TO_HF_PARAM_MAPPING,
     "llama3.1-70b": LLAMA31_MAXTEXT_TO_HF_PARAM_MAPPING,
     "llama3.1-405b": LLAMA31_MAXTEXT_TO_HF_PARAM_MAPPING,
-    "qwen3-30b-a3b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
-    "qwen3-235b-a22b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
-    "qwen3-coder-480b-a35b": QWEN3_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-30b-a3b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-235b-a22b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "qwen3-coder-480b-a35b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
     "deepseek3-671b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gpt-oss-20b": GPT_OSS_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gpt-oss-120b": GPT_OSS_MAXTEXT_TO_HF_PARAM_MAPPING,
@@ -2364,18 +2399,23 @@ HOOK_FNS = {
     "gemma3-4b": GEMMA3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "gemma3-12b": GEMMA3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "gemma3-27b": GEMMA3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
-    "qwen3-0.6b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
-    "qwen3-4b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
-    "qwen3-4b-thinking-2507": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
-    "qwen3-8b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
-    "qwen3-14b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
-    "qwen3-32b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen2.5-0.5b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen2.5-1.5b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen2.5-3b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen2.5-7b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen2.5-14b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-0.6b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-4b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-4b-thinking-2507": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-8b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-14b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-32b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "llama3.1-8b": LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "llama3.1-70b": LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "llama3.1-405b": LLAMA31_MAXTEXT_TO_HF_PARAM_HOOK_FN,
-    "qwen3-30b-a3b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
-    "qwen3-235b-a22b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
-    "qwen3-coder-480b-a35b": QWEN3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-30b-a3b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-235b-a22b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "qwen3-coder-480b-a35b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "deepseek3-671b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "gpt-oss-20b": GPT_OSS_TO_HF_PARAM_HOOK_FN,
     "gpt-oss-120b": GPT_OSS_TO_HF_PARAM_HOOK_FN,

--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -92,6 +92,7 @@ class DecoderBlockType(enum.Enum):
   GEMMA = "gemma"
   GEMMA2 = "gemma2"
   GEMMA3 = "gemma3"
+  QWEN2 = "qwen2"
   QWEN3 = "qwen3"
   QWEN3_MOE = "qwen3_moe"
   QWEN3_NEXT = "qwen3_next"

--- a/src/maxtext/configs/models/qwen2.5-14b.yml
+++ b/src/maxtext/configs/models/qwen2.5-14b.yml
@@ -1,0 +1,34 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qwen 2.5 14B Instruct Configuration
+# https://huggingface.co/Qwen/Qwen2.5-14B-Instruct
+
+base_emb_dim: 5120
+base_num_query_heads: 40
+base_num_kv_heads: 8
+base_mlp_dim: 13824
+base_num_decoder_layers: 48
+head_dim: 128
+mlp_activations: ["silu", "linear"]
+vocab_size: 152064
+decoder_block: "qwen2"
+normalization_layer_epsilon: 1.0e-6
+rope_max_timescale: 1000000.0
+use_qk_norm: False
+# Bias for q, k, v proj.
+attention_bias: True
+logits_via_embedding: False
+normalize_embedding_logits: False
+tokenizer_type: "huggingface"

--- a/src/maxtext/configs/models/qwen2.5-7b.yml
+++ b/src/maxtext/configs/models/qwen2.5-7b.yml
@@ -1,0 +1,34 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qwen 2.5 7B Instruct Configuration
+# https://huggingface.co/Qwen/Qwen2.5-7B-Instruct
+
+base_emb_dim: 3584
+base_num_query_heads: 28
+base_num_kv_heads: 4
+base_mlp_dim: 18944
+base_num_decoder_layers: 28
+head_dim: 128
+mlp_activations: ["silu", "linear"]
+vocab_size: 152064
+decoder_block: "qwen2"
+normalization_layer_epsilon: 1e-06
+rope_max_timescale: 1000000.0
+use_qk_norm: False
+# Bias for q, k, v proj.
+attention_bias: True
+logits_via_embedding: False
+normalize_embedding_logits: False
+tokenizer_type: "huggingface"

--- a/src/maxtext/configs/pyconfig_deprecated.py
+++ b/src/maxtext/configs/pyconfig_deprecated.py
@@ -460,6 +460,8 @@ def validate_model_name(s: str) -> bool:
       "gemma3-4b",
       "gemma3-12b",
       "gemma3-27b",
+      "qwen2.5-7b",
+      "qwen2.5-14b",
       "qwen3-0.6b",
       "qwen3-4b",
       "qwen3-4b-thinking-2507",

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -232,6 +232,8 @@ ModelName = Literal[
     "gemma3-4b",
     "gemma3-12b",
     "gemma3-27b",
+    "qwen2.5-7b",
+    "qwen2.5-14b",
     "qwen3-0.6b",
     "qwen3-4b",
     "qwen3-4b-thinking-2507",

--- a/src/maxtext/integration/tunix/weight_mapping/__init__.py
+++ b/src/maxtext/integration/tunix/weight_mapping/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023–2025 Google LLC
+# Copyright 2023–2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ model name. This allows for easy extension to support new models.
 from maxtext.integration.tunix.weight_mapping.deepseek3 import DEEPSEEK_VLLM_MAPPING
 from maxtext.integration.tunix.weight_mapping.gpt_oss import GPT_OSS_VLLM_MAPPING
 from maxtext.integration.tunix.weight_mapping.llama3 import LLAMA3_VLLM_MAPPING
+from maxtext.integration.tunix.weight_mapping.qwen2 import QWEN2_VLLM_MAPPING
 from maxtext.integration.tunix.weight_mapping.qwen3 import QWEN3_VLLM_MAPPING
 
 
@@ -30,6 +31,8 @@ class StandaloneVllmWeightMapping:
   def __getattr__(self, name):
     if name.startswith("llama3.1"):
       return LLAMA3_VLLM_MAPPING
+    elif name.startswith("qwen2"):
+      return QWEN2_VLLM_MAPPING
     elif name.startswith("qwen3"):
       return QWEN3_VLLM_MAPPING
     elif name.startswith("deepseek3"):

--- a/src/maxtext/integration/tunix/weight_mapping/qwen2.py
+++ b/src/maxtext/integration/tunix/weight_mapping/qwen2.py
@@ -1,0 +1,136 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Defines the weight mapping from MaxText's Qwen2 model to a vLLM-compatible format.
+
+This module provides the `QWEN2_VLLM_MAPPING` dataclass, which contains all the
+necessary configurations to convert MaxText's Qwen2 model weights into a
+format that can be loaded by HuggingFace's vLLM. This includes:
+- A direct mapping of parameter names.
+- Sharding specifications for distributed environments.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class QWEN2_VLLM_MAPPING:
+  """Mapping MaxText Qwen2 weights to vLLM's Qwen2 weights."""
+
+  @staticmethod
+  def to_hf_hook_fns():
+    """Returns a dictionary of hook functions to be applied to MaxText weights.
+
+    Returns:
+      An empty dictionary, as no hook functions are needed for this mapping.
+    """
+
+    return {}
+
+  @staticmethod
+  def to_hf_transpose_keys():
+    """Returns a list of keys for weights that need to be transposed.
+
+    Returns:
+      An empty dictionary, as no keys require transposition for this mapping.
+    """
+    return {}
+
+  @staticmethod
+  def lora_to_hf_mappings():
+    """Provides the mapping for LoRA (Low-Rank Adaptation) weights.
+
+    Returns:
+      None, as LoRA mappings are not defined for this model.
+    """
+    return None
+
+  @staticmethod
+  def to_hf_mapping():
+    """Mapping from MaxText model to HuggingFace vLLM model.
+
+    Currently, the param mapping conforms to the Tunix API, which combines the
+    param name & sharding in one dictionary.
+    This is subject to change in the future where we can decouple the two.
+    """
+    return {
+        # Token embeddings - shard vocab dimension
+        "base.token_embedder.embedding": (
+            "model.embed.embedding",
+            ("model", None),
+        ),
+        # Final layer norm - no sharding needed
+        "base.decoder.decoder_norm.scale": (
+            "model.norm.scale",
+            (None,),
+        ),
+        # LM head (logits projection) - shard vocab dimension
+        "base.decoder.logits_dense.kernel": (
+            "model.lm_head",
+            (None, "model"),
+        ),
+        # Layer-specific mappings (scanned -> unscanned)
+        # MLP components - shard hidden dimensions
+        "base.decoder.layers.mlp.wi_0.kernel": (
+            "model.layers.*.mlp.gate_proj.kernel",
+            (None, "layer", "model"),
+        ),
+        "base.decoder.layers.mlp.wi_1.kernel": (
+            "model.layers.*.mlp.up_proj.kernel",
+            (None, "layer", "model"),
+        ),
+        "base.decoder.layers.mlp.wo.kernel": (
+            "model.layers.*.mlp.down_proj.kernel",
+            ("model", "layer", None),
+        ),
+        # Layer norms - no sharding needed
+        "base.decoder.layers.pre_self_attention_layer_norm.scale": (
+            "model.layers.*.input_layernorm.scale",
+            (None, "layer"),
+        ),
+        "base.decoder.layers.post_self_attention_layer_norm.scale": (
+            "model.layers.*.post_attention_layernorm.scale",
+            (None, "layer"),
+        ),
+        # Attention components - shard head dimensions
+        "base.decoder.layers.self_attention.query.kernel": (
+            "model.layers.*.self_attn.q_proj.kernel",
+            (None, "layer", "model", None),
+        ),
+        "base.decoder.layers.self_attention.key.kernel": (
+            "model.layers.*.self_attn.k_proj.kernel",
+            (None, "layer", "model", None),
+        ),
+        "base.decoder.layers.self_attention.value.kernel": (
+            "model.layers.*.self_attn.v_proj.kernel",
+            (None, "layer", "model", None),
+        ),
+        "base.decoder.layers.self_attention.out.kernel": (
+            "model.layers.*.self_attn.o_proj.kernel",
+            ("model", "layer", None, None),
+        ),
+        # Attention biases
+        "base.decoder.layers.self_attention.query.bias": (
+            "model.layers.*.self_attn.q_proj.bias",
+            (None, "layer", "model", None),
+        ),
+        "base.decoder.layers.self_attention.key.bias": (
+            "model.layers.*.self_attn.k_proj.bias",
+            (None, "layer", "model", None),
+        ),
+        "base.decoder.layers.self_attention.value.bias": (
+            "model.layers.*.self_attn.v_proj.bias",
+            (None, "layer", "model", None),
+        ),
+    }

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -436,6 +436,7 @@ class Attention(nnx.Module):
     # Use the rope type specified in the arguments if provided, otherwise fall back to the one in the config.
     self.rope_type = (rope_type or self.config.rope_type).lower()
 
+    self.is_qwen2 = self.config.decoder_block == DecoderBlockType.QWEN2
     self.is_qwen3_next = self.config.decoder_block == DecoderBlockType.QWEN3_NEXT
 
     # Module attribute names must match names previously passed to Linen for checkpointing
@@ -720,7 +721,7 @@ class Attention(nnx.Module):
         quant=self.quant,
         shard_mode=self.config.shard_mode,
         matmul_precision=self.config.matmul_precision,
-        use_bias=self.use_bias_in_projections,
+        use_bias=False if self.is_qwen2 else self.use_bias_in_projections,
         rngs=self.rngs,
     )
 

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -52,6 +52,7 @@ from maxtext.models import (
     mistral,
     mixtral,
     olmo3,
+    qwen2,
     qwen3,
     simple_layer,
 )
@@ -467,6 +468,8 @@ class Decoder(nn.Module):
         return [gpt3.Gpt3DecoderLayerToLinen]
       case DecoderBlockType.GPT_OSS:
         return [gpt_oss.GptOssScannableBlockToLinen] if self.config.scan_layers else [gpt_oss.GptOssDecoderLayerToLinen]
+      case DecoderBlockType.QWEN2:
+        return [qwen2.Qwen2DecoderLayerToLinen]
       case DecoderBlockType.QWEN3:
         return [qwen3.Qwen3DecoderLayerToLinen]
       case DecoderBlockType.QWEN3_MOE:
@@ -525,6 +528,7 @@ class Decoder(nn.Module):
         DecoderBlockType.GEMMA,
         DecoderBlockType.GEMMA2,
         DecoderBlockType.GEMMA3,
+        DecoderBlockType.QWEN2,
         DecoderBlockType.QWEN3,
         DecoderBlockType.QWEN3_MOE,
         DecoderBlockType.GPT_OSS,

--- a/src/maxtext/models/qwen2.py
+++ b/src/maxtext/models/qwen2.py
@@ -1,0 +1,219 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen2 family of model decoder layers."""
+# pylint: disable=arguments-differ
+# pylint: disable=no-name-in-module
+
+from typing import Any
+
+from jax.ad_checkpoint import checkpoint_name
+from jax.sharding import Mesh
+import jax.numpy as jnp
+
+from flax import linen as nn
+from flax import nnx
+
+from maxtext.common.common_types import Config
+from maxtext.layers import initializers as max_initializers
+from maxtext.layers import nnx_wrappers
+from maxtext.layers import quantizations
+from maxtext.layers.normalizations import RMSNorm
+from maxtext.layers.quantizations import AqtQuantization as Quant
+from maxtext.layers.attentions import Attention
+from maxtext.layers.linears import MlpBlock
+from maxtext.inference import page_manager
+from maxtext.utils import max_utils
+
+
+# -----------------------------------------
+# The Base Decoder Layer for Qwen2
+# -----------------------------------------
+class AttentionWithNorm(nnx.Module):
+  """Base class with shared common components: self-attention block with normalization."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      quant: None | Quant,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.quant = quant
+
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+    # Corresponds to Qwen2's `input_layernorm`
+    self.pre_self_attention_layer_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=rngs,
+    )
+
+    # Self-attention block
+    query_pre_attn_scalar = config.head_dim**-0.5  # Qwen2 specific scaling
+    self.self_attention = Attention(
+        config=config,
+        num_query_heads=config.num_query_heads,
+        num_kv_heads=config.num_kv_heads,
+        head_dim=config.head_dim,
+        max_target_length=config.max_target_length,
+        max_prefill_predict_length=config.max_prefill_predict_length,
+        attention_kernel=config.attention,
+        inputs_q_shape=dummy_inputs_shape,
+        inputs_kv_shape=dummy_inputs_shape,
+        mesh=mesh,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        dropout_rate=config.dropout_rate,
+        float32_qk_product=config.float32_qk_product,
+        float32_logits=config.float32_logits,
+        quant=quant,
+        kv_quant=quantizations.configure_kv_quant(config),
+        use_ragged_attention=config.use_ragged_attention,
+        ragged_block_size=config.ragged_block_size,
+        use_qk_norm=config.use_qk_norm,
+        use_bias_in_projections=config.attention_bias,
+        query_pre_attn_scalar=query_pre_attn_scalar,
+        model_mode=model_mode,
+        use_mrope=config.use_mrope,
+        mrope_section=config.mrope_section,
+        rngs=rngs,
+    )
+
+    # Post Attention LayerNorm (corresponds to Qwen2's `post_attention_layernorm`)
+    self.post_self_attention_layer_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        epsilon=config.normalization_layer_epsilon,
+        rngs=rngs,
+    )
+
+  def apply_attention_with_norm(
+      self,
+      inputs: jnp.ndarray,
+      decoder_segment_ids: None | jnp.ndarray,
+      decoder_positions: None | jnp.ndarray,
+      deterministic: bool,
+      model_mode: str,
+      kv_cache: None | jnp.ndarray = None,
+      attention_metadata: None | dict[str, Any] = None,
+  ):
+    """Applies self-attention with pre and post-layer normalization."""
+    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
+    # Pre attention norm
+    lnx = self.pre_self_attention_layer_norm(inputs)
+    lnx = nn.with_logical_constraint(lnx, self.activation_axis_names)
+    # Self attention
+    attention_lnx, kv_cache = self.self_attention(
+        lnx,
+        lnx,
+        decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        deterministic=deterministic,
+        model_mode=model_mode,
+        kv_cache=kv_cache,
+        attention_metadata=attention_metadata,
+    )
+    attention_lnx = nn.with_logical_constraint(attention_lnx, self.activation_axis_names)
+    # Residual connection after attention
+    intermediate_inputs = inputs + attention_lnx
+    # Post attention norm
+    hidden_states = self.post_self_attention_layer_norm(intermediate_inputs)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+    return hidden_states, intermediate_inputs, kv_cache
+
+
+# -----------------------------------------
+# The Dense Decoder Layer for Qwen2
+# -----------------------------------------
+class Qwen2DecoderLayer(AttentionWithNorm):
+  """Qwen2 Transformer decoder layer (dense)."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      quant: None | Quant,
+      rngs: nnx.Rngs,
+  ):
+    super().__init__(config, mesh, model_mode, quant, rngs)
+    self.mlp = MlpBlock(
+        in_features=config.emb_dim,
+        intermediate_dim=config.mlp_dim,
+        activations=config.mlp_activations,
+        intermediate_dropout_rate=config.dropout_rate,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        config=config,
+        mesh=mesh,
+        quant=quant,
+        model_mode=model_mode,
+        rngs=rngs,
+    )
+
+  def __call__(
+      self,
+      inputs: jnp.ndarray,
+      decoder_segment_ids: None | jnp.ndarray,
+      decoder_positions: None | jnp.ndarray,
+      deterministic: bool,
+      model_mode: str,
+      previous_chunk=None,
+      page_state: None | page_manager.PageState = None,
+      slot: None | int = None,
+      kv_cache: None | jnp.ndarray = None,
+      attention_metadata: None | dict[str, Any] = None,
+  ):
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
+    hidden_states, intermediate_inputs, kv_cache = self.apply_attention_with_norm(
+        inputs,
+        decoder_segment_ids,
+        decoder_positions,
+        deterministic,
+        model_mode,
+        kv_cache=kv_cache,
+        attention_metadata=attention_metadata,
+    )
+
+    mlp_lnx = self.mlp(hidden_states, deterministic=deterministic)
+    mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
+
+    layer_output = intermediate_inputs + mlp_lnx
+    layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
+
+    if self.config.scan_layers:
+      return layer_output, None
+    else:
+      return layer_output, kv_cache
+
+
+Qwen2DecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Qwen2DecoderLayer,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)

--- a/src/maxtext/utils/globals.py
+++ b/src/maxtext/utils/globals.py
@@ -50,6 +50,8 @@ HF_IDS = {
     "gemma3-4b": "google/gemma-3-4b-it",  # hf multi-modal should also support the pure-text
     "gemma3-12b": "google/gemma-3-12b-it",
     "gemma3-27b": "google/gemma-3-27b-it",
+    "qwen2.5-7b": "Qwen/Qwen2.5-7B-Instruct",
+    "qwen2.5-14b": "Qwen/Qwen2.5-14B-Instruct",
     "qwen3-0.6b": "Qwen/Qwen3-0.6B",
     "qwen3-4b": "Qwen/Qwen3-4B",
     "qwen3-4b-thinking-2507": "Qwen/Qwen3-4B-Thinking-2507",

--- a/tests/end_to_end/tpu/qwen/dense/qwen2.5-14b/test_qwen2.5-14b.sh
+++ b/tests/end_to_end/tpu/qwen/dense/qwen2.5-14b/test_qwen2.5-14b.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# This script runs end-to-end tests for qwen2.5-14b on MaxText.
+# The flow of this file is as follows:
+# 1. Convert the HuggingFace checkpoint to MaxText-compatible checkpoint (scanned and unscanned).
+# 2. Run logit check against the HuggingFace model.
+# 3. Run Decode.
+# 4. Run SFT.
+# 5. Run Pre-train.
+
+# Example Usage: export BASE_OUTPUT_PATH=<GCS_bucket_path> bash test_qwen2.5-14b.sh
+
+set -ex
+
+export MODEL_NAME='qwen2.5-14b'
+export HF_MODEL_ID='Qwen/Qwen2.5-14B-Instruct'
+export TOKENIZER_PATH=${HF_MODEL_ID}
+
+if [ -z "${BASE_OUTPUT_PATH}" ]; then
+    export BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d-%H-%M)
+    echo "BASE_OUTPUT_PATH is not set, using BASE_OUTPUT_PATH = ${BASE_OUTPUT_PATH}"
+fi
+
+export BASE_OUTPUT_PATH_PREFIX="${BASE_OUTPUT_PATH}/${MODEL_NAME}/$(date +%Y-%m-%d-%H-%M)"
+
+# Installing torch for deps in forward_pass_logit_checker.py
+#python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# Step 1: Checkpoint conversion
+echo "--- Starting Checkpoint Conversion ---"
+
+# 1.1 Convert checkpoint to `scanned` format
+JAX_PLATFORMS=cpu python3 -m maxtext.checkpoint_conversion.to_maxtext \
+  "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+  model_name=${MODEL_NAME} \
+  base_output_directory=${BASE_OUTPUT_PATH_PREFIX}/scanned \
+  run_name=scanned_conversion \
+  tokenizer_path=${TOKENIZER_PATH} \
+  async_checkpointing=false \
+  scan_layers=true
+
+export SCANNED_CKPT_PATH=${BASE_OUTPUT_PATH_PREFIX}/scanned/0/items
+
+# 1.2 Convert checkpoint to `unscanned` format
+JAX_PLATFORMS=cpu python3 -m maxtext.checkpoint_conversion.to_maxtext \
+  "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+  model_name=${MODEL_NAME} \
+  base_output_directory=${BASE_OUTPUT_PATH_PREFIX}/unscanned \
+  run_name=unscanned_conversion \
+  tokenizer_path=${TOKENIZER_PATH} \
+  async_checkpointing=false \
+  scan_layers=false
+
+export UNSCANNED_CKPT_PATH=${BASE_OUTPUT_PATH_PREFIX}/unscanned/0/items
+
+# Step 2: Forward pass logit checker
+echo "--- Starting Forward Pass Logit Checker ---"
+# 2.1 Check unscanned checkpoint
+JAX_PLATFORMS=cpu python3 -m tests.utils.forward_pass_logit_checker \
+    "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    run_name=forward_pass_test_unscanned \
+    model_name=${MODEL_NAME} \
+    tokenizer_path=${TOKENIZER_PATH} \
+    load_parameters_path=${UNSCANNED_CKPT_PATH} \
+    max_prefill_predict_length=4 \
+    max_target_length=4 \
+    dataset_type=synthetic \
+    scan_layers=false \
+    per_device_batch_size=1 \
+    skip_jax_distributed_system=True \
+    weight_dtype=bfloat16 \
+    --max_kl_div=0.015 \
+    --run_hf_model=True \
+    --hf_model_path=${HF_MODEL_ID}
+
+# 2.2 Check scanned checkpoint
+JAX_PLATFORMS=cpu python3 -m tests.utils.forward_pass_logit_checker \
+    "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    run_name=forward_pass_test_scanned \
+    model_name=${MODEL_NAME} \
+    tokenizer_path=${TOKENIZER_PATH} \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    max_prefill_predict_length=4 \
+    max_target_length=4 \
+    dataset_type=synthetic \
+    scan_layers=true \
+    per_device_batch_size=1 \
+    skip_jax_distributed_system=True \
+    weight_dtype=bfloat16 \
+    --max_kl_div=0.015 \
+    --run_hf_model=True \
+    --hf_model_path=${HF_MODEL_ID}
+
+# Step 3: Decode
+echo "--- Starting Decode ---"
+python3 -m maxtext.inference.decode \
+    "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    model_name=${MODEL_NAME} \
+    tokenizer_path=${TOKENIZER_PATH} \
+    load_parameters_path=${UNSCANNED_CKPT_PATH} \
+    per_device_batch_size=1 \
+    run_name=decode_test \
+    max_prefill_predict_length=8 \
+    max_target_length=16 \
+    dataset_type=synthetic \
+    steps=10 \
+    async_checkpointing=false \
+    scan_layers=false \
+    prompt="I love to" \
+    tokenizer_type=huggingface
+
+# Step 4: SFT
+echo "--- Starting SFT ---"
+python3 -m maxtext.trainers.post_train.sft.train_sft \
+    "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/post_train/sft.yml \
+    base_output_directory=${BASE_OUTPUT_PATH_PREFIX}/finetuned \
+    run_name=sft_test \
+    model_name=${MODEL_NAME} \
+    tokenizer_path=${TOKENIZER_PATH} \
+    tokenizer_type=huggingface \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    dataset_type=hf \
+    scan_layers=true \
+    per_device_batch_size=4 \
+    learning_rate=1.3e-5 \
+    steps=5 \
+    max_target_length=1024 \
+    weight_dtype=bfloat16
+
+# Step 5: Pre-train
+echo "--- Starting Pre-train ---"
+export DATASET_PATH=gs://maxtext-dataset
+python3 -m maxtext.trainers.pre_train.train \
+    "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    model_name=${MODEL_NAME} \
+    base_output_directory=${BASE_OUTPUT_PATH_PREFIX}/pretrain \
+    dataset_path=${DATASET_PATH} \
+    tokenizer_path=${TOKENIZER_PATH} \
+    per_device_batch_size=1 \
+    run_name=pretrain_test \
+    steps=10 \
+    enable_checkpointing=false \
+    sharding_tolerance=0.03 \
+    tokenizer_type=huggingface

--- a/tests/end_to_end/tpu/qwen/dense/qwen2.5-7b/test_qwen2.5-7b.sh
+++ b/tests/end_to_end/tpu/qwen/dense/qwen2.5-7b/test_qwen2.5-7b.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# This script runs end-to-end tests for qwen2.5-7b on MaxText.
+# The flow of this file is as follows:
+# 1. Convert the HuggingFace checkpoint to MaxText-compatible checkpoint (scanned and unscanned).
+# 2. Run logit check against the HuggingFace model.
+# 3. Run Decode.
+# 4. Run SFT.
+# 5. Run Pre-train.
+
+# Example Usage: export BASE_OUTPUT_PATH=<GCS_bucket_path> bash test_qwen2.5-7b.sh
+
+set -ex
+
+export MODEL_NAME='qwen2.5-7b'
+export HF_MODEL_ID='Qwen/Qwen2.5-7B-Instruct'
+export TOKENIZER_PATH=${HF_MODEL_ID}
+
+if [ -z "${BASE_OUTPUT_PATH}" ]; then
+    export BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d-%H-%M)
+    echo "BASE_OUTPUT_PATH is not set, using BASE_OUTPUT_PATH = ${BASE_OUTPUT_PATH}"
+fi
+
+export BASE_OUTPUT_PATH_PREFIX="${BASE_OUTPUT_PATH}/${MODEL_NAME}/$(date +%Y-%m-%d-%H-%M)"
+
+# Installing torch for deps in forward_pass_logit_checker.py
+#python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# Step 1: Checkpoint conversion
+echo "--- Starting Checkpoint Conversion ---"
+
+# 1.1 Convert checkpoint to `scanned` format
+JAX_PLATFORMS=cpu python3 -m maxtext.checkpoint_conversion.to_maxtext \
+  "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+  model_name=${MODEL_NAME} \
+  base_output_directory=${BASE_OUTPUT_PATH_PREFIX}/scanned \
+  run_name=scanned_conversion \
+  tokenizer_path=${TOKENIZER_PATH} \
+  async_checkpointing=false \
+  scan_layers=true
+
+export SCANNED_CKPT_PATH=${BASE_OUTPUT_PATH_PREFIX}/scanned/0/items
+
+# 1.2 Convert checkpoint to `unscanned` format
+JAX_PLATFORMS=cpu python3 -m maxtext.checkpoint_conversion.to_maxtext \
+  "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+  model_name=${MODEL_NAME} \
+  base_output_directory=${BASE_OUTPUT_PATH_PREFIX}/unscanned \
+  run_name=unscanned_conversion \
+  tokenizer_path=${TOKENIZER_PATH} \
+  async_checkpointing=false \
+  scan_layers=false
+
+export UNSCANNED_CKPT_PATH=${BASE_OUTPUT_PATH_PREFIX}/unscanned/0/items
+
+# Step 2: Forward pass logit checker
+echo "--- Starting Forward Pass Logit Checker ---"
+# 2.1 Check unscanned checkpoint
+JAX_PLATFORMS=cpu python3 -m tests.utils.forward_pass_logit_checker \
+    "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    run_name=forward_pass_test_unscanned \
+    model_name=${MODEL_NAME} \
+    tokenizer_path=${TOKENIZER_PATH} \
+    load_parameters_path=${UNSCANNED_CKPT_PATH} \
+    max_prefill_predict_length=4 \
+    max_target_length=4 \
+    dataset_type=synthetic \
+    scan_layers=false \
+    per_device_batch_size=1 \
+    skip_jax_distributed_system=True \
+    weight_dtype=bfloat16 \
+    --max_kl_div=0.017 \
+    --run_hf_model=True \
+    --hf_model_path=${HF_MODEL_ID}
+
+# 2.2 Check scanned checkpoint
+JAX_PLATFORMS=cpu python3 -m tests.utils.forward_pass_logit_checker \
+    "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    run_name=forward_pass_test_scanned \
+    model_name=${MODEL_NAME} \
+    tokenizer_path=${TOKENIZER_PATH} \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    max_prefill_predict_length=4 \
+    max_target_length=4 \
+    dataset_type=synthetic \
+    scan_layers=true \
+    per_device_batch_size=1 \
+    skip_jax_distributed_system=True \
+    weight_dtype=bfloat16 \
+    --max_kl_div=0.017 \
+    --run_hf_model=True \
+    --hf_model_path=${HF_MODEL_ID}
+
+# Step 3: Decode
+echo "--- Starting Decode ---"
+python3 -m maxtext.inference.decode \
+    "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    model_name=${MODEL_NAME} \
+    tokenizer_path=${TOKENIZER_PATH} \
+    load_parameters_path=${UNSCANNED_CKPT_PATH} \
+    per_device_batch_size=1 \
+    run_name=decode_test \
+    max_prefill_predict_length=8 \
+    max_target_length=16 \
+    dataset_type=synthetic \
+    steps=10 \
+    async_checkpointing=false \
+    scan_layers=false \
+    prompt="I love to" \
+    tokenizer_type=huggingface
+
+# Step 4: SFT
+echo "--- Starting SFT ---"
+python3 -m maxtext.trainers.post_train.sft.train_sft \
+    "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/post_train/sft.yml \
+    base_output_directory=${BASE_OUTPUT_PATH_PREFIX}/finetuned \
+    run_name=sft_test \
+    model_name=${MODEL_NAME} \
+    tokenizer_path=${TOKENIZER_PATH} \
+    tokenizer_type=huggingface \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    dataset_type=hf \
+    scan_layers=true \
+    per_device_batch_size=4 \
+    learning_rate=1.3e-5 \
+    steps=5 \
+    max_target_length=1024 \
+    weight_dtype=bfloat16
+
+# Step 5: Pre-train
+echo "--- Starting Pre-train ---"
+export DATASET_PATH=gs://maxtext-dataset
+python3 -m maxtext.trainers.pre_train.train \
+    "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    model_name=${MODEL_NAME} \
+    base_output_directory=${BASE_OUTPUT_PATH_PREFIX}/pretrain \
+    dataset_path=${DATASET_PATH} \
+    tokenizer_path=${TOKENIZER_PATH} \
+    per_device_batch_size=1 \
+    run_name=pretrain_test \
+    steps=10 \
+    enable_checkpointing=false \
+    sharding_tolerance=0.03 \
+    tokenizer_type=huggingface

--- a/tests/end_to_end/tpu/qwen/dense/run_qwen2.5_dense.md
+++ b/tests/end_to_end/tpu/qwen/dense/run_qwen2.5_dense.md
@@ -1,0 +1,36 @@
+# Qwen2.5 Dense
+
+Qwen2.5 is the latest series of large language models by Qwen, released in September 2024. The models use a dense
+transformer architecture. You can find more information in the [blog](https://qwenlm.github.io/blog/qwen2.5/). The currently supported models
+are [qwen2.5-7b](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct)
+and [qwen2.5-14b](https://huggingface.co/Qwen/Qwen2.5-14B-Instruct).
+
+## Running the End-to-End Test
+
+The `test_qwen2.5-7b.sh` script automates the following steps:
+
+1. **Checkpoint Conversion**: Converts the Hugging Face checkpoint to MaxText-compatible format (scanned and unscanned).
+1. **Logit Check**: Verifies the forward pass logits against the Hugging Face model.
+1. **Decode**: Runs a decoding test using the unscanned checkpoint.
+1. **SFT**: Runs a Supervised Fine-Tuning (SFT) job.
+1. **Pre-train**: Runs a pre-training job.
+
+### Prerequisites
+
+- Ensure you have write access to a GCS bucket for output logs and checkpoints.
+
+### Usage
+
+To run the test for Qwen 2.5 7B:
+
+```bash
+export BASE_OUTPUT_PATH=gs://your-gcs-bucket/
+bash tests/end_to_end/tpu/qwen/dense/qwen2.5-7b/test_qwen2.5-7b.sh
+```
+
+Similarly, for Qwen 2.5 14B:
+
+```bash
+export BASE_OUTPUT_PATH=gs://your-gcs-bucket/
+bash tests/end_to_end/tpu/qwen/dense/qwen2.5-14b/test_qwen2.5-14b.sh
+```

--- a/tests/utils/hf_checkpoint_conversion_checker.py
+++ b/tests/utils/hf_checkpoint_conversion_checker.py
@@ -26,6 +26,7 @@ from safetensors import safe_open
 import numpy as np
 
 import jax
+from tqdm import tqdm
 
 
 def load_hf(hf_checkpoint_folder):
@@ -83,7 +84,8 @@ def compare_pytrees(tree1, tree2, atol=0.001):
   named_leaves2 = get_named_leaves(tree2)
 
   print(f"There are {len(named_leaves1.keys())} leaves to check.")
-  for key in named_leaves1:  # pylint: disable=C0206
+  for key in (pb := tqdm(named_leaves1)):  # pylint: disable=C0206
+    pb.set_postfix_str(key)
     if key not in named_leaves2:
       print(f"Missing key in second tree: {key}")
       return


### PR DESCRIPTION
# Description

## Changes
- Added Qwen2 implementation.
   - Implemented Qwen2 layers, these are mostly identical to Qwen3 but include the ability to apply attention bias.
   - Enabled attention bias specifically for QKV (excluding O) when using Qwen2. [ref](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2/modeling_qwen2.py#L203)
   - Renamed Qwen3 to Qwen in hf_shape and param_mapping, and adding conversion for attention bias weights
   - Added end-to-end testing scripts.
  
Fix b/471703114

# Tests
## Logit Verification  for HF -> MT
```
JAX_PLATFORMS=cpu python3 -m tests.utils.forward_pass_logit_checker src/maxtext/configs/base.yml run_name=forward_pass_test_unscanned model_name=qwen2.5-7b tokenizer_path=Qwen/Qwen2.5-7B-Instruct load_parameters_path=${CHECKPOINT_PATH} max_prefill_predict_length=4 max_target_length=4 dataset_type=synthetic scan_layers=true per_device_batch_size=1 skip_jax_distributed_system=True --max_kl_div=0.017 --run_hf_model=True weight_dtype=bfloat16 --hf_model_path=Qwen/Qwen2.5-7B-Instruct
```

- qwen2.5-14B [scanned](https://paste.googleplex.com/5853877045952512)
- qwen2.5-14B [unscanned](https://paste.googleplex.com/6280052306214912)
- qwen2.5-7B [scanned](https://paste.googleplex.com/5742152266153984)
- qwen2.5-7B [unscanned](https://paste.googleplex.com/6648587092099072)

## MT -> HF Checkpoint Check 

- [qwen2.5-7B](https://paste.googleplex.com/6302867536347136)
- [qwen2.5-14B](https://paste.googleplex.com/6606371635200000)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
