### PR TITLE
RL parsing: Greedy match outermost </reasoning> tag

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -152,7 +152,7 @@ max_num_seqs: null
 # If True, enables asynchronous scheduling in vLLM for faster generation
 async_scheduling: True
 # stop generation when any of these strings is generated
-stop_strings: [</answer>]
+stop_strings: null
 
 # ====== Checkpoint Configuration ======
 enable_checkpointing: True

--- a/src/maxtext/trainers/post_train/rl/utils_rl.py
+++ b/src/maxtext/trainers/post_train/rl/utils_rl.py
@@ -106,7 +106,7 @@ def get_match_format_regex(tmvp_config):
   match_format = re.compile(
       (
           r"^[\s]{0,}"
-          rf"{tmvp_config.reasoning_start_token}.+?{tmvp_config.reasoning_end_token}.*?"
+          rf"{tmvp_config.reasoning_start_token}.+{tmvp_config.reasoning_end_token}.*?"
           rf"{tmvp_config.solution_start_token}(.+?){tmvp_config.solution_end_token}"
       ),
       flags=re.MULTILINE | re.DOTALL,


### PR DESCRIPTION
# Description

The format regex used a lazy `.+?` for the reasoning block, causing it to stop at the first `</reasoning>` encountered. When a response contains nested `<reasoning>` or `<answer>` tags inside the reasoning text, this would match the wrong closing tag and extract a garbage answer. Changing to greedy `.+` ensures the regex backtracks to the outermost </reasoning>, correctly isolating the final `<answer>` block.

The `(.+?)` inside `<answer>...</answer>` stays lazy (which is correct — it should stop at the first `</answer>` **beyond the outermost reasoning tag**.

FIXES: [b/490168125](https://b.corp.google.com/issues/490168125)

# Tests

[Manual tests](https://b.corp.google.com/issues/490168125#comment2).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
