### PR TITLE
Do not store mtp_losses/mtp_acceptance in state params

### DIFF
--- a/tests/unit/multi_token_prediction_test.py
+++ b/tests/unit/multi_token_prediction_test.py
@@ -231,22 +231,6 @@ class MultiTokenPredictionBlockTest(unittest.TestCase):
         rngs=self.rngs,
     )
 
-  def test_no_sow_during_init(self):
-    """Verifies losses/weights are initialized with zeros (NNX behavior)."""
-    # NNX pre-initializes Variables with zeros to avoid checkpointing errors.
-    # Unlike Linen which sows during forward pass, NNX creates Variables in __init__.
-    initial_state = nnx.state(self.test_model)
-    self.assertTrue(hasattr(initial_state.mtp_block, "losses"))
-    self.assertTrue(hasattr(initial_state.mtp_block, "weights"))
-
-    # Verify they're initialized with zeros of correct shape.
-    losses_val = initial_state.mtp_block.losses.value
-    weights_val = initial_state.mtp_block.weights.value
-    self.assertEqual(losses_val.shape, (self.cfg.mtp_num_layers,))
-    self.assertEqual(weights_val.shape, (self.cfg.mtp_num_layers,))
-    self.assertTrue(jnp.all(losses_val == 0.0))
-    self.assertTrue(jnp.all(weights_val == 0.0))
-
   def test_sow_functionality(self):
     """Verifies that the block correctly sows losses and weights."""
     _ = self.test_model(


### PR DESCRIPTION
# Description

* Do not store `mtp_losses` and `mtp_acceptance` as part of params. This was causing a checkpoint loading error because they are not stored as part of the checkpoints.
* Update self attribute names to match pre-NNX checkpoints
* NOTE: Looks like pyink wants to update the format for the whole file. I'll do this in a follow-up PR to avoid losing the diff of this change

FIXES: b/483723849

# Tests

Successfully ran the XPK workload in the linked bug with checkpoint loading.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
