### PR TITLE
Add math-verify and pathwaysutils to the setup_post_training_requirements.sh

### DIFF
--- a/tools/setup/setup_post_training_requirements.sh
+++ b/tools/setup/setup_post_training_requirements.sh
@@ -32,3 +32,7 @@ uv pip install vllm-tpu
 uv pip install numba==0.61.2
 
 uv pip install --no-deps qwix==0.1.4
+
+uv pip install math-verify==0.9.0
+
+uv pip install --upgrade 'pathwaysutils>=0.1.4'


### PR DESCRIPTION
# Description

Add missing dependencies to fix the `ModuleNotFoundError: No module named 'math_verify'` error when running `train_rl.py`.

# Tests

Manual invocation of `setup_post_training_requirements.sh` followed by `test_rl.py` locally on a TPU VM. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
