### PR TITLE
[DECOUPLED-MODE] Add ICI parallelism logic for decoupled mode for partial rotary embedding test

### DIFF
--- a/tests/unit/partial_rotary_embedding_test.py
+++ b/tests/unit/partial_rotary_embedding_test.py
@@ -33,7 +33,7 @@ import numpy as np
 from maxtext.layers.embeddings import PartialRotaryEmbedding, RotaryEmbedding
 from maxtext.configs import pyconfig
 from maxtext.utils import maxtext_utils
-from tests.utils.test_helpers import get_test_config_path
+from tests.utils.test_helpers import get_test_config_path, get_decoupled_parallelism_overrides
 
 
 class PartialRotaryEmbeddingTest(unittest.TestCase):
@@ -42,10 +42,12 @@ class PartialRotaryEmbeddingTest(unittest.TestCase):
   def setUp(self):
     super().setUp()
     # build a simple config and mesh like other embedding tests
+    extra_args = get_decoupled_parallelism_overrides()
     self.cfg = pyconfig.initialize(
         [sys.argv[0], get_test_config_path()],
         run_name="test_embeddings",
         enable_checkpointing=False,
+        **extra_args,
     )
     devices_array = maxtext_utils.create_device_mesh(self.cfg)
     self.mesh = Mesh(devices_array, self.cfg.mesh_axes)


### PR DESCRIPTION
# Description
Add ICI parallelism logic for decoupled mode for partial rotary embedding test
# Tests
Tests passing in decoupled mode

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
