### PR TITLE
Fix MTP loss aggregation when using gradient accumulation

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -189,6 +189,12 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
     total_z_loss = jnp.sum(z_loss)
 
   total_weights = jnp.sum(data["targets_segmentation"] != 0)
+
+  # Calculate MTP Loss
+  mtp_loss_avg = 0.0
+  if config.mtp_num_layers > 0 and is_train:
+    mtp_loss_avg = calculate_mtp_loss(intermediate_outputs, config)
+
   # If gradient accumulation is enabled, we don't need to divide total_loss
   # by total_weights and then multiply the computed gradient by total_weights,
   # since it's equivalent to computing the gradient from total_loss.
@@ -198,22 +204,23 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
   # EPS was used to avoid division by zero, but it's not needed when gradient
   # accumulation is enabled since there's no division.
   if config.gradient_accumulation_steps > 1 and not config.use_tunix_gradient_accumulation:
-    loss = total_loss
+    # GA is ON: 'total_loss' is a SUM. We project the MTP average into a SUM 
+    # by multiplying it by the main model's weight count.
+    loss = total_loss + (mtp_loss_avg * total_weights)
   else:
     # When using Tunix gradient accumulation, we revert to standard normalization.
     # Unlike the manual accumulation path above, Tunix (via optax.MultiSteps) expects
     # a normalized loss for each step. It handles the accumulation state
     # updates and scaling internally.
-    loss = total_loss / (total_weights + EPS)
+    loss = (total_loss / (total_weights + EPS)) + mtp_loss_avg
 
   # We keep z-loss normalized by total_weights.
   total_z_loss = total_z_loss / (total_weights + EPS)
 
-  # Calculate and Add MTP Loss
-  mtp_loss = 0.0
-  if config.mtp_num_layers > 0 and is_train:
-    mtp_loss = calculate_mtp_loss(intermediate_outputs, config)
-    loss += mtp_loss
+  # Handle GA accumulation for aux variables so the logger doesn't artificially multiply them
+  if config.gradient_accumulation_steps > 1:
+    total_z_loss = total_z_loss / config.gradient_accumulation_steps
+    mtp_loss_avg = mtp_loss_avg / config.gradient_accumulation_steps
 
   # get MoE load balance loss
   moe_lb_loss = 0.0
@@ -255,7 +262,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
       "total_weights": total_weights,
       "moe_lb_loss": moe_lb_loss,
       "moe_bias_updates": moe_bias_updates,
-      "mtp_loss": mtp_loss,
+      "mtp_loss": mtp_loss_avg,
   }
   return loss, aux
 


### PR DESCRIPTION

# Description

This PR fixes a mathematical mismatch when combining Multi-Token Prediction (`mtp_num_layers > 0`) with Gradient Accumulation (`gradient_accumulation_steps > 1`).

**The Problem:**
When Gradient Accumulation (GA) is enabled, `train.py` intentionally leaves the main model loss as an unnormalized sum. However, the MTP loss is calculated natively as a normalized average. Previously, the code added the MTP average directly to the main model sum. Because of this, the MTP gradient contribution was dwarfed, and ultimately crushed to near-zero when XLA divided the accumulated gradients by the total batch size at the end of the GA loop.

Additionally, this caused a logging bug. The background GA loop summed the `aux` dictionary variables `gradient_accumulation_steps` times. The `MetricLogger` subtracted this artificially inflated MTP value from the normalized total loss, resulting in negative reported `main_model_loss` metrics.

**The Solution:**
We enforce mathematical symmetry in `loss_fn` without altering MTP's internal padding mask logic:
1. When GA is ON: We project the pure MTP average into a sum by multiplying it by the main model's `total_weights` before adding the losses. When XLA divides the accumulated totals later, the MTP gradients scale perfectly.
2. When GA is OFF: Both losses are treated correctly as averages.
3. We divide the `mtp_loss` in the `aux` dictionary by `config.gradient_accumulation_steps` so the background accumulation loop outputs the true, uninflated average to the terminal.

FIXES: 489534248

# Tests

I verified this fix locally by running 50-step training tests on a v6e TPU to ensure gradients flow correctly and logs maintain the mathematical ratios.

**1. Tested with GA = 8:**
```bash
python3 src/maxtext/trainers/pre_train/train.py src/maxtext/configs/base.yml\
    run_name=mtp-test-fix-ga8\
    model_name=llama2-7b\
    mtp_num_layers=1\
    gradient_accumulation_steps=8\
    per_device_batch_size=4\
    steps=50

```

*Result:* `mtp_loss` correctly printed as ~1.08, `main_model_loss` remained positive (~10.0), and both losses decreased smoothly, proving XLA accumulated the gradients perfectly.

**2\. Tested with GA = 1 (No Accumulation):**

Bash

```
python3 src/maxtext/trainers/pre_train/train.py src/maxtext/configs/base.yml\
    run_name=mtp-test-fix-no-ga\
    model_name=llama2-7b\
    mtp_num_layers=1\
    gradient_accumulation_steps=1\
    per_device_batch_size=4\
    steps=50

```

*Result:* Behavior remained identical and mathematically sound.

Checklist
=========

Before submitting this PR, please make sure (put X in square brackets):

-   [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.

-   [x] I have necessary comments in my code, particularly in hard-to-understand areas.

-   [x] I have run end-to-end tests tests and provided workload links above if applicable.

-   [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).