### PR TITLE
Using synthetic dataset_type to decrease the training time and optimize the UT in CI workflow

### DIFF
--- a/tests/integration/gradient_accumulation_test.py
+++ b/tests/integration/gradient_accumulation_test.py
@@ -62,6 +62,7 @@ class GradientAccumulationTest(unittest.TestCase):
         get_test_config_path(),
         f"base_output_directory={self.base_output_directory}",
         f"dataset_path={self.dataset_path}",
+        "dataset_type=synthetic",
         "gradient_clipping_threshold=0",  # Ensures we are testing raw scales of gradients (clipping off)
         "enable_checkpointing=False",
         "enable_goodput_recording=False",


### PR DESCRIPTION
# Description

Using synthetic dataset_type to decrease the training time and optimize the UT in CI workflow

FIX b/496210310

# Tests

python3 -m pytest -v tests/integration/gradient_accumulation_test.py::GradientAccumulationTest::test_grad_accumulate_same_loss

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
