### PR TITLE
Enable grain input pipeline save and restore for distillation.

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -1,0 +1,299 @@
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility classes for MaxText Distillation with Tunix.
+
+This module contains adapter classes that bridge MaxText's data loading and
+model structures with Tunix's training interfaces.
+"""
+
+from typing import Any, Iterator
+
+import flax
+from flax import nnx
+import jax
+import jax.numpy as jnp
+import optax
+from orbax import checkpoint
+
+from maxtext.utils import max_logging
+# Reuse MaxText's native checkpointing logic
+from maxtext.common.checkpointing import GrainCheckpointHandler, GrainCheckpointSave, GrainCheckpointRestore
+from tunix.distillation import distillation_trainer
+from tunix.distillation.strategies import logit
+from tunix.sft import checkpoint_manager as tunix_checkpoint_manager
+
+
+# -----------------------------------------------------------------------------
+# Custom Data Structures
+# -----------------------------------------------------------------------------
+
+
+@flax.struct.dataclass(frozen=True)
+class MaxTextTrainingInput(distillation_trainer.TrainingInput):
+  """Extended TrainingInput dataclass to carry MaxText-specific fields."""
+
+  #: Position indices for the tokens (for RoPE).
+  positions: jax.Array = None
+  #: Segment IDs for packed sequences (0=padding, 1+=examples).
+  decoder_segment_ids: jax.Array = None
+  #: Ground truth target tokens (used for loss calculation and logging).
+  targets: jax.Array = None
+
+
+# -----------------------------------------------------------------------------
+# Data Loading Adapter
+# -----------------------------------------------------------------------------
+
+
+class MaxTextToTunixIterator:
+  """Adapts the raw dictionary output of MaxText's data loader to Tunix objects.
+
+  MaxText's `input_pipeline_interface.create_data_iterator` yields a dictionary.
+  Tunix expects an object with specific attributes (input_tokens, etc.).
+  """
+
+  def __init__(self, maxtext_iterator: Iterator):
+    """Initializes the adapter.
+
+    Args:
+      maxtext_iterator: The upstream iterator created by MaxText's input pipeline.
+    """
+    self._iterator = maxtext_iterator
+
+  def __iter__(self):
+    """Returns self as the iterator."""
+    return self
+
+  def __next__(self) -> MaxTextTrainingInput:
+    """Fetches the next batch and converts it to the Tunix data class.
+
+    Returns:
+      A MaxTextTrainingInput object containing the batch data.
+
+    Raises:
+      StopIteration: If the upstream iterator is exhausted.
+    """
+    batch = next(self._iterator)
+
+    # Ensure segmentation exists, default to ones if missing (standard non-packed)
+    if "inputs_segmentation" in batch:
+      input_mask = batch["inputs_segmentation"] != 0
+      seg_ids = batch["inputs_segmentation"]
+    else:
+      # Fallback for non-packed datasets
+      input_mask = jnp.ones_like(batch["inputs"], dtype=bool)
+      seg_ids = None
+
+    # pylint: disable=unexpected-keyword-arg
+    return MaxTextTrainingInput(
+        input_tokens=batch["inputs"],
+        input_mask=input_mask,
+        teacher_output=None,
+        positions=batch["inputs_position"],
+        decoder_segment_ids=seg_ids,
+        targets=batch["targets"],
+    )
+
+
+# -----------------------------------------------------------------------------
+# Distillation Strategy
+# -----------------------------------------------------------------------------
+class MonitoredLogitStrategy(logit.LogitStrategy):
+  """Logit Strategy that returns detailed metrics for TensorBoard."""
+
+  def compute_loss(
+      self,
+      student_output: jax.Array,
+      teacher_output: jax.Array,
+      labels: jax.Array,
+  ) -> tuple[jax.Array, dict[str, jax.Array]]:
+    """Computes Loss and Auxiliary Metrics."""
+    # Calculate Distillation Loss (KL Divergence)
+    # Scale logits by temperature T for soft targets
+    # We use explicit float32 casting for stability in loss calculation
+    s_logits = student_output.astype(jnp.float32)
+    t_logits = teacher_output.astype(jnp.float32)
+
+    log_student_probs_temp = jax.nn.log_softmax(s_logits / self.temperature, axis=-1)
+    teacher_probs_temp = jax.nn.softmax(t_logits / self.temperature, axis=-1)
+
+    # KL(Teacher || Student)
+    kl_div = optax.kl_divergence(log_student_probs_temp, teacher_probs_temp)
+
+    # Scale gradients by T^2 (Hinton et al.)
+    soft_loss = jnp.mean(kl_div) * (self.temperature**2)
+
+    # 1. Student Hard Loss (Existing)
+    ce_loss_student = optax.softmax_cross_entropy(logits=s_logits, labels=labels)
+    hard_loss = jnp.mean(ce_loss_student)
+
+    # 2. Teacher Hard Loss (For Verification)
+    ce_loss_teacher = optax.softmax_cross_entropy(logits=t_logits, labels=labels)
+    teacher_hard_loss = jnp.mean(ce_loss_teacher)
+
+    # 3. Combine losses
+    total_loss = (self.alpha * soft_loss) + ((1.0 - self.alpha) * hard_loss)
+
+    # 4. Return Loss AND Metrics
+    metrics = {
+        "distill/soft_loss": soft_loss,
+        "distill/hard_loss": hard_loss,
+        "distill/kl_div": jnp.mean(kl_div),
+        "distill/teacher_loss": teacher_hard_loss,
+    }
+    return total_loss, metrics
+
+  def compute_eval_loss(
+      self,
+      student_output: jax.Array,
+      labels: jax.Array,
+  ) -> tuple[jax.Array, dict[str, jax.Array]]:
+    """Computes Eval Loss and returns empty aux dict (required for consistency)."""
+    # Parent logic for task loss
+    # We re-implement simple CE here to ensure float32 casting
+    s_logits = student_output.astype(jnp.float32)
+    ce_loss = optax.softmax_cross_entropy(logits=s_logits, labels=labels)
+    task_loss = jnp.mean(ce_loss)
+
+    # Must return a tuple because _has_aux=True expects it
+    return task_loss, {}
+
+
+# -----------------------------------------------------------------------------
+# Checkpoint Manager
+# -----------------------------------------------------------------------------
+
+
+class MaxTextCheckpointManager(tunix_checkpoint_manager.CheckpointManager):
+  """Custom CheckpointManager that uses MaxText's native handlers.
+
+  This manager extends Tunix to support saving/restoring the MaxText input pipeline
+  (Grain) alongside the model and optimizer.
+  """
+
+  def __init__(
+      self,
+      raw_iterator: Any | None,
+      root_directory: str | None = None,
+      options: checkpoint.CheckpointManagerOptions | None = None,
+  ):
+    super().__init__(root_directory=root_directory, options=options)
+    self._iterator = raw_iterator
+
+    # Re-initialize internal Orbax manager with MaxText's Grain handler
+    # pylint: disable=access-member-before-definition
+    if self._checkpoint_manager is not None:
+      root_directory = self._checkpoint_manager.directory
+
+      if options is None:
+        options = getattr(self._checkpoint_manager, "options", None)
+
+      item_handlers = {
+          "model_params": checkpoint.PyTreeCheckpointHandler(),
+          "optimizer_state": checkpoint.PyTreeCheckpointHandler(),
+          "custom_metadata": checkpoint.JsonCheckpointHandler(),
+          # Use MaxText's handler for the iterator
+          "iter": GrainCheckpointHandler(),
+      }
+
+      self._checkpoint_manager.close()
+      self._checkpoint_manager = checkpoint.CheckpointManager(
+          root_directory,
+          item_handlers=item_handlers,
+          options=options,
+      )
+    # pylint: enable=access-member-before-definition
+
+  def save(self, step, model, optimizer=None, save_only_lora_params=False, force=False, custom_metadata=None):
+    """Saves the checkpoint including the input pipeline state (if available)."""
+    if self._checkpoint_manager is None:
+      return False
+    if not force and not self._checkpoint_manager.should_save(step):
+      return False
+
+    # Standard Tunix Logic for Model/Optimizer
+    if save_only_lora_params:
+      params = nnx.state(model, nnx.LoRAParam)
+    else:
+      params = nnx.state(model)
+
+    # Define standard SaveArgs once to reuse
+    default_save_args = checkpoint.SaveArgs()
+    cp_save_args = {
+        "model_params": checkpoint.args.PyTreeSave(
+            item=params, save_args=jax.tree.map(lambda _: default_save_args, params)
+        ),
+    }
+    if optimizer is not None:
+      optimizer_state = nnx.state(optimizer, nnx.optimizer.OptState)
+      cp_save_args["optimizer_state"] = checkpoint.args.PyTreeSave(
+          item=optimizer_state, save_args=jax.tree.map(lambda _: default_save_args, optimizer_state)
+      )
+
+    if self._iterator is not None:
+      # Follow MaxText's logic to handle multi-process saving
+      # Logic extracted from src/maxtext/common/checkpointing.py:save_checkpoint
+      data_iterator = self._iterator
+      if not isinstance(data_iterator, list):
+        data_iterator = [data_iterator]
+
+      grain_iters_to_save = []
+      process_count_total = jax.process_count() * len(data_iterator)
+
+      for i, data_iter in enumerate(data_iterator):
+        process_index = jax.process_index() + i * jax.process_count()
+        # MaxText iterators (MultiHostDataLoadIterator) wrap the actual Grain iterator in .local_iterator
+        local_iter = data_iter.local_iterator if hasattr(data_iter, "local_iterator") else data_iter
+        grain_iters_to_save.append((local_iter, process_index, process_count_total))
+
+      # Use GrainCheckpointSave wrapper
+      cp_save_args["iter"] = GrainCheckpointSave(item=grain_iters_to_save)
+
+    return self._checkpoint_manager.save(
+        step,
+        args=checkpoint.args.Composite(**cp_save_args),
+        custom_metadata=custom_metadata or {},
+        force=force,
+    )
+
+  def restore_iterator(self):
+    """Restores the iterator using MaxText's logic."""
+    if self._checkpoint_manager is None or self._iterator is None:
+      return None
+
+    step = self._checkpoint_manager.latest_step()
+    if step is None:
+      return None
+
+    try:
+      # MaxText logic for restoration (simplified for standard case)
+      # We assume 1-to-1 process mapping for now (no elasticity logic here yet)
+      data_iter = self._iterator
+      local_iter = data_iter.local_iterator if hasattr(data_iter, "local_iterator") else data_iter
+
+      restore_args = GrainCheckpointRestore(item=local_iter)
+
+      self._checkpoint_manager.restore(step, args=checkpoint.args.Composite(iter=restore_args))
+      # Since Grain restores in-place via set_state(), we return the original object
+      return self._iterator
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      max_logging.log(f"Warning: Could not restore input pipeline: {e}")
+      return None
+
+  def wait_until_finished(self):
+    """Blocks until all outstanding checkpoint operations are complete."""
+    if self._checkpoint_manager is not None:
+      self._checkpoint_manager.wait_until_finished()

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -33,10 +33,8 @@ Architecture Overview:
    a standard interface (call signature) that the Tunix `DistillationTrainer` expects.
 """
 
-from typing import Any, Iterator, Sequence, Dict, Tuple
-
+from typing import Sequence
 from absl import app
-import flax
 from flax import nnx
 from flax.linen import partitioning as nn_partitioning
 import jax
@@ -50,13 +48,13 @@ from MaxText import optimizers
 from MaxText import pyconfig
 from maxtext.input_pipeline import tokenizer
 from maxtext.input_pipeline import input_pipeline_interface
+from maxtext.trainers.post_train.distillation import distillation_utils
 from maxtext.utils import max_logging
 from maxtext.utils import maxtext_utils
 from maxtext.utils import model_creation_utils
 
 # Tunix Imports
 from tunix.distillation import distillation_trainer
-from tunix.distillation.strategies import logit
 from tunix.sft import metrics_logger
 from tunix.sft import profiler
 
@@ -149,84 +147,6 @@ def create_forward_fn(config: pyconfig.HyperParameters):
   return model_forward_fn
 
 
-# -----------------------------------------------------------------------------
-# Custom Data Structures & Strategies
-# -----------------------------------------------------------------------------
-
-
-@flax.struct.dataclass(frozen=True)
-class MaxTextTrainingInput(distillation_trainer.TrainingInput):
-  """Extended TrainingInput dataclass to carry MaxText-specific fields."""
-
-  #: Position indices for the tokens (for RoPE).
-  positions: Any = None
-  #: Segment IDs for packed sequences (0=padding, 1+=examples).
-  decoder_segment_ids: Any = None
-  #: Ground truth target tokens (used for loss calculation and logging).
-  targets: Any = None
-
-
-class MonitoredLogitStrategy(logit.LogitStrategy):
-  """Logit Strategy that returns detailed metrics for TensorBoard."""
-
-  def compute_loss(
-      self,
-      student_output: jax.Array,
-      teacher_output: jax.Array,
-      labels: jax.Array,
-  ) -> Tuple[jax.Array, Dict[str, jax.Array]]:
-    """Computes Loss and Auxiliary Metrics."""
-    # Calculate Distillation Loss (KL Divergence)
-    # Scale logits by temperature T for soft targets
-    # We use explicit float32 casting for stability in loss calculation
-    s_logits = student_output.astype(jnp.float32)
-    t_logits = teacher_output.astype(jnp.float32)
-
-    log_student_probs_temp = jax.nn.log_softmax(s_logits / self.temperature, axis=-1)
-    teacher_probs_temp = jax.nn.softmax(t_logits / self.temperature, axis=-1)
-
-    # KL(Teacher || Student)
-    kl_div = optax.kl_divergence(log_student_probs_temp, teacher_probs_temp)
-
-    # Scale gradients by T^2 (Hinton et al.)
-    soft_loss = jnp.mean(kl_div) * (self.temperature**2)
-
-    # 1. Student Hard Loss (Existing)
-    ce_loss_student = optax.softmax_cross_entropy(logits=s_logits, labels=labels)
-    hard_loss = jnp.mean(ce_loss_student)
-
-    # 2. Teacher Hard Loss (For Verification)
-    ce_loss_teacher = optax.softmax_cross_entropy(logits=t_logits, labels=labels)
-    teacher_hard_loss = jnp.mean(ce_loss_teacher)
-
-    # 3. Combine losses
-    total_loss = (self.alpha * soft_loss) + ((1.0 - self.alpha) * hard_loss)
-
-    # 4. Return Loss AND Metrics
-    metrics = {
-        "distill/soft_loss": soft_loss,
-        "distill/hard_loss": hard_loss,
-        "distill/kl_div": jnp.mean(kl_div),
-        "distill/teacher_loss": teacher_hard_loss,
-    }
-    return total_loss, metrics
-
-  def compute_eval_loss(
-      self,
-      student_output: jax.Array,
-      labels: jax.Array,
-  ) -> Tuple[jax.Array, Dict[str, jax.Array]]:
-    """Computes Eval Loss and returns empty aux dict (required for consistency)."""
-    # Parent logic for task loss
-    # We re-implement simple CE here to ensure float32 casting
-    s_logits = student_output.astype(jnp.float32)
-    ce_loss = optax.softmax_cross_entropy(logits=s_logits, labels=labels)
-    task_loss = jnp.mean(ce_loss)
-
-    # Must return a tuple because _has_aux=True expects it
-    return task_loss, {}
-
-
 def _log_config_details(config: pyconfig.HyperParameters, label: str) -> None:
   """Logs detailed architecture configuration for verification.
 
@@ -252,7 +172,9 @@ class MaxTextDistillationTrainer(distillation_trainer.DistillationTrainer):
   (positions, segment_ids) are passed to the model.
   """
 
-  def _prepare_inputs(self, input_data: MaxTextTrainingInput) -> MaxTextTrainingInput:
+  def _prepare_inputs(
+      self, input_data: distillation_utils.MaxTextTrainingInput
+  ) -> distillation_utils.MaxTextTrainingInput:
     """Prepares inputs for the student model and runs the teacher model.
 
     This function generates the "Soft Targets" (logits) from the Teacher model
@@ -276,7 +198,7 @@ class MaxTextDistillationTrainer(distillation_trainer.DistillationTrainer):
 
     # 3. Return extended object so fields are available for Student training step
     # pylint: disable=unexpected-keyword-arg
-    return MaxTextTrainingInput(
+    return distillation_utils.MaxTextTrainingInput(
         input_tokens=input_data.input_tokens,
         input_mask=input_data.input_mask,
         teacher_output=teacher_output,
@@ -285,7 +207,7 @@ class MaxTextDistillationTrainer(distillation_trainer.DistillationTrainer):
         targets=input_data.targets,
     )
 
-  def _post_process_train_step(self, aux: Dict[str, jax.Array]) -> None:
+  def _post_process_train_step(self, aux: dict[str, jax.Array]) -> None:
     """Extracts auxiliary metrics from the strategy and buffers them for logging."""
     if self._buffered_train_metrics is None:
       return
@@ -301,59 +223,61 @@ class MaxTextDistillationTrainer(distillation_trainer.DistillationTrainer):
       self._buffered_train_metrics.additional_metrics[name][0].append(value)
 
 
-# -----------------------------------------------------------------------------
-# Data Loading Adapter
-# -----------------------------------------------------------------------------
+def _setup_and_restore_input_pipeline(trainer, raw_train_iter, config, train_config):
+  """Configures the trainer to save/restore Grain iterator state.
 
+  This function unconditionally replaces the default CheckpointManager with
+  MaxTextCheckpointManager. This ensures consistent API availability (like
+  wait_until_finished) and enables Grain checkpointing if the iterator supports it.
 
-class MaxTextToTunixIterator:
-  """Adapts the raw dictionary output of MaxText's data loader to Tunix objects.
+  Args:
+    trainer: The active DistillationTrainer instance.
+    raw_train_iter: The input pipeline iterator.
+    config: The MaxText HyperParameters.
+    train_config: The Tunix TrainingConfig.
 
-  MaxText's `input_pipeline_interface.create_data_iterator` yields a dictionary.
-  Tunix expects an object with specific attributes (input_tokens, etc.).
+  Returns:
+    The iterator to use for training (restored or original).
   """
+  is_grain_dataset = config.dataset_type == "grain"
+  has_save_method = hasattr(raw_train_iter, "save")
+  enable_checkpointing = raw_train_iter is not None and (is_grain_dataset or has_save_method)
 
-  def __init__(self, maxtext_iterator: Iterator):
-    """Initializes the adapter.
+  iterator_to_manage = raw_train_iter if enable_checkpointing else None
 
-    Args:
-      maxtext_iterator: The upstream iterator created by MaxText's input pipeline.
-    """
-    self._iterator = maxtext_iterator
-
-  def __iter__(self):
-    """Returns self as the iterator."""
-    return self
-
-  def __next__(self) -> MaxTextTrainingInput:
-    """Fetches the next batch and converts it to the Tunix data class.
-
-    Returns:
-      A MaxTextTrainingInput object containing the batch data.
-
-    Raises:
-      StopIteration: If the upstream iterator is exhausted.
-    """
-    batch = next(self._iterator)
-
-    # Ensure segmentation exists, default to ones if missing (standard non-packed)
-    if "inputs_segmentation" in batch:
-      input_mask = batch["inputs_segmentation"] != 0
-      seg_ids = batch["inputs_segmentation"]
+  if enable_checkpointing:
+    max_logging.log("Input Pipeline Checkpointing: ENABLED")
+    max_logging.log(f"Details: dataset_type='{config.dataset_type}', has_save={has_save_method}")
+  else:
+    max_logging.log("Input Pipeline Checkpointing: DISABLED")
+    if raw_train_iter is None:
+      max_logging.log("Reason: train_iter is None")
     else:
-      # Fallback for non-packed datasets
-      input_mask = jnp.ones_like(batch["inputs"], dtype=jnp.bool_)
-      seg_ids = None
+      max_logging.log(
+          f"Reason: Iterator '{type(raw_train_iter).__name__}' is not recognized as Grain "
+          f"(dataset_type='{config.dataset_type}', has_save={has_save_method})"
+      )
 
-    # pylint: disable=unexpected-keyword-arg
-    return MaxTextTrainingInput(
-        input_tokens=batch["inputs"],
-        input_mask=input_mask,
-        teacher_output=None,
-        positions=batch["inputs_position"],
-        decoder_segment_ids=seg_ids,
-        targets=batch["targets"],
-    )
+  # 1. Create the specialized manager (always)
+  maxtext_manager = distillation_utils.MaxTextCheckpointManager(
+      raw_iterator=iterator_to_manage,
+      root_directory=train_config.checkpoint_root_directory,
+      options=train_config.checkpointing_options,
+  )
+
+  # 2. Swap managers (ensure clean resource release)
+  if trainer.checkpoint_manager:
+    trainer.checkpoint_manager.close()
+  trainer.checkpoint_manager = maxtext_manager
+
+  # 3. Restore input state (if applicable)
+  if enable_checkpointing:
+    restored_iter = trainer.checkpoint_manager.restore_iterator()
+    if restored_iter is not None:
+      max_logging.log("Restored input pipeline state to match model step.")
+      return restored_iter
+
+  return raw_train_iter
 
 
 # -----------------------------------------------------------------------------
@@ -432,8 +356,8 @@ def train_distill(student_config: pyconfig.HyperParameters, teacher_config: pyco
   student_forward_fn = create_forward_fn(student_config)
   teacher_forward_fn = create_forward_fn(teacher_config)
 
-  # Use Monitored strategy to enable KL/Soft/Hard Loss logging
-  strategy = MonitoredLogitStrategy(
+  # Use Monitored strategy from Utils
+  strategy = distillation_utils.MonitoredLogitStrategy(
       student_forward_fn=student_forward_fn,
       teacher_forward_fn=teacher_forward_fn,
       labels_fn=labels_fn,
@@ -473,7 +397,12 @@ def train_distill(student_config: pyconfig.HyperParameters, teacher_config: pyco
       checkpointing_options=checkpointing_options,
   )
 
-  # 5. Initialize Trainer
+  # 5. Data Iterators (Init BEFORE Trainer)
+  # We use MaxText's native create_data_iterator which creates both train and eval iterators
+  max_logging.log("Initializing Data Iterators via MaxText pipeline...")
+  raw_train_iter, raw_eval_iter = input_pipeline_interface.create_data_iterator(student_config, mesh)
+
+  # 6. Initialize Trainer
   trainer = MaxTextDistillationTrainer(
       student_model=student_model,
       teacher_model=teacher_model,
@@ -482,12 +411,13 @@ def train_distill(student_config: pyconfig.HyperParameters, teacher_config: pyco
       training_config=train_config,
   )
   trainer.is_managed_externally = True
-
-  # Force enable auxiliary metric logging
   trainer._has_aux = True  # pylint: disable=protected-access
 
-  # 6. Configure Input Mapping
-  # Maps the attributes of MaxTextTrainingInput to the kwargs expected by model_forward_fn
+  # 7. Input Pipeline Checkpointing
+  # Replace the default CheckpointManager with a Grain-aware one, which enables iterator checkpointing for grain datasets.
+  raw_train_iter = _setup_and_restore_input_pipeline(trainer, raw_train_iter, student_config, train_config)
+
+  # 8. Configure Input Mapping
   trainer = trainer.with_gen_model_input_fn(
       lambda batch: {
           "input_tokens": batch.input_tokens,
@@ -499,28 +429,23 @@ def train_distill(student_config: pyconfig.HyperParameters, teacher_config: pyco
       }
   )
 
-  # 7. Data Iterators
-  # We use MaxText's native create_data_iterator which creates both train and eval iterators
-  # based on the config parameters (dataset_type, eval_interval, etc.)
-  max_logging.log("Initializing Data Iterators via MaxText pipeline...")
-  raw_train_iter, raw_eval_iter = input_pipeline_interface.create_data_iterator(student_config, mesh)
-
-  train_iter = MaxTextToTunixIterator(raw_train_iter)
+  # 9. Create Iterator Wrappers (Use Utils)
+  train_iter = distillation_utils.MaxTextToTunixIterator(raw_train_iter)
 
   eval_iter = None
   if raw_eval_iter is not None:
     max_logging.log("Evaluation iterator successfully initialized.")
-    eval_iter = MaxTextToTunixIterator(raw_eval_iter)
+    eval_iter = distillation_utils.MaxTextToTunixIterator(raw_eval_iter)
   elif student_config.eval_interval > 0:
     max_logging.log("Warning: eval_interval > 0 but create_data_iterator returned None for eval_iter.")
 
-  # 8. Train
+  # 10. Train
   max_logging.log("Starting Distillation Training...")
   with mesh, nn_partitioning.axis_rules(student_config.logical_axis_rules):
     # Pass both iterators to the trainer
     trainer.train(train_iter, eval_iter)
 
-  # 9. Final Save (Conditional)
+  # 11. Final Save (Conditional)
   if student_config.save_checkpoint_on_completion:
     should_save = student_config.steps % student_config.checkpoint_period
 
@@ -532,10 +457,7 @@ def train_distill(student_config: pyconfig.HyperParameters, teacher_config: pyco
         )
         if saved:
           # Ensure underlying orbax manager finishes writing
-          # pylint: disable=protected-access
-          if trainer.checkpoint_manager._checkpoint_manager is not None:
-            trainer.checkpoint_manager._checkpoint_manager.wait_until_finished()
-          # pylint: enable=protected-access
+          trainer.checkpoint_manager.wait_until_finished()
           max_logging.log("Final checkpoint saved.")
 
       except Exception as e:  # pylint: disable=broad-exception-caught

--- a/tests/unit/distillation_checkpointing_test.py
+++ b/tests/unit/distillation_checkpointing_test.py
@@ -1,0 +1,135 @@
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Distillation Checkpointing logic."""
+
+import json
+import os
+import shutil
+import tempfile
+from unittest import mock
+
+from absl.testing import absltest
+import grain
+import jax
+from flax import nnx
+import orbax.checkpoint as ocp
+from maxtext.trainers.post_train.distillation import distillation_utils
+
+
+class FakeGrainIterator(grain.DatasetIterator):
+  """A simple iterator that mimics Grain's stateful interface."""
+
+  def __init__(self):
+    super().__init__()
+    # Initialize _closed to satisfy grain.DatasetIterator.__del__
+    self._closed = False
+    self.counter = 0
+
+  def __next__(self):
+    self.counter += 1
+    return self.counter
+
+  def get_state(self):
+    return {"current_count": self.counter}
+
+  def set_state(self, state):
+    self.counter = state["current_count"]
+
+  @property
+  def element_spec(self):
+    return int
+
+
+class DummyModel(nnx.Module):
+  """Minimal NNX module to generate non-empty params for Orbax."""
+
+  def __init__(self, rngs):
+    self.layer = nnx.Linear(1, 1, rngs=rngs)
+
+
+class MaxTextCheckpointManagerTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.test_dir = tempfile.mkdtemp()
+    self.options = ocp.CheckpointManagerOptions(max_to_keep=2, create=True)
+
+  def tearDown(self):
+    if os.path.exists(self.test_dir):
+      shutil.rmtree(self.test_dir)
+    super().tearDown()
+
+  def test_save_and_restore_iterator(self):
+    """Verifies that the iterator state is saved to JSON and restored correctly."""
+
+    # 1. Setup Iterator and Advance
+    iterator = FakeGrainIterator()
+    for _ in range(10):
+      next(iterator)
+    self.assertEqual(iterator.counter, 10)
+
+    # 2. Save Checkpoint
+    manager = distillation_utils.MaxTextCheckpointManager(
+        raw_iterator=iterator, root_directory=self.test_dir, options=self.options
+    )
+
+    # Create dummy model so 'model_params' is not empty
+    model = DummyModel(nnx.Rngs(0))
+
+    # Mock jax.process_index/count to simulate single host
+    with mock.patch.object(jax, "process_index", return_value=0), mock.patch.object(jax, "process_count", return_value=1):
+      # Pass the dummy model here
+      saved = manager.save(step=100, model=model, optimizer=None, force=True)
+
+    manager.wait_until_finished()
+    self.assertTrue(saved)
+
+    # 3. Verify File Structure
+    # MaxText GrainHandler saves as: <dir>/<step>/iter/process_0-of-1.json
+    expected_file = os.path.join(self.test_dir, "100", "iter", "process_0-of-1.json")
+    self.assertTrue(os.path.exists(expected_file), f"Expected file {expected_file} not found")
+
+    with open(expected_file, "r", encoding="utf-8") as f:
+      content = json.load(f)
+      self.assertEqual(content["current_count"], 10)
+
+    # 4. Restore into New Iterator
+    new_iterator = FakeGrainIterator()
+    self.assertEqual(new_iterator.counter, 0)
+
+    restore_manager = distillation_utils.MaxTextCheckpointManager(
+        raw_iterator=new_iterator, root_directory=self.test_dir, options=self.options
+    )
+
+    with mock.patch.object(jax, "process_index", return_value=0), mock.patch.object(jax, "process_count", return_value=1):
+      restored_iter = restore_manager.restore_iterator()
+
+    self.assertIsNotNone(restored_iter)
+    self.assertEqual(new_iterator.counter, 10)
+
+  def test_restore_returns_none_if_no_checkpoint(self):
+    """Verifies restore_iterator returns None gracefully if no checkpoint exists."""
+    iterator = FakeGrainIterator()
+    manager = distillation_utils.MaxTextCheckpointManager(
+        raw_iterator=iterator, root_directory=self.test_dir, options=self.options
+    )
+
+    # No save called
+    result = manager.restore_iterator()
+    self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
# Description

This PR enables input pipeline checkpointing for the Distillation workflow, specifically supporting Grain datasets. It ensures that when a distillation run is interrupted and resumed, the data iterator restores its state correctly instead of restarting from the beginning.

**Key Changes:**
* **Input Pipeline Checkpointing:** Implemented `MaxTextCheckpointManager` in `distillation_utils.py`. This extends the Tunix checkpoint manager to utilize MaxText's native `GrainCheckpointHandler`, allowing the iterator state to be saved and restored alongside model parameters.
* **Refactoring:** Extracted distillation-specific utilities (data adapters, custom input structs, logit strategies) from `train_distill.py` into a new module `distillation_utils.py` to improve code organization and modularity.
* **Integration:** Updated `train_distill.py` to initialize the custom checkpoint manager and automatically restore the iterator state if a checkpoint exists.

# Tests

**Unit Tests:**
* Added `tests/unit/distillation_checkpointing_test.py` to verify that `MaxTextCheckpointManager` correctly saves and restores iterator state using `GrainCheckpointHandler`.
* Ran existing tests: `tests/unit/train_distill_test.py`.

**Integration Tests:**
Verified manually by running the distillation trainer with and without the Grain pipeline enabled. Confirmed that the training loop initializes and runs.

Command used:
```bash
python3 src/maxtext/trainers/post_train/distillation/train_distill.py \
    src/maxtext/configs/post_train/distillation.yml \
    run_name=$RUN_NAME \
    base_output_directory=${BASE_OUTPUT_DIRECTORY} \
    hf_access_token=${HF_TOKEN}
```   
 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
