### PR TITLE
Fix Pathways Elastic Training Goodput Gaps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @gobbleturk @khatwanimohit @bvandermoon @vipannalla @RissyRan @richjames0 @gagika @shralex @SurbhiJainUSC @hengtaoguo @A9isha @aireenmei @NuojCheng @jiangjy1982 @suexu1025 @NicoGrande @jesselu-google
+* @gobbleturk @khatwanimohit @bvandermoon @vipannalla @RissyRan @richjames0 @gagika @shralex @SurbhiJainUSC @hengtaoguo @A9isha @aireenmei @NuojCheng @jiangjy1982 @suexu1025 @NicoGrande @jesselu-google @dipannita08 @igorts-git
 
 # Model bring-up
 src/MaxText/assets @parambole @shuningjin @RissyRan @suexu1025 @jiangjy1982 @gobbleturk @bvandermoon @gagika @shralex @richjames0 @NicoGrande

--- a/src/maxtext/experimental/rl/grpo_trainer.py
+++ b/src/maxtext/experimental/rl/grpo_trainer.py
@@ -1,4 +1,4 @@
-# Copyright 2023–2025 Google LLC
+# Copyright 2023–2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,9 +74,12 @@ from maxtext.common import checkpointing, profiler
 from maxtext.common.data_loader import DataLoader
 from maxtext.common.goodput import (
     GoodputEvent,
+    RECORD_JOB_END_TIME,
+    RECORD_JOB_START_TIME,
     create_goodput_recorder,
     maybe_monitor_goodput,
     maybe_record_goodput,
+    record_goodput,
 )
 from maxtext.experimental.rl import grpo_input_pipeline
 from maxtext.experimental.rl import grpo_utils
@@ -795,6 +798,7 @@ def train_loop(config, config_inference, recorder, state=None):
   )
   generation_thread.start()
 
+  _job_completed_gracefully = False
   try:
     last_step_completion = datetime.datetime.now()
     for step in np.arange(start_step, config.steps):
@@ -881,9 +885,13 @@ def train_loop(config, config_inference, recorder, state=None):
       elif checkpoint_manager is not None:
         # in case the last checkpoint_period checkpoint is still in progress
         checkpoint_manager.wait_until_finished()
+    _job_completed_gracefully = True
   except exceptions.StopTraining as e:
     max_logging.log(f"Training stopped: {str(e)}")
+    _job_completed_gracefully = True
   finally:
+    if _job_completed_gracefully:
+      record_goodput(recorder, RECORD_JOB_END_TIME)
     metric_logger.flush_metrics_and_cleanup()
     max_logging.log("Training loop finished or exited. Signaling generation worker to stop.")
     stop_event.set()
@@ -955,8 +963,9 @@ def main(argv: Sequence[str]) -> None:
   )
   diagnostic_config = diagnostic_configuration.DiagnosticConfig(debug_config)
 
+  record_goodput(recorder, RECORD_JOB_START_TIME)
   with diagnostic.diagnose(diagnostic_config):
-    with maybe_record_goodput(recorder, GoodputEvent.JOB), maybe_monitor_goodput(config):
+    with maybe_monitor_goodput(config):
       train_loop(config, config_inference, recorder)
 
 

--- a/src/maxtext/trainers/post_train/sft/train_sft.py
+++ b/src/maxtext/trainers/post_train/sft/train_sft.py
@@ -53,9 +53,12 @@ from maxtext.configs import pyconfig
 from maxtext.trainers.pre_train.train import loss_fn
 from maxtext.common.goodput import (
     GoodputEvent,
+    RECORD_JOB_END_TIME,
+    RECORD_JOB_START_TIME,
     create_goodput_recorder,
     maybe_monitor_goodput,
     maybe_record_goodput,
+    record_goodput,
 )
 from maxtext.optimizers import optimizers
 from maxtext.trainers.post_train.sft import hooks
@@ -181,7 +184,13 @@ def train(mt_config, goodput_recorder=None):
     goodput_recorder: An optional GoodputRecorder to record performance metrics.
   """
   trainer, mesh = setup_trainer_state(mt_config, goodput_recorder)
-  trainer = train_model(mt_config, trainer, mesh)
+  _job_completed_gracefully = False
+  try:
+    trainer = train_model(mt_config, trainer, mesh)
+    _job_completed_gracefully = True
+  finally:
+    if _job_completed_gracefully:
+      record_goodput(goodput_recorder, RECORD_JOB_END_TIME)
   return trainer, mesh
 
 
@@ -198,8 +207,8 @@ def main(argv: Sequence[str]) -> None:
   max_utils.print_system_information()
 
   goodput_recorder = create_goodput_recorder(mt_config)
-
-  with maybe_record_goodput(goodput_recorder, GoodputEvent.JOB), maybe_monitor_goodput(mt_config):
+  record_goodput(goodput_recorder, RECORD_JOB_START_TIME)
+  with maybe_monitor_goodput(mt_config):
     train(mt_config, goodput_recorder)
 
 

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -1,4 +1,4 @@
-# Copyright 2023–2025 Google LLC
+# Copyright 2023–2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,9 +48,12 @@ from maxtext.layers.multi_token_prediction import calculate_mtp_acceptance_rate,
 from maxtext.common import checkpointing, profiler
 from maxtext.common.goodput import (
     GoodputEvent,
+    RECORD_JOB_END_TIME,
+    RECORD_JOB_START_TIME,
     create_goodput_recorder,
     maybe_monitor_goodput,
     maybe_record_goodput,
+    record_goodput,
 )
 from maxtext.common.gcloud_stub import cloud_diagnostics as _cloud_diag, is_decoupled
 from maxtext.common.gcloud_stub import vertex_tensorboard_modules
@@ -493,6 +496,7 @@ def train_loop(config, recorder, state=None):
   # Write train config params, num model params, and XLA flags to tensorboard
   metric_logger.write_setup_info_to_tensorboard(state.params)
 
+  _job_completed_gracefully = False
   try:
     last_step_completion = datetime.datetime.now()
     for step in np.arange(start_step, config.steps):
@@ -558,9 +562,13 @@ def train_loop(config, recorder, state=None):
     if checkpoint_manager is not None:
       # in case the last checkpoint_period checkpoint is still in progress
       checkpoint_manager.wait_until_finished()
+    _job_completed_gracefully = True
   except exceptions.StopTraining as e:
     max_logging.log(f"Training stopped: {str(e)}")
+    _job_completed_gracefully = True
   finally:
+    if _job_completed_gracefully:
+      record_goodput(recorder, RECORD_JOB_END_TIME)
     metric_logger.flush_metrics_and_cleanup()
 
   return state
@@ -623,7 +631,6 @@ def run(config, recorder, diagnostic_config):
 
   with (
       diagnostics_context,
-      maybe_record_goodput(recorder, GoodputEvent.JOB),
       max_utils.maybe_get_transformer_engine_context(config),
   ):
     train_loop(config, recorder)
@@ -631,6 +638,7 @@ def run(config, recorder, diagnostic_config):
 
 def main(argv: Sequence[str]) -> None:
   config, recorder, diagnostic_config = initialize(argv)
+  record_goodput(recorder, RECORD_JOB_START_TIME)
   with maybe_monitor_goodput(config):
     run(config, recorder, diagnostic_config)
 

--- a/tests/unit/goodput_utils_test.py
+++ b/tests/unit/goodput_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2023–2025 Google LLC
+# Copyright 2023–2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,15 @@ from unittest import mock
 import pytest
 
 from maxtext.configs import pyconfig
-from maxtext.common.goodput import create_goodput_recorder, maybe_monitor_goodput, maybe_record_goodput, GoodputEvent
+from maxtext.common.goodput import (
+    GoodputEvent,
+    RECORD_JOB_END_TIME,
+    RECORD_JOB_START_TIME,
+    create_goodput_recorder,
+    maybe_monitor_goodput,
+    maybe_record_goodput,
+    record_goodput,
+)
 from tests.utils.test_helpers import get_test_config_path, get_test_base_output_directory
 
 pytestmark = [pytest.mark.external_training]
@@ -79,6 +87,59 @@ class GoodputUtilsTest(unittest.TestCase):
     with maybe_monitor_goodput(self.config):
       mock_start_goodput_uploader.assert_called()
     mock_stop_goodput_uploader.assert_called()
+
+  def test_job_recording_constants(self):
+    """Constants must map to the recorder method names."""
+    self.assertEqual(RECORD_JOB_START_TIME, "record_job_start_time")
+    self.assertEqual(RECORD_JOB_END_TIME, "record_job_end_time")
+
+  @mock.patch("ml_goodput_measurement.goodput.GoodputRecorder.record_job_end_time")
+  @mock.patch("ml_goodput_measurement.goodput.GoodputRecorder.record_job_start_time")
+  @mock.patch("google.cloud.logging.Client")
+  def test_explicit_job_recording_graceful_completion(
+      self, mock_cloud_logger, mock_record_job_start_time, mock_record_job_end_time
+  ):
+    """Both start and end are recorded when the job completes gracefully."""
+    mock_cloud_logger.return_value = mock.MagicMock()
+    recorder = create_goodput_recorder(self.config)
+
+    record_goodput(recorder, RECORD_JOB_START_TIME)
+    _job_completed_gracefully = False
+    try:
+      _job_completed_gracefully = True
+    finally:
+      if _job_completed_gracefully:
+        record_goodput(recorder, RECORD_JOB_END_TIME)
+
+    mock_record_job_start_time.assert_called_once()
+    mock_record_job_end_time.assert_called_once()
+
+  @mock.patch("ml_goodput_measurement.goodput.GoodputRecorder.record_job_end_time")
+  @mock.patch("ml_goodput_measurement.goodput.GoodputRecorder.record_job_start_time")
+  @mock.patch("google.cloud.logging.Client")
+  def test_explicit_job_recording_elastic_restart(
+      self, mock_cloud_logger, mock_record_job_start_time, mock_record_job_end_time
+  ):
+    """Only start is recorded when the elastic manager handles the error internally.
+
+    This simulates the elastic-restart scenario: the manager catches the JAX
+    exception inside train_loop, so the loop exits without raising.  The
+    _job_completed_gracefully flag is never set, so record_job_end_time must
+    not be called.
+    """
+    mock_cloud_logger.return_value = mock.MagicMock()
+    recorder = create_goodput_recorder(self.config)
+
+    record_goodput(recorder, RECORD_JOB_START_TIME)
+    _job_completed_gracefully = False
+    try:
+      pass  # Elastic manager caught and suppressed the exception.
+    finally:
+      if _job_completed_gracefully:
+        record_goodput(recorder, RECORD_JOB_END_TIME)
+
+    mock_record_job_start_time.assert_called_once()
+    mock_record_job_end_time.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

When Pathways elastic training catches a JAX error and triggers a restart, a `job_end_time` entry was being incorrectly written to the goodput log. Occurance of a `job_end_time` prior to the restart is a condition that the library doesn't support (similar to re-using a workload_id for a new unrelated run). This results in undetermined behavior, sometimes resulting in inability to calculate metrics and skipping uploads., which skews goodput and badput metrics for the whole workload.

Changes:
- Job start and end times are now recorded explicitly instead of automatically by a context manager. The `job_end_time` entry is only written when training genuinely completes. Any other exit, including elastic restarts, leaves no end-time log.
- This fix is applied consistently across all trainer entry points: pre-training, SFT (both variants), and GRPO.
- The goodput context manager used for exisiting events (device initialization, data loading, training preparation, step timing) is unchanged.
- Unit tests added to cover graceful completion, elastic restart, and constant correctness.
- Named constants (`RECORD_JOB_START_TIME`, `RECORD_JOB_END_TIME`) replace raw strings so the recorder method names are defined in one place.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/486232512, b/489779448

# Tests
- E2E MaxText run with simulated restarts
- https://screenshot.googleplex.com/B6iZe3bULyfH4Jc
- 
<img width="3426" height="1850" alt="image" src="https://github.com/user-attachments/assets/36ba22dc-cb94-4c41-93f5-01ecc7c87489" />

- Unit Tests
- Github CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
