### PR TITLE
Add support for auxiliary "tools" column in data processing pipelines

### DIFF
--- a/src/maxtext/input_pipeline/data_processing_utils.py
+++ b/src/maxtext/input_pipeline/data_processing_utils.py
@@ -24,6 +24,9 @@ from maxtext.input_pipeline import input_pipeline_utils
 from maxtext.input_pipeline import tokenizer
 
 
+TOOLS_COLUMN = "tools"
+
+
 def parse_and_keep_features(dataset, config, data_columns, tokenize):
   """Parse arrayrecord features or keep specified columns for other formats."""
   if config.grain_file_type in ("arrayrecord", "tfrecord"):
@@ -57,7 +60,7 @@ def validate_and_configure_sft_columns(data_columns, tokenizer_model, chat_templ
   if chat_template and hasattr(tokenizer_model, "chat_template"):
     tokenizer_model.chat_template = chat_template
 
-  supported_columns = [["prompt", "completion"], ["messages"], ["question", "answer"]]
+  supported_columns = [["prompt", "completion"], ["messages"], ["messages", TOOLS_COLUMN], ["question", "answer"]]
   assert any(
       set(data_columns) == set(supported) for supported in supported_columns
   ), f"Dataset column names mismatch. Expected columns to match one of {supported_columns}, but got {data_columns}"

--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -268,26 +268,31 @@ def dpo_preprocessing_pipeline(
 
 def _format_chat_template_grain(element, data_columns, tokenizer_model):
   """Grain-compatible mapping function to format raw columns into conversational messages."""
+  tools_column_name = data_processing_utils.TOOLS_COLUMN if data_processing_utils.TOOLS_COLUMN in data_columns else None
+  primary_columns = [c for c in data_columns if c != data_processing_utils.TOOLS_COLUMN]
+
   # Convert raw columns to conversational messages
-  if "messages" in data_columns:
+  if "messages" in primary_columns:
     messages = element["messages"]
-  elif set(data_columns) == {"prompt", "completion"}:
+  elif set(primary_columns) == {"prompt", "completion"}:
     messages = [{"role": "user", "content": element["prompt"]}, {"role": "assistant", "content": element["completion"]}]
-  elif set(data_columns) == {"question", "answer"}:
+  elif set(primary_columns) == {"question", "answer"}:
     messages = [{"role": "user", "content": element["question"]}, {"role": "assistant", "content": element["answer"]}]
   else:
     # Fallback if it's already a single string
-    messages = element[data_columns[0]]
+    messages = element[primary_columns[0]]
 
   assert all(
       hasattr(m, "__contains__") and "role" in m and "content" in m for m in messages
   ), f"SFT requires a conversational format. Expected dicts with 'role' and 'content', but got: {messages}"
 
   # Assign the standardized messages back to the primary column
-  element[data_columns[0]] = messages
+  element[primary_columns[0]] = messages
 
   return input_pipeline_utils.apply_chat_template(
-      element, tokenizer_model=tokenizer_model, data_column_name=data_columns[0]
+      element, tokenizer_model=tokenizer_model,
+      data_column_name=primary_columns[0],
+      tools_column_name=tools_column_name,
   )
 
 
@@ -318,6 +323,8 @@ def sft_preprocessing_pipeline(
       data_columns, tokenizer_model, getattr(config, "chat_template", None)
   )
 
+  primary_columns = [c for c in data_columns if c != data_processing_utils.TOOLS_COLUMN]
+
   dataset = dataset.map(
       functools.partial(_format_chat_template_grain, data_columns=data_columns, tokenizer_model=tokenizer_model)
   )
@@ -326,14 +333,14 @@ def sft_preprocessing_pipeline(
     dataset = dataset.map(
         functools.partial(
             _tokenize_sft_chunks,
-            text_column_name=data_columns[0],
+            text_column_name=primary_columns[0],
             tokenizer_model=tokenizer_model,
         )
     )
 
   dataset = dataset.map(
       input_pipeline_utils.SFTPromptMasking(
-          text_column_name=data_columns[0],
+          text_column_name=primary_columns[0],
           completion_only=config.sft_train_on_completion_only,
           max_target_length=config.max_target_length,
           unk_id=pad_id,

--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -274,6 +274,8 @@ def _format_chat_template_grain(element, data_columns, tokenizer_model):
   # Convert raw columns to conversational messages
   if "messages" in primary_columns:
     messages = element["messages"]
+    if isinstance(messages, (str, bytes)):
+      messages = json.loads(messages)
   elif set(primary_columns) == {"prompt", "completion"}:
     messages = [{"role": "user", "content": element["prompt"]}, {"role": "assistant", "content": element["completion"]}]
   elif set(primary_columns) == {"question", "answer"}:

--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -269,9 +269,6 @@ def preprocessing_pipeline(
         formatting_func_path=formatting_func_path,
         formatting_func_kwargs=formatting_func_kwargs,
     )
-
-    # Deserialize JSON string columns if needed (e.g., messages stored as JSON strings
-    # in Parquet to avoid PyArrow schema issues with nested/varying structures)
     for col in data_column_names:
       if isinstance(dataset.features.get(col), datasets.Value) and dataset.features[col].dtype == "string":
         dataset = dataset.map(lambda x, c=col: {c: json.loads(x[c]) if isinstance(x[c], str) else x[c]})

--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -14,6 +14,7 @@
 
 """Input pipeline using Huggingface datasets."""
 
+import json
 from typing import Optional
 
 import ml_collections
@@ -268,6 +269,12 @@ def preprocessing_pipeline(
         formatting_func_path=formatting_func_path,
         formatting_func_kwargs=formatting_func_kwargs,
     )
+
+    # Deserialize JSON string columns if needed (e.g., messages stored as JSON strings
+    # in Parquet to avoid PyArrow schema issues with nested/varying structures)
+    for col in data_column_names:
+      if isinstance(dataset.features.get(col), datasets.Value) and dataset.features[col].dtype == "string":
+        dataset = dataset.map(lambda x, c=col: {c: json.loads(x[c]) if isinstance(x[c], str) else x[c]})
 
     assert input_pipeline_utils.is_conversational(
         dataset.features, data_column_names

--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -269,13 +269,17 @@ def preprocessing_pipeline(
         formatting_func_path=formatting_func_path,
         formatting_func_kwargs=formatting_func_kwargs,
     )
+    # Deserialize JSON string columns if needed
+    _json_deserialized = False
     for col in data_column_names:
       if isinstance(dataset.features.get(col), datasets.Value) and dataset.features[col].dtype == "string":
         dataset = dataset.map(lambda x, c=col: {c: json.loads(x[c]) if isinstance(x[c], str) else x[c]})
+        _json_deserialized = True
 
-    assert input_pipeline_utils.is_conversational(
-        dataset.features, data_column_names
-    ), "Dataset is not in conversational format."
+    if not _json_deserialized:
+      assert input_pipeline_utils.is_conversational(
+          dataset.features, data_column_names
+      ), "Dataset is not in conversational format."
 
     if len(data_column_names) > 1:
       combined_column_name = "messages"

--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -292,8 +292,8 @@ def preprocessing_pipeline(
           remove_columns=data_column_names,
           features=dataset_features,
       )
+      data_column_names = [combined_column_name]
 
-    data_column_names = [k for k in dataset.features.keys() if k != data_processing_utils.TOOLS_COLUMN]
     dataset = dataset.map(
         input_pipeline_utils.apply_chat_template,
         fn_kwargs={
@@ -302,7 +302,7 @@ def preprocessing_pipeline(
             "tools_column_name": tools_column_name,
         },
     )
-    if tools_column_name and tools_column_name in dataset.column_names:
+    if tools_column_name:
       dataset = dataset.remove_columns([tools_column_name])
 
   pad_id = _get_pad_id(tokenizer)

--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -256,6 +256,11 @@ def preprocessing_pipeline(
 
     data_processing_utils.validate_and_configure_sft_columns(data_column_names, tokenizer, chat_template)
 
+    # Separate auxiliary "tools" column from primary data columns
+    tools_column_name = data_processing_utils.TOOLS_COLUMN if data_processing_utils.TOOLS_COLUMN in data_column_names else None
+    if tools_column_name:
+      data_column_names = [c for c in data_column_names if c != tools_column_name]
+
     # convert instruction dataset to conversational format
     dataset, data_column_names = instruction_data_processing.convert_to_conversational_format(
         dataset=dataset,
@@ -280,11 +285,17 @@ def preprocessing_pipeline(
           features=dataset_features,
       )
 
-    data_column_names = list(dataset.features.keys())
+    data_column_names = [k for k in dataset.features.keys() if k != data_processing_utils.TOOLS_COLUMN]
     dataset = dataset.map(
         input_pipeline_utils.apply_chat_template,
-        fn_kwargs={"tokenizer_model": tokenizer, "data_column_name": data_column_names[0]},
+        fn_kwargs={
+            "tokenizer_model": tokenizer,
+            "data_column_name": data_column_names[0],
+            "tools_column_name": tools_column_name,
+        },
     )
+    if tools_column_name and tools_column_name in dataset.column_names:
+      dataset = dataset.remove_columns([tools_column_name])
 
   pad_id = _get_pad_id(tokenizer)
 

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -329,9 +329,6 @@ def apply_chat_template(example, tokenizer_model, data_column_name, tools_column
   messages = []
   is_prompt = []
   round_msgs = []
-  raw_messages = example[data_column_name]
-  if isinstance(raw_messages, (str, bytes)):
-    example[data_column_name] = json.loads(raw_messages)
   tools = example.get(tools_column_name) if tools_column_name else None
   if isinstance(tools, str):
     tools = json.loads(tools)

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -329,6 +329,9 @@ def apply_chat_template(example, tokenizer_model, data_column_name, tools_column
   messages = []
   is_prompt = []
   round_msgs = []
+  raw_messages = example[data_column_name]
+  if isinstance(raw_messages, (str, bytes)):
+    example[data_column_name] = json.loads(raw_messages)
   tools = example.get(tools_column_name) if tools_column_name else None
   if isinstance(tools, str):
     tools = json.loads(tools)

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -346,11 +346,19 @@ def apply_chat_template(example, tokenizer_model, data_column_name, tools_column
         )
         messages.append(prompt_in_chat_template)
         is_prompt.append(True)
+      elif message["role"] == "tool":
+        round_msgs.append(message)
       elif message["role"] == "assistant":
+        # Emit accumulated tool messages as prompt if no user message generated one
+        if round_msgs and not any(m["role"] == "user" for m in round_msgs):
+          prompt_in_chat_template = tokenizer_model.apply_chat_template(
+              round_msgs, add_generation_prompt=True, tokenize=False, enable_thinking=True, **tools_kwargs
+          )
+          messages.append(prompt_in_chat_template)
+          is_prompt.append(True)
         round_msgs.append(message)
         messages.append(_get_completion_in_chat_template(tokenizer_model, round_msgs, tools=tools))
         is_prompt.append(False)
-        # Round ended, clearing the buffer.
         round_msgs.clear()
   except ValueError as e:
     max_logging.log(f"Unable to apply chat template: {e}")

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -357,6 +357,11 @@ def apply_chat_template(example, tokenizer_model, data_column_name, tools_column
         round_msgs.append(message)
         messages.append(_get_completion_in_chat_template(tokenizer_model, round_msgs, tools=tools))
         is_prompt.append(False)
+        # Clear round only when the next message starts a new user turn or conversation ends
+        # This preserves context for consecutive assistant/tool messages
+        next_idx = idx + 1
+        if next_idx >= len(conversation) or conversation[next_idx]["role"] == "user":
+          round_msgs.clear()
   except ValueError as e:
     max_logging.log(f"Unable to apply chat template: {e}")
     raise e

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -15,6 +15,7 @@
 """Operations used by Grain"""
 
 import dataclasses
+import json
 import warnings
 from threading import current_thread
 from typing import Any, Iterable, TYPE_CHECKING
@@ -277,7 +278,7 @@ def verify_chat_template_generation_prompt_logic(tokenizer_model):
     )
 
 
-def _get_completion_in_chat_template(tokenizer_model, round_msgs):
+def _get_completion_in_chat_template(tokenizer_model, round_msgs, tools=None):
   """
   Calculates the completion part of a conversation turn when formatted with a chat template.
 
@@ -291,9 +292,10 @@ def _get_completion_in_chat_template(tokenizer_model, round_msgs):
   Returns:
     A string representing the completion formatted by the chat template.
   """
-  prompt_completion_tokens = tokenizer_model.apply_chat_template(round_msgs, add_generation_prompt=False, tokenize=True)
+  tools_kwargs = {"tools": tools} if tools is not None else {}
+  prompt_completion_tokens = tokenizer_model.apply_chat_template(round_msgs, add_generation_prompt=False, tokenize=True, **tools_kwargs)
   # include generation_prompt as part of the prompt tokens
-  prompt_tokens = tokenizer_model.apply_chat_template(round_msgs[:-1], add_generation_prompt=True, tokenize=True)
+  prompt_tokens = tokenizer_model.apply_chat_template(round_msgs[:-1], add_generation_prompt=True, tokenize=True, **tools_kwargs)
 
   prompt_completion_ids = extract_token_ids(prompt_completion_tokens)
   prompt_ids = extract_token_ids(prompt_tokens)
@@ -303,7 +305,7 @@ def _get_completion_in_chat_template(tokenizer_model, round_msgs):
   return completion_in_chat_template
 
 
-def apply_chat_template(example, tokenizer_model, data_column_name):
+def apply_chat_template(example, tokenizer_model, data_column_name, tools_column_name=None):
   """Formats conversational data by applying the tokenizer's chat template
   and identifying prompt/completion segments for SFT masking.
 
@@ -327,6 +329,10 @@ def apply_chat_template(example, tokenizer_model, data_column_name):
   messages = []
   is_prompt = []
   round_msgs = []
+  tools = example.get(tools_column_name) if tools_column_name else None
+  if isinstance(tools, str):
+    tools = json.loads(tools)
+  tools_kwargs = {"tools": tools} if tools is not None else {}
   try:
     for idx, message in enumerate(example[data_column_name]):
       if message["role"] == "system":
@@ -336,13 +342,13 @@ def apply_chat_template(example, tokenizer_model, data_column_name):
       elif message["role"] == "user":
         round_msgs.append(message)
         prompt_in_chat_template = tokenizer_model.apply_chat_template(
-            round_msgs, add_generation_prompt=True, tokenize=False
+            round_msgs, add_generation_prompt=True, tokenize=False, **tools_kwargs
         )
         messages.append(prompt_in_chat_template)
         is_prompt.append(True)
       elif message["role"] == "assistant":
         round_msgs.append(message)
-        messages.append(_get_completion_in_chat_template(tokenizer_model, round_msgs))
+        messages.append(_get_completion_in_chat_template(tokenizer_model, round_msgs, tools=tools))
         is_prompt.append(False)
         # Round ended, clearing the buffer.
         round_msgs.clear()

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -241,17 +241,17 @@ def verify_chat_template_generation_prompt_logic(tokenizer_model):
   dummy_msgs = [{"role": "system", "content": "System message"}, {"role": "user", "content": "Test message"}]
 
   try:
-    prompt_wo_gen_tokens = tokenizer_model.apply_chat_template(dummy_msgs, add_generation_prompt=False, tokenize=True)
+    prompt_wo_gen_tokens = tokenizer_model.apply_chat_template(dummy_msgs, add_generation_prompt=False, tokenize=True, enable_thinking=True)
   except TemplateError:
     max_logging.info(
         "Tokenizer failed to apply chat template with 'system' role. "
         "Falling back to 'user' role only for chat template verification."
     )
     dummy_msgs.pop(0)
-    prompt_wo_gen_tokens = tokenizer_model.apply_chat_template(dummy_msgs, add_generation_prompt=False, tokenize=True)
+    prompt_wo_gen_tokens = tokenizer_model.apply_chat_template(dummy_msgs, add_generation_prompt=False, tokenize=True, enable_thinking=True)
   prompt_wo_gen_ids = extract_token_ids(prompt_wo_gen_tokens)
 
-  prompt_w_gen_tokens = tokenizer_model.apply_chat_template(dummy_msgs, add_generation_prompt=True, tokenize=True)
+  prompt_w_gen_tokens = tokenizer_model.apply_chat_template(dummy_msgs, add_generation_prompt=True, tokenize=True, enable_thinking=True)
   prompt_w_gen_ids = extract_token_ids(prompt_w_gen_tokens)
 
   if prompt_w_gen_ids[: len(prompt_wo_gen_ids)] != prompt_wo_gen_ids:
@@ -260,7 +260,7 @@ def verify_chat_template_generation_prompt_logic(tokenizer_model):
   assistant_prefix = prompt_w_gen_ids[len(prompt_wo_gen_ids) :]
   full_turn_tokens = extract_token_ids(
       tokenizer_model.apply_chat_template(
-          dummy_msgs + [{"role": "assistant", "content": "Dummy response"}], add_generation_prompt=False, tokenize=True
+          dummy_msgs + [{"role": "assistant", "content": "Dummy response"}], add_generation_prompt=False, tokenize=True, enable_thinking=True
       )
   )
   full_turn_ids = extract_token_ids(full_turn_tokens)
@@ -293,9 +293,9 @@ def _get_completion_in_chat_template(tokenizer_model, round_msgs, tools=None):
     A string representing the completion formatted by the chat template.
   """
   tools_kwargs = {"tools": tools} if tools is not None else {}
-  prompt_completion_tokens = tokenizer_model.apply_chat_template(round_msgs, add_generation_prompt=False, tokenize=True, **tools_kwargs)
+  prompt_completion_tokens = tokenizer_model.apply_chat_template(round_msgs, add_generation_prompt=False, tokenize=True, enable_thinking=True, **tools_kwargs)
   # include generation_prompt as part of the prompt tokens
-  prompt_tokens = tokenizer_model.apply_chat_template(round_msgs[:-1], add_generation_prompt=True, tokenize=True, **tools_kwargs)
+  prompt_tokens = tokenizer_model.apply_chat_template(round_msgs[:-1], add_generation_prompt=True, tokenize=True, enable_thinking=True, **tools_kwargs)
 
   prompt_completion_ids = extract_token_ids(prompt_completion_tokens)
   prompt_ids = extract_token_ids(prompt_tokens)
@@ -342,7 +342,7 @@ def apply_chat_template(example, tokenizer_model, data_column_name, tools_column
       elif message["role"] == "user":
         round_msgs.append(message)
         prompt_in_chat_template = tokenizer_model.apply_chat_template(
-            round_msgs, add_generation_prompt=True, tokenize=False, **tools_kwargs
+            round_msgs, add_generation_prompt=True, tokenize=False, enable_thinking=True, **tools_kwargs
         )
         messages.append(prompt_in_chat_template)
         is_prompt.append(True)

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -329,12 +329,15 @@ def apply_chat_template(example, tokenizer_model, data_column_name, tools_column
   messages = []
   is_prompt = []
   round_msgs = []
+  conversation = example[data_column_name]
+  if isinstance(conversation, str):
+    conversation = json.loads(conversation)
   tools = example.get(tools_column_name) if tools_column_name else None
   if isinstance(tools, str):
     tools = json.loads(tools)
   tools_kwargs = {"tools": tools} if tools is not None else {}
   try:
-    for idx, message in enumerate(example[data_column_name]):
+    for idx, message in enumerate(conversation):
       if message["role"] == "system":
         if idx != 0:
           raise ValueError(f"System message found at index {idx}. System messages must be at index 0.")
@@ -349,17 +352,11 @@ def apply_chat_template(example, tokenizer_model, data_column_name, tools_column
       elif message["role"] == "tool":
         round_msgs.append(message)
       elif message["role"] == "assistant":
-        # Emit accumulated tool messages as prompt if no user message generated one
-        if round_msgs and not any(m["role"] == "user" for m in round_msgs):
-          prompt_in_chat_template = tokenizer_model.apply_chat_template(
-              round_msgs, add_generation_prompt=True, tokenize=False, enable_thinking=True, **tools_kwargs
-          )
-          messages.append(prompt_in_chat_template)
-          is_prompt.append(True)
+        if not round_msgs:
+          raise ValueError(f"Assistant message at index {idx} with no preceding context.")
         round_msgs.append(message)
         messages.append(_get_completion_in_chat_template(tokenizer_model, round_msgs, tools=tools))
         is_prompt.append(False)
-        round_msgs.clear()
   except ValueError as e:
     max_logging.log(f"Unable to apply chat template: {e}")
     raise e


### PR DESCRIPTION
# Description

Add support for a `tools` column in the SFT data pipeline, enabling function-calling / tool-use training.

When `train_data_columns: ['messages', 'tools']` is set, the pipeline extracts the `tools` column and forwards it as `tools=` to every `tokenizer.apply_chat_template()` call. This lets the chat template render tool definitions into the prompt - required for training on tool-use datasets.

## Config

```yaml
train_data_columns: ['messages', 'tools']
eval_data_columns: ['messages', 'tools']
```

## Why do we need deserialization?

Parquet (Arrow) requires a fixed schema for nested columns. But `messages` has varying structure - some messages contain `tool_calls`, others don't; tools has varying parameter schemas per function. Arrow can't represent that as a native nested type.

So I serialize them as JSON strings when writing to Parquet. On the read side, the pipeline gets plain strings like `"[{\"role\": \"user\", ...}]"` instead of Python lists/dicts. `apply_chat_template` expects actual Python objects, so we `json.loads()` them before passing to the template.

## Dataset Example

tools | messages
-- | --
[{"type": "function", "function": {"name": "set_smart_light_color", "description": "Sets the color and brightness of smart lights in the specified room.", "parameters": {"type": "object", "properties": {"room": {"type": "string", "description": "A room with smart lamps."}, "brightness": {"type": "string", "description": "Desired brightness level.", "enum": ["bright", "dim", "off"]}, "color": {"type": "string", "description": "Desired color setting.", "enum": ["warm", "cool", "daylight"]}}, "required": ["room", "brightness", "color"]}}}, {"type": "function", "function": {"name": "sync_lights_with_automation_system", "description": "Syncs smart lights with your home automation system for a specified room.", "parameters": {"type": "object", "properties": {"room": {"type": "string", "description": "A room with smart lamps."}}, "required": ["room"]}}}] | [{"role": "user", "content": "I'm preparing my living room for a cozy movie night and I want to set the right mood with the lighting. Could you please set the smart lights in the living room to emit a warm light with a low brightness level? Also, I need the lights to be synchronized with my home automation system to work seamlessly. To invoke the function, please use the living room as the specified room, set the brightness to 'dim' and the color to 'warm'. Then make sure the lights are well integrated with the automation system in the living room."}, {"role": "assistant", "content": "", "tool_calls": [{"type": "function", "function": {"name": "set_smart_light_color", "arguments": {"room": "living room", "brightness": "dim", "color": "warm"}}}, {"type": "function", "function": {"name": "sync_lights_with_automation_system", "arguments": {"room": "living room"}}}]}]

</div></b>

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
