### PR TITLE
Add support for check vma in megablox kernel

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -622,6 +622,9 @@ ici_autoregressive_parallelism: 1
 ici_pipeline_parallelism: 1
 ici_expert_parallelism: 1
 
+# Enabling check_vma is recommended for improved performance. Only supported for EP / FSDP ICI parallelisms, shard_mode: "auto", use_ragged_sort: False, use_ring_of_experts: False, and use_tokamax_gmm=False.
+check_vma: False
+
 # Enable ZeRO-1 optimizer sharding over data axis
 shard_optimizer_over_data: false
 

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -921,6 +921,11 @@ class LayoutAndSharding(BaseModel):
       le=1.0,
       description="Allowed percentage of non-sharded parameters.",
   )
+  check_vma: bool = Field(
+      False,
+      description="Enabled check_vma flag in shard_map calls. Recommended for improved performance but only supported "
+      "with auto sharding, megablox kernel, and EP / FSDP parallelisms.",
+  )
   shard_optimizer_over_data: bool = Field(False, description="Enable ZeRO-1 optimizer sharding over the data axis.")
   internal_compile: bool = Field(False, description="Use internal_compile to bypass open-source topology mappings.")
   internal_compile_num_devices: int = Field(-1, description="Number of devices when using internal_compile.")
@@ -2348,6 +2353,26 @@ class MaxTextConfig(
     """This method is a no-op because `pyconfig` handles model-specific config loading."""
     return values
 
+  def _validate_check_vma_is_supported(self):
+    """Validates that check_vma is used with supported settings."""
+    if not self.check_vma:
+      return
+    if self.shard_mode != ShardMode.AUTO:
+      raise ValueError(f"check_vma requires shard_mode='auto', got shard_mode='{self.shard_mode.value}'.")
+    if self.use_tokamax_gmm:
+      raise ValueError("check_vma is not yet supported with tokamax gmm kernel.")
+    if self.use_ragged_sort:
+      raise ValueError("check_vma is not yet supported with ragged sort kernel.")
+    if self.use_ring_of_experts:
+      raise ValueError("check_vma is not yet supported with ring of experts.")
+    _allowed = {"ici_expert_parallelism", "ici_fsdp_parallelism"}
+    active = [name for name in IciParallelism.model_fields if name not in _allowed and getattr(self, name) != 1]
+    if active:
+      raise ValueError(
+          f"check_vma=True only supports ici_expert_parallelism and ici_fsdp_parallelism. "
+          f"Found other ICI axes enabled: {active}."
+      )
+
   def validate_ragged_buffer_factor(self):
     if self.ragged_buffer_factor <= 0:
       return  # Nothing to validate if not using ragged buffer factor
@@ -3200,6 +3225,8 @@ class MaxTextConfig(
           "incompatibility between tokamax's GroupSizes vmap_rule and JAX's scan batching. "
           "Please set use_tokamax_gmm=False."
       )
+
+    self._validate_check_vma_is_supported()
 
     # Final string-to-enum conversions if they haven't been coerced by pydantic yet.
     if isinstance(self.decoder_block, str):

--- a/src/maxtext/kernels/megablox/backend.py
+++ b/src/maxtext/kernels/megablox/backend.py
@@ -298,6 +298,7 @@ LutFn = Callable[[int, int, int], Optional[tuple[int, int, int]]]
         "tiling",
         "transpose_rhs",
         "interpret",
+        "varying_axes",
     ],
 )
 def gmm(
@@ -310,6 +311,7 @@ def gmm(
     existing_out: jnp.ndarray | None = None,
     transpose_rhs: bool = False,
     interpret: bool = False,
+    varying_axes: tuple[str, ...] = (),
 ) -> jnp.ndarray:
   """Compute lhs[sizes[i-1]:sizes[i], :] @ rhs for each group 'i'.
 
@@ -522,7 +524,9 @@ def gmm(
   }
   call_gmm = qpl.pallas_call(
       kernel,
-      out_shape=jax.ShapeDtypeStruct((m, n), preferred_element_type),
+      out_shape=jax.ShapeDtypeStruct(
+          (m, n), preferred_element_type, manual_axis_type=jax.sharding.ManualAxisType(varying=frozenset(varying_axes))
+      ),
       grid_spec=pltpu.PrefetchScalarGridSpec(
           num_scalar_prefetch=2,
           in_specs=[
@@ -565,6 +569,7 @@ def gmm(
         "tiling",
         "num_actual_groups",
         "interpret",
+        "varying_axes",
     ],
 )
 def tgmm(
@@ -577,6 +582,7 @@ def tgmm(
     num_actual_groups: int | None = None,
     existing_out: jnp.ndarray | None = None,
     interpret: bool = False,
+    varying_axes: tuple[str, ...] = (),
 ) -> jnp.ndarray:
   """Compute lhs[:, sizes[i-1]:sizes[i]] @ rhs[sizes[i-1]:sizes[i], :].
 
@@ -775,7 +781,11 @@ def tgmm(
   }
   call_gmm = qpl.pallas_call(
       kernel,
-      out_shape=jax.ShapeDtypeStruct((num_actual_groups, k, n), preferred_element_type),
+      out_shape=jax.ShapeDtypeStruct(
+          (num_actual_groups, k, n),
+          preferred_element_type,
+          manual_axis_type=jax.sharding.ManualAxisType(varying=frozenset(varying_axes)),
+      ),
       grid_spec=pltpu.PrefetchScalarGridSpec(
           num_scalar_prefetch=2,
           in_specs=[

--- a/src/maxtext/kernels/megablox/ops.py
+++ b/src/maxtext/kernels/megablox/ops.py
@@ -60,6 +60,8 @@ def gmm(
     use_qwix_quantization: bool = False,
     use_tokamax_backend: bool = False,
     weight_gather_axes: List[Tuple[str, int]] | None = None,
+    lhs_vma_axes: tuple = tuple(),
+    rhs_vma_axes: tuple = tuple(),
     # TODO(amandaliang): get rid of the qwix_rule in favor of Qwix's interception feature
     qwix_rule: qwix.QtRule | None = None,
     use_manual_quantization: bool = False,
@@ -82,7 +84,7 @@ def gmm(
       )
 
   gmm_fwd_bwd = lambda *args: _gmm_fwd(*args)[0]  # pylint: disable=C3001
-  gmm_fwd_bwd = jax.custom_vjp(gmm_fwd_bwd, nondiff_argnums=(3, 4, 7, 8, 9, 10, 11, 12))
+  gmm_fwd_bwd = jax.custom_vjp(gmm_fwd_bwd, nondiff_argnums=(3, 4, 7, 8, 9, 10, 11, 12, 13, 14))
   gmm_fwd_bwd.defvjp(_gmm_fwd, functools.partial(_gmm_bwd, lhs.dtype, rhs.dtype))
   return gmm_fwd_bwd(
       lhs,
@@ -98,6 +100,8 @@ def gmm(
       use_tokamax_backend,
       weight_gather_axes,
       use_manual_quantization,
+      lhs_vma_axes,
+      rhs_vma_axes,
   )
 
 
@@ -125,6 +129,8 @@ def _gmm_fwd(
     use_tokamax_backend: bool = False,
     weight_gather_axes: List[Tuple[str, int]] | None = None,
     use_manual_quantization: bool = False,
+    lhs_vma_axes: tuple = tuple(),
+    rhs_vma_axes: tuple = tuple(),
 ) -> tuple[
     jnp.ndarray,
     tuple[
@@ -205,6 +211,9 @@ def _gmm_fwd(
         transpose_rhs=transpose_rhs,
         interpret=interpret,
     )
+    for axis in lhs_vma_axes:
+      out = jax.lax.pcast(out, axis_name=axis, to="varying")
+
   return out, (lhs, rhs, group_sizes, group_offset)
 
 
@@ -219,6 +228,8 @@ def _gmm_bwd(
     use_tokamax_backend: bool,
     weight_gather_axes: List[Tuple[str, int]] | None,
     use_manual_quantization: bool,
+    lhs_vma_axes: tuple,
+    rhs_vma_axes: tuple,
     residual: tuple[
         jnp.ndarray | qpl.QArray,
         jnp.ndarray | qpl.QArray,
@@ -334,7 +345,9 @@ def _gmm_bwd(
         group_offset,
         transpose_rhs=not transpose_rhs,
         interpret=interpret,
+        varying_axes=lhs_vma_axes,
     )
+
     drhs = backend.tgmm(
         lhs.swapaxes(0, 1),
         drhs_dout,
@@ -344,6 +357,7 @@ def _gmm_bwd(
         group_offset,
         num_actual_groups,
         interpret=interpret,
+        varying_axes=rhs_vma_axes,
     )
 
   # NOTE: If the rhs transposition is fused into the forward pass we need to

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -1185,6 +1185,20 @@ class RoutedMoE(nnx.Module):
       return lhs_quantize_dtype, rhs_quantize_dtype
 
     def gmm(inputs, kernel, tiling, group_sizes, expert_assignments, weight_gather_axes):
+      def extract_vma(tensor):
+        # Parses the varying mesh axes from JAX's type string for a tensor inside shard_map.
+        # jax.typeof(t) renders as e.g. 'f32[128,256]{V:(expert, fsdp)}'; this extracts
+        # ('expert', 'fsdp'). Returns () if the tensor has no varying axes.
+        type_str = str(jax.typeof(tensor))
+        if "{V:" in type_str:
+          start = type_str.index("{V:") + 3
+          end = type_str.index("}", start)
+          vma_content = type_str[start:end].strip("()")
+          return tuple(sorted(a.strip() for a in vma_content.split(",")))
+        return tuple()
+
+      lhs_vma_axes = extract_vma(inputs)
+      rhs_vma_axes = extract_vma(kernel)
       if inputs.shape[0] != expert_assignments.shape[0]:
         raise ValueError("The number of input tokens must match the number of expert assignments!")
 
@@ -1210,6 +1224,8 @@ class RoutedMoE(nnx.Module):
               use_qwix_quantization=self.config.use_qwix_quantization,
               use_tokamax_backend=self.config.use_tokamax_gmm,
               weight_gather_axes=weight_gather_axes,
+              lhs_vma_axes=lhs_vma_axes,
+              rhs_vma_axes=rhs_vma_axes,
           )
         else:  # tokamax (unquantized)
           output = tokamax.ragged_dot(
@@ -1232,6 +1248,8 @@ class RoutedMoE(nnx.Module):
             use_qwix_quantization=self.config.use_qwix_quantization,
             use_tokamax_backend=self.config.use_tokamax_gmm,
             weight_gather_axes=weight_gather_axes,
+            lhs_vma_axes=lhs_vma_axes,
+            rhs_vma_axes=rhs_vma_axes,
         )
       else:  # jax.lax.ragged_dot
         output = jax_ragged_dot_gmm(inputs, kernel, tiling, group_sizes, expert_assignments, padding_amount)
@@ -1532,7 +1550,7 @@ class RoutedMoE(nnx.Module):
             P(),  # Handle None or replicate the output
             P(),  # Handle None or replicate the output
         ),
-        check_vma=False,
+        check_vma=self.config.check_vma,
     )
     def wrapper(x, logits, pre_bias_logits, w0, w1, wo, w0_bias, w1_bias, wo_bias, rngs):
       batch_size, sequence_length, _ = x.shape

--- a/tests/integration/check_vma_test.py
+++ b/tests/integration/check_vma_test.py
@@ -1,0 +1,163 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for check_vma in megablox MoE training."""
+
+import os
+
+# Must be set before JAX imports so the TPU backend initializes correctly.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+os.environ.setdefault("TPU_LIBRARY_PATH", os.path.join(_REPO_ROOT, "libtpu.so"))
+os.environ.setdefault("JAX_PLATFORMS", "tpu,cpu")
+os.environ.setdefault("ENABLE_PJRT_COMPATIBILITY", "true")
+os.environ.setdefault("ENABLE_PATHWAYS_PERSISTENCE", "1")
+
+import pytest
+from absl.testing import absltest
+from tempfile import gettempdir
+
+from maxtext.trainers.pre_train.train_compile import main as train_compile_main
+from tests.utils.test_helpers import get_test_config_path
+
+_BASE_ARGS = (
+    None,
+    get_test_config_path(),
+    "compile_topology=tpu7x-16",
+    "compile_topology_num_slices=1",
+    "shard_mode=auto",
+    "allow_split_physical_axes=true",
+    "model_name=deepseek3-test",
+    "num_experts=16",
+    "override_model_config=True",
+    "sparse_matmul=True",
+    "megablox=True",
+    "use_ring_of_experts=false",
+    "use_random_routing=false",
+    "per_device_batch_size=4",
+    "max_target_length=128",
+    "attention=flash",
+    "dtype=bfloat16",
+    "use_iota_embed=true",
+    "enable_checkpointing=false",
+    "async_checkpointing=false",
+)
+
+
+@pytest.mark.tpu_backend
+class CheckVmaTest(absltest.TestCase):
+  """Tests that megablox MoE compiles under different check_vma / shard_mode settings."""
+
+  @pytest.mark.cpu_only
+  def test_check_vma(self):
+    """check_vma=True with fsdp and expert parallelism."""
+    temp_dir = gettempdir()
+    train_compile_main(
+        _BASE_ARGS
+        + (
+            f"compiled_trainstep_file={os.path.join(temp_dir, 'check_vma.pickle')}",
+            "check_vma=True",
+            "ici_fsdp_parallelism=4",
+            "ici_expert_parallelism=-1",
+        )
+    )
+
+  @pytest.mark.cpu_only
+  def test_check_vma_disabled(self):
+    """check_vma=False (default) should also compile correctly."""
+    temp_dir = gettempdir()
+    train_compile_main(
+        _BASE_ARGS
+        + (
+            f"compiled_trainstep_file={os.path.join(temp_dir, 'check_vma_disabled.pickle')}",
+            "check_vma=False",
+            "ici_fsdp_parallelism=4",
+            "ici_expert_parallelism=-1",
+        )
+    )
+
+  @pytest.mark.cpu_only
+  def test_check_vma_pure_fsdp(self):
+    """check_vma=True with only FSDP parallelism (no expert parallelism)."""
+    temp_dir = gettempdir()
+    train_compile_main(
+        _BASE_ARGS
+        + (
+            f"compiled_trainstep_file={os.path.join(temp_dir, 'check_vma_pure_fsdp.pickle')}",
+            "check_vma=True",
+            "ici_fsdp_parallelism=-1",
+            "ici_expert_parallelism=1",
+        )
+    )
+
+  @pytest.mark.cpu_only
+  def test_check_vma_pure_ep(self):
+    """check_vma=True with only expert parallelism (no FSDP)."""
+    temp_dir = gettempdir()
+    train_compile_main(
+        _BASE_ARGS
+        + (
+            f"compiled_trainstep_file={os.path.join(temp_dir, 'check_vma_pure_ep.pickle')}",
+            "check_vma=True",
+            "ici_fsdp_parallelism=1",
+            "ici_expert_parallelism=-1",
+        )
+    )
+
+  @pytest.mark.cpu_only
+  def test_check_vma_error_extra_parallelism(self):
+    """check_vma=True must raise ValueError when a non-EP/FSDP ICI axis is enabled."""
+    with self.assertRaises(ValueError):
+      train_compile_main(
+          _BASE_ARGS
+          + (
+              f"compiled_trainstep_file={os.path.join(gettempdir(), 'check_vma_extra_par.pickle')}",
+              "check_vma=True",
+              "ici_fsdp_parallelism=4",
+              "ici_expert_parallelism=-1",
+              "ici_data_parallelism=2",
+          )
+      )
+
+  @pytest.mark.cpu_only
+  def test_check_vma_error_tokamax_gmm(self):
+    """check_vma=True must raise ValueError when use_tokamax_gmm=True."""
+    with self.assertRaises(ValueError):
+      train_compile_main(
+          _BASE_ARGS
+          + (
+              f"compiled_trainstep_file={os.path.join(gettempdir(), 'check_vma_tokamax.pickle')}",
+              "check_vma=True",
+              "ici_fsdp_parallelism=4",
+              "ici_expert_parallelism=-1",
+              "use_tokamax_gmm=True",
+          )
+      )
+
+  @pytest.mark.cpu_only
+  def test_explicit_shard_mode(self):
+    """shard_mode=explicit should compile correctly without check_vma (check_vma not supported here)."""
+    temp_dir = gettempdir()
+    train_compile_main(
+        _BASE_ARGS
+        + (
+            f"compiled_trainstep_file={os.path.join(temp_dir, 'explicit_shard.pickle')}",
+            "shard_mode=explicit",
+            "ici_fsdp_parallelism=4",
+            "ici_expert_parallelism=-1",
+        )
+    )
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
PUBLIC:
Add support for check vma in megablox kernel. This removes unnecessary collectives in the backward pass, and improves performance significantly when per device batch size is low. 

Benchmarking results (diff is with check vma enabled):
| Configuration | | TFLOP/s/dev | tokens/s/dev | TFLOP/s improvement | tokens/s improvement |
|---|---|---|---|---|---|
| High batch size | Baseline | ~260 | ~1020 | — | — |
| High batch size | Diff | ~260 | ~1030 | 0% | +1% |
| FSDP only | Baseline | ~60 | ~240 | — | — |
| FSDP only | Diff | ~80 | ~319 | +33% | +33% |
| FSDP + EP | Baseline | ~47 | ~188 | — | — |
| FSDP + EP | Diff | ~68 | ~271 | +45% | +44% |

check_vma is a jax.shard_map flag that lets callers explicitly declare which mesh axes a tensor varies over. When disabled (the default), JAX infers sharding and injects defensive all-reduces (psums) in the backward pass to guarantee correctness, even when those communications are redundant. Enabling it and passing the correct varying axes removes those unnecessary collectives.

Example command for FSDP only sharding:
```
#!/bin/bash

# --- Environment Variables ---
export CLUSTER_NAME=bodaborg-super-xpk-v54
export ZONE=us-central1-ai1a 
export PROJECT_ID=cloud-tpu-multipod-dev
export BASE_OUTPUT_DIR=gs://shuwenf-maxtext-logs 
export DEVICE_TYPE=tpu7x-256
export WORKLOAD_NAME="$(printf "%.26s" "${USER//_/-}-ds3-671b-4x4x8")-$(date +%Y%m%d-%H%M)"

# XLA Flags
XLA_FLAGS=" \
  --xla_tpu_dvfs_p_state=7 \
  --xla_tpu_scoped_vmem_limit_kib=65536 \
  --xla_tpu_bf16_emission_mode=NATIVE_EMISSION \
  --xla_tpu_enable_sparse_core_reduce_scatter_v2=true \
  --xla_tpu_enable_sparse_core_collective_offload_all_gather=true \
  --xla_tpu_enable_sparse_core_collective_offload_2d_all_gather=true \
  --xla_tpu_enable_all_gather_offload_tracing=true \
  --xla_tpu_use_tc_device_shape_on_sc=True \
  --xla_sc_disable_megacore_partitioning=True \
  --xla_tpu_enable_async_collective_fusion_fuse_all_gather=false \
  --xla_enable_async_all_gather=true \
  --xla_tpu_prefer_async_allgather_to_allreduce=true \
  --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true \
  --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true \
  --xla_tpu_enable_sparse_core_collective_offload_3d_all_gather=true \
  --xla_tpu_use_single_sparse_core_for_all_gather_offload=true \
  --xla_tpu_enable_concurrent_sparse_core_offloading=true \
  --xla_tpu_aggressive_opt_barrier_removal=true \
  --xla_tpu_enable_offloading_gather_to_sparsecore=true \
  --xla_tpu_sparse_core_all_gather_latency_multiplier=1 \
  --xla_tpu_sparse_core_reduce_scatter_latency_multiplier=3 \
  --xla_tpu_enable_sparse_core_collective_aggregator=true \
  --xla_tpu_enable_latency_hiding_layer_scheduler=true \
  --xla_tpu_scheduler_percent_shared_memory_limit=150 \
  --xla_tpu_enable_layer_scheduler_for_dependent_collectives=true \
  --xla_tpu_enable_sparse_core_collective_offload_nd_reduce_scatter=true \
  --xla_tpu_pcie_bandwidth_multiplier=0.03 \
  --xla_tpu_enable_sparse_core_offload_queuing_in_lhs=true \
  --xla_tpu_enable_multi_compute_overlap_in_layer_scheduler=false \
  --xla_tpu_enable_3d_reduce_scatter_decomposer=false "

# MaxText Workload Overrides
MAXTEXT_ARGS="\
model_name=deepseek3-671b \
per_device_batch_size=1.0 \
max_target_length=4096 \
dcn_pipeline_parallelism=1 \
dcn_data_parallelism=-1 \
ici_pipeline_parallelism=1 \
ici_fsdp_transpose_parallelism=1 \
ici_fsdp_parallelism=-1 \
allow_split_physical_axes=True \
use_iota_embed=True \
remat_policy=custom \
decoder_layer_input=offload \
opt_type=adamw \
mu_dtype=bfloat16 \
grad_dtype=bfloat16 \
use_random_routing=True \
megablox=True \
sparse_matmul=True \
use_custom_sort_vjp=True \
shard_exp_on_fsdp=True \
sa_use_fused_bwd_kernel=True \
sa_block_q=2048 \
sa_block_kv=2048 \
sa_block_q_dkv=2048 \
sa_block_kv_dkv=2048 \
sa_block_kv_dkv_compute=2048 \
sa_block_kv_dq=2048 \
sa_block_q_dq=2048 \
attention=flash \
use_tokamax_splash=True \
use_max_logit_estimate=-1 \
cost_estimate_flops_fwd=5000000000000 \
cost_estimate_flops_bwd=5000000000000 \
float32_weight_sum=False \
use_tokamax_gmm=False \
tokenizer_path=assets/tokenizer.mistral-v3 \
dataset_type=synthetic \
dataset_path=gs://max-datasets-rogue \
enable_checkpointing=False \
steps=30 \
log_config=true \
profiler=xplane \
base_output_directory=${BASE_OUTPUT_DIR} \
run_name=${WORKLOAD_NAME}"

xpk workload create \
  --cluster=$CLUSTER_NAME \
  --project=$PROJECT_ID \
  --zone=$ZONE \
  --priority=very-high \
  --max-restarts=0 \
  --device-type=tpu7x-4x4x8 \
  --num-slices=1 \
  --docker-image=gcr.io/tpu-prod-env-one-vm/chengnuojin_google_com_checkvma \
  --workload="${WORKLOAD_NAME}" \
  --command="set -e && export ENABLE_PATHWAYS_PERSISTENCE='1' && \
export LIBTPU_INIT_ARGS='${XLA_FLAGS}' && \
export TF_CPP_MIN_LOG_LEVEL=0 && \
export JAX_PLATFORMS='tpu,cpu' && export ENABLE_PJRT_COMPATIBILITY='true' && \
python3 -m MaxText.train maxtext/configs/base.yml ${MAXTEXT_ARGS}"
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

