### PR TITLE
Enable training strategy for Indexer

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -356,15 +356,15 @@ moba_topk: 8
 
 # DeepSeek Sparse Attention (DSA)
 # deepseek3.2 introduces indexer in MLA
-use_sparse_indexer: False
-index_head_dim: 128
-index_n_heads: 64
-index_topk: 2048
-# Determines the token selection strategy for indexer loss: 
-# - False: Uses all tokens (Dense Warm-up).
-# - True: Uses only top-k tokens (Sparse Training).
+use_indexer: False
+indexer_head_dim: 128
+indexer_n_heads: 64
+indexer_topk: 2048
+# Determines the training strategy for the indexer:
+# - False (Dense Warm-up): Computes indexer loss over all tokens. Used with `trainable_parameters_mask` to freeze other model parameters.
+# - True (Sparse Training): Computes indexer loss over top-k tokens only and detaches the indexer input for independent optimization.
 # Note: This is only active when `indexer_loss_scaling_factor` > 0.
-sparse_indexer_loss: False
+indexer_sparse_training: False
 # Multiplier for the indexer KL divergence loss
 indexer_loss_scaling_factor: 0.0
 
@@ -789,6 +789,10 @@ gradient_clipping_threshold: 1.0
 gradient_accumulation_steps: 1
 
 opt_type: "adamw"  # one of "adamw", "adam_pax", "sgd", or "muon"
+# List of parameter names/patterns to train.
+# If non-empty, all other parameters will be frozen. Example: ['.*indexer.*'].
+# If empty (default), all parameters are trained.
+trainable_parameters_mask: []
 
 # AdamW optimizer parameters
 # We use AdamW following Llama2's training details, see https://arxiv.org/pdf/2307.09288.pdf section 2.2

--- a/src/maxtext/configs/models/deepseek-custom.yml
+++ b/src/maxtext/configs/models/deepseek-custom.yml
@@ -56,10 +56,10 @@ rope_interleave: True
 rope_truncate: True
 rope_attention_scaling: False
 # Indexer for DeepSeek Sparse Attention
-use_sparse_indexer: True
-index_n_heads: 16              # Reduced from 64
-index_head_dim: 64             # Reduced from 128
-index_topk: 256                # Reduced from 2048
+use_indexer: True
+indexer_n_heads: 16              # Reduced from 64
+indexer_head_dim: 64             # Reduced from 128
+indexer_topk: 256                # Reduced from 2048
 # Hyper-connections: mHC enabled
 mhc_expansion_rate: 4
 sinkhorn_iterations: 20

--- a/src/maxtext/configs/models/deepseek3.2-671b.yml
+++ b/src/maxtext/configs/models/deepseek3.2-671b.yml
@@ -53,7 +53,7 @@ rope_interleave: True
 rope_truncate: True
 rope_attention_scaling: False
 # Indexer for DeepSeek Sparse Attention
-use_sparse_indexer: True
-index_n_heads: 64
-index_head_dim: 128
-index_topk: 2048
+use_indexer: True
+indexer_n_heads: 64
+indexer_head_dim: 128
+indexer_topk: 2048

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -542,11 +542,14 @@ class MlaAttention(BaseModel):
 class AttentionIndexer(BaseModel):
   """Configuration for DeepSeek Sparse Attention (DSA): DeepSeek3.2-style MLA with indexer."""
 
-  use_sparse_indexer: bool = Field(False, description="Whether to use sparse indexer for MLA.")
-  index_head_dim: NonNegativeInt = Field(128, description="Head dim for indexer query and key.")
-  index_n_heads: NonNegativeInt = Field(64, description="Number of query heads in indexer.")
-  index_topk: NonNegativeInt = Field(2048, description="Number of tokens selected by the query token in indexer.")
-  sparse_indexer_loss: bool = Field(False, description="Determines the token selection strategy for indexer loss.")
+  use_indexer: bool = Field(False, description="Whether to use sparse indexer for MLA.")
+  indexer_head_dim: NonNegativeInt = Field(128, description="Head dim for indexer query and key.")
+  indexer_n_heads: NonNegativeInt = Field(64, description="Number of query heads in indexer.")
+  indexer_topk: NonNegativeInt = Field(2048, description="Number of tokens selected by the query token in indexer.")
+  indexer_sparse_training: bool = Field(
+      False,
+      description="Determines the training strategy for the indexer: Dense Warm-up or Sparse Training stage.",
+  )
   indexer_loss_scaling_factor: float = Field(0.0, description="Multiplier for the indexer KL divergence loss.")
 
 
@@ -1184,6 +1187,13 @@ class Optimizer(BaseModel):
       -1,
       ge=-1,
       description="Total steps for the LR schedule. -1 defaults to `steps`.",
+  )
+  trainable_parameters_mask: list[str] = Field(
+      default_factory=list,
+      description=(
+          "List of parameter names/patterns to train. If non-empty, all other parameters will be frozen, "
+          "example: ['.*indexer.*']. If empty (default), all parameters are trained."
+      ),
   )
 
 
@@ -2388,7 +2398,7 @@ class MaxTextConfig(
         raise ValueError("`local_checkpoint_period` must be > 0 for emergency checkpointing.")
     if self.moba and self.attention not in ("dot_product"):
       raise ValueError("MoBA is only supported with dot_product attention.")
-    if self.use_sparse_indexer:
+    if self.use_indexer:
       if self.q_lora_rank == 0:
         raise NotImplementedError("Sparse indexer has not implemented for q_lora_rank = 0.")
       supports_dot_product = self.attention == "dot_product"

--- a/src/maxtext/layers/attention_mla.py
+++ b/src/maxtext/layers/attention_mla.py
@@ -110,9 +110,9 @@ class Indexer(nnx.Module):
     self.dtype = config.dtype
     self.weight_dtype = config.weight_dtype
 
-    self.n_heads = config.index_n_heads
-    self.head_dim = config.index_head_dim
-    self.index_topk = config.index_topk
+    self.n_heads = config.indexer_n_heads
+    self.head_dim = config.indexer_head_dim
+    self.indexer_topk = config.indexer_topk
     self.emb_dim = config.emb_dim
     self.rope_head_dim = config.qk_rope_head_dim
     self.q_lora_rank = config.q_lora_rank
@@ -180,13 +180,13 @@ class Indexer(nnx.Module):
     2. Input Layout: Indexer uses concatenated layout (interleave=False), whereas MLA uses interleaved (interleave=True).
 
     Args:
-      inputs: Input array of shape [batch, seqlen, index_n_heads, index_head_dim].
+      inputs: Input array of shape [batch, seqlen, indexer_n_heads, indexer_head_dim].
       positions: Position array of shape [batch, seqlen].
 
     Returns:
-      Array with partial RoPE applied, with shape [batch, seqlen, index_n_heads, index_head_dim]
+      Array with partial RoPE applied, with shape [batch, seqlen, indexer_n_heads, indexer_head_dim]
     """
-    # index_head_dim -> [rope_head_dim, index_head_dim - rope_head_dim]
+    # indexer_head_dim -> [rope_head_dim, indexer_head_dim - rope_head_dim]
     x_pe, x_nope = jnp.split(inputs, [self.rope_head_dim], axis=-1)
     # x_pe [B, S, H, rope_head_dim], positions [B, S]
     x_pe = self.rotary_embedding(x_pe, position=inputs_positions)
@@ -256,14 +256,37 @@ class Indexer(nnx.Module):
       b: Batch size
       t: Query Sequence Length (Target), note t = s here
       s: Key/Value Sequence Length (Source)
-      h: Number of Indexer Heads (index_n_heads)
-      d: Indexer Head Dimension (index_head_dim)
+      h: Number of Indexer Heads (indexer_n_heads)
+      d: Indexer Head Dimension (indexer_head_dim)
     """
     # NOTE: If sequence length <= topk, indexer always selects all tokens.
-    if self.config.max_target_length <= self.index_topk:
+    if self.config.max_target_length <= self.indexer_topk:
       return None, None, None
 
     bsz, seqlen, _ = inputs_q.shape  # s = t = seqlen
+    # ==============================================================================
+    # Gradient Isolation Strategy: Main Model vs. Indexer
+    # ==============================================================================
+    # This creates a barrier to train both components independently, and applies
+    # for both Dense Warm-up and Sparse Training stages:
+    #
+    # Forward Pass:
+    # - The Indexer receives a detached copy of the inputs (via `stop_gradient`)
+    #   to independently calculate its scores and `indexer_loss`.
+    #
+    # Backward Pass (Main Model):
+    # - The main model optimizes its weights based solely on the LM loss.
+    # - The `indexer_mask` in the Attention layer prevents gradients from the main
+    #   loss from flowing into the Indexer's weights.
+    #
+    # Backward Pass (Indexer):
+    # - Gradients from the `indexer_loss` flow back to update the Indexer's weights.
+    # - The `stop_gradient` applied to the inputs acts as a mathematical wall, dropping
+    #   gradients to 0.0 and preventing the Indexer loss from altering the main model's
+    #   earlier layers.
+    inputs_q = jax.lax.stop_gradient(inputs_q)
+    low_rank_q = jax.lax.stop_gradient(low_rank_q)
+    inputs_kv = jax.lax.stop_gradient(inputs_kv)
 
     # Query Processing: Project from Latent low_rank_q
     q = self.wq_b(low_rank_q)  # [b, t, q_lora_rank] -> [b, t, h * d]
@@ -295,7 +318,7 @@ class Indexer(nnx.Module):
       indexer_score += attention_mask
 
     # TopK selection based on index score
-    _, topk_indices = jax.lax.top_k(indexer_score, k=self.index_topk)  # topk_indices [b, t, k]
+    _, topk_indices = jax.lax.top_k(indexer_score, k=self.indexer_topk)  # topk_indices [b, t, k]
 
     # Create Sparse Index Mask: 0 and large negatives
     indexer_mask = self.generate_mask(topk_indices, seqlen)  # [b, t, s]
@@ -607,8 +630,8 @@ class MLA(Attention):
     )
 
     # Initialize Indexer
-    self.use_sparse_indexer = config.use_sparse_indexer
-    if self.use_sparse_indexer:
+    self.use_indexer = config.use_indexer
+    if self.use_indexer:
       # Need two versions of rope.
       # MLA applies yarn with interleave layout.
       # Indexer applies yarn with concatenate layout.
@@ -989,6 +1012,13 @@ class MLA(Attention):
     Returns:
       The computed KL divergence loss.
     """
+    # Detach main model components from the computational graph.
+    # The indexer should match the main model, but the main model should not be influenced
+    # by the indexer's learning progress via this loss in sparse training stage.
+    # We also apply this during the Dense Warm-up stage to save compute and memory.
+    query = jax.lax.stop_gradient(query)
+    key = jax.lax.stop_gradient(key)
+
     # Compute attention scores: [b, t, h, d] @ [b, s, h, d] -> [b, h, t, s]
     attention_scores = jnp.einsum("bthd, bshd -> bhts", query, key, precision=self.config.matmul_precision)
 
@@ -1080,7 +1110,7 @@ class MLA(Attention):
 
     # Indexer Logic
     indexer_mask = None
-    if self.use_sparse_indexer:
+    if self.use_indexer:
       if model_mode != MODEL_MODE_TRAIN:
         raise NotImplementedError("Sparse indexer has not implemented for inference yet.")
       # generate mask: with 0 and large negative, [b, 1, 1, q_len, kv_len] -> [b, q_len, kv_len]
@@ -1098,14 +1128,14 @@ class MLA(Attention):
           attention_mask=attention_mask,
       )
 
-      if self.config.indexer_loss_scaling_factor > 0.0:
+      if indexer_mask is not None and self.config.indexer_loss_scaling_factor > 0.0:
         indexer_loss = self.calculate_indexer_loss(
             indexer_score=indexer_score,
             query=query,
             key=key,
             attention_mask=attention_mask,
             indexer_mask=indexer_mask,
-            sparse_loss=self.config.sparse_indexer_loss,
+            sparse_loss=self.config.indexer_sparse_training,
             scaling_factor=self.config.indexer_loss_scaling_factor,
         )
         self.sow(nnx.Intermediate, "indexer_loss", indexer_loss)

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -1415,7 +1415,7 @@ class AttentionOp(nnx.Module):
         decoder_segment_ids_tuple = None
 
       if self.config.use_tokamax_splash:
-        if self.config.use_sparse_indexer and indexer_mask is not None:
+        if self.config.use_indexer and indexer_mask is not None:
           # Construct the splash kernel call with dynamic mask
           def dynamic_mask_splash_kernel(q, k, v, segment, sinks, indexer_mask):
             splash_kernel = tokamax_splash_kernel.make_dynamic_splash_mha(

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -1081,7 +1081,10 @@ class Decoder(nn.Module):
     # When invoking from vLLM with RPA attention, logit computation is deferred to a later stage.
     if cfg.attention == "vllm_rpa":
       logits = None
-
+    # When in the Indexer Dense Warm-up stage, skip the expensive output head projection
+    # for efficiency, as the main model is frozen and the LM loss is not needed.
+    elif (cfg.use_indexer and not cfg.indexer_sparse_training) and self.model_mode == MODEL_MODE_TRAIN:
+      logits = None
     # When vocab tiling is enabled in training mode, full logits won't generate to reduce memory
     # Instead, we keep track on the hidden states, which has smaller size compared to full logits
     elif cfg.num_vocab_tiling > 1 and self.model_mode == MODEL_MODE_TRAIN:

--- a/src/maxtext/optimizers/optimizers.py
+++ b/src/maxtext/optimizers/optimizers.py
@@ -24,31 +24,35 @@ from optax.contrib._muon import muon
 from maxtext.utils.muon_utils import get_muon_weight_dimension_numbers
 
 
-def get_adamw_mask(config):
-  """Create a mask function for AdamW optimizer to exclude certain parameters from weight decay."""
-  if not getattr(config, "adamw_mask", None):
+def _get_path_mask_fn(patterns, match_returns_true=True):
+  """Helper to create a mask function from a list of regex patterns."""
+  if not patterns:
     return None
 
-  compiled_patterns = [re.compile(pattern) for pattern in config.adamw_mask]
+  compiled_patterns = [re.compile(pattern) for pattern in patterns]
 
   def mask_fn(params):
-    def _is_decayed(path, _):
+    def _is_masked(path, _):
       # Join path keys into a single string for pattern matching (e.g., "layer1/bias")
-      path_str = "/".join(str(getattr(p, "key", getattr(p, "idx", getattr(p, "name", p)))) for p in path)
-      # If any pattern in adamw_mask matches the path, exclude from weight decay (return False).
-      # Otherwise, apply weight decay (return True).
-      return not any(pattern.search(path_str) for pattern in compiled_patterns)
+      path_str = jax.tree_util.keystr(path, simple=True, separator="/")
+      matched = any(pattern.search(path_str) for pattern in compiled_patterns)
+      return matched if match_returns_true else not matched
 
-    return jax.tree_util.tree_map_with_path(_is_decayed, params)
+    return jax.tree_util.tree_map_with_path(_is_masked, params)
 
   return mask_fn
+
+
+def get_adamw_mask(config):
+  """Create a mask function for AdamW optimizer to exclude certain parameters from weight decay."""
+  return _get_path_mask_fn(getattr(config, "adamw_mask", None), match_returns_true=False)
 
 
 def get_optimizer(config, learning_rate_schedule, model=None):
   """Create optimizer."""
   if config.opt_type == "adamw":
     # Create AdamW Optimizer following Llama2's training details, see https://arxiv.org/pdf/2307.09288.pdf section 2.2
-    return optax.adamw(
+    base_opt = optax.adamw(
         learning_rate_schedule,
         b1=config.adam_b1,
         b2=config.adam_b2,
@@ -59,7 +63,7 @@ def get_optimizer(config, learning_rate_schedule, model=None):
         mask=get_adamw_mask(config),
     )
   elif config.opt_type == "adam_pax":
-    return adam_pax(
+    base_opt = adam_pax(
         learning_rate_schedule,
         beta1=config.adam_b1,
         beta2=config.adam_b2,
@@ -69,7 +73,7 @@ def get_optimizer(config, learning_rate_schedule, model=None):
         mask=get_adamw_mask(config),
     )
   elif config.opt_type == "sgd":
-    return optax.sgd(learning_rate_schedule)
+    base_opt = optax.sgd(learning_rate_schedule)
   elif config.opt_type == "muon":
     # extract muon dimension number from model structure
     if model is not None:
@@ -92,9 +96,25 @@ def get_optimizer(config, learning_rate_schedule, model=None):
         "adam_eps_root": config.adam_eps_root,
         "adam_weight_decay": config.adam_weight_decay,
     }
-    return muon(**muon_kwargs)
+    base_opt = muon(**muon_kwargs)
   else:
     raise ValueError(f"{config.opt_type=} is not a supported.")
+
+  # If a whitelist of trainable parameters is provided, freeze everything else.
+  # When trainable_parameters_mask is empty, freeze_mask_fn is None and all parameters are trained.
+  trainable_patterns = getattr(config, "trainable_parameters_mask", None)
+  freeze_mask_fn = _get_path_mask_fn(trainable_patterns, match_returns_true=False)
+  if freeze_mask_fn is not None:
+    # Use optax.multi_transform to explicitly map frozen parameters to a stateless set_to_zero() optimizer.
+    # If we simply wrapped base_opt in optax.masked() or chained it, Optax would still allocate
+    # massive states (momentum, variance) for the entire model before zeroing the updates.
+    # By using multi_transform, only the trainable parameters get states allocated.
+    return optax.multi_transform(
+        {"trainable": base_opt, "frozen": optax.set_to_zero()},
+        lambda params: jax.tree_util.tree_map(lambda x: "frozen" if x else "trainable", freeze_mask_fn(params)),
+    )
+
+  return base_opt
 
 
 def adam_pax(

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -136,7 +136,12 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
         decoder_target_mask=data["targets_segmentation"],
     )
 
-    if config.num_vocab_tiling > 1:
+    if (config.use_indexer and not config.indexer_sparse_training) and is_train:
+      # In Dense Warm-up stage, we skip main model loss calculation for efficiency.
+      # The main model parameters are frozen and only the indexer is trained via KL divergence.
+      total_loss = 0.0
+      total_z_loss = 0.0
+    elif config.num_vocab_tiling > 1:
       hidden_state_key = ("intermediates", "decoder", "hidden_states")
       hidden_states = maxtext_utils.get_nested_value(intermediate_outputs, hidden_state_key)[0]
       total_loss, total_z_loss = vocab_tiling_linen_loss(hidden_states, data, config, model, params, is_train)
@@ -178,18 +183,25 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
         decoder_target_mask=data["targets_segmentation"],
     )
     intermediate_outputs = {}
-    one_hot_targets = jax.nn.one_hot(data["targets"], config.vocab_size)
-    xent, z_loss = max_utils.cross_entropy_with_logits(logits, one_hot_targets, z_loss=config.z_loss_multiplier)
 
-    xent = nn.with_logical_constraint(xent, ("activation_embed_and_logits_batch", "activation_length"))
-    z_loss = nn.with_logical_constraint(z_loss, ("activation_embed_and_logits_batch", "activation_length"))
+    if (config.use_indexer and not config.indexer_sparse_training) and is_train:
+      # In Dense Warm-up stage, we skip main model loss calculation for efficiency.
+      # The main model parameters are frozen and only the indexer is trained via KL divergence.
+      total_loss = 0.0
+      total_z_loss = 0.0
+    else:
+      one_hot_targets = jax.nn.one_hot(data["targets"], config.vocab_size)
+      xent, z_loss = max_utils.cross_entropy_with_logits(logits, one_hot_targets, z_loss=config.z_loss_multiplier)
 
-    # Mask out paddings at the end of each example.
-    xent = xent * (data["targets_segmentation"] != 0)
-    z_loss = z_loss * (data["targets_segmentation"] != 0)
+      xent = nn.with_logical_constraint(xent, ("activation_embed_and_logits_batch", "activation_length"))
+      z_loss = nn.with_logical_constraint(z_loss, ("activation_embed_and_logits_batch", "activation_length"))
 
-    total_loss = jnp.sum(xent)
-    total_z_loss = jnp.sum(z_loss)
+      # Mask out paddings at the end of each example.
+      xent = xent * (data["targets_segmentation"] != 0)
+      z_loss = z_loss * (data["targets_segmentation"] != 0)
+
+      total_loss = jnp.sum(xent)
+      total_z_loss = jnp.sum(z_loss)
 
   total_weights = jnp.sum(data["targets_segmentation"] != 0)
   # If gradient accumulation is enabled, we don't need to divide total_loss
@@ -220,7 +232,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
 
   # get indexer loss
   indexer_loss = 0.0
-  if config.use_sparse_indexer and config.indexer_loss_scaling_factor > 0.0:
+  if config.use_indexer and config.indexer_loss_scaling_factor > 0.0:
     indexer_losses = []
     # Extract 'indexer_loss' from model intermediates.
     # We check for paths ending in ('self_attention', 'indexer_loss').

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -326,7 +326,7 @@ def calculate_llama4_attention_tflops(config):
   return attention_tflops
 
 
-def calculate_indexer_mask_ratio(index_topk, max_target_length):
+def calculate_indexer_mask_ratio(indexer_topk, max_target_length):
   """
   Calculates the sparse-to-dense ratio for Indexer TFLOPs.
 
@@ -367,7 +367,7 @@ def calculate_indexer_mask_ratio(index_topk, max_target_length):
   """
 
   T = float(max_target_length)
-  K = float(index_topk)
+  K = float(indexer_topk)
 
   ratio = K / T
   mask_multiplier = ratio - (0.5 * ratio**2)
@@ -379,20 +379,20 @@ def calculate_indexer_tflops_per_device(config):
   batch_len = config.per_device_batch_size * config.max_target_length
 
   # 1. Calculate projections flops
-  # Query: [batch, seq, q_lora_rank] @ [q_lora_rank, index_n_heads, index_head_dim]
-  q_flops = 2 * batch_len * config.q_lora_rank * config.index_n_heads * config.index_head_dim
-  # Key: [batch, seq, emb_dim] @ [emb_dim, index_head_dim]
-  k_flops = 2 * batch_len * config.emb_dim * config.index_head_dim
-  # Head weight: [batch, seq, emb_dim] @ [emb_dim, index_n_heads]
-  head_weight_flops = 2 * batch_len * config.emb_dim * config.index_n_heads
+  # Query: [batch, seq, q_lora_rank] @ [q_lora_rank, indexer_n_heads, indexer_head_dim]
+  q_flops = 2 * batch_len * config.q_lora_rank * config.indexer_n_heads * config.indexer_head_dim
+  # Key: [batch, seq, emb_dim] @ [emb_dim, indexer_head_dim]
+  k_flops = 2 * batch_len * config.emb_dim * config.indexer_head_dim
+  # Head weight: [batch, seq, emb_dim] @ [emb_dim, indexer_n_heads]
+  head_weight_flops = 2 * batch_len * config.emb_dim * config.indexer_n_heads
   proj_flops = q_flops + k_flops + head_weight_flops
 
   # 2. Calculate index score flops
-  # QK product [batch, seq, index_n_heads, index_head_dim] @ [batch, seq, index_head_dim]
-  # --> [batch, seq, seq, index_n_heads]
-  qk_product_flops = 2 * batch_len * config.max_target_length * config.index_n_heads * config.index_head_dim
-  # Aggregate heads [batch, seq, seq, index_n_heads] @ [batch, seq, index_n_heads]
-  head_reduction_flops = 2 * batch_len * config.max_target_length * config.index_n_heads
+  # QK product [batch, seq, indexer_n_heads, indexer_head_dim] @ [batch, seq, indexer_head_dim]
+  # --> [batch, seq, seq, indexer_n_heads]
+  qk_product_flops = 2 * batch_len * config.max_target_length * config.indexer_n_heads * config.indexer_head_dim
+  # Aggregate heads [batch, seq, seq, indexer_n_heads] @ [batch, seq, indexer_n_heads]
+  head_reduction_flops = 2 * batch_len * config.max_target_length * config.indexer_n_heads
   # Apply causal mask: Divide by 2 to account for triangular interactions
   # The mask restricts the indexer's search space prior to Top-K filtering
   scoring_flops = (qk_product_flops + head_reduction_flops) / 2
@@ -428,14 +428,14 @@ def calculate_mla_tflops_per_device(config):
   qkv_flops = q_flops + kv_flops
 
   # 3. calculate attention
-  if config.use_sparse_indexer and config.max_target_length > config.index_topk:
+  if config.use_indexer and config.max_target_length > config.indexer_topk:
     # get indexer flops
     indexer_proj_flops, indexer_scoring_flops = calculate_indexer_tflops_per_device(config)
     qkv_flops += indexer_proj_flops
 
     # calculate the proportion of the T x T causal matrix that the Indexer actually explores
-    # this follows the area: (TK - 0.5*K^2) / T^2 (T: max_target_length, K: index_topk)
-    multiplier = calculate_indexer_mask_ratio(config.index_topk, config.max_target_length)
+    # this follows the area: (TK - 0.5*K^2) / T^2 (T: max_target_length, K: indexer_topk)
+    multiplier = calculate_indexer_mask_ratio(config.indexer_topk, config.max_target_length)
     attention_flops = (
         2
         * batch_len
@@ -446,7 +446,7 @@ def calculate_mla_tflops_per_device(config):
     )
     attention_flops += indexer_scoring_flops
   else:
-    # standard MLA & max_target_length <= index_topk in sparse indexer
+    # standard MLA & max_target_length <= indexer_topk in sparse indexer
     # in both cases, the indexer is bypassed as the causal mask remains the efficient representation
     attention_flops = (
         2 * batch_len * config.max_target_length * config.num_query_heads * (qk_head_dim_sum + config.v_head_dim)

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -39,6 +39,7 @@ from maxtext.common.common_types import (
 from maxtext.layers.attention_mla import MLA
 from maxtext.layers.attention_op import ChunkedCausalMask, _generate_chunk_attention_mask, _make_bidirectional_block_mask
 from maxtext.layers.attentions import Attention
+from maxtext.layers import embeddings
 from maxtext.configs import pyconfig
 from maxtext.models.qwen3 import Qwen3NextGatedDeltaNet
 import numpy as np
@@ -1612,7 +1613,7 @@ class MLATest(attention_test_util.MLATestBase):
     """Test indexer loss computation."""
     mla_config_args = self.config_arguments.copy()
     mla_config_args.update(get_decoupled_parallelism_overrides())
-    mla_config_args["use_sparse_indexer"] = True
+    mla_config_args["use_indexer"] = True
     mla_config_args["attention"] = "dot_product"
     _, mla = self.init_mla(mla_config_args, rope_type="default")
 
@@ -1659,7 +1660,7 @@ class MLATest(attention_test_util.MLATestBase):
     """Test that KL divergence is 0 when target and pred distributions match exactly."""
     mla_config_args = self.config_arguments.copy()
     mla_config_args.update(get_decoupled_parallelism_overrides())
-    mla_config_args["use_sparse_indexer"] = True
+    mla_config_args["use_indexer"] = True
     mla_config_args["attention"] = "dot_product"
     _, mla = self.init_mla(mla_config_args, rope_type="default")
 
@@ -1694,6 +1695,104 @@ class MLATest(attention_test_util.MLATestBase):
     )
 
     np.testing.assert_allclose(loss, 0.0, atol=1e-5)
+
+  def test_indexer_gradients(self):
+    # Test that gradients do NOT flow back to inputs
+    bsz, seqlen = 2, 8
+    inputs_positions = jnp.broadcast_to(jnp.arange(seqlen)[None, :], (bsz, seqlen))
+
+    for sparse_training in [False, True]:
+      with self.subTest(indexer_sparse_training=sparse_training):
+        argv = [
+            "",
+            get_test_config_path(),
+            "run_name=test",
+            "attention_type=mla",
+            "attention=dot_product",
+            "use_indexer=True",
+            f"indexer_sparse_training={sparse_training}",
+            "max_target_length=16",
+            "indexer_topk=4",
+            "indexer_n_heads=2",
+            "indexer_head_dim=8",
+            "emb_dim=16",
+            "qk_rope_head_dim=4",
+            "q_lora_rank=16",
+        ]
+        config = pyconfig.initialize(argv)
+        rngs = nnx.Rngs(0)
+        mesh = jax.sharding.Mesh(jax.devices(), ("data",))
+        rope = embeddings.RotaryEmbedding(
+            min_timescale=1,
+            max_timescale=10000,
+            mesh=mesh,
+            embedding_dims=config.qk_rope_head_dim,
+            fprop_dtype=jnp.float32,
+            rngs=rngs,
+        )
+        rope.interleave = False
+
+        mla = MLA(
+            config=config,
+            num_query_heads=config.num_query_heads,
+            num_kv_heads=config.num_kv_heads,
+            head_dim=config.head_dim,
+            max_target_length=config.max_target_length,
+            mesh=mesh,
+            attention_kernel="dot_product",
+            inputs_q_shape=(bsz, seqlen, config.emb_dim),
+            inputs_kv_shape=(bsz, seqlen, config.emb_dim),
+            dtype=jnp.float32,
+            weight_dtype=jnp.float32,
+            q_lora_rank=config.q_lora_rank,
+            kv_lora_rank=config.kv_lora_rank,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
+            rngs=rngs,
+        )
+
+        inputs_q = jnp.ones((bsz, seqlen, config.emb_dim))
+        inputs_kv = jnp.ones((bsz, seqlen, config.emb_dim))
+        low_rank_q = jnp.ones((bsz, seqlen, config.q_lora_rank))
+
+        def full_indexer_loss_fn(inputs_q, inputs_kv, low_rank_q, mla, sparse_training=sparse_training):
+          # 1. Main model projections
+          # We ignore the low_rank_q returned here and use the explicitly passed one
+          # to directly verify its gradients.
+          query, _ = mla.mla_query_projection(inputs_q, inputs_positions, MODEL_MODE_TRAIN)
+          key, _, _ = mla.mla_kv_projection(inputs_kv, inputs_positions, None, MODEL_MODE_TRAIN, None)
+
+          # 2. Indexer forward
+          indexer_mask, _, indexer_score = mla.indexer(
+              inputs_q=inputs_q,
+              low_rank_q=low_rank_q,
+              inputs_kv=inputs_kv,
+              inputs_positions=inputs_positions,
+          )
+
+          # 3. Calculate full KL loss
+          loss = mla.calculate_indexer_loss(
+              indexer_score=indexer_score,
+              query=query,
+              key=key,
+              attention_mask=None,
+              indexer_mask=indexer_mask,
+              sparse_loss=sparse_training,
+              scaling_factor=1.0,
+          )
+          return loss
+
+        # Calculate gradients with respect to input embeddings and low_rank_q
+        grad_fn = nnx.grad(full_indexer_loss_fn, argnums=(0, 1, 2))
+        grad_q, grad_kv, grad_low_rank_q = grad_fn(inputs_q, inputs_kv, low_rank_q, mla)
+
+        # Gradients should be exactly zero because:
+        # a) Indexer inputs are detached in Indexer.__call__
+        # b) Main model query/key are detached in calculate_indexer_loss
+        self.assertTrue(jnp.all(grad_q == 0.0))
+        self.assertTrue(jnp.all(grad_kv == 0.0))
+        self.assertTrue(jnp.all(grad_low_rank_q == 0.0))
 
 
 class Qwen3NextGatedDeltaNetTest(unittest.TestCase):

--- a/tests/unit/deepseek32_vs_reference_test.py
+++ b/tests/unit/deepseek32_vs_reference_test.py
@@ -96,9 +96,9 @@ class Config:
   rope_truncate: bool = True
   rope_attention_scaling: bool = False
   # indexer
-  use_sparse_indexer: bool = True
-  index_n_heads: int = 64
-  index_head_dim: int = 128  # > qk_rope_head_dim
+  use_indexer: bool = True
+  indexer_n_heads: int = 64
+  indexer_head_dim: int = 128  # > qk_rope_head_dim
 
 
 class ModelArgs:
@@ -128,8 +128,8 @@ class ModelArgs:
     self.beta_slow = config.beta_slow
     self.mscale = config.mscale
     # indexer
-    self.index_n_heads = config.index_n_heads
-    self.index_head_dim = config.index_head_dim
+    self.index_n_heads = config.indexer_n_heads
+    self.index_head_dim = config.indexer_head_dim
     self.index_topk = index_topk
 
 
@@ -751,7 +751,7 @@ def get_jax_mla_weights(pt_mla, cfg):
   }
 
 
-def get_cfg_and_mesh(config, run_name, dtype, batch_size, seq_len, attention, index_topk):
+def get_cfg_and_mesh(config, run_name, dtype, batch_size, seq_len, attention, indexer_topk):
   """Returns MaxText configuration and mesh."""
   cfg = pyconfig.initialize(
       [None, get_test_config_path()],
@@ -768,7 +768,7 @@ def get_cfg_and_mesh(config, run_name, dtype, batch_size, seq_len, attention, in
       max_target_length=seq_len,
       max_prefill_predict_length=seq_len,
       attention=attention,
-      index_topk=index_topk,
+      indexer_topk=indexer_topk,
       **asdict(config),
   )
   devices_array = maxtext_utils.create_device_mesh(cfg)
@@ -831,7 +831,7 @@ class DeepseekTestBase(parameterized.TestCase):
 class DeepseekV32IndexerTest(DeepseekTestBase):
   """Tests for the Sparse Indexer (Top-K Selection)."""
 
-  # index_topk=4
+  # indexer_topk=4
   def test_indexer_match(self, seq_len=8):
     """Verifies Indexer output matches PyTorch output."""
     torch_inputs, jax_inputs = self.get_data(seq_len)
@@ -864,7 +864,7 @@ class DeepseekV32IndexerTest(DeepseekTestBase):
         batch_size=self.batch_size,
         seq_len=self.seq_len,
         attention="dot_product",
-        index_topk=4,
+        indexer_topk=4,
     )
 
     # Indexer specific RoPE (interleave=False)
@@ -914,49 +914,49 @@ class DeepseekV32MLATest(DeepseekTestBase):
           "testcase_name": "dot_product_s2_k4",
           "attention": "dot_product",
           "seq_len": 2,
-          "index_topk": 4,
+          "indexer_topk": 4,
       },
       {
           "testcase_name": "dot_product_s8_k4",
           "attention": "dot_product",
           "seq_len": 8,
-          "index_topk": 4,
+          "indexer_topk": 4,
       },
       {
           "testcase_name": "dot_product_s128_k4",
           "attention": "dot_product",
           "seq_len": 128,
-          "index_topk": 4,
+          "indexer_topk": 4,
           "check_norm": True,
       },
       {
           "testcase_name": "dot_product_s128_k128",
           "attention": "dot_product",
           "seq_len": 128,
-          "index_topk": 128,
+          "indexer_topk": 128,
           "check_norm": True,
       },
       {
           "testcase_name": "flash_s128_k4",
           "attention": "flash",
           "seq_len": 128,
-          "index_topk": 4,
+          "indexer_topk": 4,
           "check_norm": True,
       },
       {
           "testcase_name": "flash_s128_k128",
           "attention": "flash",
           "seq_len": 128,
-          "index_topk": 128,
+          "indexer_topk": 128,
           "check_norm": True,
       },
   )
-  def test_mla_parity(self, attention, seq_len, index_topk, check_norm=False):
+  def test_mla_parity(self, attention, seq_len, indexer_topk, check_norm=False):
     """Verifies JAX MLA output against the PyTorch reference implementation."""
     torch_inputs, jax_inputs = self.get_data(seq_len)
 
     # 1. PyTorch Run
-    pt_mla = MLA(self.pt_args, index_topk)
+    pt_mla = MLA(self.pt_args, indexer_topk)
     init_torch_weights(pt_mla)
     pt_mla.eval()
 
@@ -977,7 +977,7 @@ class DeepseekV32MLATest(DeepseekTestBase):
         batch_size=self.batch_size,
         seq_len=self.seq_len,
         attention=attention,
-        index_topk=index_topk,
+        indexer_topk=indexer_topk,
     )
 
     jax_mla = attention_mla.MLA(

--- a/tests/unit/flop_calculation_test.py
+++ b/tests/unit/flop_calculation_test.py
@@ -467,12 +467,12 @@ class FlopCalculation(unittest.TestCase):
         "v_head_dim": 128,
         "skip_jax_distributed_system": True,
         # Indexer for DeepSeek Sparse Attention
-        "use_sparse_indexer": True,
-        "index_n_heads": 64,
-        "index_head_dim": 128,
-        "index_topk": 2048,
-        # TODO(ranran): remove after flash attention is supported
-        "attention": "dot_product",
+        "use_indexer": True,
+        "indexer_n_heads": 64,
+        "indexer_head_dim": 128,
+        "indexer_topk": 2048,
+        "attention": "flash",
+        "use_tokamax_splash": True,
     }
     B = kwargs["per_device_batch_size"]
     S = kwargs["max_target_length"]

--- a/tests/unit/optimizers_test.py
+++ b/tests/unit/optimizers_test.py
@@ -362,5 +362,71 @@ class AdamWMaskTest(parameterized.TestCase):
       self.assertIsNone(kwargs["mask"])
 
 
+class TrainableParametersMaskTest(parameterized.TestCase):
+  """Tests for the trainable parameters mask functionality via get_optimizer"""
+
+  def test_get_optimizer_with_trainable_mask(self):
+    """Test get_optimizer with a valid trainable_parameters_mask."""
+    argv = [
+        "",
+        get_test_config_path(),
+        "run_name=test_with_trainable_mask",
+        "trainable_parameters_mask=['.*indexer.*', 'layer_norm']",
+    ]
+    config = pyconfig.initialize(argv)
+
+    # Use a constant learning rate > 0 to ensure non-zero updates
+    def learning_rate_schedule(step):
+      return 1.0
+
+    opt = optimizers.get_optimizer(config, learning_rate_schedule)
+
+    # We can test the optimizer by creating some dummy params and gradients
+    # and checking if the updates are zeroed out for non-trainable parameters.
+    params = {
+        "layer1": {"kernel": jax.numpy.ones((2, 2)), "indexer": jax.numpy.ones((2, 2))},
+        "layer2": {"layer_norm": {"scale": jax.numpy.ones((2, 2))}},
+        "layer3": {"ln": {"scale": jax.numpy.ones((2, 2))}},
+    }
+
+    # Give some non-zero gradients
+    grads = jax.tree_util.tree_map(lambda x: jax.numpy.ones_like(x) * 0.5, params)
+
+    # Initialize optimizer state
+    opt_state = opt.init(params)
+
+    # Compute updates
+    updates, _ = opt.update(grads, opt_state, params)
+
+    # 'layer1/kernel' doesn't match the trainable mask, so it should be frozen (update == 0)
+    self.assertTrue(jax.numpy.all(updates["layer1"]["kernel"] == 0))
+    # 'layer3/ln/scale' doesn't match the trainable mask, so it should be frozen (update == 0)
+    self.assertTrue(jax.numpy.all(updates["layer3"]["ln"]["scale"] == 0))
+    # 'layer1/indexer' matches, so it should be trained (update != 0)
+    self.assertFalse(jax.numpy.all(updates["layer1"]["indexer"] == 0))
+    # 'layer2/layer_norm/scale' matches, so it should be trained (update != 0)
+    self.assertFalse(jax.numpy.all(updates["layer2"]["layer_norm"]["scale"] == 0))
+
+  def test_get_optimizer_without_trainable_mask(self):
+    """Test get_optimizer when trainable_parameters_mask is empty."""
+    argv = ["", get_test_config_path(), "run_name=test", "trainable_parameters_mask=[]"]
+    config = pyconfig.initialize(argv)
+
+    # Use a constant learning rate > 0 to ensure non-zero updates
+    def learning_rate_schedule(step):
+      return 1.0
+
+    opt = optimizers.get_optimizer(config, learning_rate_schedule)
+
+    params = {"layer1": {"kernel": jax.numpy.ones((2, 2))}}
+    grads = {"layer1": {"kernel": jax.numpy.ones((2, 2)) * 0.5}}
+
+    opt_state = opt.init(params)
+    updates, _ = opt.update(grads, opt_state, params)
+
+    # When no trainable mask is provided, nothing is frozen by this mechanism
+    self.assertFalse(jax.numpy.all(updates["layer1"]["kernel"] == 0))
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -801,6 +801,55 @@ class TrainCompile(unittest.TestCase):
     )
 
   @pytest.mark.cpu_only
+  def test_indexer_dense_warmup(self):
+    # test deepseek3.2 with sparse attention
+    compiled_trainstep_file = "/tmp/test_indexer_dense_warmup.pickle"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "model_name=deepseek-custom",
+            "per_device_batch_size=4",
+            "scan_layers=True",
+            "max_target_length=1024",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "engram_layers=[]",
+            # dense warmup
+            "indexer_sparse_training=False",
+            "indexer_loss_scaling_factor=0.1",
+            "trainable_parameters_mask=['.*indexer.*']",
+        )
+    )
+
+  @pytest.mark.cpu_only
+  def test_indexer_sparse_training(self):
+    # test deepseek3.2 with sparse attention
+    compiled_trainstep_file = "/tmp/test_indexer_sparse_training.pickle"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "model_name=deepseek-custom",
+            "per_device_batch_size=4",
+            "scan_layers=True",
+            "max_target_length=1024",
+            "attention=flash",
+            "use_tokamax_splash=True",
+            "engram_layers=[]",
+            # sparse training
+            "indexer_sparse_training=True",
+            "indexer_loss_scaling_factor=0.1",
+        )
+    )
+
+  @pytest.mark.cpu_only
   def test_olmo3_7b(self):
     """AOT test for Olmo3 7B implementation"""
     compiled_trainstep_file = "/tmp/test_olmo3_7b"


### PR DESCRIPTION
# Description

Enable selective parameter training strategy for DeeSeek V3.2 Indexer - [paper](https://screenshot.googleplex.com/BHqSonnvgEw9R4a)
* Dense warm up stage:
   * Add `trainable_parameters_mask` flag, allowing specific parameters to be targeted for training while freezing the rest of the model.
   * Add `TrainableParametersMaskTest` unit tests for validation.
* Sparse training stage:
  * Update `indexer_sparse_training` flag to indicate Dense Warm-up stage or Sparse Training stage for DS v3.2. 
  * Add `test_indexer_gradients` unit test to verify proper gradient isolation.
* Renaming flags to avoid confusion
  * `use_sparse_indexer` --> `use_indexer`; `index_head_dim` --> `indexer_head_dim`; `index_n_heads` --> `indexer_n_heads`, and `index_topk` --> `indexer_topk`

# Tests

* Expect added unit tests are all green
* End-to-end functional - [logs](https://paste.googleplex.com/5503321424134144)
* Sanity check deepseek32_vs_reference_test - [link](https://paste.googleplex.com/4984126433263616), same as b/491486716

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
