### PR TITLE
Disable insert-license pre-commit hook to prevent widespread disruptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,20 +2,6 @@
 files: ^(.*\.(py|md|sh|yaml|yml|in|cfg|txt|rst|toml|precommit-toml|wordlist))$
 exclude: ^(\.[^/]*(cache|assets|uv|venv)/.*)$
 repos:
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
-    hooks:
-      - id: insert-license
-        name: Add license for all Python files
-        files: \.py$|\.bzl$|BUILD$|BUILD\.bazel$
-        args:
-          - --comment-style
-          - "|#|"
-          - --license-filepath
-          - LICENSE_HEADER
-          - --use-current-year
-          - --allow-past-years
-
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:


### PR DESCRIPTION
# Description

Temporarily disable the insert-license pre-commit hook that was recently added.
Unfortunately, it causes a lot of existing files to re-format because of inconsistent formatting of the existing license strings.

# Tests

Manually ran pre-commit.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
