### PR TITLE
add distillation forward output class to distillation pipeline.

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -33,7 +33,7 @@ Architecture Overview:
    a standard interface (call signature) that the Tunix `DistillationTrainer` expects.
 """
 
-from typing import Sequence
+from typing import Sequence, Callable
 from absl import app
 from flax import nnx
 from flax.linen import partitioning as nn_partitioning
@@ -119,7 +119,7 @@ def get_distillation_optimizer(config, max_train_steps):
   return optimizer
 
 
-def create_forward_fn(config: pyconfig.HyperParameters):
+def create_forward_fn(config: pyconfig.HyperParameters) -> Callable[..., distillation_utils.DistillationForwardOutput]:
   """Creates a forward function closure that binds the specific model configuration.
 
   Args:
@@ -130,7 +130,9 @@ def create_forward_fn(config: pyconfig.HyperParameters):
     Tunix `LogitStrategy` and handles the MaxText-specific forward call.
   """
 
-  def model_forward_fn(model, input_tokens, positions, attention_mask, decoder_segment_ids=None, cache=None, **kwargs):
+  def model_forward_fn(
+      model, input_tokens, positions, attention_mask, decoder_segment_ids=None, cache=None, **kwargs
+  ) -> distillation_utils.DistillationForwardOutput:
     """Forward pass wrapper adapted for raw MaxText models."""
     del kwargs  # Unused
     del attention_mask  # Unused
@@ -141,10 +143,14 @@ def create_forward_fn(config: pyconfig.HyperParameters):
         decoder_segment_ids=decoder_segment_ids,
         enable_dropout=config.enable_dropout,
     )
-    hidden_features = None
+    out_projection_activations = None
     if config.distill_beta > 0.0:
-      hidden_features = maxtext_utils.get_intermediate_value(model, "out_projection_activations", clear=True)
-    return logits, hidden_features
+      out_projection_activations = maxtext_utils.get_intermediate_value(model, "out_projection_activations", clear=True)
+
+    retval = distillation_utils.DistillationForwardOutput(
+        logits=logits, out_projection_activations=out_projection_activations
+    )
+    return retval
 
   return model_forward_fn
 


### PR DESCRIPTION
# Description

Addresses comments from https://github.com/AI-Hypercomputer/maxtext/pull/3218.
- Cleaner class definitions for output values of the forward function for student/teacher.
- Fixes eval loss function.

# Tests

- tests.unit.train_distill_test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
