### PR TITLE
Make `to_maxtext.py` capable of running as a library to fix `demo_decoding.ipynb`

### DIFF
--- a/docs/tutorials/first_run.md
+++ b/docs/tutorials/first_run.md
@@ -75,7 +75,7 @@ In the same TPU VM where you just installed all the dependencies of MaxText, You
 
 #### Decoding in MaxText via notebook
 
-You can use [demo_decoding.ipynb](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/examples/demo_decoding.ipynb) to try out decoding on MaxText's `Llama3.1-8b` model implementation. In this notebook, we give `"I love to"` as the prompt, and the greedily sampled first output token is `" cook"`. Please remember to provide the path to your `Llama3.1-8b` checkpoint for the `load_parameters_path` argument in the config inside the notebook. You can use [to_maxtext.py](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/MaxText/checkpoint_conversion/to_maxtext.py) to create a MaxText/Orbax checkpoint from a Huggingface checkpoint.
+You can use [demo_decoding.ipynb](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/examples/demo_decoding.ipynb) to try out decoding on MaxText's `Llama3.1-8b` model implementation. In this notebook, we give `"I love to"` as the prompt, and the greedily sampled first output token is `" cook"`. Please remember to provide the path to your `Llama3.1-8b` checkpoint for the `load_parameters_path` argument in the config inside the notebook. You can use [to_maxtext.py](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/checkpoint_conversion/to_maxtext.py) to create a MaxText/Orbax checkpoint from a Huggingface checkpoint.
 
 ### Run MaxText on NVIDIA GPUs
 

--- a/src/maxtext/examples/demo_decoding.ipynb
+++ b/src/maxtext/examples/demo_decoding.ipynb
@@ -92,7 +92,10 @@
         "!uv pip install nest_asyncio\n",
         "\n",
         "# Install the PyTorch library\n",
-        "!uv pip install torch"
+        "!uv pip install torch\n",
+        "\n",
+        "# This is needed for the Hugging Face login to work\n",
+        "!uv pip install ipywidgets"
       ]
     },
     {
@@ -122,6 +125,22 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "915db240",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from absl import logging as absl_logging\n",
+        "\n",
+        "# This will make `max_logging.log(...)` outputs visible in the Notebook.\n",
+        "# This statement needs to be invoked before we import jax, otherwise it won't work.\n",
+        "absl_logging.set_verbosity(absl_logging.INFO)\n",
+        "\n",
+        "absl_logging.error(\"Test - you should see this message below\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "id": "a8e986cb",
       "metadata": {},
       "outputs": [],
@@ -136,18 +155,24 @@
         "import MaxText as mt\n",
         "from MaxText import common_types\n",
         "from MaxText import pyconfig\n",
-        "from MaxText.input_pipeline import _input_pipeline_utils\n",
+        "from maxtext.input_pipeline import input_pipeline_utils\n",
         "from maxtext.checkpoint_conversion import to_maxtext\n",
         "from maxtext.inference import inference_utils\n",
         "from maxtext.utils import maxtext_utils\n",
         "from maxtext.utils import max_logging\n",
+        "from maxtext.utils import model_creation_utils\n",
         "\n",
-        "from google.colab import userdata\n",
+        "try:\n",
+        "  from google.colab import userdata\n",
+        "except ModuleNotFoundError:\n",
+        "  userdata = os.environ\n",
+        "\n",
         "from huggingface_hub import login\n",
         "\n",
         "MAXTEXT_PKG_DIR = os.path.dirname(mt.__file__)\n",
         "MAXTEXT_REPO_ROOT = os.path.dirname(os.path.dirname(MAXTEXT_PKG_DIR))\n",
         "MAXTEXT_ASSETS_ROOT = os.path.join(MAXTEXT_REPO_ROOT, \"src\", \"maxtext\", \"assets\")\n",
+        "MAXTEXT_CONFIGS_DIR = os.path.join(MAXTEXT_REPO_ROOT, \"src/maxtext/configs\")\n",
         "\n",
         "nest_asyncio.apply()"
       ]
@@ -291,7 +316,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "model = mt.from_config(config)\n",
+        "model = model_creation_utils.from_config(config)\n",
         "mesh = model.mesh\n",
         "init_rng = jax.random.PRNGKey(config.init_weights_seed)\n",
         "state, _ = maxtext_utils.setup_decode_state(model, config, init_rng, mesh, None)\n",
@@ -313,7 +338,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "tokenizer = _input_pipeline_utils.get_tokenizer(\n",
+        "tokenizer = input_pipeline_utils.get_tokenizer(\n",
         "    f\"{MAXTEXT_ASSETS_ROOT}/tokenizers/qwen3-tokenizer\",\n",
         "    \"huggingface\",\n",
         "    add_bos=True,\n",


### PR DESCRIPTION
# Description

* Make `to_maxtext.main()` function capable of running with arguments that can be easily constructed in Python. Previously it was taking an `ArgumentParser` object, which prevented it from being invoked from other modules.
* Fix the broken references to `to_maxtext` in the documentation.
* Updated docstrings to show a correctly working example of the `to_maxtext` invocation.
* Fixed a few minor issues with the `demo_decoding.ipynb` notebook.

# Tests

* Manual execution of the `demo_decoding.ipynb` notebook.
* Manual invocation of `to_maxtext` binary.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
