### PR TITLE
Fix src/MaxText references in GPU/runner Dockerfiles

### DIFF
--- a/src/dependencies/dockerfiles/maxtext_gpu_dependencies.Dockerfile
+++ b/src/dependencies/dockerfiles/maxtext_gpu_dependencies.Dockerfile
@@ -46,7 +46,7 @@ ENV TESTS_DIR=$TESTS_DIR
 
 ENV MAXTEXT_ASSETS_ROOT=/deps/src/maxtext/assets
 ENV MAXTEXT_TEST_ASSETS_ROOT=/deps/tests/assets
-ENV MAXTEXT_PKG_DIR=/deps/src/MaxText
+ENV MAXTEXT_PKG_DIR=/deps/src/maxtext
 ENV MAXTEXT_REPO_ROOT=/deps
 
 # Set the working directory in the container
@@ -56,7 +56,7 @@ WORKDIR /deps
 COPY ${PACKAGE_DIR}/dependencies/github_deps/ src/dependencies/github_deps/
 COPY ${PACKAGE_DIR}/dependencies/requirements/ src/dependencies/requirements/
 COPY ${PACKAGE_DIR}/dependencies/scripts/ src/dependencies/scripts/
-COPY ${PACKAGE_DIR}/maxtext/integration/vllm/ src/MaxText/integration/vllm/
+COPY ${PACKAGE_DIR}/maxtext/integration/vllm/ src/maxtext/integration/vllm/
 
 # Install dependencies - these steps are cached unless the copied files change
 RUN echo "Running command: bash setup.sh MODE=$ENV_MODE JAX_VERSION=$ENV_JAX_VERSION DEVICE=${ENV_DEVICE}"
@@ -65,7 +65,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     bash /deps/src/dependencies/scripts/setup.sh MODE=${ENV_MODE} JAX_VERSION=${ENV_JAX_VERSION} DEVICE=${ENV_DEVICE}
 
 # Now copy the remaining code (source files that may change frequently)
-COPY ${PACKAGE_DIR}/maxtext/ src/MaxText/
+COPY ${PACKAGE_DIR}/maxtext/ src/maxtext/
 COPY ${TESTS_DIR}*/ tests/
 
 # Download test assets from GCS if building image with test assets

--- a/src/dependencies/dockerfiles/maxtext_runner.Dockerfile
+++ b/src/dependencies/dockerfiles/maxtext_runner.Dockerfile
@@ -8,7 +8,7 @@ ENV PACKAGE_DIR=$PACKAGE_DIR
 
 ENV MAXTEXT_ASSETS_ROOT=/deps/src/maxtext/assets
 ENV MAXTEXT_TEST_ASSETS_ROOT=/deps/tests/assets
-ENV MAXTEXT_PKG_DIR=/deps/src/MaxText
+ENV MAXTEXT_PKG_DIR=/deps/src/maxtext
 ENV MAXTEXT_REPO_ROOT=/deps
 
 # Set the working directory in the container
@@ -18,4 +18,4 @@ WORKDIR /deps
 COPY ${PACKAGE_DIR}/maxtext/assets/ "${MAXTEXT_ASSETS_ROOT}"
 
 # Copy all files except assets from local workspace into docker container
-COPY --exclude=${PACKAGE_DIR}/maxtext/assets/ ${PACKAGE_DIR}/maxtext/ src/MaxText/
+COPY --exclude=${PACKAGE_DIR}/maxtext/assets/ ${PACKAGE_DIR}/maxtext/ src/maxtext/


### PR DESCRIPTION
# Description

Fix `src/maxtext` references that are getting overwritten by copybara.

# Tests

CI will build and run this GPU Docker image

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
