### PR TITLE
Add Multi-tiered Checkpointing Support to Pathways

### DIFF
--- a/benchmarks/globals.py
+++ b/benchmarks/globals.py
@@ -20,10 +20,12 @@ import os.path
 MAXTEXT_PKG_DIR = os.environ.get("MAXTEXT_PKG_DIR", "src/MaxText")
 
 # This is the maxtext repo root: with ".git" folder; "README.md"; "pyproject.toml"; &etc.
-MAXTEXT_REPO_ROOT = os.environ.get(
-    "MAXTEXT_REPO_ROOT",
-    r if os.path.isdir(os.path.join(r := os.path.dirname(os.path.dirname(__file__)), ".git")) else MAXTEXT_PKG_DIR,
-)
+# MAXTEXT_REPO_ROOT = os.environ.get(
+#     "MAXTEXT_REPO_ROOT",
+#     r if os.path.isdir(os.path.join(r := os.path.dirname(os.path.dirname(__file__)), ".git")) else MAXTEXT_PKG_DIR,
+# )
+
+MAXTEXT_REPO_ROOT = "/deps/"
 
 # This is the configs root: with "base.yml"; "models/"; &etc.
 MAXTEXT_CONFIGS_DIR = os.environ.get("MAXTEXT_CONFIGS_DIR", os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs"))

--- a/benchmarks/maxtext_v5e_model_configs.py
+++ b/benchmarks/maxtext_v5e_model_configs.py
@@ -236,6 +236,14 @@ llama3_1_8b_8192_v5e_256 = _add_to_model_dictionary(
             "profiler": "xplane",
             "skip_first_n_steps_for_profiler": 10,
             "profiler_steps": 5,
+            # MTC params
+            "enable_checkpointing": True,
+            "async_checkpointing": False,  # False for now to verify correctness.
+            "enable_multi_tier_checkpointing": True,
+            "multi_tier_checkpointing_backup_interval_minutes": "5",
+            "local_checkpoint_directory": "/tmp/mtc_checkpoints",
+            "local_checkpoint_period": "5",
+            "colocated_python_checkpointing": True,
         },
         xla_flags=(
             xla_flags_library.DENSE_VMEM_LIMIT_FLAG

--- a/benchmarks/recipes/user_configs.py
+++ b/benchmarks/recipes/user_configs.py
@@ -112,20 +112,22 @@ class UserConfig:
 
 # Define the required configuration here
 USER_CONFIG = UserConfig(
-    user="user_name",
-    cluster_name="v6e-256-cluster",
-    project="tpu-prod-env-cluster",
-    zone="us-east5-b",
-    device_type="v6e-256",
+    user="sujinesh",
+    cluster_name="pw-scale-test-v5e-32",
+    project="cloud-tpu-multipod-dev",
+    zone="us-south1-a",
+    device_type="v5litepod-32",
     benchmark_steps=20,
     num_slices_list=[2],
-    server_image="us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server",
-    proxy_image="us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server",
-    runner="us-docker.pkg.dev/path/to/maxtext_runner",
+    server_image="us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest",
+    proxy_image=(
+        "us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest"
+    ),
+    colocated_python_image="us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/sujinesh/sidecar_mtc:latest",
+    runner="us-docker.pkg.dev/cloud-tpu-v2-images-dev/pathways/sujinesh/maxtext_mtc:latest",
     selected_model_framework=["pathways"],
-    selected_model_names=["llama3_1_8b_8192"],
+    selected_model_names=["llama3_1_8b_8192_v5e_256"],
     priority="medium",
-    base_output_directory=None,  # GCS Bucket path
-    # Optional parameters, useful for single controller data loading optimizations
-    # proxy_flags="--sidecar_name=external",
+    proxy_flags="--sidecar_name=external",
+    base_output_directory="gs://sujinesh-us-west1/colocated_checkpointing/",
 )

--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -34,8 +34,8 @@ from orbax.checkpoint import v1 as ocp_v1
 from orbax.checkpoint._src.arrays import sharding as sharding_utils
 from orbax.checkpoint._src.checkpoint_managers import preservation_policy as preservation_policy_lib
 from orbax.checkpoint._src.checkpoint_managers import save_decision_policy as save_decision_policy_lib
-import orbax.checkpoint.experimental.emergency.checkpoint_manager as emergency_checkpoint_manager
-import orbax.checkpoint.experimental.emergency.replicator_checkpoint_manager as emergency_replicator_checkpoint_manager
+from orbax.checkpoint.experimental.emergency import checkpoint_manager as emergency_checkpoint_manager
+from orbax.checkpoint.experimental.emergency import replicator_checkpoint_manager as emergency_replicator_checkpoint_manager
 # pylint: disable=too-many-positional-arguments
 import dataclasses
 import json
@@ -217,9 +217,6 @@ def create_orbax_checkpoint_manager(
     enable_continuous_checkpointing: bool = False,
     max_num_checkpoints_to_keep: int = 10,
     checkpoint_storage_concurrent_gb: int = 96,
-    enable_single_controller: bool = False,
-    colocated_python_checkpointing: bool = False,
-    enable_single_replica_ckpt_restoring: bool = False,
 ):
   """Returns specified Orbax (async or not) CheckpointManager or None if checkpointing is disabled."""
   if not enable_checkpointing:
@@ -272,17 +269,6 @@ def create_orbax_checkpoint_manager(
       logger=orbax_logger,
   )
 
-  # Use Colocated Python checkpointing optimization (Single Controller only).
-  if enable_single_controller and colocated_python_checkpointing:
-    max_logging.log("Registering colocated python array handler")
-    checkpointing_impl = ocp.pathways.CheckpointingImpl.from_options(
-        use_colocated_python=True,
-    )
-    ocp.pathways.register_type_handlers(
-        use_single_replica_array_handler=enable_single_replica_ckpt_restoring,
-        checkpointing_impl=checkpointing_impl,
-    )
-
   max_logging.log("Checkpoint manager created!")
   return manager
 
@@ -330,6 +316,7 @@ def create_orbax_emergency_replicator_checkpoint_manager(
     local_checkpoint_dir: str,
     save_interval_steps: int,
     global_mesh: jax.sharding.Mesh,
+    colocated_python_checkpointing: bool = False,
 ):
   """Returns an emergency replicator checkpoint manager."""
   flags.FLAGS.experimental_orbax_use_distributed_process_id = True
@@ -339,6 +326,7 @@ def create_orbax_emergency_replicator_checkpoint_manager(
       epath.Path(local_checkpoint_dir),
       options=emergency_replicator_checkpoint_manager.ReplicatorCheckpointManagerOptions(
           save_interval_steps=save_interval_steps,
+          use_colocated_python=colocated_python_checkpointing,
       ),
       global_mesh=global_mesh,
   )

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -669,7 +669,7 @@ colocated_python_data_input: False  # experimental feature, under testing
 steps: 150_001 # If set to -1 then will inherit value from learning_rate_schedule_steps
 log_period: 100 # The frequency of Tensorboard flush, gcs metrics writing, and managed profiler metrics updating.
 
-jax_distributed_initialization_timeout: 300 # This is the default timeout in https://github.com/jax-ml/jax/blob/main/jax/_src/distributed.py
+jax_distributed_initialization_timeout: 60 # This is the default timeout in https://github.com/jax-ml/jax/blob/main/jax/_src/distributed.py
 # Note there are two separate initializations - the jax coordination service (aka jax.distributed.initialize) and the backend (e.g. PjRT), the timeout above refers
 # only to the jax coordination service.
 jax_debug_log_modules: "" # Set this to "jax" to enable jax verbose logging such as for the jax coordination service initialization.

--- a/src/maxtext/utils/max_utils.py
+++ b/src/maxtext/utils/max_utils.py
@@ -198,6 +198,16 @@ def maybe_initialize_jax_distributed_system(raw_keys):
     return
   if raw_keys["enable_single_controller"]:
     max_logging.log("Skipping jax distributed system since its not needed for single controller.")
+    if raw_keys["enable_multi_tier_checkpointing"]:
+      max_logging.log("Initializing multi-tier checkpointing for single controller...")
+      initialize_multi_tier_checkpointing(
+        local_checkpoint_directory=raw_keys["local_checkpoint_directory"],
+        backup_interval_minutes=raw_keys["multi_tier_checkpointing_backup_interval_minutes"],
+        run_name=raw_keys["run_name"],
+        jax_initialization_timeout_seconds=raw_keys["jax_distributed_initialization_timeout"],
+        data_parallelism=raw_keys["mtc_data_parallelism"],
+        use_colocated_python=True
+      )
     return
   if jax.distributed.is_initialized():
     max_logging.log("Jax distributed system is already initialized.")

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -33,8 +33,8 @@ import jax.numpy as jnp
 
 import optax
 
-import orbax.checkpoint.experimental.emergency.checkpoint_manager as emergency_checkpoint_manager
-import orbax.checkpoint.experimental.emergency.replicator_checkpoint_manager as emergency_replicator_checkpoint_manager
+from orbax.checkpoint.experimental.emergency import checkpoint_manager as emergency_checkpoint_manager
+from orbax.checkpoint.experimental.emergency import replicator_checkpoint_manager as emergency_replicator_checkpoint_manager
 
 from maxtext.common.common_types import DecoderBlockType, MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE
 from maxtext.configs import types


### PR DESCRIPTION
# Description

Adds Multi-tiered checkpointing support to MaxText. This will work with Elastic Training Pause & Resume, but does not currently work with Replica Resize.

This feature is expected to roughly increase the goodput by ~6.5% and is only dependent on Orbax.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: <Add bug>

# Tests

Tested on TPU cluster. More details in <Add doc>

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
