### PR TITLE
Distillation optimizer fix

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -199,7 +199,11 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
   """
 
   def __init__(self, model, strategy, optimizer, training_config, **kwargs):
-    super().__init__(model=model, optimizer=optimizer, training_config=training_config, **kwargs)
+    # We pass a dummy optimizer to the base PeftTrainer temporarily to prevent PeftTrainer from eagerly
+    # allocating massive optimizer states for the entire ModelBundle (including the frozen teacher) before
+    # redefining the trainer optimizer here.
+    dummy_optimizer = optax.set_to_zero()
+    super().__init__(model=model, optimizer=dummy_optimizer, training_config=training_config, **kwargs)
 
     self.strategy = strategy
 


### PR DESCRIPTION
# Description

With the introduction of ModelBundle in the distill pipeline, it allocates the optimizer state for both models in the base Tunix peft trainer. 

Since the optimizer logic is completely revised in the MaxTextDistillationTrainer anyway, the fix is simply to send a dummy optimizer to the base class.

# Tests
Not appllicable

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
