### PR TITLE
Update build_maxtext.md with small image name format cleanup

### DIFF
--- a/docs/build_maxtext.md
+++ b/docs/build_maxtext.md
@@ -131,7 +131,7 @@ build_maxtext_docker_image WORKFLOW=post-training
 > **Note:** You will need the [**Artifact Registry Writer**](https://docs.cloud.google.com/artifact-registry/docs/access-control#permissions) role to push Docker images to your project's Artifact Registry and to allow the cluster to pull them during workload execution. If you don't have this permission, contact your project administrator to grant you this role through "Google Cloud Console -> IAM -> Grant access".
 
 ```bash
-# Make sure to replace <Docker Image Name> with your desired image name.
+# Make sure to set `CLOUD_IMAGE_NAME` with your desired image name.
 export CLOUD_IMAGE_NAME=<Docker Image Name>
 upload_maxtext_docker_image CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME?}
 ```


### PR DESCRIPTION
# Description

Update code comment to point to variable name instead of the inline variable setting. This is a minor change but it was giving the same variable fill-in option twice, and filling in one didn't auto-fill in the other one. So changing this so it only has to be written out once

# Tests

Currently running this notebook

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
