### PR TITLE
Update Qwen3 vLLM layer names to match tpu-inference mappings.

### DIFF
--- a/src/maxtext/integration/tunix/weight_mapping/qwen3.py
+++ b/src/maxtext/integration/tunix/weight_mapping/qwen3.py
@@ -67,12 +67,12 @@ class QWEN3_VLLM_MAPPING:
     return {
         # Token embeddings - shard vocab dimension
         "base.token_embedder.embedding": (
-            "model.embed.embedding",
+            "model.embed_tokens.weight",
             ("model", None),
         ),
         # Final layer norm - no sharding needed
         "base.decoder.decoder_norm.scale": (
-            "model.norm.scale",
+            "model.norm.weight",
             (None,),
         ),
         # LM head (logits projection) - shard vocab dimension
@@ -83,49 +83,49 @@ class QWEN3_VLLM_MAPPING:
         # Layer-specific mappings (scanned -> unscanned)
         # MLP components - shard hidden dimensions
         "base.decoder.layers.mlp.wi_0.kernel": (
-            "model.layers.*.mlp.gate_proj.kernel",
+            "model.layers.*.mlp.gate_proj.weight",
             (None, "layer", "model"),
         ),
         "base.decoder.layers.mlp.wi_1.kernel": (
-            "model.layers.*.mlp.up_proj.kernel",
+            "model.layers.*.mlp.up_proj.weight",
             (None, "layer", "model"),
         ),
         "base.decoder.layers.mlp.wo.kernel": (
-            "model.layers.*.mlp.down_proj.kernel",
+            "model.layers.*.mlp.down_proj.weight",
             ("model", "layer", None),
         ),
         # Layer norms - no sharding needed
         "base.decoder.layers.pre_self_attention_layer_norm.scale": (
-            "model.layers.*.input_layernorm.scale",
+            "model.layers.*.input_layernorm.weight",
             (None, "layer"),
         ),
         "base.decoder.layers.post_self_attention_layer_norm.scale": (
-            "model.layers.*.post_attention_layernorm.scale",
+            "model.layers.*.post_attention_layernorm.weight",
             (None, "layer"),
         ),
         # Attention components - shard head dimensions
         "base.decoder.layers.self_attention.query.kernel": (
-            "model.layers.*.self_attn.q_proj.kernel",
+            "model.layers.*.self_attn.q_proj.weight",
             (None, "layer", "model", None),
         ),
         "base.decoder.layers.self_attention.key.kernel": (
-            "model.layers.*.self_attn.k_proj.kernel",
+            "model.layers.*.self_attn.k_proj.weight",
             (None, "layer", "model", None),
         ),
         "base.decoder.layers.self_attention.value.kernel": (
-            "model.layers.*.self_attn.v_proj.kernel",
+            "model.layers.*.self_attn.v_proj.weight",
             (None, "layer", "model", None),
         ),
         "base.decoder.layers.self_attention.out.kernel": (
-            "model.layers.*.self_attn.o_proj.kernel",
+            "model.layers.*.self_attn.o_proj.weight",
             ("model", "layer", None, None),
         ),
         "base.decoder.layers.self_attention.query_norm.scale": (
-            "model.layers.*.self_attn.q_norm.scale",
+            "model.layers.*.self_attn.q_norm.weight",
             (None, "layer"),
         ),
         "base.decoder.layers.self_attention.key_norm.scale": (
-            "model.layers.*.self_attn.k_norm.scale",
+            "model.layers.*.self_attn.k_norm.weight",
             (None, "layer"),
         ),
     }


### PR DESCRIPTION
# Description

Update Qwen3 vLLM layer names to match tpu-inference mappings. 

FIXES: b/484414167

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Tested these mapping with `src/maxtext/examples/sft_qwen3_demo.ipynb`
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
