### PR TITLE
Fix parsing regex for RL

### DIFF
--- a/src/maxtext/trainers/post_train/rl/utils_rl.py
+++ b/src/maxtext/trainers/post_train/rl/utils_rl.py
@@ -108,7 +108,6 @@ def get_match_format_regex(tmvp_config):
           r"^[\s]{0,}"
           rf"{tmvp_config.reasoning_start_token}.+?{tmvp_config.reasoning_end_token}.*?"
           rf"{tmvp_config.solution_start_token}(.+?){tmvp_config.solution_end_token}"
-          r"[\s]{0,}$"
       ),
       flags=re.MULTILINE | re.DOTALL,
   )
@@ -308,7 +307,7 @@ def fix_latex_escaping(text: str) -> str:
       ("\t", "imes", r"\times"),  # \t (tab) → \times
       ("\t", "ext", r"\text"),  # \t (tab) → \text
       ("\t", "extbf", r"\textbf"),  # \t (tab) → \textbf
-      ("\t", "extit", r"\textit"),  # \t (tab) → \textit
+      ("\t", "extit", r"\textit"),  # \t (tab) → \textit  # codespell:ignore
       ("\r", "ightarrow", r"\rightarrow"),  # \r (carriage return) → \rightarrow
       ("\r", "ightarrow", r"\Rightarrow"),  # \r (carriage return) → \Rightarrow (capital R handled separately)
       ("\b", "eta", r"\beta"),  # \b (backspace) → \beta


### PR DESCRIPTION
# Description

In our previous parsing regex function `get_match_format_regex` in utils_rl.py, `get_match_format_regex` was enforcing that the string must end (with optional whitespace) immediately after the solution_end_token (e.g., </answer>). When the response contains <end_of_turn> or other tokens after the answer, the regex fails to match, causing score_responses to fail extraction.

To fix this, we need remove the strict end-of-string anchor r"[\s]{0,}$" from the regex. This will allow the regex to match the reasoning and answer structure regardless of what follows it.

FIXES: b/487394329

# Tests

Locally tested samples of parsing which were failing previously

```
question = "James buys a new wardrobe.  He buys 10 suits and 10 dress pants.  He also buys 3 dress shirts per suit.  The suits cost $750 each and the dress pants cost 1/5 that cost.  The dress shirts were $60 each.  How much did everything cost?"
answer = "1170"
responses = ['<reasoning>\nThe problem states that James buys a ring with a diamond costing $600 and gold costing $300. The total cost of the materials is $600 + $300 = $900. He pays a 30% premium on this total cost. To find the premium amount, we calculate 30% of $900, which is 0.30 * $900 = $270.  The total amount he pays is the original cost plus the premium, so $900 + $270 = $1170.\n\n</reasoning>\n<answer>1170</answer><end_of_turn>']

is_correct, is_partially_correct, has_correct_format = score_responses(trainer_config, question, responses, answer)
print(f"{is_correct=}, {is_partially_correct=}, {has_correct_format=}")
```

Outputs:
```
is_correct=True, is_partially_correct=True, has_correct_format=True
```
As well as RL train command

```
python3 -m src.maxtext.trainers.post_train.rl.train_rl src/maxtext/configs/post_train/rl.yml  \
 model_name=llama3.1-8b   tokenizer_path=meta-llama/Llama-3.1-8B-Instruct   load_parameters_path=/path/to/checkpoint \
  run_name=maz-8b-$RANDOM   base_output_directory=/path/to/gcs  \
 hf_access_token=$HF_TOKEN dataset_name=gsm8k steps=4 2>&1 | tee logs_ll_gsm8k.txt

```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
