### PR TITLE
Add model bringup doc into index file

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -55,6 +55,13 @@ Tools for observability: goodput monitoring, hung job debugging, and Vertex AI T
 
 Interactive development guides for running MaxText on Google Colab or local JupyterLab environments.
 :::
+
+:::{grid-item-card} 🌱 Model Bringup
+:link: guides/model_bringup
+:link-type: doc
+
+A step-by-step guide for the community to help expand MaxText's model library.
+:::
 ::::
 
 ```{toctree}
@@ -66,4 +73,5 @@ guides/data_input_pipeline.md
 guides/checkpointing_solutions.md
 guides/monitoring_and_debugging.md
 guides/run_python_notebook.md
+guides/model_bringup.md
 ```


### PR DESCRIPTION
# Description

Add model bringup doc into index file with auto reformat from pre-commit.

# Tests

Manual check

**Note: mdformat is currently failing in the pre-commit hooks. I’ve linked the [auto-formatted diff here](https://diff.googleplex.com/#key=9kBxsZV5FLAG); could you confirm if these changes are expected? This is not aligned with other existing formats**

Jacobo helped build UI locally: [link](https://screenshot.googleplex.com/7iy73sjeBPJV34L)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
