### PR TITLE
Fix gpt-oss weight mapping issue in RL

### DIFF
--- a/src/maxtext/integration/tunix/weight_mapping/gpt_oss.py
+++ b/src/maxtext/integration/tunix/weight_mapping/gpt_oss.py
@@ -80,7 +80,7 @@ class GPT_OSS_VLLM_MAPPING:
         target_indices = range(start, start + layers_per_block)
 
       regex_indices = "|".join(map(str, target_indices))
-      layer_regex = f"layers\.({regex_indices})"
+      layer_regex = fr"layers\.({regex_indices})"
 
       # --- 3. Block Mappings (Standard) ---
       mapping.update(


### PR DESCRIPTION
# Description

Fix the SyntaxWarning error for testing GPT-OSS model in RL. Detailed error: "/deps/src/MaxText/integration/tunix/weight_mapping/gpt_oss.py:83: SyntaxWarning: invalid escape sequence '\.'"

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/482450484

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Have tested GPT-OSS 20B on v5p-32 with this commit. Run successfully.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
