### PR TITLE
Configure pre-commit for license headers and automatic pyink reformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,20 @@
 files: ^(.*\.(py|md|sh|yaml|yml|in|cfg|txt|rst|toml|precommit-toml|wordlist))$
 exclude: ^(\.[^/]*(cache|assets|uv|venv)/.*)$
 repos:
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+      - id: insert-license
+        name: Add license for all Python files
+        files: \.py$|\.bzl$|BUILD$|BUILD\.bazel$
+        args:
+          - --comment-style
+          - "|#|"
+          - --license-filepath
+          - LICENSE_HEADER
+          - --use-current-year
+          - --allow-past-years
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
@@ -52,7 +66,6 @@ repos:
         args:
           - '--pyink-indentation=2'
           - '--line-length=122'
-          - '--check'
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,0 +1,13 @@
+ Copyright 2023–2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.


### PR DESCRIPTION
# Description

Add a third-party pre-commit hook to automatically add license headers if it is not present already.
Also allow pyink to automatically format files rather than just check them.
In both cases the newly modified files need to be `git add`'ed again to be commited.

Reminder: To benefit from this one needs to run `pre-commit install` once in their git repo.

# Tests

Manually modified existing files to remove the license and to break code formatting.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
