### PR TITLE
fix: Gemma3 scan_layers=True checkpoint conversion param mapping

### DIFF
--- a/docs/guides/checkpointing_solutions/convert_checkpoint.md
+++ b/docs/guides/checkpointing_solutions/convert_checkpoint.md
@@ -9,7 +9,7 @@ The following models are supported:
 | Model Family            | Sizes                  | HF $\\to$ Orbax (scan) | HF $\\to$ Orbax (unscan) | Orbax (scan) $\\to$ HF | Orbax (unscan) $\\to$ HF |
 | :---------------------- | :--------------------- | :--------------------: | :----------------------: | :--------------------: | :----------------------: |
 | **Gemma2**              | 2B, 9B, 27B            |           √            |            √             |           √            |            √             |
-| **Gemma3** (Multimodal) | 4B, 12B, 27B           |           -            |            √             |           -            |            √             |
+| **Gemma3** (Multimodal) | 4B, 12B, 27B           |           √            |            √             |           √            |            √             |
 | **Llama3.1**            | 8B, 70B, 450B          |           √            |            √             |           √            |            √             |
 | **Qwen3**               | 0.6B, 4B, 8B, 14B, 32B |           √            |            √             |           √            |            √             |
 | **Qwen3 MoE**           | 30B, 235B, 480B        |           √            |            √             |           √            |            √             |

--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh
@@ -40,16 +40,15 @@ python3 -m maxtext.checkpoint_conversion.to_maxtext "${MAXTEXT_CONFIGS_DIR:-${MA
 
 export UNSCANNED_CKPT_PATH=${MODEL_BUCKET}/${MODEL_VARIATION}/unscanned/${idx}/0/items
 
-# # To get scanned ckpt, flip the scan_layers.
-# ToDo: gemma3 multimodal scanned ckpt
-# python3 -m maxtext.checkpoint_conversion.to_maxtext src/maxtext/configs/base.yml \
-#     model_name=${MODEL_NAME} \
-#     hf_access_token=${HF_TOKEN} \
-#     base_output_directory=${MODEL_BUCKET}/${MODEL_VARIATION}/scanned/${idx} \
-#     use_multimodal=${USE_MULTIMODAL} \
-#     scan_layers=true
+# To get scanned ckpt, flip the scan_layers.
+python3 -m maxtext.checkpoint_conversion.to_maxtext "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"//base.yml \
+    model_name=${MODEL_NAME} \
+    hf_access_token=${HF_TOKEN} \
+    base_output_directory=${MODEL_BUCKET}/${MODEL_VARIATION}/scanned/${idx} \
+    use_multimodal=${USE_MULTIMODAL} \
+    scan_layers=true
 
-# export SCANNED_CKPT_PATH=${MODEL_BUCKET}/${MODEL_VARIATION}/scanned/${idx}/0/items
+export SCANNED_CKPT_PATH=${MODEL_BUCKET}/${MODEL_VARIATION}/scanned/${idx}/0/items
 
 # We also test whether the forward pass logits match the original HF model
 # to get higher precision (eg. float32) run on CPU with `JAX_PLATFORMS=cpu`


### PR DESCRIPTION
# Description

Fix HF <-> Orbax checkpoint conversion for Gemma3 models when `scan_layers=True`. Previously, conversion failed with `ValueError: maxtext_state_dict must be a subset of flattened param_map` because the parameter mapping generated incorrect key paths for scanned layers.

Gemma3 uses `Gemma3ScannableBlock` with **6 sub-layers** per scan block (5 local-sliding + 1 global attention), producing a two-level key structure (`layers-layers_{idx}-...`). The existing mapping generated flat keys (`layers-...`), missing the sub-layer level entirely and not handling remainder layers.

Three bugs are fixed in `param_mapping.py`:

1. **Text decoder scan mapping** - was generating a single flat key per parameter instead of per-sub-layer keys with correctly interleaved HF indices, plus a remainder block for layers that don't fill a complete scan group.

2. **Vision encoder scan mapping** - a nested loop overwrote the same dict key on every iteration, so only the last layer's mapping survived. Replaced with a list comprehension that collects all HF targets.

3. **Hook function prefixes** - used a single flat prefix for all scanned layers instead of generating correct prefixes for all 6 sub-layers + any remainder sub-layers.

# Tests

- `scan_layers=False`: no change in behavior - unscanned paths are unchanged.
- `scan_layers=True`: conversion now proceeds past `validate_and_filter_param_map_keys` with correct key mapping for all three Gemma3 variants (4b, 12b, 27b).

Reproduction command:

```bash
python3 -m maxtext.checkpoint_conversion.to_maxtext \
                maxtext/configs/base.yml \
                model_name=gemma3-4b \
                hf_access_token=${HF_TOKEN} \
                base_output_directory=gs://mymodel-training/checkpoints/gemma-3-4b-pt-orbax \
                per_device_batch_size=1 \
                run_name=convert \
                async_checkpointing=false \
                scan_layers=true \
                hardware=cpu \
                skip_jax_distributed_system=True \
                --hf_model_path=google/gemma-3-4b-pt \
                --simulated_cpu_devices_count=16
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
