### PR TITLE
Support Deepstack in qwen3-omni

### DIFF
--- a/src/maxtext/configs/models/qwen3-omni-30b-a3b.yml
+++ b/src/maxtext/configs/models/qwen3-omni-30b-a3b.yml
@@ -39,6 +39,7 @@ max_position_embeddings: 65536
 
 # General Model Settings
 enable_dropout: False
+scan_layers: False  # deepstack does not support scan_layers
 
 # Vision Encoder Configuration
 # Based on https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1928,6 +1928,13 @@ class MaxTextConfig(
     if self.steps == -1:
       self.steps = self.learning_rate_schedule_steps
 
+    # Validate deepstack + scan_layers incompatibility
+    if self.deepstack_visual_indexes_for_vit and self.scan_layers:
+      raise ValueError(
+          "Deepstack visual embedding injection requires scan_layers=False. "
+          "Set scan_layers=False in your config to use deepstack features."
+      )
+
     # Validate WSD learning rate schedule fractions
     if self.lr_schedule_type == LearningRateScheduleType.WSD:
       total_fraction = self.warmup_steps_fraction + self.wsd_decay_steps_fraction

--- a/src/maxtext/layers/encoders.py
+++ b/src/maxtext/layers/encoders.py
@@ -65,7 +65,6 @@ class VisionEncoder(nnx.Module):
     # vision encoder output, frozen params in many cases
     encoder = getattr(self, self.encoder_name)
     encoder_output = encoder(input_images, deterministic=deterministic)
-
     deep_feats = None
     if isinstance(encoder_output, tuple):
       embeddings = encoder_output[0]
@@ -75,6 +74,8 @@ class VisionEncoder(nnx.Module):
 
     if self.config.freeze_vision_encoder_params:
       embeddings = jax.lax.stop_gradient(embeddings)
+      if deep_feats is not None:
+        deep_feats = [jax.lax.stop_gradient(feat) for feat in deep_feats]
 
     # vision embedder / projection layer, not frozen in most cases, trained / finetuned together with main model
     projector = getattr(self, self.projector_name)

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -151,10 +151,12 @@ class TransformerLinenPure(nn.Module):
     bidirectional_mask = None
     image_embeddings = None
     audio_embeddings = None
+    deepstack_visual_embeds = None
 
     if self.config.use_multimodal and encoder_images is not None:
-      # qwen3-omni-30b-a3b returns deep features from the vision encoder.
-      image_embeddings, _ = self.vision_encoder(input_images=encoder_images, deterministic=not enable_dropout)
+      image_embeddings, deepstack_visual_embeds = self.vision_encoder(
+          input_images=encoder_images, deterministic=not enable_dropout
+      )
       bidirectional_mask = mm_processor.get_bidirectional_mask_vision(self.config, decoder_input_tokens)
 
     if self.config.use_multimodal and encoder_audios is not None and self.audio_encoder is not None:
@@ -182,6 +184,7 @@ class TransformerLinenPure(nn.Module):
         audio_masks=audio_masks,
         kv_caches=kv_caches,
         attention_metadata=attention_metadata,
+        deepstack_visual_embeds=deepstack_visual_embeds,
     )
 
     # If we are initializing the model AND MTP is enabled, we must create
@@ -458,8 +461,11 @@ class Transformer(nnx.Module):
 
     bidirectional_mask = None
     image_embeddings = None
+    deepstack_visual_embeds = None
     if self.config.use_multimodal and encoder_images is not None:
-      image_embeddings, _ = self.vision_encoder(input_images=encoder_images, deterministic=not enable_dropout)
+      image_embeddings, deepstack_visual_embeds = self.vision_encoder(
+          input_images=encoder_images, deterministic=not enable_dropout
+      )
       bidirectional_mask = mm_processor.get_bidirectional_mask_vision(self.config, decoder_input_tokens)
 
     audio_embeddings = None
@@ -488,6 +494,7 @@ class Transformer(nnx.Module):
         audio_masks=audio_masks,
         kv_caches=kv_caches,
         attention_metadata=attention_metadata,
+        deepstack_visual_embeds=deepstack_visual_embeds,
     )
 
     # Materialize hidden state when vocab tiling is enabled


### PR DESCRIPTION
# Description

Original work #2729
* rebase and minor fixes
* add unit test TestDeepstackProcess

# Tests
qwen3_omni_layer_test.py pass locally
The pylint error is unrelated and will be fixed by #3219  

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
