### PR TITLE
PR #3249: Move MaxText.globals

### DIFF
--- a/src/MaxText/get_flops.py
+++ b/src/MaxText/get_flops.py
@@ -15,7 +15,7 @@
 """ A wrapper file for easily calculating training TFLOPs. """
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from maxtext.utils.maxtext_utils import calculate_tflops_training_per_device
 import os
 from typing import Sequence, cast

--- a/src/MaxText/pyconfig.py
+++ b/src/MaxText/pyconfig.py
@@ -29,7 +29,7 @@ import jax.numpy as jnp
 import omegaconf
 
 from MaxText import pyconfig_deprecated
-from MaxText.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
 from maxtext.common.common_types import DecoderBlockType, ShardMode
 from maxtext.configs import types
 from maxtext.configs.types import MaxTextConfig

--- a/src/MaxText/pyconfig_deprecated.py
+++ b/src/MaxText/pyconfig_deprecated.py
@@ -29,7 +29,7 @@ from jax.tree_util import register_pytree_node_class
 import omegaconf
 
 from MaxText import accelerator_to_spec_map
-from MaxText.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_REPO_ROOT, MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_REPO_ROOT, MAXTEXT_PKG_DIR
 from maxtext.common.common_types import AttentionType, DecoderBlockType, ShardMode
 from maxtext.utils import gcs_utils
 from maxtext.utils import max_logging

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_gpt3_ckpt_from_paxml.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_gpt3_ckpt_from_paxml.py
@@ -43,7 +43,7 @@ import jax
 from jax import random
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from maxtext.common import checkpointing
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.layers import quantizations

--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -22,7 +22,7 @@ import datetime
 from etils import epath
 from flax.training import train_state
 import jax
-from MaxText.globals import DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE
+from maxtext.utils.globals import DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE
 from maxtext.input_pipeline.multihost_dataloading import MultiHostDataLoadIterator
 from maxtext.input_pipeline.multihost_dataloading import RemoteIterator
 from maxtext.input_pipeline.synthetic_data_processing import PlaceHolderDataIterator

--- a/src/maxtext/common/metric_logger.py
+++ b/src/maxtext/common/metric_logger.py
@@ -25,7 +25,7 @@ import numpy as np
 
 import jax
 
-from MaxText.globals import EPS
+from maxtext.utils.globals import EPS
 from maxtext.common.gcloud_stub import mldiagnostics_modules
 from maxtext.common.gcloud_stub import workload_monitor
 from maxtext.common.managed_mldiagnostics import ManagedMLDiagnostics

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -30,8 +30,8 @@ import jax
 from maxtext.common.common_types import AttentionType, DecoderBlockType, ShardMode
 from maxtext.utils import gcs_utils
 from maxtext.utils import max_utils
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from MaxText import accelerator_to_spec_map
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
 from pydantic.config import ConfigDict
 from pydantic.fields import Field
 from pydantic.functional_validators import field_validator, model_validator

--- a/src/maxtext/examples/sft_llama3_demo.ipynb
+++ b/src/maxtext/examples/sft_llama3_demo.ipynb
@@ -1,388 +1,429 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/AI-Hypercomputer/maxtext/blob/main/src/maxtext/examples/sft_llama3_demo.ipynb)\n",
-    "\n",
-    "# Llama3.1-8B-Instruct Supervised Fine-Tuning (SFT) Demo\n"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "iBmRfde4Kgv4"
+      },
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/AI-Hypercomputer/maxtext/blob/main/src/maxtext/examples/sft_llama3_demo.ipynb)\n",
+        "\n",
+        "# Llama3.1-8B-Instruct Supervised Fine-Tuning (SFT) Demo\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "x8QDt1zoKgv4"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "This notebook demonstrates how to perform Supervised Fine-Tuning (SFT) on Llama3.1-8B-Instruct using the Hugging Face ultrachat_200k dataset with MaxText and Tunix integration for efficient training.\n",
+        "\n",
+        "This notebook can run on **TPU v6e-8** or **v5p-8**."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SDLlkqKJKgv4"
+      },
+      "source": [
+        "## Prerequisites\n",
+        "\n",
+        "### Change Runtime Type (only if running on Google Colab)\n",
+        "\n",
+        "**Instructions:**\n",
+        "1.  Navigate to the menu at the top of the screen.\n",
+        "2.  Click on **Runtime**.\n",
+        "3.  Select **Change runtime type** from the dropdown menu.\n",
+        "4.  Select **v6e-8** or **v5p-8 TPU** as the **Hardware accelerator**.\n",
+        "5. Click on **Save**."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Du2WAe9JKgv4"
+      },
+      "source": [
+        "### Get Your Hugging Face Token\n",
+        "\n",
+        "To access model checkpoint from the Hugging Face Hub, you need to authenticate with a personal access token.\n",
+        "\n",
+        "**Follow these steps to get your token:**\n",
+        "\n",
+        "1.  **Navigate to the Access Tokens page** in your Hugging Face account settings. You can go there directly by visiting this URL:\n",
+        "    *   [https://huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)\n",
+        "\n",
+        "2.  **Create a new token** by clicking the **\"+ Create new token\"** button.\n",
+        "\n",
+        "3.  **Give your token a name** and assign it a **`read` role**. The `read` role is sufficient for downloading models.\n",
+        "\n",
+        "4.  **Copy the generated token**. You will need this in the later steps.\n",
+        "\n",
+        "**Follow these steps to store your token (only if running on Google Colab):**\n",
+        "\n",
+        "1. On the left sidebar of your Colab window, click the key icon (the Secrets tab).\n",
+        "\n",
+        "2. Click **\"+ Add new secret\"**.\n",
+        "\n",
+        "3. Set the Name as **HF_TOKEN**.\n",
+        "\n",
+        "4. Paste your token into the Value field.\n",
+        "\n",
+        "5. Ensure the Notebook access toggle is turned On."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "__TGXwlkKgv4"
+      },
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "  from google.colab import userdata\n",
+        "  print(\"Running the notebook on Google Colab\")\n",
+        "  IN_COLAB = True\n",
+        "except ImportError:\n",
+        "    print(\"Running the notebook on Visual Studio or JupyterLab\")\n",
+        "    IN_COLAB = False"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yuvt9qDPKgv4"
+      },
+      "source": [
+        "### Installation: MaxText & Other Dependencies"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fh72UTvUKgv4"
+      },
+      "source": [
+        "**⚠️ Note:** The installation process in following cell may take a few minutes to complete. Please be patient."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "YGhCeyj6Kgv4"
+      },
+      "outputs": [],
+      "source": [
+        "if IN_COLAB:\n",
+        "    !git clone https://github.com/AI-Hypercomputer/maxtext.git\n",
+        "    %cd /content/maxtext\n",
+        "\n",
+        "    # Install uv, a fast Python package installer\n",
+        "    !pip install uv\n",
+        "\n",
+        "    # Install MaxText and its dependencies\n",
+        "    !uv pip install -e .[tpu] --resolution=lowest\n",
+        "    !python3 -m MaxText.install_maxtext_extra_deps"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xywQLus-Kgv5"
+      },
+      "source": [
+        "### Restart Session (only if running on Google Colab)\n",
+        "To apply certain changes, you need to restart the session.\n",
+        "\n",
+        "**Instructions:**\n",
+        "1.  Navigate to the menu at the top of the screen.\n",
+        "2.  Click on **Runtime**.\n",
+        "3.  Select **Restart session** from the dropdown menu.\n",
+        "\n",
+        "You will be asked to confirm the action in a pop-up dialog. Click on **Yes**."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "o_w4iLJyKgv5"
+      },
+      "source": [
+        "## Environment Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "BXLzWnjUKgv5",
+        "language": "python"
+      },
+      "outputs": [],
+      "source": [
+        "import datetime\n",
+        "import os\n",
+        "from MaxText import pyconfig\n",
+        "from maxtext.utils.globals import MAXTEXT_PKG_DIR\n",
+        "from maxtext.trainers.post_train.sft import train_sft\n",
+        "import jax\n",
+        "from huggingface_hub import login\n",
+        "\n",
+        "\n",
+        "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "goXDCIB4Kgv5"
+      },
+      "outputs": [],
+      "source": [
+        "if not jax.distributed.is_initialized():\n",
+        "  jax.distributed.initialize()\n",
+        "print(f\"JAX version: {jax.__version__}\")\n",
+        "print(f\"JAX devices: {jax.devices()}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "dzMQJ6RXKgv5"
+      },
+      "outputs": [],
+      "source": [
+        "if IN_COLAB:\n",
+        "    HF_TOKEN = userdata.get(\"HF_TOKEN\")\n",
+        "else:\n",
+        "    HF_TOKEN = os.environ.get(\"HF_TOKEN\", \"\")\n",
+        "\n",
+        "# If not found in the environment, prompt the user for input securely\n",
+        "# getpass function ensures the token is hidden while you type\n",
+        "if not HF_TOKEN:\n",
+        "    from getpass import getpass\n",
+        "    HF_TOKEN = getpass(\"Hugging Face token not found in environment. Please enter it here: \")\n",
+        "\n",
+        "if HF_TOKEN:\n",
+        "    login(token=HF_TOKEN)\n",
+        "    print(\"Authenticated with Hugging Face successfully!\")\n",
+        "else:\n",
+        "    print(\"Authentication failed: Hugging Face token is not set.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "v2evOnbOKgv5"
+      },
+      "source": [
+        "## Model Configurations"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pdvqPIB_Kgv5"
+      },
+      "outputs": [],
+      "source": [
+        "MODEL_NAME = \"llama3.1-8b\"\n",
+        "TOKENIZER_PATH = \"meta-llama/Llama-3.1-8B-Instruct\"\n",
+        "\n",
+        "# set the path to the model checkpoint or leave empty to download from HuggingFace\n",
+        "MODEL_CHECKPOINT_PATH = \"\"\n",
+        "if not MODEL_CHECKPOINT_PATH:\n",
+        "   MODEL_CHECKPOINT_PATH = f\"{MAXTEXT_PKG_DIR}/llama_checkpoint\"\n",
+        "   print(\"Model checkpoint will be downloaded from HuggingFace at: \",  MODEL_CHECKPOINT_PATH)\n",
+        "   print(\"Set MODEL_CHECKPOINT_PATH if you do not wish to download the checkpoint.\")\n",
+        "\n",
+        "BASE_OUTPUT_DIRECTORY = f\"{MAXTEXT_PKG_DIR}/sft_llama3_output\"\n",
+        "RUN_NAME = datetime.datetime.now().strftime(\"%Y-%m-%d-%H-%M-%S\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "w8hpE43wKgv5"
+      },
+      "source": [
+        "## Download Llama3.1-8B Model Checkpoint from Hugging Face"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "uupzLQl5Kgv5"
+      },
+      "outputs": [],
+      "source": [
+        "if not os.path.exists(MODEL_CHECKPOINT_PATH):\n",
+        "    import subprocess\n",
+        "    import sys\n",
+        "\n",
+        "    # Install torch for the conversion script\n",
+        "    print(\"Installing torch...\")\n",
+        "    subprocess.run(\n",
+        "        [\n",
+        "            sys.executable, \"-m\", \"pip\", \"install\",\n",
+        "            \"torch\", \"--index-url\", \"https://download.pytorch.org/whl/cpu\"\n",
+        "        ],\n",
+        "        check=True\n",
+        "    )\n",
+        "\n",
+        "    # Run checkpoint conversion with environment variables\n",
+        "    print(\"Converting checkpoint from HuggingFace...\")\n",
+        "    env = os.environ.copy()\n",
+        "    env[\"JAX_PLATFORMS\"] = \"cpu\"\n",
+        "    # env[\"PYTHONPATH\"] = MAXTEXT_PKG_DIR\n",
+        "\n",
+        "    subprocess.run(\n",
+        "        [\n",
+        "            sys.executable,\n",
+        "            \"-m\", \"maxtext.checkpoint_conversion.to_maxtext\",\n",
+        "            f\"{MAXTEXT_PKG_DIR}/configs/base.yml\",\n",
+        "            f\"model_name={MODEL_NAME}\",\n",
+        "            f\"base_output_directory={MODEL_CHECKPOINT_PATH}\",\n",
+        "            f\"hf_access_token={HF_TOKEN}\",\n",
+        "            \"use_multimodal=false\",\n",
+        "            \"scan_layers=true\",\n",
+        "            \"skip_jax_distributed_system=True\",\n",
+        "        ],\n",
+        "        check=True,\n",
+        "        env=env\n",
+        "    )\n",
+        "\n",
+        "if not os.path.exists(MODEL_CHECKPOINT_PATH):\n",
+        "    raise ValueError(\"Model checkpoint conversion failed. Check the logs above.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tFlbPuOAKgv6"
+      },
+      "source": [
+        "## MaxText Configurations"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "In-jdp1AAwrL"
+      },
+      "outputs": [],
+      "source": [
+        "# Load configuration for SFT training\n",
+        "config_argv = [\n",
+        "    \"\",\n",
+        "    f\"{MAXTEXT_PKG_DIR}/configs/post_train/sft.yml\",\n",
+        "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}/0/items\",\n",
+        "    f\"model_name={MODEL_NAME}\",\n",
+        "    \"steps=100\",\n",
+        "    \"per_device_batch_size=1\",\n",
+        "    \"max_target_length=1024\",\n",
+        "    \"learning_rate=2.0e-5\",\n",
+        "    \"weight_dtype=bfloat16\",\n",
+        "    \"dtype=bfloat16\",\n",
+        "    \"hf_path=HuggingFaceH4/ultrachat_200k\",\n",
+        "    f\"hf_access_token={HF_TOKEN}\",\n",
+        "    f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
+        "    f\"run_name={RUN_NAME}\",\n",
+        "    f\"tokenizer_path={TOKENIZER_PATH}\",\n",
+        "    \"profiler=xplane\",\n",
+        "]\n",
+        "\n",
+        "config = pyconfig.initialize(config_argv)\n",
+        "\n",
+        "print(\"✓ SFT configuration loaded:\")\n",
+        "print(f\" Model: {config.model_name}\")\n",
+        "print(f\" Training Steps: {config.steps}\")\n",
+        "print(f\" Output Directory: {config.base_output_directory}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fFSQOH3CKgv6"
+      },
+      "source": [
+        "## SFT Training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "mgwpNgQYCJEd"
+      },
+      "outputs": [],
+      "source": [
+        "print(\"=\" * 60)\n",
+        "print(\"🚀 Starting SFT Training...\")\n",
+        "print(\"=\" * 60)\n",
+        "\n",
+        "try:\n",
+        "    trainer, mesh = train_sft.train(config)\n",
+        "\n",
+        "    print(\"\\n\" + \"=\" * 60)\n",
+        "    print(\"✅ Training Completed Successfully!\")\n",
+        "    print(\"=\" * 60)\n",
+        "    print(f\"📁 Checkpoints saved to: {config.checkpoint_dir}\")\n",
+        "except Exception as e:\n",
+        "    print(\"\\n\" + \"=\" * 60)\n",
+        "    print(\"❌Training Failed!\")\n",
+        "    print(\"=\" * 60)\n",
+        "    print(f\"Error: {str(e)}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vzW1NXX6Kgv6"
+      },
+      "source": [
+        "## 📚 Learn More\n",
+        "\n",
+        "- **CLI Usage**: https://maxtext.readthedocs.io/en/latest/tutorials/posttraining/sft.html\n",
+        "- **Configuration**: See `src/maxtext/configs/post_train/sft.yml` for all available options\n",
+        "- **Documentation**: Check `src/MaxText/sft/sft_trainer.py` for the `sft_train` function implementation"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "gpuType": "V5E1",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.2"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Overview\n",
-    "\n",
-    "This notebook demonstrates how to perform Supervised Fine-Tuning (SFT) on Llama3.1-8B-Instruct using the Hugging Face ultrachat_200k dataset with MaxText and Tunix integration for efficient training.\n",
-    "\n",
-    "This notebook can run on **TPU v6e-8** or **v5p-8**."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Prerequisites\n",
-    "\n",
-    "### Change Runtime Type (only if running on Google Colab)\n",
-    "\n",
-    "**Instructions:**\n",
-    "1.  Navigate to the menu at the top of the screen.\n",
-    "2.  Click on **Runtime**.\n",
-    "3.  Select **Change runtime type** from the dropdown menu.\n",
-    "4.  Select **v6e-8** or **v5p-8 TPU** as the **Hardware accelerator**.\n",
-    "5. Click on **Save**."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Get Your Hugging Face Token\n",
-    "\n",
-    "To access model checkpoint from the Hugging Face Hub, you need to authenticate with a personal access token.\n",
-    "\n",
-    "**Follow these steps to get your token:**\n",
-    "\n",
-    "1.  **Navigate to the Access Tokens page** in your Hugging Face account settings. You can go there directly by visiting this URL:\n",
-    "    *   [https://huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)\n",
-    "\n",
-    "2.  **Create a new token** by clicking the **\"+ Create new token\"** button.\n",
-    "\n",
-    "3.  **Give your token a name** and assign it a **`read` role**. The `read` role is sufficient for downloading models.\n",
-    "\n",
-    "4.  **Copy the generated token**. You will need this in the later steps.\n",
-    "\n",
-    "**Follow these steps to store your token (only if running on Google Colab):**\n",
-    "\n",
-    "1. On the left sidebar of your Colab window, click the key icon (the Secrets tab).\n",
-    "\n",
-    "2. Click **\"+ Add new secret\"**.\n",
-    "\n",
-    "3. Set the Name as **HF_TOKEN**.\n",
-    "\n",
-    "4. Paste your token into the Value field.\n",
-    "\n",
-    "5. Ensure the Notebook access toggle is turned On."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "  from google.colab import userdata\n",
-    "  print(\"Running the notebook on Google Colab\")\n",
-    "  IN_COLAB = True\n",
-    "except ImportError:\n",
-    "    print(\"Running the notebook on Visual Studio or JupyterLab\")\n",
-    "    IN_COLAB = False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Installation: MaxText & Other Dependencies"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**⚠️ Note:** The installation process in following cell may take a few minutes to complete. Please be patient."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if IN_COLAB:\n",
-    "    !git clone https://github.com/AI-Hypercomputer/maxtext.git\n",
-    "    %cd /content/maxtext\n",
-    "\n",
-    "    # Install uv, a fast Python package installer\n",
-    "    !pip install uv\n",
-    "\n",
-    "    # Install MaxText and its dependencies\n",
-    "    !uv pip install -e .[tpu] --resolution=lowest\n",
-    "    !python3 -m MaxText.install_maxtext_extra_deps"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Restart Session (only if running on Google Colab)\n",
-    "To apply certain changes, you need to restart the session.\n",
-    "\n",
-    "**Instructions:**\n",
-    "1.  Navigate to the menu at the top of the screen.\n",
-    "2.  Click on **Runtime**.\n",
-    "3.  Select **Restart session** from the dropdown menu.\n",
-    "\n",
-    "You will be asked to confirm the action in a pop-up dialog. Click on **Yes**."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Environment Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import datetime\n",
-    "import os\n",
-    "from MaxText import pyconfig\n",
-    "from MaxText.globals import MAXTEXT_PKG_DIR\n",
-    "from maxtext.trainers.post_train.sft import train_sft\n",
-    "import jax\n",
-    "from huggingface_hub import login\n",
-    "\n",
-    "\n",
-    "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if not jax.distributed.is_initialized():\n",
-    "  jax.distributed.initialize()\n",
-    "print(f\"JAX version: {jax.__version__}\")\n",
-    "print(f\"JAX devices: {jax.devices()}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if IN_COLAB:\n",
-    "    HF_TOKEN = userdata.get(\"HF_TOKEN\")\n",
-    "else:\n",
-    "    HF_TOKEN = os.environ.get(\"HF_TOKEN\", \"\")\n",
-    "\n",
-    "# If not found in the environment, prompt the user for input securely\n",
-    "# getpass function ensures the token is hidden while you type\n",
-    "if not HF_TOKEN:\n",
-    "    from getpass import getpass\n",
-    "    HF_TOKEN = getpass(\"Hugging Face token not found in environment. Please enter it here: \")\n",
-    "\n",
-    "if HF_TOKEN:\n",
-    "    login(token=HF_TOKEN)\n",
-    "    print(\"Authenticated with Hugging Face successfully!\")\n",
-    "else:\n",
-    "    print(\"Authentication failed: Hugging Face token is not set.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Model Configurations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "MODEL_NAME = \"llama3.1-8b\"\n",
-    "TOKENIZER_PATH = \"meta-llama/Llama-3.1-8B-Instruct\"\n",
-    "\n",
-    "# set the path to the model checkpoint or leave empty to download from HuggingFace\n",
-    "MODEL_CHECKPOINT_PATH = \"\"\n",
-    "if not MODEL_CHECKPOINT_PATH:\n",
-    "   MODEL_CHECKPOINT_PATH = f\"{MAXTEXT_PKG_DIR}/llama_checkpoint\"\n",
-    "   print(\"Model checkpoint will be downloaded from HuggingFace at: \",  MODEL_CHECKPOINT_PATH)\n",
-    "   print(\"Set MODEL_CHECKPOINT_PATH if you do not wish to download the checkpoint.\")\n",
-    "\n",
-    "BASE_OUTPUT_DIRECTORY = f\"{MAXTEXT_PKG_DIR}/sft_llama3_output\"\n",
-    "RUN_NAME = datetime.datetime.now().strftime(\"%Y-%m-%d-%H-%M-%S\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Download Llama3.1-8B Model Checkpoint from Hugging Face"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if not os.path.exists(MODEL_CHECKPOINT_PATH):\n",
-    "    import subprocess\n",
-    "    import sys\n",
-    "\n",
-    "    # Install torch for the conversion script\n",
-    "    print(\"Installing torch...\")\n",
-    "    subprocess.run(\n",
-    "        [\n",
-    "            sys.executable, \"-m\", \"pip\", \"install\",\n",
-    "            \"torch\", \"--index-url\", \"https://download.pytorch.org/whl/cpu\"\n",
-    "        ],\n",
-    "        check=True\n",
-    "    )\n",
-    "\n",
-    "    # Run checkpoint conversion with environment variables\n",
-    "    print(\"Converting checkpoint from HuggingFace...\")\n",
-    "    env = os.environ.copy()\n",
-    "    env[\"JAX_PLATFORMS\"] = \"cpu\"\n",
-    "    # env[\"PYTHONPATH\"] = MAXTEXT_PKG_DIR\n",
-    "\n",
-    "    subprocess.run(\n",
-    "        [\n",
-    "            sys.executable,\n",
-    "            \"-m\", \"maxtext.checkpoint_conversion.to_maxtext\",\n",
-    "            f\"{MAXTEXT_PKG_DIR}/configs/base.yml\",\n",
-    "            f\"model_name={MODEL_NAME}\",\n",
-    "            f\"base_output_directory={MODEL_CHECKPOINT_PATH}\",\n",
-    "            f\"hf_access_token={HF_TOKEN}\",\n",
-    "            \"use_multimodal=false\",\n",
-    "            \"scan_layers=true\",\n",
-    "            \"skip_jax_distributed_system=True\",\n",
-    "        ],\n",
-    "        check=True,\n",
-    "        env=env\n",
-    "    )\n",
-    "\n",
-    "if not os.path.exists(MODEL_CHECKPOINT_PATH):\n",
-    "    raise ValueError(\"Model checkpoint conversion failed. Check the logs above.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## MaxText Configurations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "In-jdp1AAwrL"
-   },
-   "outputs": [],
-   "source": [
-    "# Load configuration for SFT training\n",
-    "config_argv = [\n",
-    "    \"\",\n",
-    "    f\"{MAXTEXT_PKG_DIR}/configs/post_train/sft.yml\",\n",
-    "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}/0/items\",\n",
-    "    f\"model_name={MODEL_NAME}\",\n",
-    "    \"steps=100\",\n",
-    "    \"per_device_batch_size=1\",\n",
-    "    \"max_target_length=1024\",\n",
-    "    \"learning_rate=2.0e-5\",\n",
-    "    \"weight_dtype=bfloat16\",\n",
-    "    \"dtype=bfloat16\",\n",
-    "    \"hf_path=HuggingFaceH4/ultrachat_200k\",\n",
-    "    f\"hf_access_token={HF_TOKEN}\",\n",
-    "    f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
-    "    f\"run_name={RUN_NAME}\",\n",
-    "    f\"tokenizer_path={TOKENIZER_PATH}\",\n",
-    "    \"profiler=xplane\",\n",
-    "]\n",
-    "\n",
-    "config = pyconfig.initialize(config_argv)\n",
-    "\n",
-    "print(\"✓ SFT configuration loaded:\")\n",
-    "print(f\" Model: {config.model_name}\")\n",
-    "print(f\" Training Steps: {config.steps}\")\n",
-    "print(f\" Output Directory: {config.base_output_directory}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## SFT Training"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "mgwpNgQYCJEd"
-   },
-   "outputs": [],
-   "source": [
-    "print(\"=\" * 60)\n",
-    "print(\"🚀 Starting SFT Training...\")\n",
-    "print(\"=\" * 60)\n",
-    "\n",
-    "try:\n",
-    "    trainer, mesh = train_sft.train(config)\n",
-    "\n",
-    "    print(\"\\n\" + \"=\" * 60)\n",
-    "    print(\"✅ Training Completed Successfully!\")\n",
-    "    print(\"=\" * 60)\n",
-    "    print(f\"📁 Checkpoints saved to: {config.checkpoint_dir}\")\n",
-    "except Exception as e:\n",
-    "    print(\"\\n\" + \"=\" * 60)\n",
-    "    print(\"❌Training Failed!\")\n",
-    "    print(\"=\" * 60)\n",
-    "    print(f\"Error: {str(e)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 📚 Learn More\n",
-    "\n",
-    "- **CLI Usage**: https://maxtext.readthedocs.io/en/latest/tutorials/posttraining/sft.html\n",
-    "- **Configuration**: See `src/maxtext/configs/post_train/sft.yml` for all available options\n",
-    "- **Documentation**: Check `src/MaxText/sft/sft_trainer.py` for the `sft_train` function implementation"
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "TPU",
-  "colab": {
-   "gpuType": "V5E1",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.2"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/src/maxtext/examples/sft_train_and_evaluate.py
+++ b/src/maxtext/examples/sft_train_and_evaluate.py
@@ -86,7 +86,7 @@ import transformers
 from flax import nnx
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_REPO_ROOT
+from maxtext.utils.globals import MAXTEXT_REPO_ROOT
 from maxtext.integration.tunix.tunix_adapter import TunixMaxTextAdapter
 from maxtext.input_pipeline import instruction_data_processing
 from maxtext.trainers.post_train.sft import train_sft

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/utils/save_param.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/utils/save_param.py
@@ -28,7 +28,7 @@ import argparse
 from transformers import AutoModelForCausalLM, AutoConfig
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from maxtext.inference.maxengine import maxengine
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils

--- a/src/maxtext/experimental/rl/grpo_trainer.py
+++ b/src/maxtext/experimental/rl/grpo_trainer.py
@@ -68,7 +68,7 @@ from ml_goodput_measurement.src.goodput import GoodputRecorder
 
 import MaxText as mt
 from MaxText import pyconfig
-from MaxText.globals import EPS
+from maxtext.utils.globals import EPS
 from maxtext.trainers.pre_train.train import get_first_step
 from maxtext.common import checkpointing, profiler
 from maxtext.common.data_loader import DataLoader

--- a/src/maxtext/inference/maxengine/maxengine.py
+++ b/src/maxtext/inference/maxengine/maxengine.py
@@ -37,7 +37,7 @@ from flax.linen import partitioning as nn_partitioning
 import flax
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from maxtext.models import models
 from maxtext.layers import quantizations
 from maxtext.inference import inference_utils
@@ -1747,7 +1747,10 @@ def create_engine_from_config_flags(
   assert "load_parameters_path" in args, "load_parameters_path must be defined"
   if maxengine_config_filepath is None:
     maxengine_config_filepath = os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")
-  updated_args = [os.path.join(MAXTEXT_PKG_DIR, "inference", "maxengine", "maxengine_server.py"), maxengine_config_filepath]
+  updated_args = [
+      os.path.join(MAXTEXT_PKG_DIR, "inference", "maxengine", "maxengine_server.py"),
+      maxengine_config_filepath,
+  ]
   for k, v in args.items():
     option = f"{k}={v}"
     updated_args.append(option)

--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -22,7 +22,7 @@ import flax.linen as nn
 from jax import numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
 from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE
 from maxtext.utils import max_logging
 from maxtext.utils import model_creation_utils

--- a/src/maxtext/layers/multi_token_prediction.py
+++ b/src/maxtext/layers/multi_token_prediction.py
@@ -22,7 +22,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from maxtext.common.common_types import Config, MODEL_MODE_TRAIN
-from MaxText.globals import EPS
+from maxtext.utils.globals import EPS
 from maxtext.layers import nnx_wrappers
 from maxtext.layers.decoders import DecoderLayer
 from maxtext.layers.initializers import variable_to_logically_partitioned
@@ -126,7 +126,6 @@ class MultiTokenPredictionLayer(nnx.Module):
         model_mode=MODEL_MODE_TRAIN,
     )
 
-
   @property
   def embedding_norm(self):
     return getattr(self, f"mtp_{self.layer_number}_embedding_norm")
@@ -158,7 +157,6 @@ class MultiTokenPredictionLayer(nnx.Module):
   @transformer_layer.setter
   def transformer_layer(self, module):
     setattr(self, f"mtp_{self.layer_number}_transformer_layer", module)
-
 
   def __call__(
       self,

--- a/src/maxtext/scratch_code/demo_from_config.ipynb
+++ b/src/maxtext/scratch_code/demo_from_config.ipynb
@@ -18,7 +18,7 @@
         "import os\n",
         "import sys\n",
         "\n",
-        "from MaxText.globals import MAXTEXT_REPO_ROOT\n",
+        "from maxtext.utils.globals import MAXTEXT_REPO_ROOT\n",
         "\n",
         "# Add the project root to the system path if it's not already there\n",
         "if MAXTEXT_REPO_ROOT not in sys.path:\n",
@@ -477,7 +477,7 @@
         }
       ],
       "source": [
-        "from MaxText.globals import MAXTEXT_PKG_DIR\n",
+        "from maxtext.utils.globals import MAXTEXT_PKG_DIR\n",
         "\n",
         "config = pyconfig.initialize(\n",
         "    [os.path.join(MAXTEXT_PKG_DIR, \"decode.py\"), os.path.join(MAXTEXT_PKG_DIR, \"configs\", \"base.yml\")],\n",
@@ -518,7 +518,7 @@
         }
       ],
       "source": [
-        "from MaxText.globals import MAXTEXT_ASSETS_ROOT\n",
+        "from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT\n",
         "\n",
         "source_tokenizer = _input_pipeline_utils.get_tokenizer(\n",
         "    os.path.join(MAXTEXT_ASSETS_ROOT, \"tokenizers\", \"tokenizer_llama3.tiktoken\"),\n",

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -72,7 +72,7 @@ from tunix.sft import metrics_logger, profiler
 os.environ["SKIP_JAX_PRECOMPILE"] = "1"
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
 from maxtext.integration.tunix.tunix_adapter import TunixMaxTextAdapter
 from maxtext.trainers.post_train.rl.evaluate_rl import evaluate
 from maxtext.trainers.post_train.rl import utils_rl

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -38,9 +38,9 @@ import jax.numpy as jnp
 from flax import linen as nn
 from flax.linen import partitioning as nn_partitioning
 
-from maxtext.common.common_types import ShardMode
 from MaxText import pyconfig
-from MaxText.globals import EPS
+from maxtext.common.common_types import ShardMode
+from maxtext.utils.globals import EPS
 # Placeholder: internal
 
 # pylint: disable=too-many-positional-arguments

--- a/src/maxtext/trainers/tokenizer/train_tokenizer.py
+++ b/src/maxtext/trainers/tokenizer/train_tokenizer.py
@@ -32,7 +32,7 @@ import jax
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 
 _DATASET_PATH = flags.DEFINE_string("dataset_path", None, "Path to the dataset", required=True)
 _DATASET_NAME = flags.DEFINE_string("dataset_name", None, "Name to the dataset", required=True)

--- a/src/maxtext/utils/globals.py
+++ b/src/maxtext/utils/globals.py
@@ -16,21 +16,22 @@
 
 import os.path
 
-# This is the MaxText root: with "max_utils.py"; &etc. TODO: Replace `os.path.basename` with `os.path.abspath`
-MAXTEXT_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+# This is the maxtext package root (src/MaxText)
+# Since this file is at src/maxtext/utils/globals.py, we need to go up 2 levels
+MAXTEXT_PKG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # This is the maxtext repo root: with ".git" folder; "README.md"; "pyproject.toml"; &etc.
 MAXTEXT_REPO_ROOT = os.environ.get(
     "MAXTEXT_REPO_ROOT",
     r
-    if os.path.isdir(os.path.join(r := os.path.dirname(os.path.dirname(os.path.dirname(__file__))), ".git"))
+    if os.path.isdir(
+        os.path.join(r := os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))), ".git")
+    )
     else MAXTEXT_PKG_DIR,
 )
 
 # This is the configs root: with "base.yml"; "models/"; &etc.
-MAXTEXT_CONFIGS_DIR = os.environ.get(
-    "MAXTEXT_CONFIGS_DIR", os.path.join(os.path.dirname(os.path.dirname(__file__)), "maxtext", "configs")
-)
+MAXTEXT_CONFIGS_DIR = os.environ.get("MAXTEXT_CONFIGS_DIR", os.path.join(MAXTEXT_PKG_DIR, "configs"))
 
 # This is the assets root: with "tokenizers/"; &etc.
 MAXTEXT_ASSETS_ROOT = os.environ.get("MAXTEXT_ASSETS_ROOT", os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "assets"))

--- a/src/maxtext/utils/muon_utils.py
+++ b/src/maxtext/utils/muon_utils.py
@@ -32,7 +32,7 @@ from typing import Optional, Tuple
 import flax.linen as nn
 import jax
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.utils import maxtext_utils

--- a/src/maxtext/vllm_decode.py
+++ b/src/maxtext/vllm_decode.py
@@ -46,6 +46,7 @@ import transformers
 
 from maxtext.utils import model_creation_utils
 from maxtext.utils import max_logging
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
 from maxtext.common.common_types import Config
 from maxtext.integration.tunix.tunix_adapter import TunixMaxTextAdapter
 from tunix.rl.rollout import base_rollout
@@ -53,7 +54,6 @@ from tunix.rl.rollout.vllm_rollout import VllmRollout
 from vllm import LLM
 from vllm.sampling_params import SamplingParams
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_CONFIGS_DIR
 
 os.environ["SKIP_JAX_PRECOMPILE"] = "1"
 os.environ["NEW_MODEL_DESIGN"] = "1"

--- a/tests/assets/logits_generation/generate_grpo_golden_logits.py
+++ b/tests/assets/logits_generation/generate_grpo_golden_logits.py
@@ -31,7 +31,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 import jsonlines
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
 from maxtext.common.common_types import Array, MODEL_MODE_TRAIN
 from maxtext.experimental.rl.grpo_trainer import _merge_grpo_state, generate_completions, grpo_loss_fn
 from maxtext.experimental.rl.grpo_utils import compute_log_probs

--- a/tests/assets/logits_generation/generate_sft_golden_data.py
+++ b/tests/assets/logits_generation/generate_sft_golden_data.py
@@ -39,7 +39,7 @@ from transformers import TrainingArguments, AutoModelForCausalLM, AutoTokenizer
 from trl import SFTConfig, SFTTrainer
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
 from tests.integration.sft_trainer_correctness_test import get_maxtext_logits, get_token_log_probs, prepare_maxtext_inputs
 
 

--- a/tests/inference/benchmark_offline_engine.py
+++ b/tests/inference/benchmark_offline_engine.py
@@ -28,10 +28,10 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from MaxText.globals import MAXTEXT_PKG_DIR
 from MaxText import pyconfig
 from maxtext.inference.offline_engine import OfflineEngine, InputData, CompletionOutput
 from maxtext.utils import max_logging
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 
 
 def get_metrics(results: list[CompletionOutput], start_time, end_time):

--- a/tests/integration/checkpoint_compatibility_test.py
+++ b/tests/integration/checkpoint_compatibility_test.py
@@ -30,7 +30,7 @@ import json
 import os
 import pytest
 from maxtext.trainers.pre_train.train import main as train_main
-from MaxText.globals import MAXTEXT_REPO_ROOT
+from maxtext.utils.globals import MAXTEXT_REPO_ROOT
 from tests.integration.checkpointing_test import get_checkpointing_command
 
 

--- a/tests/integration/checkpointing_test.py
+++ b/tests/integration/checkpointing_test.py
@@ -35,7 +35,7 @@ import pytest
 
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.trainers.pre_train.train import main as train_main
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from tests.utils.test_helpers import get_test_config_path, get_test_base_output_directory
 
 

--- a/tests/integration/decode_tests.py
+++ b/tests/integration/decode_tests.py
@@ -23,7 +23,7 @@ from absl.testing import absltest
 from contextlib import redirect_stdout
 
 from maxtext.inference.decode import main as decode_main
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
 
 pytestmark = [pytest.mark.tpu_only, pytest.mark.external_serving, pytest.mark.integration_test]

--- a/tests/integration/generate_param_only_checkpoint_test.py
+++ b/tests/integration/generate_param_only_checkpoint_test.py
@@ -22,8 +22,8 @@ import pytest
 
 from maxtext.inference.decode import main as decode_main
 from maxtext.trainers.pre_train.train import main as train_main
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from MaxText.generate_param_only_checkpoint import main as generate_param_only_ckpt_main
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
 from tests.integration.checkpointing_test import get_checkpointing_command
 from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
 

--- a/tests/integration/gradient_accumulation_test.py
+++ b/tests/integration/gradient_accumulation_test.py
@@ -27,8 +27,8 @@ import os.path
 
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.trainers.pre_train.train import main as train_main
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from MaxText.sft_trainer import main as sft_main
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
 
 from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
 

--- a/tests/integration/grpo_correctness.py
+++ b/tests/integration/grpo_correctness.py
@@ -24,7 +24,7 @@ from MaxText import pyconfig
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.experimental.rl.grpo_trainer import _merge_grpo_state, grpo_loss_fn
 from maxtext.experimental.rl.grpo_utils import compute_log_probs
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from maxtext.models import models
 from maxtext.utils import maxtext_utils
 import numpy as np

--- a/tests/integration/grpo_trainer_correctness_test.py
+++ b/tests/integration/grpo_trainer_correctness_test.py
@@ -36,7 +36,7 @@ from jax.sharding import Mesh
 import jsonlines
 import MaxText as mt
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.experimental.rl import grpo_utils
 from maxtext.experimental.rl.grpo_trainer import _merge_grpo_state, grpo_loss_fn, setup_train_loop
@@ -72,15 +72,9 @@ def setup_maxtext_model(config, mesh):
   init_rng = jax.random.PRNGKey(config.init_weights_seed)
   quant = quantizations.configure_quantization(config)
 
-  maxtext_model = models.transformer_as_linen(
-      config=config, mesh=mesh, quant=quant, model_mode=MODEL_MODE_TRAIN
-  )
-  state, state_mesh_annotations = maxtext_utils.setup_decode_state(
-      maxtext_model, config, init_rng, mesh, None
-  )
-  state_mesh_shardings = nn.logical_to_mesh_sharding(
-      state_mesh_annotations, mesh, config.logical_axis_rules
-  )
+  maxtext_model = models.transformer_as_linen(config=config, mesh=mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
+  state, state_mesh_annotations = maxtext_utils.setup_decode_state(maxtext_model, config, init_rng, mesh, None)
+  state_mesh_shardings = nn.logical_to_mesh_sharding(state_mesh_annotations, mesh, config.logical_axis_rules)
   data_sharding = jax.NamedSharding(mesh, jax.sharding.PartitionSpec(None))
   reference_params = jax.tree.map(jnp.copy, state.params["params"])
   state = _merge_grpo_state(state, reference_params)
@@ -98,16 +92,12 @@ def prepare_maxtext_inputs(input_str, tokenizer_model):
   """prepare maxtext inputs"""
   prompt = tokenizer_model.encode(input_str)
   input_ids = jnp.pad(
-      jnp.tile(
-          jnp.concat([jnp.array(prompt), jnp.array(prompt)], axis=-1), (4, 1)
-      ),
+      jnp.tile(jnp.concat([jnp.array(prompt), jnp.array(prompt)], axis=-1), (4, 1)),
       ((0, 0), (0, 4)),
       constant_values=tokenizer_model.pad_token_type_id,
   )  # pad some tokens at the end of input prompt
   input_segmentation = (input_ids > 0).astype(jnp.int32)
-  input_position = jnp.where(
-      input_segmentation, jnp.arange(input_segmentation.shape[1]), 0
-  )
+  input_position = jnp.where(input_segmentation, jnp.arange(input_segmentation.shape[1]), 0)
   completion_segmentation = jnp.tile(
       jnp.pad(
           jnp.array([0] * len(prompt) + [1] * len(prompt)),
@@ -136,9 +126,7 @@ class GrpoTrainerTest(unittest.TestCase):
     self.config = pyconfig.initialize(
         [
             None,
-            os.path.join(
-                MAXTEXT_PKG_DIR, "experimental", "rl", "grpo_trainer_test.yml"
-            ),
+            os.path.join(MAXTEXT_PKG_DIR, "experimental", "rl", "grpo_trainer_test.yml"),
         ],
         run_name="unit_test_grpo_trainer",
         tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "llama3.1-tokenizer"),
@@ -148,16 +136,13 @@ class GrpoTrainerTest(unittest.TestCase):
     self.config_inference = pyconfig.initialize(
         [
             None,
-            os.path.join(
-                MAXTEXT_PKG_DIR, "experimental", "rl", "grpo_trainer_test.yml"
-            ),
+            os.path.join(MAXTEXT_PKG_DIR, "experimental", "rl", "grpo_trainer_test.yml"),
         ],
         run_name="unit_test_grpo_trainer_inference",
         tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "llama3.1-tokenizer"),
         enable_checkpointing=False,
         ici_tensor_parallelism=4,
-        per_device_batch_size=self.config.per_device_batch_size
-        * self.config.rl["num_generations"],
+        per_device_batch_size=self.config.per_device_batch_size * self.config.rl["num_generations"],
     )
     self.model = mt.from_config(self.config)
     self.inference_model = mt.from_config(self.config_inference)
@@ -179,24 +164,17 @@ class GrpoTrainerTest(unittest.TestCase):
         mesh=self.inference_model.mesh,
     )
 
-  @pytest.mark.skip(
-      reason=(
-          "Logit output test fragile, failing on jax upgrade to 0.6.2 - see"
-          " b/425997645"
-      )
-  )
+  @pytest.mark.skip(reason="Logit output test fragile, failing on jax upgrade to 0.6.2 - see b/425997645")
   @pytest.mark.integration_test
   @pytest.mark.tpu_only  # ATTENTION: Only run on TPU V4-8
   def test_grpo_trainer_correctness(self):
     # Get the expected (golden) data.
     golden_data = get_golden_data(self.config)
     # Initialize the model and related objects.
-    maxtext_model, state, reference_params, rng, _, _ = setup_maxtext_model(
-        self.config, self.mesh
-    )
+    maxtext_model, state, reference_params, rng, _, _ = setup_maxtext_model(self.config, self.mesh)
     # Prepare inputs for the model.
-    input_ids, input_segmentation, input_position, completion_segmentation = (
-        prepare_maxtext_inputs(self.config.prompt, self.tokenizer_model)
+    input_ids, input_segmentation, input_position, completion_segmentation = prepare_maxtext_inputs(
+        self.config.prompt, self.tokenizer_model
     )
     # Obtain per-token logits.
     maxtext_per_token_logps, _ = compute_log_probs(
@@ -216,16 +194,10 @@ class GrpoTrainerTest(unittest.TestCase):
     )
     jax.debug.print(
         "golden_per_token_logps={golden_per_token_logps}",
-        golden_per_token_logps=golden_data[
-            "maxtext_per_token_logps_no_ckpt_loading"
-        ],
+        golden_per_token_logps=golden_data["maxtext_per_token_logps_no_ckpt_loading"],
     )
-    golden_maxtext_logits = np.array(
-        golden_data["maxtext_per_token_logps_no_ckpt_loading"]
-    )
-    self.assertTrue(
-        jnp.all(np.array(golden_data["input_ids"]) == np.array(input_ids[0]))
-    )
+    golden_maxtext_logits = np.array(golden_data["maxtext_per_token_logps_no_ckpt_loading"])
+    self.assertTrue(jnp.all(np.array(golden_data["input_ids"]) == np.array(input_ids[0])))
     self.assertTrue(
         jax.numpy.allclose(
             maxtext_per_token_logps[0],
@@ -235,9 +207,7 @@ class GrpoTrainerTest(unittest.TestCase):
             equal_nan=False,
         )
     )
-    max_diff = np.max(
-        np.abs(np.subtract(maxtext_per_token_logps[0], golden_maxtext_logits))
-    )
+    max_diff = np.max(np.abs(np.subtract(maxtext_per_token_logps[0], golden_maxtext_logits)))
     print("Max numerical difference:", max_diff)
 
     # Create the data dictionary required for computing the loss.
@@ -248,9 +218,7 @@ class GrpoTrainerTest(unittest.TestCase):
         "ar_completions_segmentation": completion_segmentation,
     }
     # Compute the loss and auxiliary values.
-    maxtext_loss, aux = grpo_loss_fn(
-        maxtext_model, self.config, data, rng, state.params, reference_params
-    )
+    maxtext_loss, aux = grpo_loss_fn(maxtext_model, self.config, data, rng, state.params, reference_params)
 
     # Assert that the computed loss and auxiliary averages match the golden data.
     self.assertEqual(maxtext_loss.tolist(), golden_data["maxtext_loss"])
@@ -275,9 +243,7 @@ class GrpoTrainerTest(unittest.TestCase):
           InputData(
               id=f"input_{i}",
               tokens=np.array(d),
-              true_length=np.array(
-                  data[f"{self.config.train_data_columns}_true_length"][i]
-              )[0],
+              true_length=np.array(data[f"{self.config.train_data_columns}_true_length"][i])[0],
           )
       )
 
@@ -315,9 +281,7 @@ class ReshardingTest(unittest.TestCase):
     )
     return config
 
-  @pytest.mark.skip(
-      reason="This test only runs on multihost cluster with pathways backend"
-  )
+  @pytest.mark.skip(reason="This test only runs on multihost cluster with pathways backend")
   @pytest.mark.tpu_only
   def test_pw_reshard_pytree(self):
     """Test that reshard_pytree correctly reshards a PyTree."""
@@ -330,13 +294,9 @@ class ReshardingTest(unittest.TestCase):
     )
 
     # Create a second mesh of 16 devices for inference
-    dst_config = self.init_pyconfig(
-        "grpo_inference.yml", ici_data_parallelism=4, ici_tensor_parallelism=4
-    )
+    dst_config = self.init_pyconfig("grpo_inference.yml", ici_data_parallelism=4, ici_tensor_parallelism=4)
 
-    _, _, _, dest_sharding, *_, state = setup_train_loop(
-        source_config, dst_config, None
-    )
+    _, _, _, dest_sharding, *_, state = setup_train_loop(source_config, dst_config, None)
     pytree = state.params
 
     # Reshard the PyTree from the source to the destination sharding.

--- a/tests/integration/sft_trainer_correctness_test.py
+++ b/tests/integration/sft_trainer_correctness_test.py
@@ -35,9 +35,9 @@ from jax.sharding import Mesh
 import jsonlines
 from MaxText import pyconfig
 from maxtext.common.common_types import MODEL_MODE_TRAIN
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
-from MaxText.globals import MAXTEXT_PKG_DIR
-from MaxText.globals import MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_TEST_ASSETS_ROOT
 from maxtext.input_pipeline import input_pipeline_utils
 from maxtext.layers import quantizations
 from maxtext.models import models

--- a/tests/integration/shmap_collective_matmul_test.py
+++ b/tests/integration/shmap_collective_matmul_test.py
@@ -19,7 +19,7 @@ import sys
 
 import pytest
 
-from MaxText.globals import MAXTEXT_REPO_ROOT
+from maxtext.utils.globals import MAXTEXT_REPO_ROOT
 
 sys.path.append(os.path.join(MAXTEXT_REPO_ROOT, "pedagogical_examples"))
 

--- a/tests/integration/simple_decoder_layer_test.py
+++ b/tests/integration/simple_decoder_layer_test.py
@@ -18,7 +18,7 @@ import unittest
 import os.path
 import pytest
 
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.trainers.pre_train.train import main as train_main
 from tests.utils.test_helpers import get_test_config_path
 

--- a/tests/integration/smoke/inference_microbenchmark_smoke_test.py
+++ b/tests/integration/smoke/inference_microbenchmark_smoke_test.py
@@ -20,7 +20,7 @@ import unittest
 from absl.testing import absltest
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_CONFIGS_DIR, MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR, MAXTEXT_ASSETS_ROOT
 from maxtext.common.gcloud_stub import is_decoupled
 
 pytestmark = [pytest.mark.external_serving]

--- a/tests/integration/smoke/train_gpu_smoke_test.py
+++ b/tests/integration/smoke/train_gpu_smoke_test.py
@@ -20,7 +20,7 @@ from absl.testing import absltest
 
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.trainers.pre_train.train import main as train_main
-from MaxText.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_PKG_DIR
 from tests.utils.test_helpers import get_test_dataset_path, get_test_base_output_directory
 
 

--- a/tests/integration/smoke/train_int8_smoke_test.py
+++ b/tests/integration/smoke/train_int8_smoke_test.py
@@ -20,7 +20,7 @@ from absl.testing import absltest
 
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.trainers.pre_train.train import main as train_main
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
 
 

--- a/tests/integration/smoke/train_smoke_test.py
+++ b/tests/integration/smoke/train_smoke_test.py
@@ -21,7 +21,7 @@ from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path
 
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.trainers.pre_train.train import main as train_main
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 
 
 class Train(unittest.TestCase):

--- a/tests/integration/standalone_dl_ckpt_test.py
+++ b/tests/integration/standalone_dl_ckpt_test.py
@@ -17,7 +17,7 @@ import unittest
 import pytest
 from tools.gcs_benchmarks.standalone_checkpointer import main as sckpt_main
 from tools.gcs_benchmarks.standalone_dataloader import main as sdl_main
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.common.gcloud_stub import is_decoupled
 
 from datetime import datetime

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -21,7 +21,7 @@ import jax
 from absl.testing import absltest
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.trainers.pre_train.train import main as train_main
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
 
 

--- a/tests/integration/vision_encoder_test.py
+++ b/tests/integration/vision_encoder_test.py
@@ -23,7 +23,7 @@ import jax
 import jax.numpy as jnp
 import jsonlines
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_TEST_ASSETS_ROOT
 from maxtext.inference.maxengine import maxengine
 from maxtext.models import models
 from maxtext.multimodal import processor_gemma3

--- a/tests/unit/configs_test.py
+++ b/tests/unit/configs_test.py
@@ -33,7 +33,7 @@ from pydantic import ValidationError
 from yaml import YAMLError
 
 from maxtext.configs import types as pydantic_types
-from MaxText.globals import MAXTEXT_REPO_ROOT
+from maxtext.utils.globals import MAXTEXT_REPO_ROOT
 
 # Define the root directory where configuration files are located.
 CONFIGS_DIR = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs")

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -21,9 +21,9 @@ from unittest.mock import patch, MagicMock
 import pydantic
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_REPO_ROOT
 from MaxText.pyconfig import initialize_pydantic
 from maxtext.configs import types
+from maxtext.utils.globals import MAXTEXT_REPO_ROOT
 
 # Path to the base.yml config. This assumes that `pytest` is run from the project root.
 _BASE_CONFIG_PATH = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "base.yml")

--- a/tests/unit/distillation_data_processing_test.py
+++ b/tests/unit/distillation_data_processing_test.py
@@ -24,7 +24,7 @@ import transformers
 
 from datasets import Dataset
 
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.input_pipeline import distillation_data_processing
 
 PROMPT_DATA = [

--- a/tests/unit/engram_vs_reference_test.py
+++ b/tests/unit/engram_vs_reference_test.py
@@ -45,7 +45,6 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 
-from MaxText.globals import MAXTEXT_PKG_DIR
 from MaxText import pyconfig
 from MaxText import maxtext_utils
 
@@ -54,6 +53,7 @@ from maxtext.layers.engram import NgramHashMapping as NgramHashMappingJAX
 from maxtext.layers.engram import MultiHeadEmbedding as MultiHeadEmbeddingJAX
 from maxtext.layers.engram import ShortConv as ShortConvJAX
 from maxtext.layers.engram import Engram as EngramJAX
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 
 
 def setUpModule():

--- a/tests/unit/grain_data_processing_test.py
+++ b/tests/unit/grain_data_processing_test.py
@@ -30,7 +30,7 @@ from jax.experimental import mesh_utils
 from MaxText import pyconfig
 from maxtext.input_pipeline import grain_data_processing
 from maxtext.input_pipeline import input_pipeline_interface
-from MaxText.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_REPO_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_REPO_ROOT
 from maxtext.common.gcloud_stub import is_decoupled
 from tests.utils.test_helpers import get_test_base_output_directory, get_test_config_path, get_test_dataset_path
 

--- a/tests/unit/mhc_test.py
+++ b/tests/unit/mhc_test.py
@@ -26,7 +26,7 @@ from jax.sharding import Mesh
 import numpy as np
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from maxtext.common.common_types import HyperConnectionType
 from maxtext.layers import attention_mla, linears, mhc, moe
 from maxtext.layers.initializers import nd_dense_init

--- a/tests/unit/multimodal_utils_test.py
+++ b/tests/unit/multimodal_utils_test.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_REPO_ROOT
+from maxtext.utils.globals import MAXTEXT_REPO_ROOT
 from maxtext.multimodal import processor as mm_processor
 from maxtext.multimodal import utils as mm_utils
 from maxtext.multimodal import processor_gemma3

--- a/tests/unit/pipeline_parallelism_test.py
+++ b/tests/unit/pipeline_parallelism_test.py
@@ -26,7 +26,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.layers import nnx_wrappers

--- a/tests/unit/profiler_test.py
+++ b/tests/unit/profiler_test.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from maxtext.configs import types
 from maxtext.common import profiler
 from tests.utils.test_helpers import get_test_config_path

--- a/tests/unit/pyconfig_deprecated_test.py
+++ b/tests/unit/pyconfig_deprecated_test.py
@@ -18,8 +18,8 @@ import unittest
 import os.path
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR
 from MaxText.pyconfig_deprecated import resolve_config_path
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from tests.utils.test_helpers import get_test_config_path
 
 

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -19,7 +19,7 @@ import os.path
 
 from MaxText import pyconfig
 from MaxText.pyconfig import resolve_config_path
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from tests.utils.test_helpers import get_test_config_path, get_post_train_test_config_path
 
 

--- a/tests/unit/quantizations_test.py
+++ b/tests/unit/quantizations_test.py
@@ -27,7 +27,7 @@ from jax import lax
 from jax import numpy as jnp
 from jax.sharding import Mesh
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
 from maxtext.common.gcloud_stub import is_decoupled
 from maxtext.common.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR
 from maxtext.kernels.megablox import gmm

--- a/tests/unit/qwen3_omni_layers_test.py
+++ b/tests/unit/qwen3_omni_layers_test.py
@@ -25,9 +25,9 @@ from flax import nnx
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from maxtext.common import common_types
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_REPO_ROOT
+from maxtext.common import common_types
+from maxtext.utils.globals import MAXTEXT_REPO_ROOT
 from maxtext.inference.maxengine import maxengine
 from maxtext.layers.attentions import Attention
 from maxtext.layers.embeddings import (

--- a/tests/unit/sft_data_processing_test.py
+++ b/tests/unit/sft_data_processing_test.py
@@ -26,7 +26,7 @@ import transformers
 from parameterized import parameterized_class
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_PKG_DIR, MAXTEXT_CONFIGS_DIR, MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_PKG_DIR, MAXTEXT_CONFIGS_DIR, MAXTEXT_ASSETS_ROOT
 from maxtext.input_pipeline import hf_data_processing
 from maxtext.input_pipeline import input_pipeline_interface
 from maxtext.input_pipeline.hf_data_processing import _get_pad_id

--- a/tests/unit/sft_hooks_test.py
+++ b/tests/unit/sft_hooks_test.py
@@ -26,7 +26,7 @@ from unittest.mock import MagicMock, patch
 from jax.sharding import Mesh
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
 from maxtext.trainers.post_train.sft import hooks
 from maxtext.utils import maxtext_utils
 

--- a/tests/unit/sharding_compare_test.py
+++ b/tests/unit/sharding_compare_test.py
@@ -23,7 +23,7 @@ from MaxText import maxtext_utils
 from MaxText import pyconfig
 # import optax
 
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.optimizers import optimizers

--- a/tests/unit/tfds_data_processing_test.py
+++ b/tests/unit/tfds_data_processing_test.py
@@ -25,7 +25,7 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.input_pipeline import tfds_data_processing
 from maxtext.input_pipeline import input_pipeline_interface
 from maxtext.common.gcloud_stub import is_decoupled

--- a/tests/unit/tokenizer_test.py
+++ b/tests/unit/tokenizer_test.py
@@ -15,7 +15,7 @@
 """Tests for tokenizer"""
 
 import numpy as np
-from MaxText.globals import MAXTEXT_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.input_pipeline import input_pipeline_utils
 from maxtext.trainers.tokenizer import train_tokenizer
 

--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -45,7 +45,7 @@ from google.cloud import storage
 import jax
 import jax.numpy as jnp
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_TEST_ASSETS_ROOT
 from maxtext.checkpoint_conversion.utils.hf_utils import convert_jax_weight_to_torch
 from maxtext.common.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_TRAIN
 from maxtext.layers import quantizations

--- a/tests/utils/run_sharding_dump.py
+++ b/tests/utils/run_sharding_dump.py
@@ -46,7 +46,7 @@ Example:
 
 from typing import Sequence
 
-from MaxText.globals import MAXTEXT_PKG_DIR, MAXTEXT_REPO_ROOT
+from maxtext.utils.globals import MAXTEXT_PKG_DIR, MAXTEXT_REPO_ROOT
 from tests.utils.sharding_dump import TEST_CASES
 import os
 import subprocess

--- a/tests/utils/sharding_dump.py
+++ b/tests/utils/sharding_dump.py
@@ -28,7 +28,7 @@ from jax.sharding import NamedSharding, PartitionSpec
 from jax.tree_util import tree_flatten_with_path
 from MaxText import maxtext_utils
 from MaxText import pyconfig
-from MaxText.globals import MAXTEXT_REPO_ROOT
+from maxtext.utils.globals import MAXTEXT_REPO_ROOT
 from maxtext.models import models
 from maxtext.optimizers import optimizers
 from maxtext.trainers.pre_train.train_compile import get_shaped_inputs, get_topology_mesh, validate_config
@@ -403,8 +403,7 @@ def main(argv: Sequence[str]) -> None:
   """Load a config that describes a model with topology and slices to be dumped."""
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   os.environ["LIBTPU_INIT_ARGS"] = (
-      os.environ.get("LIBTPU_INIT_ARGS", "")
-      + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
+      os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
   )
   print("Starting sharding_tests.py...", flush=True)
 
@@ -422,9 +421,7 @@ def main(argv: Sequence[str]) -> None:
     topology_mesh = get_topology_mesh(config)
     learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(config)
     optimizers.get_optimizer(config, learning_rate_schedule)
-    shaped_train_args, _, state_mesh_shardings, logical_annotations, _ = (
-        get_shaped_inputs(topology_mesh, config)
-    )
+    shaped_train_args, _, state_mesh_shardings, logical_annotations, _ = get_shaped_inputs(topology_mesh, config)
   except Exception as e:  # pylint: disable=broad-except
     print(f"Error generating inputs: {e}")
     return
@@ -435,18 +432,11 @@ def main(argv: Sequence[str]) -> None:
 
   # 1. Generate New Output
   # Physical: Tree of NamedSharding
-  named_shardings = named_shardings_to_json(
-      state_mesh_shardings, shaped_train_args[0]
-  )
+  named_shardings = named_shardings_to_json(state_mesh_shardings, shaped_train_args[0])
   # Logical: Tree of PartitionSpec (direct from get_shaped_inputs)
-  logical_shardings = partition_specs_to_json(
-      logical_annotations, shaped_train_args[0]
-  )
+  logical_shardings = partition_specs_to_json(logical_annotations, shaped_train_args[0])
 
-  print(
-      f"Got {len(named_shardings)} Physical entries and"
-      f" {len(logical_shardings)} Logical entries."
-  )
+  print(f"Got {len(named_shardings)} Physical entries and" f" {len(logical_shardings)} Logical entries.")
 
   # 2. Save New Output (Overwrite)
   print(f"\nSaving updated shardings to {base_path}...")

--- a/tests/utils/test_helper.py
+++ b/tests/utils/test_helper.py
@@ -21,7 +21,7 @@ returned.
 
 import os
 from maxtext.common.gcloud_stub import is_decoupled
-from MaxText.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
 
 
 def get_test_config_path():

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -21,7 +21,7 @@ of Google Cloud Storage paths.
 
 import os
 from maxtext.common.gcloud_stub import is_decoupled
-from MaxText.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
 
 
 def get_test_config_path():


### PR DESCRIPTION
PR #3249: Move MaxText.globals

Imported from GitHub PR https://github.com/AI-Hypercomputer/maxtext/pull/3249

# Description

Move `MaxText.globals` to `maxtext.utils.globals` as per [guidance](https://screenshot.googleplex.com/5tMjQmKCm3Vaijf).

# Tests

CI

Pushed a new docker [image](https://pantheon.corp.google.com/artifacts/docker/tpu-prod-env-multipod/us/gcr.io/hengtaoguo_google_com_runner/sha256:b64fab4ace9588088549abf3424231c36e1a853811d9a30d622e69cbb53963ea?e=13802955&mods=allow_workbench_image_override&project=tpu-prod-env-multipod) and ran an XPK [workload](https://pantheon.corp.google.com/kubernetes/service/europe-west4/v5p-8-bodaborg-europe-west4-b/default/hengtaoguo-2026-02-25-22-24-22/details?project=cloud-tpu-multipod-dev&e=13802955&mods=allow_workbench_image_override) ([command](https://paste.googleplex.com/4771787670945792), [logs](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22v5p-8-bodaborg-europe-west4-b%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22hengtaoguo-2026-02-25-22-24-22-slice-job-0-0-%22%20severity%3E%3DDEFAULT%0Atimestamp%20%3E%3D%20%222026-02-25T22:26:30.254070209Z%22%20AND%20timestamp%20%3C%3D%20%222026-02-25T22:34:15.373450481Z%22;storageScope=project;cursorTimestamp=2026-02-25T22:27:09.980799988Z;duration=P1D?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev))
```
completed step: 19, seconds: 0.682, TFLOP/s/device: 239.034, Tokens/s/device: 36029.802, total_weights: 79158, loss: 8.030
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

Copybara import of the project:

--
94d4ac4a3d8194a5659ae1c66dc7cbf72f626c57 by hengtaoguo <hengtaoguo@google.com>:

Move MaxText.globals

pylint

Merging this change closes #3249

FUTURE_COPYBARA_INTEGRATE_REVIEW=https://github.com/AI-Hypercomputer/maxtext/pull/3249 from AI-Hypercomputer:hengtaoguo-globals 94d4ac4a3d8194a5659ae1c66dc7cbf72f626c57
