### PR TITLE
[DECOUPLED-MODE] Add ICI parallelism decoupled logic to new tests

### DIFF
--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -1611,6 +1611,7 @@ class MLATest(attention_test_util.MLATestBase):
   def test_indexer_loss(self):
     """Test indexer loss computation."""
     mla_config_args = self.config_arguments.copy()
+    mla_config_args.update(get_decoupled_parallelism_overrides())
     mla_config_args["use_sparse_indexer"] = True
     mla_config_args["attention"] = "dot_product"
     _, mla = self.init_mla(mla_config_args, rope_type="default")
@@ -1657,6 +1658,7 @@ class MLATest(attention_test_util.MLATestBase):
   def test_indexer_loss_kl_divergence_zero(self):
     """Test that KL divergence is 0 when target and pred distributions match exactly."""
     mla_config_args = self.config_arguments.copy()
+    mla_config_args.update(get_decoupled_parallelism_overrides())
     mla_config_args["use_sparse_indexer"] = True
     mla_config_args["attention"] = "dot_product"
     _, mla = self.init_mla(mla_config_args, rope_type="default")


### PR DESCRIPTION
# Description
Following tests were failing in decoupled mode, added ICI parallelism logic to them:
```
tests/unit/attention_test.py::MLATest::test_indexer_loss_kl_divergence_zero
tests/unit/attention_test.py::MLATest::test_indexer_loss
```

# Tests

Ran tests, they are passing in decoupled mode

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
