### PR TITLE
Fix scale to 1.0 for cudnn_flash_jax

### DIFF
--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -1672,7 +1672,7 @@ class AttentionOp(nnx.Module):
           key,
           value,
           mask_type=MaskType.CAUSAL,
-          scale=1.0 / math.sqrt(head_dim),
+          scale=1.0,
           dropout_rate=self.dropout_rate,
           qkv_layout="BTNH",
           return_residual=True,


### PR DESCRIPTION
# Description

The `'cudnn_flash_jax'` implementation diverged from the others as it was incorrectly calling `dot_product_attention` with `scale=1.0` while usually that's handled by `self.query_pre_attn_scalar` https://github.com/AI-Hypercomputer/maxtext/blob/d272058f58671c6ccf3a66cb3e25f49832aa2e40/src/maxtext/layers/attentions.py#L1098 or in other places (e.g. https://github.com/AI-Hypercomputer/maxtext/blob/d272058f58671c6ccf3a66cb3e25f49832aa2e40/src/maxtext/layers/attention_mla.py#L808)

FIXES: #3138 

# Tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
