### PR TITLE
Fix extras deps in the build hook

### DIFF
--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -91,7 +91,13 @@ jobs:
           python3 -m uv venv --seed
           source .venv/bin/activate
           maxtext_wheel=$(ls maxtext-*-py3-none-any.whl 2>/dev/null)
-          uv pip install ${maxtext_wheel}[${MAXTEXT_PACKAGE_EXTRA}] --resolution=lowest
+          # TEST: If MAXTEXT_PACKAGE_EXTRA=tpu, install maxtext without the [tpu] extra
+          # to ensure the wheel is built correctly with tpu-specific dependencies by default.
+          if [ "${MAXTEXT_PACKAGE_EXTRA}" == "tpu" ]; then
+            uv pip install ${maxtext_wheel} --resolution=lowest
+          else
+            uv pip install ${maxtext_wheel}[${MAXTEXT_PACKAGE_EXTRA}] --resolution=lowest
+          fi
           uv pip install -r src/install_maxtext_extra_deps/extra_deps_from_github.txt
           python3 --version
           python3 -m pip freeze

--- a/tests/unit/distillation_checkpointing_test.py
+++ b/tests/unit/distillation_checkpointing_test.py
@@ -14,6 +14,11 @@
 
 """Unit tests for Distillation Checkpointing logic."""
 
+import pytest
+
+pytest.importorskip("tunix")
+pytestmark = [pytest.mark.tpu_only]
+
 import json
 import os
 import shutil

--- a/tests/unit/sft_hooks_test.py
+++ b/tests/unit/sft_hooks_test.py
@@ -15,6 +15,7 @@
 """Tests for training and data loading hooks for SFT"""
 import pytest
 
+pytest.importorskip("tunix")
 pytestmark = [pytest.mark.tpu_only, pytest.mark.external_training]
 
 import jax

--- a/tests/unit/sharding_compare_test.py
+++ b/tests/unit/sharding_compare_test.py
@@ -109,6 +109,8 @@ def compare_sharding_jsons(json1: dict, model1_name: str, json2: dict, model2_na
   return has_diff
 
 
+# Requires JAX TPU support to generate the simulated TPU topology.
+@pytest.mark.tpu_only
 @pytest.mark.parametrize("model_name, topology, num_slice", TEST_CASES)
 def test_sharding_dump_for_model(model_name: str, topology: str, num_slice: str) -> None:
   """
@@ -215,6 +217,8 @@ def abstract_state_and_shardings(request):
 class TestGetAbstractState:
   """Test class for get_abstract_state function and sharding comparison."""
 
+  # Requires JAX TPU support to generate the simulated TPU topology.
+  @pytest.mark.tpu_only
   def test_get_abstract_state_sharding(self, abstract_state_and_shardings):  # pylint: disable=redefined-outer-name
     """Tests that get_abstract_state returns a state with the correct abstract structure and compares sharding."""
 

--- a/tests/unit/train_distill_test.py
+++ b/tests/unit/train_distill_test.py
@@ -15,6 +15,11 @@
 
 """Unit tests for the Distillation Trainer."""
 
+import pytest
+
+pytest.importorskip("tunix")
+pytestmark = [pytest.mark.tpu_only]
+
 import shutil
 import tempfile
 import unittest


### PR DESCRIPTION
# Description

- Modified build_hooks.py to conditionally inject TPU dependencies using
  extra markers to prevent TPU-specific dependencies from leaking into
  other extras;
- Added `pytest.importorskip("tunix")` to the top of test files that
  imports tunix. As tunix is not available in GPU environments, top-level
  imports in test files were causing pytest to crash during the collection
  phase before hardware markers could be evaluated.
- Also skipped sharding_compare_test tests as they
  attempt to generate a TPU topology to compare model sharding. On
  non-TPU environments, e.g., GPU env, this results in a RuntimeError as
  the required JAX TPU backend is missing.

# Tests

All presubmits passed.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
