### PR TITLE
Fix SFT mask to avoid calculating loss on generation prompt tokens

### DIFF
--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -173,7 +173,7 @@ def is_conversational(features, data_columns):
 
 def apply_chat_template(example, tokenizer_model, data_column_name):
   """Formats conversational data by applying the tokenizer's chat template
-  and identifying prompt/completion segments.
+  and identifying prompt/completion segments for SFT masking.
 
   Args:
     example: A dictionary containing conversational data. It is expected to have a key
@@ -187,9 +187,10 @@ def apply_chat_template(example, tokenizer_model, data_column_name):
     The modified `example` dictionary.
       - The `data_column_name` column will be updated to a list of
         messages, each formatted according to the tokenizer's chat template.
-      - A new column named "is_prompt" will be added, where `True`
-        indicates a system message or a user message (prompt) and `False` indicates an assistant
-        message (completion).
+      - A new column "is_prompt" is added, where `True` indicates the
+        tokens contain the system message, user message, and generation
+        prompt (if applicable). `False` indicates the expected LLM
+        completion, excluding the assistant's start tokens.
   """
   messages = []
   is_prompt = []
@@ -203,7 +204,7 @@ def apply_chat_template(example, tokenizer_model, data_column_name):
       elif message["role"] == "user":
         round_msgs.append(message)
         prompt_in_chat_template = tokenizer_model.apply_chat_template(
-            round_msgs, add_generation_prompt=False, tokenize=False
+            round_msgs, add_generation_prompt=True, tokenize=False
         )
         messages.append(prompt_in_chat_template)
         is_prompt.append(True)
@@ -212,7 +213,8 @@ def apply_chat_template(example, tokenizer_model, data_column_name):
         prompt_completion_tokens = tokenizer_model.apply_chat_template(
             round_msgs, add_generation_prompt=False, tokenize=True
         )
-        prompt_tokens = tokenizer_model.apply_chat_template(round_msgs[:-1], add_generation_prompt=False, tokenize=True)
+        # include generation_prompt as part of the prompt tokens
+        prompt_tokens = tokenizer_model.apply_chat_template(round_msgs[:-1], add_generation_prompt=True, tokenize=True)
         completion_tokens = prompt_completion_tokens[len(prompt_tokens) :]
         completion_in_chat_template = tokenizer_model.decode(completion_tokens, skip_special_tokens=False)
         messages.append(completion_in_chat_template)

--- a/tests/unit/sft_data_processing_test.py
+++ b/tests/unit/sft_data_processing_test.py
@@ -208,16 +208,20 @@ QWEN_DATA = {
         "truncated_exp1_targets": (
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
-            "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
             + "<|endoftext|>" * 9
-            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer two<|endoftext|>"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nexample one answer two<|endoftext|>"
         ),
         "truncated_exp1_targets_predictable": (
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
-            "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
             + "<|endoftext|>" * 9
-            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer two<|endoftext|>"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nexample one answer two<|endoftext|>"
         ),
         "packed_exp2_inputs": (
             "<|im_start|>user\nquestion two<|im_end|>\n"
@@ -227,15 +231,22 @@ QWEN_DATA = {
         ),
         "packed_exp2_targets": (
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
-            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer two<|im_end|>\n"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nanswer two<|im_end|>\n"
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
-            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer three<|im_end|>\n" + "!" * 14 + "<|endoftext|>"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nanswer three<|im_end|>\n"
+            + "!" * 14
+            + "<|endoftext|>"
         ),
         "packed_exp2_targets_predictable": (
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
-            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer two<|im_end|>\n"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nanswer two<|im_end|>\n"
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
-            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer three<|im_end|>\n" + "<|endoftext|>" * 15
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nanswer three<|im_end|>\n"
+            + "<|endoftext|>" * 15
         ),
     },
     "prompt_completion": {
@@ -248,16 +259,20 @@ QWEN_DATA = {
         ),
         "truncated_exp1_targets": (
             "<|endoftext|>" * 8
-            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
             + "<|endoftext|>" * 9
-            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer two<|im_end|>\n"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nexample one answer two<|im_end|>\n"
             + "<|endoftext|>" * 7
         ),
         "truncated_exp1_targets_predictable": (
             "<|endoftext|>" * 8
-            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nexample one answer one<|im_end|>\n"
             + "<|endoftext|>" * 9
-            + "<|im_start|>assistant\n<think>\n\n</think>\n\nexample one answer two<|im_end|>\n"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nexample one answer two<|im_end|>\n"
             + "<|endoftext|>" * 7
         ),
         "packed_exp2_inputs": (
@@ -268,15 +283,22 @@ QWEN_DATA = {
         ),
         "packed_exp2_targets": (
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
-            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer two<|im_end|>\n"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nanswer two<|im_end|>\n"
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
-            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer three<|im_end|>\n" + "!" * 14 + "<|endoftext|>"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nanswer three<|im_end|>\n"
+            + "!" * 14
+            + "<|endoftext|>"
         ),
         "packed_exp2_targets_predictable": (
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
-            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer two<|im_end|>\n"
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nanswer two<|im_end|>\n"
             "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>"
-            "<|im_start|>assistant\n<think>\n\n</think>\n\nanswer three<|im_end|>\n" + "<|endoftext|>" * 15
+            + "<|endoftext|>" * 3
+            + "<think>\n\n</think>\n\nanswer three<|im_end|>\n"
+            + "<|endoftext|>" * 15
         ),
     },
 }


### PR DESCRIPTION
# Description

- Modern models like Llama 3 or Qwen add [generation prompt tokens](https://huggingface.co/docs/transformers/en/chat_templating#addgenerationprompt) to indicate the start of an `assistant response`. These are appened during inference, therefore, are not part of the completion tokens.

- Many LLM fine-tuning frameworks, such as `unsloth+trl`, and `ms-swift`, do not calculate loss on the generation prompt.
  - [Unsloth splits tokens after generation_prompt as the 'response_part'](https://github.com/unslothai/unsloth/blob/34ceb6b77ec8b7d32346d57c8520285e1c35f470/tests/saving/language_models/test_merge_model_perplexity_llama-3.2.py#L196-L201)
  - [Visualise Unslosh masking](https://paste.googleplex.com/4726806671392768)
![Screenshot 2026-03-02 at 3 40 26 PM](https://github.com/user-attachments/assets/86527d05-d6d6-4318-b9f8-391de598bd8b)

- This PR aligns the MaxText SFT masking logic with these other frameworks
  - Include `generation_prompt` tokens as part of prompt tokens [here](https://github.com/AI-Hypercomputer/maxtext/pull/3284/changes#diff-c5ac5a9b65c6bf38dfd293500d48ece2fcca584bbe2e49bb1eb3f62ed976c095), hence, the loss would not be calculated during SFT.

FIXES: b/475383130

# Tests
## Unit Test
```
python3 -m pytest  tests/unit/sft_data_processing_test.py
```
## Compare sft qwen3-4b initial loss
- Drop from `5.868` to `5.1988` 
![maxtext_ori_vs_fix_mask](https://github.com/user-attachments/assets/550ceae0-0355-4550-9382-6942fed90138)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
