### PR TITLE
Fix `KeyError` by providing fallback for USER environment variable

### DIFF
--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -586,12 +586,13 @@ def generate_xpk_workload_cmd(
     cluster_config: XpkClusterConfig,
     wl_config: WorkloadConfig,
     workload_name=None,
-    user=os.environ["USER"],
+    user=None,
     temp_key=None,
     exp_name=None,
 ):
   """Generates a command to run a maxtext model on XPK."""
 
+  user = user or os.environ.get("USER", "user")
   is_pathways_enabled = wl_config.pathways_config is not None
   is_pathways_headless_enabled = wl_config.pathways_config and wl_config.pathways_config.headless
 
@@ -719,7 +720,7 @@ def run_xpk_workload(
 def xpk_benchmark_runner(
     cluster_config: XpkClusterConfig,
     workload_configs: list[WorkloadConfig],
-    user=os.environ["USER"],
+    user=None,
     disruption_manager: DisruptionManager = DisruptionManager(),
     exp_name: str = None,
 ):
@@ -738,6 +739,7 @@ def xpk_benchmark_runner(
   Returns:
     The DisruptionManager instance, potentially updated with new workloads.
   """
+  user = user or os.environ.get("USER", "user")
   xpk_workload_names = []
   xpk_workload_cmds = []
   for wl_config in workload_configs:


### PR DESCRIPTION
# Description

This PR addresses a `KeyError: 'USER'` that occurs when Python scripts run in environments (such as certain Kubernetes configurations) where the `USER` environment variable is not explicitly defined.

# Changes:
 - Updated `generate_xpk_workload_cmd` and `xpk_benchmark_runner` to provide a resilient default value for the user argument.
 - Ensures the workload command generation does not fail if the environment shell is restricted.


FIXES: b/486699931


# Tests

https://paste.googleplex.com/4652104816918528

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
