### PR TITLE
Support NNX ckpt in forward_pass_logit_checker

### DIFF
--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -31,7 +31,7 @@ import jax.numpy as jnp
 import numpy as np
 from jax.sharding import Mesh
 from maxtext.configs import pyconfig
-from maxtext.common.common_types import MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import max_logging
@@ -580,20 +580,21 @@ def from_pretrained(
               }
           }
         else:
-          # structure of nnx checkpoint: {'decoder': {'value': ...}}
+          # NNX checkpoint: {'decoder': {'value': ...}}, or NNX-RL with extra 'base' nesting.
+          # Restore only nnx.Param — RNG variable shapes may differ between checkpoint and model.
           target_for_restore = jax.tree.map(
               lambda v: {"value": v.value},
               sharded_state,
               is_leaf=lambda n: isinstance(n, nnx.Variable),
           )
-          target_for_restore = _adjust_target_for_moe_fusion(target_for_restore, metadata.item_metadata.tree, True)
-          item_to_restore = target_for_restore
-          base_restore_args = ocp.checkpoint_utils.construct_restore_args(target_for_restore)
+          has_base_key = "base" in metadata.item_metadata.tree
+          meta_tree_for_params = metadata.item_metadata.tree.get("base", metadata.item_metadata.tree)
+          target_for_restore = _adjust_target_for_moe_fusion(target_for_restore, meta_tree_for_params, True)
+          item_to_restore = {"base": target_for_restore} if has_base_key else target_for_restore
           restore_args = _fix_restore_args_for_shape_mismatch(
-              base_restore_args,
-              metadata.item_metadata.tree,
-              mesh,
+              ocp.checkpoint_utils.construct_restore_args(target_for_restore), meta_tree_for_params, mesh
           )
+          restore_args = {"base": restore_args} if has_base_key else restore_args
 
         restored = ckptr.restore(
             epath.Path(config.load_parameters_path),
@@ -603,9 +604,10 @@ def from_pretrained(
         )
 
         if is_nnx_checkpoint:
+          restored_root = restored["base"] if has_base_key else restored
           checkpoint = jax.tree.map(
               lambda v: v["value"],
-              restored,
+              restored_root,
               is_leaf=lambda x: isinstance(x, dict) and "value" in x and not isinstance(x.get("value"), dict),
           )
         else:
@@ -656,6 +658,13 @@ def from_pretrained(
           # This prevents the replicated intermediate copies from persisting until function return.
           del restored
 
+          def _filter_to_model_keys(ckpt, model):
+            """Recursively keep only keys present in model, dropping checkpoint-only fields (e.g. to_nnx__rngs)."""
+            if not hasattr(ckpt, "items") or not hasattr(model, "items"):
+              return ckpt
+            return {k: _filter_to_model_keys(ckpt[k], model[k]) for k in model if k in ckpt}
+
+          checkpoint = _filter_to_model_keys(checkpoint, model_arrays)
           checkpoint = jax.tree.map(_expand_checkpoint_to_model_shapes, checkpoint, model_arrays)
           nnx.update(model, checkpoint)
 
@@ -672,3 +681,44 @@ def from_pretrained(
       return model
     else:
       return model, mesh
+
+
+def setup_decode_state_from_nnx(model, config, rng, mesh):
+  """Setup decode state by loading an NNX or NNX-RL checkpoint into a linen TrainState.
+
+  Calls from_pretrained (which handles NNX and NNX-RL 'base'-nested checkpoints and
+  applies mesh sharding internally), then extracts nnx.Param values into a plain dict
+  for the linen TrainState. For linen checkpoints, use maxtext_utils.setup_decode_state instead.
+
+  Args:
+    model: the flax linen model to initialize
+    config: config object
+    rng: jax.prng key
+    mesh: jax.devices() mesh
+
+  Returns:
+    state: linen TrainState with params loaded from the NNX checkpoint
+    state_mesh_annotations: the mesh annotations for the state
+  """
+  init_state_fn = partial(maxtext_utils.init_initial_state, model, None, config, False, rng)
+  _, state_mesh_annotations, _ = maxtext_utils.get_abstract_state(config, mesh, init_state_fn, False)
+
+  # Load the NNX model; from_pretrained handles sharding via jax.jit(out_shardings=...).
+  nnx_model = from_pretrained(config, mesh=mesh, model_mode=MODEL_MODE_AUTOREGRESSIVE)
+
+  # Extract nnx.Param values, converting the State pytree to a plain nested dict.
+  def _state_to_dict(tree):
+    if isinstance(tree, nnx.Variable):
+      return tree.value
+    if hasattr(tree, "items") and not isinstance(tree, jax.Array):
+      return {k: _state_to_dict(v) for k, v in tree.items()}
+    return tree
+
+  nnx_param_state = nnx.state(nnx_model, nnx.Param)
+  raw_params = _state_to_dict(nnx_param_state)
+  del nnx_model, nnx_param_state  # free memory
+
+  params = {"params": raw_params}
+
+  state = maxtext_utils.init_decode_state(model.apply, params)
+  return state, state_mesh_annotations

--- a/tests/unit/model_creation_utils_test.py
+++ b/tests/unit/model_creation_utils_test.py
@@ -26,8 +26,9 @@ from flax import nnx
 from jax.sharding import Mesh
 from orbax import checkpoint as ocp
 
+from flax.training import train_state
 from maxtext.configs import pyconfig
-from maxtext.common.common_types import MODEL_MODE_TRAIN, MODEL_MODE_PREFILL
+from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN, MODEL_MODE_PREFILL
 from maxtext.models import models
 from maxtext.utils import maxtext_utils
 from maxtext.utils import model_creation_utils
@@ -391,6 +392,55 @@ class TestCreateNnxModel(unittest.TestCase):
     cfg = _make_config(enable_checkpointing=True, load_parameters_path="gs://fake/bad_ckpt")
     with self.assertRaises(ValueError):
       model_creation_utils.from_pretrained(cfg, self.mesh)
+
+
+class TestSetupDecodeStateFromNnx(unittest.TestCase):
+  """Tests for setup_decode_state_from_nnx()."""
+
+  def setUp(self):
+    self.config = _make_config()
+    self.mesh = _make_mesh(self.config)
+    self.rng = jax.random.PRNGKey(0)
+
+  def test_returns_linen_train_state_and_annotations(self):
+    """Should return a linen TrainState whose params mirror the NNX model's nnx.Param values."""
+    # Build a real (small) NNX model WITHOUT any patch active so from_pretrained
+    # runs normally and produces concrete jax.Array weights.
+    real_nnx_model = model_creation_utils.from_pretrained(self.config, mesh=self.mesh)
+
+    linen_model = model_creation_utils.from_config(self.config, mesh=self.mesh, rngs=None)
+
+    # Now patch from_pretrained so setup_decode_state_from_nnx never touches a checkpoint.
+    with patch("maxtext.utils.model_creation_utils.from_pretrained", return_value=real_nnx_model) as mock_fp:
+      state, state_mesh_annotations = model_creation_utils.setup_decode_state_from_nnx(
+          linen_model, self.config, self.rng, self.mesh
+      )
+
+    # from_pretrained must have been called with the right model_mode.
+    mock_fp.assert_called_once()
+    _, call_kwargs = mock_fp.call_args
+    self.assertEqual(call_kwargs.get("model_mode"), MODEL_MODE_AUTOREGRESSIVE)
+
+    # The result should be a linen TrainState.
+    self.assertIsInstance(state, train_state.TrainState)
+
+    # Params must be nested under "params" and be non-empty concrete arrays.
+    self.assertIn("params", state.params)
+    param_leaves = jax.tree.leaves(state.params["params"])
+    self.assertGreater(len(param_leaves), 0)
+    for leaf in param_leaves:
+      self.assertIsInstance(leaf, jax.Array)
+
+    # The NNX Param values and the extracted linen params must be numerically identical.
+    nnx_param_state = nnx.state(real_nnx_model, nnx.Param)
+    nnx_leaves = jax.tree.leaves(nnx_param_state)
+    linen_leaves = jax.tree.leaves(state.params["params"])
+    self.assertEqual(len(nnx_leaves), len(linen_leaves))
+    for nnx_val, linen_val in zip(nnx_leaves, linen_leaves):
+      self.assertTrue(jnp.all(nnx_val == linen_val))
+
+    # state_mesh_annotations must be returned (non-None).
+    self.assertIsNotNone(state_mesh_annotations)
 
 
 if __name__ == "__main__":

--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -53,6 +53,7 @@ from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import max_logging
 from maxtext.utils import maxtext_utils
+from maxtext.utils import model_creation_utils
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -447,7 +448,10 @@ def main(config, test_args):  # pylint: disable=W0621
     else:
       maxtext_model = models.transformer_as_linen(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
       init_state_fn = functools.partial(maxtext_utils.init_initial_state, maxtext_model, None, config, False, rng1)
-    maxtext_state, _ = maxtext_utils.setup_decode_state(config, mesh, None, init_state_fn)
+    if test_args.ckpt_type == "linen":
+      maxtext_state, _ = maxtext_utils.setup_decode_state(config, mesh, None, init_state_fn)
+    else:
+      maxtext_state, _ = model_creation_utils.setup_decode_state_from_nnx(maxtext_model, config, rng1, mesh)
 
     prompts = ["I love to", "Today is a", "What is the"]
     all_data_to_save = []
@@ -553,6 +557,14 @@ if __name__ == "__main__":
       required=False,
       default=False,
       help="Skip the first token during comparison to ignore BOS/init mismatches.",
+  )
+  parser.add_argument(
+      "--ckpt_type",
+      type=str,
+      required=False,
+      default="linen",
+      choices=["linen", "nnx"],
+      help="Checkpoint format to load: 'linen' (default) or 'nnx'.",
   )
 
   # Parse known args returns the namespace AND the list of remaining arguments


### PR DESCRIPTION
# Description
Support NNX checkpoint in forward_pass_logit_checker.py:
- [New] Add a flag `--ckpt_type=["linen", "nnx"]` to support nnx ckpt. Default to linen.
- Implement `setup_decode_state_from_nnx()`, which now calls `from_pretrained()` to natively load an NNX model and shard properly across devices (instead of loading to CPU or duplicating across TPUs). This function will return a linen `maxtext_state` for decoding purposes.

When loading an NNX checkpoint that was saved via `TunixMaxTextAdapter` (e.g. an RL training checkpoint), the on-disk pytree can contain extra top-level keys such as to_nnx__rngs that are present in the checkpoint but absent from the target model's parameter tree. Passing both trees directly to `jax.tree.map` requires them to have identical structure, so the extra checkpoint keys cause a key-mismatch error. 
- `_filter_to_model_keys` prunes the restored checkpoint dict down to only the keys present in `model_arrays`, ensuring the two trees are structurally identical before the `jax.tree.map(_expand_checkpoint_to_model_shapes, ...)` call, without silently skipping any weights the model actually needs.


# Tests

Added unit test `test_returns_linen_train_state_and_annotations` which verifies that `setup_decode_state_from_nnx`:
1. Calls `from_pretrained` with `model_mode=MODEL_MODE_AUTOREGRESSIVE` (never touches a real checkpoint in CI)
2. Returns a linen `TrainState` with concrete `jax.Array` params nested under `state.params["params"]`
3. Extracts param values faithfully — each leaf is numerically identical to the source NNX model's `nnx.Param` values

End-to-end runs:
- NNX-RL with `base`, `--ckpt_type=nnx`: [example1](https://paste.googleplex.com/5791541516959744), [example2](https://paste.googleplex.com/5402751547867136)
- NNX-SFT without `base`, `--ckpt_type=nnx`: [example3](https://paste.googleplex.com/6319774511529984)
- Linen ckpt unimpacted: [example4](https://paste.googleplex.com/5626151453196288)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
