### PR TITLE
Fix Maxtext CI error (importing maxtext_utils) 

### DIFF
--- a/tests/unit/engram_vs_reference_test.py
+++ b/tests/unit/engram_vs_reference_test.py
@@ -46,7 +46,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 
 from maxtext.configs import pyconfig
-from maxtext import maxtext_utils
+from maxtext.utils import maxtext_utils
 
 from maxtext.layers.engram import CompressedTokenizer as CompressedTokenizerJAX
 from maxtext.layers.engram import NgramHashMapping as NgramHashMappingJAX

--- a/tests/unit/moba_vs_reference_test.py
+++ b/tests/unit/moba_vs_reference_test.py
@@ -31,7 +31,8 @@ import numpy as np
 import torch
 from jax.sharding import Mesh
 
-from maxtext import maxtext_utils, pyconfig
+from maxtext.configs import pyconfig
+from maxtext.utils import maxtext_utils
 from maxtext.layers.attention_op import AttentionOp
 from tests.utils.test_helpers import get_test_config_path
 

--- a/tests/unit/sharding_compare_test.py
+++ b/tests/unit/sharding_compare_test.py
@@ -19,7 +19,7 @@ import json
 import os
 import jax
 import jax.numpy as jnp
-from maxtext import maxtext_utils
+from maxtext.utils import maxtext_utils
 from maxtext.configs import pyconfig
 # import optax
 

--- a/tests/utils/sharding_dump.py
+++ b/tests/utils/sharding_dump.py
@@ -26,7 +26,7 @@ from absl import app
 import jax
 from jax.sharding import NamedSharding, PartitionSpec
 from jax.tree_util import tree_flatten_with_path
-from maxtext import maxtext_utils
+from maxtext.utils import maxtext_utils
 from maxtext.configs import pyconfig
 
 from maxtext.utils.globals import MAXTEXT_REPO_ROOT


### PR DESCRIPTION
# Description

With repo restructuring, import maxtext_utils needs to be from maxtext.utils. This is breaking our CI testing and needs to be fixed.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456

# Tests

PR Tests should all pass

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
