### PR TITLE
Add runner installation option to ReadTheDocs

### DIFF
--- a/docs/install_maxtext.md
+++ b/docs/install_maxtext.md
@@ -22,6 +22,7 @@ MaxText offers three installation modes:
 1. maxtext[tpu]. Used for pre-training and decode on TPUs.
 2. maxtext[cuda12]. Used for pre-training and decode on GPUs.
 3. maxtext[tpu-post-train]. Used for post-training on TPUs. Currently, this option should also be used for running vllm_decode on TPUs.
+4. maxtext[runner]. Used for building MaxText's Docker images and scheduling workloads through XPK.
 
 ## From PyPI (Recommended)
 
@@ -49,6 +50,9 @@ install_maxtext_cuda12_github_dep
 # Option 3: Installing maxtext[tpu-post-train]
 uv pip install "maxtext[tpu-post-train]>=0.2.0" --resolution=lowest
 install_maxtext_tpu_post_train_extra_deps
+
+# Option 4: Installing maxtext[runner]
+uv pip install maxtext[runner] --resolution=lowest
 ```
 
 > **Note:** The `install_maxtext_tpu_github_deps`, `install_maxtext_cuda12_github_dep`, and
@@ -85,6 +89,9 @@ install_maxtext_cuda12_github_dep
 # Option 3: Installing .[tpu-post-train]
 uv pip install -e .[tpu-post-train] --resolution=lowest
 install_maxtext_tpu_post_train_extra_deps
+
+# Option 4: Installing maxtext[runner]
+uv pip install .[runner] --resolution=lowest
 ```
 
 After installation, you can verify the package is available with `python3 -c "import maxtext"` and run training jobs with `python3 -m maxtext.trainers.pre_train.train ...`.


### PR DESCRIPTION
# Description

Add the new maxtext[runner] installation option for scheduling workloads.

Next steps: Update other docs to show when this option should be used

# Tests

N/A - documentation change only

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
