### PR TITLE
Update vLLM path in install_post_train_extra_deps.py

### DIFF
--- a/src/install_maxtext_extra_deps/install_post_train_extra_deps.py
+++ b/src/install_maxtext_extra_deps/install_post_train_extra_deps.py
@@ -71,7 +71,7 @@ def main():
         "uv",
         "pip",
         "install",
-        "src/MaxText/integration/vllm",
+        "src/maxtext/integration/vllm",
         "--no-deps",
   ]
 


### PR DESCRIPTION
# Description

* Update vLLM path in `install_post_train_extra_deps` from `MaxText` -> `maxtext`
* This keeps getting switched due to copybara. Will fix this internally when merging

# Tests

Previously ran with:
```
uv pip install -e .[tpu-post-train] --resolution=lowest
install_maxtext_tpu_post_train_extra_deps
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
