### PR TITLE
Use non-tokamax group sizes for expert parallelism

### DIFF
--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -897,7 +897,8 @@ class RoutedMoE(nnx.Module):
         inputs, kernel, tiling, group_sizes, expert_assignments, weight_gather_axes, input_buffer_count, combine_scopes
     ):
       # TODO (b/491979205) pipeline fsdp ag per repeat fails tokamax gmm
-      if self.config.using_pipeline_parallelism and self.config.pipeline_fsdp_ag_per_repeat:
+      # TODO (b/493621965) Expert parallelism fails tokamax gmm when vLLM uses MaxText models
+      if (self.config.using_pipeline_parallelism and self.config.pipeline_fsdp_ag_per_repeat) or self.config.rollout_expert_parallelism > 1:
         tokamax_group_sizes = group_sizes
       else:
         tokamax_group_sizes = tokamax.RaggedDotGroupSizes(


### PR DESCRIPTION
# Description

Use non-tokamax group sizes for expert parallelism.

On v7x, when vLLM uses MaxText models, there is `ValueError: Representative value must have the same length as the group sizes`. 

FIXES: b/493621965

# Tests

Tested on GKE for Qwen3-235B on v7x.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
