### PR TITLE
Migrate PlaceHolderDataIterator from tf to np

### DIFF
--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -238,7 +238,7 @@ def pretrain_preprocessing_pipeline(
     # global_batch_size_to_load has been expanded in pyconfig.py when expansion_factor_real_data > 1.
     # But when using Grain, we want to keep the batch_size consistent with that in the checkpoint.
     # We revert the batch_size expansion here, but load multiple batches per step in multihost_dataloading.py.
-    batch_size = batch_size // config.expansion_factor_real_data
+    batch_size = int(batch_size // config.expansion_factor_real_data)
 
   if config.packing:
     length_struct = {col: config.max_target_length for col in data_columns}

--- a/src/maxtext/input_pipeline/multihost_dataloading.py
+++ b/src/maxtext/input_pipeline/multihost_dataloading.py
@@ -125,7 +125,7 @@ class MultiHostDataLoadIterator:
             # expansion_loading_factor_for_grain times to get the
             # right batch_size for the host that is loading real data.
             local_data_list = [local_data]
-            for _ in range(1, self.expansion_loading_factor_for_grain):
+            for _ in range(1, int(self.expansion_loading_factor_for_grain)):
               next_batch = next(self.local_iterator)
               local_data_list.append(next_batch)
             local_data = jtu.tree_map(lambda *xs: np.concatenate(xs, axis=0), *local_data_list)


### PR DESCRIPTION
# Description
This is part of the plan of removing TF dependency in MaxText.
Also fix a bug caused by expansion_factor_real_data is type float but some places expect int.

# Tests

* PlaceHolderDataIterator is only used when expansion_factor_real_data > 1, on the hosts that are NOT loading real data. The data produced by PlaceHolderDataIterator are all -1 and will be discarded.
Tested with the following script, set `max_checkify=true` to error out if training batch contains -1 batch produced by PlaceHolderDataIterator 
```
 python3 /mnt/disks/pd2/xpk/xpk.py workload create \
  --project ${PROJECT} \
  --zone ${ZONE} \
  --cluster ${CLUSTER_NAME} \
  --workload ${RUN_NAME} \
  --base-docker-image ${BASE_IMAGE} \
  --tpu-type ${TPU_TYPE} \
  --num-slices 1 \
  --command "pip install --no-deps -e . && python3 -m MaxText.train src/maxtext/configs/base.yml \
  run_name=${RUN_NAME} base_output_directory=${OUTPUT_DIR} \
  dataset_type=grain dataset_path=gs://maxtext-dataset \
  grain_train_files=gs://maxtext-dataset/array-record/c4/en/3.0.1/c4-train* \
  expansion_factor_real_data=2 max_checkify=true \
  steps=10 enable_checkpointing=false"
```
[cloud log](https://cloudlogging.app.goo.gl/4jJdzntMp5w8oHaXA)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
