### PR TITLE
[Fixit] add notes for sudoless docker

### DIFF
--- a/docs/run_maxtext/run_maxtext_via_pathways.md
+++ b/docs/run_maxtext/run_maxtext_via_pathways.md
@@ -37,6 +37,8 @@ Before you can run a MaxText workload, you must complete the following setup ste
 
 3. **Build and upload a MaxText Docker image** to your project's Artifact Registry.
 
+   [Follow the steps to configure sudoless Docker](https://docs.docker.com/engine/install/linux-postinstall/) before running the commands below.
+
    Step 1: Build the Docker image for a TPU device. This image contains MaxText and its dependencies.
 
    ```shell

--- a/docs/run_maxtext/run_maxtext_via_xpk.md
+++ b/docs/run_maxtext/run_maxtext_via_xpk.md
@@ -51,7 +51,7 @@ Before you begin, you must have the necessary tools installed and permissions co
 
 - **kubectl:** The Kubernetes command-line tool.
 
-- **Docker:** Follow the [installation instructions](https://docs.docker.com/engine/install/) and complete the [post-install steps](https://docs.docker.com/engine/install/linux-postinstall/) to run Docker without `sudo`.
+- **Docker:** Follow the [installation instructions](https://docs.docker.com/engine/install/) and [follow the steps to configure sudoless Docker](https://docs.docker.com/engine/install/linux-postinstall/).
 
 ### GCP permissions
 
@@ -117,6 +117,10 @@ pip install xpk
 ______________________________________________________________________
 
 ## 4. Build the MaxText Docker image
+
+```{note}
+Ensure Docker is configured for sudoless use before running the build script. Follow the steps to [configure sudoless Docker](https://docs.docker.com/engine/install/linux-postinstall/).
+```
 
 1. **Clone the MaxText repository**
 

--- a/docs/tutorials/posttraining/rl_on_multi_host.md
+++ b/docs/tutorials/posttraining/rl_on_multi_host.md
@@ -60,6 +60,7 @@ Before starting, ensure you have:
 - Permissions for Google Artifact Registry (Artifact Registry Writer role).
 - XPK installed (follow [official documentation](https://github.com/AI-Hypercomputer/xpk/blob/main/docs/installation.md)).
 - A Pathways-ready GKE cluster (see [create GKE cluster](https://docs.cloud.google.com/ai-hypercomputer/docs/workloads/pathways-on-cloud/create-gke-cluster)).
+- **Docker** installed and configured for sudoless use. Follow the steps to [configure sudoless Docker](https://docs.docker.com/engine/install/linux-postinstall/).
 
 ## Setup Environment Variables
 
@@ -106,7 +107,9 @@ export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucke
 
 ## Build and upload MaxText Docker image with post-training dependencies
 
-Before building the Docker image, authenticate to
+Before building the Docker image, follow the steps to [configure sudoless Docker](https://docs.docker.com/engine/install/linux-postinstall/).
+
+Then, authenticate to
 [Google Artifact Registry](https://docs.cloud.google.com/artifact-registry/docs/docker/authentication#gcloud-helper)
 for permission to push your images and other access.
 

--- a/docs/tutorials/posttraining/sft_on_multi_host.md
+++ b/docs/tutorials/posttraining/sft_on_multi_host.md
@@ -37,7 +37,7 @@ cd maxtext
 
 ### 1.2. Build MaxText Docker image
 
-Before building the Docker image, authenticate to [Google Artifact Registry](https://docs.cloud.google.com/artifact-registry/docs/docker/authentication#gcloud-helper) for permission to push your images and other access.
+Before building the Docker image, follow the steps to [configure sudoless Docker](https://docs.docker.com/engine/install/linux-postinstall/). Then, authenticate to [Google Artifact Registry](https://docs.cloud.google.com/artifact-registry/docs/docker/authentication#gcloud-helper) for permission to push your images and other access.
 
 ```bash
 # Authenticate your user account for gcloud CLI access


### PR DESCRIPTION
# Description

Adds consistent reminders across four documentation files to configure Docker for sudoless use before building MaxText Docker images. Affected docs: run_maxtext_via_pathways.md, run_maxtext_via_xpk.md, rl_on_multi_host.md, and sft_on_multi_host.md.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/490520302

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
