### PR TITLE
Temporarily remove workflow prereq due to a known issue

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -44,7 +44,9 @@ jobs:
       
   publish_maxtext_package_to_pypi:
     name: Publish MaxText package to PyPI
-    needs: [build_and_test_maxtext_package]
+    # Temporarily only require release_approval for a one-time upload.
+    # Immediately revert this to `needs: [build_and_test_maxtext_package]`.
+    needs: [release_approval]
     runs-on: ubuntu-latest
     environment: release
     steps:


### PR DESCRIPTION
# Description

Temporarily remove the test run prereq for the PyPI release. This is for a single PyPI release, and will be reverted afterwards.

There is an issue with the post-training notebook test requiring a HF token. All [other tests succeeded](https://github.com/AI-Hypercomputer/maxtext/actions/runs/22741964656/job/65957299253) in the run. Since we have tested post-training manual, we will continue with the release and fix any potential issues with a minor version bump. There is currently no post-training option in PyPI, so this would not be breaking existing functionality.

# Tests

All other CI tests. We have an extensive manual testing internal doc that has been verified as well

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
