### PR TITLE
Enable KV Cache Support for Scanned Decoder Layers and Improve vLLM Integration

### DIFF
--- a/src/maxtext/inference/vllm_decode.py
+++ b/src/maxtext/inference/vllm_decode.py
@@ -48,6 +48,9 @@ from tunix.rl.rollout.vllm_rollout import VllmRollout
 from vllm import LLM
 from vllm.sampling_params import SamplingParams
 from maxtext.configs import pyconfig
+import maxtext.integration.vllm.maxtext_vllm_adapter as adapter
+
+adapter.register()
 
 os.environ["SKIP_JAX_PRECOMPILE"] = "1"
 os.environ["NEW_MODEL_DESIGN"] = "1"
@@ -83,6 +86,7 @@ def decode_with_vllm(config: Config) -> None:
               "allow_split_physical_axes": True,
               "debug_sharding": config.debug_sharding,
               "prefuse_moe_weights": config.prefuse_moe_weights,
+              "scan_layers": config.scan_layers,
           },
           "sharding": {
               "sharding_strategy": {
@@ -141,11 +145,15 @@ def decode_with_vllm(config: Config) -> None:
         f"max_target_length ({config.max_target_length}) must be greater than max_prompt_length ({max_prompt_length})"
     )
 
+  # MaxText uses -1 to mean "disabled"; vLLM requires top_p in (0, 1].
+  top_p = config.decode_sampling_nucleus_p if config.decode_sampling_nucleus_p > 0 else 1.0
+  top_k = config.decode_sampling_top_k if config.decode_sampling_top_k > 0 else -1
+
   sampling_params = SamplingParams(
       temperature=config.decode_sampling_temperature,
       max_tokens=max_tokens_to_generate,
-      top_k=config.decode_sampling_top_k,
-      top_p=config.decode_sampling_nucleus_p,
+      top_k=top_k,
+      top_p=top_p,
   )
 
   outputs = llm.generate(prompts, sampling_params)

--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -104,6 +104,11 @@ class MaxTextForCausalLM(nnx.Module):
   of the decoding step.
   """
 
+  # Signal to tpu-inference model_loader that this class manages its own
+  # JIT-sharded initialization (via create_nnx_model with out_shardings).
+  # When True, model_loader skips wrapping __init__ in an outer bare @jax.jit,
+  _self_manages_sharding: bool = True
+
   def __init__(self, vllm_config: VllmConfig, rng_key: jax.Array, mesh: Mesh):
     """Initializes the MaxTextForCausalLM model.
 

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -981,7 +981,7 @@ class Attention(nnx.Module):
       value: Array,
       rpa_kv_cache: list[Array] | None = None,
       rpa_metadata: dict[str, Any] | None = None,
-  ) -> tuple[list[Array], Array]:
+  ) -> tuple[Array, list[Array]]:
     """Forward function for vLLM serving with RPA attention."""
     try:
       # pylint: disable=import-outside-toplevel
@@ -992,12 +992,13 @@ class Attention(nnx.Module):
           "vLLM RPA attention ops require the vllm-tpu package. Please install it with `pip install vllm-tpu`."
       ) from e
 
-    if rpa_kv_cache is None or rpa_metadata is None:
-      raise ValueError("kv_cache and attention_metadata must be provided when using vLLM.")
-
     query = query.reshape(-1, query.shape[2], query.shape[3])
     key = key.reshape(-1, key.shape[2], key.shape[3])
     value = value.reshape(-1, value.shape[2], value.shape[3])
+
+    if rpa_kv_cache is None or rpa_metadata is None:
+      # Return dummy values for dry runs (e.g. during model initialization or JIT tracing)
+      return query, []
 
     if self.config.sliding_window_size > 0:
       attention_chunk_size = self.config.sliding_window_size
@@ -1026,7 +1027,7 @@ class Attention(nnx.Module):
         k_scale,
         v_scale,
     )
-    return kv_cache, output
+    return output, kv_cache
 
   def __call__(
       self,
@@ -1169,7 +1170,7 @@ class Attention(nnx.Module):
 
     elif self.config.attention == "vllm_rpa" and model_mode != MODEL_MODE_TRAIN:
       batch, seq_len, num_heads, head_dim = query.shape
-      updated_kv, attn_out = self.forward_serve_vllm(
+      attn_out, updated_kv = self.forward_serve_vllm(
           query, key, value, rpa_kv_cache=kv_cache, rpa_metadata=attention_metadata
       )
       out = attn_out.reshape(batch, seq_len, num_heads, head_dim)

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -989,16 +989,58 @@ class Decoder(nn.Module):
                 "nope_layer_interval": self.config.nope_layer_interval,
                 "interleave_moe_layer_step": self.config.interleave_moe_layer_step,
             }
-          y, _ = self.scan_decoder_layers(
-              cfg,
-              RemattedBlockLayer,
-              scan_length,
-              "layers",
-              mesh,
-              in_axes_tuple=(nn.broadcast,) * len(broadcast_args),
-              model_mode=model_mode,
-              **layer_kwargs,
-          )(y, *broadcast_args)
+          # Update broadcast_args and in_axes_tuple for vLLM RPA
+          in_axes_tuple = (nn.broadcast,) * len(broadcast_args)
+          current_broadcast_args = list(broadcast_args)
+          current_in_axes_tuple = list(in_axes_tuple)
+
+          if kv_caches is not None:
+            # Stack kv_caches for scan: [num_layers, ...]
+            stacked_kv_cache = jnp.stack(kv_caches, axis=0)
+
+            # We pass (y, stacked_kv_cache, 0) as the carry
+            carry = (y, stacked_kv_cache, 0)
+
+            # We don't pass kv_cache as a scanned argument anymore
+
+            # Pass None for previous_chunk, slot, page_state, kv_cache to align with __call__ signature
+            current_broadcast_args.extend([None, None, None, None, attention_metadata])
+            current_in_axes_tuple.extend([nn.broadcast] * 5)
+
+            max_logging.info(f"DEBUG: len(current_broadcast_args)={len(current_broadcast_args)}")
+            max_logging.info(f"DEBUG: current_broadcast_args={[type(a) for a in current_broadcast_args]}")
+
+            final_carry, _ = self.scan_decoder_layers(
+                cfg,
+                RemattedBlockLayer,
+                scan_length,
+                "layers",
+                mesh,
+                in_axes_tuple=tuple(current_in_axes_tuple),
+                model_mode=model_mode,
+                **layer_kwargs,
+            )(carry, *current_broadcast_args)
+
+            y, returned_kv_cache, _ = final_carry
+
+            # Update the list of KV caches from the scanned results
+            for i in range(cfg.num_decoder_layers):
+              kv_caches[i] = returned_kv_cache[i]
+          else:
+            # Fallback to old behavior if kv_caches is None (not vLLM RPA)
+            current_broadcast_args.append(None)
+            current_in_axes_tuple.append(nn.broadcast)
+
+            y, _ = self.scan_decoder_layers(
+                cfg,
+                RemattedBlockLayer,
+                scan_length,
+                "layers",
+                mesh,
+                in_axes_tuple=tuple(current_in_axes_tuple),
+                model_mode=model_mode,
+                **layer_kwargs,
+            )(y, *current_broadcast_args)
       else:
         if cfg.decoder_block == DecoderBlockType.DEEPSEEK:
           assert len(RemattedBlockLayers) == 2, "Unscanned layers must have a length of 2 using deepseek."

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -428,8 +428,23 @@ class NNXDecoder(nnx.Module):
 
     return out
 
-  def _apply_layers_sequentially(self, layers, x_in, *args, length: int, **kwargs):
-    """Runs the layer stack using nnx.scan."""
+  def _apply_layers_sequentially(self, layers, x_in, *args, length: int, kv_caches_stacked=None, **kwargs):
+    """Runs the layer stack using nnx.scan.
+
+    Args:
+      layers: The stacked NNX module whose params are scanned over.
+      x_in: The carry (hidden state) fed into the first layer.
+      *args: Positional args broadcast to every layer call.
+      length: Number of scan iterations (= number of layers).
+      kv_caches_stacked: Optional pytree whose leaves have shape [num_layers, ...].
+        When provided, the i-th slice is passed as `kv_cache=` to layer i and the
+        updated caches are returned as a third element of the tuple.
+      **kwargs: Keyword args forwarded to the layer (filtered by the layer signature).
+
+    Returns:
+      (final_carry, updated_layers) when kv_caches_stacked is None.
+      (final_carry, updated_layers, returned_kv_stacked) otherwise.
+    """
     policy = self.get_remat_policy()
     prevent_cse = maxtext_utils.should_prevent_cse_in_remat(self.config)
     graphdef, params, state = nnx.split(
@@ -450,9 +465,15 @@ class NNXDecoder(nnx.Module):
     # Filter kwargs to only include keys that exist in the layer's signature
     valid_kwargs = {k: v for k, v in kwargs.items() if k in sig.parameters or "kwargs" in sig.parameters}
 
+    use_kv = kv_caches_stacked is not None
+
     def layer_fn(carry, scanned_vars):
       # Unpack the sliced variables for THIS layer
-      current_params, current_state = scanned_vars
+      if use_kv:
+        current_params, current_state, kv_cache_layer = scanned_vars
+      else:
+        current_params, current_state = scanned_vars
+        kv_cache_layer = None
 
       if self.config.parameter_memory_host_offload:
         current_params = jax.tree.map(lambda x: jax.device_put(x, max_utils.device_space()), current_params)
@@ -460,26 +481,64 @@ class NNXDecoder(nnx.Module):
       # Merge using the SLICED state
       layer = nnx.merge(graphdef, current_params, current_state)
 
-      # Run the layer (Filter kwargs if using the solution from previous turn)
-      layer_out = layer(carry, *args, **valid_kwargs)
+      # Build call kwargs, injecting per-layer kv_cache when available
+      call_kwargs = dict(valid_kwargs)
+      if kv_cache_layer is not None:
+        call_kwargs["kv_cache"] = kv_cache_layer
 
-      new_carry = layer_out[0] if isinstance(layer_out, tuple) else layer_out
+      layer_out = layer(carry, *args, **call_kwargs)
+
+      if isinstance(layer_out, tuple):
+        new_carry = layer_out[0]
+        updated_kv = layer_out[1] if len(layer_out) > 1 else None
+      else:
+        new_carry = layer_out
+        updated_kv = None
 
       # Extract the updated state to return it
-      # _, new_current_state = nnx.split(layer, nnx.Param, ...)
       new_current_state = nnx.state(layer)
+
+      if use_kv:
+        return new_carry, (new_current_state, updated_kv)
       return new_carry, new_current_state
 
     layer_fn = jax.checkpoint(layer_fn, policy=policy, prevent_cse=prevent_cse)
 
-    final_carry, scanned_state = jax.lax.scan(layer_fn, x_in, (params, state))
+    if use_kv:
+      # If kv_caches is provided (e.g., from vLLM), we CANNOT use jax.lax.scan
+      # because scanning requires stacking the kv_caches list, which creates a copy
+      # and breaks the in-place memory updates required by vLLM's PagedAttention.
+      # Therefore, we must unroll the loop statically when kv_caches is provided.
+
+      # kv_caches_stacked is actually the original kv_caches list in this new flow
+      kv_caches_list = kv_caches_stacked
+
+      current_carry = x_in
+
+      for i in range(length):
+        # Statically slice the parameters and state for this layer
+        current_params = jax.tree.map(lambda x, i=i: x[i], params)
+        current_state = jax.tree.map(lambda x, i=i: x[i], state)
+
+        # Call the layer
+        current_carry, (_, updated_kv) = layer_fn(current_carry, (current_params, current_state, kv_caches_list[i]))
+
+        # Update the list in-place (mutates the list passed by reference)
+        kv_caches_list[i] = updated_kv
+
+      # We don't need to rebuild scanned_state or return it because during
+      # inference with vLLM, parameters do not change and we don't need intermediates.
+      return current_carry, layers, None
+    else:
+      final_carry, scanned_state = jax.lax.scan(layer_fn, x_in, (params, state))
+      returned_kv_stacked = None
 
     if scan_axis != 0:
       scanned_params, scanned_other = scanned_state.split(nnx.Param, ...)
       scanned_params = jax.tree.map(lambda x: jnp.moveaxis(x, 0, scan_axis), scanned_params)
       scanned_state = nnx.State.merge(scanned_params, scanned_other)
 
-    return final_carry, nnx.merge(graphdef, scanned_state)
+    return final_carry, nnx.merge(graphdef, scanned_state), returned_kv_stacked if use_kv else None
 
   def get_decoder_layers(self):
     """Retrieves decoder layer classes based on config using a dictionary lookup."""
@@ -859,7 +918,7 @@ class NNXDecoder(nnx.Module):
       chunk_stack = nnx.merge(graphdef, chunk_state)
 
       # Apply sequentially
-      y, chunk_stack = self._apply_layers_sequentially(
+      y, chunk_stack, _ = self._apply_layers_sequentially(
           chunk_stack, y, *args, length=scan_length, **kwargs.get("layer_kwargs", {})
       )
 
@@ -966,7 +1025,7 @@ class NNXDecoder(nnx.Module):
               **common_kwargs,
           )
         else:
-          y, self.dense_layers = self._apply_layers_sequentially(
+          y, self.dense_layers, _ = self._apply_layers_sequentially(
               self.dense_layers, y, *layer_args, length=cfg.first_num_dense_layers, **layer_kwargs
           )
 
@@ -984,7 +1043,7 @@ class NNXDecoder(nnx.Module):
                 num_layers=num_moe,
             )
           else:
-            y, self.moe_layer = self._apply_layers_sequentially(
+            y, self.moe_layer, _ = self._apply_layers_sequentially(
                 self.moe_layer, y, *layer_args, length=num_moe, **layer_kwargs
             )
       elif self.is_gemma3:
@@ -1001,7 +1060,18 @@ class NNXDecoder(nnx.Module):
         )
       else:
         scan_length = int(cfg.num_decoder_layers / cfg.inhomogeneous_layer_cycle_interval)
-        y, self.layers = self._apply_layers_sequentially(self.layers, y, *layer_args, length=scan_length, **layer_kwargs)
+        if kv_caches is not None:
+          # Pass the kv_caches list directly to avoid copying in jnp.stack,
+          # which breaks vLLM PagedAttention in-place memory updates.
+          # The _apply_layers_sequentially function will handle it by statically unrolling.
+          y, self.layers, _ = self._apply_layers_sequentially(
+              self.layers, y, *layer_args, length=scan_length, kv_caches_stacked=kv_caches, **layer_kwargs
+          )
+          # kv_caches list is updated in-place inside _apply_layers_sequentially
+        else:
+          y, self.layers, _ = self._apply_layers_sequentially(
+              self.layers, y, *layer_args, length=scan_length, **layer_kwargs
+          )
     else:
       prevent_cse = maxtext_utils.should_prevent_cse_in_remat(cfg)
 
@@ -1085,7 +1155,7 @@ class NNXDecoder(nnx.Module):
 
     # Apply the main scan over the full blocks
     if scan_length > 0:
-      y, self.layers = self._apply_layers_sequentially(self.layers, y, *layer_args, length=scan_length, **layer_kwargs)
+      y, self.layers, _ = self._apply_layers_sequentially(self.layers, y, *layer_args, length=scan_length, **layer_kwargs)
 
     # Apply any remaining layers that did not fit into a full scanned block
     num_remaining_layers = cfg.num_decoder_layers % attention_pattern_length

--- a/src/maxtext/models/gemma.py
+++ b/src/maxtext/models/gemma.py
@@ -30,6 +30,7 @@ from maxtext.layers.attentions import Attention
 from maxtext.layers.linears import Dropout, MlpBlock
 from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
+from maxtext.inference import page_manager
 from maxtext.utils import max_utils
 
 
@@ -126,8 +127,7 @@ class GemmaDecoderLayer(nnx.Module):
       deterministic,
       model_mode,
       previous_chunk=None,
-      page_manager=None,
-      page_state=None,
+      page_state: None | page_manager.PageState = None,
       slot=None,
       kv_cache=None,
       attention_metadata=None,

--- a/src/maxtext/models/gemma3.py
+++ b/src/maxtext/models/gemma3.py
@@ -194,7 +194,13 @@ class Gemma3DecoderLayer(nnx.Module):
   ):
     cfg = self.config
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
-    if isinstance(inputs, tuple):
+    is_scan_carry = False
+    if isinstance(inputs, tuple) and len(inputs) == 3:
+      hidden_states, stacked_kv_cache, layer_idx = inputs
+      kv_cache = stacked_kv_cache[layer_idx]
+      inputs = hidden_states
+      is_scan_carry = True
+    elif isinstance(inputs, tuple):
       inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
@@ -244,7 +250,16 @@ class Gemma3DecoderLayer(nnx.Module):
           jnp.sum(layer_output == 0) / jnp.size(layer_output),
       )
 
-    if cfg.scan_layers:
+    if is_scan_carry:
+
+      def update_cache(cache, val):
+        if jnp.size(val) > 0:
+          return cache.at[layer_idx].set(val)
+        return cache
+
+      stacked_kv_cache = jax.tree_util.tree_map(update_cache, stacked_kv_cache, kv_cache)
+      return (layer_output, stacked_kv_cache, layer_idx + 1), None
+    elif cfg.scan_layers:
       return layer_output, None
     else:
       return layer_output, kv_cache

--- a/src/maxtext/models/gemma4.py
+++ b/src/maxtext/models/gemma4.py
@@ -322,7 +322,13 @@ class Gemma4DecoderLayer(nnx.Module):
   ):
     cfg = self.config
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
-    if isinstance(inputs, tuple):
+    is_scan_carry = False
+    if isinstance(inputs, tuple) and len(inputs) == 3:
+      hidden_states, stacked_kv_cache, layer_idx = inputs
+      kv_cache = stacked_kv_cache[layer_idx]
+      inputs = hidden_states
+      is_scan_carry = True
+    elif isinstance(inputs, tuple):
       inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
@@ -383,7 +389,16 @@ class Gemma4DecoderLayer(nnx.Module):
           jnp.sum(layer_output == 0) / jnp.size(layer_output),
       )
 
-    if cfg.scan_layers:
+    if is_scan_carry:
+
+      def update_cache(cache, val):
+        if jnp.size(val) > 0:
+          return cache.at[layer_idx].set(val)
+        return cache
+
+      stacked_kv_cache = jax.tree_util.tree_map(update_cache, stacked_kv_cache, kv_cache)
+      return (layer_output, stacked_kv_cache, layer_idx + 1), None
+    elif cfg.scan_layers:
       return layer_output, None
     else:
       return layer_output, kv_cache

--- a/src/maxtext/models/gpt_oss.py
+++ b/src/maxtext/models/gpt_oss.py
@@ -23,6 +23,7 @@ from typing import Optional
 from flax import linen as nn
 from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
+import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from maxtext.common.common_types import AttentionType, Config
@@ -34,6 +35,7 @@ from maxtext.layers import quantizations
 from maxtext.layers.attentions import Attention
 from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
+from maxtext.inference import page_manager
 from maxtext.utils import max_utils
 
 # -----------------------------------------
@@ -138,14 +140,20 @@ class GptOssDecoderLayer(nnx.Module):
       deterministic,
       model_mode,
       previous_chunk=None,
-      page_state=None,
+      page_state: None | page_manager.PageState = None,
       slot=None,
       kv_cache=None,
       attention_metadata=None,
   ):
     cfg = self.config
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
-    if isinstance(inputs, tuple):
+    is_scan_carry = False
+    if isinstance(inputs, tuple) and len(inputs) == 3:
+      hidden_states, stacked_kv_cache, layer_idx = inputs
+      kv_cache = stacked_kv_cache[layer_idx]
+      inputs = hidden_states
+      is_scan_carry = True
+    elif isinstance(inputs, tuple):
       inputs = inputs[0]
 
     inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
@@ -200,7 +208,16 @@ class GptOssDecoderLayer(nnx.Module):
           jnp.sum(layer_output == 0) / jnp.size(layer_output),
       )
 
-    if cfg.scan_layers:
+    if is_scan_carry:
+
+      def update_cache(cache, val):
+        if jnp.size(val) > 0:
+          return cache.at[layer_idx].set(val)
+        return cache
+
+      stacked_kv_cache = jax.tree_util.tree_map(update_cache, stacked_kv_cache, kv_cache)
+      return (layer_output, stacked_kv_cache, layer_idx + 1), None
+    elif cfg.scan_layers:
       return layer_output, None
     else:
       return layer_output, kv_cache
@@ -258,6 +275,11 @@ class GptOssScannableBlock(nnx.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
+      page_state: None | page_manager.PageState = None,
+      slot=None,
+      kv_cache=None,
+      attention_metadata=None,
   ):
     cfg = self.config
 
@@ -267,19 +289,19 @@ class GptOssScannableBlock(nnx.Module):
     for layer_id in range(cfg.inhomogeneous_layer_cycle_interval):
       layer_name = f"layers_{layer_id}"
       layer = getattr(self, layer_name)
-      y = layer(
+      y, kv_cache = layer(
           y,
           decoder_segment_ids,
           decoder_positions,
           deterministic,
           model_mode,
+          previous_chunk=previous_chunk,
+          page_state=page_state,
+          slot=slot,
+          kv_cache=kv_cache,
+          attention_metadata=attention_metadata,
       )
-      if cfg.scan_layers:
-        y = y[0]
-    if cfg.scan_layers:
-      return y, None
-    else:
-      return y
+    return y, kv_cache
 
 
 GptOssScannableBlockToLinen = nnx_wrappers.to_linen_class(

--- a/src/maxtext/models/llama2.py
+++ b/src/maxtext/models/llama2.py
@@ -19,6 +19,7 @@
 import functools
 from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
+import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from maxtext.common.common_types import Config
@@ -143,16 +144,22 @@ class LlamaDecoderLayer(nnx.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
       slot: None | int = None,
       page_state: None | page_manager.PageState = None,
-      previous_chunk=None,
       kv_cache=None,
       attention_metadata=None,
   ):
     cfg = self.config
 
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
-    if isinstance(inputs, tuple):
+    is_scan_carry = False
+    if isinstance(inputs, tuple) and len(inputs) == 3:
+      hidden_states, stacked_kv_cache, layer_idx = inputs
+      kv_cache = stacked_kv_cache[layer_idx]
+      inputs = hidden_states
+      is_scan_carry = True
+    elif isinstance(inputs, tuple):
       inputs = inputs[0]
     inputs = self._maybe_shard_with_logical(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
@@ -206,7 +213,16 @@ class LlamaDecoderLayer(nnx.Module):
           jnp.sum(layer_output == 0) / jnp.size(layer_output),
       )
 
-    if cfg.scan_layers:
+    if is_scan_carry:
+
+      def update_cache(cache, val):
+        if jnp.size(val) > 0:
+          return cache.at[layer_idx].set(val)
+        return cache
+
+      stacked_kv_cache = jax.tree_util.tree_map(update_cache, stacked_kv_cache, kv_cache)
+      return (layer_output, stacked_kv_cache, layer_idx + 1), None
+    elif cfg.scan_layers:
       return layer_output, None
     else:
       return layer_output, kv_cache
@@ -219,6 +235,7 @@ class LlamaLTIDecoderLayer(LearnToInitDecoderLayer):
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, base_layer_cls=LlamaDecoderLayer, **kwargs)
+
 
 LlamaLTIDecoderLayerToLinen = nnx_wrappers.to_linen_class(
     LlamaLTIDecoderLayer,

--- a/src/maxtext/models/llama4.py
+++ b/src/maxtext/models/llama4.py
@@ -19,6 +19,7 @@ import math
 
 from flax import linen as nn
 from flax import nnx
+import jax
 from jax import lax
 from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
@@ -442,9 +443,9 @@ class Llama4DecoderLayer(nnx.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
       slot: None | int = None,
       page_state: None | page_manager.PageState = None,
-      previous_chunk=None,
       kv_cache=None,
       attention_metadata=None,
   ):
@@ -452,7 +453,13 @@ class Llama4DecoderLayer(nnx.Module):
     assert cfg.num_experts >= 1, "Expected the Llama4 config to have `num_experts > 1`."
 
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
-    if isinstance(inputs, tuple):
+    is_scan_carry = False
+    if isinstance(inputs, tuple) and len(inputs) == 3:
+      hidden_states, stacked_kv_cache, layer_idx = inputs
+      kv_cache = stacked_kv_cache[layer_idx]
+      inputs = hidden_states
+      is_scan_carry = True
+    elif isinstance(inputs, tuple):
       inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
@@ -504,7 +511,16 @@ class Llama4DecoderLayer(nnx.Module):
           jnp.sum(layer_output == 0) / jnp.size(layer_output),
       )
 
-    if cfg.scan_layers:
+    if is_scan_carry:
+
+      def update_cache(cache, val):
+        if jnp.size(val) > 0:
+          return cache.at[layer_idx].set(val)
+        return cache
+
+      stacked_kv_cache = jax.tree_util.tree_map(update_cache, stacked_kv_cache, kv_cache)
+      return (layer_output, stacked_kv_cache, layer_idx + 1), None
+    elif cfg.scan_layers:
       return layer_output, None
     else:
       return layer_output, kv_cache
@@ -570,9 +586,11 @@ class Llama4ScannableBlock(nnx.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
       slot: None | int = None,
       page_state: None | page_manager.PageState = None,
-      previous_chunk=None,
+      kv_cache=None,
+      attention_metadata=None,
   ):
 
     cfg = self.config
@@ -590,6 +608,8 @@ class Llama4ScannableBlock(nnx.Module):
           previous_chunk=previous_chunk,
           page_state=page_state,
           slot=slot,
+          kv_cache=kv_cache,
+          attention_metadata=attention_metadata,
       )
       if cfg.scan_layers:
         y = y[0]

--- a/src/maxtext/models/mistral.py
+++ b/src/maxtext/models/mistral.py
@@ -19,9 +19,11 @@
 from flax import linen as nn
 from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
+import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from maxtext.common.common_types import Config
+from maxtext.inference import page_manager
 from maxtext.layers import initializers, nnx_wrappers
 from maxtext.layers import quantizations
 from maxtext.layers.attentions import Attention
@@ -126,16 +128,22 @@ class MistralDecoderLayer(nnx.Module):
       decoder_positions,
       deterministic,
       model_mode,
-      page_state: None | int = None,
-      slot: None | int = None,
       previous_chunk=None,
+      slot: None | int = None,
+      page_state: None | page_manager.PageState = None,
       kv_cache=None,
       attention_metadata=None,
   ):
     cfg = self.config
 
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
-    if isinstance(inputs, tuple):
+    is_scan_carry = False
+    if isinstance(inputs, tuple) and len(inputs) == 3:
+      hidden_states, stacked_kv_cache, layer_idx = inputs
+      kv_cache = stacked_kv_cache[layer_idx]
+      inputs = hidden_states
+      is_scan_carry = True
+    elif isinstance(inputs, tuple):
       inputs = inputs[0]
     inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
     inputs = checkpoint_name(inputs, "decoder_layer_input")
@@ -180,7 +188,16 @@ class MistralDecoderLayer(nnx.Module):
           jnp.sum(layer_output == 0) / jnp.size(layer_output),
       )
 
-    if cfg.scan_layers:
+    if is_scan_carry:
+
+      def update_cache(cache, val):
+        if jnp.size(val) > 0:
+          return cache.at[layer_idx].set(val)
+        return cache
+
+      stacked_kv_cache = jax.tree_util.tree_map(update_cache, stacked_kv_cache, kv_cache)
+      return (layer_output, stacked_kv_cache, layer_idx + 1), None
+    elif cfg.scan_layers:
       return layer_output, None
     else:
       return layer_output, kv_cache

--- a/src/maxtext/models/olmo3.py
+++ b/src/maxtext/models/olmo3.py
@@ -24,6 +24,7 @@ from typing import Optional
 from flax import linen as nn
 from flax import nnx
 from jax.ad_checkpoint import checkpoint_name
+import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
 from maxtext.common.common_types import AttentionType, Config
@@ -155,7 +156,13 @@ class Olmo3DecoderLayer(nnx.Module):
   ):
     cfg = self.config
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
-    if isinstance(inputs, tuple):
+    is_scan_carry = False
+    if isinstance(inputs, tuple) and len(inputs) == 3:
+      hidden_states, stacked_kv_cache, layer_idx = inputs
+      kv_cache = stacked_kv_cache[layer_idx]
+      inputs = hidden_states
+      is_scan_carry = True
+    elif isinstance(inputs, tuple):
       inputs = inputs[0]
 
     inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
@@ -209,7 +216,16 @@ class Olmo3DecoderLayer(nnx.Module):
           jnp.sum(layer_output == 0) / jnp.size(layer_output),
       )
 
-    if cfg.scan_layers:
+    if is_scan_carry:
+
+      def update_cache(cache, val):
+        if jnp.size(val) > 0:
+          return cache.at[layer_idx].set(val)
+        return cache
+
+      stacked_kv_cache = jax.tree_util.tree_map(update_cache, stacked_kv_cache, kv_cache)
+      return (layer_output, stacked_kv_cache, layer_idx + 1), None
+    elif cfg.scan_layers:
       return layer_output, None
     else:
       return layer_output, kv_cache
@@ -267,6 +283,11 @@ class Olmo3ScannableBlock(nnx.Module):
       decoder_positions,
       deterministic,
       model_mode,
+      previous_chunk=None,
+      page_state=None,
+      slot=None,
+      kv_cache=None,
+      attention_metadata=None,
   ):
     cfg = self.config
 
@@ -282,6 +303,11 @@ class Olmo3ScannableBlock(nnx.Module):
           decoder_positions,
           deterministic,
           model_mode,
+          previous_chunk=previous_chunk,
+          page_state=page_state,
+          slot=slot,
+          kv_cache=kv_cache,
+          attention_metadata=attention_metadata,
       )
       if cfg.scan_layers:
         y = y[0]

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -896,6 +896,8 @@ class Qwen3NextScannableBlock(nnx.Module):
       previous_chunk=None,
       page_state: None | page_manager.PageState = None,
       slot: None | int = None,
+      kv_cache=None,
+      attention_metadata=None,
   ) -> tuple[Array, None]:
     """Applies the block of decoder layers to the input carry.
 
@@ -924,6 +926,8 @@ class Qwen3NextScannableBlock(nnx.Module):
           previous_chunk,
           page_state,
           slot,
+          kv_cache=kv_cache,
+          attention_metadata=attention_metadata,
       )
 
     # The output of the block is the carry for the next scan iteration.
@@ -1235,10 +1239,7 @@ class Qwen3DecoderLayer(AttentionWithNorm):
     layer_output = intermediate_inputs + mlp_lnx
     layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
 
-    if self.config.scan_layers:
-      return layer_output, None
-    else:
-      return layer_output, kv_cache
+    return layer_output, kv_cache
 
 
 # -----------------------------------------
@@ -1284,6 +1285,14 @@ class Qwen3MoeDecoderLayer(AttentionWithNorm):
       attention_metadata: None | dict[str, Any] = None,
   ):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    is_scan_carry = False
+    if isinstance(inputs, tuple) and len(inputs) == 3:
+      hidden_states, stacked_kv_cache, layer_idx = inputs
+      kv_cache = stacked_kv_cache[layer_idx]
+      inputs = hidden_states
+      is_scan_carry = True
+    elif isinstance(inputs, tuple):
+      inputs = inputs[0]
     if isinstance(inputs, tuple):
       inputs = inputs[0]
     hidden_states, intermediate_inputs, kv_cache = self.apply_attention_with_norm(
@@ -1304,8 +1313,15 @@ class Qwen3MoeDecoderLayer(AttentionWithNorm):
     layer_output = intermediate_inputs + mlp_lnx
     layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
 
-    if self.config.scan_layers:
-      return layer_output, None
+    if is_scan_carry:
+
+      def update_cache(cache, val):
+        if jnp.size(val) > 0:
+          return cache.at[layer_idx].set(val)
+        return cache
+
+      stacked_kv_cache = jax.tree_util.tree_map(update_cache, stacked_kv_cache, kv_cache)
+      return (layer_output, stacked_kv_cache, layer_idx + 1), None
     else:
       return layer_output, kv_cache
 

--- a/src/maxtext/models/simple_layer.py
+++ b/src/maxtext/models/simple_layer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Simple decoder layers for testing and debugging purposes."""
+"""Simple decoder layers for testing and debugging purposes."""
 
 from jax import numpy as jnp
 from jax.sharding import Mesh
@@ -58,7 +58,17 @@ class SimpleDecoderLayer(nnx.Module):
     )
 
   def __call__(
-      self, inputs: jnp.ndarray, positions, segmentation, deterministic, model_mode, previous_chunk=None, page_state=None
+      self,
+      inputs: jnp.ndarray,
+      positions,
+      segmentation,
+      deterministic,
+      model_mode,
+      previous_chunk=None,
+      page_state=None,
+      slot=None,
+      kv_cache=None,
+      attention_metadata=None,
   ):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):
@@ -121,6 +131,8 @@ class SimpleMlpDecoderLayer(nnx.Module):
       previous_chunk=None,
       page_state=None,
       slot=0,
+      kv_cache=None,
+      attention_metadata=None,
   ):
     # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
     if isinstance(inputs, tuple):

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -122,27 +122,65 @@ def _fix_restore_args_for_shape_mismatch(restore_args, stored_metadata_tree, mes
     return node
 
   mismatched_paths = []
+  rank_mismatched_paths = []
+  missing_paths = []  # paths in model that are absent from the checkpoint tree
+  found_array_count = [0]
 
   def _fix_one(path, restore_arg):
     if not isinstance(restore_arg, ocp.ArrayRestoreArgs):
       return restore_arg
     stored_meta = _lookup_stored_meta(path)
-    if stored_meta is not None and _is_orbax_array_metadata(stored_meta):
+    if stored_meta is None:
+      missing_paths.append(f"  {'.'.join(_key_str(k) for k in path)}")
+      return restore_arg
+    if _is_orbax_array_metadata(stored_meta):
       stored_shape = tuple(stored_meta.shape)
-      if (
-          restore_arg.global_shape is not None
-          and restore_arg.global_shape != stored_shape
-          and len(stored_shape) == len(restore_arg.global_shape)
-      ):
-        mismatched_paths.append(
-            f"  {'.'.join(_key_str(k) for k in path)}: stored={stored_shape} -> model={restore_arg.global_shape}"
-        )
-        return dataclasses.replace(
-            restore_arg, global_shape=None, shape=None, sharding=replicated, mesh=None, mesh_axes=None
-        )
+      if restore_arg.global_shape is not None and restore_arg.global_shape != stored_shape:
+        if len(stored_shape) != len(restore_arg.global_shape):
+          rank_mismatched_paths.append(
+              f"  {'.'.join(_key_str(k) for k in path)}: "
+              f"checkpoint shape {stored_shape} (rank {len(stored_shape)}) "
+              f"vs model shape {restore_arg.global_shape} (rank {len(restore_arg.global_shape)})"
+          )
+        else:
+          mismatched_paths.append(
+              f"  {'.'.join(_key_str(k) for k in path)}: stored={stored_shape} -> model={restore_arg.global_shape}"
+          )
+          found_array_count[0] += 1
+          return dataclasses.replace(
+              restore_arg, global_shape=None, shape=None, sharding=replicated, mesh=None, mesh_axes=None
+          )
+      else:
+        found_array_count[0] += 1
     return restore_arg
 
   fixed = jax.tree_util.tree_map_with_path(_fix_one, restore_args, is_leaf=lambda x: isinstance(x, ocp.ArrayRestoreArgs))
+  if rank_mismatched_paths:
+    sample = "\n".join(rank_mismatched_paths[:5])
+    more = f"\n  ... and {len(rank_mismatched_paths) - 5} more" if len(rank_mismatched_paths) > 5 else ""
+    raise ValueError(
+        f"Checkpoint rank mismatches detected ({len(rank_mismatched_paths)} arrays). "
+        "This usually means a scanned (scan_layers=True) checkpoint was loaded with "
+        "scan_layers=False, or vice versa. Please ensure the checkpoint format matches "
+        f"the scan_layers setting.\n{sample}{more}"
+    )
+
+  # Detect structural mismatch (e.g. scanned checkpoint loaded into unscanned model).
+  # In that case the checkpoint tree has "layers" (all layers stacked) but the model
+  # expects "layers_0", "layers_1", etc., so _lookup_stored_meta returns None for every
+  # layer parameter and nearly all paths end up in missing_paths.
+  total_arrays = found_array_count[0] + len(rank_mismatched_paths) + len(missing_paths)
+  if total_arrays > 0 and len(missing_paths) / total_arrays > 0.8:
+    sample = "\n".join(missing_paths[:5])
+    more = f"\n  ... and {len(missing_paths) - 5} more" if len(missing_paths) > 5 else ""
+    raise ValueError(
+        f"Checkpoint structure mismatch: {len(missing_paths)} of {total_arrays} model parameter "
+        "paths were not found in the checkpoint. "
+        "This usually means a scanned (scan_layers=True) checkpoint is being loaded with "
+        "scan_layers=False, or vice versa. Please ensure the checkpoint format matches the "
+        f"scan_layers setting.\nExample missing paths:\n{sample}{more}"
+    )
+
   if mismatched_paths:
     max_logging.log(
         f"Checkpoint shape mismatches ({len(mismatched_paths)} arrays): loading with replicated "
@@ -613,15 +651,6 @@ def from_pretrained(
         else:
           checkpoint = restored["params"]["params"]
 
-        loaded_count = len(jax.tree_util.tree_leaves(checkpoint))
-        expected_count = len(jax.tree_util.tree_leaves(target_for_restore))
-        if loaded_count < expected_count:
-          raise ValueError(
-              f"Checkpoint at '{config.load_parameters_path}' loaded only {loaded_count} of {expected_count} "
-              "expected parameter arrays. This usually means a scanned (stacked-layers) checkpoint was provided "
-              "where an unscanned checkpoint is required. Please convert the checkpoint to unscanned format first."
-          )
-
         if checkpoint:
           model_arrays = jax.tree.map(
               lambda v: v.value,
@@ -667,6 +696,13 @@ def from_pretrained(
           checkpoint = _filter_to_model_keys(checkpoint, model_arrays)
           checkpoint = jax.tree.map(_expand_checkpoint_to_model_shapes, checkpoint, model_arrays)
           nnx.update(model, checkpoint)
+        else:
+          raise ValueError(
+              f"Checkpoint restore from '{config.load_parameters_path}' yielded no parameters. "
+              "This usually means the checkpoint format is incompatible with the model configuration "
+              "(e.g. a scanned checkpoint loaded with scan_layers=False, or vice versa). "
+              "Please ensure the checkpoint format matches the scan_layers setting."
+          )
 
       except Exception as e:
         raise ValueError(f"Checkpoint loading failed: {e}") from e

--- a/tests/unit/model_creation_utils_test.py
+++ b/tests/unit/model_creation_utils_test.py
@@ -106,15 +106,14 @@ class FixRestoreArgsRankGuardTest(unittest.TestCase):
     metadata_tree = {"kernel": _FakeArrayMetadata(shape=stored_shape)}
     return _fix_restore_args_for_shape_mismatch(restore_args, metadata_tree, self.mesh)
 
-  def test_scanned_ckpt_unscanned_model_not_modified(self):
+  def test_scanned_ckpt_unscanned_model_raises_error(self):
     """Rank mismatch (scanned ckpt rank 4 vs unscanned model rank 3): arg must be unchanged."""
     # Simulates: scanned checkpoint key kernel (94, 4096, 4, 128) vs vLLM model (4096, 64, 128).
     stored_shape = (94, 4096, 4, 128)
     model_shape = (4096, 64, 128)
-    fixed = self._run_fix(stored_shape, model_shape)
-    arg = fixed["kernel"]
-    # The restore arg should be unchanged — global_shape still points to model_shape.
-    self.assertEqual(arg.global_shape, model_shape)
+    with self.assertRaises(ValueError) as cm:
+      self._run_fix(stored_shape, model_shape)
+    self.assertIn("Checkpoint rank mismatches detected", str(cm.exception))
 
   def test_same_rank_shape_mismatch_is_modified(self):
     """Same rank, shape mismatch (KV padding): arg should be switched to replicated."""


### PR DESCRIPTION
# Description

This PR enables passing KV caches through scanned decoder layers, which is essential for efficient decoding when layer scanning is enabled (a common optimization for large models). It also refines the vLLM adapter and attention layers to better handle sharding and JIT tracing.


If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Tested vllm_decode with Llama3.1-8B
```
NEW_MODEL_DESIGN=1 HF_TOKEN=your_hf_token_here python src/maxtext/inference/vllm_decode.py src/maxtext/configs/inference/vllm.yml \
    model_name=llama3.1-8b \
    tokenizer_path=meta-llama/Llama-3.1-8B \
    ici_tensor_parallelism=1 \
    ici_expert_parallelism=1 \
    enable_dp_attention=false \
    hbm_utilization_vllm=0.3 \
    vllm_hf_overrides='{architectures: [\"MaxTextForCausalLM\"]}' \
    prompt=\"Suggest some famous landmarks in London.\" \
    load_parameters_path=gs://maxtext-model-checkpoints/llama3.1-8b/2025-01-23-19-04/scanned/0/items \
    scan_layers=true
```
Output: 
```
I0420 17:34:25.625178 134458074281792 vllm_decode.py:163] Prompt: Suggest some famous landmarks in London., Generated text:  Recall the information that each landmark's design was decided in.
According to popular theories, what gender Victorian people considered fashionable?
According to the historian Walter Scott, how was Queen Victoria dressed at her Coronation?
....
```
Tested Qwen3-30B using vllm serve on a v5p-8
```
VLLM_ENABLE_V1_MULTIPROCESSING=0 NEW_MODEL_DESIGN=1 TPU_BACKEND_TYPE=jax vllm serve Qwen/Qwen3-30B-A3B \
  --seed 42 \
  --max-model-len 2048 \
  --no-enable-prefix-caching \
  --disable-log-requests \
  --max-num-batched-tokens 8192 \
  --async-scheduling \
  --tensor_parallel_size 1 \
  --gpu-memory-utilization 0.3 \
  --max-num-seqs 256 \
  --hf_overrides '{"architectures": ["MaxTextForCausalLM"]}' \
  --additional-config='{"sharding":{"sharding_strategy": {"enable_dp_attention": true, "expert_parallelism": 4}}, "maxtext_config": {"model_name": "qwen3-30b-a3b", "scan_layers": true, "log_config":false, "load_parameters_path": "gs://maxtext-model-checkpoints/qwen3-30b/2025-11-11/pathways/scanned/0/items"}}'
  ```
  
  Received a response 
  ```
  {
  "id": "cmpl-9f0419af227ee518",
  "object": "text_completion",
  "created": 1773193183,
  "model": "Qwen/Qwen3-30B-A3B",
  "choices": [
    {
      "index": 0,
      "text": " city in the U.S. state of Washington, and the county seat of King",
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "token_ids": null,
      "prompt_logprobs": null,
      "prompt_token_ids": null
    }
  ],
  "usage": {
    "prompt_tokens": 3,
    "total_tokens": 19,
    "completion_tokens": 16,
    "prompt_tokens_details": null
  },
  "kv_transfer_params": null
}
```
Error message when you try to load a scanned checkpoint with unscanned model or vice versa
```
rank0]: ValueError: Checkpoint loading failed: Checkpoint structure mismatch: 290 of 293 model parameter paths were not found in the checkpoint. This usually means a scanned (scan_layers=True) checkpoint is being loaded with scan_layers=False, or vice versa. Please ensure the checkpoint format matches the scan_layers setting.
[rank0]: Example missing paths:
[rank0]:   decoder.layers_0.mlp.wi_0.kernel
[rank0]:   decoder.layers_0.mlp.wi_1.kernel
[rank0]:   decoder.layers_0.mlp.wo.kernel
[rank0]:   decoder.layers_0.post_self_attention_layer_norm.scale
[rank0]:   decoder.layers_0.pre_self_attention_layer_norm.scale
[rank0]:   ... and 285 more
```
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
