### PR TITLE
docs: fix LaTeX formula rendering and cleanup formatting

### DIFF
--- a/docs/guides/checkpointing_solutions/convert_checkpoint.md
+++ b/docs/guides/checkpointing_solutions/convert_checkpoint.md
@@ -6,7 +6,7 @@ This guide provides instructions to use [checkpoint conversion scripts](https://
 
 The following models are supported:
 
-| Model Family            | Sizes                  | HF $\\to$ Orbax (scan) | HF $\\to$ Orbax (unscan) | Orbax (scan) $\\to$ HF | Orbax (unscan) $\\to$ HF |
+| Model Family            | Sizes                  | HF $\to$ Orbax (scan) | HF $\to$ Orbax (unscan) | Orbax (scan) $\to$ HF | Orbax (unscan) $\to$ HF |
 | :---------------------- | :--------------------- | :--------------------: | :----------------------: | :--------------------: | :----------------------: |
 | **Gemma2**              | 2B, 9B, 27B            |           √            |            √             |           √            |            √             |
 | **Gemma3** (Multimodal) | 4B, 12B, 27B           |           √            |            √             |           √            |            √             |

--- a/docs/guides/checkpointing_solutions/convert_checkpoint.md
+++ b/docs/guides/checkpointing_solutions/convert_checkpoint.md
@@ -7,19 +7,19 @@ This guide provides instructions to use [checkpoint conversion scripts](https://
 The following models are supported:
 
 | Model Family            | Sizes                  | HF $\to$ Orbax (scan) | HF $\to$ Orbax (unscan) | Orbax (scan) $\to$ HF | Orbax (unscan) $\to$ HF |
-| :---------------------- | :--------------------- | :--------------------: | :----------------------: | :--------------------: | :----------------------: |
-| **Gemma2**              | 2B, 9B, 27B            |           √            |            √             |           √            |            √             |
-| **Gemma3** (Multimodal) | 4B, 12B, 27B           |           √            |            √             |           √            |            √             |
-| **Llama3.1**            | 8B, 70B, 450B          |           √            |            √             |           √            |            √             |
-| **Qwen2.5**             | 1.5B, 7B, 14B          |           √            |            √             |           √            |            √             |
-| **Qwen3**               | 0.6B, 4B, 8B, 14B, 32B |           √            |            √             |           √            |            √             |
-| **Qwen3 MoE**           | 30B, 235B, 480B        |           √            |            √             |           √            |            √             |
-| **Mixtral**             | 8x7B, 8x22B            |           √            |            √             |           √            |            √             |
-| **GPT-OSS**             | 20B, 120B              |           √            |            √             |           √            |            √             |
-| **DeepSeek2**           | 16B                    |           √            |            √             |           √            |            √             |
-| **DeepSeek3**           | 671B                   |           √            |            √             |           √            |            √             |
-| **DeepSeek3.2**         | 671B                   |           √            |            √             |           -            |            -             |
-| **Qwen3 Next**          | 80B                    |           √            |            √             |           √            |            √             |
+| :---------------------- | :--------------------- | :-------------------: | :---------------------: | :-------------------: | :---------------------: |
+| **Gemma2**              | 2B, 9B, 27B            |           √           |            √            |           √           |            √            |
+| **Gemma3** (Multimodal) | 4B, 12B, 27B           |           √           |            √            |           √           |            √            |
+| **Llama3.1**            | 8B, 70B, 450B          |           √           |            √            |           √           |            √            |
+| **Qwen2.5**             | 1.5B, 7B, 14B          |           √           |            √            |           √           |            √            |
+| **Qwen3**               | 0.6B, 4B, 8B, 14B, 32B |           √           |            √            |           √           |            √            |
+| **Qwen3 MoE**           | 30B, 235B, 480B        |           √           |            √            |           √           |            √            |
+| **Mixtral**             | 8x7B, 8x22B            |           √           |            √            |           √           |            √            |
+| **GPT-OSS**             | 20B, 120B              |           √           |            √            |           √           |            √            |
+| **DeepSeek2**           | 16B                    |           √           |            √            |           √           |            √            |
+| **DeepSeek3**           | 671B                   |           √           |            √            |           √           |            √            |
+| **DeepSeek3.2**         | 671B                   |           √           |            √            |           -           |            -            |
+| **Qwen3 Next**          | 80B                    |           √           |            √            |           √           |            √            |
 
 ## Prerequisites
 

--- a/docs/guides/monitoring_and_debugging/understand_logs_and_metrics.md
+++ b/docs/guides/monitoring_and_debugging/understand_logs_and_metrics.md
@@ -197,7 +197,7 @@ The **model FLOPs** are the floating point operations to perform model computati
 - The number of model FLOPs is dependent on model architecture, input size (batch size, sequence length), and gradient accumulation steps. It does not include optimization operations.
 - We break down the FLOPs into two parts:
   - "Learnable weight FLOPs" are matmuls between activations and learnable weights. Specifically, this occurs in embedding, feed forward networks, attention-related projections, and unembedding.
-  - "Attention FLOPs" are matmuls in attention score computation like $\\mathrm{softmax}{\\left(\\frac{QK^\\top}{\\sqrt{d}}\\right)} V$.
+  - "Attention FLOPs" are matmuls in attention score computation like $\mathrm{softmax}{\left(\frac{QK^\top}{\sqrt{d}}\right)} V$.
 
 One **TFLOP** (TeraFLOP) is equal to $10^{12}$ FLOPs. The log shows the theoretical estimate of **model TFLOP per device**:
 
@@ -207,7 +207,7 @@ Per train step:
  split as 94.54% learnable weight flops and 5.46% attention flops
 ```
 
-In this example, given `model=deepseek2-16b`, `per_device_batch_size=24`, `max_target_length=2048`, and no gradient accumulation, we have $\\text{model tflop per device} \\approx 764.67$.
+In this example, given `model=deepseek2-16b`, `per_device_batch_size=24`, `max_target_length=2048`, and no gradient accumulation, we have $\text{model tflop per device} \approx 764.67$.
 
 - 94.54% of the TFLOPs are attributed to learnable weight and 5.46% are attributed to attention.
 - As you will see next, this number is important for calculating performance metrics, such as TFLOP/s/device and Model FLOPs Utilization (MFU).
@@ -233,8 +233,8 @@ completed step: 9, seconds: 5.667, TFLOP/s/device: 134.924, Tokens/s/device: 867
 
 Before we dive deep here, recall a few numbers from previous sections:
 
-- $\\text{max target length} = 2048$, $\\text{per device batch size} = 24$
-- $\\text{model tflop per device} \\approx 764.67$ (rounded), $\\text{number of devices} = 4$
+- $\text{max target length} = 2048$, $\text{per device batch size} = 24$
+- $\text{model tflop per device} \approx 764.67$ (rounded), $\text{number of devices} = 4$
 
 ### 4.1. Performance metrics
 
@@ -244,38 +244,38 @@ The performance metrics fluctuate at the beginning, and become stable towards th
 completed step: 9, seconds: 5.667, TFLOP/s/device: 134.924, Tokens/s/device: 8672.758, total_weights: 196608, loss: 10.374
 ```
 
-As shown in `seconds: 5.667`, $\\text{measured step time in seconds} \\approx 5.667$ (rounded).
+As shown in `seconds: 5.667`, $\text{measured step time in seconds} \approx 5.667$ (rounded).
 
 **TFLOP per second per device**
 
 - It is [computed](https://github.com/AI-Hypercomputer/maxtext/blob/28e5097ac467ed8b1d17676d68aa5acc50f9d60d/src/MaxText/metric_logger.py#L211-L213) as
 
-$$\\text{tflop/s/device} = \\frac{\\text{model tflop per device}}{\\text{measured step time in seconds}}$$
+$$\text{tflop/s/device} = \frac{\text{model tflop per device}}{\text{measured step time in seconds}}$$
 
 - Here we have `TFLOP/s/device: 134.924`. Let's try to verify manually: $764.67 / 5.667 = 134.934$. Not exactly the same but close, since the both tflop and time are rounded in the log.
 - Further, we can calculate **Model FLOPs Utilization (MFU)** from this:
 
-$$\\text{MFU} = \\frac{\\text{tflop/s/device}}{\\text{peak hardware tflop/s}}$$
+$$\text{MFU} = \frac{\text{tflop/s/device}}{\text{peak hardware tflop/s}}$$
 
-For TPU v5p, $\\text{peak hardware tflop/s}=459$. Thus, $134.924 / 459 = 29.40$%. Note this is an example for explanation with small batch size and sequence length, so the MFU is not optimal.
+For TPU v5p, $\text{peak hardware tflop/s}=459$. Thus, $134.924 / 459 = 29.40$%. Note this is an example for explanation with small batch size and sequence length, so the MFU is not optimal.
 
 **Tokens per second per device (throughput)**
 
 - It is [computed](https://github.com/AI-Hypercomputer/maxtext/blob/28e5097ac467ed8b1d17676d68aa5acc50f9d60d/src/MaxText/metric_logger.py#L215-L217) as
 
-$$\\text{token/s/device} = \\frac{\\text{number of tokens per device}}{\\text{measured step time in seconds}}$$
+$$\text{token/s/device} = \frac{\text{number of tokens per device}}{\text{measured step time in seconds}}$$
 
 - The numerator is from [calculate_tokens_training_per_device](https://github.com/AI-Hypercomputer/maxtext/blob/28e5097ac467ed8b1d17676d68aa5acc50f9d60d/src/MaxText/maxtext_utils.py#L148)
 
-$$\\text{number of tokens per device} = \\text{per device batch size} \\times \\text{max target length}$$
+$$\text{number of tokens per device} = \text{per device batch size} \times \text{max target length}$$
 
-- Here we have `Tokens/s/device: 8672.758`. Let's try to verify manually: $24 \\times 2048 / 5.667 = 8673.372$. Not exactly the same but close, since the time is rounded in the log.
+- Here we have `Tokens/s/device: 8672.758`. Let's try to verify manually: $24 \times 2048 / 5.667 = 8673.372$. Not exactly the same but close, since the time is rounded in the log.
 
 ### 4.2. Learning metrics
 
 **Loss**. The loss is the key indicator of learning progress, which should decrease over training steps. In this example, the loss is `12.038` at Step 0 and decreases to `10.374` at Step 9. Ideally, we want the loss to converge to a small value with sufficiently large training steps.
 
-**Total weights**. When discussing the throughput, we have $\\text{number of tokens} = \\text{per device batch size} \\times \\text{max target length} \\times \\text{number of device}$. In this example, $\\text{number of tokens} = 24 \\times 2048 \\times 4 = 196608$. There are two types of tokens: real tokens and pad tokens. The pad tokens are placeholders introduced by data preprocessing: We truncate or pad each sentence to max target length. Only real tokens contribute to the learning signal (i.e., loss). Therefore, we monitor $\\text{number of real tokens}$, which is shown as [total weights](https://github.com/AI-Hypercomputer/maxtext/blob/28e5097ac467ed8b1d17676d68aa5acc50f9d60d/src/MaxText/train.py#L151).
+**Total weights**. When discussing the throughput, we have $\text{number of tokens} = \text{per device batch size} \times \text{max target length} \times \text{number of device}$. In this example, $\text{number of tokens} = 24 \times 2048 \times 4 = 196608$. There are two types of tokens: real tokens and pad tokens. The pad tokens are placeholders introduced by data preprocessing: We truncate or pad each sentence to max target length. Only real tokens contribute to the learning signal (i.e., loss). Therefore, we monitor $\text{number of real tokens}$, which is shown as [total weights](https://github.com/AI-Hypercomputer/maxtext/blob/28e5097ac467ed8b1d17676d68aa5acc50f9d60d/src/MaxText/train.py#L151).
 
 - Here we see `total_weights: 196608` for all steps. This is because we are using `dataset_type=synthetic`, where all sentences are generated with a length of `max_target_length=2048`. As a result, there are no pad tokens and total weights = number of tokens.
 - However, in real datasets, sentences can have variable lengths and total weights < number of tokens. For example, we can set `dataset_type=tfds dataset_path=gs://maxtext-dataset dataset_name='c4/en:3.0.1'`, and will see total weights smaller than `196608`:

--- a/docs/guides/optimization/sharding.md
+++ b/docs/guides/optimization/sharding.md
@@ -26,14 +26,14 @@ When considering different sharding strategies, the main concern is the amount o
 
 We illustrate our sharding notation with an example matmul:
 
-$$B_xE \\times EM = B_xM$$
+$$B_xE \times EM = B_xM$$
 
 Where B, E and M are names of dimensions and a subscript denotes sharding. For example, $B_xE$ is a 2-dimensional matrix sharded along the $B$ dimension, using the $x$ mesh axis. Dimensions without a subscript are not sharded.
-This example is of standard data parallelism, only the batch dimension is sharded. Note that $B$ refers to the batch dimension, $B_x$ to the local shard of this dimension, whereas we use $\\left|B\\right|$ and $\\left|B_x\\right|$ to refer to the lengths of single axes, and $\\left|x\\right|$ as the degree of sharding on the x axis, e.g. $\\left|B_x\\right| = \\left|B\\right|/\\left|x\\right|$. We drop this $\\left|\\cdot\\right|$ notation when there is a product to reduce clutter, e.g. we use $BEM_x$ instead of $\\left|B\\right|\\left|E\\right|\\left|M_x\\right|$.
+This example is of standard data parallelism, only the batch dimension is sharded. Note that $B$ refers to the batch dimension, $B_x$ to the local shard of this dimension, whereas we use $|B|$ and $|B_x|$ to refer to the lengths of single axes, and $|x|$ as the degree of sharding on the x axis, e.g. $|B_x| = |B|/|x|$. We drop this $|\cdot|$ notation when there is a product to reduce clutter, e.g. we use $BEM_x$ instead of $|B||E||M_x|$.
 
 We illustrate this notation on model parallelism as well:
 
-$BM_x \\times M_xE = BE \\rightarrow \\text{Reduce-Scatter (RS) over x} \\rightarrow BE_x$
+$BM_x \times M_xE = BE \rightarrow \text{Reduce-Scatter (RS) over x} \rightarrow BE_x$
 
 Explanation: Both the activations ($BM$) and weights ($ME$) are sharded on the M dimension. Thus each device is able to perform the matmul locally with its shard of the $M_x$ dimension, the local result is of the right global shape ($BE$) but is only a partial result - it needs to be summed with the other shards to get the full result. This is achieved with a reduce scatter (which does the summation and additionally shards the activations). Note that some flavors of tensor parallelism call for an all reduce instead a reduce scatter, but generally in maxtext we use a reduce scatter here.
 
@@ -49,11 +49,11 @@ Explanation: Both the activations ($BM$) and weights ($ME$) are sharded on the M
 
 Note for the feed forward computation the batch and sequence dimensions act the same and thus we use only one $B$ axis (which you can think of as a token batch dimension, a reshaping of batch and sequence into one axis), but for context and sequence parallelism they act differently and thus we use both a $B$ and $S$ dimension and the $B$ dimension is really batch in sequences. For example a matmul with an explicit sequence dimension might look like
 
-$$BSE \\times EM = BSM$$
+$$BSE \times EM = BSM$$
 
 But for arithmetic intensity roofline analysis purposes the $B$ and $S$ axis act as one, and generally we omit the $S$ axis except for when its needed (context/sequence parallelism), thus we only write
 
-$$BE \\times EM = BM$$
+$$BE \times EM = BM$$
 
 We recognize this overloads the definition of $B$ but for arithmetic intensity purposes the only batch size that matters is batch in tokens - which imagines combining the $B$ and $S$ axis into one.
 
@@ -69,9 +69,9 @@ We will see why this is a useful definition by walking through an example.
 
 We want to be compute bound (because there is a fixed amount of compute to perform), which means we want the compute to take longer than the communication. Consider the above example (model parallelism aka tensor parallelism)
 
-$$ BM_x \\times M_xE = BE \\text{ (partial result)} \\rightarrow \\text{RS over x} \\rightarrow BE_x $$
+$$ BM_x \times M_xE = BE \text{ (partial result)} \rightarrow \text{RS over x} \rightarrow BE_x $$
 
-The compute is $BM_x \\times M_xE = BE$ matmul, which takes $2BM_xE$ flops (you can think of this as $\\left|B\\right| * \\left|E\\right|$ dot products each of length $\\left|M_x\\right|$, thus there are $BEM_x$ multiplications and additions to perform.
+The compute is $BM_x \times M_xE = BE$ matmul, which takes $2BM_xE$ flops (you can think of this as $|B| * |E|$ dot products each of length $|M_x|$, thus there are $BEM_x$ multiplications and additions to perform.
 
 **Compute time** = Flops / compute speed = $2BEM_x$ / compute speed
 
@@ -95,23 +95,23 @@ Operation Arithmetic Intensity > Hardware Arithmetic Intensity
 
 The LHS (Compute Flops / Comm bytes) is the “Operation” or “Model” arithmetic intensity, whereas the RHS (Compute Speed / comm speed) is the hardware arithmetic intensity. This re-arrangement has a huge benefit in that it separates model from hardware - the operational intensity is independent of the hardware. Note however that arithmetic has this funky unity of flops/byte - intuitively you can think of this as the amount of flops unlocked by communicating a certain amount of bytes.
 
-Operation Arithmetic Intensity for this example: $2BM_xE$ flops / $2BE$ bytes = $\\left|M_x\\right|$ flops/byte
+Operation Arithmetic Intensity for this example: $2BM_xE$ flops / $2BE$ bytes = $|M_x|$ flops/byte
 
 Hardware Arithmetic Intensity: Compute speed / comm speed
 
-Example hardware for trillium (See https://cloud.google.com/tpu/docs/v6e), compute speed = $917$ TFLOPs, and comm speed of 1 ICI axis is $180$ GB/s so the ratio $917 * 10^12 / 180 * 10^ 9 = 5100$. Thus we would need $\\left|M_x\\right| > 5100$ (Operational AI > Hardware AI) to be compute bound for this operation. This is an example of key insights that arithmetic intensity gives us - it tells us we need a large $\\left|M\\right|$ to achieve high utilization for model parallelism because the operational intensity is proportional to $\\left|M\\right|$.
+Example hardware for trillium (See https://cloud.google.com/tpu/docs/v6e), compute speed = $917$ TFLOPs, and comm speed of 1 ICI axis is $180$ GB/s so the ratio $917 * 10^{12} / 180 * 10^9 = 5100$. Thus we would need $|M_x| > 5100$ (Operational AI > Hardware AI) to be compute bound for this operation. This is an example of key insights that arithmetic intensity gives us - it tells us we need a large $|M|$ to achieve high utilization for model parallelism because the operational intensity is proportional to $|M|$.
 
 ## Arithmetic Intensity: Mixed sharding strategies
 
-When we use multiple sharding strategies together it seems intractable to keep track of all of the compute vs communication ratios. However it turns out (not obvious at first), that the arithmetic intensity analysis of a “pure” sharding strategy generalizes to when it's used in a mix. For instance, if we added data parallelism to the above tensor parallelism example then the batch dimension $B$ would also be sharded by a new mesh axes $y$. Both the compute and communication would decrease by this sharding factor $\\left|y\\right|$, and thus the ratio of compute to comms for tensor parallelism would remain the same ($\\left|M\\right|\\left|x\\right|$, independent of $\\left|y\\right|$). Concretely this would look like
+When we use multiple sharding strategies together it seems intractable to keep track of all of the compute vs communication ratios. However it turns out (not obvious at first), that the arithmetic intensity analysis of a “pure” sharding strategy generalizes to when it's used in a mix. For instance, if we added data parallelism to the above tensor parallelism example then the batch dimension $B$ would also be sharded by a new mesh axes $y$. Both the compute and communication would decrease by this sharding factor $|y|$, and thus the ratio of compute to comms for tensor parallelism would remain the same ($|M||x|$, independent of $|y|$). Concretely this would look like
 
-$$B_yM_x \\times M_xE = B_yE \\rightarrow \\text{RS over x } \\rightarrow B_yE_x $$
+$$B_yM_x \times M_xE = B_yE \rightarrow \text{RS over x } \rightarrow B_yE_x $$
 
 **Compute:** = $2B_yM_xE$ Flops
 
 **TP comms (RS)** = $2B_yE$ bytes
 
-**Ratio (Arithmetic Intensity)** = $\\left|M_x\\right|$ Flops/byte
+**Ratio (Arithmetic Intensity)** = $|M_x|$ Flops/byte
 
 This "independence" of sharding strategies is true for the main four parallelisms (data, model (tensor), pipeline, and expert). Note that data, fsdp, context and sequence parallelism are all roughly the same for the purpose of
 arithmetic intensity analysis since they shard the batch, as we will illustrate in the individual sections below. In addition both data and pipeline parallelism (microbatches) shard the batch which decreases the HBM arithmetic intensity.
@@ -163,11 +163,11 @@ The simplest parallelization is data parallelization. Each chip works on a diffe
 
 Roughly approximate the entire backward pass:
 
-**Compute**: $4 * \\text{local batch} * \\text{params}$
+**Compute**: $4 * \text{local batch} * \text{params}$
 
-We saw above that each matmul performs $2 * \\text{local batch} * \\text{params}$ flops, it turns out that the backward pass requires twice as many flops as the forward pass. We don't derive this here but highly recommend reading these [slides](https://www.cs.toronto.edu/~rgrosse/courses/csc321_2017/slides/lec6.pdf) from University of Toronto to explain the mathematics and implementation of backprop.
+We saw above that each matmul performs $2 * \text{local batch} * \text{params}$ flops, it turns out that the backward pass requires twice as many flops as the forward pass. We don't derive this here but highly recommend reading these [slides](https://www.cs.toronto.edu/~rgrosse/courses/csc321_2017/slides/lec6.pdf) from University of Toronto to explain the mathematics and implementation of backprop.
 
-**Communicate**: All reduce size of params (`bf16`) : $4 * \\text{params}$ (`2*` since `bf16`, another `2*` since an optimal all reduce algorithm turns out to require two passes of communicating data (generally a reduce scatter followed by an all-gather))
+**Communicate**: All reduce size of params (`bf16`) : $4 * \text{params}$ (`2*` since `bf16`, another `2*` since an optimal all reduce algorithm turns out to require two passes of communicating data (generally a reduce scatter followed by an all-gather))
 
 **Ratio (arithmetic intensity)**: `local_batch`
 
@@ -181,22 +181,22 @@ e.g. the original activations have grown by a factor of `expert_per_token` and a
 
 `batch_per_expert` = `batch` * (`expert_per_token`/`expert`) = `batch` / `sparsity`
 
-We denote the local `batch_per_expert` with $\\beta$ and analyze an MoE feedfoward matmul to calculate arithmetic intensity:
+We denote the local `batch_per_expert` with $\beta$ and analyze an MoE feedfoward matmul to calculate arithmetic intensity:
 
-$$\\beta EX \\times EMX = \\beta MX$$
+$$\beta EX \times EMX = \beta MX$$
 
-**Compute:** $4\\beta EMX$ Flops (2x in backward pass)
+**Compute:** $4\beta EMX$ Flops (2x in backward pass)
 
 **Comms:** All Reduce Gradient of size $EMX$: $4EMX$ bytes
 
-**Ratio (arithmetic intensity):** $\\left|\\beta\\right| = \\text{local batch} / \\text{sparsity}$
+**Ratio (arithmetic intensity):** $|\beta| = \text{local batch} / \text{sparsity}$
 
 ### DP Arithmetic Intensity (Hierarchical)
 
 For a hierarchal mesh (TPU: within slice ICI, across slice DCN, GPU: within NVL domain, across NVL Domains), only one set of gradients need to be communicated
 across the slower network per slice/NVL Domain (as opposed to one set per chip). This is generally achieved for us automatically by the XLA compiler:
 
-Reduce Scatter grads on fast network $\\rightarrow$ All Reduce across slow $\\rightarrow$ All Gather on faster network
+Reduce Scatter grads on fast network $\rightarrow$ All Reduce across slow $\rightarrow$ All Gather on faster network
 
 We can compute the arithmetic intensity of these cross slice/NVL Domain comms by imagining the chips forming a slice or NVL Domain as one "super chip". This "super chip" processes all of the tokens within its domain, but it only
 has to share one copy of the gradients to its super chip neighbors.
@@ -207,11 +207,11 @@ If the local per device batch size is `local batch`, then we can imagine each "s
 
 We can then perform the same arithmetic intensity analysis as before, and indeed get the same result:
 
-**Compute (per super chip):** $4 * \\text{super batch} * \\text{params}$ flops
+**Compute (per super chip):** $4 * \text{super batch} * \text{params}$ flops
 
-**Comms (per super chip):** All reduce params $\\rightarrow 4 * \\text{params}$ bytes
+**Comms (per super chip):** All reduce params $\rightarrow 4 * \text{params}$ bytes
 
-**Ratio (arithmetic intensity):** $\\text{super batch } (\\text{super batch} / \\text{sparsity} \\text{ for sparse models})$
+**Ratio (arithmetic intensity):** $\text{super batch } (\text{super batch} / \text{sparsity} \text{ for sparse models})$
 
 This illustrates there are more than one way to calculate arithmetic intensity - we could also derive the same expression
 from the chip level as long as we are consistent for the compute and comms - either both the compute and comms should be at the super chip level, or both should be at the regular chip level.
@@ -230,9 +230,9 @@ Approximate a typical weight @ activation = activation matmul:
 
 Start with activations sharded like $B_xE$ and weights sharded like $E_xM$ (it doesn't matter which axis of weights is sharded). We must first All Gather (AG) the weights
 
-$$E_xM \\rightarrow \\text{AG } x \\rightarrow EM$$
+$$E_xM \rightarrow \text{AG } x \rightarrow EM$$
 
-**Compute**: $B_xE \\times EM = B_xM$
+**Compute**: $B_xE \times EM = B_xM$
 
 This takes $2B_xEM$ flops
 
@@ -284,11 +284,11 @@ The main communications are the same as `FSDP` (all gather weights and synchroni
 
 Sequence parallelism has an additional cost of transferring the sharding from sequence to heads (and back again) for attention. This is executed via and all-to-all which are generally cheap operations, analyzed below:
 
-**Compute**: Attention (`4 * batch * seq_len^2 * heads * head_dim \ |SP|`)
+**Compute**: Attention ($4 * batch * seq_len^2 * heads * head_dim / |SP|$)
 
-**Communicate:** A2A QKV activations and output activations (roughly `4 * batch * seq_len * heads * head_dim`)
+**Communicate:** A2A QKV activations and output activations (roughly $4 * batch * seq_len * heads * head_dim$)
 
-**Ratio (Arithmetic Intensity)**: Proportional to `seq_len / |SP|`
+**Ratio (Arithmetic Intensity)**: Proportional to $seq_len / |SP|$
 
 The exact ratio depends on MHA vs GQA, how many kv heads there are and the efficiency of an all-to-all on the given hardware.
 
@@ -300,7 +300,7 @@ Shard the activations along the feature dimensions (e.g. model or `embed` dimens
 
 Analyze one pattern of TP as given above
 
-$$ BM_x \\times M_xE = BE \\text{ (local partial result) } \\rightarrow \\text{ Reduce-Scatter (RS) } x \\rightarrow BE_x $$
+$$ BM_x \times M_xE = BE \text{ (local partial result) } \rightarrow \text{ Reduce-Scatter (RS) } x \rightarrow BE_x $$
 
 **Compute:** $2BM_xE$ Flops
 
@@ -308,11 +308,11 @@ $$ BM_x \\times M_xE = BE \\text{ (local partial result) } \\rightarrow \\text{ 
 
 **Ratio (arithmetic intensity)**
 
-$\\left|M_x\\right| = \\left|M\\right|/\\left|TP\\right|$
+$|M_x| = |M|/|TP|$
 
 Note this is one pattern of TP where the contracting dimension is sharded. By contrast for the initial feed forward matmul the non-contracting weight dimension is sharded:
 
-$$BE_x \\times EM_x \\rightarrow \\text{AG activations over } x\\rightarrow BE \\times EM_x = BM_x$$
+$$BE_x \times EM_x \rightarrow \text{AG activations over } x\rightarrow BE \times EM_x = BM_x$$
 
 This is the same amount of compute, and also the same amount of communication - again activations of $BE$ are communicated, but in this case it is an initial all-gathering instead of secondary all-reduce. Ideally these activations (all-gather or reduce scatter) can be overlapped with the compute by the XLA compiler - an idea called a **collective matmul**. This is fairly challenging for the compiler since the comms and compute do depend on each other - to achieve overlap the computation and communication have to be chunked into smaller pieces and pipelined.
 
@@ -334,13 +334,13 @@ Similar to tensor parallelism, but instead of sharding the feed forward weights 
 
 This is really just swapping $E$ and $M$ of the TP analysis above, but we will include it here:
 
-$$BE_x \\times E_xM = BM_x$$
+$$BE_x \times E_xM = BM_x$$
 
 **Compute:** $2BE_xM$ FLOPS
 
 **Communicate:** Reduce scatter $BM$ (`bf16`): $2BM$ bytes
 
-**Ratio (arithmetic intensity):** $\\left|E_x\\right|=\\left|E\\right|/\\left|TP\\right|$
+**Ratio (arithmetic intensity):** $|E_x|=|E|/|TP|$
 
 ## Expert Parallelism (EP)
 
@@ -358,19 +358,19 @@ An all-to-all (A2A) is needed to move between data sharding (fsdp) prior to the 
 
 Analyze only 1 feed forward matmul
 
-$$ BEX_x \\times EMX_x = BMX_x $$
+$$ BEX_x \times EMX_x = BMX_x $$
 
-$$ 2BEX_x \\text{ Flops} $$
+$$ 2BEX_x \text{ Flops} $$
 
 **Communicate**
 
-$$ B_xEX \\rightarrow A2A \\rightarrow BEX_x $$
+$$ B_xEX \rightarrow A2A \rightarrow BEX_x $$
 
 Ideally this `A2A` only requires moving around $BEX_x$ elements per shard, but it depends on if the hardware is connected with an all to all network (true for `GPUs` and `TPU DCN` but not for `TPU ICI`)
 
 With a true all-to-all network this takes $2BEX_x$ bytes. Over TPU ICI, an all-to-all is instead as costly as `1/4` of all gathering the entire activation as nicely drawn [here](https://jax-ml.github.io/scaling-book/sharding/#our-final-communication-primitive-the-alltoall) in jax's sharding doc.
 
-**Ratio (arithmetic intensity)**: $2BEMX_x / 2BEX_x = \\left|M\\right|$
+**Ratio (arithmetic intensity)**: $2BEMX_x / 2BEX_x = |M|$
 
 Note: The batch $B$ cancels in above arithmetic intensity - the batch dimension is present in both the compute and communication since we are communicating activations so cancels from the arithmetic intensity ratio regardless of how it is shaped (e.g.`batch` or `batch_per_exp`)
 

--- a/docs/reference/core_concepts/tiling.md
+++ b/docs/reference/core_concepts/tiling.md
@@ -28,23 +28,23 @@ The effectiveness of tiling stems from the **linearity** of many operations in L
 
 For instance, consider the matrix multiplication operation:
 
-$$A[M, N] \\times B[N, 1] = C[M, 1]$$
+$$A[M, N] \times B[N, 1] = C[M, 1]$$
 
-If the matrices `A` is too large to fit into memory, you can tile the operation. By splitting matrix `A` into $K$ smaller chunks along its `M` dimension ($A_0[M/K, N], \\dots, A\_{K-1}[M/K, N]$), you can load each chunk separately and compute a corresponding portion of the output matrix `C` ($C_0[M/K, 1], \\dots, C\_{K-1}[M/K, 1]$) follows
+If the matrices `A` is too large to fit into memory, you can tile the operation. By splitting matrix `A` into $K$ smaller chunks along its `M` dimension ($A_0[M/K, N], \dots, A_{K-1}[M/K, N]$), you can load each chunk separately and compute a corresponding portion of the output matrix `C` ($C_0[M/K, 1], \dots, C_{K-1}[M/K, 1]$) follows
 
-$$A_i[M/K, N]\\times B[N, 1] = C_i[M/K, 1] \\quad \\forall i=0, \\dots, K-1.$$
+$$A_i[M/K, N] \times B[N, 1] = C_i[M/K, 1] \quad \forall i=0, \dots, K-1.$$
 
 Finally, you can concatenate the smaller `C` matrices to form the complete result.
 
 This principle extends to the backward pass as well. Instead of computing the full gradient `dA[M, N]`, which also exceeds memory capacity, you can compute the gradient for each tile individually:
 
-$$dC_i[M/K, 1] \\times B^\\intercal[1, N] = dA_i[M/K, N] \\quad \\forall i=0,\\dots,K-1.$$
+$$dC_i[M/K, 1] \times B^\intercal[1, N] = dA_i[M/K, N] \quad \forall i=0,\dots,K-1.$$
 
 Similarly, the gradient on `B` is the accumulation
 
-$$\\sum\_{i=0}^{K-1}dC_i^\\intercal[1, M/K] \\times A_i[M/K, N] = dB[N, 1] \\quad \\forall i=0,\\dots,K-1.$$
+$$\sum_{i=0}^{K-1}dC_i^\intercal[1, M/K] \times A_i[M/K, N] = dB[N, 1] \quad \forall i=0,\dots,K-1.$$
 
-This tiling approach reduces the peak memory usage from $\\mathcal{O}(MN)$ to $\\mathcal{O}(MN/K)$, which facilitates model training with limited memory resources.
+This tiling approach reduces the peak memory usage from $\mathcal{O}(MN)$ to $\mathcal{O}(MN/K)$, which facilitates model training with limited memory resources.
 
 ## Tiling in MaxText
 

--- a/docs/reference/performance_metrics.md
+++ b/docs/reference/performance_metrics.md
@@ -27,34 +27,34 @@ Model Flops Utilization (MFU) is one of the most commonly used metrics to summar
 Model FLOPs are the floating point operations required to perform model computations regardless of implementation or hardware limitations.
 For training, this corresponds to the operations in a single forward and backward pass (one model step).
 
-$$ MFU:= \\frac{\\text{model flops/s}}{\\text{peak hardware flops/s}} $$
+$$ MFU:= \frac{\text{model flops/s}}{\text{peak hardware flops/s}} $$
 
-Model flops are generally easy to calculate/estimate theoretically since the model is mostly performing matmuls, and so we can just sum up the flops of each matmul. For example a $[A,B] \\times [B,C] = [A,C]$ matmul has $2ABC$ flops. Hence, to calculate the observed model flops/s we can sum up the theoretical flops required in a training step of the model and then divide by the measured step time (in seconds).
+Model flops are generally easy to calculate/estimate theoretically since the model is mostly performing matmuls, and so we can just sum up the flops of each matmul. For example a $[A,B] \times [B,C] = [A,C]$ matmul has $2ABC$ flops. Hence, to calculate the observed model flops/s we can sum up the theoretical flops required in a training step of the model and then divide by the measured step time (in seconds).
 
-$$ MFU = \\frac{\\text{model flops/s}}{\\text{peak hardware flops/s}} = \\frac{\\text{theoretical model flops per step}}{\\text{measured step time} \\times \\text{peak hardware flops/s}}$$
+$$ MFU = \frac{\text{model flops/s}}{\text{peak hardware flops/s}} = \frac{\text{theoretical model flops per step}}{\text{measured step time} \times \text{peak hardware flops/s}}$$
 
 Furthermore, since
 
 $$
-\\frac{\\text{theoretical model flops per step}}
-{\\text{peak hardware flops/s}}
-= \\text{theoretically optimal step time}
+\frac{\text{theoretical model flops per step}}
+{\text{peak hardware flops/s}}
+= \text{theoretically optimal step time}
 $$
 
 we also get that:
 
 $$
-MFU = \\frac{\\text{theoretically optimal step time}}
-{\\text{measured step time}}
+MFU = \frac{\text{theoretically optimal step time}}
+{\text{measured step time}}
 $$
 
 Finally, we can also look at throughput utilization. In each training step, the model processes $\text{batch\_size} \times \text{seq\_length}$ tokens. Since the (optimal or measured) number of tokens per second is just the number of tokens per step divided by step time (optimal or measured, respectively), we get that:
 
 $$
-MFU = \\frac{\\text{theoretically optimal step time}}
-{\\text{measured step time}} = \\frac{\\text{number of tokens per step / optimal tokens/s}}
-{\\text{number of tokens per step / measured tokens/s}} = \\frac{\\text{measured tokens/s}}
-{\\text{optimal tokens/s}}
+MFU = \frac{\text{theoretically optimal step time}}
+{\text{measured step time}} = \frac{\text{number of tokens per step / optimal tokens/s}}
+{\text{number of tokens per step / measured tokens/s}} = \frac{\text{measured tokens/s}}
+{\text{optimal tokens/s}}
 $$
 
 Hence, MFU is the fraction of peak hardware performance actually utilized by the model, and can be expressed in different units — step time, throughput, or raw flops/s.
@@ -78,7 +78,7 @@ Which maxtext now uses since this [PR/1988](https://github.com/AI-Hypercomputer/
 
 Note that
 
-$$ \\text{Total Flops} = \\text{Attention (quadratic in sequence) + Non-attention (linear)}$$
+$$ \text{Total Flops} = \text{Attention (quadratic in sequence) + Non-attention (linear)}$$
 
 Thus the distinction between causal vs non causal flops is particularly important for long sequence when the attention flops dominate / are a significant fraction of the total flops. For 8k sequence length, the attention flops are generally around 10% of total flops (depending on exact model dims), whereas for 128k seq, the attention flops may be around 90%. Note however the attention flops also vary by attention type, e.g. sliding window flops are not quadratic in sequence, but are only linear in both sequence length and window length. We updated our model flops calculation to account for sliding window attention and chunked attention in [PR 2009](https://github.com/AI-Hypercomputer/maxtext/pull/2009) and [PR 2030](https://github.com/AI-Hypercomputer/maxtext/pull/2030).
 
@@ -97,11 +97,11 @@ MFU is a very useful metric to understand your systems performance, but like ste
 
 Step time, tokens/s, and MFU all can be used to calculate how long training will take (e.g. how long will it take to train my model on $T$ tokens given $C$ chips?)
 
-$$\\begin{align\*}
-\\text{training time} &= \\text{step time} \\times \\text{num steps} \\
-&= \\frac{T tokens}{\\text{measured tokens per second per chip} \\times C} \\
-&= \\frac{\\text{theoretical flops to train T tokens}}{\\text{MFU} \\times C \\times \\text{chip peak speed}}
-\\end{align\*}$$
+$$\begin{align*}
+\text{training time} &= \text{step time} \times \text{num steps} \\
+&= \frac{T tokens}{\text{measured tokens per second per chip} \times C} \\
+&= \frac{\text{theoretical flops to train T tokens}}{\text{MFU} \times C \times \text{chip peak speed}}
+\end{align*}$$
 
 This shows any of step time, tokens/s or MFU can be used to determine how long training will take and are proportionally (or inversely proportionally) related. MFU is most useful to compare across different models/hardwares and while optimizing performance, whereas step time or tokens/second may be more useful when these are fixed.
 

--- a/docs/tutorials/posttraining/multimodal.md
+++ b/docs/tutorials/posttraining/multimodal.md
@@ -153,12 +153,12 @@ python -m maxtext.trainers.post_train.sft.train_sft_deprecated \
 - **Setting appropriate prefill length**: To prevent truncation and ensure your full input (text + image) is processed, the prefill length should be set longer than the total combined length of your text tokens and image tokens. This combined length makes up the final sequence fed to the decoder. We recommend to estimate the combined sequence length from your full input and then add a buffer when setting your `max_prefill_predict_length` for decoding. Token estimation rules:
   - For text tokens, a good estimate is:
 
-    $\\text{Text Tokens} \\approx 1.3 \\times \\text{Number of Words in Prompt}$.
+    $\text{Text Tokens} \approx 1.3 \times \text{Number of Words in Prompt}$.
 
-  - For Gemma3, each image is resized to 896\*896 and contributes 256 tokens:
+  - For Gemma3, each image is resized to 896*896 and contributes 256 tokens:
 
-    $\\text{Total Tokens} \\approx \\text{Text Tokens} + \\text{Number of Images} * 256$.
+    $\text{Total Tokens} \approx \text{Text Tokens} + \text{Number of Images} * 256$.
 
   - For Llama4 models, each image is dynamically tiled based on its size, with each resulting tile contributing 144 tokens:
 
-    $\\text{Total Tokens} \\approx \\text{Text Tokens} + 144 \\times \\sum\_{i=1}^{N} \\text{Number of Tiles of Image}\_i$.
+    $\text{Total Tokens} \approx \text{Text Tokens} + 144 \times \sum_{i=1}^{N} \text{Number of Tiles of Image}_i$.

--- a/docs/tutorials/posttraining/multimodal.md
+++ b/docs/tutorials/posttraining/multimodal.md
@@ -155,7 +155,7 @@ python -m maxtext.trainers.post_train.sft.train_sft_deprecated \
 
     $\text{Text Tokens} \approx 1.3 \times \text{Number of Words in Prompt}$.
 
-  - For Gemma3, each image is resized to 896*896 and contributes 256 tokens:
+  - For Gemma3, each image is resized to 896\*896 and contributes 256 tokens:
 
     $\text{Total Tokens} \approx \text{Text Tokens} + \text{Number of Images} * 256$.
 


### PR DESCRIPTION
- Fixed LaTeX formulas across multiple documentation files by replacing double backslashes with single ones for correct MyST rendering.
- Cleaned up sharding.md and performance_metrics.md formulas and notation.

# Tests

Tested by building docs locally.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
