### PR TITLE
Add tpu_backend test marker for tests requiring TPU-enabled jaxlib

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -24,6 +24,7 @@ addopts =
     --ignore=tests/unit/engram_vs_reference_test.py
 markers =
     tpu_only: marks tests to be run on TPUs only
+    tpu_backend: marks tests that require a TPU-enabled JAX install (TPU PJRT plugin), but not TPU hardware
     gpu_only: marks tests to be run on GPUs only
     cpu_only: marks tests to be run on CPUs only
     decoupled: tests that validate offline / DECOUPLE_GCLOUD=TRUE mode.

--- a/tests/unit/sharding_compare_test.py
+++ b/tests/unit/sharding_compare_test.py
@@ -33,6 +33,8 @@ import pytest
 
 Transformer = models.transformer_as_linen
 
+pytestmark = [pytest.mark.cpu_only, pytest.mark.tpu_backend]
+
 
 def compute_checksum(d: dict) -> str:
   """Compute a checksum (SHA256) of a dictionary."""

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -28,7 +28,7 @@ import pytest
 from maxtext.trainers.pre_train.train_compile import main as train_compile_main
 from tests.utils.test_helpers import get_test_config_path
 
-pytestmark = [pytest.mark.external_training]
+pytestmark = [pytest.mark.external_training, pytest.mark.tpu_backend]
 
 
 class TrainCompile(unittest.TestCase):


### PR DESCRIPTION
# Description

- Add a new pytest marker, tpu_backend, for tests that do not require TPU hardware but do require a TPU-enabled JAX install (TPU PJRT plugin) to generate TPU topologies (e.g. via jax.experimental.topologies / xb.make_pjrt_tpu_topology).
- Implement collection-time skipping for tpu_backend when TPU support is not present in the JAX install, with a clear skip reason explaining how to run them.
- Mark TPU-topology sharding/compile tests as cpu_only + tpu_backend so they don’t run in GPU test jobs while remaining runnable in CPU environments that have TPU-enabled JAX.

# Motivation / Context

- Some “unit” tests parameterize TPU topologies (e.g. tpu7x-*, v6e-*, v5p-*) and call get_topology_mesh(), which triggers TPU topology generation via the PJRT TPU plugin. On CPU/GPU environments with a non-TPU JAX build this fails with:
`RuntimeError: JAX TPU support not installed; cannot generate TPU topology.`
- These tests should not require TPU-enabled JAX in standard CPU/GPU CI runs unless explicitly intended.

# Changes

- New marker: tpu_backend (registered in pytest.ini and tests/conftest.py)
- Skip logic: skip tpu_backend tests when TPU PJRT plugin is not available in the installed jaxlib

# Updated tests:

- tests/unit/sharding_compare_test.py: add pytestmark = [cpu_only, tpu_backend]
- tests/unit/train_compile_test.py: add tpu_backend at module level (tests already cpu_only)

# Tests

`python3 -m pytest -q -rs -m "tpu_backend"  tests/unit/sharding_compare_test.py  tests/unit/train_compile_test.py`

All tests skipped with "Skipped: requires a TPU-enabled JAX install (TPU PJRT plugin). Install a TPU-enabled jax/jaxlib build to run this test." message.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
