### PR TITLE
Re-enable pre-commit insert-license hook (another implementation).

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,22 @@
 files: ^(.*\.(py|md|sh|yaml|yml|in|cfg|txt|rst|toml|precommit-toml|wordlist))$
 exclude: ^(\.[^/]*(cache|assets|uv|venv)/.*)$
 repos:
+  - repo: local
+    hooks:
+      - id: addlicense
+        name: Add license for all Python files
+        entry: addlicense
+        language: golang
+        additional_dependencies:
+          - github.com/google/addlicense@v1.1.1
+        args:
+          - -c
+          - "Google LLC"
+          - -f
+          - LICENSE_HEADER
+          - -y
+          - "2023-2026"
+        files: \.py$|\.bzl$|BUILD$|BUILD\.bazel$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,13 +1,13 @@
- Copyright 2023–2026 Google LLC
+Copyright 2023–2026 Google LLC
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
# Description

Re-enable the license inserting pre-commit hook using a different implementation.
This one is using  google/addlicense hook, which is smarter than the previous implementation. 
It can ignore formatting issues and won't attempt to add second license if the formatting does not match.

# Tests

Manual running of pre-commit with a few locally modified files to test various scenarios, such as different space formatting, different years in the copyright string, complete removal of the license, etc.
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
