### PR TITLE
Move __init__ from src/MaxText to src/maxtext

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling", "hatch-requirements-txt"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
-path = "src/MaxText/__init__.py"
+path = "src/maxtext/__init__.py"
 
 [project]
 name = "maxtext"

--- a/src/maxtext/__init__.py
+++ b/src/maxtext/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023–2025 Google LLC
+# Copyright 2023–2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/maxtext/experimental/rl/grpo_trainer.py
+++ b/src/maxtext/experimental/rl/grpo_trainer.py
@@ -66,7 +66,7 @@ import transformers
 
 from ml_goodput_measurement.src.goodput import GoodputRecorder
 
-import MaxText as mt
+import maxtext as mt
 from maxtext.configs import pyconfig
 from maxtext.utils.globals import EPS
 from maxtext.trainers.pre_train.train import get_first_step

--- a/tests/integration/grpo_trainer_correctness_test.py
+++ b/tests/integration/grpo_trainer_correctness_test.py
@@ -34,7 +34,7 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 import jsonlines
-import MaxText as mt
+import maxtext as mt
 from maxtext.configs import pyconfig
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT, MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT
 from maxtext.common.common_types import MODEL_MODE_TRAIN

--- a/tests/unit/engram_vs_reference_test.py
+++ b/tests/unit/engram_vs_reference_test.py
@@ -46,7 +46,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 
 from maxtext.configs import pyconfig
-from MaxText import maxtext_utils
+from maxtext import maxtext_utils
 
 from maxtext.layers.engram import CompressedTokenizer as CompressedTokenizerJAX
 from maxtext.layers.engram import NgramHashMapping as NgramHashMappingJAX

--- a/tests/unit/moba_vs_reference_test.py
+++ b/tests/unit/moba_vs_reference_test.py
@@ -31,7 +31,7 @@ import numpy as np
 import torch
 from jax.sharding import Mesh
 
-from MaxText import maxtext_utils, pyconfig
+from maxtext import maxtext_utils, pyconfig
 from maxtext.layers.attention_op import AttentionOp
 from tests.utils.test_helpers import get_test_config_path
 

--- a/tests/unit/sharding_compare_test.py
+++ b/tests/unit/sharding_compare_test.py
@@ -19,7 +19,7 @@ import json
 import os
 import jax
 import jax.numpy as jnp
-from MaxText import maxtext_utils
+from maxtext import maxtext_utils
 from maxtext.configs import pyconfig
 # import optax
 

--- a/tests/utils/sharding_dump.py
+++ b/tests/utils/sharding_dump.py
@@ -26,7 +26,7 @@ from absl import app
 import jax
 from jax.sharding import NamedSharding, PartitionSpec
 from jax.tree_util import tree_flatten_with_path
-from MaxText import maxtext_utils
+from maxtext import maxtext_utils
 from maxtext.configs import pyconfig
 
 from maxtext.utils.globals import MAXTEXT_REPO_ROOT


### PR DESCRIPTION
# Description

* Move `__init__` from `src/MaxText` to `src/maxtext`
* Update imports

# Tests

New command:
```
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
    run_name=<run_name> \
    base_output_directory=<gcs_bucket> \
    dataset_type=synthetic \
    steps=10 \
    enable_checkpointing=false
```

Old command:
```
python3 -m MaxText.train src/maxtext/configs/base.yml \
    run_name=<run_name> \
    base_output_directory=<gcs_bucket> \
    dataset_type=synthetic \
    steps=10 \
    enable_checkpointing=false
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
