### PR TITLE
Re-enable train_compile tests in CPU

### DIFF
--- a/tests/unit/sharding_compare_test.py
+++ b/tests/unit/sharding_compare_test.py
@@ -33,8 +33,6 @@ import pytest
 
 Transformer = models.transformer_as_linen
 
-pytestmark = [pytest.mark.cpu_only, pytest.mark.tpu_backend]
-
 
 def compute_checksum(d: dict) -> str:
   """Compute a checksum (SHA256) of a dictionary."""

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -28,8 +28,6 @@ import pytest
 from maxtext.trainers.pre_train.train_compile import main as train_compile_main
 from tests.utils.test_helpers import get_test_config_path
 
-pytestmark = [pytest.mark.external_training, pytest.mark.tpu_backend]
-
 
 class TrainCompile(unittest.TestCase):
   """Tests for the Ahead of Time Compilation functionality, train_compile.py"""


### PR DESCRIPTION
# Description

Re-enable CPU tests by removing mis-configured module-level `pytestmark` from `train_compile_test.py` and `sharding_compare_test.py` that caused many tests to be skipped or deselected on CPU CI runners ([previous commit](https://github.com/AI-Hypercomputer/maxtext/commit/cf9f9a338495c54b5d6aec3958fac5c1fc46c5dc)). Individual tests already have the correct hardware markers (`cpu_only`, `tpu_only`) so no test selection behavior changes for tests that really require specific hardware.

FIXES: [b/490412248](https://buganizer.corp.google.com/issues/490412248)

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
