### PR TITLE
Add Engram tflops

### DIFF
--- a/src/maxtext/layers/engram.py
+++ b/src/maxtext/layers/engram.py
@@ -469,7 +469,7 @@ class ShortConv(nnx.Module):
       B: Batch size
       S: Sequence length (temporal dimension)
       G: Number of branches (mhc_expansion_rate)
-      D: Hidden size (base_emb_dim)
+      D: Hidden size (emb_dim)
     """
     B, S, G, D = x.shape
 
@@ -557,7 +557,7 @@ class Engram(nnx.Module):
     # retrieved n-gram memory -> Key, from D_en to [G, D]
     self.key_proj = DenseGeneral(
         in_features_shape=self.engram_dim,
-        out_features_shape=(mhc_expansion_rate, config.base_emb_dim),
+        out_features_shape=(mhc_expansion_rate, config.emb_dim),
         axis=-1,
         kernel_init=self.kernel_init,
         kernel_axes=("engram_dim", "mhc", "embed"),
@@ -578,7 +578,7 @@ class Engram(nnx.Module):
     @nnx.vmap(in_axes=0, out_axes=0)
     def create_norms(rngs):
       return RMSNorm(
-          num_features=config.base_emb_dim,
+          num_features=config.emb_dim,
           dtype=config.dtype,
           weight_dtype=config.weight_dtype,
           epsilon=config.normalization_layer_epsilon,
@@ -594,7 +594,7 @@ class Engram(nnx.Module):
     # Value Projection (Shared): Retrieved memory -> Value
     self.value_proj = DenseGeneral(
         in_features_shape=self.engram_dim,
-        out_features_shape=config.base_emb_dim,
+        out_features_shape=config.emb_dim,
         axis=-1,
         kernel_init=self.kernel_init,
         kernel_axes=("engram_dim", "embed"),
@@ -611,7 +611,7 @@ class Engram(nnx.Module):
     # Applies depthwise causal convolution to smooth the retrieved memory over time.
     self.short_conv = ShortConv(
         config=config,
-        hidden_size=config.base_emb_dim,
+        hidden_size=config.emb_dim,
         kernel_size=self.conv_kernel_size,
         dilation=self.max_ngram_size,
         mhc_expansion_rate=mhc_expansion_rate,
@@ -635,7 +635,7 @@ class Engram(nnx.Module):
       S: Sequence Length
       G: mhc_expansion_rate, Number of Branches
       H_total: Total number of heads across n-grams. num_head * num_ngrams
-      D: base_emb_dim
+      D: emb_dim
       D_head: Dimension of a single head embedding
       D_en: Dimension of flattened embedding across heads and n-grams
     """

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -669,6 +669,38 @@ def calculate_llama4_vision_layers_tflops_per_device(config):
   return total_tflops, learnable_weight_tflops, total_attn_tflops
 
 
+def calculate_engram_tflops(config):
+  """Calculate engram TFLOPs per device."""
+  B = config.per_device_batch_size
+  S = config.max_target_length
+  G = config.mhc_expansion_rate  # Multi-manifold branches
+  D = config.emb_dim  # Hidden dimension
+  k = config.engram_kernel_size  # Conv window
+
+  num_ngram_orders = config.engram_max_ngram_size - 1
+  engram_dim = config.engram_num_heads * config.engram_head_dim * num_ngram_orders
+
+  # 1. Key Projection
+  key_flops = 2 * (B * S) * engram_dim * (G * D)
+  # 2. Value Projection
+  value_flops = 2 * (B * S) * engram_dim * D
+  # 3. QK Attention
+  attention_flops = 2 * (B * S) * G * D
+  # 4. Short Convolution
+  # Standard flops as 2 * kernel_size * input_channels * output_channels / feature_group_count
+  # In Engram, the feature_group_count = input_channels = output_channels
+  # Unlike global attention, convolution work is constant per token (not O(S^2)),
+  # so we do not apply the 0.5 causal scaling factor.
+  total_channels = G * D
+  conv_flops = 2 * (B * S) * k * total_channels
+
+  num_layers = len(config.engram_layers)
+  # account for both the forward (1x) and backward (2x) passes
+  learnable_tflops = num_layers * (key_flops + value_flops + conv_flops) * 3 / 1e12
+  attention_tflops = num_layers * attention_flops * 3 / 1e12
+  return learnable_tflops, attention_tflops
+
+
 def calculate_vision_encoder_tflops(config):
   """Calculate vision encoder TFLOPs per prefill step per device."""
   if config.model_name.startswith("gemma3"):
@@ -786,18 +818,11 @@ def calculate_tflops_training_per_device(config, log=True):
     )
     attention_tflops = causal_attention_flops * config.num_decoder_layers * 3 / 10**12
 
-  learnable_weight_tflops = learnable_weight_tflops * config.gradient_accumulation_steps
-  attention_tflops = attention_tflops * config.gradient_accumulation_steps
-
-  # DPO includes one additional forward pass per gradient accumulation step
-  if config.use_dpo:
-    reference_model_tflops = learnable_weight_tflops / 3  # additional forward pass
-    reference_model_attention_tflops = attention_tflops / 3
-    attention_tflops = attention_tflops + reference_model_attention_tflops
-  else:
-    reference_model_tflops = 0
-
-  total_tflops = learnable_weight_tflops + attention_tflops + reference_model_tflops
+  # Engram flops
+  if config.engram_layers:
+    engram_learnable_tflops, engram_attention_tflops = calculate_engram_tflops(config)
+    learnable_weight_tflops += engram_learnable_tflops
+    attention_tflops += engram_attention_tflops
 
   if config.use_multimodal:
     # Add vision layers TFLOPs for multimodal models
@@ -810,9 +835,21 @@ def calculate_tflops_training_per_device(config, log=True):
           f"and {100 * mm_attention_tflops/mm_total_tflops:.2f}% attention flops;\n",
           f"learnable weight {mm_learnable_weight_tflops:.2f} TFLOPs, attention {mm_attention_tflops:.2f} TFLOPs",
       )
-    total_tflops += mm_total_tflops
     learnable_weight_tflops += mm_learnable_weight_tflops
     attention_tflops += mm_attention_tflops
+
+  learnable_weight_tflops = learnable_weight_tflops * config.gradient_accumulation_steps
+  attention_tflops = attention_tflops * config.gradient_accumulation_steps
+
+  # DPO includes one additional forward pass per gradient accumulation step
+  if config.use_dpo:
+    reference_model_tflops = learnable_weight_tflops / 3  # additional forward pass
+    reference_model_attention_tflops = attention_tflops / 3
+    attention_tflops = attention_tflops + reference_model_attention_tflops
+  else:
+    reference_model_tflops = 0
+
+  total_tflops = learnable_weight_tflops + attention_tflops + reference_model_tflops
 
   if log:
     print(


### PR DESCRIPTION
# Description

Add Engram tflops calculation:
* Add matmul related flops into Engram for MFU (key/value projections are dominant)
* Didn't take Engram table building into account for "model" utilization
* Add test accordingly

# Tests

Expect all tests are green - [link](https://paste.googleplex.com/5895150124531712) for flop_calculation_test test.

```
python3 -m unittest tests.unit.flop_calculation_test
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
