### PR TITLE
Fix DS v3.2 decoding issue

### DIFF
--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -1102,11 +1102,14 @@ class Decoder(nn.Module):
       logits = None
     # When in the Indexer Dense Warm-up stage, skip the expensive output head projection
     # for efficiency, as the main model is frozen and the LM loss is not needed.
-    elif (cfg.use_indexer and not cfg.indexer_sparse_training) and self.model_mode == MODEL_MODE_TRAIN:
+    # TODO(b/501446870): Investigate model_mode as train at beginning for decoding stage
+    elif (
+        cfg.use_indexer and cfg.indexer_loss_scaling_factor > 0.0 and not cfg.indexer_sparse_training
+    ) and model_mode == MODEL_MODE_TRAIN:
       logits = None
     # When vocab tiling is enabled in training mode, full logits won't generate to reduce memory
     # Instead, we keep track on the hidden states, which has smaller size compared to full logits
-    elif cfg.num_vocab_tiling > 1 and self.model_mode == MODEL_MODE_TRAIN:
+    elif cfg.num_vocab_tiling > 1 and model_mode == MODEL_MODE_TRAIN:
       logits = None
       self.sow("intermediates", "hidden_states", hidden_state)
 


### PR DESCRIPTION
# Description

Fix DeepSeek V3.2 model decoding issue, see more details in b/500088962.

* We should enable the Dense warm up only when `indexer_loss_scaling_factor > 0` like mentioned [here](https://github.com/AI-Hypercomputer/maxtext/blob/b83ff02ca64b3a26feeaf9efe79670d7483cfa36/src/maxtext/configs/base.yml#L385).
* We should use `model_mode` instead of `self.model_mode`. Updated other branches as well.

# Tests

* Before the change: random outputs
* After the change: reasonable decoding [outputs](https://screenshot.googleplex.com/9TdgJTW46b4UihA)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
