### PR TITLE
Skip Tokamax RaggedDotGroupSizes for FP8

### DIFF
--- a/src/maxtext/models/deepseek_batchsplit.py
+++ b/src/maxtext/models/deepseek_batchsplit.py
@@ -804,16 +804,11 @@ def compute(x, w0, w1, wo, group_sizes, weights, *, config, mesh):
       input_buffer_count,
       combine_scopes,
   ):
-
-    tokamax_group_sizes = tokamax.RaggedDotGroupSizes(
-        group_sizes,
-        max_utils.generate_representative_group_sizes(inputs.shape[0], kernel.shape[0]),
-    )
     if config.use_qwix_quantization:
       output = megablox.gmm(
           lhs=inputs,
           rhs=kernel,
-          group_sizes=tokamax_group_sizes,
+          group_sizes=group_sizes,
           preferred_element_type=preferred_element_type,
           tiling=tiling,
           use_qwix_quantization=config.use_qwix_quantization,
@@ -827,7 +822,10 @@ def compute(x, w0, w1, wo, group_sizes, weights, *, config, mesh):
       output = tokamax.ragged_dot(
           lhs=inputs,
           rhs=kernel,
-          group_sizes=tokamax_group_sizes,
+          group_sizes=tokamax.RaggedDotGroupSizes(
+              group_sizes,
+              max_utils.generate_representative_group_sizes(inputs.shape[0], kernel.shape[0]),
+          ),
           precision=jax.lax.Precision.DEFAULT,
           preferred_element_type=preferred_element_type,
           implementation="mosaic",


### PR DESCRIPTION

# Description

FP8 path is still using tokamax internal backend APIs. The new `RaggedDotGroupSizes` was introduced ([pull3330](https://github.com/AI-Hypercomputer/maxtext/pull/3330)) for Tokamax public APIs in bf16 path, which broke FP8.

# Tests

Benchmarks were run internally.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
