### PR TITLE
Fix NNX ValueError in NNXDecoder

### DIFF
--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -335,8 +335,8 @@ class Transformer(nnx.Module):
     if cfg.pure_nnx_decoder:
       self.decoder = NNXDecoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode, rngs=rngs)
     else:
-      self.decoder = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
-      self.decoder = nnx_wrappers.ToNNX(self.decoder, rngs=rngs)
+      decoder_linen = Decoder(config=cfg, mesh=mesh, quant=self.quant, model_mode=self.model_mode)
+      self.decoder = nnx_wrappers.ToNNX(decoder_linen, rngs=rngs)
     self.hidden_states = None
 
     batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config=cfg, model_mode=model_mode)
@@ -529,7 +529,7 @@ class Transformer(nnx.Module):
           attention_metadata=attention_metadata,
           deepstack_visual_embeds=deepstack_visual_embeds,
           mutable=mutable_collections,
-      ) # pytype: disable=wrong-keyword-args
+      )  # pytype: disable=wrong-keyword-args
 
     # Materialize hidden state when vocab tiling is enabled
     if self.config.num_vocab_tiling > 1:


### PR DESCRIPTION
# Description

To fix the NNX ValueError
ValueError: Cannot assign data value of type '<class 'maxtext.layers.nnx_wrappers.ToNNX'>' to static attribute 'decoder' of Pytree type '<class 'maxtext.models.models.Transformer'>'. 

# Tests

Run distill_train

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
