### PR TITLE
Add support z-loss in pre-training

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -334,6 +334,7 @@ sliding_window_size: 0
 chunk_attn_window_size: 0
 attn_logits_soft_cap: 0.0
 final_logits_soft_cap: 0.0
+z_loss_multiplier: 0.0
 use_post_attn_norm: False
 use_post_ffw_norm: False
 mla_naive_kvcache: True

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -462,6 +462,7 @@ class Logits(BaseModel):
       None,
       description="Soft-cap value for the final logits. None or 0.0 means no cap.",
   )
+  z_loss_multiplier: float = Field(0.0, description="The multiplier for the z-loss (e.g., 1e-4). 0.0 to disable.")
 
 
 class Attention(BaseModel):


### PR DESCRIPTION
# Description

This PR implements Z-loss to improve numerical stability and prevent runaway logits. Alongside techniques like QK-normalization and logit soft-capping, it is a key mechanism for stabilizing low-precision (BF16/FP8) training.

**Key Changes:**
- **Configuration:** Added a `z_loss_multiplier` parameter to `types.py` (defaults to `0.0`).
- **Integration:** Wired the existing Z-loss utility (`max_utils.cross_entropy_with_logits`) into the standard training loop (`loss_fn`) and the vocabulary tiling path (`vocab_tiling_linen_loss`).
- **Logging:** Normalized Z-loss is now exported to the `aux` dictionary and logged to TensorBoard as `learning/z_loss`.

# Tests

- **Math Verification:** Added `test_cross_entropy_with_z_loss` in `max_utils_test.py` to verify the penalty calculation is mathematically correct.
- **Integration/Tiling:** Added `test_vocab_tiling_gradient_with_z_loss` in `tiling_test.py` to ensure loss and gradients match exactly between standard and vocabulary-tiled computations when Z-loss is enabled.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
