### PR TITLE
Gate TPU power profiling events behind profile_power_events flag

### DIFF
--- a/src/maxtext/common/profiler.py
+++ b/src/maxtext/common/profiler.py
@@ -51,7 +51,7 @@ class Profiler:
       ManagedMLDiagnostics(config)  # Initialize the MLRun instance.
 
     self.profiling_options = jax.profiler.ProfileOptions()
-    if self.mode == "xplane" and not self.managed_mldiagnostics:
+    if self.mode == "xplane" and not self.managed_mldiagnostics and config.profile_power_events:
       self.profiling_options.advanced_configuration = {
           "tpu_power_trace_level": config.xprof_tpu_power_trace_level,
           "e2e_enable_fw_throttle_event": config.xprof_e2e_enable_fw_throttle_event,

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -911,6 +911,7 @@ xprof_tpu_power_trace_level: 0
 xprof_e2e_enable_fw_throttle_event: False
 xprof_e2e_enable_fw_power_level_event: False
 xprof_e2e_enable_fw_thermal_event: False
+profile_power_events: False # Set to True to enable TPU-specific power/thermal profiling events. Defaults to False to avoid breaking GPU xplane tracing.
 
 log_config: True # Prints the config (after defaults have been set by pyconfig logic)
 debug_sharding: False # Prints model weights sharding info

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1380,6 +1380,7 @@ class Profiling(BaseModel):
   xprof_e2e_enable_fw_throttle_event: bool = Field(False, description="Enable FW throttle event.")
   xprof_e2e_enable_fw_power_level_event: bool = Field(False, description="Enable FW power level event.")
   xprof_e2e_enable_fw_thermal_event: bool = Field(False, description="Enable FW thermal event.")
+  profile_power_events: bool = Field(False, description="Enable TPU-specific power/thermal profiling events. Defaults to False to avoid breaking GPU xplane tracing.")
 
 
 class HloDump(BaseModel):


### PR DESCRIPTION
## Problem
Using `profiler=xplane` on a GPU host fails because `advanced_configuration` is
unconditionally populated with TPU-specific keys (`tpu_power_trace_level`,
`e2e_enable_fw_*_event`). CUPTI does not recognise these keys and throws
`INVALID_ARGUMENT`, aborting the GPU trace and leaving only CPU traces behind.

## Fix
Introduce a `profile_power_events: False` flag in `base.yml`. The
`advanced_configuration` block in `profiler.py` is now gated behind this flag —
GPU runs work out of the box by default; TPU users who want power/thermal tracing
can opt in with `profile_power_events=True`.

## Testing
- GPU: `profiler=xplane` now captures full GPU traces without INVALID_ARGUMENT error
- TPU: existing behaviour preserved when `profile_power_events=True`
- Default `profile_power_events=False` is backward-compatible for all existing runs