### PR TITLE
Workflow to save top-k teacher logits in GCS to use in distillaiton

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/save_top_k_teacher_logits.py
+++ b/src/maxtext/trainers/post_train/distillation/save_top_k_teacher_logits.py
@@ -1,3 +1,17 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 This module provides functionality to save top-k teacher logits
 for distillation purposes in MaxText.

--- a/src/maxtext/trainers/post_train/distillation/verify_saved_logits.py
+++ b/src/maxtext/trainers/post_train/distillation/verify_saved_logits.py
@@ -1,3 +1,17 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Verification script to check the correctness of saved top-k teacher logits.
 


### PR DESCRIPTION
# Description

This PR introduces a standalone script (`save_top_k_teacher_logits.py`) to generate, extract, and save top-K logits and their corresponding vocabulary indices from a teacher model directly to a GCS bucket for offline distillation. In the current form of distillation, both the teacher and student models are loaded together into memory, and the process of distillation is done in an "online" fashion. This can lead to slower training times due to computing the teacher's probability distribution on the fly and training the student model simultaneously. In this change, we are saving the top-k teacher outputs in a GCS bucket (instead of the full probability distribution), so that this can be used to train the student model more efficiently without having to use extra memory to compute teacher logits on the fly. 

# Tests

Distillation YAML used to run this script: [https://paste.googleplex.com/5736358690816000](https://paste.googleplex.com/5736358690816000)

Ran the following command from the head of the Maxtext directory:
`python3 src/maxtext/trainers/post_train/distillation/save_top_k_teacher_logits.py src/maxtext/configs/post_train/distillation.yml`

Terminal output for the above command (truncated due to size): [https://paste.googleplex.com/4609623547052032](https://paste.googleplex.com/4609623547052032)

Verified that the ArrayRecord file has been written to a GS bucket in the correct path.  

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
