### PR TITLE
fix optimizer number of steps

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -248,6 +248,9 @@ class CombinedDistillationStrategy:
         "distill/teacher_loss": teacher_hard_loss,
         "distill/out_proj_feature_loss": feature_loss,
         "distill/total_loss": total_loss,
+        "distill/temperature": self.temperature,
+        "distill/alpha": self.alpha,
+        "distill/beta_feature": self.beta_feature,
     }
     return total_loss, metrics
 

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -464,8 +464,7 @@ def train_distill(student_config: pyconfig.HyperParameters, teacher_config: pyco
   )
 
   # 4. Optimizer & Config
-  total_updates = student_config.steps // student_config.gradient_accumulation_steps
-  optimizer = get_distillation_optimizer(student_config, total_updates)
+  optimizer = get_distillation_optimizer(student_config, student_config.steps)
 
   checkpointing_options = checkpoint.CheckpointManagerOptions(
       save_interval_steps=student_config.checkpoint_period,

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -399,6 +399,9 @@ class TrainDistillTest(unittest.TestCase):
         "distill/teacher_loss",
         "distill/out_proj_feature_loss",
         "distill/total_loss",
+        "distill/temperature",
+        "distill/alpha",
+        "distill/beta_feature",
     ]
     for key in expected_keys:
       self.assertIn(key, metrics)


### PR DESCRIPTION
# Description

Fixes the amount of optimizer steps that are set when using gradient accumulation with optax.MultiStep.

By using student_config.steps, we ensure that the maxtext optimizer, lr_scheduler and optax.MultiStep stay in sync with the difference being how many backward passes are performed based on gradient_accumulation. Ex:

- ga=1, 5k steps, will do 5k backward passes.
- ga=2, 5k steps, will do 5k/2 backward passes.

The number of samples seen by the model stay exactly the same. 

# Tests

Ran:
- tests.unit.distillation_checkpointing_test
- tests.unit.train_distill_test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
