### PR TITLE
Auto-set ZARR3 and OCDBT to False for Pathways in config

### DIFF
--- a/docs/tutorials/posttraining/sft_on_multi_host.md
+++ b/docs/tutorials/posttraining/sft_on_multi_host.md
@@ -159,7 +159,7 @@ xpk workload create-pathways \
 --workload=${WORKLOAD_NAME?} \
 --tpu-type=${TPU_TYPE?} \
 --num-slices=${TPU_SLICE?} \
---command="JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE=1 python3 -m maxtext.trainers.post_train.sft.train_sft src/maxtext/configs/post_train/sft.yml run_name=${WORKLOAD_NAME?} base_output_directory=${OUTPUT_PATH?} model_name=${MODEL_NAME?} load_parameters_path=${MODEL_CHECKPOINT_PATH?} hf_access_token=${HF_TOKEN?} tokenizer_path=${TOKENIZER_PATH?} per_device_batch_size=1 steps=${STEPS?} profiler=xplane checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False enable_single_controller=True"
+--command="JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE=1 python3 -m maxtext.trainers.post_train.sft.train_sft src/maxtext/configs/post_train/sft.yml run_name=${WORKLOAD_NAME?} base_output_directory=${OUTPUT_PATH?} model_name=${MODEL_NAME?} load_parameters_path=${MODEL_CHECKPOINT_PATH?} hf_access_token=${HF_TOKEN?} tokenizer_path=${TOKENIZER_PATH?} per_device_batch_size=1 steps=${STEPS?} profiler=xplane enable_single_controller=True"
 ```
 
 Once the fine-tuning is completed, you can access your model checkpoints at `$OUTPUT_PATH/$WORKLOAD_NAME/checkpoints`.

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/llama_or_mistral_ckpt.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/llama_or_mistral_ckpt.py
@@ -1801,7 +1801,12 @@ if __name__ == "__main__":
   parser.add_argument("--huggingface-checkpoint", type=str2bool, required=False, default=False)
   parser.add_argument("--use-ocdbt", type=str2bool, required=False, default=True)
   parser.add_argument("--use-zarr3", type=str2bool, required=False, default=True)
+  parser.add_argument("--enable-single-controller", type=str2bool, required=False, default=False)
   args = parser.parse_args()
+
+  if args.enable_single_controller:
+    args.use_ocdbt = False
+    args.use_zarr3 = False
 
   if args.model_size not in MODEL_PARAMS_DICT:
     raise NotImplementedError

--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -77,8 +77,6 @@ decoder_layer_input: 'offload'
 query_proj: 'offload'
 key_proj: 'offload'
 value_proj: 'offload'
-checkpoint_storage_use_ocdbt: False # For Pathways
-checkpoint_storage_use_zarr3: False # For Pathways
 use_pathways: True
 log_period: 20
 

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2313,7 +2313,13 @@ class MaxTextConfig(
       ):
         self.logical_axis_rules.append(["aqt_amax_history", ("stage",)])
 
-    # H. RUN ALL CROSS-FIELD VALIDATIONS
+    # H. PATHWAYS/SINGLE-CONTROLLER OVERRIDES
+    # TODO(b/368121306): Remove this once zarr3 support is plumbed on the backend
+    if self.enable_single_controller and not self.colocated_python_checkpointing:
+      self.checkpoint_storage_use_ocdbt = False
+      self.checkpoint_storage_use_zarr3 = False
+
+    # I. RUN ALL CROSS-FIELD VALIDATIONS
     if self.load_parameters_path and self.load_full_state_path:
       raise ValueError("At most one of `load_parameters_path` or `load_full_state_path` should be set.")
     if (self.load_parameters_path or self.load_full_state_path) and not self.enable_checkpointing:
@@ -2538,7 +2544,7 @@ class MaxTextConfig(
     if self.share_kv_projections and self.attention_type == "mla":
       raise ValueError("`share_kv_projections` is not compatible with `attention_type='mla'`.")
 
-    # I. FINAL TYPE CONVERSIONS AND DERIVED LISTS
+    # J. FINAL TYPE CONVERSIONS AND DERIVED LISTS
     # Create the ici_parallelism and dcn_parallelism lists for legacy compatibility.
     if self.using_pipeline_parallelism and self.mesh_axes and self.mesh_axes[0] == "stage":
       self.ici_parallelism = [

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -17,7 +17,7 @@ RL Trainer
 
 This module provides a unified `rl_train` function that consolidates the common
 RL training logic. It handles model loading, reward function setup, dataset
-processing, and training orchestration. By default, we run Group Relative Policy Optimization (GRPO) on 
+processing, and training orchestration. By default, we run Group Relative Policy Optimization (GRPO) on
 GSM8K math reasoning benchmark. The script is also flexible enough to run Group Sequence Policy Optimization (GSPO).
 
 Usage Examples:
@@ -84,14 +84,14 @@ def get_maxtext_model(config, devices=None):
   """
   Load MaxText model with Tunix adapter.
   # Note: pass the path to your scanned checkpoint for 'load_parameters_path'.
-  # To create a scanned checkpoint, you can use /maxtext/src/MaxText/checkpoint_conversion/to_maxtext.py and if
-  # using Pathways, please set `checkpoint_storage_use_ocdbt=False checkpoint_storage_use_zarr3=False`
-  # python src/MaxText/checkpoint_conversion/to_maxtext.py \
-  #  --model_name="gemma2-2b" \
-  #  --base_output_directory="/path/to/your/output/directory" \
-  #  --scan_layers=True \
-  # --checkpoint_storage_use_ocdbt=False\
-  # checkpoint_storage_use_zarr3=False
+  # To create a scanned checkpoint, you can use `src/maxtext/checkpoint_conversion/to_maxtext.py` and if
+  # using Pathways, please set `enable_single_controller=True`
+  # python src/maxtext/checkpoint_conversion/to_maxtext.py \
+  #   maxtext/configs/base.yml \
+  #   model_name="gemma2-2b" \
+  #   base_output_directory="/path/to/your/output/directory" \
+  #   scan_layers=True \
+  #   enable_single_controller=True
   # Please ensure that you pass the full path ending in `/0/items` for load_parameters_path to train_rl.py i.e.,
   # load_parameters_path=/path/to/your/output/directory/0/items
   """

--- a/src/maxtext/utils/train_utils.py
+++ b/src/maxtext/utils/train_utils.py
@@ -58,12 +58,6 @@ def create_training_tools(config, model, mesh):
         logger,
     )
   else:
-    # TODO(b/368121306): Remove this once zarr3 support is plumbed on the backend
-    use_ocdbt = config.checkpoint_storage_use_ocdbt
-    use_zarr3 = config.checkpoint_storage_use_zarr3
-    if config.enable_single_controller and not config.colocated_python_checkpointing:
-      use_ocdbt, use_zarr3 = False, False
-
     checkpoint_dir = ""
     if config.enable_checkpointing:
       checkpoint_dir = config.checkpoint_dir
@@ -74,8 +68,8 @@ def create_training_tools(config, model, mesh):
         config.checkpoint_period,
         config.dataset_type,
         logger,
-        use_ocdbt,
-        use_zarr3,
+        config.checkpoint_storage_use_ocdbt,
+        config.checkpoint_storage_use_zarr3,
         config.enable_continuous_checkpointing,
         config.max_num_checkpoints_to_keep,
         config.checkpoint_storage_concurrent_gb,

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -115,6 +115,34 @@ class PyconfigTest(unittest.TestCase):
       finally:
         os.chdir(orig)
 
+  def test_pathways_checkpoint_overrides(self):
+    """Verifies that OCDBT and ZARR3 are False for Pathways by default."""
+    config = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        enable_single_controller=True,
+        colocated_python_checkpointing=False,
+        checkpoint_storage_use_ocdbt=True,  # Try to set it to True
+        checkpoint_storage_use_zarr3=True,  # Try to set it to True
+    )
+
+    self.assertFalse(config.checkpoint_storage_use_ocdbt)
+    self.assertFalse(config.checkpoint_storage_use_zarr3)
+
+  def test_pathways_no_override_when_colocated(self):
+    """Verifies that no override occurs if colocated_python_checkpointing is True."""
+    config = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        enable_single_controller=True,
+        colocated_python_checkpointing=True,
+        checkpoint_storage_use_ocdbt=True,
+        checkpoint_storage_use_zarr3=True,
+    )
+
+    self.assertTrue(config.checkpoint_storage_use_ocdbt)
+    self.assertTrue(config.checkpoint_storage_use_zarr3)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description

Address b/490520104: ZARR3 and OCDBT flags must be manually set to False for Pathways (should be default).

When `enable_single_controller==True` we automatically set ZARR3 and OCDBT flags to False.

One potentially controversial change as part of this PR is that the checkpoint conversion script `to_maxtext` now needs to be explicitly told `enable_single_controller=True`. I did not see a way around it.

FIXES: b/490520104

Pair-programmed with Gemini-CLI.

# Tests

Added a unit test. Manually ran a tiny Pathways workload.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
