### PR TITLE
Kimi-K2 release update

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See our guide on running MaxText in decoupled mode, without any GCP dependencies
 
 ## 🔥 Latest news 🔥
 
+* \[April 13, 2026\] Kimi-K2 is now supported, along with MuonClip optimizer. Try the [kimi-k2-1t](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/models/kimi-k2-1t.yml) config and check the [user guide](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/kimi/Run_Kimi.md).  
 * \[April 10, 2026\] [DeepSeek-V3.2](https://arxiv.org/pdf/2512.02556) is now supported, featuring DeepSeek Sparse Attention for long context. Try it out with the [deepseek3.2-671b](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/models/deepseek3.2-671b.yml) config. See the [user guide](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/deepseek/Run_DeepSeek.md) for more details.  
 * \[April 2, 2026\] Gemma 4 multi-modal models (26B MoE, 31B dense) are now supported! Try them out with our [gemma4-26b](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/models/gemma4-26b.yml) and [gemma4-31b](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/models/gemma4-31b.yml) configs. For more details, see [Run_Gemma4.md](https://github.com/AI-Hypercomputer/maxtext/blob/main/tests/end_to_end/tpu/gemma4/Run_Gemma4.md).
 * \[March 6, 2026\] New features from DeepSeek-AI are now supported: Conditional Memory via Scalable Lookup ([Engram](https://arxiv.org/abs/2601.07372)) and Manifold-Constrained Hyper-Connections ([mHC](https://arxiv.org/abs/2512.24880)). Try them out with our [deepseek-custom](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/models/deepseek-custom.yml) starter config.
@@ -120,9 +121,12 @@ MaxText aims to provide you with the best OSS models, whether as a reference imp
   * Qwen 3 MoE (30B, 235B)
   * Qwen 3 Dense (0.6B, 1.7B, 4B, 8B, 14B, 32B)
 * DeepSeek
+  * DeepSeek V3.2 (671B)  
   * DeepSeek V3.1 (671B)
   * DeepSeek V3 0324 (671B) & DeepSeek R1 0528 (671B)
   * DeepSeek V2 (16B, 236B)
+* Kimi
+  * Kimi K2
 * Meta
   * Llama 4 Scout (109B) & Maverick (400B)
   * Llama 3.3 70B, 3.1 (8B, 70B, 405B), 3.0 (8B, 70B, 405B)

--- a/tests/end_to_end/tpu/kimi/Run_Kimi.md
+++ b/tests/end_to_end/tpu/kimi/Run_Kimi.md
@@ -1,0 +1,190 @@
+<!--
+ # Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ -->
+
+# Kimi
+
+Kimi is a family of high-performance, open-weights sparse MoE models by Moonshot AI designed for agentic intelligence. The currently supported models are **Kimi K2 (1T)**.
+
+* **[Kimi K2](https://arxiv.org/pdf/2507.20534)** features a massive 1.04 trillion total parameters with 32 billion activated parameters. The architecture is similar to DeepSeek-V3. It utilizes **Multi-Head Latent Attention (MLA)** and an ultra-sparse MoE with **384 experts**, optimized for long-context and agentic tasks.
+* **MuonClip Optimizer**: Kimi K2 was trained using the token-efficient [Muon](https://kellerjordan.github.io/posts/muon) optimizer combined with a novel **QK-clip** technique to ensure training stability and eliminate loss spikes during large-scale pre-training.
+* **Agentic Excellence**: K2 is specifically post-trained using a large-scale agentic data synthesis pipeline and Reinforcement Learning (RL), achieving state-of-the-art performance on benchmarks like Tau2-Bench and SWE-Bench.
+
+## Checkpoint Conversion
+1. To get started, download the model from HuggingFace: [moonshotai/Kimi-K2-Instruct](https://huggingface.co/moonshotai/Kimi-K2-Instruct). Weights are provided in FP8.
+
+```sh
+hf download moonshotai/Kimi-K2-Instruct --local-dir $LOCAL_FP8_PATH
+```
+
+2. Convert the weights from FP8 to BF16 using script [deepseek_fp8_to_bf16.py](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/checkpoint_conversion/standalone_scripts/deepseek_fp8_to_bf16.py) on CPU
+```sh
+python3 -m maxtext.checkpoint_conversion.standalone_scripts.deepseek_fp8_to_bf16 --input-fp8-hf-path=$LOCAL_FP8_PATH --output-bf16-hf-path=$LOCAL_BF16_PATH
+```
+Alternatively, we can use the official DeepSeek script [fp8_cast_bf16.py](https://github.com/deepseek-ai/DeepSeek-V3/blob/main/inference/fp8_cast_bf16.py) to convert on GPU.
+
+3. To convert the checkpoint for MaxText compatibility in [Orbax](https://orbax.readthedocs.io/en/latest/guides/checkpoint/orbax_checkpoint_101.html) 
+- Run [convert_deepseek_family_ckpt.py](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/checkpoint_conversion/standalone_scripts/convert_deepseek_family_ckpt.py) to convert the checkpoint to scanned format in Orbax for training and fine-tuning.
+```sh
+python3 -m maxtext.checkpoint_conversion.standalone_scripts.convert_deepseek_family_ckpt --model_size kimi-k2-1t --base_model_path $LOCAL_BF16_PATH --maxtext_model_path $GCS_PATH_TO_SAVE
+```
+- Run [convert_deepseek_family_unscanned_ckpt.py](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/checkpoint_conversion/standalone_scripts/convert_deepseek_family_unscanned_ckpt.py) to convert the checkpoint to unscanned format in Orbax for decoding.
+```sh
+python3 -m maxtext.checkpoint_conversion.standalone_scripts.convert_deepseek_family_unscanned_ckpt --model_size kimi-k2-1t --base_model_path $LOCAL_BF16_PATH --maxtext_model_path $GCS_PATH_TO_SAVE
+```
+
+## Pre-training
+You can train from scratch to generate a new checkpoint. One example command to run pre-training with Kimi K2 on tpu7x-512 (adjust parallelism for the 1T parameter scale).
+
+```sh
+python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
+    run_name=kimi_k2_pre_training \
+    per_device_batch_size=16 \
+    enable_checkpointing=false \
+    model_name=kimi-k2-1t \
+    ici_fsdp_parallelism=64 \
+    ici_expert_parallelism=8 \
+    steps=5 \
+    max_target_length=1024 \
+    async_checkpointing=false \
+    tokenizer_type=huggingface \
+    tokenizer_path=moonshotai/Kimi-K2-Instruct \
+    attention=flash \
+    use_tokamax_splash=True \
+    use_tokamax_gmm=False \
+    dtype=bfloat16 \
+    weight_dtype=bfloat16 \
+    megablox=True \
+    sparse_matmul=True \
+    dataset_type=synthetic \
+    scan_layers=True \
+    use_ring_of_experts=True \
+    opt_type=muon \
+    muon_consistent_rms=0.2 \
+    muon_weight_decay=0.1 \
+    use_qk_clip=True \
+    qk_clip_threshold=100
+```
+
+## Fine-tuning
+After you have a MaxText compatible checkpoint, you can fine-tune Kimi K2. The Kimi team recommends using the **Muon optimizer** during fine-tuning, as it produces the best performance with a Muon-pre-trained checkpoint.
+
+Example command for General Fine-tuning on tpu7x-512:
+
+```sh
+python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
+    run_name=kimi_k2_fine_tuning \
+    per_device_batch_size=16 \
+    enable_checkpointing=true \
+    model_name=kimi-k2-1t \
+    ici_fsdp_parallelism=64 \
+    ici_expert_parallelism=8 \
+    steps=5 \
+    max_target_length=1024 \
+    async_checkpointing=false \
+    tokenizer_type=huggingface \
+    tokenizer_path=moonshotai/Kimi-K2-Instruct \
+    attention=flash \
+    use_tokamax_splash=True \
+    use_tokamax_gmm=False \
+    dtype=bfloat16 \
+    weight_dtype=bfloat16 \
+    megablox=True \
+    sparse_matmul=True \
+    dataset_path=${DATASET_PATH?} \
+    scan_layers=True \
+    load_parameters_path=${SCANNED_CHECKPOINT?} \
+    use_ring_of_experts=True \
+    opt_type=muon \
+    muon_consistent_rms=0.2 \
+    muon_weight_decay=0.1 \
+    use_qk_clip=True \
+    qk_clip_threshold=100
+```
+
+## Decoding
+Example command to run decoding with Kimi K2. Given its 1T size, high tensor parallelism is recommended.
+
+```sh
+python3 -m maxtext.inference.decode src/maxtext/configs/base.yml \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
+    load_parameters_path=${CONVERTED_CHECKPOINT?} \
+    run_name=kimi_decode \
+    per_device_batch_size=1 \
+    model_name=kimi-k2-1t \
+    max_target_length=2048 \
+    tokenizer_type=huggingface \
+    tokenizer_path=moonshotai/Kimi-K2-Instruct \
+    attention=dot_product \
+    ici_tensor_parallelism=128 \
+    ici_fsdp_parallelism=1 \
+    prompt="The primary goal of agentic intelligence is to " \
+    scan_layers=False
+```
+
+## Correctness
+
+To verify the correctness of the Kimi K2 implementation, we perform two primary validation steps:
+
+  * **Logit Comparison**: We compare the logits generated by our implementation against those from a HuggingFace implementation for a set of given prompts.
+  * **MMLU Score Validation**: We validate the MMLU score against established benchmarks. 
+
+### Logit Comparison
+
+Use the following example to generate "golden" logits from the HuggingFace reference model for Kimi K2.
+
+```sh
+python3 -m tests.assets.logits_generation.generate_hf_golden_logits \  
+  --model-id=moonshotai/Kimi-K2-Instruct \  
+  --prompts='I love to' \  
+  --output-path=golden_Kimi-K2.jsonl \  
+  --gcs-bucket=$my-gcs-bucket \  
+  --hf-model-path=$LOCAL_BF16_PATH \  
+  --hf-load-dtype=bfloat16 \  
+  --trust-remote-code=True  
+```
+
+```sh
+JAX_PLATFORMS=cpu python3 -m tests.forward_pass_logit_checker \  
+  src/maxtext/configs/base.yml \  
+  base_output_directory=${BASE_OUTPUT_PATH?} \  
+  run_name=forward_logits_check \  
+  model_name=kimi-k2-1t \  
+  load_parameters_path=${UNSCANNED_CKPT_PATH?} \  
+  scan_layers=False \  
+  async_checkpointing=False \  
+  checkpoint_storage_concurrent_gb=1024 \  
+  weight_dtype=bfloat16 \  
+  ici_fsdp_parallelism=1 ici_expert_parallelism=-1 \  
+  attention=dot_product \  
+  per_device_batch_size=1 \  
+  max_prefill_predict_length=4 max_target_length=4 \  
+  sparse_matmul=False \  
+  --golden_logits_path=${GOLDEN_LOGITS_DISK_LOCATION?} \  
+  --atol=1.5 --rtol=1.5 --max_kl_div=0.1 \  
+  --skip_first_token \  
+  skip_jax_distributed_system=True
+```
+
+To run MMLU benchmarks and validate the model's performance, follow the instructions provided [here]( https://github.com/AI-Hypercomputer/maxtext/blob/main/benchmarks/api_server/README.md).
+
+## Supported MoE strategy
+* Dropless
+  * [MegaBlocks](https://arxiv.org/abs/2211.15841) implementation with flag `sparse_matmul=True megablox=True`.
+  * [JAX ragged_dot](https://github.com/jax-ml/jax/blob/a8fb0e01f8d083fff337d3c26375bb1b77344a99/jax/_src/lax/lax.py#L2415) implementation with flag `sparse_matmul=True megablox=False`.
+  * General dense matmul implementation with flag `sparse_matmul=False capacity_factor=-1`.
+* Dropping implementation with flag `sparse_matmul=False` and reasonable `capacity_factor`, commonly used from 1 to 1.25.


### PR DESCRIPTION
# Description

update the README with Kimi-K2 release

# Tests

Best pretraining MFU currently 6.43%, on TPU7x-512 (256 chips), optimizer=Muon, EP=8, FSDP=64, PDBS=16, and SEQ_LEN=1024

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
