### PR TITLE
Claim support for Engram and mHC

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See our guide on running MaxText in decoupled mode, without any GCP dependencies
 
 ## 🔥 Latest news 🔥
 
+* \[March 6, 2026\] New features from DeepSeek-AI are now supported: Conditional Memory via Scalable Lookup ([Engram](https://arxiv.org/abs/2601.07372)) and Manifold-Constrained Hyper-Connections ([mHC](https://arxiv.org/abs/2512.24880)). Try them out with our [deepseek-custom](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/models/deepseek-custom.yml) starter config.
 * \[March 5, 2026\] New `tpu-post-train` [target in PyPI](https://pypi.org/project/maxtext). Please also use this installation option for running vllm_decode. See the [MaxText installation instructions](https://maxtext.readthedocs.io/en/latest/install_maxtext.html) for more info.
 * \[March 5, 2026\] [Qwen3-Next](https://github.com/AI-Hypercomputer/maxtext/blob/7656eb8d1c9eb0dd91e617a6fdf6ad805221221a/tests/end_to_end/tpu/qwen/next/run_qwen3_next.md) is now supported.
 * \[February 27, 2026\] New MaxText structure! MaxText has been restructured according to [RESTRUCTURE.md](https://github.com/AI-Hypercomputer/maxtext/blob/1b9e38aa0a19b6018feb3aed757406126b6953a1/RESTRUCTURE.md). Please feel free to share your thoughts and feedback. 

--- a/src/maxtext/configs/models/deepseek-custom.yml
+++ b/src/maxtext/configs/models/deepseek-custom.yml
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 # Small model config for testing (derived from DeepSeek V3.2 - 671B)
+# Included modules: DeepSeek Sparse Attention, Engram, mHC
+
+# Example command:
+# python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} run_name=demo model_name=deepseek-custom scan_layers=True attention=flash use_tokamax_splash=True enable_checkpointing=false async_checkpointing=false dataset_type=synthetic steps=5 per_device_batch_size=4 max_target_length=1024 dtype=bfloat16 weight_dtype=bfloat16 tokenizer_type=huggingface tokenizer_path=deepseek-ai/DeepSeek-V3.2 hf_access_token=${HF_TOKEN}
 
 base_emb_dim: 1024             # Reduced from 7168
 base_num_query_heads: 16       # Reduced from 128


### PR DESCRIPTION
# Description

**We have added support for two latest features from DeepSeek-AI**
- Engram: Conditional Memory via Scalable Lookup, [paper](https://arxiv.org/pdf/2601.07372)
- mHC: Manifold-Constrained Hyper-Connections, [paper](https://arxiv.org/pdf/2512.24880)

Engram PRs
- https://github.com/AI-Hypercomputer/maxtext/pull/3010
- https://github.com/AI-Hypercomputer/maxtext/pull/3183
- https://github.com/AI-Hypercomputer/maxtext/pull/3223
- https://github.com/AI-Hypercomputer/maxtext/pull/3255

mHC PRs
- https://github.com/AI-Hypercomputer/maxtext/pull/3065
- https://github.com/AI-Hypercomputer/maxtext/pull/3115

----


**Try them out with starter config: [deepseek-custom](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/models/deepseek-custom.yml)**

Example command
```
BASE_OUTPUT_PATH=gs://runner-maxtext-logs
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} run_name=demo model_name=deepseek-custom scan_layers=True attention=flash use_tokamax_splash=True enable_checkpointing=false async_checkpointing=false dataset_type=synthetic steps=5 per_device_batch_size=4 max_target_length=1024 dtype=bfloat16 weight_dtype=bfloat16 tokenizer_type=huggingface tokenizer_path=deepseek-ai/DeepSeek-V3.2 hf_access_token=${HF_TOKEN}
```

# Tests

Example command output on v5p-8:
https://paste.googleplex.com/5955657581854720
```
Per train step:
 Total TFLOPs: 6.77 
 split as 97.47% learnable weight flops and 2.53% attention flops
I0306 20:45:42.936144 139740321982464 metric_logger.py:275] number parameters: 4.223 billion
I0306 20:46:48.514095 139740321982464 max_utils.py:700] 
Memstats: After params initialized:
I0306 20:46:48.514538 139740321982464 max_utils.py:706] 	Using (GB) 6.17 / 95.74 (6.444537%) on TPU_0(process=0,(0,0,0,0))
I0306 20:46:48.514614 139740321982464 max_utils.py:706] 	Using (GB) 6.17 / 95.74 (6.444537%) on TPU_1(process=0,(1,0,0,0))
I0306 20:46:48.514667 139740321982464 max_utils.py:706] 	Using (GB) 6.17 / 95.74 (6.444537%) on TPU_2(process=0,(0,1,0,0))
I0306 20:46:48.514716 139740321982464 max_utils.py:706] 	Using (GB) 6.17 / 95.74 (6.444537%) on TPU_3(process=0,(1,1,0,0))
I0306 20:46:48.717036 139740321982464 metric_logger.py:181] completed step: 0, seconds: 65.514, TFLOP/s/device: 0.103, Tokens/s/device: 62.521, total_weights: 16384, loss: 12.274
I0306 20:46:48.719586 139740321982464 metric_logger.py:255] To see full metrics 'tensorboard --logdir=gs://runner-maxtext-logs/demo/tensorboard/'
I0306 20:46:49.150607 139740321982464 metric_logger.py:181] completed step: 1, seconds: 0.201, TFLOP/s/device: 33.718, Tokens/s/device: 20385.615, total_weights: 16384, loss: 12.245
I0306 20:46:49.276521 139740321982464 metric_logger.py:181] completed step: 2, seconds: 0.434, TFLOP/s/device: 15.613, Tokens/s/device: 9439.528, total_weights: 16384, loss: 12.217
I0306 20:46:49.407483 139740321982464 metric_logger.py:181] completed step: 3, seconds: 0.010, TFLOP/s/device: 673.778, Tokens/s/device: 407359.523, total_weights: 16384, loss: 12.196
I0306 20:46:49.538367 139740321982464 metric_logger.py:181] completed step: 4, seconds: 0.126, TFLOP/s/device: 53.845, Tokens/s/device: 32554.184, total_weights: 16384, loss: 12.194
```


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
