### PR TITLE
Remove input variable name due to internal change of name

### DIFF
--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -898,7 +898,7 @@ class RoutedMoE(nnx.Module):
     ):
       tokamax_group_sizes = tokamax.RaggedDotGroupSizes(
           group_sizes,
-          representative_value=max_utils.generate_representative_group_sizes(inputs.shape[0], kernel.shape[0]),
+          max_utils.generate_representative_group_sizes(inputs.shape[0], kernel.shape[0]),
       )
       pad_length = self.config.wi_tile_fwd_batch_seq
       hs_shape = inputs.shape

--- a/src/maxtext/models/deepseek_batchsplit.py
+++ b/src/maxtext/models/deepseek_batchsplit.py
@@ -807,7 +807,7 @@ def compute(x, w0, w1, wo, group_sizes, weights, *, config, mesh):
 
     tokamax_group_sizes = tokamax.RaggedDotGroupSizes(
         group_sizes,
-        representative_value=max_utils.generate_representative_group_sizes(inputs.shape[0], kernel.shape[0]),
+        max_utils.generate_representative_group_sizes(inputs.shape[0], kernel.shape[0]),
     )
     if config.use_qwix_quantization:
       output = megablox.gmm(


### PR DESCRIPTION
# Description

Remove input names for tokamax RaggedDotGroupSizes due to recent change of input name.

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
