### PR TITLE
Make sure that maxtext_venv does not get packaged into docker images.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git
+maxtext_venv

--- a/dependencies/scripts/docker_upload_runner.sh
+++ b/dependencies/scripts/docker_upload_runner.sh
@@ -56,8 +56,30 @@ if [[ ! -v CLOUD_IMAGE_NAME ]]; then
   exit 1
 fi
 
-# Check for dangling symbolic links (target does not exist).
-DANGLING_LINKS=$(find -L . -type l)
+# In the following sections we will want to check that the files that we are
+# packaging in the Docker image don't have outside symbolic links.
+# However, we want to exclude files and dirs listed in `.dockerignore` from this check
+
+# Build find exclusion arguments
+EXCLUDE_PATHS=()
+if [ -f .dockerignore ]; then
+  while IFS= read -r pattern; do
+    # Ignore empty lines and comments
+    if [[ -n "$pattern" && ! "$pattern" =~ ^# ]]; then
+      EXCLUDE_PATHS+=(-o -path "./$pattern")
+    fi
+  done < .dockerignore
+fi
+
+PRUNE_ARGS=()
+if [ ${#EXCLUDE_PATHS[@]} -gt 0 ]; then
+  # Remove leading -o and create the prune expression for find
+  # This tells find not to descend into these paths.
+  PRUNE_ARGS=(\( "${EXCLUDE_PATHS[@]:1}" \) -prune -o)
+fi
+
+# Check for dangling symbolic links (target does not exist), excluding .dockerignore paths.
+DANGLING_LINKS=$(find -L . "${PRUNE_ARGS[@]}" -type l -print)
 if [ -n "$DANGLING_LINKS" ]; then
   echo "ERROR: Found dangling symbolic links in the build context:"
   echo "$DANGLING_LINKS"
@@ -67,7 +89,7 @@ if [ -n "$DANGLING_LINKS" ]; then
 fi
 
 # Check for absolute symbolic links, which Docker can't follow outside the build context.
-ABSOLUTE_LINKS=$(find . -type l -lname '/*')
+ABSOLUTE_LINKS=$(find . "${PRUNE_ARGS[@]}" -type l -lname '/*' -print)
 if [ -n "$ABSOLUTE_LINKS" ]; then
   echo "ERROR: Found symbolic links with absolute paths in the build context:"
   echo "$ABSOLUTE_LINKS"


### PR DESCRIPTION
# Description

For customers who have the "maxtext_venv" under their "maxtext" directory we add "maxtext_venv" to ".dockerignore". This makes sure that `docker_build_dependency_image.sh` does not produce unnecessarily large docker images (5.9GB vs 18.8GB).

Also updated the file checks in the `docker_upload_runner.sh` script to respect the `.dockerignore` file and to exclude these files/dirs from the checks.

For reference, the Maxtext installation instructions (from source option) are instructing our users to create the `maxtext_venv` under the "maxtext" directory: https://maxtext.readthedocs.io/en/latest/install_maxtext.html#from-source

We could potentially save about 60MB extra space by removing unit tests, documentation, and some other files from the docker image. However, I don't think it would make a meaningful difference.

# Tests

Invoked  `bash dependencies/scripts/docker_build_dependency_image.sh DEVICE=tpu MODE=stable` on my VM to confirm that it runs much faster and the produced image size is significantly smaller.

Invoked `bash dependencies/scripts/docker_upload_runner.sh CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}` command to validate that its checks respect the `.dockerignore` file.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
