### PR TITLE
Add option to start test_batch in train_rl from a specific index, also add default tokenizer_path for default model

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -100,6 +100,7 @@ micro_batch_size: -1
 # Keep `num_test_batches` low so that evaluation runs quickly. It can be
 # increased to a max. of 330 (if batch size is 4).
 num_test_batches: 5  # 200
+test_batch_start_index: 0
 train_fraction: 1.0
 
 eval_interval: 10  # this doesn't matter if `TRAIN_FRACTION = 1.0`.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1636,6 +1636,7 @@ class RLDataset(BaseModel):
   batch_size: int = Field(1, description="Global batch size for the dataset loader in RL.")
   num_batches: int = Field(4, description="Number of batches for RL training.")
   num_test_batches: int = Field(5, description="Number of batches for RL evaluation.")
+  test_batch_start_index: int = Field(0, description="Start index for the test dataset")
   train_fraction: float = Field(1.0, description="Fraction of the dataset to be used for training.")
   micro_batch_size: int = Field(-1, description="Micro batch size for rollout and training.")
 

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -416,7 +416,9 @@ def rl_train(trainer_config, sampler_config, trainer_devices, sampler_devices):
   train_dataset = train_dataset.to_iter_dataset().batch(trainer_config.batch_size)
 
   test_dataset = test_dataset.filter(_filter_long_prompts)
-  test_dataset = test_dataset[: trainer_config.num_test_batches * trainer_config.batch_size]
+  test_dataset = test_dataset[
+      trainer_config.test_batch_start_index : trainer_config.num_test_batches * trainer_config.batch_size
+  ]
 
   test_dataset = test_dataset.to_iter_dataset().batch(trainer_config.batch_size)
 

--- a/src/maxtext/utils/globals.py
+++ b/src/maxtext/utils/globals.py
@@ -74,6 +74,8 @@ HF_IDS = {
     "olmo3-7b": "allenai/Olmo-3-7B-Instruct",
     "olmo3-7b-pt": "allenai/Olmo-3-1025-7B",
     "olmo3-32b": "allenai/Olmo-3-32B-Think",
+    # "default" is not HF model, but adding to to avoid confusing warning about tokenizer_path
+    "default": os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers/tokenizer.llama2"),
 }
 
 __all__ = [


### PR DESCRIPTION
# Description

Add an option for the test dataset to start at a specifiable index instead of always starting at 0 in train_rl.py.

Also, adding the MaxText `default` model to `HF_IDS` in `src/maxtext/utils/globals.py` so that it doesn't raise warning about tokenizer_path during `vllm_config` creation in `train_rl.py`

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

CI and also ran locally on v5p-8

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
