### PR TITLE
remove tf dependency from tokenizer.py

### DIFF
--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -213,7 +213,6 @@ def pretrain_preprocessing_pipeline(
       config.add_bos,
       config.add_eos,
       config.hf_access_token,
-      config.dataset_type,
   )
   if tokenizer_model.pad_id is not None:
     pad_id = tokenizer_model.pad_id
@@ -321,7 +320,6 @@ def dpo_preprocessing_pipeline(
       config.add_bos,
       config.add_eos,
       config.hf_access_token,
-      config.dataset_type,
   )
   if tokenizer_model.pad_id is not None:
     pad_id = tokenizer_model.pad_id

--- a/src/maxtext/input_pipeline/grain_tokenizer.py
+++ b/src/maxtext/input_pipeline/grain_tokenizer.py
@@ -30,7 +30,7 @@ class TokenizerTransformBase:
   # pylint: disable=attribute-defined-outside-init
   feature_names: str | Sequence[str]
   sequence_length: int | Sequence[int]
-  tokenizer: tokenizer.SentencePieceTokenizerGrain | tokenizer.HFTokenizer
+  tokenizer: tokenizer.SentencePieceTokenizer | tokenizer.HFTokenizer
 
   def __post_init__(self):
     self._processor = None

--- a/src/maxtext/input_pipeline/tfds_data_processing.py
+++ b/src/maxtext/input_pipeline/tfds_data_processing.py
@@ -25,7 +25,6 @@ import tensorflow_datasets as tfds
 import jax
 
 from maxtext.input_pipeline import multihost_dataloading
-from maxtext.input_pipeline import tokenizer
 from maxtext.input_pipeline.packing import sequence_packing
 from maxtext.input_pipeline import input_pipeline_utils
 
@@ -116,7 +115,9 @@ def preprocessing_pipeline(
 
   if tokenize:
     dataset = dataset.map(
-        lambda x: tokenizer.TokenizeOp(tokenizer=tokenizer_model, features=x, data_keys=data_column_names),
+        lambda x: input_pipeline_utils.TokenizeOp(
+            tokenizer_model=tokenizer_model, features=x, data_keys=data_column_names
+        ),
         num_parallel_calls=AUTOTUNE,
     )
 

--- a/src/maxtext/input_pipeline/tfds_data_processing_c4_mlperf.py
+++ b/src/maxtext/input_pipeline/tfds_data_processing_c4_mlperf.py
@@ -27,10 +27,10 @@ import jax
 import jax.numpy as jnp
 from jax.experimental import multihost_utils
 
-from maxtext.input_pipeline import tokenizer
 from maxtext.input_pipeline import multihost_dataloading
 from maxtext.input_pipeline.packing import sequence_packing
 from maxtext.input_pipeline.input_pipeline_utils import get_tokenizer
+from maxtext.input_pipeline.input_pipeline_utils import TokenizeOp
 from maxtext.utils import max_logging
 
 AUTOTUNE = tf.data.experimental.AUTOTUNE
@@ -258,7 +258,7 @@ def preprocess_train_dataset(
   else:
     pad_id = -1
   train_ds = train_ds.map(
-      lambda x: tokenizer.TokenizeOp(tokenizer=sp_tokenizer, features=x, data_keys=("targets",)),
+      lambda x: TokenizeOp(tokenizer_model=sp_tokenizer, features=x, data_keys=("targets",)),
       num_parallel_calls=AUTOTUNE,
   )
   train_ds = reduce_concat_tokens(train_ds, feature_key="targets", batch_size=4096)
@@ -283,7 +283,7 @@ def preprocess_eval_dataset(
   # group text up to max_target_length if the dataset is not pre-tokenized/pre-processed
   if not is_tokenized_dataset:
     eval_ds = eval_ds.map(
-        lambda x: tokenizer.TokenizeOp(tokenizer=sp_tokenizer, features=x, data_keys=("targets",)),
+        lambda x: TokenizeOp(tokenizer_model=sp_tokenizer, features=x, data_keys=("targets",)),
         num_parallel_calls=AUTOTUNE,
     )
     # hardcode batch_sizes 24567 i.e. the exp size in split validation_24567exp

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -408,7 +408,6 @@ def train_distill(student_config: pyconfig.HyperParameters, teacher_config: pyco
       add_bos=student_config.add_bos,
       add_eos=student_config.add_eos,
       hf_access_token=student_config.hf_access_token,
-      dataset_type=student_config.dataset_type,
   )
   pad_id = tok.pad_id if tok.pad_id is not None else 0
 

--- a/tests/unit/tokenizer_test.py
+++ b/tests/unit/tokenizer_test.py
@@ -67,7 +67,7 @@ class TokenizerTest(unittest.TestCase):
   @pytest.mark.tpu_only
   def test_tokenize(self):
     text = "This is a test"
-    self.assertTrue(np.array_equal(self.source_tokenizer.encode(text).numpy(), self.test_tokenizer.encode(text).numpy()))
+    self.assertTrue(np.array_equal(self.source_tokenizer.encode(text), self.test_tokenizer.encode(text)))
 
   @pytest.mark.tpu_only
   def test_detokenize(self):


### PR DESCRIPTION
# Description
This is part of the bigger plan of removing tensorflow dependency in MaxText
* combine SentencePieceTokenizerGrain and SentencePieceTokenizer under the name SentencePieceTokenizer
* Uses the sentencepiece library to load sentencepiece tokenizer instead of the tensorflow_text library
* replace tf.io.gfile with Google Storage client for gs:// path
* move TokenizeOp to input_pipeline_utils.py, in the future will put functions using tf to a separate input_pipeline_utils_tf.py to make installing tf optional

# Tests
CI test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
