### PR TITLE
Add job to build and upload docker image to pypi_release workflow

### DIFF
--- a/.github/workflows/build_and_push_docker_image.yml
+++ b/.github/workflows/build_and_push_docker_image.yml
@@ -35,7 +35,7 @@ on:
         required: true
         type: string
       image_date:
-        required: true
+        required: false
         type: string
       base_image:
         required: false
@@ -45,6 +45,10 @@ on:
         required: false
         type: string
         default: 'pre-training'
+      version_name:
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -115,7 +119,7 @@ jobs:
           push: true
           context: .
           file: ${{ inputs.dockerfile }}
-          tags: gcr.io/tpu-prod-env-multipod/${{ inputs.image_name }}:latest
+          tags: gcr.io/tpu-prod-env-multipod/${{ inputs.image_name }}:${{ github.run_id }}
           cache-from: type=gha
           outputs: type=image,compression=zstd,force-compression=true
           build-args: |
@@ -133,26 +137,33 @@ jobs:
         run: |
           SOURCE_IMAGE="gcr.io/tpu-prod-env-multipod/${INPUTS_IMAGE_NAME}"
 
-          # Add date tag
-          gcloud container images add-tag "$SOURCE_IMAGE:latest" "$SOURCE_IMAGE:${INPUTS_IMAGE_DATE}" --quiet
+          if [[ $INPUTS_VERSION_NAME ]]; then
+            echo "Tagging docker images corresponding to PyPI release..."
+            gcloud container images add-tag "$SOURCE_IMAGE:${{ github.run_id }}" "$SOURCE_IMAGE:${INPUTS_VERSION_NAME}" --quiet
+          else
+            echo "Tagging docker images corresponding to nightly release..."
 
-          # Convert date to YYYYMMDD format
-          clean_date=$(echo "${INPUTS_IMAGE_DATE}" | sed 's/[-:]//g' | cut -c1-8)
+            # Add date tag
+            gcloud container images add-tag "$SOURCE_IMAGE:${{ github.run_id }}" "$SOURCE_IMAGE:${INPUTS_IMAGE_DATE}" --quiet
 
-          # Add MaxText tag
-          maxtext_hash=$(git rev-parse --short HEAD)
-          gcloud container images add-tag "$SOURCE_IMAGE:latest" "$SOURCE_IMAGE:maxtext_${maxtext_hash}_${clean_date}" --quiet
+            # Convert date to YYYYMMDD format
+            clean_date=$(echo "${INPUTS_IMAGE_DATE}" | sed 's/[-:]//g' | cut -c1-8)
 
+            # Add MaxText tag
+            maxtext_hash=$(git rev-parse --short HEAD)
+            gcloud container images add-tag "$SOURCE_IMAGE:${{ github.run_id }}" "$SOURCE_IMAGE:maxtext_${maxtext_hash}_${clean_date}" --quiet
 
           # Add post-training dependencies tags
           if [ "${{ inputs.workflow }}" == "post-training" ]; then
             for dir in tunix vllm tpu-inference; do
               if [ -d "./$dir" ]; then
                 dir_hash=$(git -C "$dir" rev-parse --short HEAD)
-                gcloud container images add-tag "$SOURCE_IMAGE:latest" "$SOURCE_IMAGE:${dir}_${dir_hash}_${clean_date}" --quiet
-              fi
-            done
+                gcloud container images add-tag "$SOURCE_IMAGE:${{ github.run_id }}" "$SOURCE_IMAGE:${dir}_${dir_hash}_${clean_date}" --quiet
+                fi
+              done
+            fi
           fi
         env:
           INPUTS_IMAGE_NAME: ${{ inputs.image_name }}
           INPUTS_IMAGE_DATE: ${{ inputs.image_date }}
+          INPUTS_VERSION_NAME: ${{ inputs.version_name }}

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -41,12 +41,11 @@ jobs:
     name: Build and Test MaxText Package
     needs: [release_approval]
     uses: ./.github/workflows/build_and_test_maxtext.yml
+    secrets: inherit
       
   publish_maxtext_package_to_pypi:
     name: Publish MaxText package to PyPI
-    # Temporarily only require release_approval for a one-time upload.
-    # Immediately revert this to `needs: [build_and_test_maxtext_package]`.
-    needs: [release_approval]
+    needs: [build_and_test_maxtext_package]
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -61,3 +60,66 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: dist/
+
+  get_latest_maxtext_pypi_version:
+    name: Get latest MaxText PyPI version
+    needs: [publish_maxtext_package_to_pypi]
+    runs-on: ubuntu-latest
+    outputs:
+      latest_pypi_version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Fetch latest version of maxtext from PyPI
+        id: get_version
+        run: |
+          # Fetch JSON from PyPI for 'maxtext'
+          echo "Fetching latest version from https://pypi.org/pypi/maxtext/json"
+          pypi_json=$(curl -s https://pypi.org/pypi/maxtext/json)
+
+          # Extract the version from the "info" section using jq
+          latest_version=$(echo "$pypi_json" | jq -r ".info.version")
+
+          if [ -z "$latest_version" ] || [ "$latest_version" == "null" ]; then
+            echo "Error: Could not parse latest version from PyPI JSON."
+            exit 1
+          fi
+
+          echo "Successfully fetched latest MaxText version on PyPI: $latest_version"
+          # Set the output variable for other jobs to consume
+          echo "version=$latest_version" >> "$GITHUB_OUTPUT"
+
+  # This job builds and pushes MaxText stable Docker images for both TPU and GPU devices.
+  # It runs only after a new release is published to PyPI.
+  # Creates docker image for MaxText commit corresponding to the release.
+  upload_maxtext_docker_images:
+    name: ${{ matrix.image_name }}
+    needs: [get_latest_maxtext_pypi_version]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - device: tpu
+            build_mode: stable
+            image_name: maxtext_jax_stable
+            workflow: pre-training
+            dockerfile: ./src/dependencies/dockerfiles/maxtext_tpu_dependencies.Dockerfile
+          - device: gpu
+            build_mode: stable
+            image_name: maxtext_gpu_jax_stable
+            workflow: pre-training
+            dockerfile: ./src/dependencies/dockerfiles/maxtext_gpu_dependencies.Dockerfile
+          - device: tpu
+            build_mode: stable
+            image_name: maxtext_post_training_stable
+            workflow: post-training
+            dockerfile: ./src/dependencies/dockerfiles/maxtext_tpu_dependencies.Dockerfile
+    uses: ./.github/workflows/build_and_push_docker_image.yml
+    with:
+      image_name: ${{ matrix.image_name }}
+      device: ${{ matrix.device }}
+      build_mode: ${{ matrix.build_mode }}
+      workflow: ${{ matrix.workflow }}
+      dockerfile: ${{ matrix.dockerfile }}
+      maxtext_sha: ${{ github.sha }}
+      version_name: ${{ needs.get_latest_maxtext_pypi_version.outputs.latest_pypi_version }}


### PR DESCRIPTION
# Description

- Revert https://github.com/AI-Hypercomputer/maxtext/pull/3333 that temporarily remove the test run prereq for the PyPI release after fixing the issue
- Build and push MaxText stable docker images (pre-training and post-training) after a new PyPI version has been released. Also, tag the image with MAxText PyPI version.

# Tests

- Tested the fix for the issue identified in PR #3333: https://github.com/AI-Hypercomputer/maxtext/actions/runs/22924861319/job/66533075060?pr=3369
- Tested MaxText stable docker images build for latest pypi release: https://github.com/AI-Hypercomputer/maxtext/actions/runs/22925991031/job/66536370998?pr=3369

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
