### PR TITLE
add date tag for maxtext_jax_stable image

### DIFF
--- a/.github/workflows/build_and_push_docker_image.yml
+++ b/.github/workflows/build_and_push_docker_image.yml
@@ -131,6 +131,7 @@ jobs:
           # Add MaxText tag
           maxtext_hash=$(git rev-parse --short HEAD)
           gcloud container images add-tag "$TEMP_IMG" "$SOURCE_IMAGE:maxtext_${maxtext_hash}_${clean_date}" --quiet
+          gcloud container images add-tag "$TEMP_IMG" "$SOURCE_IMAGE:${{ inputs.image_date }}" --quiet
 
           # Add post-training dependencies tags
           for dir in tunix vllm tpu-inference; do


### PR DESCRIPTION
# Description

In [PR](https://github.com/AI-Hypercomputer/maxtext/commit/8f501bd3dbe890c9b00ac271891917475e2063fb#diff-8e10134a09add1c9718ad1f03f47e672b7b8a228b22ba5390e3408fd8715ab9aR126), date tag for maxtext_jax_stable image is remove which caused the XLML DAGs which used this tag failed for [gcr.io/tpu-prod-env-multipod/maxtext_jax_stable:2026-02-13] is not found or is not a valid name. Add this date tag again.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/484256749

# Tests

No test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
