### PR TITLE
Fix test_prompt_filtering which got broken after a rebase.

### DIFF
--- a/tests/post_training/unit/train_rl_test.py
+++ b/tests/post_training/unit/train_rl_test.py
@@ -331,6 +331,7 @@ class TrainRLTest(unittest.TestCase):
         train_fraction=1.0,
         num_epoch=1,
         num_test_batches=1,
+        test_batch_start_index=0,
     )
 
     # Patch everything!


### PR DESCRIPTION
# Description

Fix train_rl_test that I somehow managed to break in PR #3399.

The tests passed originally, but then it broke after a rebase. I am not sure why the GitHub tests did not catch this.

# Tests

Ran the affected tests:
```
pytest tests/post_training/unit/train_rl_test.py
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
