### PR TITLE
add feature cosine similarity loss

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1120,3 +1120,11 @@ engram_vocab_bases: []
 engram_kernel_size: 4
 # The seed for Engram hash mapping.
 engram_seed: 0
+
+##### Distillation parameters
+distill_alpha: 0.5
+distill_temperature: 1.0
+# distill_beta is used for cosine similarity loss between intermediate activataitions of out_proj in teacher/student models.
+# 0.0 value disables this feature.
+distill_beta: 0.0
+distill_layer_indices: None

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1055,6 +1055,8 @@ class Distillation(BaseModel):
   # --- Loss Params ---
   distill_alpha: float = Field(0.5, description="Weight for the distillation loss component.")
   distill_temperature: float = Field(1.0, description="Temperature for distillation softening.")
+  distill_beta: float = Field(0.0, description="Weight for the feature loss component. Use 0.0 to disable")
+  distill_layer_indices: None | list = Field(None, description="Feature indices for feature loss.")
 
 
 class TrainingLoop(BaseModel):
@@ -2007,6 +2009,13 @@ class MaxTextConfig(
 
     # Validate and initiate hlo dump related configs
     validate_and_set_hlo_dump_defaults()
+
+    # Validate nnx sow incompatibility
+    if self.distill_beta > 0.0:
+      if not self.scan_layers:
+        raise ValueError("a value of self.distill_beta > 0.0 requires self.scan_layers = True")
+      if not self.enable_nnx:
+        raise ValueError("a value of self.distill_beta > 0.0 requires self.enable_nnx = True")
 
     # D. CALCULATE MODEL DIMENSIONS from global_parameter_scale
     # This allows scaling the model size up or down easily with a single power-of-two factor.

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -1162,5 +1162,7 @@ class Attention(nnx.Module):
       out = out.reshape(batch_size, seq_len, self.config.num_query_heads * self.config.head_dim)
       out = out * jax.nn.sigmoid(gate)
     out = self.out_projection(out, out_sharding=out_sharding)
+    if self.config.distill_beta > 0.0:
+      self.sow(nnx.Intermediate, "out_projection_activations", out)
     out = checkpoint_name(out, "out_proj")
     return out, kv_cache

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -477,6 +477,12 @@ class Transformer(nnx.Module):
     if audio_embeddings is not None:
       audio_masks = mm_processor.get_bidirectional_mask_audio(self.config, decoder_input_tokens)
 
+    mutable_collections = []
+    if self.config.record_internal_nn_metrics:
+      mutable_collections.append("intermediates")
+    if self.config.distill_beta > 0.0 and "intermediates" not in mutable_collections:
+      mutable_collections.append("intermediates")
+
     logits, hidden_state, kv_caches = self.decoder(
         shared_embedding=self.token_embedder,
         decoder_input_tokens=decoder_input_tokens,
@@ -495,6 +501,7 @@ class Transformer(nnx.Module):
         kv_caches=kv_caches,
         attention_metadata=attention_metadata,
         deepstack_visual_embeds=deepstack_visual_embeds,
+        mutable=mutable_collections,
     )
 
     # Materialize hidden state when vocab tiling is enabled

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -897,6 +897,34 @@ def get_nested_value(dictionary, nested_key, default=None):
   return current_level
 
 
+def get_intermediate_value(model, nested_key, default=None, clear=False):
+  """
+  Retrieves an intermediate value from an NNX model. This functions has context about
+  where the intermediate value is located.
+
+  Args:
+    model: The NNX model.
+    nested_key: A string representing the nested key, e.g., hidden_states_norm_out
+    default: The value to return if the nested key is not found.
+    clear: Clears the intermediate value from the model.
+
+  Returns:
+    The value associated with the nested key, or the default value if not found.
+  """
+  intermediate_value = default
+  match nested_key:
+    case "out_projection_activations":
+      if nested_key in model.decoder.layers["self_attention"]:
+        intermediate_value = model.decoder.layers["self_attention"][nested_key].get_value()[-1]
+        if clear:
+          del model.decoder.layers["self_attention"][nested_key]
+    case _:
+      # Default case to handle any unknown nested keys
+      raise ValueError(f"Incorrect nested_key: {nested_key}")
+
+  return intermediate_value
+
+
 def update_state_param(state, target_path, value):
   """
   Updates a specific parameter in state.params at the given path.


### PR DESCRIPTION
# Description

Adds optional cosine similarity loss between attention outputs of various layers of teacher/student.

# Tests

- Updated train_distill_test unit test.
- Ran train_distill.py on llama3.1-8b both with cosine loss enabled/disabled.
- Updated maxtext_utils tests.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
