### PR TITLE
Migrate maxtext common_types

### DIFF
--- a/src/MaxText/generate_param_only_checkpoint.py
+++ b/src/MaxText/generate_param_only_checkpoint.py
@@ -32,7 +32,7 @@ from jax.sharding import Mesh
 from MaxText import optimizers
 from MaxText import pyconfig
 from maxtext.common import checkpointing
-from MaxText.common_types import DecoderBlockType, MODEL_MODE_TRAIN
+from maxtext.common.common_types import DecoderBlockType, MODEL_MODE_TRAIN
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import gcs_utils

--- a/src/MaxText/gradient_accumulation.py
+++ b/src/MaxText/gradient_accumulation.py
@@ -18,7 +18,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import NamedSharding
 
-from MaxText.common_types import ShardMode
+from maxtext.common.common_types import ShardMode
 from MaxText.sharding import maybe_shard_with_name
 
 

--- a/src/MaxText/layerwise_quantization.py
+++ b/src/MaxText/layerwise_quantization.py
@@ -39,8 +39,7 @@ from flax import nnx
 from flax.linen import partitioning as nn_partitioning
 import jax
 import jax.numpy as jnp
-from MaxText import common_types
-from MaxText import pyconfig
+from maxtext.common import common_types
 from maxtext.common import checkpointing
 from maxtext.layers import quantizations
 from maxtext.models import deepseek, models
@@ -49,6 +48,7 @@ from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
 import orbax.checkpoint as ocp
 from tqdm import tqdm
+from MaxText import pyconfig
 
 IGNORE = ocp.PLACEHOLDER
 PRNGKeyType = Any

--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -29,8 +29,8 @@ import jax.numpy as jnp
 import omegaconf
 
 from MaxText import pyconfig_deprecated
-from MaxText.common_types import DecoderBlockType, ShardMode
 from MaxText.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.common.common_types import DecoderBlockType, ShardMode
 from maxtext.configs import types
 from maxtext.configs.types import MaxTextConfig
 from maxtext.inference.inference_utils import str2bool

--- a/src/MaxText/pyconfig_deprecated.py
+++ b/src/MaxText/pyconfig_deprecated.py
@@ -30,7 +30,7 @@ import omegaconf
 
 from MaxText import accelerator_to_spec_map
 from MaxText.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_REPO_ROOT, MAXTEXT_PKG_DIR
-from MaxText.common_types import AttentionType, DecoderBlockType, ShardMode
+from maxtext.common.common_types import AttentionType, DecoderBlockType, ShardMode
 from maxtext.utils import gcs_utils
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils

--- a/src/MaxText/sharding.py
+++ b/src/MaxText/sharding.py
@@ -25,7 +25,7 @@ from jax.sharding import PartitionSpec as P, NamedSharding, reshard
 
 import optax
 
-from MaxText.common_types import ShardMode
+from maxtext.common.common_types import ShardMode
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 

--- a/src/MaxText/vocabulary_tiling.py
+++ b/src/MaxText/vocabulary_tiling.py
@@ -25,7 +25,7 @@ from MaxText.sharding import (
     all_gather_over_fsdp,
     create_sharding,
 )
-from MaxText.common_types import ShardMode
+from maxtext.common.common_types import ShardMode
 from maxtext.utils import max_utils
 
 

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_gpt3_ckpt_from_paxml.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_gpt3_ckpt_from_paxml.py
@@ -44,9 +44,9 @@ from jax import random
 from jax.sharding import Mesh
 from MaxText import optimizers
 from MaxText import pyconfig
-from maxtext.common import checkpointing
-from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.common import checkpointing
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.layers import quantizations
 from maxtext.models.models import transformer_as_linen
 from maxtext.utils import max_logging

--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -71,7 +71,7 @@ import flax.linen as nn
 from huggingface_hub import hf_hub_download, list_repo_files
 import jax
 from MaxText import pyconfig
-from MaxText.common_types import MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.checkpoint_conversion.standalone_scripts.llama_or_mistral_ckpt import save_weights_to_checkpoint
 from maxtext.checkpoint_conversion.utils.param_mapping import HOOK_FNS, PARAM_MAPPING
 from maxtext.checkpoint_conversion.utils.utils import HF_IDS, MemoryMonitorTqdm, apply_hook_fns, get_hf_model, print_peak_memory, print_ram_usage, validate_and_filter_param_map_keys

--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -1,4 +1,4 @@
-# Copyright 2023–2025 Google LLC
+# Copyright 2023–2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -27,17 +27,16 @@ from tempfile import gettempdir
 from typing import Any, Literal, NewType, Optional
 
 import jax
-from MaxText import accelerator_to_spec_map
-from MaxText.common_types import AttentionType, DecoderBlockType, ShardMode
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.common.common_types import AttentionType, DecoderBlockType, ShardMode
 from maxtext.utils import gcs_utils
 from maxtext.utils import max_utils
+from MaxText import accelerator_to_spec_map
+from MaxText.globals import MAXTEXT_ASSETS_ROOT
 from pydantic.config import ConfigDict
 from pydantic.fields import Field
 from pydantic.functional_validators import field_validator, model_validator
 from pydantic.main import BaseModel
 from pydantic.types import NonNegativeFloat, NonNegativeInt, PositiveInt
-
 
 class XProfTPUPowerTraceMode(enum.IntEnum):  # pylint: disable=invalid-name
   """Enum for XProfTPUPowerTraceMode."""

--- a/src/maxtext/examples/demo_decoding.ipynb
+++ b/src/maxtext/examples/demo_decoding.ipynb
@@ -153,7 +153,7 @@
         "import numpy as np\n",
         "\n",
         "import MaxText as mt\n",
-        "from MaxText import common_types\n",
+        "from maxtext.common import common_types\n",
         "from MaxText import pyconfig\n",
         "from maxtext.input_pipeline import input_pipeline_utils\n",
         "from maxtext.checkpoint_conversion import to_maxtext\n",

--- a/src/maxtext/experimental/rl/grpo_utils.py
+++ b/src/maxtext/experimental/rl/grpo_utils.py
@@ -21,7 +21,7 @@ import jax.numpy as jnp
 import jaxtyping
 from typing import Any, Callable
 
-from MaxText.common_types import DecoderBlockType
+from maxtext.common.common_types import DecoderBlockType
 from maxtext.inference.offline_engine import InputData
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils

--- a/src/maxtext/inference/kvcache.py
+++ b/src/maxtext/inference/kvcache.py
@@ -29,8 +29,8 @@ from aqt.jax.v2.flax import aqt_flax
 from maxtext.layers import nnx_wrappers
 from maxtext.layers.initializers import variable_to_logically_partitioned
 
-from MaxText.common_types import Array, AxisNames, AxisIdxes, Config, CACHE_BATCH_PREFILL, DType, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, MODEL_MODE_AUTOREGRESSIVE, CACHE_HEADS_NONE, DECODING_ACTIVE_SEQUENCE_INDICATOR
-from MaxText.common_types import CACHE_BATCH, CACHE_SEQUENCE, CACHE_HEADS, CACHE_KV, CACHE_SCALE_BATCH, CACHE_SCALE_SEQUENCE, CACHE_SCALE_HEADS, CACHE_SCALE_KV
+from maxtext.common.common_types import Array, AxisNames, AxisIdxes, Config, CACHE_BATCH_PREFILL, DType, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, MODEL_MODE_AUTOREGRESSIVE, CACHE_HEADS_NONE, DECODING_ACTIVE_SEQUENCE_INDICATOR
+from maxtext.common.common_types import CACHE_BATCH, CACHE_SEQUENCE, CACHE_HEADS, CACHE_KV, CACHE_SCALE_BATCH, CACHE_SCALE_SEQUENCE, CACHE_SCALE_HEADS, CACHE_SCALE_KV
 
 
 MAX_INT8 = 127.5

--- a/src/maxtext/inference/maxengine/maxengine.py
+++ b/src/maxtext/inference/maxengine/maxengine.py
@@ -37,7 +37,6 @@ from flax.linen import partitioning as nn_partitioning
 import flax
 
 from MaxText import pyconfig
-from MaxText.common_types import MODEL_MODE_PREFILL, DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE
 from MaxText.globals import MAXTEXT_PKG_DIR
 from maxtext.models import models
 from maxtext.layers import quantizations
@@ -48,6 +47,7 @@ from maxtext.utils import lora_utils
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
 from maxtext.common.gcloud_stub import jetstream, is_decoupled
+from maxtext.common.common_types import MODEL_MODE_PREFILL, DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE
 
 config_lib, engine_api, token_utils, tokenizer_api, _token_params_ns = jetstream()
 TokenizerParameters = getattr(_token_params_ns, "TokenizerParameters", object)  # type: ignore[assignment]

--- a/src/maxtext/inference/page_manager.py
+++ b/src/maxtext/inference/page_manager.py
@@ -31,7 +31,7 @@ from flax import struct
 
 from jaxtyping import Array, Integer, Bool
 
-from MaxText.common_types import Config
+from maxtext.common.common_types import Config
 
 # Aliases using <Dims><Type><Rank>d convention
 # We use string names for dimensions as they are symbolic within the type hints.

--- a/src/maxtext/inference/paged_attention.py
+++ b/src/maxtext/inference/paged_attention.py
@@ -26,7 +26,7 @@ from jax.experimental.pallas.ops.tpu.paged_attention import paged_attention_kern
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
-from MaxText.common_types import Array, AxisNames, BATCH, DType, D_KV, HEAD, LENGTH, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL
+from maxtext.common.common_types import Array, AxisNames, BATCH, DType, D_KV, HEAD, LENGTH, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL
 from maxtext.inference import page_manager
 from maxtext.inference import paged_attention_kernel_v2
 from maxtext.layers.initializers import variable_to_logically_partitioned

--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -22,8 +22,8 @@ import flax.linen as nn
 from jax import numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from MaxText.common_types import MODEL_MODE_AUTOREGRESSIVE
 from MaxText.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE
 from maxtext.utils import max_logging
 from maxtext.utils import model_creation_utils
 

--- a/src/maxtext/kernels/attention/ragged_attention.py
+++ b/src/maxtext/kernels/attention/ragged_attention.py
@@ -24,7 +24,7 @@ from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 import jax.numpy as jnp
 
-from MaxText.common_types import DEFAULT_MASK_VALUE
+from maxtext.common.common_types import DEFAULT_MASK_VALUE
 
 
 def get_mha_cost_estimate(shape_dtype):

--- a/src/maxtext/layers/attention_mla.py
+++ b/src/maxtext/layers/attention_mla.py
@@ -32,7 +32,7 @@ else:
 
 from flax import nnx
 
-from MaxText.common_types import (
+from maxtext.common.common_types import (
     Array,
     AxisIdxes,
     AxisNames,

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -33,7 +33,7 @@ from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_ke
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask
 import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding
-from MaxText.common_types import (
+from maxtext.common.common_types import (
     Array,
     AttentionType,
     AxisIdxes,

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -25,7 +25,7 @@ import jax.numpy as jnp
 
 from flax import nnx
 
-from MaxText.common_types import (
+from maxtext.common.common_types import (
     DecoderBlockType,
     BATCH,
     BATCH_NO_EXP,

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -28,8 +28,8 @@ from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText import sharding
-from MaxText.common_types import Config, DecoderBlockType, EP_AS_CONTEXT, ShardMode
-from MaxText.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN
+from maxtext.common.common_types import Config, DecoderBlockType, EP_AS_CONTEXT, ShardMode
+from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN
 from maxtext.inference import page_manager
 from maxtext.layers import linears
 from maxtext.layers import mhc

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -25,7 +25,7 @@ from jax.sharding import Mesh, NamedSharding
 from flax import nnx
 
 from MaxText.sharding import logical_to_mesh_axes, create_sharding
-from MaxText.common_types import ShardMode, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, Array, Config, DType
+from maxtext.common.common_types import ShardMode, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, Array, Config, DType
 from maxtext.layers import nnx_wrappers
 from maxtext.layers.initializers import Initializer, default_embed_init, variable_to_logically_partitioned
 from maxtext.utils import max_logging

--- a/src/maxtext/layers/encoders.py
+++ b/src/maxtext/layers/encoders.py
@@ -18,7 +18,7 @@ import jax
 from flax import nnx
 from jax.sharding import Mesh
 
-from MaxText.common_types import Config
+from maxtext.common.common_types import Config
 from maxtext.layers import nnx_wrappers
 from maxtext.layers import initializers
 

--- a/src/maxtext/layers/engram.py
+++ b/src/maxtext/layers/engram.py
@@ -24,7 +24,7 @@ from flax import nnx
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText.common_types import Array, Config, MODEL_MODE_TRAIN
+from maxtext.common.common_types import Array, Config, MODEL_MODE_TRAIN
 from maxtext.input_pipeline.tokenizer import HFTokenizer
 from maxtext.layers.embeddings import Embed
 from maxtext.layers.initializers import NdInitializer, nd_dense_init

--- a/src/maxtext/layers/initializers.py
+++ b/src/maxtext/layers/initializers.py
@@ -22,7 +22,7 @@ from flax import linen as nn
 from flax import nnx
 from aqt.jax.v2 import aqt_tensor
 
-from MaxText.common_types import Array, DType, Shape, PRNGKey
+from maxtext.common.common_types import Array, DType, Shape, PRNGKey
 
 Initializer = Callable[[PRNGKey, Shape, DType], Array]
 InitializerAxis = int | tuple[int, ...]

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -30,8 +30,8 @@ from flax import nnx
 import flax.linen as nn
 
 from MaxText.sharding import maybe_shard_with_logical
-from MaxText.common_types import DecoderBlockType, ShardMode, DType, Array, Config
-from MaxText.common_types import MODEL_MODE_TRAIN, MODEL_MODE_PREFILL, EP_AS_CONTEXT
+from maxtext.common.common_types import DecoderBlockType, ShardMode, DType, Array, Config
+from maxtext.common.common_types import MODEL_MODE_TRAIN, MODEL_MODE_PREFILL, EP_AS_CONTEXT
 from maxtext.layers import nnx_wrappers, quantizations
 from maxtext.layers import normalizations
 from maxtext.layers.initializers import NdInitializer, nd_dense_init, default_bias_init, variable_to_logically_partitioned

--- a/src/maxtext/layers/mhc.py
+++ b/src/maxtext/layers/mhc.py
@@ -19,8 +19,8 @@ from flax import nnx
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText.common_types import Array, Config
-from MaxText.common_types import HyperConnectionType
+from maxtext.common.common_types import Array, Config
+from maxtext.common.common_types import HyperConnectionType
 from maxtext.layers.initializers import default_bias_init, default_scalar_init, nd_dense_init
 from maxtext.layers.normalizations import RMSNorm
 

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -29,8 +29,8 @@ from jax.experimental import xla_metadata
 from jax.sharding import NamedSharding, Mesh
 from jax.sharding import PartitionSpec as P
 import jax.numpy as jnp
-from MaxText import common_types as ctypes
-from MaxText.common_types import ShardMode
+from maxtext.common import common_types as ctypes
+from maxtext.common.common_types import ShardMode
 from MaxText.sharding import maybe_shard_with_logical, create_sharding
 from MaxText.sharding import logical_to_mesh_axes
 from maxtext.layers import attentions, linears, nnx_wrappers, quantizations

--- a/src/maxtext/layers/multi_token_prediction.py
+++ b/src/maxtext/layers/multi_token_prediction.py
@@ -22,7 +22,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText import sharding
-from MaxText.common_types import Config, MODEL_MODE_TRAIN
+from maxtext.common.common_types import Config, MODEL_MODE_TRAIN
 from MaxText.globals import EPS
 from maxtext.layers import nnx_wrappers
 from maxtext.layers.decoders import DecoderLayer

--- a/src/maxtext/layers/normalizations.py
+++ b/src/maxtext/layers/normalizations.py
@@ -23,7 +23,7 @@ import jax
 from jax import lax
 import jax.numpy as jnp
 from jax.sharding import NamedSharding
-from MaxText.common_types import Array, DType, ShardMode
+from maxtext.common.common_types import Array, DType, ShardMode
 from maxtext.layers import nnx_wrappers
 from maxtext.layers.initializers import Initializer, variable_to_logically_partitioned
 from maxtext.utils import max_logging

--- a/src/maxtext/layers/pipeline.py
+++ b/src/maxtext/layers/pipeline.py
@@ -28,7 +28,7 @@ from flax.core import meta
 from flax import linen as nn
 from flax.linen.spmd import LogicallyPartitioned
 
-from MaxText.common_types import Config, MODEL_MODE_TRAIN, EP_AS_CONTEXT, ShardMode
+from maxtext.common.common_types import Config, MODEL_MODE_TRAIN, EP_AS_CONTEXT, ShardMode
 from MaxText.sharding import (
     maybe_shard_with_logical,
     maybe_shard_with_name,

--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -36,7 +36,7 @@ from flax.linen import fp8_ops
 from flax.linen import initializers as flax_initializers
 import flax.linen as nn
 
-from MaxText.common_types import DType, Config
+from maxtext.common.common_types import DType, Config
 from maxtext.inference.kvcache import KVQuant
 
 # Params used to define mixed precision quantization configs

--- a/src/maxtext/models/deepseek.py
+++ b/src/maxtext/models/deepseek.py
@@ -22,8 +22,8 @@ from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText.common_types import Config
-from MaxText.common_types import HyperConnectionType, MODEL_MODE_PREFILL
+from maxtext.common.common_types import Config
+from maxtext.common.common_types import HyperConnectionType, MODEL_MODE_PREFILL
 from maxtext.inference import page_manager
 from maxtext.layers import attention_mla
 from maxtext.layers import initializers

--- a/src/maxtext/models/gemma.py
+++ b/src/maxtext/models/gemma.py
@@ -22,7 +22,7 @@ from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
 import jax.numpy as jnp
 
-from MaxText.common_types import Config
+from maxtext.common.common_types import Config
 from maxtext.layers import initializers
 from maxtext.layers import nnx_wrappers
 from maxtext.layers import quantizations

--- a/src/maxtext/models/gemma2.py
+++ b/src/maxtext/models/gemma2.py
@@ -22,7 +22,7 @@ from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
 import jax.numpy as jnp
 
-from MaxText.common_types import MODEL_MODE_PREFILL, Config
+from maxtext.common.common_types import MODEL_MODE_PREFILL, Config
 from maxtext.layers import attentions
 from maxtext.layers import initializers
 from maxtext.layers import nnx_wrappers

--- a/src/maxtext/models/gemma3.py
+++ b/src/maxtext/models/gemma3.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 from flax import linen as nn
 from flax import nnx
 
-from MaxText.common_types import Config, AttentionType, MODEL_MODE_PREFILL
+from maxtext.common.common_types import Config, AttentionType, MODEL_MODE_PREFILL
 from maxtext.layers import quantizations
 from maxtext.layers import nnx_wrappers
 from maxtext.layers import initializers

--- a/src/maxtext/models/gpt3.py
+++ b/src/maxtext/models/gpt3.py
@@ -27,7 +27,7 @@ from jax.sharding import Mesh, NamedSharding
 from flax import linen as nn
 from flax import nnx
 
-from MaxText.common_types import Config, DType, AxisNames, BATCH, LENGTH, EMBED, HEAD, D_KV, Array, MODEL_MODE_TRAIN
+from maxtext.common.common_types import Config, DType, AxisNames, BATCH, LENGTH, EMBED, HEAD, D_KV, Array, MODEL_MODE_TRAIN
 from maxtext.layers import initializers, nnx_wrappers
 from maxtext.layers.linears import DenseGeneral, MlpBlock, canonicalize_tuple, normalize_axes
 from maxtext.layers import quantizations

--- a/src/maxtext/models/gpt_oss.py
+++ b/src/maxtext/models/gpt_oss.py
@@ -25,7 +25,7 @@ from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText.common_types import AttentionType, Config
+from maxtext.common.common_types import AttentionType, Config
 from maxtext.layers import attentions
 from maxtext.layers import initializers
 from maxtext.layers import moe

--- a/src/maxtext/models/llama2.py
+++ b/src/maxtext/models/llama2.py
@@ -21,8 +21,8 @@ from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText.common_types import Config
-from MaxText.common_types import MODEL_MODE_PREFILL
+from maxtext.common.common_types import Config
+from maxtext.common.common_types import MODEL_MODE_PREFILL
 from maxtext.inference import page_manager
 from maxtext.layers import initializers
 from maxtext.layers import nnx_wrappers
@@ -31,8 +31,8 @@ from maxtext.layers.attentions import Attention
 from maxtext.layers.linears import Dropout, MlpBlock
 from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
-from MaxText.sharding import create_sharding, maybe_shard_with_logical
 from maxtext.utils import max_utils
+from MaxText.sharding import create_sharding, maybe_shard_with_logical
 
 # -----------------------------------------
 # The Decoder Layer specific for Llama2

--- a/src/maxtext/models/llama4.py
+++ b/src/maxtext/models/llama4.py
@@ -23,8 +23,8 @@ from jax import lax
 from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText.common_types import Array, AttentionType, Config, MODEL_MODE_TRAIN
-from MaxText.common_types import MODEL_MODE_PREFILL
+from maxtext.common.common_types import Array, AttentionType, Config, MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_PREFILL
 from maxtext.inference import page_manager
 from maxtext.layers import initializers
 from maxtext.layers import linears

--- a/src/maxtext/models/mistral.py
+++ b/src/maxtext/models/mistral.py
@@ -21,7 +21,7 @@ from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText.common_types import Config
+from maxtext.common.common_types import Config
 from maxtext.layers import initializers, nnx_wrappers
 from maxtext.layers import quantizations
 from maxtext.layers.attentions import Attention

--- a/src/maxtext/models/mixtral.py
+++ b/src/maxtext/models/mixtral.py
@@ -22,7 +22,7 @@ from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText.common_types import Config
+from maxtext.common.common_types import Config
 from maxtext.layers import initializers, nnx_wrappers
 from maxtext.layers import moe
 from maxtext.layers import quantizations

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -23,7 +23,7 @@ from flax import nnx
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText.common_types import Config, DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN
+from maxtext.common.common_types import Config, DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN
 from maxtext.inference import page_manager
 from maxtext.layers import initializers
 from maxtext.layers import nnx_wrappers
@@ -49,9 +49,9 @@ class TransformerLinenPure(nn.Module):
   config: Config
   mesh: Mesh
   quant: Quant
-  # Possible model_mode values can be found in MaxText.common_types.
-  # We generally use MaxText.common_types.MODEL_MODE_TRAIN or
-  # MaxText.common_types.MODEL_MODE_PREFILL for initializations here.
+  # Possible model_mode values can be found in maxtext.common.common_types.
+  # We generally use maxtext.common.common_types.MODEL_MODE_TRAIN or
+  # maxtext.common.common_types.MODEL_MODE_PREFILL for initializations here.
   # TODO: Make model_mode required after confirming no users are affected.
   model_mode: str = MODEL_MODE_TRAIN  # May be different than the model_mode passed to __call__
   # pylint: enable=attribute-defined-outside-init

--- a/src/maxtext/models/olmo3.py
+++ b/src/maxtext/models/olmo3.py
@@ -26,7 +26,7 @@ from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText.common_types import AttentionType, Config
+from maxtext.common.common_types import AttentionType, Config
 from maxtext.layers import attentions
 from maxtext.layers import initializers
 from maxtext.layers import nnx_wrappers

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -29,7 +29,7 @@ import jax.numpy as jnp
 from flax import linen as nn
 from flax import nnx
 
-from MaxText.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED, MODEL_MODE_TRAIN
+from maxtext.common.common_types import AttentionType, Config, DType, Array, BATCH, LENGTH_NO_EXP, EMBED, MODEL_MODE_TRAIN
 from maxtext.layers import attentions
 from maxtext.layers import initializers as max_initializers
 from maxtext.layers import moe

--- a/src/maxtext/models/simple_layer.py
+++ b/src/maxtext/models/simple_layer.py
@@ -18,7 +18,7 @@ from jax import numpy as jnp
 from jax.sharding import Mesh
 
 from flax import nnx
-from MaxText.common_types import Config, ShardMode
+from maxtext.common.common_types import Config, ShardMode
 from MaxText.sharding import create_sharding
 from maxtext.layers import quantizations, nnx_wrappers
 from maxtext.layers.initializers import variable_to_logically_partitioned

--- a/src/maxtext/scratch_code/demo_from_config.ipynb
+++ b/src/maxtext/scratch_code/demo_from_config.ipynb
@@ -53,7 +53,7 @@
         "import numpy as np\n",
         "from MaxText.input_pipeline import _input_pipeline_utils\n",
         "import os\n",
-        "from MaxText import common_types\n",
+        "from maxtext.common import common_types\n",
         "import jax\n",
         "from maxtext.inference import inference_utils\n",
         "from maxtext.utils import max_logging\n",

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -38,9 +38,9 @@ import jax.numpy as jnp
 from flax import linen as nn
 from flax.linen import partitioning as nn_partitioning
 
+from maxtext.common.common_types import ShardMode
 from MaxText import pyconfig
 from MaxText import sharding
-from MaxText.common_types import ShardMode
 from MaxText.globals import EPS
 # Placeholder: internal
 

--- a/src/maxtext/trainers/pre_train/train_compile.py
+++ b/src/maxtext/trainers/pre_train/train_compile.py
@@ -36,7 +36,7 @@ from MaxText import accelerator_to_spec_map
 from MaxText import optimizers
 from MaxText import pyconfig
 from MaxText import sharding
-from MaxText.common_types import MODEL_MODE_TRAIN, ShardMode
+from maxtext.common.common_types import MODEL_MODE_TRAIN, ShardMode
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.trainers.diloco import diloco

--- a/src/maxtext/utils/max_utils.py
+++ b/src/maxtext/utils/max_utils.py
@@ -41,7 +41,7 @@ import psutil
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.common.gcloud_stub import writer, _TENSORBOARDX_AVAILABLE
 from maxtext.utils import max_logging
-from MaxText.common_types import MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN
 
 initialize_multi_tier_checkpointing = initialization.initialize_multi_tier_checkpointing
 HYBRID_RING_64X4 = "hybrid_ring_64x4"

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -37,7 +37,7 @@ import orbax.checkpoint.experimental.emergency.checkpoint_manager as emergency_c
 import orbax.checkpoint.experimental.emergency.replicator_checkpoint_manager as emergency_replicator_checkpoint_manager
 
 from MaxText import sharding
-from MaxText.common_types import DecoderBlockType, MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
+from maxtext.common.common_types import DecoderBlockType, MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
 from maxtext.configs import types
 from maxtext.inference.page_manager import PageState
 from maxtext.common import checkpointing

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -25,7 +25,7 @@ import flax.linen as nn
 import jax
 from jax.sharding import AxisType, Mesh
 from MaxText import pyconfig
-from MaxText.common_types import MODEL_MODE_TRAIN, ShardMode
+from maxtext.common.common_types import MODEL_MODE_TRAIN, ShardMode
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import max_utils

--- a/src/maxtext/vllm_decode.py
+++ b/src/maxtext/vllm_decode.py
@@ -46,14 +46,14 @@ import transformers
 
 from maxtext.utils import model_creation_utils
 from maxtext.utils import max_logging
-from MaxText import pyconfig
-from MaxText.common_types import Config
-from MaxText.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.common.common_types import Config
 from maxtext.integration.tunix.tunix_adapter import TunixMaxTextAdapter
 from tunix.rl.rollout import base_rollout
 from tunix.rl.rollout.vllm_rollout import VllmRollout
 from vllm import LLM
 from vllm.sampling_params import SamplingParams
+from MaxText import pyconfig
+from MaxText.globals import MAXTEXT_CONFIGS_DIR
 
 os.environ["SKIP_JAX_PRECOMPILE"] = "1"
 os.environ["NEW_MODEL_DESIGN"] = "1"

--- a/tests/assets/logits_generation/generate_grpo_golden_logits.py
+++ b/tests/assets/logits_generation/generate_grpo_golden_logits.py
@@ -31,8 +31,8 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 import jsonlines
 from MaxText import pyconfig
-from MaxText.common_types import Array, MODEL_MODE_TRAIN
 from MaxText.globals import MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.common.common_types import Array, MODEL_MODE_TRAIN
 from maxtext.experimental.rl.grpo_trainer import _merge_grpo_state, generate_completions, grpo_loss_fn
 from maxtext.experimental.rl.grpo_utils import compute_log_probs
 from maxtext.inference.maxengine import maxengine

--- a/tests/inference/kvcache_test.py
+++ b/tests/inference/kvcache_test.py
@@ -19,7 +19,7 @@ import unittest
 import jax
 import jax.numpy as jnp
 
-from MaxText.common_types import MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
+from maxtext.common.common_types import MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
 from maxtext.inference import kvcache
 
 

--- a/tests/integration/grpo_correctness.py
+++ b/tests/integration/grpo_correctness.py
@@ -21,7 +21,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from MaxText.common_types import MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.experimental.rl.grpo_trainer import _merge_grpo_state, grpo_loss_fn
 from maxtext.experimental.rl.grpo_utils import compute_log_probs
 from MaxText.globals import MAXTEXT_PKG_DIR

--- a/tests/integration/grpo_trainer_correctness_test.py
+++ b/tests/integration/grpo_trainer_correctness_test.py
@@ -36,8 +36,8 @@ from jax.sharding import Mesh
 import jsonlines
 import MaxText as mt
 from MaxText import pyconfig
-from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.experimental.rl import grpo_utils
 from maxtext.experimental.rl.grpo_trainer import _merge_grpo_state, grpo_loss_fn, setup_train_loop
 from maxtext.experimental.rl.grpo_utils import compute_log_probs

--- a/tests/integration/sft_trainer_correctness_test.py
+++ b/tests/integration/sft_trainer_correctness_test.py
@@ -34,7 +34,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 import jsonlines
 from MaxText import pyconfig
-from MaxText.common_types import MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from MaxText.globals import MAXTEXT_ASSETS_ROOT
 from MaxText.globals import MAXTEXT_PKG_DIR
 from MaxText.globals import MAXTEXT_TEST_ASSETS_ROOT

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -28,8 +28,7 @@ from jax.sharding import AxisType, Mesh
 from maxtext.utils import maxtext_utils
 from maxtext.common.gcloud_stub import is_decoupled
 
-from MaxText import pyconfig
-from MaxText.common_types import (
+from maxtext.common.common_types import (
     AttentionType,
     DECODING_ACTIVE_SEQUENCE_INDICATOR,
     MODEL_MODE_AUTOREGRESSIVE,
@@ -39,6 +38,7 @@ from MaxText.common_types import (
 from maxtext.layers.attention_mla import MLA
 from maxtext.layers.attention_op import ChunkedCausalMask, _generate_chunk_attention_mask, _make_bidirectional_block_mask
 from maxtext.layers.attentions import Attention
+from MaxText import pyconfig
 import numpy as np
 import pytest
 

--- a/tests/unit/deepseek32_vs_reference_test.py
+++ b/tests/unit/deepseek32_vs_reference_test.py
@@ -52,7 +52,7 @@ from flax import nnx
 
 from MaxText import pyconfig
 from maxtext.layers import embeddings, attention_mla
-from MaxText.common_types import MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.utils import maxtext_utils
 from tests.utils.test_helpers import get_test_config_path
 

--- a/tests/unit/gpt3_test.py
+++ b/tests/unit/gpt3_test.py
@@ -21,7 +21,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from MaxText.common_types import MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import maxtext_utils

--- a/tests/unit/llama4_layers_test.py
+++ b/tests/unit/llama4_layers_test.py
@@ -25,11 +25,11 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 from jax.experimental import mesh_utils
 
-from MaxText.common_types import MODEL_MODE_TRAIN, AttentionType
-from MaxText import pyconfig
 from maxtext.layers import attentions, embeddings
 from maxtext.models import llama4
+from maxtext.common.common_types import MODEL_MODE_TRAIN, AttentionType
 from maxtext.utils import maxtext_utils
+from MaxText import pyconfig
 import numpy as np
 from tests.utils.test_helpers import get_test_config_path
 

--- a/tests/unit/maxengine_test.py
+++ b/tests/unit/maxengine_test.py
@@ -22,7 +22,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_PREFILL
+from maxtext.common.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_PREFILL
 from maxtext.layers import quantizations
 from maxtext.inference.maxengine import maxengine
 from maxtext.models import models

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -28,12 +28,12 @@ import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from MaxText import pyconfig
 from MaxText import sharding
+from MaxText.sharding import assert_params_sufficiently_sharded, get_formatted_sharding_annotations
 from maxtext.common.gcloud_stub import is_decoupled
-from MaxText.common_types import MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.inference import inference_utils
 from maxtext.layers import quantizations
 from maxtext.models import models
-from MaxText.sharding import assert_params_sufficiently_sharded, get_formatted_sharding_annotations
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
 from tests.utils.test_helpers import get_test_config_path

--- a/tests/unit/mhc_test.py
+++ b/tests/unit/mhc_test.py
@@ -26,8 +26,8 @@ from jax.sharding import Mesh
 import numpy as np
 
 from MaxText import pyconfig
-from MaxText.common_types import HyperConnectionType
 from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.common.common_types import HyperConnectionType
 from maxtext.layers import attention_mla, linears, mhc, moe
 from maxtext.layers.initializers import nd_dense_init
 from maxtext.layers.normalizations import RMSNorm

--- a/tests/unit/model_test.py
+++ b/tests/unit/model_test.py
@@ -21,7 +21,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
 from maxtext.common.gcloud_stub import is_decoupled
-from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN
+from maxtext.common.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import maxtext_utils

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -23,7 +23,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
 from maxtext.common.gcloud_stub import is_decoupled
-from MaxText.common_types import Config, DType
+from maxtext.common.common_types import Config, DType
 from maxtext.layers import linears
 from maxtext.layers import moe
 from maxtext.layers import nnx_wrappers

--- a/tests/unit/multi_token_prediction_test.py
+++ b/tests/unit/multi_token_prediction_test.py
@@ -20,12 +20,12 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 from flax import nnx
 
-from MaxText.common_types import Config
 from MaxText import pyconfig
 from maxtext.layers.decoders import DecoderLayer
 from maxtext.layers import multi_token_prediction  # The class under test
 from maxtext.layers import embeddings
-from MaxText.common_types import MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_TRAIN
+from maxtext.common.common_types import Config
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.utils import max_logging
 from maxtext.utils import maxtext_utils

--- a/tests/unit/pipeline_parallelism_test.py
+++ b/tests/unit/pipeline_parallelism_test.py
@@ -26,8 +26,8 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from MaxText.common_types import MODEL_MODE_TRAIN
 from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.layers import nnx_wrappers
 from maxtext.layers import pipeline

--- a/tests/unit/quantizations_test.py
+++ b/tests/unit/quantizations_test.py
@@ -27,9 +27,9 @@ from jax import lax
 from jax import numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from maxtext.common.gcloud_stub import is_decoupled
-from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR
 from MaxText.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.common.gcloud_stub import is_decoupled
+from maxtext.common.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR
 from maxtext.kernels.megablox import gmm
 from maxtext.layers import nnx_wrappers, quantizations
 from maxtext.utils import maxtext_utils

--- a/tests/unit/qwen3_omni_layers_test.py
+++ b/tests/unit/qwen3_omni_layers_test.py
@@ -25,10 +25,10 @@ from flax import nnx
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from MaxText import common_types
 from MaxText import maxengine
 from MaxText import pyconfig
 from MaxText.globals import MAXTEXT_REPO_ROOT
+from maxtext.common import common_types
 from maxtext.layers.attentions import Attention
 from maxtext.layers.embeddings import (
     PositionalEmbedding,

--- a/tests/unit/state_dtypes_test.py
+++ b/tests/unit/state_dtypes_test.py
@@ -21,7 +21,7 @@ from jax.sharding import Mesh
 from MaxText import optimizers
 from MaxText import pyconfig
 from maxtext.common.gcloud_stub import is_decoupled
-from MaxText.common_types import MODEL_MODE_TRAIN
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import maxtext_utils

--- a/tests/unit/tiling_test.py
+++ b/tests/unit/tiling_test.py
@@ -24,13 +24,13 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from MaxText.common_types import Config
-from MaxText.common_types import MODEL_MODE_TRAIN
+from MaxText.vocabulary_tiling import vocab_tiling_linen_loss
+from maxtext.common.common_types import Config
+from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
-from MaxText.vocabulary_tiling import vocab_tiling_linen_loss
 from tests.utils.test_helpers import get_test_config_path
 import pytest
 

--- a/tests/utils/attention_test_util.py
+++ b/tests/utils/attention_test_util.py
@@ -22,10 +22,10 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 from MaxText import pyconfig
-from maxtext.common.gcloud_stub import is_decoupled
-from MaxText.common_types import AttentionType, DECODING_ACTIVE_SEQUENCE_INDICATOR, EP_AS_CONTEXT, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, ShardMode
-from maxtext.layers.attention_mla import MLA
 from MaxText.sharding import maybe_shard_with_name
+from maxtext.common.gcloud_stub import is_decoupled
+from maxtext.common.common_types import AttentionType, DECODING_ACTIVE_SEQUENCE_INDICATOR, EP_AS_CONTEXT, MODEL_MODE_PREFILL, MODEL_MODE_TRAIN, ShardMode
+from maxtext.layers.attention_mla import MLA
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
 from tests.utils.test_helpers import get_test_config_path

--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -45,9 +45,9 @@ from google.cloud import storage
 import jax
 import jax.numpy as jnp
 from MaxText import pyconfig
-from maxtext.checkpoint_conversion.utils.hf_utils import convert_jax_weight_to_torch
-from MaxText.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_TRAIN
 from MaxText.globals import MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.checkpoint_conversion.utils.hf_utils import convert_jax_weight_to_torch
+from maxtext.common.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_TRAIN
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import max_logging


### PR DESCRIPTION
# Description

Move maxtext common_types to maxtext/common/.

# Tests

- Unit tests
- Github CI

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
