### PR TITLE
Simple fix on debug sharding log

### DIFF
--- a/src/MaxText/sharding.py
+++ b/src/MaxText/sharding.py
@@ -78,7 +78,7 @@ def maybe_shard_with_logical(
   named_sharding = create_sharding(mesh, logical_axes, rules=rules)
 
   if debug_sharding and isinstance(inputs, Tracer):
-    log_key = (str(jax.typeof(inputs)), logical_axes, extra_stack_level)
+    log_key = (str(jax.typeof(inputs)), tuple(logical_axes), extra_stack_level)
 
     if log_key not in _LOGGED_LOGICAL_AXES:
       max_logging.info(f"Logical:  {log_key[0]:.<60} {log_key[1]}", stacklevel=3 + extra_stack_level)


### PR DESCRIPTION
# Description

Debug sharding logging requires logical axes being hashable, while some recent changes make logical axes in deepseek  as list. This PR fixes this issue by enforcing tuple on logical axes.

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
