### PR TITLE
Fix GPT OSS regex issue in vLLM mapping.

### DIFF
--- a/src/maxtext/integration/tunix/weight_mapping/gpt_oss.py
+++ b/src/maxtext/integration/tunix/weight_mapping/gpt_oss.py
@@ -80,7 +80,7 @@ class GPT_OSS_VLLM_MAPPING:
         target_indices = range(start, start + layers_per_block)
 
       regex_indices = "|".join(map(str, target_indices))
-      layer_regex = f"layers\.({regex_indices})"
+      layer_regex = rf"layers\.({regex_indices})"
 
       # --- 3. Block Mappings (Standard) ---
       mapping.update(


### PR DESCRIPTION
# Description
Fix GPT OSS regex issue in vLLM mapping.

Current issue break RL e2e flow during weight sync on tunix side:
`"/deps/src/MaxText/integration/tunix/weight_mapping/gpt_oss.py:83: SyntaxWarning: invalid escape sequence '.'"`

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/482450484

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
