### PR TITLE
Fix the gradients' device memory space when enabling parameter offloading

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -355,6 +355,11 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
       lambda x: x.astype(config.grad_dtype) if x.dtype == jnp.float32 else x,
       raw_grads,
   )
+  if config.parameter_memory_host_offload:
+    raw_grads = jax.device_put(
+        raw_grads,
+        max_utils.with_memory_kind(params_shardings, "device"),
+    )
   intermediate_outputs = aux["intermediate_outputs"]
   total_weights = aux["total_weights"]
   moe_lb_loss = aux["moe_lb_loss"]

--- a/src/maxtext/utils/max_utils.py
+++ b/src/maxtext/utils/max_utils.py
@@ -25,6 +25,8 @@ import subprocess
 import time
 from typing import Any
 
+from packaging.version import Version
+
 from etils import epath
 import flax
 import jax
@@ -82,7 +84,7 @@ def calculate_num_params_from_pytree(params):
 def device_space():
   """Version guard for jax.memory.Space.Device."""
   # See b/436565838 for more.
-  if jax.__version__ >= "0.7.1":
+  if Version(jax.__version__) >= Version("0.7.1"):
     return jax.memory.Space.Device  # pytype: disable=module-attr
   else:
     return jax._src.sharding_impls.TransferToMemoryKind("device")  # pylint: disable=protected-access # pytype: disable=module-attr


### PR DESCRIPTION
# Description

Fix gradient memory placement when parameter offloading is enabled with parameter_memory_host_offload=True.   
                                                                                                                
When parameter offloading is active, model parameters live in host memory and are streamed to device during the forward pass. However, JAX's autodiff computes gradients in the same memory space as the inputs, meaning the backward pass produces gradients that are also on the host. Previously, these host-resident gradients were passed directly to gradient clipping and the optimizer update without being moved to device first, causing a runtime error when gradients are used in a device operation.

This PR adds a jax.device_put call immediately after the backward pass to explicitly move raw_grads back to device memory with the correct sharding before any further gradient processing. The fix is a one-time transfer per training step and is gated behind the existing parameter_memory_host_offload config flag.

# Tests

The existing integration test test_gpu_parameter_offload in tests/integration/train_tests.py covers this fix. It runs 10 training steps with parameter_memory_host_offload=True on a GPU, exercising the backward pass and the gradient device_put added by this change.                                                                 
                  
  pytest tests/integration/train_tests.py::GPUTest::test_gpu_parameter_offload -v

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
