### PR TITLE
Bump up Tunix, tpu-inference and vllm versions

### DIFF
--- a/src/install_maxtext_extra_deps/extra_post_train_deps_from_github.txt
+++ b/src/install_maxtext_extra_deps/extra_post_train_deps_from_github.txt
@@ -1,5 +1,5 @@
 google-jetstream @ https://github.com/AI-Hypercomputer/JetStream/archive/29329e8e73820993f77cfc8efe34eb2a73f5de98.zip
-google-tunix @ https://github.com/google/tunix/archive/615934aa47b3c7bd15b27c858d753274550cf0ad.zip
+google-tunix @ https://github.com/google/tunix/archive/336d102fe32ca0edbe42a8f66ff0fd533cebdf52.zip
 mlperf-logging @ https://github.com/mlcommons/logging/archive/38ab22670527888c8eb7825a4ece176fcc36a95d.zip
-tpu-inference @ https://github.com/vllm-project/tpu-inference/archive/eb2bd54c70f443775d8870caf56b78ab0b671269.zip
-vllm @ git+https://github.com/vllm-project/vllm@3bbb2046ff320395c80c139e55e7c1947c3fb5e1
+tpu-inference @ https://github.com/vllm-project/tpu-inference/archive/0cae84fc9a883ba1bde02d4f07930e6af9e92958.zip
+vllm @ git+https://github.com/vllm-project/vllm@ee8a29511fc69e3f0f6291fa6ff1cf6e47f7750d


### PR DESCRIPTION
# Description

Update the Tunix, tpu-inference and vllm versions

# Tests

Built a docker image with these versions and ran on v5p-128 for trainer and 2xv5p-128 for sampling. Also, ran locally on a v5p-8.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
