### PR TITLE
Fix config resolution for pip installed maxtext

### DIFF
--- a/src/maxtext/configs/pyconfig.py
+++ b/src/maxtext/configs/pyconfig.py
@@ -59,6 +59,12 @@ def resolve_config_path(param: str) -> str:
     lowercase_param = param.replace("MaxText", "maxtext")
     if os.path.isfile(lowercase_param):
       return lowercase_param
+  # For pip-installed packages, strip the src prefix and resolve against
+  # the installed configs directory (MAXTEXT_CONFIGS_DIR).
+  if param.startswith("src/maxtext/configs/"):
+    candidate = os.path.join(MAXTEXT_CONFIGS_DIR, param[len("src/maxtext/configs/"):])
+    if os.path.isfile(candidate):
+      return candidate
   return os.path.join("src", param)
 
 

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -23,7 +23,7 @@ GSM8K math reasoning benchmark. The script is also flexible enough to run Group 
 Usage Examples:
 
 # GRPO on Llama3.1-8B-Instruct
-python3 -m src.maxtext.trainers.post_train.rl.train_rl src/maxtext/configs/post_train/rl.yml \
+python3 -m maxtext.trainers.post_train.rl.train_rl src/maxtext/configs/post_train/rl.yml \
   model_name=llama3.1-8b \
   tokenizer_path=meta-llama/Llama-3.1-8B-Instruct \
   load_parameters_path=gs://path/to/checkpoint/0/items \
@@ -32,7 +32,7 @@ python3 -m src.maxtext.trainers.post_train.rl.train_rl src/maxtext/configs/post_
   hf_access_token=${HF_TOKEN?}
 
 # GSPO on Llama3.1-70B-Instruct
-python3 -m src.maxtext.trainers.post_train.rl.train_rl src/maxtext/configs/post_train/rl.yml \
+python3 -m maxtext.trainers.post_train.rl.train_rl src/maxtext/configs/post_train/rl.yml \
   model_name=llama3.1-70b \
   tokenizer_path=meta-llama/Llama-3.1-70B-Instruct \
   load_parameters_path=gs://path/to/checkpoint/0/items \

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -14,12 +14,13 @@
 
 """Tests for pyconfig."""
 
-import unittest
 import os.path
+import tempfile
+import unittest
 
 from maxtext.configs import pyconfig
 from maxtext.configs.pyconfig import resolve_config_path
-from maxtext.utils.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR, MAXTEXT_PKG_DIR
 from tests.utils.test_helpers import get_test_config_path, get_post_train_test_config_path
 
 
@@ -100,6 +101,19 @@ class PyconfigTest(unittest.TestCase):
   def test_resolve_config_path(self):
     self.assertEqual(resolve_config_path("foo"), os.path.join("src", "foo"))
     self.assertEqual(resolve_config_path(__file__), __file__)
+
+  def test_resolve_config_path_pip_install(self):
+    """Simulates pip-installed env where cwd has no src/ folder."""
+    orig = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmpdir:
+      try:
+        os.chdir(tmpdir)
+        result = resolve_config_path("src/maxtext/configs/base.yml")
+        self.assertEqual(result, os.path.join(MAXTEXT_CONFIGS_DIR, "base.yml"))
+        result = resolve_config_path("src/maxtext/configs/post_train/rl.yml")
+        self.assertEqual(result, os.path.join(MAXTEXT_CONFIGS_DIR, "post_train/rl.yml"))
+      finally:
+        os.chdir(orig)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

When we run maxtext workload with pip-installed maxtext, the config path does not get resolved correctly resulting in the need to clone MaxText to pass config when running with pip.

The `resolve_config_path` now handles this case, by resolving the config file using `MAXTEXT_CONFIGS_DIR`.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/491156065

# Tests
- CI
- Build a test wheel and install in a tmp dir with no src/ folder:

```
uv pip install --python ~/maxtext/maxtext_venv_2/bin/python \
  "$(ls ~/maxtext/dist/maxtext-*.whl)[tpu]"
Using Python 3.12.13 environment at: /home/dishaw_google_com/maxtext/maxtext_venv_2
Resolved 263 packages in 783ms
      Built pylatexenc==2.10
Prepared 139 packages in 30.81s
Installed 262 packages in 1.23s

/tmp/maxtext_test$ ~/maxtext/maxtext_venv_2/bin/python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
  run_name=dishaw_test_pip_install \
  base_output_directory=$OUTPUT_PATH \
  dataset_type=synthetic \
  steps=3
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
