### PR TITLE
NNX migration decoders

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1079,6 +1079,7 @@ subslice_shape: ""
 
 # NNX
 enable_nnx: false
+pure_nnx_decoder: false
 
 ################################## Qwen3-Next Specific Configs ##################################
 # Kernel size for the 1D convolution in the Gated Delta Net

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -777,6 +777,7 @@ class HardwareAndMesh(BaseModel):
   enable_nnx: bool = Field(False, description="Whether to use NNX for model definition.")
   optimize_mesh_for_tpu_v6e: bool = Field(False, description="Apply transformations to the mesh for TPU v6e.")
   shardy: bool = Field(True, description="Whether to use shardy XLA backend.")
+  pure_nnx_decoder: bool = Field(False, description="Whether to enable pure NNX decoder.")
 
 
 class LayoutAndSharding(BaseModel):

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -533,14 +533,14 @@ class Attention(nnx.Module):
     elif self.is_qwen3_next:
       self.query_norm = Qwen3NextRMSNorm(
           num_features=self.config.head_dim,
-          eps=self.config.normalization_layer_epsilon,
+          epsilon=self.config.normalization_layer_epsilon,
           dtype=self.config.dtype,
           weight_dtype=self.config.weight_dtype,
           rngs=self.rngs,
       )
       self.key_norm = Qwen3NextRMSNorm(
           num_features=self.config.head_dim,
-          eps=self.config.normalization_layer_epsilon,
+          epsilon=self.config.normalization_layer_epsilon,
           dtype=self.config.dtype,
           weight_dtype=self.config.weight_dtype,
           rngs=self.rngs,

--- a/src/maxtext/layers/multi_token_prediction.py
+++ b/src/maxtext/layers/multi_token_prediction.py
@@ -22,8 +22,8 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from maxtext.common.common_types import Config, MODEL_MODE_TRAIN
+from maxtext.layers.nnx_decoders import NNXDecoderLayer
 from maxtext.utils.globals import EPS
-from maxtext.layers import nnx_wrappers
 from maxtext.layers.decoders import DecoderLayer
 from maxtext.layers.initializers import variable_to_logically_partitioned
 from maxtext.layers.linears import DenseGeneral
@@ -70,7 +70,7 @@ class MultiTokenPredictionLayer(nnx.Module):
       config: Config,
       mesh: Mesh,
       layer_number: int,
-      transformer_layer_module: Type[DecoderLayer],
+      transformer_layer_module: Type[NNXDecoderLayer],
       *,
       rngs: nnx.Rngs,
   ):
@@ -108,22 +108,12 @@ class MultiTokenPredictionLayer(nnx.Module):
         rngs=rngs,
     )
     # Use MODEL_MODE_TRAIN for initialization; runtime model_mode is passed dynamically.
-    mtp_transformer_layer = transformer_layer_module(
+    self.transformer_layer = transformer_layer_module(
         config=cfg,
         mesh=mesh,
         model_mode=MODEL_MODE_TRAIN,
         name=f"mtp_{k}_transformer_layer",
-    )
-    self.transformer_layer = nnx_wrappers.ToNNX(mtp_transformer_layer, rngs=rngs)
-
-    # ToNNX requires explicit initialization with sample inputs for proper parameter setup.
-    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config=cfg, model_mode=MODEL_MODE_TRAIN)
-    self.transformer_layer.lazy_init(
-        inputs=jnp.zeros((batch_size, seq_len, self.config.emb_dim), dtype=self.config.dtype),
-        decoder_segment_ids=None,
-        decoder_positions=jnp.zeros((batch_size, seq_len), dtype=jnp.int32),
-        deterministic=True,
-        model_mode=MODEL_MODE_TRAIN,
+        rngs=rngs,
     )
 
   @property
@@ -212,7 +202,7 @@ class MultiTokenPredictionBlock(nnx.Module):
       self,
       config: Config,
       mesh: Mesh,
-      transformer_layer_module: Type[DecoderLayer],
+      transformer_layer_module: Type[NNXDecoderLayer],
       decoder: nnx.Module,
       rngs: nnx.Rngs,
   ):

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1,0 +1,1139 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for decoder layers"""
+# pylint: disable=arguments-differ
+# pylint: disable=no-name-in-module
+
+import functools
+import inspect
+import warnings
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from flax import linen as nn
+from flax import nnx
+from flax.nnx import wrappers as nnx_wrappers
+from jax.ad_checkpoint import checkpoint_name
+from jax.sharding import Mesh
+
+from maxtext.common.common_types import (
+    EP_AS_CONTEXT,
+    MODEL_MODE_AUTOREGRESSIVE,
+    MODEL_MODE_PREFILL,
+    MODEL_MODE_TRAIN,
+    Config,
+    DecoderBlockType,
+    ShardMode,
+)
+from maxtext.inference import page_manager
+from maxtext.layers import initializers, linears, mhc, normalizations, quantizations
+from maxtext.layers.attentions import Attention
+from maxtext.layers.embeddings import Embed, PositionalEmbedding, attend_on_embedding
+from maxtext.layers.normalizations import RMSNorm
+from maxtext.layers.quantizations import AqtQuantization as Quant
+from maxtext.models import (
+    deepseek,
+    deepseek_batchsplit,
+    gemma,
+    gemma2,
+    gemma3,
+    gpt3,
+    gpt_oss,
+    llama2,
+    llama4,
+    mistral,
+    mixtral,
+    olmo3,
+    qwen3,
+    simple_layer,
+)
+from maxtext.multimodal import utils as mm_utils
+from maxtext.utils import max_logging, max_utils, maxtext_utils, sharding
+from maxtext.utils.sharding import create_sharding
+
+# ------------------------------------------------------------------------------
+# The network: Decoder Definitions
+# ------------------------------------------------------------------------------
+
+
+class NNXDecoderLayer(nnx.Module):
+  """
+  Transformer decoder layer converted to NNX.
+  """
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      quant: None | Quant = None,
+      name: str = "decoder_layer",
+      *,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.quant = quant
+
+    cfg = self.config
+
+    self.pre_self_attention_norm = RMSNorm(
+        num_features=cfg.emb_dim,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        epsilon=cfg.normalization_layer_epsilon,
+        kernel_axes=("norm",),
+        rngs=rngs,
+    )
+
+    self.self_attention = Attention(
+        config=self.config,
+        num_query_heads=cfg.num_query_heads,
+        num_kv_heads=cfg.num_kv_heads,
+        head_dim=cfg.head_dim,
+        max_target_length=cfg.max_target_length,
+        max_prefill_predict_length=cfg.max_prefill_predict_length,
+        attention_kernel=cfg.attention,
+        inputs_q_shape=(1, 1, cfg.emb_dim),
+        inputs_kv_shape=(1, 1, cfg.emb_dim),
+        mesh=mesh,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        dropout_rate=cfg.dropout_rate,
+        float32_qk_product=cfg.float32_qk_product,
+        float32_logits=cfg.float32_logits,
+        quant=self.quant,
+        kv_quant=quantizations.configure_kv_quant(cfg),
+        prefill_cache_axis_order=tuple(map(int, cfg.prefill_cache_axis_order.split(","))),
+        ar_cache_axis_order=tuple(map(int, cfg.ar_cache_axis_order.split(","))),
+        compute_axis_order=tuple(map(int, cfg.compute_axis_order.split(","))),
+        reshape_q=cfg.reshape_q,
+        use_mrope=cfg.use_mrope,
+        mrope_section=cfg.mrope_section,
+        share_kv_projections=cfg.share_kv_projections,
+        model_mode=model_mode,
+        rngs=rngs,
+    )
+
+    self.mlp = linears.MlpBlock(
+        in_features=cfg.emb_dim,
+        intermediate_dim=cfg.mlp_dim,
+        activations=cfg.mlp_activations,
+        intermediate_dropout_rate=cfg.dropout_rate,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        model_mode=model_mode,
+        config=cfg,
+        quant=self.quant,
+        mesh=self.mesh,
+        rngs=rngs,
+    )
+
+    self.dropout = linears.Dropout(rate=cfg.dropout_rate, rngs=rngs, broadcast_dims=(-2,))
+
+  def __call__(
+      self,
+      inputs,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      previous_chunk=None,
+      slot: None | int = None,
+      page_state: None | page_manager.PageState = None,
+      kv_cache: jax.Array | None = None,
+      attention_metadata: dict[str, Any] | None = None,
+  ):
+    cfg = self.config
+    mesh = self.mesh
+    _maybe_shard_with_logical = functools.partial(
+        sharding.maybe_shard_with_logical,
+        mesh=mesh,
+        shard_mode=cfg.shard_mode,
+        debug_sharding=cfg.debug_sharding,
+    )
+
+    if self.model_mode == MODEL_MODE_PREFILL:
+      logical_axis_names = ("activation_batch", "prefill_activation_length", "activation_embed")
+    elif self.config.expert_shard_attention_option == EP_AS_CONTEXT and self.model_mode == MODEL_MODE_TRAIN:
+      logical_axis_names = ("activation_batch_no_exp", "activation_length", "activation_embed")
+    else:
+      logical_axis_names = ("activation_batch", "activation_length_no_exp", "activation_embed")
+
+    inputs = _maybe_shard_with_logical(inputs, logical_axis_names)
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
+
+    lnx = self.pre_self_attention_norm(inputs)
+    lnx = _maybe_shard_with_logical(lnx, logical_axis_names)
+
+    attention_lnx, kv_cache = self.self_attention(
+        lnx,
+        lnx,
+        decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        deterministic=deterministic,
+        model_mode=model_mode,
+        kv_cache=kv_cache,
+        attention_metadata=attention_metadata,
+    )
+    attention_lnx = _maybe_shard_with_logical(attention_lnx, logical_axis_names)
+
+    mlp_lnx = self.mlp(lnx, deterministic=deterministic)
+    mlp_lnx = _maybe_shard_with_logical(mlp_lnx, logical_axis_names)
+
+    next_layer_addition = mlp_lnx + attention_lnx
+    next_layer_addition_dropped_out = self.dropout(next_layer_addition, deterministic=deterministic)
+
+    layer_output = next_layer_addition_dropped_out + inputs
+    layer_output = _maybe_shard_with_logical(layer_output, logical_axis_names)
+
+    if cfg.record_internal_nn_metrics:
+      self.sow(nnx.Intermediate, "activation_mean", jnp.mean(layer_output))
+      self.sow(nnx.Intermediate, "activation_stdev", jnp.std(layer_output))
+      self.sow(
+          nnx.Intermediate,
+          "activation_fraction_zero",
+          jnp.sum(layer_output == 0) / jnp.size(layer_output),
+      )
+
+    if cfg.scan_layers:
+      return layer_output, None
+    else:
+      return layer_output, kv_cache
+
+
+def deepstack_process(hidden_states, bidirectional_mask, visual_embeds):
+  """Process deepstack visual embeddings by adding them to hidden states at visual token positions.
+
+  Args:
+    hidden_states: [batch, seq_len, hidden_dim] decoder hidden states
+    bidirectional_mask: [batch, seq_len] boolean mask marking visual token positions
+    visual_embeds: [batch, num_visual_tokens, hidden_dim] visual features from encoder layer
+
+  Returns:
+    Updated hidden_states with visual features added at visual positions
+  """
+  # Expand mask to [batch, seq_len, 1] for broadcasting
+  mask_expanded = bidirectional_mask[:, :, jnp.newaxis]
+  # Use cumsum to map each True position in mask to its index in visual_embeds
+  visual_token_idx = jnp.cumsum(bidirectional_mask, axis=1) - 1  # [batch, seq_len], 0-indexed
+
+  # Gather visual tokens: for each position, get the corresponding visual token
+  batch_idx = jnp.arange(hidden_states.shape[0])[:, jnp.newaxis]  # [batch, 1]
+  visual_embeds_scattered = visual_embeds[batch_idx, visual_token_idx, :]  # [batch, seq_len, hidden]
+
+  # Only add where mask is True: hidden_states += visual_embeds * mask
+  hidden_states = hidden_states + visual_embeds_scattered * mask_expanded
+  return hidden_states
+
+
+class NNXDecoder(nnx.Module):
+  """A stack of decoder layers as a part of an encoder-decoder architecture, using NNX."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      quant: None | Quant = None,
+      model_mode: str = MODEL_MODE_TRAIN,
+      *,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.quant = quant
+    self.model_mode = model_mode
+    self.rngs = rngs
+
+    decoder_block_classes = self.get_decoder_layers()
+
+    self.decoder_norm = self.get_norm_layer(num_features=config.emb_dim, rngs=rngs)(
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        epsilon=config.normalization_layer_epsilon,
+        kernel_axes=("norm",),
+        parameter_memory_host_offload=config.parameter_memory_host_offload,
+    )
+
+    if config.trainable_position_size > 0:
+      self.position_embedder = Embed(
+          num_embeddings=config.trainable_position_size,
+          num_features=config.emb_dim,
+          dtype=config.dtype,
+          embedding_init=nn.initializers.normal(stddev=1.0),
+          config=config,
+          mesh=self.mesh,
+          rngs=rngs,
+      )
+
+    self.dropout = linears.Dropout(rate=config.dropout_rate, rngs=rngs, broadcast_dims=(-2,))
+
+    self.positional_embedding = PositionalEmbedding(embedding_dims=config.base_emb_dim)
+
+    if not config.logits_via_embedding:
+      self.logits_dense = linears.DenseGeneral(
+          in_features_shape=config.emb_dim,
+          out_features_shape=config.vocab_size,
+          weight_dtype=config.weight_dtype,
+          dtype=jnp.float32 if config.logits_dot_in_fp32 else config.dtype,
+          kernel_axes=("embed", "vocab"),
+          shard_mode=config.shard_mode,
+          matmul_precision=self.config.matmul_precision,
+          parameter_memory_host_offload=config.parameter_memory_host_offload,
+          rngs=rngs,
+      )
+
+    self.scanned_layers = None
+    self.is_deepseek = self.config.decoder_block == DecoderBlockType.DEEPSEEK
+    self.is_gemma3 = self.config.decoder_block == DecoderBlockType.GEMMA3
+
+    if self.config.scan_layers:
+      if self.is_deepseek:
+        assert len(decoder_block_classes) == 2
+        dense_cls, moe_cls = decoder_block_classes
+
+        num_dense = config.first_num_dense_layers
+        self.dense_layers = self._create_scanned_layers(dense_cls, length=num_dense, rngs=rngs)
+
+        num_moe = config.num_decoder_layers - config.first_num_dense_layers
+
+        self.moe_layer = self._create_scanned_layers(moe_cls, length=num_moe, rngs=rngs)
+      elif self.is_gemma3:
+        attention_pattern_length = len(gemma3.GEMMA3_ATTENTION_PATTERN)
+        scan_length = config.num_decoder_layers // attention_pattern_length
+        num_remaining_layers = config.num_decoder_layers % attention_pattern_length
+        layer_kwargs = {"num_of_layers": attention_pattern_length}
+
+        rem_layer_kwargs = {"num_of_layers": num_remaining_layers}
+
+        RemattedGemma3Block = gemma3.Gemma3ScannableBlock
+
+        if scan_length > 0:
+          self.layers = self._create_scanned_layers(RemattedGemma3Block, length=scan_length, rngs=rngs, **layer_kwargs)
+        self.layers_remainder = RemattedGemma3Block(
+            config=self.config, mesh=mesh, quant=self.quant, model_mode=self.model_mode, **rem_layer_kwargs, rngs=rngs
+        )  # pytype: disable=wrong-keyword-args
+      else:
+        layer_cls = decoder_block_classes[0]
+        num_layers = int(config.num_decoder_layers / config.inhomogeneous_layer_cycle_interval)
+        layer_kwargs = {}
+        if config.decoder_block == DecoderBlockType.LLAMA4:
+          layer_kwargs = {
+              "nope_layer_interval": self.config.nope_layer_interval,
+              "interleave_moe_layer_step": self.config.interleave_moe_layer_step,
+          }
+
+        self.layers = self._create_scanned_layers(layer_cls, length=num_layers, rngs=rngs, **layer_kwargs)
+    else:
+      self.layers = nnx.List([])
+
+      if self.is_deepseek:
+        dense_cls, moe_cls = decoder_block_classes
+        for i in range(config.first_num_dense_layers):
+          self._create_and_register_layer(dense_cls, rngs, "dense_layer", i)
+        for i in range(config.num_decoder_layers - config.first_num_dense_layers):
+          self._create_and_register_layer(moe_cls, rngs, "moe_layer", i)
+      else:
+        layer_cls = decoder_block_classes[0]
+
+        for lyr in range(config.num_decoder_layers):
+          layer_kwargs = {}
+          if config.decoder_block == DecoderBlockType.GEMMA3:
+            layer_kwargs = {"attention_type": gemma3.get_attention_type(layer_id=lyr)}
+          elif config.decoder_block == DecoderBlockType.LLAMA4:
+            layer_kwargs = {
+                "is_nope_layer": llama4.determine_is_nope_layer(lyr, self.config.nope_layer_interval),
+                "is_moe_layer": llama4.determine_is_moe_layer(lyr, self.config.interleave_moe_layer_step),
+            }
+          elif config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+            layer_kwargs = {"layer_idx": lyr}
+          elif config.decoder_block == DecoderBlockType.GPT_OSS:
+            layer_kwargs = {"attention_type": gpt_oss.get_attention_type(layer_id=lyr)}
+          elif config.decoder_block == DecoderBlockType.OLMO3:
+            layer_kwargs = {"attention_type": olmo3.get_attention_type(layer_id=lyr)}
+
+          self._create_and_register_layer(layer_cls, rngs, "layers", lyr, **layer_kwargs)
+
+  def _create_and_register_layer(self, layer_cls, rngs, base_name, i, **layer_kwargs):
+    attr_name = f"{base_name}_{i}"
+    layer = self._create_single_layer(layer_cls, rngs, **layer_kwargs)
+    setattr(self, attr_name, layer)
+    self.layers.append(layer)
+
+  def _create_single_layer(self, decoder_layer_class, rngs, **kwargs):
+    """Helper to create a single layer (Linen or NNX)."""
+    if issubclass(decoder_layer_class, nnx.Module):
+      return decoder_layer_class(
+          config=self.config, mesh=self.mesh, quant=self.quant, model_mode=self.model_mode, rngs=rngs, **kwargs
+      )
+    else:
+      layer_linen = decoder_layer_class(
+          config=self.config, mesh=self.mesh, quant=self.quant, model_mode=self.model_mode, **kwargs
+      )
+      return nnx_wrappers.ToNNX(layer_linen, rngs=rngs)
+
+  def _create_scanned_layers(self, decoder_layer_class, length: int, rngs: nnx.Rngs, **layer_kwargs):
+    """Creates a VMapped stack of layers, forcing parameter init for Compact modules."""
+
+    def create_layer_fn(rng):
+      layer = decoder_layer_class(
+          config=self.config, mesh=self.mesh, quant=self.quant, model_mode=self.model_mode, rngs=rng, **layer_kwargs
+      )
+
+      return layer
+
+    # Workaround for Deepseek MTP test failure.
+    # TODO: Handle this properly.
+    try:
+      forked_rngs = rngs.fork(split=length)
+
+    except:  # pylint: disable=bare-except
+      pass
+
+    out_axes = nnx.StateAxes({nnx.Param: self.config.param_scan_axis, ...: 0})
+    layers_vmapped = nnx.vmap(
+        create_layer_fn,
+        in_axes=0,
+        out_axes=out_axes,
+        axis_name="layers",
+        transform_metadata={nnx.PARTITION_NAME: "layers"},
+    )(forked_rngs)
+
+    return layers_vmapped
+
+  def _apply_layer_with_remat(self, layer: nnx.Module, y: jax.Array, policy: Any, prevent_cse: bool, **kwargs):
+    """Helper to cleanly apply jax.checkpoint to a single unscanned layer or block."""
+
+    graphdef, state = nnx.split(layer)
+
+    def pure_layer_fn(state_in, y_in):
+      merged_layer = nnx.merge(graphdef, state_in)
+      out = merged_layer(y_in, **kwargs)
+      return out, nnx.state(merged_layer)
+
+    checkpointed_fn = jax.checkpoint(pure_layer_fn, policy=policy, prevent_cse=prevent_cse)
+    out, new_state = checkpointed_fn(state, y)
+    nnx.update(layer, new_state)
+
+    return out
+
+  def _apply_layers_sequentially(self, layers, x_in, *args, length: int, **kwargs):
+    """Runs the layer stack using nnx.scan."""
+    policy = self.get_remat_policy()
+    prevent_cse = maxtext_utils.should_prevent_cse_in_remat(self.config)
+    graphdef, params, state = nnx.split(
+        layers, nnx.Param, ...
+    )  # state: the mutable state we carry (KV cache, RNGs, etc.)
+
+    scan_axis = self.config.param_scan_axis
+    if scan_axis != 0:
+      # Move scan_axis to 0 so scan can iterate over it
+      params = jax.tree.map(lambda x: jnp.moveaxis(x, scan_axis, 0), params)
+
+    layer_cls = layers.__class__
+    sig = inspect.signature(layer_cls.__call__)
+    valid_kwargs = {k: v for k, v in kwargs.items() if k in sig.parameters or "kwargs" in sig.parameters}
+
+    layer_cls = layers.__class__  # Access the underlying class
+    sig = inspect.signature(layer_cls.__call__)
+    # Filter kwargs to only include keys that exist in the layer's signature
+    valid_kwargs = {k: v for k, v in kwargs.items() if k in sig.parameters or "kwargs" in sig.parameters}
+
+    def layer_fn(carry, scanned_vars):
+      # Unpack the sliced variables for THIS layer
+      current_params, current_state = scanned_vars
+
+      if self.config.parameter_memory_host_offload:
+        current_params = jax.tree.map(lambda x: jax.device_put(x, max_utils.device_space()), current_params)
+
+      # Merge using the SLICED state
+      layer = nnx.merge(graphdef, current_params, current_state)
+
+      # Run the layer (Filter kwargs if using the solution from previous turn)
+      layer_out = layer(carry, *args, **valid_kwargs)
+
+      new_carry = layer_out[0] if isinstance(layer_out, tuple) else layer_out
+
+      # Extract the updated state to return it
+      # _, new_current_state = nnx.split(layer, nnx.Param, ...)
+      new_current_state = nnx.state(layer)
+      return new_carry, new_current_state
+
+    layer_fn = jax.checkpoint(layer_fn, policy=policy, prevent_cse=prevent_cse)
+
+    final_carry, scanned_state = jax.lax.scan(layer_fn, x_in, (params, state))
+
+    if scan_axis != 0:
+      scanned_params, scanned_other = scanned_state.split(nnx.Param, ...)
+      scanned_params = jax.tree.map(lambda x: jnp.moveaxis(x, 0, scan_axis), scanned_params)
+      scanned_state = nnx.State.merge(scanned_params, scanned_other)
+
+    return final_carry, nnx.merge(graphdef, scanned_state)
+
+  def get_decoder_layers(self):
+    """Retrieves decoder layer classes based on config using a dictionary lookup."""
+    cfg = self.config
+
+    def get_scannable(normal_cls, scannable_cls):
+      return [scannable_cls] if cfg.scan_layers else [normal_cls]
+
+    def get_deepseek():
+      if cfg.use_batch_split_schedule:
+        return [deepseek_batchsplit.DeepSeekDenseLayer, deepseek_batchsplit.DeepSeekMoELayer]
+      return [deepseek.DeepSeekDenseLayer, deepseek.DeepSeekMoELayer]
+
+    layer_map = {
+        DecoderBlockType.DEFAULT: [NNXDecoderLayer],
+        DecoderBlockType.LLAMA2: [llama2.LlamaDecoderLayer],
+        DecoderBlockType.MISTRAL: [mistral.MistralDecoderLayer],
+        DecoderBlockType.MIXTRAL: [mixtral.MixtralDecoderLayer],
+        DecoderBlockType.GEMMA: [gemma.GemmaDecoderLayer],
+        DecoderBlockType.GEMMA2: [gemma2.Gemma2DecoderLayer],
+        DecoderBlockType.GEMMA3: [gemma3.Gemma3DecoderLayer],
+        DecoderBlockType.GPT3: [gpt3.Gpt3DecoderLayer],
+        DecoderBlockType.QWEN3: [qwen3.Qwen3DecoderLayer],
+        DecoderBlockType.QWEN3_MOE: [qwen3.Qwen3MoeDecoderLayer],
+        DecoderBlockType.SIMPLE: [simple_layer.SimpleDecoderLayer],
+        DecoderBlockType.SIMPLE_MLP: [simple_layer.SimpleMlpDecoderLayer],
+        DecoderBlockType.DEEPSEEK: get_deepseek(),
+        DecoderBlockType.GPT_OSS: get_scannable(gpt_oss.GptOssDecoderLayer, gpt_oss.GptOssScannableBlock),
+        DecoderBlockType.QWEN3_NEXT: get_scannable(qwen3.Qwen3NextDecoderLayer, qwen3.Qwen3NextScannableBlock),
+        DecoderBlockType.LLAMA4: get_scannable(llama4.Llama4DecoderLayer, llama4.Llama4ScannableBlock),
+        DecoderBlockType.OLMO3: get_scannable(olmo3.Olmo3DecoderLayer, olmo3.Olmo3ScannableBlock),
+    }
+
+    if cfg.decoder_block not in layer_map:
+      raise ValueError(f"Incorrect decoder_block name {cfg.decoder_block.value=}")
+
+    return layer_map[cfg.decoder_block]
+
+  def minimal_policy(self, with_context=False, with_quantization=False):
+    """Helper for creating minimal checkpoint policies."""
+    names = [
+        "query_proj",
+        "value_proj",
+        "key_proj",
+        "qkv_proj",
+        "out_proj",
+        "mlpwi_0",
+        "mlpwi_1",
+        "mlpwi",
+        "mlpwo",
+    ]
+    if with_context:
+      names.append("context")
+    if with_quantization:
+      names.append("quantization")
+    return jax.checkpoint_policies.save_only_these_names(*names)
+
+  def get_remat_policy(self):
+    """Get remat policy for jax.checkpoint."""
+    policy = None
+    cfg = self.config
+    if cfg.remat_policy != "none":
+      if cfg.remat_policy in ("minimal_with_context", "minimal_flash"):
+        # save all
+        if cfg.remat_policy == "minimal_flash":
+          max_logging.log("WARNING: 'minimal_flash' will be deprecated soon, please use 'minimal_with_context' instead.")
+        policy = self.minimal_policy(with_context=True)
+      elif cfg.remat_policy == "minimal":
+        # save all except context
+        policy = self.minimal_policy()
+      elif cfg.remat_policy == "minimal_with_quantization":
+        if cfg.scan_layers:
+          warnings.warn(
+              "Scan layers can introduce overhead to checkpointed values that in some configurations is slower"
+              "than not checkpointing at all. If you are using scan layers, benchmark with and without quantization "
+              "checkpointing in your workflow to see which is faster. Without scan layers, checkpointing quantizations is "
+              "beneficial for performance."
+          )
+        policy = self.minimal_policy(with_context=False, with_quantization=True)
+      elif cfg.remat_policy == "minimal_with_context_and_quantization":
+        if cfg.scan_layers:
+          warnings.warn(
+              "Scan layers can introduce overhead to checkpointed values that in some configurations is slower"
+              "than not checkpointing at all. If you are using scan layers, benchmark with and without quantization "
+              "checkpointing in your workflow to see which is faster. Without scan layers, checkpointing quantizations is "
+              "beneficial for performance."
+          )
+        policy = self.minimal_policy(with_context=True, with_quantization=True)
+      elif cfg.remat_policy == "save_dot_with_context_except_mlp":
+        policy = jax.checkpoint_policies.save_only_these_names(
+            "query_proj",
+            "value_proj",
+            "key_proj",
+            "qkv_proj",
+            "context",
+            "out_proj",
+        )
+      elif cfg.remat_policy == "save_dot_except_mlpwi":
+        policy = jax.checkpoint_policies.save_only_these_names(
+            "query_proj",
+            "value_proj",
+            "key_proj",
+            "qkv_proj",
+            "out_proj",
+            "mlpwo",
+        )
+      elif cfg.remat_policy == "save_dot_except_mlp":
+        policy = jax.checkpoint_policies.save_only_these_names(
+            "query_proj",
+            "value_proj",
+            "key_proj",
+            "qkv_proj",
+            "out_proj",
+        )
+      elif cfg.remat_policy == "save_qkv_proj":
+        policy = jax.checkpoint_policies.save_only_these_names(
+            "query_proj",
+            "value_proj",
+            "key_proj",
+            "qkv_proj",
+        )
+      elif cfg.remat_policy == "qkv_proj_offloaded":
+        policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+            names_which_can_be_saved=[],
+            names_which_can_be_offloaded=["query_proj", "value_proj", "key_proj"],
+            offload_src="device",
+            offload_dst="pinned_host",
+        )
+      elif cfg.remat_policy == "minimal_offloaded":
+        # offload all except context
+        policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+            names_which_can_be_saved=[],
+            names_which_can_be_offloaded=[
+                "query_proj",
+                "value_proj",
+                "key_proj",
+                "qkv_proj",
+                "out_proj",
+                "mlpwi_0",
+                "mlpwi_1",
+                "mlpwi",
+                "mlpwo",
+            ],
+            offload_src="device",
+            offload_dst="pinned_host",
+        )
+      elif cfg.remat_policy == "custom":
+        policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+            names_which_can_be_saved=cfg.tensors_on_device,
+            names_which_can_be_offloaded=cfg.tensors_to_offload,
+            offload_src="device",
+            offload_dst="pinned_host",
+        )
+      elif cfg.remat_policy == "save_out_proj":
+        policy = jax.checkpoint_policies.save_only_these_names("out_proj")
+      else:
+        assert cfg.remat_policy == "full", "Remat policy needs to be on list of remat policies"
+        policy = None
+    return policy
+
+  def get_norm_layer(self, num_features: int, rngs: nnx.Rngs):
+    """get normalization layer (return type inherits from nn.Module)"""
+    if self.config.decoder_block in (
+        DecoderBlockType.DEFAULT,
+        DecoderBlockType.LLAMA2,
+        DecoderBlockType.MISTRAL,
+        DecoderBlockType.MIXTRAL,
+        DecoderBlockType.DEEPSEEK,
+        DecoderBlockType.GEMMA,
+        DecoderBlockType.GEMMA2,
+        DecoderBlockType.GEMMA3,
+        DecoderBlockType.QWEN3,
+        DecoderBlockType.QWEN3_MOE,
+        DecoderBlockType.GPT_OSS,
+        DecoderBlockType.SIMPLE,
+        DecoderBlockType.SIMPLE_MLP,
+        DecoderBlockType.LLAMA4,
+        DecoderBlockType.OLMO3,
+    ):
+      return functools.partial(RMSNorm, num_features=num_features, shard_mode=self.config.shard_mode, rngs=rngs)
+    elif self.config.decoder_block == DecoderBlockType.GPT3:
+      return functools.partial(
+          gpt3.Gpt3LayerNorm, num_features=num_features, reductions_in_fp32=False, use_bias=True, rngs=rngs
+      )
+    elif self.config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+      return functools.partial(
+          normalizations.Qwen3NextRMSNorm, num_features=num_features, shard_mode=self.config.shard_mode, rngs=rngs
+      )
+    else:
+      raise ValueError(f"Incorrect decoder_block name {self.config.decoder_block.value=}")
+
+  def _apply_embedding(
+      self,
+      shared_embedding: nnx.Module,
+      decoder_input_tokens,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      image_embeddings=None,
+      bidirectional_mask=None,
+      image_masks=None,
+      audio_embeddings=None,
+      audio_masks=None,
+  ):
+    """Applies token and positional embeddings to the input tokens."""
+    cfg = self.config
+
+    y = shared_embedding(decoder_input_tokens.astype("int32"), model_mode=model_mode)
+
+    # Merge the image embeddings with the text embeddings for multimodal models
+    if image_embeddings is not None and cfg.use_multimodal:
+      if cfg.model_name in [
+          "gemma3-4b",
+          "gemma3-12b",
+          "gemma3-27b",
+          "llama4-17b-16e",
+          "llama4-17b-128e",
+          "qwen3-omni-30b-a3b",
+      ]:
+        y = mm_utils.merge_mm_embeddings(
+            text_embeddings=y,
+            multimodal_embeddings=image_embeddings,
+            mask=bidirectional_mask,
+            token_masks=image_masks,
+        )
+      # TODO(hengtaoguo): Add support for other multimodal models such as Llama4, refactor if needed
+      else:
+        raise ValueError(f"Unsupported model_name for multimodal: {cfg.model_name}")
+
+    if audio_embeddings is not None and cfg.use_audio:
+      if cfg.model_name in ["qwen3-omni-30b-a3b"]:
+        y = mm_utils.merge_mm_embeddings(
+            text_embeddings=y,
+            multimodal_embeddings=audio_embeddings,
+            mask=audio_masks,
+            token_masks=None,
+        )
+      else:
+        raise ValueError(f"Unsupported model_name for audio: {cfg.model_name}")
+
+    y = self.dropout(y, deterministic=deterministic)
+    y = y.astype(cfg.dtype)
+
+    if cfg.use_untrainable_positional_embedding:
+      y += self.positional_embedding(y, decoder_positions)
+
+    if cfg.trainable_position_size > 0 and self.position_embedder:
+      y += self.position_embedder(decoder_positions.astype("int32"), model_mode=model_mode)
+
+    return y
+
+  def apply_output_head(self, shared_embedding, y, deterministic, model_mode):
+    """Applies final normalization and projects hidden states to logits."""
+
+    cfg = self.config
+    if cfg.shard_mode == ShardMode.EXPLICIT:
+      norm_out_sharding = create_sharding(self.mesh, ("activation_batch", "activation_length_no_exp", "activation_embed"))
+    else:
+      norm_out_sharding = None
+
+    y = self.decoder_norm(y, out_sharding=norm_out_sharding)
+    y = self.dropout(y, deterministic=deterministic)  # NNX call
+
+    if model_mode in (MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE):
+      out_sharding = create_sharding(self.mesh, (None, None, "activation_vocab"))
+    else:
+      out_sharding = create_sharding(
+          self.mesh, ("activation_embed_and_logits_batch", "activation_length_no_exp", "activation_vocab")
+      )
+
+    # [batch, length, emb_dim] -> [batch, length, vocab_size]
+    if cfg.logits_via_embedding:
+      # Use the transpose of embedding matrix for logit transform.
+      if isinstance(shared_embedding, nnx.Module):
+        embedding_table = shared_embedding.embedding.value
+      else:
+        embedding_table = shared_embedding.variables["params"]["embedding"]
+      if isinstance(embedding_table, nn.spmd.LogicallyPartitioned):
+        embedding_table = embedding_table.unbox()
+      attend_dtype = jnp.float32 if cfg.logits_dot_in_fp32 else cfg.dtype
+      logits = attend_on_embedding(y, embedding_table, attend_dtype, self.config, out_sharding)
+
+      if self.config.normalize_embedding_logits:
+        # Correctly normalize pre-softmax logits for this shared case.
+        logits = logits / jnp.sqrt(y.shape[-1])
+      if cfg.final_logits_soft_cap:
+        logits = logits / cfg.final_logits_soft_cap
+        logits = jnp.tanh(logits) * cfg.final_logits_soft_cap
+    else:
+      logits = self.logits_dense(y, out_sharding=out_sharding)
+
+    if self.config.cast_logits_to_fp32:
+      logits = logits.astype(jnp.float32)
+
+    return logits
+
+  def _build_linen_params(self, moe_stack: nnx.Module) -> dict:
+    """
+    Bridges NNX to Linen by creating a dictionary that mimics the exact variable
+    structure expected by `deepseek_batchsplit.fetch_weights`.
+    """
+
+    return {
+        "pre_self_attention_layer_norm": {
+            "scale": moe_stack.pre_self_attention_layer_norm.scale,
+        },
+        "post_self_attention_layer_norm": {
+            "scale": moe_stack.post_self_attention_layer_norm.scale,
+        },
+        "self_attention": {
+            "wq_a": {"kernel": moe_stack.self_attention.wq_a.kernel},
+            "wq_b": {"kernel": moe_stack.self_attention.wq_b.kernel},
+            "q_norm": {"scale": moe_stack.self_attention.q_norm.scale},
+            "wkv_a": {"kernel": moe_stack.self_attention.wkv_a.kernel},
+            "wkv_b": {"kernel": moe_stack.self_attention.wkv_b.kernel},
+            "kv_norm": {"scale": moe_stack.self_attention.kv_norm.scale},
+            "out": {"kernel": moe_stack.self_attention.out.kernel},
+        },
+        "DeepSeekMoeBlock_0": {
+            "MoeBlock_0": {
+                "gate": {
+                    "kernel": moe_stack.DeepSeekMoeBlock_0.MoeBlock_0.gate.kernel,
+                    "bias": moe_stack.DeepSeekMoeBlock_0.MoeBlock_0.gate.bias,
+                },
+                "wi_0": moe_stack.DeepSeekMoeBlock_0.MoeBlock_0.wi_0,
+                "wi_1": moe_stack.DeepSeekMoeBlock_0.MoeBlock_0.wi_1,
+                "wo": moe_stack.DeepSeekMoeBlock_0.MoeBlock_0.wo,
+            },
+            "shared_experts": {
+                "wi_0": {"kernel": moe_stack.DeepSeekMoeBlock_0.shared_experts.wi_0.kernel},
+                "wi_1": {"kernel": moe_stack.DeepSeekMoeBlock_0.shared_experts.wi_1.kernel},
+                "wo": {"kernel": moe_stack.DeepSeekMoeBlock_0.shared_experts.wo.kernel},
+            },
+        },
+    }
+
+  def _find_next_boundary(self, current_idx, end_idx, engram_indices):
+    """Finds the next index boundary, either the next Engram layer index or the overall end index."""
+    next_engrams = [l for l in engram_indices if l > current_idx]
+    if next_engrams:
+      return min(end_idx, *next_engrams)
+    return end_idx
+
+  def _apply_single_engram_layer(self, y, current_idx, layer_stack, *args, **kwargs):
+    """Applies a single, unscanned Engram layer by dynamically slicing the NNX state."""
+    graphdef, state = nnx.split(layer_stack)
+
+    # Slice the parameters for the current index (assuming scan axis is 0)
+    sliced_state = jax.tree.map(lambda x: x[current_idx], state)
+    single_layer = nnx.merge(graphdef, sliced_state)
+
+    # Run the single layer
+    out = single_layer(
+        y, *args, decoder_input_tokens=kwargs.get("decoder_input_tokens"), **kwargs.get("layer_kwargs", {})
+    )
+    y = out[0] if isinstance(out, tuple) else out
+
+    # Re-merge the updated state back into the specific slice of the stack
+    new_single_state = nnx.state(single_layer)
+    updated_state = jax.tree.map(
+        lambda s, new_s: jax.lax.dynamic_update_slice_in_dim(s, jnp.expand_dims(new_s, axis=0), current_idx, axis=0),
+        state,
+        new_single_state,
+    )
+    nnx.update(layer_stack, updated_state)
+
+    return y
+
+  def _apply_scanned_chunk(self, y, current_idx, next_boundary, layer_stack, *args, **kwargs):
+    """Applies a contiguous chunk of layers using scan over a state slice."""
+    scan_length = next_boundary - current_idx
+    if scan_length > 0:
+      graphdef, state = nnx.split(layer_stack)
+
+      # Slice the chunk state
+      chunk_state = jax.tree.map(lambda x: jax.lax.dynamic_slice_in_dim(x, current_idx, scan_length, axis=0), state)
+      chunk_stack = nnx.merge(graphdef, chunk_state)
+
+      # Apply sequentially
+      y, chunk_stack = self._apply_layers_sequentially(
+          chunk_stack, y, *args, length=scan_length, **kwargs.get("layer_kwargs", {})
+      )
+
+      # Update the original stack state
+      new_chunk_state = nnx.state(chunk_stack)
+      updated_state = jax.tree.map(
+          lambda s, new_s: jax.lax.dynamic_update_slice_in_dim(s, new_s, current_idx, axis=0), state, new_chunk_state
+      )
+      nnx.update(layer_stack, updated_state)
+
+    return y
+
+  def _apply_interleaved_scanned_layers(self, y, layer_stack, start_idx, end_idx, engram_indices, *args, **kwargs):
+    """Applies a mix of scanned standard layers and unscanned Engram layers."""
+    current_idx = start_idx
+    while current_idx < end_idx:
+      if current_idx in engram_indices:
+        y = self._apply_single_engram_layer(y, current_idx, layer_stack, *args, **kwargs)
+        current_idx += 1
+      else:
+        next_boundary = self._find_next_boundary(current_idx, end_idx, engram_indices)
+        y = self._apply_scanned_chunk(y, current_idx, next_boundary, layer_stack, *args, **kwargs)
+        current_idx = next_boundary
+    return y
+
+  def __call__(
+      self,
+      shared_embedding: Any,
+      decoder_input_tokens,
+      decoder_positions,
+      decoder_segment_ids=None,
+      deterministic=False,
+      model_mode=MODEL_MODE_TRAIN,
+      previous_chunk=None,
+      slot: None | int = None,
+      page_state: None | page_manager.PageState = None,
+      bidirectional_mask: None | Any = None,
+      image_embeddings: None | jnp.ndarray = None,
+      image_masks: None | jnp.ndarray = None,
+      kv_caches: list[jax.Array] | None = None,
+      attention_metadata=None,
+      audio_embeddings: None | jnp.ndarray = None,
+      audio_masks: None | jnp.ndarray = None,
+      deepstack_visual_embeds: None | list[jnp.ndarray] = None,
+  ):
+    cfg = self.config
+    assert decoder_input_tokens.ndim == 2  # [batch, len]
+
+    policy = self.get_remat_policy()
+
+    # [batch, length] -> [batch, length, emb_dim]
+    y = self._apply_embedding(
+        shared_embedding,
+        decoder_input_tokens,
+        decoder_positions,
+        deterministic,
+        model_mode,
+        image_embeddings,
+        bidirectional_mask,
+        image_masks,
+        audio_embeddings,
+        audio_masks,
+    )
+
+    mhc_expand, mhc_reduce = mhc.get_functions(cfg.mhc_expansion_rate)
+    if cfg.mhc_expansion_rate > 1:
+      # (batch, length, emb_dim) --> (batch, length, mhc_expansion_rate, emb_dim)
+      y = mhc_expand(y)
+
+    layer_args = (decoder_segment_ids, decoder_positions, deterministic, model_mode)
+
+    layer_kwargs = {}
+    if cfg.decoder_block == DecoderBlockType.GEMMA3:
+      layer_kwargs["bidirectional_mask"] = bidirectional_mask
+
+    if attention_metadata is not None:
+      layer_kwargs["attention_metadata"] = attention_metadata
+
+    if cfg.scan_layers:
+      if self.is_deepseek:
+        layer_kwargs = {
+            "previous_chunk": previous_chunk,
+            "page_state": page_state,
+            "slot": slot,
+        }
+
+        if cfg.engram_layers:
+          common_kwargs = {
+              "layer_kwargs": layer_kwargs,
+              "decoder_input_tokens": decoder_input_tokens,
+          }
+
+          y = self._apply_interleaved_scanned_layers(
+              y, self.dense_layers, 0, cfg.first_num_dense_layers, cfg.engram_layers, *layer_args, **common_kwargs
+          )
+
+          y = self._apply_interleaved_scanned_layers(
+              y,
+              self.moe_layer,
+              0,
+              (cfg.num_decoder_layers - cfg.first_num_dense_layers),
+              [e - cfg.first_num_dense_layers for e in cfg.engram_layers],
+              *layer_args,
+              **common_kwargs,
+          )
+        else:
+          y, self.dense_layers = self._apply_layers_sequentially(
+              self.dense_layers, y, *layer_args, length=cfg.first_num_dense_layers, **layer_kwargs
+          )
+
+          num_moe = cfg.num_decoder_layers - cfg.first_num_dense_layers
+
+          if cfg.use_batch_split_schedule:
+            policy = self.get_remat_policy()
+
+            mock_params = self._build_linen_params(self.moe_layer)
+
+            y = deepseek_batchsplit.scan_batch_split_layers(
+                y,
+                mock_params,
+                decoder_positions,
+                decoder_segment_ids,
+                model_mode=model_mode,
+                mesh=self.mesh,
+                quant=self.quant,
+                cfg=cfg,
+                policy=policy,
+            )
+          else:
+            y, self.moe_layer = self._apply_layers_sequentially(
+                self.moe_layer, y, *layer_args, length=num_moe, **layer_kwargs
+            )
+      elif self.is_gemma3:
+        y = self._apply_gemma3_scanned_blocks(
+            y,
+            decoder_segment_ids,
+            decoder_positions,
+            deterministic,
+            model_mode,
+            bidirectional_mask,
+            previous_chunk,
+            page_state,
+            slot,
+        )
+      else:
+        scan_length = int(cfg.num_decoder_layers / cfg.inhomogeneous_layer_cycle_interval)
+        y, self.layers = self._apply_layers_sequentially(self.layers, y, *layer_args, length=scan_length, **layer_kwargs)
+    else:
+      prevent_cse = maxtext_utils.should_prevent_cse_in_remat(cfg)
+
+      # Hoisted function to preserve XLA cache ID
+      def pure_layer_fn(graphdef, state_in, y_in, kv_in):
+
+        if cfg.parameter_memory_host_offload:
+          state_in = jax.tree.map(lambda x: jax.device_put(x, max_utils.device_space()), state_in)
+
+        merged_layer = nnx.merge(graphdef, state_in)
+        out_y, out_kv = merged_layer(y_in, *layer_args, kv_cache=kv_in, **layer_kwargs)
+        return out_y, out_kv, nnx.state(merged_layer)
+
+      checkpointed_fn = jax.checkpoint(pure_layer_fn, policy=policy, prevent_cse=prevent_cse)
+
+      for lyr, layer in enumerate(self.layers):
+        graphdef, state = nnx.split(layer)
+        kv_cache = kv_caches[lyr] if kv_caches is not None else None
+
+        input_tokens = decoder_input_tokens if cfg.engram_layers else None
+        if input_tokens is not None:
+          layer_kwargs["decoder_input_tokens"] = input_tokens
+
+        y, kv_cache, new_state = checkpointed_fn(graphdef, state, y, kv_cache)
+        nnx.update(layer, new_state)
+
+        if kv_caches is not None and kv_cache is not None:
+          kv_caches[lyr] = kv_cache
+
+        if deepstack_visual_embeds is not None and lyr < len(deepstack_visual_embeds):
+          visual_embeds = deepstack_visual_embeds[lyr]
+          if bidirectional_mask is not None and visual_embeds is not None:
+            y = deepstack_process(y, bidirectional_mask, visual_embeds)
+
+    assert isinstance(y, jax.Array)
+
+    # After the final transformer layer, `y` holds the raw, un-normalized hidden state.
+    if cfg.mhc_expansion_rate > 1:
+      # (batch, length, mhc_expansion_rate, emb_dim) --> (batch, length, emb_dim)
+      hidden_state = mhc_reduce(y)
+    else:
+      hidden_state = y
+
+    # When invoking from vLLM with RPA attention, logit computation is deferred to a later stage.
+    if cfg.attention == "vllm_rpa":
+      logits = None
+
+    # When vocab tiling is enabled in training mode, full logits won't generate to reduce memory
+    # Instead, we keep track on the hidden states, which has smaller size compared to full logits
+    if cfg.num_vocab_tiling > 1 and self.model_mode == MODEL_MODE_TRAIN:
+      logits = None
+      self.sow(nnx.Intermediate, "hidden_states", hidden_state)
+
+    else:
+      logits = self.apply_output_head(shared_embedding, hidden_state, deterministic, model_mode)
+
+    return logits, hidden_state, kv_caches
+
+  def _apply_gemma3_scanned_blocks(
+      self,
+      y,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      bidirectional_mask,
+      previous_chunk,
+      page_state,
+      slot,
+  ):
+    """Applies Gemma3 scanned decoder blocks, handling main scan and remainders."""
+
+    cfg = self.config
+
+    # Define the repeating pattern length and calculate how many full blocks to scan
+    attention_pattern_length = len(gemma3.GEMMA3_ATTENTION_PATTERN)
+    scan_length = cfg.num_decoder_layers // attention_pattern_length
+
+    layer_args = (decoder_segment_ids, decoder_positions, deterministic, model_mode)
+    layer_kwargs = {"bidirectional_mask": bidirectional_mask}
+
+    # Apply the main scan over the full blocks
+    if scan_length > 0:
+      y, self.layers = self._apply_layers_sequentially(self.layers, y, *layer_args, length=scan_length, **layer_kwargs)
+
+    # Apply any remaining layers that did not fit into a full scanned block
+    num_remaining_layers = cfg.num_decoder_layers % attention_pattern_length
+    if num_remaining_layers > 0:
+      policy = self.get_remat_policy()
+      prevent_cse = maxtext_utils.should_prevent_cse_in_remat(cfg)
+
+      def pure_gemma_fn(graphdef, state_in, y_in):
+        merged_layer = nnx.merge(graphdef, state_in)
+        out_y, _ = merged_layer(
+            y_in, *layer_args, previous_chunk=previous_chunk, page_state=page_state, slot=slot, **layer_kwargs
+        )
+        return out_y, nnx.state(merged_layer)
+
+      checkpointed_gemma_fn = jax.checkpoint(pure_gemma_fn, policy=policy, prevent_cse=prevent_cse)
+
+      graphdef, state = nnx.split(self.layers_remainder)
+      y, new_state = checkpointed_gemma_fn(graphdef, state, y)
+      nnx.update(self.layers_remainder, new_state)
+
+    return y
+
+
+def decoder_as_linen(
+    config: Config,
+    mesh: Mesh,
+    rngs: nnx.Rngs,
+    model_mode: str,
+    quant: None | Quant = None,
+):
+  """Creates a Decoder module."""
+  module = nnx_wrappers.to_linen(
+      NNXDecoder,
+      config=config,
+      mesh=mesh,
+      model_mode=model_mode,
+      rngs=rngs,
+      quant=quant,
+      name="decoder",
+      abstract_init=False,
+      metadata_fn=initializers.variable_to_logically_partitioned,
+  )
+  return module

--- a/src/maxtext/layers/normalizations.py
+++ b/src/maxtext/layers/normalizations.py
@@ -102,7 +102,17 @@ class GlobalRMSNorm(RMSNorm):
     return y_flat.reshape(input_shape)
 
 
-def Qwen3NextRMSNorm(num_features: int, eps: float, dtype: DType, weight_dtype: DType, *, rngs: nnx.Rngs):
+def Qwen3NextRMSNorm(
+    num_features: int,
+    epsilon: float,
+    dtype: DType,
+    weight_dtype: DType,
+    shard_mode: ShardMode = ShardMode.AUTO,
+    kernel_axes: tuple[None | str, ...] = (),
+    parameter_memory_host_offload: bool = False,
+    *,
+    rngs: nnx.Rngs,
+):
   """
   Used for input and post attention layernorms
   in Qwen3NextDecoderLayer.
@@ -115,10 +125,13 @@ def Qwen3NextRMSNorm(num_features: int, eps: float, dtype: DType, weight_dtype: 
   return nnx.data(
       RMSNorm(
           num_features=num_features,
-          epsilon=eps,
+          epsilon=epsilon,
           dtype=dtype,
           weight_dtype=weight_dtype,
+          shard_mode=shard_mode,
+          kernel_axes=kernel_axes,
           scale_init=linen_initializers.zeros,
+          parameter_memory_host_offload=parameter_memory_host_offload,
           scale_offset=1.0,
           rngs=rngs,
       )

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -18,13 +18,16 @@
 
 from typing import Any
 
-from flax import linen as nn
-from flax import nnx
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
+
+from flax import linen as nn
+from flax import nnx
+
 from maxtext.common.common_types import Config, DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN
 from maxtext.inference import page_manager
+from maxtext.layers.nnx_decoders import NNXDecoder
 from maxtext.layers import initializers
 from maxtext.layers import nnx_wrappers
 from maxtext.layers.decoders import Decoder
@@ -86,6 +89,7 @@ class TransformerLinenPure(nn.Module):
     self.vision_encoder = vision_encoder_as_linen(config=cfg, mesh=mesh) if cfg.use_multimodal else None
     self.audio_encoder = audio_encoder_as_linen(config=cfg, mesh=mesh) if cfg.use_audio else None
     self.decoder = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
+
     # If MTP is enabled via config, set up the MTP block.
     if self.config.mtp_num_layers > 0:
       # Get the list of layer blueprints for the current model.
@@ -328,9 +332,11 @@ class Transformer(nnx.Module):
     )
     self.vision_encoder = VisionEncoder(config=cfg, mesh=mesh, rngs=rngs) if cfg.use_multimodal else None
     self.audio_encoder = AudioEncoder(config=cfg, mesh=mesh, rngs=rngs) if cfg.use_audio else None
-
-    decoder_linen = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
-    self.decoder = nnx_wrappers.ToNNX(decoder_linen, rngs=rngs)
+    if cfg.pure_nnx_decoder:
+      self.decoder = NNXDecoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode, rngs=rngs)
+    else:
+      self.decoder = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
+      self.decoder = nnx_wrappers.ToNNX(self.decoder, rngs=rngs)
     self.hidden_states = None
 
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config=cfg, model_mode=model_mode)
@@ -356,12 +362,13 @@ class Transformer(nnx.Module):
     else:
       dummy_attention_metadata = None
 
-    self.decoder.lazy_init(
-        shared_embedding=self.token_embedder,
-        decoder_input_tokens=dummy_decoder_input_tokens,
-        decoder_positions=dummy_decoder_positions,
-        attention_metadata=dummy_attention_metadata,
-    )
+    if not cfg.pure_nnx_decoder:
+      self.decoder.lazy_init(
+          shared_embedding=self.token_embedder,
+          decoder_input_tokens=dummy_decoder_input_tokens,
+          decoder_positions=dummy_decoder_positions,
+          attention_metadata=dummy_attention_metadata,
+      )
 
     # If MTP is enabled via config, set up the MTP block.
     if self.config.mtp_num_layers > 0:
@@ -483,26 +490,47 @@ class Transformer(nnx.Module):
     if self.config.distill_beta > 0.0 and "intermediates" not in mutable_collections:
       mutable_collections.append("intermediates")
 
-    logits, hidden_state, kv_caches = self.decoder(
-        shared_embedding=self.token_embedder,
-        decoder_input_tokens=decoder_input_tokens,
-        decoder_positions=decoder_positions,
-        decoder_segment_ids=decoder_segment_ids,
-        deterministic=not enable_dropout,
-        model_mode=model_mode,
-        previous_chunk=previous_chunk,
-        slot=slot,
-        page_state=page_state,
-        bidirectional_mask=bidirectional_mask,
-        image_embeddings=image_embeddings,
-        image_masks=encoder_image_masks,
-        audio_embeddings=audio_embeddings,
-        audio_masks=audio_masks,
-        kv_caches=kv_caches,
-        attention_metadata=attention_metadata,
-        deepstack_visual_embeds=deepstack_visual_embeds,
-        mutable=mutable_collections,
-    )
+    if self.config.pure_nnx_decoder:
+      logits, hidden_state, kv_caches = self.decoder(
+          shared_embedding=self.token_embedder,
+          decoder_input_tokens=decoder_input_tokens,
+          decoder_positions=decoder_positions,
+          decoder_segment_ids=decoder_segment_ids,
+          deterministic=not enable_dropout,
+          model_mode=model_mode,
+          previous_chunk=previous_chunk,
+          slot=slot,
+          page_state=page_state,
+          bidirectional_mask=bidirectional_mask,
+          image_embeddings=image_embeddings,
+          image_masks=encoder_image_masks,
+          audio_embeddings=audio_embeddings,
+          audio_masks=audio_masks,
+          kv_caches=kv_caches,
+          attention_metadata=attention_metadata,
+          deepstack_visual_embeds=deepstack_visual_embeds,
+      )
+    else:
+      logits, hidden_state, kv_caches = self.decoder(
+          shared_embedding=self.token_embedder,
+          decoder_input_tokens=decoder_input_tokens,
+          decoder_positions=decoder_positions,
+          decoder_segment_ids=decoder_segment_ids,
+          deterministic=not enable_dropout,
+          model_mode=model_mode,
+          previous_chunk=previous_chunk,
+          slot=slot,
+          page_state=page_state,
+          bidirectional_mask=bidirectional_mask,
+          image_embeddings=image_embeddings,
+          image_masks=encoder_image_masks,
+          audio_embeddings=audio_embeddings,
+          audio_masks=audio_masks,
+          kv_caches=kv_caches,
+          attention_metadata=attention_metadata,
+          deepstack_visual_embeds=deepstack_visual_embeds,
+          mutable=mutable_collections,
+      )
 
     # Materialize hidden state when vocab tiling is enabled
     if self.config.num_vocab_tiling > 1:

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -962,7 +962,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
     # First LayerNorm, applied before the attention block.
     self.input_layernorm = Qwen3NextRMSNorm(
         num_features=cfg.emb_dim,
-        eps=cfg.normalization_layer_epsilon,
+        epsilon=cfg.normalization_layer_epsilon,
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
         rngs=rngs,
@@ -987,7 +987,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
     # Second LayerNorm, applied before the MoE block.
     self.post_attention_layernorm = Qwen3NextRMSNorm(
         num_features=cfg.emb_dim,
-        eps=cfg.normalization_layer_epsilon,
+        epsilon=cfg.normalization_layer_epsilon,
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
         rngs=rngs,

--- a/tests/unit/multi_token_prediction_test.py
+++ b/tests/unit/multi_token_prediction_test.py
@@ -21,11 +21,11 @@ from jax.sharding import Mesh
 from flax import nnx
 
 from maxtext.configs import pyconfig
-from maxtext.layers.decoders import DecoderLayer
 from maxtext.layers import multi_token_prediction  # The class under test
 from maxtext.layers import embeddings
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.common.common_types import Config
+from maxtext.layers.nnx_decoders import NNXDecoderLayer
 from maxtext.utils import max_logging
 from maxtext.utils import maxtext_utils
 
@@ -54,12 +54,11 @@ class MultiTokenPredictionLayerTest(unittest.TestCase):
     devices_array = maxtext_utils.create_device_mesh(self.cfg)
     self.mesh = Mesh(devices_array, self.cfg.mesh_axes)
 
-    # Instantiate the Layer
     self.mtp_layer = multi_token_prediction.MultiTokenPredictionLayer(
         config=self.cfg,
         mesh=self.mesh,
         layer_number=TEST_LAYER_NUM,
-        transformer_layer_module=DecoderLayer,
+        transformer_layer_module=NNXDecoderLayer,
         rngs=self.rngs,
     )
 
@@ -157,7 +156,7 @@ class MTPBlockTestModel(nnx.Module):
     self.mtp_block = multi_token_prediction.MultiTokenPredictionBlock(
         config=self.config,
         mesh=self.mesh,
-        transformer_layer_module=DecoderLayer,
+        transformer_layer_module=NNXDecoderLayer,
         decoder=self.decoder,
         rngs=self.rngs,
     )

--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -1,0 +1,536 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for nnx_decoders module.
+
+Tests cover:
+  - deepstack_process: pure-JAX helper for injecting visual embeddings
+  - NNXDecoderLayer: single transformer decoder layer (init + forward)
+  - NNXDecoder: decoder stack utilities (get_decoder_layers, get_norm_layer,
+                get_remat_policy, minimal_policy, and full forward pass)
+"""
+
+import sys
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import linen as nn
+from flax import nnx
+from jax.sharding import Mesh
+
+from maxtext.common.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_TRAIN, DecoderBlockType
+from maxtext.configs import pyconfig
+from maxtext.layers import linears
+from maxtext.layers.attentions import Attention
+from maxtext.layers.embeddings import Embed
+from maxtext.layers.nnx_decoders import NNXDecoder, NNXDecoderLayer, deepstack_process
+from maxtext.layers.normalizations import RMSNorm
+from maxtext.models.gpt3 import Gpt3LayerNorm
+from maxtext.models.llama2 import LlamaDecoderLayer
+from maxtext.utils import maxtext_utils
+from tests.utils.test_helpers import get_decoupled_parallelism_overrides, get_test_config_path
+
+# ---------------------------------------------------------------------------
+# Shared minimal config overrides used across most tests
+# ---------------------------------------------------------------------------
+_BASE_CONFIG = {
+    "per_device_batch_size": 1.0,
+    "run_name": "nnx_decoder_test",
+    "enable_checkpointing": False,
+    "base_num_decoder_layers": 2,
+    "attention": "dot_product",
+    "max_target_length": 16,
+    "base_emb_dim": 256,
+    "base_num_query_heads": 2,
+    "base_num_kv_heads": 2,
+    "base_mlp_dim": 512,
+    "max_prefill_predict_length": 4,
+    "scan_layers": False,
+}
+
+
+def _make_config(**overrides):
+  """Return a pyconfig Config object suitable for unit tests."""
+  extra_args = get_decoupled_parallelism_overrides()
+  return pyconfig.initialize(
+      [sys.argv[0], get_test_config_path()],
+      **_BASE_CONFIG,
+      **extra_args,
+      **overrides,
+  )
+
+
+def _make_mesh(cfg):
+  devices_array = maxtext_utils.create_device_mesh(cfg)
+  return Mesh(devices_array, cfg.mesh_axes)
+
+
+# ---------------------------------------------------------------------------
+# 1. deepstack_process
+# ---------------------------------------------------------------------------
+
+
+class TestDeepstackProcess(unittest.TestCase):
+  """Tests for the deepstack_process pure function."""
+
+  def _make_inputs(self, batch=2, seq_len=8, hidden_dim=16, num_visual=3, seed=0):
+    key = jax.random.PRNGKey(seed)
+    k1, k2 = jax.random.split(key)
+    hidden_states = jax.random.normal(k1, (batch, seq_len, hidden_dim))
+    mask = jnp.zeros((batch, seq_len), dtype=bool).at[:, :num_visual].set(True)
+    visual_embeds = jax.random.normal(k2, (batch, num_visual, hidden_dim))
+    return hidden_states, mask, visual_embeds
+
+  def test_output_shape_matches_hidden_states(self):
+    """Output shape must equal input hidden_states shape."""
+    hidden_states, mask, visual_embeds = self._make_inputs()
+    result = deepstack_process(hidden_states, mask, visual_embeds)
+    self.assertEqual(result.shape, hidden_states.shape)
+
+  def test_unmasked_positions_are_unchanged(self):
+    """Positions outside the bidirectional mask must not be modified."""
+    batch, seq_len, hidden_dim, num_visual = 1, 6, 8, 2
+    hidden_states = jnp.ones((batch, seq_len, hidden_dim))
+    mask = jnp.zeros((batch, seq_len), dtype=bool).at[:, :num_visual].set(True)
+    # Zero visual embeds ensure any addition at mask=True positions is a no-op
+    visual_embeds = jnp.zeros((batch, num_visual, hidden_dim))
+
+    result = deepstack_process(hidden_states, mask, visual_embeds)
+
+    np.testing.assert_allclose(
+        np.array(result[:, num_visual:, :]),
+        np.ones((batch, seq_len - num_visual, hidden_dim)),
+    )
+
+  def test_masked_positions_receive_visual_embeds(self):
+    """Visual embeddings must be added at masked (True) positions."""
+    batch, seq_len, hidden_dim, num_visual = 1, 4, 4, 2
+    hidden_states = jnp.zeros((batch, seq_len, hidden_dim))
+    mask = jnp.zeros((batch, seq_len), dtype=bool).at[:, :num_visual].set(True)
+    visual_embeds = jnp.ones((batch, num_visual, hidden_dim))
+
+    result = deepstack_process(hidden_states, mask, visual_embeds)
+
+    # At masked positions: 0 + 1 = 1
+    np.testing.assert_allclose(
+        np.array(result[:, :num_visual, :]),
+        np.ones((batch, num_visual, hidden_dim)),
+    )
+    # At unmasked positions: unchanged (still 0)
+    np.testing.assert_allclose(
+        np.array(result[:, num_visual:, :]),
+        np.zeros((batch, seq_len - num_visual, hidden_dim)),
+    )
+
+  def test_zero_visual_embeds_leave_hidden_states_unchanged(self):
+    """When all visual embeddings are zero, output equals input."""
+    hidden_states, mask, _ = self._make_inputs()
+    num_visual = 3
+    batch = hidden_states.shape[0]
+    hidden_dim = hidden_states.shape[2]
+    zero_visual = jnp.zeros((batch, num_visual, hidden_dim))
+
+    result = deepstack_process(hidden_states, mask, zero_visual)
+
+    np.testing.assert_allclose(np.array(result), np.array(hidden_states))
+
+  def test_all_positions_masked(self):
+    """Works correctly when every token position is a visual token."""
+    batch, seq_len, hidden_dim = 1, 4, 8
+    hidden_states = jnp.zeros((batch, seq_len, hidden_dim))
+    mask = jnp.ones((batch, seq_len), dtype=bool)
+    visual_embeds = jnp.ones((batch, seq_len, hidden_dim)) * 2.0
+
+    result = deepstack_process(hidden_states, mask, visual_embeds)
+
+    np.testing.assert_allclose(
+        np.array(result),
+        np.full((batch, seq_len, hidden_dim), 2.0),
+    )
+
+  def test_no_positions_masked(self):
+    """When no positions are masked, hidden states are unchanged."""
+    batch, seq_len, hidden_dim, num_visual = 2, 6, 8, 1
+    hidden_states = jnp.ones((batch, seq_len, hidden_dim))
+    mask = jnp.zeros((batch, seq_len), dtype=bool)
+    visual_embeds = jnp.ones((batch, num_visual, hidden_dim)) * 99.0
+
+    result = deepstack_process(hidden_states, mask, visual_embeds)
+
+    np.testing.assert_allclose(np.array(result), np.array(hidden_states))
+
+
+# ---------------------------------------------------------------------------
+# 2. NNXDecoderLayer
+# ---------------------------------------------------------------------------
+
+
+class TestNNXDecoderLayer(unittest.TestCase):
+  """Tests for the NNXDecoderLayer NNX module."""
+
+  def setUp(self):
+    super().setUp()
+    self.cfg = _make_config()
+    self.mesh = _make_mesh(self.cfg)
+    self.rng = jax.random.PRNGKey(0)
+
+  def _make_layer(self, model_mode=MODEL_MODE_TRAIN):
+    return NNXDecoderLayer(
+        config=self.cfg,
+        mesh=self.mesh,
+        model_mode=model_mode,
+        rngs=nnx.Rngs(params=0, dropout=1),
+    )
+
+  def _make_inputs(self):
+    cfg = self.cfg
+    batch = cfg.global_batch_size_to_train_on
+    seq_len = cfg.max_target_length
+    emb_dim = cfg.emb_dim
+    inputs = jax.random.normal(self.rng, (batch, seq_len, emb_dim)).astype(cfg.dtype)
+    segment_ids = jnp.full((batch, seq_len), DECODING_ACTIVE_SEQUENCE_INDICATOR)
+    positions = jnp.broadcast_to(jnp.arange(seq_len)[None], (batch, seq_len))
+    return inputs, segment_ids, positions
+
+  # --- instantiation ---------------------------------------------------------
+
+  def test_has_pre_self_attention_norm(self):
+    layer = self._make_layer()
+    self.assertIsInstance(layer.pre_self_attention_norm, RMSNorm)
+
+  def test_has_self_attention(self):
+
+    layer = self._make_layer()
+    self.assertIsInstance(layer.self_attention, Attention)
+
+  def test_has_mlp(self):
+
+    layer = self._make_layer()
+    self.assertIsInstance(layer.mlp, linears.MlpBlock)
+
+  # --- forward pass ----------------------------------------------------------
+
+  def test_forward_output_shape_train(self):
+    """Forward pass output shape matches input shape in train mode."""
+    layer = self._make_layer(MODEL_MODE_TRAIN)
+    inputs, segment_ids, positions = self._make_inputs()
+    out, _ = layer(inputs, segment_ids, positions, deterministic=True, model_mode=MODEL_MODE_TRAIN)
+    self.assertEqual(out.shape, inputs.shape)
+
+  def test_forward_output_dtype(self):
+    """Output dtype matches config dtype."""
+    layer = self._make_layer()
+    inputs, segment_ids, positions = self._make_inputs()
+    out, _ = layer(inputs, segment_ids, positions, deterministic=True, model_mode=MODEL_MODE_TRAIN)
+    self.assertEqual(out.dtype, self.cfg.dtype)
+
+  def test_forward_kv_cache_is_none_when_scan_layers_false(self):
+    """kv_cache return value is not None when scan_layers=False (non-scan returns cache)."""
+    # With scan_layers=False the layer returns (output, kv_cache).
+    # kv_cache may be None in train mode (no cache is populated); we just
+    # verify the call doesn't raise and returns a 2-tuple.
+    layer = self._make_layer()
+    inputs, segment_ids, positions = self._make_inputs()
+    result = layer(inputs, segment_ids, positions, deterministic=True, model_mode=MODEL_MODE_TRAIN)
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(len(result), 2)
+
+  def test_forward_deterministic_and_stochastic_consistent_shape(self):
+    """Output shape is the same regardless of the deterministic flag."""
+    layer = self._make_layer()
+    inputs, segment_ids, positions = self._make_inputs()
+    out_det, _ = layer(inputs, segment_ids, positions, deterministic=True, model_mode=MODEL_MODE_TRAIN)
+    out_stoch, _ = layer(inputs, segment_ids, positions, deterministic=False, model_mode=MODEL_MODE_TRAIN)
+    self.assertEqual(out_det.shape, out_stoch.shape)
+
+
+# ---------------------------------------------------------------------------
+# 3. NNXDecoder.get_decoder_layers
+# ---------------------------------------------------------------------------
+
+
+class TestNNXDecoderGetDecoderLayers(unittest.TestCase):
+  """Tests for NNXDecoder.get_decoder_layers."""
+
+  def setUp(self):
+    super().setUp()
+    self.cfg = _make_config()
+    self.mesh = _make_mesh(self.cfg)
+
+  def _make_decoder(self, **cfg_overrides):
+    cfg = _make_config(**cfg_overrides) if cfg_overrides else self.cfg
+    mesh = _make_mesh(cfg) if cfg_overrides else self.mesh
+    return NNXDecoder(config=cfg, mesh=mesh, rngs=nnx.Rngs(params=0, dropout=1))
+
+  def test_default_decoder_block_returns_nnx_decoder_layer(self):
+    decoder = self._make_decoder(decoder_block=DecoderBlockType.DEFAULT)
+    layers = decoder.get_decoder_layers()
+    self.assertEqual(layers, [NNXDecoderLayer])
+
+  def test_get_decoder_layers_returns_list(self):
+    decoder = self._make_decoder()
+    result = decoder.get_decoder_layers()
+    self.assertIsInstance(result, list)
+    self.assertGreater(len(result), 0)
+
+  def test_llama2_decoder_block(self):
+
+    decoder = self._make_decoder(model_name="llama2-7b")
+    layers = decoder.get_decoder_layers()
+    self.assertEqual(layers, [LlamaDecoderLayer])
+
+  def test_get_decoder_layers_idempotent(self):
+    """Calling get_decoder_layers twice returns the same result."""
+    decoder = self._make_decoder()
+    self.assertEqual(decoder.get_decoder_layers(), decoder.get_decoder_layers())
+
+
+# ---------------------------------------------------------------------------
+# 4. NNXDecoder.get_norm_layer
+# ---------------------------------------------------------------------------
+
+
+class TestNNXDecoderGetNormLayer(unittest.TestCase):
+  """Tests for NNXDecoder.get_norm_layer."""
+
+  def setUp(self):
+    super().setUp()
+    self.cfg = _make_config()
+    self.mesh = _make_mesh(self.cfg)
+    self.decoder = NNXDecoder(
+        config=self.cfg,
+        mesh=self.mesh,
+        rngs=nnx.Rngs(params=0, dropout=1),
+    )
+
+  def test_default_returns_rms_norm(self):
+    """DEFAULT decoder block should use RMSNorm."""
+    # get_norm_layer returns a functools.partial wrapping RMSNorm.
+    # The decoder_norm attribute is already instantiated via that partial.
+    self.assertIsInstance(self.decoder.decoder_norm, RMSNorm)
+
+  def test_gpt3_returns_gpt3_layer_norm(self):
+
+    cfg = _make_config(model_name="gpt3-52k")
+    mesh = _make_mesh(cfg)
+    decoder = NNXDecoder(config=cfg, mesh=mesh, rngs=nnx.Rngs(params=0, dropout=1))
+    self.assertIsInstance(decoder.decoder_norm, Gpt3LayerNorm)
+
+
+# ---------------------------------------------------------------------------
+# 5. NNXDecoder.get_remat_policy / minimal_policy
+# ---------------------------------------------------------------------------
+
+
+class TestNNXDecoderRematPolicy(unittest.TestCase):
+  """Tests for NNXDecoder.get_remat_policy and minimal_policy."""
+
+  def setUp(self):
+    super().setUp()
+    self.cfg = _make_config(remat_policy="full")
+    self.mesh = _make_mesh(self.cfg)
+    self.decoder = NNXDecoder(
+        config=self.cfg,
+        mesh=self.mesh,
+        rngs=nnx.Rngs(params=0, dropout=1),
+    )
+
+  def test_remat_policy_none_returns_none(self):
+    self.assertIsNone(self.decoder.get_remat_policy())
+
+  def test_remat_policy_full_returns_none(self):
+    cfg = _make_config(remat_policy="full")
+    mesh = _make_mesh(cfg)
+    decoder = NNXDecoder(config=cfg, mesh=mesh, rngs=nnx.Rngs(params=0, dropout=1))
+    self.assertIsNone(decoder.get_remat_policy())
+
+  def test_remat_policy_minimal_returns_non_none(self):
+    cfg = _make_config(remat_policy="minimal")
+    mesh = _make_mesh(cfg)
+    decoder = NNXDecoder(config=cfg, mesh=mesh, rngs=nnx.Rngs(params=0, dropout=1))
+    self.assertIsNotNone(decoder.get_remat_policy())
+
+  def test_remat_policy_minimal_with_context_returns_non_none(self):
+    cfg = _make_config(remat_policy="minimal_with_context")
+    mesh = _make_mesh(cfg)
+    decoder = NNXDecoder(config=cfg, mesh=mesh, rngs=nnx.Rngs(params=0, dropout=1))
+    self.assertIsNotNone(decoder.get_remat_policy())
+
+  def test_remat_policy_save_qkv_proj_returns_non_none(self):
+    cfg = _make_config(remat_policy="save_qkv_proj")
+    mesh = _make_mesh(cfg)
+    decoder = NNXDecoder(config=cfg, mesh=mesh, rngs=nnx.Rngs(params=0, dropout=1))
+    self.assertIsNotNone(decoder.get_remat_policy())
+
+  def test_remat_policy_save_out_proj_returns_non_none(self):
+    cfg = _make_config(remat_policy="save_out_proj")
+    mesh = _make_mesh(cfg)
+    decoder = NNXDecoder(config=cfg, mesh=mesh, rngs=nnx.Rngs(params=0, dropout=1))
+    self.assertIsNotNone(decoder.get_remat_policy())
+
+  # --- minimal_policy -------------------------------------------------------
+
+  def test_minimal_policy_no_flags(self):
+    policy = self.decoder.minimal_policy()
+    self.assertIsNotNone(policy)
+
+  def test_minimal_policy_with_context(self):
+    policy = self.decoder.minimal_policy(with_context=True)
+    self.assertIsNotNone(policy)
+
+  def test_minimal_policy_with_quantization(self):
+    policy = self.decoder.minimal_policy(with_quantization=True)
+    self.assertIsNotNone(policy)
+
+  def test_minimal_policy_with_context_and_quantization(self):
+    policy = self.decoder.minimal_policy(with_context=True, with_quantization=True)
+    self.assertIsNotNone(policy)
+
+  def test_minimal_policy_returns_distinct_objects_for_different_flags(self):
+    """Different flag combinations should produce different policy objects."""
+    p1 = self.decoder.minimal_policy(with_context=False)
+    p2 = self.decoder.minimal_policy(with_context=True)
+    # They're different checkpoint policies; at minimum they're both non-None
+    # and Python objects that are not the same instance.
+    self.assertIsNotNone(p1)
+    self.assertIsNotNone(p2)
+
+
+# ---------------------------------------------------------------------------
+# 6. NNXDecoder full forward pass
+# ---------------------------------------------------------------------------
+
+
+class TestNNXDecoderForwardPass(unittest.TestCase):
+  """Integration-style test for NNXDecoder.__call__ in train mode."""
+
+  def setUp(self):
+    super().setUp()
+    self.cfg = _make_config()
+    self.mesh = _make_mesh(self.cfg)
+    self.rng = jax.random.PRNGKey(0)
+    self.rngs = nnx.Rngs(params=0, dropout=1)
+
+    self.decoder = NNXDecoder(
+        config=self.cfg,
+        mesh=self.mesh,
+        model_mode=MODEL_MODE_TRAIN,
+        rngs=self.rngs,
+    )
+    self.shared_embedding = Embed(
+        num_embeddings=self.cfg.vocab_size,
+        num_features=self.cfg.emb_dim,
+        dtype=self.cfg.dtype,
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        config=self.cfg,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+
+  def _make_token_inputs(self):
+    cfg = self.cfg
+    batch = cfg.global_batch_size_to_train_on
+    seq_len = cfg.max_target_length
+    ids = jax.random.randint(self.rng, (batch, seq_len), 0, cfg.vocab_size)
+    segment_ids = jnp.full((batch, seq_len), DECODING_ACTIVE_SEQUENCE_INDICATOR)
+    positions = jnp.broadcast_to(jnp.arange(seq_len)[None], (batch, seq_len))
+    return ids, segment_ids, positions
+
+  def test_forward_pass_returns_three_tuple(self):
+    """__call__ must return (logits, hidden_state, kv_caches)."""
+    ids, segment_ids, positions = self._make_token_inputs()
+    result = self.decoder(
+        self.shared_embedding,
+        ids,
+        positions,
+        decoder_segment_ids=segment_ids,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(len(result), 3)
+
+  def test_logits_shape(self):
+    """Logits shape: [batch, seq_len, vocab_size]."""
+    cfg = self.cfg
+    ids, segment_ids, positions = self._make_token_inputs()
+    logits, _, _ = self.decoder(
+        self.shared_embedding,
+        ids,
+        positions,
+        decoder_segment_ids=segment_ids,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    expected = (cfg.global_batch_size_to_train_on, cfg.max_target_length, cfg.vocab_size)
+    self.assertEqual(logits.shape, expected)
+
+  def test_hidden_state_shape(self):
+    """hidden_state shape: [batch, seq_len, emb_dim]."""
+    cfg = self.cfg
+    ids, segment_ids, positions = self._make_token_inputs()
+    _, hidden_state, _ = self.decoder(
+        self.shared_embedding,
+        ids,
+        positions,
+        decoder_segment_ids=segment_ids,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    expected = (cfg.global_batch_size_to_train_on, cfg.max_target_length, cfg.emb_dim)
+    self.assertEqual(hidden_state.shape, expected)
+
+  def test_logits_are_finite(self):
+    """Logits must not contain NaN or Inf in a simple forward pass."""
+    ids, segment_ids, positions = self._make_token_inputs()
+    logits, _, _ = self.decoder(
+        self.shared_embedding,
+        ids,
+        positions,
+        decoder_segment_ids=segment_ids,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    self.assertTrue(jnp.all(jnp.isfinite(logits)))
+
+  def test_different_random_seeds_produce_different_logits(self):
+    """Two randomly-initialised decoders should not produce identical logits."""
+    cfg = self.cfg
+    mesh = self.mesh
+    rngs2 = nnx.Rngs(params=99, dropout=1)
+    decoder2 = NNXDecoder(config=cfg, mesh=mesh, model_mode=MODEL_MODE_TRAIN, rngs=rngs2)
+    shared_emb2 = Embed(
+        num_embeddings=cfg.vocab_size,
+        num_features=cfg.emb_dim,
+        dtype=cfg.dtype,
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        config=cfg,
+        mesh=mesh,
+        rngs=rngs2,
+    )
+    ids, segment_ids, positions = self._make_token_inputs()
+    common_kwargs = {
+        "decoder_segment_ids": segment_ids,
+        "deterministic": True,
+        "model_mode": MODEL_MODE_TRAIN,
+    }
+    logits1, _, _ = self.decoder(self.shared_embedding, ids, positions, **common_kwargs)
+    logits2, _, _ = decoder2(shared_emb2, ids, positions, **common_kwargs)
+    self.assertFalse(jnp.allclose(logits1, logits2))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -611,6 +611,8 @@ class TrainCompile(unittest.TestCase):
             "pipeline_parallel_layers=56",
             "ici_expert_parallelism=16",
             "dcn_pipeline_parallelism=8",
+            "first_num_dense_layers=8",
+            "base_num_decoder_layers=72",
         )
     )
 
@@ -628,7 +630,7 @@ class TrainCompile(unittest.TestCase):
             "per_device_batch_size=1",
             "max_target_length=1024",
             "pipeline_parallel_layers=56",
-            "base_num_decoder_layers=61",  # Remainder of 5 will fail when sharded incorrectly.
+            "base_num_decoder_layers=64",  # Must be divisible by dcn_pipeline_parallelism=8 in NNX scan path.
             "ici_expert_parallelism=16",
             "dcn_pipeline_parallelism=8",
         )


### PR DESCRIPTION
# NNX migration for Decoders

Initial change of NNX migration for Decoders.
The main part of this change is adding NNXDecoder (based on nnx.Module)

    1. add new file nnx_decoders.py in parallel with decoder.py (linen based)
    2. add new config pure_nnx_decoder to control if model will use NNXDecoder
    3. modify relative code to accomodate the change
    4. add/modify unit test

# Tests

With pure_nnx_decoder = true, model with use NNXDecoder replacing Linen-based Decoder. However, as the other parts of main branch are still depending on Linen->NNX migration, not all functionalities are achieved parity with existing latest main. A lot of components are still pending on NNX migration (i.e. pipeline, trainer), the default value of pure_nnx_decoder is set to false at this moment.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
