### PR TITLE
Install MaxText vLLM directory from extra deps script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,4 +48,4 @@ packages = ["src/MaxText", "src/maxtext", "src/install_maxtext_extra_deps"]
 [project.scripts]
 install_maxtext_tpu_github_deps = "install_maxtext_extra_deps.install_github_deps:main"
 install_maxtext_cuda12_github_deps = "install_maxtext_extra_deps.install_github_deps:main"
-install_maxtext_tpu_post_train_github_deps = "install_maxtext_extra_deps.install_post_train_github_deps:main"
+install_maxtext_tpu_post_train_extra_deps = "install_maxtext_extra_deps.install_post_train_extra_deps:main"

--- a/src/install_maxtext_extra_deps/install_post_train_extra_deps.py
+++ b/src/install_maxtext_extra_deps/install_post_train_extra_deps.py
@@ -65,11 +65,21 @@ def main():
       "--no-deps",
   ]
 
+  local_vllm_install_command = [
+      sys.executable,  # Use the current Python executable's pip to ensure the correct environment
+        "-m",
+        "uv",
+        "pip",
+        "install",
+        "src/maxtext/integration/vllm",
+        "--no-deps",
+  ]
+
   print(f"Installing extra dependencies from '{extra_deps_file}' using uv...")
   print(f"Running command: {' '.join(command)}")
 
   try:
-    # Run the command
+    # Run the command to install Github dependencies
     process = subprocess.run(command, check=True, capture_output=True, text=True)
     print("Extra dependencies installed successfully!")
     print("--- Output from uv ---")
@@ -77,6 +87,15 @@ def main():
     if process.stderr:
       print("--- Errors/Warnings from uv (if any) ---")
       print(process.stderr)
+
+    # Run the command to install the MaxText vLLM directory
+    vllm_install_process = subprocess.run(local_vllm_install_command, check=True, capture_output=True, text=True)
+    print("MaxText vLLM dependency installed successfully!")
+    print("--- Output from uv ---")
+    print(vllm_install_process.stdout)
+    if vllm_install_process.stderr:
+      print("--- Errors/Warnings from uv (if any) ---")
+      print(vllm_install_process.stderr)
   except subprocess.CalledProcessError as e:
     print("Failed to install extra dependencies.")
     print(f"Command '{' '.join(e.cmd)}' returned non-zero exit status {e.returncode}.")


### PR DESCRIPTION
# Description

* Move `uv pip install src/maxtext/integration/vllm --no-deps` step to the existing `install_maxtext_tpu_post_train_extra_deps` script. This way users only need to run one command after `uv pip install -e .[tpu-post-train] --resolution=lowest`
* Renamed `install_maxtext_tpu_post_train_github_deps` to `install_maxtext_tpu_post_train_extra_deps` now that we are installing more than just Github dependencies

# Tests

Ran this on a clean venv:
```
uv pip install -e .[tpu-post-train] --resolution=lowest
install_maxtext_tpu_post_train_extra_deps

export HF_TOKEN=<hf_token>
export WORKLOAD=gemma3_rl_5
export OUTPUT_PATH=<gcs_bucket>

NEW_MODEL_DESIGN=1 TPU_BACKEND_TYPE=jax python3 -m src.maxtext.trainers.post_train.rl.train_rl src/maxtext/configs/post_train/rl.yml \
  model_name=gemma3-4b \
  tokenizer_path=google/gemma-3-4b-it \
  run_name=$WORKLOAD \
  base_output_directory=$OUTPUT_PATH \
  hf_access_token=$HF_TOKEN \
  batch_size=4 \
  num_batches=5 \
  scan_layers=False \
  hbm_utilization_vllm=0.4 \
  rollout_data_parallelism=2 \
  rollout_tensor_parallelism=2 \
  allow_split_physical_axes=true \
load_parameters_path=<gcs_checkpoint_path> \
vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
vllm_additional_config='{"maxtext_config": {"model_name": "gemma3-4b", "log_config": "false"}}' 2>&1 | tee  grpo_out_gemma3.txt
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
