### PR TITLE
fix: remove unused import of maxtext_google from train.py

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -42,8 +42,6 @@ from MaxText import pyconfig
 from MaxText import sharding
 from MaxText.common_types import ShardMode
 from MaxText.globals import EPS
-# pylint: disable-next=unused-import
-from maxtext import maxtext_google
 
 from MaxText.gradient_accumulation import gradient_accumulation_loss_and_grad
 from MaxText.vocabulary_tiling import vocab_tiling_linen_loss


### PR DESCRIPTION
# Description

Remove import `from maxtext import maxtext_google` that was introduced in commit `4ef205efe3c4f31a700ff7621e7f1502575bd72c` (merge of PR #3189).

- **Problem:** Running `python3 -m maxtext.trainers.pre_train.train` fails immediately with `ImportError: cannot import name 'maxtext_google' from 'maxtext'`. No `maxtext_google` module exists in the open-source repo - it is a Google-internal side-effect import.
- **Fix:** Remove the two lines (`# pylint: disable-next=unused-import` and `from maxtext import maxtext_google`). The import was unused (pylint disable confirms this) and served only as an internal instrumentation hook.

Error in commit `4ef205efe3c4f31a700ff7621e7f1502575bd72c`:
```text
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/deps/src/maxtext/trainers/pre_train/train.py", line 46, in <module>
    from maxtext import maxtext_google
ImportError: cannot import name 'maxtext_google' from 'maxtext' (unknown location)
```

# Tests

```bash
# Verify the import error is gone
python3 -c "import maxtext.trainers.pre_train.train"
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
