### PR TITLE
modify process_data to generate separate user/system parts in prompts

### DIFF
--- a/src/maxtext/trainers/post_train/rl/utils_rl.py
+++ b/src/maxtext/trainers/post_train/rl/utils_rl.py
@@ -527,28 +527,28 @@ def process_data(dataset_name, model_tokenizer, template_config, tmvp_config, x)
     answer = extract_hash_answer(answer)
 
   return {
-    # passed to model forward pass
-    "prompts": model_tokenizer.apply_chat_template(
-      [
-        {
-          "role": "system",
-          "content": template_config["SYSTEM_PROMPT"].format(
-            reasoning_start_token=tmvp_config.reasoning_start_token,
-            reasoning_end_token=tmvp_config.reasoning_end_token,
-            solution_start_token=tmvp_config.solution_start_token,
-            solution_end_token=tmvp_config.solution_end_token,
-          ),
-        },
-        {
-          "role": "user",
-          "content": question,
-        }
-      ],
-      tokenize=False,
-      add_generation_prompt=True,
-    ),
-    # passed to reward functions
-    "question": question,
-    # passed to reward functions
-    "answer": answer,
+      # passed to model forward pass
+      "prompts": model_tokenizer.apply_chat_template(
+          [
+              {
+                  "role": "system",
+                  "content": template_config["SYSTEM_PROMPT"].format(
+                      reasoning_start_token=tmvp_config.reasoning_start_token,
+                      reasoning_end_token=tmvp_config.reasoning_end_token,
+                      solution_start_token=tmvp_config.solution_start_token,
+                      solution_end_token=tmvp_config.solution_end_token,
+                  ),
+              },
+              {
+                  "role": "user",
+                  "content": question,
+              },
+          ],
+          tokenize=False,
+          add_generation_prompt=True,
+      ),
+      # passed to reward functions
+      "question": question,
+      # passed to reward functions
+      "answer": answer,
   }

--- a/src/maxtext/trainers/post_train/rl/utils_rl.py
+++ b/src/maxtext/trainers/post_train/rl/utils_rl.py
@@ -527,27 +527,28 @@ def process_data(dataset_name, model_tokenizer, template_config, tmvp_config, x)
     answer = extract_hash_answer(answer)
 
   return {
-      # passed to model forward pass
-      "prompts": model_tokenizer.apply_chat_template(
-          [
-              {
-                  "role": "user",
-                  "content": template_config["TEMPLATE"].format(
-                      system_prompt=template_config["SYSTEM_PROMPT"].format(
-                          reasoning_start_token=tmvp_config.reasoning_start_token,
-                          reasoning_end_token=tmvp_config.reasoning_end_token,
-                          solution_start_token=tmvp_config.solution_start_token,
-                          solution_end_token=tmvp_config.solution_end_token,
-                      ),
-                      question=question,
-                  ),
-              },
-          ],
-          tokenize=False,
-          add_generation_prompt=True,
-      ),
-      # passed to reward functions
-      "question": question,
-      # passed to reward functions
-      "answer": answer,
+    # passed to model forward pass
+    "prompts": model_tokenizer.apply_chat_template(
+      [
+        {
+          "role": "system",
+          "content": template_config["SYSTEM_PROMPT"].format(
+            reasoning_start_token=tmvp_config.reasoning_start_token,
+            reasoning_end_token=tmvp_config.reasoning_end_token,
+            solution_start_token=tmvp_config.solution_start_token,
+            solution_end_token=tmvp_config.solution_end_token,
+          ),
+        },
+        {
+          "role": "user",
+          "content": question,
+        }
+      ],
+      tokenize=False,
+      add_generation_prompt=True,
+    ),
+    # passed to reward functions
+    "question": question,
+    # passed to reward functions
+    "answer": answer,
   }


### PR DESCRIPTION
# Description

modify process_data to generate separate user/system parts in prompts, for consistency with tunix.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X]  I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
