### PR TITLE
Fix max_logit shape mismatch error

### DIFF
--- a/src/maxtext/utils/qk_clip_utils.py
+++ b/src/maxtext/utils/qk_clip_utils.py
@@ -53,7 +53,8 @@ def calculate_max_logit_metric(intermediate_outputs):
   if not all_max_logits:
     return None
 
-  return jnp.max(jnp.stack(all_max_logits))
+  # Compute max per layer first to handle potential shape mismatches
+  return jnp.max(jnp.stack([jnp.max(x) for x in all_max_logits]))
 
 
 def apply_qk_clip(state, intermediate_outputs, config):

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -839,3 +839,31 @@ class TrainCompile(unittest.TestCase):
             "hf_access_token=fake",
         )
     )
+
+  @pytest.mark.cpu_only
+  def test_qk_clip(self):
+    """AOT test for qk-clip with DeepSeek3 Tiny model"""
+    compiled_trainstep_file = "/tmp/test_qk_clip.pickle"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "model_name=deepseek3-tiny",
+            "scan_layers=True",
+            "sparse_matmul=True",
+            "megablox=True",
+            "use_tokamax_gmm=False",
+            # TODO(agagik): update to flash after support
+            "attention=dot_product",
+            "use_tokamax_splash=True",
+            "max_target_length=128",
+            "per_device_batch_size=1",
+            "dtype=bfloat16",
+            "weight_dtype=float32",
+            "use_qk_clip=true",
+            "qk_clip_threshold=100",
+        )
+    )


### PR DESCRIPTION
# Description

This PR updates `calculate_max_logit_metric` in `qk_clip_utils.py` to fix a shape mismatch crash when logging max logits for QK-Clip. 

Previously, the code attempted to stack all `max_logits` arrays directly using `jnp.stack(all_max_logits)`. This caused a `ValueError: All input arrays must have the same shape.` when different attention layers (or complex model configurations like MoE and varying sequence packing) returned logit arrays of different shapes. 


# Tests

* Verified the fix by running a training job with `use_qk_clip=true` and varying attention configurations where the `ValueError` previously triggered. 

```
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml   run_name=deepseek-qk-clip-test   base_output_directory=gs://...  model_name
=deepseek3-tiny   dataset_type=synthetic   steps=200 use_qk_clip=true    qk_clip_threshold=12 use_tokamax_splash=true attention=dot_product

```

Training now successfully completes and accurately logs `learning/max_logits` to TensorBoard.

https://screenshot.googleplex.com/7s9tK9tUXxVYd2a

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
