### PR TITLE
Support merging gating gmm kernels

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -214,6 +214,8 @@ wo_tile_drhs_buffer_count: 2
 wi_combine_scopes: False
 wo_combine_scopes: False
 
+merge_gating_gmm: False
+
 norm_topk_prob: false # boolean to enable the top-k probability normalization. qwen3-specific normalization of router weights.
 
 # how the expert axis is used to shard attention weights and activations

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -685,6 +685,8 @@ class MoEKernels(BaseModel):
   wi_combine_scopes: bool = Field(False, description="whether to use combine_scopes features for tgmm for wi.")
   wo_combine_scopes: bool = Field(False, description="whether to use combine_scopes features for tgmm for wo.")
 
+  merge_gating_gmm: bool = Field(False, description="whether to merge the two gating gmm kernels into one.")
+
 
 class DeepSeekMoE(BaseModel):
   """Configuration specific to DeepSeek-style MoE layers."""


### PR DESCRIPTION
# Description

This PR optimizes the MoE compute block by merging the two gating GMM kernels ($W_0$ and $W_1$) into a single, unified matrix multiplication pass.

Motivation
In the previous SwiGLU/GLU implementation, the gate-projection and up-projection were processed using two sequential `gmm_fn` calls. By concatenating these weights and processing them together, we effectively double the contiguous hidden dimension of the kernel. This is especially critical for FP8 utilizing Expert Parallelism (EP) that shard along the contracting dimension. Because this sharding strategy inherently shrinks the local MLP hidden dimension on each device, the matrix multiplications can become small and bottlenecked by memory bandwidth. Merging $W_0$ and $W_1$ effectively gives us a 2X increase in that local dimension, restoring arithmetic intensity and hardware utilization.
Expected Impact

Performance: Increased forward and backward pass throughput for the MoE layers, particularly on EP setups sharded along the contracting dimension due to the 2X larger local GMM sizes.

# Tests

The operation is mathematically equivalent to the previous implementation. The quality has been verified through convergence test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
