### PR TITLE
Specifically install maxtext 0.2.1 in documentation

### DIFF
--- a/docs/build_maxtext.md
+++ b/docs/build_maxtext.md
@@ -61,7 +61,7 @@ source ${VENV_NAME?}/bin/activate
 
 # Install MaxText with the [runner] extra
 # This enables Docker image building and workload scheduling via XPK
-uv pip install maxtext[runner] --resolution=lowest
+uv pip install maxtext[runner]==0.2.1 --resolution=lowest
 ```
 
 > **Note:** The `maxtext[runner]` extra includes all necessary dependencies for building MaxText Docker images and running workloads through XPK. It automatically installs XPK, so you do not need to install it separately to manage your clusters and workloads.

--- a/docs/install_maxtext.md
+++ b/docs/install_maxtext.md
@@ -40,19 +40,19 @@ source maxtext_venv/bin/activate
 # installation option from this list to fit your use case.
 
 # Option 1: Installing maxtext[tpu]
-uv pip install maxtext[tpu] --resolution=lowest
+uv pip install maxtext[tpu]==0.2.1 --resolution=lowest
 install_maxtext_tpu_github_deps
 
 # Option 2: Installing maxtext[cuda12]
-uv pip install maxtext[cuda12] --resolution=lowest
+uv pip install maxtext[cuda12]==0.2.1 --resolution=lowest
 install_maxtext_cuda12_github_dep
 
 # Option 3: Installing maxtext[tpu-post-train]
-uv pip install maxtext[tpu-post-train] --resolution=lowest
+uv pip install maxtext[tpu-post-train]==0.2.1 --resolution=lowest
 install_maxtext_tpu_post_train_extra_deps
 
 # Option 4: Installing maxtext[runner]
-uv pip install maxtext[runner] --resolution=lowest
+uv pip install maxtext[runner]==0.2.1 --resolution=lowest
 ```
 
 > **Note:** The `install_maxtext_tpu_github_deps`, `install_maxtext_cuda12_github_dep`, and


### PR DESCRIPTION
# Description

Pin `maxtext==0.2.1` in ReadTheDocs installation guides. Our commands have been defaulting to install `maxtext==0.1.0`, which we figured out is caused by using the `--resolution=lowest` flag to keep transitive dependencies locked.

Pinning the latest version in the docs for now, but we will want to find a better long-term solution.

Next steps: Can we somehow cherry-pick this change into the ReadTheDocs `0.2.1` tag?

# Tests

```
uv pip install maxtext[tpu]==0.2.1 --resolution=lowest
pip show maxtext # gives 0.2.1
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
