### PR TITLE
Integrate Engram into custom model

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -315,6 +315,7 @@ out_proj: 'remat'
 mla_q: 'remat'
 mla_kv: 'remat'
 attention_out: 'remat'
+engram: 'remat'
 
 optimizer_memory_host_offload: False
 parameter_memory_host_offload: False
@@ -1102,3 +1103,20 @@ force_q_layout: false
 mhc_expansion_rate: 1
 # The number of iterations for the Sinkhorn-Knopp algorithm.
 sinkhorn_iterations: 20
+
+################################## DeepSeek Engram ##################################
+# Indices of transformer layers where Engram are integrated; leave empty [] to disable.
+# Example: [1, 4] attaches to the 2nd and 5th layer. 
+engram_layers: []
+# The max 'n' in N-gram. Example: n=3 means it covers both 2-grams and 3-grams.
+engram_max_ngram_size: 3
+# Number of heads dedicated to the Engram.
+engram_num_heads: 8
+# Head dimension for heads.
+engram_head_dim: 1280
+# List of minimum head vocab sizes for each n-gram order.
+engram_vocab_bases: []
+# Temporal window size for Engram convolution.
+engram_kernel_size: 4
+# The seed for Engram hash mapping.
+engram_seed: 0

--- a/src/maxtext/configs/models/deepseek-custom.yml
+++ b/src/maxtext/configs/models/deepseek-custom.yml
@@ -59,3 +59,11 @@ index_topk: 256                # Reduced from 2048
 # Hyper-connections: mHC enabled
 mhc_expansion_rate: 4
 sinkhorn_iterations: 20
+# Engram
+engram_layers: [1, 4]
+engram_num_heads: 8
+engram_head_dim: 512
+engram_vocab_bases: [226240, 226240]
+engram_max_ngram_size: 3
+engram_kernel_size: 4
+engram_seed: 0

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -897,6 +897,7 @@ class RematAndOffload(BaseModel):
       RematLocation.REMAT,
       description="Remat policy for the attention output.",
   )
+  engram: RematLocation = Field(RematLocation.REMAT, description="Remat policy for the engram output.")
 
   optimizer_memory_host_offload: bool = Field(False, description="Offload optimizer state to host memory.")
   parameter_memory_host_offload: bool = Field(False, description="Offload parameters to host memory.")
@@ -1630,6 +1631,23 @@ class SpecialTokens(BaseModel):
   solution_end_token: str = Field("</answer>", description="Token to mark the end of a solution section.")
 
 
+class Engram(BaseModel):
+  """Configuration for DeepSeek Engram (https://www.arxiv.org/pdf/2601.07372)."""
+
+  engram_layers: list[int] = Field(
+      default_factory=list,
+      description="Indices of transformer layers where Engram are integrated.",
+  )
+  engram_num_heads: int = Field(8, description="Number of heads dedicated to the Engram.")
+  engram_head_dim: int = Field(1280, description="Head dimension for heads.")
+  engram_vocab_bases: list[int] = Field(
+      default_factory=list, description="List of minimum head vocab sizes for each n-gram order."
+  )
+  engram_max_ngram_size: int = Field(3, description="The max 'n' in N-gram.")
+  engram_kernel_size: int = Field(4, description="Temporal window size for Engram convolution.")
+  engram_seed: int = Field(0, description="The seed for Engram hash mapping.")
+
+
 class DerivedValues(BaseModel):
   """Holds all fields that are derived from other config values for perfect legacy compatibility."""
 
@@ -1782,6 +1800,7 @@ class MaxTextConfig(
     Quantization,
     # Core Model Architecture
     ModelArchitecture,
+    Engram,
     MTP,
     Logits,
     # Attention Mechanisms
@@ -2262,6 +2281,18 @@ class MaxTextConfig(
         and self.gradient_accumulation_steps > 1
     ):
       raise ValueError("FP8 quantization is not compatible with gradient accumulation.")
+    if self.engram_layers:
+      if not self.hf_access_token or not self.tokenizer_path:
+        raise ValueError(
+            "Engram requires both 'hf_access_token' and 'tokenizer_path' " "to load the Hugging Face tokenizer."
+        )
+      if self.scan_layers:
+        raise NotImplementedError("Currently Engram only supports unscanned version. Please set scan_layers=False.")
+      if len(self.engram_vocab_bases) != (self.engram_max_ngram_size - 1):
+        raise ValueError(
+            f"Engram vocab size mismatch: expected {self.engram_max_ngram_size - 1} (max_ngram_size - 1), "
+            f"but got {self.engram_vocab_bases}."
+        )
     if self.num_experts > 1:
       is_fully_moe = (
           self.interleave_moe_layer_step == 1

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -916,11 +916,19 @@ class Decoder(nn.Module):
           num_moe_layers = cfg.num_decoder_layers - cfg.first_num_dense_layers
           num_layers_list = [cfg.first_num_dense_layers, num_moe_layers]
           # Iterate over the two layer groups (dense and MoE) and apply layer transformation
+          global_layer_idx_offset = 0
           for layer, num_layers, layer_prefix in zip(layers, num_layers_list, layer_prefixes):
             for index in range(num_layers):
+              global_layer_idx = global_layer_idx_offset + index
               kv_cache = kv_caches[index] if kv_caches is not None else None
+              input_tokens = decoder_input_tokens if cfg.engram_layers else None
               y, kv_cache = layer(
-                  config=cfg, mesh=mesh, name=f"{layer_prefix}_{index}", quant=self.quant, model_mode=self.model_mode
+                  config=cfg,
+                  mesh=mesh,
+                  name=f"{layer_prefix}_{index}",
+                  quant=self.quant,
+                  model_mode=self.model_mode,
+                  layer_idx=global_layer_idx,
               )(
                   y,
                   decoder_segment_ids,
@@ -932,9 +940,11 @@ class Decoder(nn.Module):
                   slot=slot,
                   kv_cache=kv_cache,
                   attention_metadata=attention_metadata,
+                  decoder_input_tokens=input_tokens,
               )
               if kv_caches is not None and kv_cache is not None:
                 kv_caches[index] = kv_cache
+            global_layer_idx_offset += num_layers
         else:
           for lyr in range(cfg.num_decoder_layers):
             RemattedBlockLayer = RemattedBlockLayers[0]

--- a/src/maxtext/models/deepseek.py
+++ b/src/maxtext/models/deepseek.py
@@ -33,11 +33,16 @@ from maxtext.layers import moe
 from maxtext.layers import nnx_wrappers
 from maxtext.layers import quantizations
 from maxtext.layers.linears import Dropout
+from maxtext.layers.engram import Engram
+from maxtext.layers.engram import NgramHashMapping
 from maxtext.layers.normalizations import RMSNorm
 from maxtext.models import deepseek_batchsplit
 from maxtext.utils import max_utils
 from maxtext.utils.sharding import create_sharding
 from maxtext.utils.sharding import maybe_shard_with_logical
+
+import transformers
+
 # -----------------------------------------
 # The Decoder Layer for DeepSeek v3
 # -----------------------------------------
@@ -57,6 +62,7 @@ class DeepSeekGenericLayer(nnx.Module):
       mesh: Mesh,
       rngs: nnx.Rngs,
       quant: Optional[quantizations.AqtQuantization] = None,
+      layer_idx: int = -1,
   ) -> None:
 
     self.config = config
@@ -65,6 +71,8 @@ class DeepSeekGenericLayer(nnx.Module):
     self.quant = quant
     self.rngs = rngs
     self.is_mhc_enabled = config.mhc_expansion_rate > 1
+    self.layer_idx = layer_idx
+    self.is_engram_enabled = config.engram_layers and layer_idx in config.engram_layers
 
     batch_size, sequence_length = max_utils.get_batch_seq_len_for_mode(self.config, self.model_mode)
     self.dummy_inputs_shape = (batch_size, sequence_length, self.config.emb_dim)
@@ -89,6 +97,43 @@ class DeepSeekGenericLayer(nnx.Module):
         epsilon=self.config.normalization_layer_epsilon,
         rngs=rngs,
     )
+
+    if self.is_engram_enabled:
+      self.engram_layer_norm = RMSNorm(
+          num_features=self.dummy_inputs_shape[-1],
+          dtype=self.config.dtype,
+          weight_dtype=self.config.weight_dtype,
+          kernel_axes=("norm",),
+          epsilon=self.config.normalization_layer_epsilon,
+          rngs=rngs,
+      )
+      tokenizer = transformers.AutoTokenizer.from_pretrained(config.tokenizer_path, token=config.hf_access_token)
+      # TODO(ranran): Refactor NgramHashMapping to initialize once globally or at the model level.
+      # Moving this to decoders.py currently causes JAX initialization errors.
+      self.ngram_hash_mapping = NgramHashMapping(
+          engram_vocab_bases=config.engram_vocab_bases,
+          max_ngram_size=config.engram_max_ngram_size,
+          engram_num_heads=config.engram_num_heads,
+          layer_ids=config.engram_layers,
+          tokenizer=tokenizer,
+          pad_id=tokenizer.pad_token_id,
+          seed=config.engram_seed,
+      )
+      self.engram = Engram(
+          config=config,
+          mesh=mesh,
+          vocab_sizes=self.ngram_hash_mapping.get_vocab_sizes(layer_idx),
+          engram_num_heads=config.engram_num_heads,
+          engram_head_dim=config.engram_head_dim,
+          engram_max_ngram_size=config.engram_max_ngram_size,
+          engram_kernel_size=config.engram_kernel_size,
+          mhc_expansion_rate=config.mhc_expansion_rate,
+          quant=quant,
+          rngs=rngs,
+      )
+    else:
+      self.engram_layer_norm = None
+      self.engram = None
 
     self.self_attention = attention_mla.MLA(
         config=self.config,
@@ -252,6 +297,11 @@ class DeepSeekGenericLayer(nnx.Module):
     hidden_states = self.post_attention_norm_op(intermediate_inputs)
     return hidden_states, intermediate_inputs
 
+  def engram_op(self, x, decoder_input_tokens):
+    normed_x = self.engram_layer_norm(x)
+    hash_ids = self.ngram_hash_mapping(decoder_input_tokens)[self.layer_idx]
+    return self.engram(normed_x, hash_ids)
+
 
 class DeepSeekDenseLayer(DeepSeekGenericLayer):
   """DeepSeek-style dense layer with Multi-Head Latent Attention."""
@@ -263,8 +313,9 @@ class DeepSeekDenseLayer(DeepSeekGenericLayer):
       mesh: Mesh,
       rngs: nnx.Rngs,
       quant: Optional[quantizations.AqtQuantization] = None,
+      layer_idx: int = -1,
   ) -> None:
-    super().__init__(config, model_mode, mesh, rngs, quant)
+    super().__init__(config, model_mode, mesh, rngs, quant, layer_idx)
     self.mlp = linears.MlpBlock(
         in_features=self.dummy_inputs_shape[-1],
         intermediate_dim=self.config.mlp_dim,
@@ -296,12 +347,17 @@ class DeepSeekDenseLayer(DeepSeekGenericLayer):
       slot: None | int = None,
       kv_cache=None,
       attention_metadata=None,
+      decoder_input_tokens=None,
   ):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
       inputs = inputs[0]
     x = self.with_logical_constraint(inputs)
     x = checkpoint_name(x, "decoder_layer_input")
+
+    if self.is_engram_enabled:
+      engram_output = self.engram_op(x, decoder_input_tokens)
+      x = x + engram_output
 
     hidden_states, intermediate_inputs = self.self_attention_with_norm_op(
         x,
@@ -349,9 +405,10 @@ class DeepSeekMoELayer(DeepSeekGenericLayer):
       mesh: Mesh,
       rngs: nnx.Rngs,
       quant: Optional[quantizations.AqtQuantization] = None,
+      layer_idx: int = -1,
   ) -> None:
 
-    super().__init__(config, model_mode, mesh, rngs, quant)
+    super().__init__(config, model_mode, mesh, rngs, quant, layer_idx)
     self.DeepSeekMoeBlock_0 = moe.RoutedAndSharedMoE(
         config=self.config,
         mesh=mesh,
@@ -375,6 +432,7 @@ class DeepSeekMoELayer(DeepSeekGenericLayer):
       slot: None | int = None,
       kv_cache=None,
       attention_metadata=None,
+      decoder_input_tokens=None,
   ):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
@@ -396,6 +454,10 @@ class DeepSeekMoELayer(DeepSeekGenericLayer):
 
     x = self.with_logical_constraint(inputs)
     x = checkpoint_name(x, "decoder_layer_input")
+
+    if self.is_engram_enabled:
+      engram_output = self.engram_op(x, decoder_input_tokens)
+      x = x + engram_output
 
     hidden_states, intermediate_inputs = self.self_attention_with_norm_op(
         x,

--- a/tests/unit/mhc_test.py
+++ b/tests/unit/mhc_test.py
@@ -107,6 +107,7 @@ class TestMHC(unittest.TestCase):
         attention="dot_product",
         routed_bias_update_rate=0.01,
         load_balance_loss_weight=0.02,
+        engram_layers=[],
     )
     devices_array = maxtext_utils.create_device_mesh(self.config)
     self.mesh = Mesh(devices_array, self.config.mesh_axes)

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -813,5 +813,29 @@ class TrainCompile(unittest.TestCase):
             "mhc_expansion_rate=4",
             "attention=flash",
             "use_tokamax_splash=True",
+            "engram_layers=[]",
+        )
+    )
+
+  @pytest.mark.cpu_only
+  def test_engram_integration(self):
+    """AOT test for Engram implementation"""
+    compiled_trainstep_file = "/tmp/test_engram_integration"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "model_name=deepseek-custom",
+            "per_device_batch_size=4",
+            "scan_layers=False",  # TODO(ranran): update to scan_layers=True after support
+            "max_target_length=1024",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "tokenizer_type=huggingface",
+            "tokenizer_path=deepseek-ai/DeepSeek-V3.2",
+            "hf_access_token=fake",
         )
     )


### PR DESCRIPTION
# Description

Integrate Engram feature into a custom model
* Add configs into `base.yml` and `type.py`, integrates with `deepseek-custom` model
* This PR supports unscan version of Engram, and scan version will be next PR.
* Tried to initialize the hash map to model level for one time initialization, but met various JAX initialization error (see more in b/478294699 and this [PR](https://github.com/AI-Hypercomputer/maxtext/pull/3125)). Also added a comment there.
* Currently, to make it work, you will see mix of `jnp` and `np` as some operations running on CPU to avoid ConcretizationTypeError and other issues. 

# Tests

* Expect github runners to pass
* Unit tests still passing for Engram: [link](https://paste.googleplex.com/4533027603611648)
* End-to-end unscan training for custom model: [link](https://paste.googleplex.com/6288392850636800)
* Sanity check for DS v2 (expect no impact)

```
Before change:

I0218 19:13:51.139775 139970093350464 max_utils.py:697] 	Using (GB) 43.98 / 95.74 (45.936912%) on TPU_1(process=0,(1,0,0,0))
I0218 19:15:18.498541 139970093350464 metric_logger.py:181] completed step: 19, seconds: 4.366, TFLOP/s/device: 123.145, Tokens/s/device: 7505.830, total_weights: 131072, loss: 8.135

After change:

I0218 19:05:35.490278 140385131265600 max_utils.py:697] 	Using (GB) 43.99 / 95.74 (45.947357%) on TPU_0(process=0,(0,0,0,0))
I0218 19:07:02.849351 140385131265600 metric_logger.py:181] completed step: 19, seconds: 4.366, TFLOP/s/device: 123.144, Tokens/s/device: 7505.806, total_weights: 131072, loss: 8.135
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
