### PR TITLE
Add sphinx.ext.mathjax to fix formula rendering

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ extensions = [
     "sphinx_design",
     "sphinx_copybutton",
     "sphinx.ext.napoleon",
+    "sphinx.ext.mathjax",
     # This needs to be before autodoc^
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",


### PR DESCRIPTION
Adds sphinx.ext.mathjax to the Sphinx extensions in conf.py to enable formula rendering in the documentation. This fixes issues where formulas parsed by MyST's dollarmath were not displayed correctly in the HTML output on ReadTheDocs.

FIXES: b/501246406

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
