### PR TITLE
Adding single-host integration test for GRPO and GSPO.

### DIFF
--- a/src/maxtext/configs/inference/vllm.yml
+++ b/src/maxtext/configs/inference/vllm.yml
@@ -14,6 +14,8 @@
 
 base_config: "base.yml"
 attention: "vllm_rpa"
+model_call_mode: "inference"
+
 # NNX required for vLLM integration
 enable_nnx: True
 # Avoid re-initializing JAX distributed system when using vLLM

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -282,39 +282,18 @@ def get_rollout_kwargs_for_parallelism(sampler_config, num_sampler_devices):
   return rollout_kwargs
 
 
-def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
-  """
-  Run RL training with the provided configuration.
-
-  Args:
-    trainer_config: MaxText configuration for the trainer.
-    sampler_config: MaxText configuration for the sampler.
-    trainer_devices: JAX devices for the trainer.
-    sampler_devices: JAX devices for the sampler.
-  """
-  if not trainer_config.debug.rl:
-    # Apply filter to suppress noisy logs
-    noise_filter = max_logging.NoisyLogFilter()
-    logging.getLogger().addFilter(noise_filter)
-    absl_logging.get_absl_logger().addFilter(noise_filter)
-
-  max_logging.log("Starting RL Training")
-  max_logging.log(f"Ensuring TensorBoard log directory exists: {trainer_config.tensorboard_dir}")
-  if not epath.Path(trainer_config.tensorboard_dir).exists():
-    epath.Path(trainer_config.tensorboard_dir).mkdir(parents=True, exist_ok=True)
-
-  if not epath.Path(trainer_config.checkpoint_dir).exists():
-    epath.Path(trainer_config.checkpoint_dir).mkdir(parents=True)
-
-  # Number of training steps.
-  max_train_steps = int(
+def get_max_train_steps(trainer_config):
+  """Calculate the total number of training steps."""
+  return int(
       trainer_config.num_batches
       * trainer_config.rl.num_iterations
       * trainer_config.train_fraction
       * trainer_config.num_epoch
   )
-  # ====== Data ======
-  # Setup data directories
+
+
+def prepare_datasets(trainer_config, model_tokenizer):
+  """Setup and return train and test datasets."""
   home = os.path.expanduser("~") + "/"
   train_data_dir = f"{home}/data/train"
   test_data_dir = f"{home}/data/test"
@@ -322,9 +301,6 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
     os.makedirs(train_data_dir)
   if not os.path.exists(test_data_dir):
     os.makedirs(test_data_dir)
-
-  # Create model tokenizer
-  model_tokenizer = AutoTokenizer.from_pretrained(trainer_config.tokenizer_path)
 
   # Load datasets
   if trainer_config.dataset_name == "huggingface:nvidia/OpenMathInstruct-2":
@@ -334,7 +310,6 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
         split: str = "train_1M",
         seed: int = 42,
         test_size: float = 0.05,
-        output_key: str = "expected_answer",
     ):
       """Load and split the OpenMathInstruct-2 dataset into train and validation sets using HF's train_test_split."""
       max_logging.log(
@@ -419,41 +394,16 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
   test_dataset = test_dataset[: trainer_config.num_test_batches * trainer_config.batch_size]
 
   test_dataset = test_dataset.to_iter_dataset().batch(trainer_config.batch_size)
+  return train_dataset, test_dataset
 
-  if trainer_config.debug.rl:
-    # Let's see how one batch of the dataset looks like!
-    if trainer_config.debug.rl:
-      for i, ele in enumerate(train_dataset):
-        if i >= 5:
-          break
-        pprint(ele)
-    if trainer_config.debug.rl:
-      for i, ele in enumerate(test_dataset):
-        if i >= 5:
-          break
-        pprint(ele)
 
-  # Load reference model
+def create_models_and_meshes(trainer_config, sampler_config, trainer_devices, sampler_devices):
+  """Create reference and actor models and their respective meshes."""
   max_logging.log("Creating reference model and also meshes for reference and rollout")
   reference_model, reference_mesh = get_maxtext_model(trainer_config, trainer_devices)
   devices_array = maxtext_utils.create_device_mesh(sampler_config, sampler_devices)
-  # if trainer_devices=sampler_devices, then rollout_mesh=reference_mesh
-  # else rollout_mesh uses sampler_devices
   rollout_mesh = Mesh(devices_array, sampler_config.mesh_axes)
-  if trainer_config.debug.rl:
-    max_logging.log("Reference Model initialized successfully")
-    nnx.display(reference_model)
-    max_logging.log(f"Reference mesh shape: {reference_mesh.shape}")
 
-    # Sanity check that weights are loaded correctly.
-    _maxtext_state_flatten = nnx.state(reference_model).flat_state()
-    maxtext_state_flatten = {".".join(str(key) for key in keys): v for keys, v in _maxtext_state_flatten}
-    max_logging.log(
-        f"maxtext_state_flatten[base.token_embedder.embedding].value=\
-          {maxtext_state_flatten['base.token_embedder.embedding'][...]}"
-    )
-
-  # TODO: @mazumdera: change this to use lora
   if trainer_config.load_checkpoint_only_once:
     max_logging.log("Creating policy model by copying reference model instead of restoring from checkpoint again.")
     with reference_mesh:
@@ -466,11 +416,22 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
     max_logging.log("Creating policy model with same config as reference model on trainer mesh")
     actor_model, actor_mesh = get_maxtext_model(trainer_config, trainer_devices)
 
-  if trainer_config.debug.rl:
-    max_logging.log("Policy Model initialized successfully")
-    nnx.display(actor_model)
-    max_logging.log(f"Policy mesh shape: {actor_mesh.shape}")
+  return reference_model, reference_mesh, actor_model, actor_mesh, rollout_mesh
 
+
+def create_rl_components(
+    trainer_config,
+    sampler_config,
+    sampler_devices,
+    actor_model,
+    actor_mesh,
+    reference_model,
+    reference_mesh,
+    rollout_mesh,
+    model_tokenizer,
+    max_train_steps,
+):
+  """Setup RL cluster, trainer, and optimizer."""
   # Setup optimizer
   optimizer = utils_rl.get_optimizer(trainer_config, max_train_steps)
 
@@ -483,7 +444,6 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
   micro_batch_size = None if trainer_config.micro_batch_size == -1 else trainer_config.micro_batch_size
 
   # Setup metrics logging
-  max_logging.log(f"Tensorboard logs directory: {trainer_config.tensorboard_dir}")
   metrics_logging_options = metrics_logger.MetricsLoggerOptions(
       log_dir=trainer_config.tensorboard_dir, flush_every_n_steps=trainer_config.log_period
   )
@@ -501,25 +461,18 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
   rollout_additional_config = None
   if trainer_config.vllm_additional_config:
     if isinstance(trainer_config.vllm_additional_config, dict):
-      # It's already parsed into a dict
       rollout_additional_config = trainer_config.vllm_additional_config
     elif isinstance(trainer_config.vllm_additional_config, str):
-      # It's a string, so we need to parse it
       try:
         rollout_additional_config = json.loads(trainer_config.vllm_additional_config)
       except json.JSONDecodeError as e:
         raise ValueError(f"Failed to parse additional_config JSON: {e}") from e
-
-    max_logging.log(f"Parsed additional config: {rollout_additional_config}")
 
   # We need to parse vLLM config to get the logical axis rules for the sampler config.
   vllm_config_path = os.path.join(MAXTEXT_CONFIGS_DIR, "inference", "vllm.yml")
   argv_list = ["", str(vllm_config_path), "log_config=False"]
   vllm_config = pyconfig.initialize(argv_list)
 
-  # RL Cluster config
-  # Note that we use vLLM as the rollout engine.
-  # and we are using Tensor Parallelism for rollout
   cluster_config = rl_cluster_lib.ClusterConfig(
       role_to_mesh={
           rl_cluster_lib.Role.ACTOR: actor_mesh,
@@ -537,15 +490,11 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
           actor_optimizer=optimizer,
           eval_every_n_steps=trainer_config.eval_interval,
           max_steps=max_train_steps,
-          # Micro batching
           mini_batch_size=trainer_config.batch_size,
           train_micro_batch_size=micro_batch_size,
           rollout_micro_batch_size=micro_batch_size,
-          # Metrics logging
           metrics_logging_options=metrics_logging_options,
-          # Profiling
           profiler_options=profiler_options,
-          # Checkpoint saving
           checkpoint_root_directory=trainer_config.checkpoint_dir,
           checkpointing_options=checkpointing_options,
       ),
@@ -579,6 +528,7 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
           **get_rollout_kwargs_for_parallelism(sampler_config, len(sampler_devices)),
       ),
   )
+
   grpo_config = GrpoConfig(
       num_generations=trainer_config.rl.num_generations,
       num_iterations=trainer_config.rl.num_iterations,
@@ -595,9 +545,6 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
       from tunix.perf import export as perf_export  # pylint: disable=import-outside-toplevel
       from tunix.perf import metrics as perf_metrics  # pylint: disable=import-outside-toplevel
 
-      max_logging.log(
-          "enable_tunix_perf_metrics is True and tunix.perf modules are available, enabling Tunix-managed metrics."
-      )
       perf_config = perf_metrics.PerfMetricsConfig()
       perf_config.custom_export_fn = perf_export.PerfMetricsExport.create_metrics_export_fn(cluster_config)
       rl_cluster_kwargs["perf_config"] = perf_config
@@ -627,9 +574,76 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
       algo_config=grpo_config,
   )
 
+  return rl_cluster, rl_trainer, optimizer
+
+
+def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
+  """
+  Run RL training with the provided configuration.
+
+  Args:
+    trainer_config: MaxText configuration for the trainer.
+    sampler_config: MaxText configuration for the sampler.
+    trainer_devices: JAX devices for the trainer.
+    sampler_devices: JAX devices for the sampler.
+  """
+  if not trainer_config.debug.rl:
+    # Apply filter to suppress noisy logs
+    noise_filter = max_logging.NoisyLogFilter()
+    logging.getLogger().addFilter(noise_filter)
+    absl_logging.get_absl_logger().addFilter(noise_filter)
+
+  max_logging.log("Starting RL Training")
+  if not epath.Path(trainer_config.tensorboard_dir).exists():
+    epath.Path(trainer_config.tensorboard_dir).mkdir(parents=True, exist_ok=True)
+
+  if not epath.Path(trainer_config.checkpoint_dir).exists():
+    epath.Path(trainer_config.checkpoint_dir).mkdir(parents=True)
+
+  max_train_steps = get_max_train_steps(trainer_config)
+
+  # Create model tokenizer
+  model_tokenizer = AutoTokenizer.from_pretrained(trainer_config.tokenizer_path)
+
+  train_dataset, test_dataset = prepare_datasets(trainer_config, model_tokenizer)
+
+  if trainer_config.debug.rl:
+    for i, ele in enumerate(train_dataset):
+      if i >= 5:
+        break
+      pprint(ele)
+    for i, ele in enumerate(test_dataset):
+      if i >= 5:
+        break
+      pprint(ele)
+
+  reference_model, reference_mesh, actor_model, actor_mesh, rollout_mesh = create_models_and_meshes(
+      trainer_config, sampler_config, trainer_devices, sampler_devices
+  )
+
+  if trainer_config.debug.rl:
+    max_logging.log("Reference Model initialized successfully")
+    nnx.display(reference_model)
+    max_logging.log(f"Reference mesh shape: {reference_mesh.shape}")
+    max_logging.log("Policy Model initialized successfully")
+    nnx.display(actor_model)
+    max_logging.log(f"Policy mesh shape: {actor_mesh.shape}")
+
+  rl_cluster, rl_trainer, _ = create_rl_components(
+      trainer_config,
+      sampler_config,
+      sampler_devices,
+      actor_model,
+      actor_mesh,
+      reference_model,
+      reference_mesh,
+      rollout_mesh,
+      model_tokenizer,
+      max_train_steps,
+  )
+
   # Before we train the model, let's evaluate the model on the test set so we can
   # see the improvement post training.
-  #
   (corr, total, accuracy, partial_accuracy, format_accuracy), _ = evaluate(
       trainer_config,
       test_dataset,
@@ -638,11 +652,9 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
       corr_lst=trainer_config.eval_corr_lst,
       make_lst=trainer_config.eval_make_lst,
   )
-  # TODO: @mazumdera: Change this to max_logging.log once b/473703277 is resolved
   max_logging.warning(f"Pre RL Training: {corr=}, {total=}, {accuracy=}%, {partial_accuracy=}%," f" {format_accuracy=}%")
 
   # Start training
-
   if trainer_config.load_checkpoint_only_once:
     max_logging.log("Capturing reference model state before training.")
     ref_state_before = nnx.to_pure_dict(nnx.state(reference_model.base, nnx.Param))

--- a/tests/integration/single_host_train_rl_test.py
+++ b/tests/integration/single_host_train_rl_test.py
@@ -1,0 +1,221 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Integration test for train RL GRPO and GSPO-token workflows with actual dataset/checkpoint.
+Tests the workflow in src/maxtext/trainers/post_train/rl/train_rl.py
+"""
+
+import os
+import logging
+import unittest
+import pytest
+import jax
+import jax.numpy as jnp
+from absl.testing import absltest
+from flax import nnx
+from transformers import AutoTokenizer
+
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.utils import max_logging
+
+
+train_rl = pytest.importorskip(
+    "maxtext.trainers.post_train.rl.train_rl",
+    reason="Tunix is not installed on the GPU image",
+)
+
+
+evaluate_rl = pytest.importorskip(
+    "maxtext.trainers.post_train.rl.evaluate_rl",
+    reason="math_verify is not installed on the GPU image",
+)
+
+
+@pytest.mark.external_training
+class RLTrainerIntegrationTests(unittest.TestCase):
+  """Integration tests for the RL GRPO workflow."""
+
+  CONFIGS = {
+      "maxtext_on_vllm": [
+          "run_name=test_qwen_rl_maxtext",
+          "vllm_hf_overrides={architectures: ['MaxTextForCausalLM']}",
+          "vllm_additional_config={'maxtext_config': {'model_name': 'qwen3-0.6b', 'log_config': 'false'}}",
+      ],
+      "vllm_native": [
+          "run_name=test_qwen_rl_native",
+      ],
+  }
+
+  def setUp(self):
+    super().setUp()
+    os.environ["NEW_MODEL_DESIGN"] = "1"
+    os.environ["TPU_BACKEND_TYPE"] = "jax"
+    os.environ["SKIP_JAX_PRECOMPILE"] = "1"
+    os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
+
+    self.base_argv = [
+        "train_rl.py",
+        os.path.join(MAXTEXT_CONFIGS_DIR, "post_train", "rl.yml"),
+        "model_name=qwen3-0.6b",
+        "tokenizer_path=Qwen/Qwen3-0.6B",
+        f"base_output_directory=/tmp/maxtext_rl_test/{jax.random.PRNGKey(0)[0]}",
+        "batch_size=4",
+        "num_batches=1",  # Minimal batches for integration test speed
+        "num_test_batches=1",
+        f"chips_per_vm={jax.device_count()}",
+        "scan_layers=True",
+        "hbm_utilization_vllm=0.4",
+        "rollout_data_parallelism=1",
+        "rollout_tensor_parallelism=-1",
+        "rl.num_generations=16",
+        "load_parameters_path=gs://maxtext-model-checkpoints/qwen3-0.6b/2025-10-27/scanned/0/items",
+    ]
+
+  def _run_rl_workflow_end_to_end(self, extra_argv):
+    """Helper method to run the full RL training workflow and verify parameter updates."""
+    argv = self.base_argv + extra_argv
+
+    trainer_config, sampler_config, trainer_devices, sampler_devices = train_rl.setup_configs_and_devices(argv)
+
+    if not trainer_config.debug.rl:
+      noise_filter = max_logging.NoisyLogFilter()
+      logging.getLogger().addFilter(noise_filter)
+
+    max_train_steps = train_rl.get_max_train_steps(trainer_config)
+    model_tokenizer = AutoTokenizer.from_pretrained(trainer_config.tokenizer_path)
+    train_dataset, test_dataset = train_rl.prepare_datasets(trainer_config, model_tokenizer)
+
+    reference_model, reference_mesh, actor_model, actor_mesh, rollout_mesh = train_rl.create_models_and_meshes(
+        trainer_config, sampler_config, trainer_devices, sampler_devices
+    )
+
+    rl_cluster, rl_trainer, _ = train_rl.create_rl_components(
+        trainer_config,
+        sampler_config,
+        sampler_devices,
+        actor_model,
+        actor_mesh,
+        reference_model,
+        reference_mesh,
+        rollout_mesh,
+        model_tokenizer,
+        max_train_steps,
+    )
+
+    # Pre-train evaluation
+    pre_metrics, _ = evaluate_rl.evaluate(
+        trainer_config,
+        test_dataset,
+        rl_cluster=rl_cluster,
+        num_passes=trainer_config.num_eval_passes,
+        corr_lst=trainer_config.eval_corr_lst,
+        make_lst=trainer_config.eval_make_lst,
+    )
+    actor_initial_state = nnx.to_pure_dict(nnx.state(actor_model.base, nnx.Param))
+    ref_initial_state = nnx.to_pure_dict(nnx.state(reference_model.base, nnx.Param))
+
+    # Training
+    rl_trainer.train(train_dataset)
+
+    # Block until training is complete and all async operations are done
+    actor_final_state = nnx.to_pure_dict(nnx.state(actor_model.base, nnx.Param))
+    ref_final_state = nnx.to_pure_dict(nnx.state(reference_model.base, nnx.Param))
+
+    # Post-train evaluation
+    post_metrics, _ = evaluate_rl.evaluate(
+        trainer_config,
+        test_dataset,
+        rl_cluster=rl_cluster,
+        num_passes=trainer_config.num_eval_passes,
+        corr_lst=trainer_config.eval_corr_lst,
+        make_lst=trainer_config.eval_make_lst,
+    )
+
+    # Verify results
+    for metrics in [pre_metrics, post_metrics]:
+      corr, total, acc, partial_acc, format_acc = metrics
+      self.assertGreaterEqual(total, 1, "There should be at least one eval item")
+      self.assertGreaterEqual(corr, 0, "Correct items should be non-negative")
+      self.assertTrue(0.0 <= partial_acc <= 100.0, "Partial accuracy should be a percentage between 0 and 100")
+      self.assertTrue(0.0 <= acc <= 100.0, "Accuracy should be a percentage between 0 and 100")
+      self.assertTrue(0.0 <= format_acc <= 100.0, "Format accuracy should be a percentage between 0 and 100")
+
+    # Reference model parameters should NOT change during training
+    self.assertTrue(
+        jax.tree_util.tree_all(jax.tree_util.tree_map(jnp.array_equal, ref_initial_state, ref_final_state)),
+        "Reference model parameters should remain unchanged.",
+    )
+
+    # Actor model parameters SHOULD change from their initial state
+    is_changed = not jax.tree_util.tree_all(
+        jax.tree_util.tree_map(jnp.array_equal, actor_initial_state, actor_final_state)
+    )
+    self.assertTrue(is_changed, "Actor model parameters should have changed after training.")
+
+    # Actor model parameters should be DIFFERENT from reference model after training
+    is_different = not jax.tree_util.tree_all(jax.tree_util.tree_map(jnp.array_equal, ref_final_state, actor_final_state))
+    self.assertTrue(is_different, "Actor model parameters should be different from reference model after training.")
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  @pytest.mark.skip
+  def test_GRPO_workflow_maxtext_on_vllm(self):
+    """Tests the RL training workflow with the maxtext_on_vllm config."""
+    self._run_rl_workflow_end_to_end(self.CONFIGS["maxtext_on_vllm"])
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  @pytest.mark.skip
+  def test_GRPO_workflow_vllm_native(self):
+    """Tests the RL training workflow with the vllm_native config."""
+    self._run_rl_workflow_end_to_end(self.CONFIGS["vllm_native"])
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  @pytest.mark.skip
+  def test_GSPO_workflow_maxtext_on_vllm(self):
+    """Tests the RL training workflow with the maxtext_on_vllm config."""
+    self._run_rl_workflow_end_to_end(self.CONFIGS["maxtext_on_vllm"] + ["rl.loss_algo=gspo-token"])
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  @pytest.mark.skip
+  def test_GSPO_workflow_vllm_native(self):
+    """Tests the RL training workflow with the vllm_native config."""
+    self._run_rl_workflow_end_to_end(self.CONFIGS["vllm_native"] + ["rl.loss_algo=gspo-token"])
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  @pytest.mark.skip
+  def test_rl_train_maxtext_on_vllm(self):
+    """Tests the rl_train API with the maxtext on vllm config."""
+    trainer_config, sampler_config, trainer_devices, sampler_devices = train_rl.setup_configs_and_devices(
+        self.CONFIGS["maxtext_on_vllm"]
+    )
+    train_rl.rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices)
+
+  @pytest.mark.integration_test
+  @pytest.mark.tpu_only
+  @pytest.mark.skip
+  def test_rl_train_native(self):
+    """Tests the rl_train API with the vllm native config."""
+    trainer_config, sampler_config, trainer_devices, sampler_devices = train_rl.setup_configs_and_devices(
+        self.CONFIGS["vllm_native"]
+    )
+    train_rl.rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
# Description

Adds an end-to-end integration test for both GRPO and GSPO workflows on qwen3-0.6b (which should work e2e on a single v6e-4 TPU VM). 

FIXES: b/490410666, b/490411100, b/490409949, b/490410743

# Tests

Tests are skipped for now pending debugging on v6e-4

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
