### PR TITLE
Remove maxtext_post_training_dependencies.Dockerfile from Github workflow

### DIFF
--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -79,31 +79,32 @@ jobs:
       maxtext_sha: ${{ needs.setup.outputs.maxtext_sha }}
       image_date: ${{ needs.setup.outputs.image_date }}
 
-  tpu-post-training:
-    name: ${{ matrix.image_name }}
-    needs: [setup, tpu-pre-training]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - device: tpu
-            build_mode: post-training
-            image_name: maxtext_post_training_stable
-            dockerfile: ./dependencies/dockerfiles/maxtext_post_training_dependencies.Dockerfile
-          - device: tpu
-            build_mode: post-training
-            image_name: maxtext_post_training_nightly
-            dockerfile: ./dependencies/dockerfiles/maxtext_post_training_local_dependencies.Dockerfile
+  tpu-post-training-stable:
+    name: tpu-post-training-stable
+    needs: setup
     uses: ./.github/workflows/build_and_push_docker_image.yml
     with:
-      image_name: ${{ matrix.image_name }}
-      device: ${{ matrix.device }}
-      build_mode: ${{ matrix.build_mode }}
-      dockerfile: ${{ matrix.dockerfile }}
+      image_name: maxtext_post_training_stable
+      device: tpu
+      build_mode: stable
+      workflow: post-training
+      dockerfile: ./dependencies/dockerfiles/maxtext_tpu_dependencies.Dockerfile
       maxtext_sha: ${{ needs.setup.outputs.maxtext_sha }}
       image_date: ${{ needs.setup.outputs.image_date }}
-      base_image: gcr.io/tpu-prod-env-multipod/maxtext_jax_stable:${{ needs.setup.outputs.image_date }}
-      is_post_training: true
+
+  tpu-post-training-nightly:
+    name: tpu-post-training-nightly
+    needs: [setup, tpu-post-training-stable]
+    uses: ./.github/workflows/build_and_push_docker_image.yml
+    with:
+      image_name: maxtext_post_training_nightly
+      device: tpu
+      build_mode: nightly
+      workflow: post-training
+      dockerfile: ./dependencies/dockerfiles/maxtext_post_training_local_dependencies.Dockerfile
+      maxtext_sha: ${{ needs.setup.outputs.maxtext_sha }}
+      image_date: ${{ needs.setup.outputs.image_date }}
+      base_image: gcr.io/tpu-prod-env-multipod/maxtext_post_training_stable:${{ needs.setup.outputs.image_date }}
 
   gpu-pre-training:
     name: ${{ matrix.image_name }}

--- a/.github/workflows/build_and_push_docker_image.yml
+++ b/.github/workflows/build_and_push_docker_image.yml
@@ -41,10 +41,10 @@ on:
         required: false
         type: string
         default: ''
-      is_post_training:
+      workflow:
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'pre-training'
 
 permissions:
   contents: read
@@ -121,6 +121,7 @@ jobs:
           build-args: |
             DEVICE=${{ inputs.device }}
             MODE=${{ inputs.build_mode }}
+            WORKFLOW=${{ inputs.workflow }}
             JAX_VERSION=NONE
             LIBTPU_VERSION=NONE
             INCLUDE_TEST_ASSETS=true
@@ -144,7 +145,7 @@ jobs:
 
 
           # Add post-training dependencies tags
-          if [ "${{ inputs.is_post_training }}" == "true" ]; then
+          if [ "${{ inputs.workflow }}" == "post-training" ]; then
             for dir in tunix vllm tpu-inference; do
               if [ -d "./$dir" ]; then
                 dir_hash=$(git -C "$dir" rev-parse --short HEAD)


### PR DESCRIPTION
# Description

[PR #3300](https://github.com/AI-Hypercomputer/maxtext/pull/3300) removed `maxtext_post_training_dependencies.Dockerfile`. This PR fixed the Github workflow that builds the MaxText docker images daily.

Fixes: [b/490220797](https://buganizer.corp.google.com/issues/490220797)

# Tests

https://github.com/AI-Hypercomputer/maxtext/actions/runs/22754116819/job/65995216657

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
