### PR TITLE
Set `TF_CPP_MIN_LOG_LEVEL=0` in `__init__.py`

### DIFF
--- a/src/MaxText/__init__.py
+++ b/src/MaxText/__init__.py
@@ -27,6 +27,12 @@ __description__ = (
 
 from collections.abc import Sequence
 
+import os
+# In order to have any effect on the C++ logging this has to be set before we import anything from jax.
+# When jax is imported, its `__init__.py` calls `cloud_tpu_init()`, which also initializes the C++ logger.
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "0")
+del os
+
 from jax.sharding import Mesh
 
 from MaxText import pyconfig

--- a/src/MaxText/train.py
+++ b/src/MaxText/train.py
@@ -523,7 +523,6 @@ def initialize(argv: Sequence[str]) -> tuple[pyconfig.HyperParameters, Any, Any]
   # TF allocates extraneous GPU memory when using TFDS data
   # this leads to CUDA OOMs. WAR for now is to hide GPUs from TF
   tf.config.set_visible_devices([], "GPU")
-  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
     os.environ["LIBTPU_INIT_ARGS"] = (
         os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"


### PR DESCRIPTION
# Description

Set `TF_CPP_MIN_LOG_LEVEL=0` in `__init__.py` instead of `train.py`.

Setting this env variable after `import jax` is called has no effect, because the C++ logging system is already initialized.

The `jax/__init__.py` sets the default value of `TF_CPP_MIN_LOG_LEVEL` to "1" ([code pointer](https://github.com/jax-ml/jax/blob/8504c16763b952b37c60f260db6cea84cc8ef387/jax/__init__.py#L17)). Then it calls `_cloud_tpu_init()`, which also initializes the C++ logging system.

There are many useful C++ LOG(INFO) messages that are suppressed without `TF_CPP_MIN_LOG_LEVEL=0`. For example, the path of the created profile trace (when running with `profiler=xplane` flag).

FIXES: b/474109045

# Tests

Local run of train.py with `profile=xplane` to confirm that the trace path is printed.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
