### PR TITLE
Change quantization_local_shard_count to number of slices

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2190,7 +2190,7 @@ class MaxTextConfig(
     # Default quantization sharding count to number of local devices if not set.
     if self.quantization_local_shard_count == -1:
       try:
-        self.quantization_local_shard_count = jax.local_device_count()
+        self.quantization_local_shard_count = 1 + max(d.slice_index for d in jax.devices())
       except RuntimeError:
         self.quantization_local_shard_count = 1
 


### PR DESCRIPTION
# Description

Set the `quantization_local_shard_count` to number of slices.

FIXES: b/454230221

# Tests

[Test logs](https://paste.googleplex.com/5791493828771840)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
