### PR TITLE
Document docker upload file path workaround

### DIFF
--- a/docs/build_maxtext.md
+++ b/docs/build_maxtext.md
@@ -128,10 +128,16 @@ build_maxtext_docker_image WORKFLOW=post-training
 
 ## Upload MaxText Docker Image to Artifact Registry
 
-> **Note:** You will need the [**Artifact Registry Writer**](https://docs.cloud.google.com/artifact-registry/docs/access-control#permissions) role to push Docker images to your project's Artifact Registry and to allow the cluster to pull them during workload execution. If you don't have this permission, contact your project administrator to grant you this role through "Google Cloud Console -> IAM -> Grant access".
-
 ```bash
 # Make sure to set `CLOUD_IMAGE_NAME` with your desired image name.
 export CLOUD_IMAGE_NAME=<Docker Image Name>
 upload_maxtext_docker_image CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME?}
 ```
+
+> **Note:** You will need the [**Artifact Registry Writer**](https://docs.cloud.google.com/artifact-registry/docs/access-control#permissions) role to push Docker images to your project's Artifact Registry and to allow the cluster to pull them during workload execution. If you don't have this permission, contact your project administrator to grant you this role through "Google Cloud Console -> IAM -> Grant access".
+
+> **Note:** If you see the following error, try adding the listed file path to `.dockerignore`:
+> ```
+> ERROR: Found symbolic links with absolute paths in the build context:
+> ./<add_this_value_to_dockerignore>
+> ```


### PR DESCRIPTION
# Description

Saw this error when running `upload_maxtext_docker_image CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME?}`:

```
ERROR: Found symbolic links with absolute paths in the build context:
./maxtext_venv/bin/python
Docker cannot follow absolute paths outside of the build context, which can cause 'failed to compute cache key' errors.
Please remove these links or convert them to relative paths before building the Docker image.
Alternatively, run the command again from a clean, empty directory to bypass your local file state entirely
```

Fixed it by adding `maxtext_venv/bin/python` to a new `.dockerignore` file. Thanks @SurbhiJainUSC for the fix

# Tests

```
upload_maxtext_docker_image CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME?}
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
