### PR TITLE
[Pathways Elastic Training] Ensure one goodput monitoring flush at the end of the workload

### DIFF
--- a/src/MaxText/train.py
+++ b/src/MaxText/train.py
@@ -590,14 +590,14 @@ def run(config, recorder, diagnostic_config):
       diagnostics_context,
       maybe_record_goodput(recorder, GoodputEvent.JOB),
       max_utils.maybe_get_transformer_engine_context(config),
-      maybe_monitor_goodput(config),
   ):
     train_loop(config, recorder)
 
 
 def main(argv: Sequence[str]) -> None:
   config, recorder, diagnostic_config = initialize(argv)
-  run(config, recorder, diagnostic_config)
+  with maybe_monitor_goodput(config):
+    run(config, recorder, diagnostic_config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Elastic restart consists of both the config initialization and run. The final metrics flush (run once at the end of `stop_goodput_uploader`) is a one time operation that waits for all metrics to be computed and uploaded, however this is designed to be done at the actual end of the workload - not before an elastic event. [This](https://github.com/CIeNET-International/maxtext2/blob/pw/user/lidanny/replica_resize/src/MaxText/train.py#L585-L609) is where the elastic manager wraps the training loop.  Doing this delays elastic restarts.

FIXES: b/484798225
FIXES: #123456


# Tests

- E2E maxtext run, example: https://screenshot.googleplex.com/awT5LF4pL3beCNm
- Github CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
