### PR TITLE
Improve environment variable setup in MaxText docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -162,6 +162,8 @@ linkcheck_ignore = [
     r"https://cla\.developers\.google\.com/.*",
     # Ignore GitHub commit history links which frequently trigger rate limiting (429)
     r"https://github\.com/jax-ml/jax/commits/.*",
+    # Ignore Hugging Face settings links which require login
+    r"https://huggingface\.co/settings/tokens",
 ]
 
 

--- a/docs/guides/monitoring_and_debugging/megascale_hang_playbook.md
+++ b/docs/guides/monitoring_and_debugging/megascale_hang_playbook.md
@@ -108,4 +108,4 @@ After [creating an HLO Dump](https://openxla.org/xla/hlo_dumps), you can share i
 gcloud storage cp -r /tmp/xla_dump gs://<bucket_location>
 ```
 
-When sharing the HLO dump, you will need to give Google permission to access the GCS bucket. A Google user can then download the HLO graph using `gsutil`.
+When sharing the HLO dump, you will need to give Google permission to access the GCS bucket. A Google user can then download the HLO graph using `gcloud storage`.

--- a/docs/run_maxtext/run_maxtext_single_host_gpu.md
+++ b/docs/run_maxtext/run_maxtext_single_host_gpu.md
@@ -135,15 +135,22 @@ https://github.com/AI-Hypercomputer/maxtext/tree/main/src/maxtext/configs/gpu/a3
 echo "Running 1vm.sh"
 
 # Example command to invoke this script via XPK
-# python3 xpk/xpk.py workload create --cluster ${CLUSTER_NAME?} \
-# --workload ${WORKLOAD_NAME?} --docker-image=gcr.io/supercomputer-testing/${LOCAL_IMAGE_NAME?} \
+# python3 xpk/xpk.py workload create --cluster ${GKE_CLUSTER?} \
+# --workload ${RUN_NAME?} --docker-image=gcr.io/supercomputer-testing/${LOCAL_IMAGE_NAME?} \
 # --device-type ${DEVICE_TYPE?} --num-slices 1 \
 # --command "bash src/maxtext/configs/gpu/a3/llama_2_7b/1vm.sh"
 
 # Stop execution if any command exits with error
 set -e
 
-export OUTPUT_PATH="provide an output path"
+# Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
+# region as your GPUs to minimize latency and costs.
+# You can list your buckets and their locations in the
+# [Cloud Console](https://console.cloud.google.com/storage/browser).
+export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
+
+# An arbitrary string to identify this specific run.
+# Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
 export RUN_NAME="llama-2-1vm-$(date +%Y-%m-%d-%H-%M)"
 
 # Set environment variables
@@ -152,7 +159,7 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
-export XLA_FLAGS="--xla_dump_to=${OUTPUT_PATH?}/${RUN_NAME?}/HLO_dumps/
+export XLA_FLAGS="--xla_dump_to=${BASE_OUTPUT_DIRECTORY?}/${RUN_NAME?}/HLO_dumps/
 --xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_triton_gemm=false
  --xla_gpu_enable_command_buffer='' --xla_gpu_enable_highest_priority_async_stream=true
  --xla_gpu_all_reduce_combine_threshold_bytes=134217728 --xla_gpu_all_gather_combine_threshold_bytes=134217728
@@ -165,6 +172,6 @@ export XLA_FLAGS="--xla_dump_to=${OUTPUT_PATH?}/${RUN_NAME?}/HLO_dumps/
 
 # 1 node, DATA_DP=1, ICI_FSDP=8
 python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/gpu/models/llama2_7b.yml run_name=${RUN_NAME?} dcn_data_parallelism=1 \
-  ici_fsdp_parallelism=8 base_output_directory=${OUTPUT_PATH?} attention=cudnn_flash_te scan_layers=False \
+  ici_fsdp_parallelism=8 base_output_directory=${BASE_OUTPUT_DIRECTORY?} attention=cudnn_flash_te scan_layers=False \
   use_iota_embed=True hardware=gpu
 ```

--- a/docs/run_maxtext/run_maxtext_via_pathways.md
+++ b/docs/run_maxtext/run_maxtext_via_pathways.md
@@ -43,20 +43,41 @@ The following commands use placeholder variables. Before running them, set these
 
 ```bash
 # -- Google Cloud Configuration --
-export PROJECT="your-gcp-project-id"
-export ZONE="your-gcp-zone"
-export CLUSTER="your-gke-cluster-name"
+# Your GCP project ID. Find it on the [Cloud Console Dashboard](https://console.cloud.google.com/home/dashboard).
+export PROJECT_ID=<GCP project ID>
+
+# The GCP location (listed as "Location" in the UI) and name of your
+# TPU-enabled GKE cluster. Both can be found on the
+# [Cloud Console](https://console.cloud.google.com/kubernetes/list).
+export ZONE=<GCP location> # e.g., 'us-central1'
+export GKE_CLUSTER=<cluster name>
 
 # -- Workload Configuration --
-export WORKLOAD_NAME="maxtext-job-$(date +%Y%m%d-%H%M%S)"
+# An arbitrary string to identify this specific run.
+# Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
+export RUN_NAME="maxtext-run-$(date +%Y%m%d-%H%M%S)"
+
+# For a full list of MaxText-supported TPU types, see: `src/maxtext/utils/accelerator_to_spec_map.py`. To see the TPU type
+# of your cluster:
+
+# 1. Connect to the cluster (required for kubectl commands later):
+# gcloud container clusters get-credentials ${GKE_CLUSTER?} --location ${ZONE?} --project ${PROJECT_ID?}
+
+# 2. Find your TPU type (e.g., 'v5p-128') by checking the accelerator labels on your nodes:
+# kubectl get nodes -l cloud.google.com/gke-tpu-accelerator -o jsonpath='{.items[*].metadata.labels.cloud\.google\.com/gke-tpu-accelerator}' | tr ' ' '\n' | sort -u
 export TPU_TYPE="v5p-8" # Or your desired TPU type, e.g., v5e-4
-export WORKLOAD_NODEPOOL_COUNT=1 # Number of TPU slices for your job
+export NUM_SLICES=1 # Number of TPU slices for your job
 
 # -- MaxText & Storage Configuration --
-export BUCKET_NAME="your-gcs-bucket-name"
-export RUN_NAME="maxtext-run-1"
+# Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
+# region as your TPUs to minimize latency and costs.
+# You can list your buckets and their locations in the
+# [Cloud Console](https://console.cloud.google.com/storage/browser).
+export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
+
 # The Docker image you pushed in the prerequisite step
-export DOCKER_IMAGE="gcr.io/${PROJECT?}/${CLOUD_IMAGE_NAME}"
+export CLOUD_IMAGE_NAME=<image name>
+export DOCKER_IMAGE="gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?}"
 ```
 
 ## 3. Running a batch workload
@@ -69,15 +90,15 @@ Use the `xpk workload create-pathways` command to start the job.
 
 ```bash
 xpk workload create-pathways \
-  --workload=${WORKLOAD_NAME?} \
-  --cluster=${CLUSTER?} \
-  --num-slices=${WORKLOAD_NODEPOOL_COUNT?} \
+  --workload=${RUN_NAME?} \
+  --cluster=${GKE_CLUSTER?} \
+  --num-slices=${NUM_SLICES?} \
   --tpu-type=${TPU_TYPE?} \
-  --project=${PROJECT?} \
+  --project=${PROJECT_ID?} \
   --zone=${ZONE?} \
   --docker-image=${DOCKER_IMAGE?} \
   --command="python3 -m maxtext.trainers.pre_train.train \
-    base_output_directory=gs://${BUCKET_NAME?} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
     per_device_batch_size=1 \
     enable_checkpointing=false \
     dataset_type=synthetic \
@@ -90,7 +111,7 @@ xpk workload create-pathways \
 You can check the status of your running workloads with the `xpk workload list` command.
 
 ```bash
-xpk workload list --cluster=${CLUSTER?} --project=${PROJECT?} --zone=${ZONE?}
+xpk workload list --cluster=${GKE_CLUSTER?} --project=${PROJECT_ID?} --zone=${ZONE?}
 ```
 
 ## 4. Running a headless (interactive) workload
@@ -104,12 +125,12 @@ This command reserves the TPUs and starts the Pathways head service on the clust
 ```bash
 xpk workload create-pathways \
   --headless \
-  --workload=${WORKLOAD_NAME?} \
-  --num-slices=${WORKLOAD_NODEPOOL_COUNT?} \
+  --workload=${RUN_NAME?} \
+  --num-slices=${NUM_SLICES?} \
   --tpu-type=${TPU_TYPE?} \
-  --project=${PROJECT?} \
+  --project=${PROJECT_ID?} \
   --zone=${ZONE?} \
-  --cluster=${CLUSTER?}
+  --cluster=${GKE_CLUSTER?}
 ```
 
 ### Step 2: Connect to the cluster via port forwarding
@@ -120,7 +141,7 @@ This command forwards local port 29000 to the controller pod in the cluster. It 
 
 ```bash
 kubectl port-forward \
-  "$(kubectl get pods -o name | grep ${WORKLOAD_NAME?}-pathways-head)" \
+  "$(kubectl get pods -o name | grep ${RUN_NAME?}-pathways-head)" \
   29000:29000 &> /dev/null &
 ```
 
@@ -135,7 +156,7 @@ export JAX_BACKEND_TARGET=grpc://127.0.0.1:29000
 
 # Run the training script
 python3 -m maxtext.trainers.pre_train.train \
-  base_output_directory=gs://${BUCKET_NAME?} \
+  base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
   per_device_batch_size=1 \
   enable_checkpointing=false \
   dataset_type=synthetic \
@@ -153,7 +174,7 @@ The output streams directly to your terminal, just as if you were running on a l
   - Ensure you have successfully pushed the image to your project's Artifact Registry.
   - Check that your GKE cluster has permissions to pull from the registry.
 - **`kubectl port-forward` fails**:
-  - Confirm that the pod from Step 1 is running (`kubectl get pods`). The name should match `${WORKLOAD_NAME?}-pathways-head-0`.
+  - Confirm that the pod from Step 1 is running (`kubectl get pods`). The name should match `${RUN_NAME?}-pathways-head-0`.
   - Ensure you are authenticated with `kubectl` and have the correct context set for your GKE cluster.
 - Make sure you import `pathwaysutils` package and call `pathwaysutils.initialize()` in your script when running the workload.
 

--- a/docs/run_maxtext/run_maxtext_via_xpk.md
+++ b/docs/run_maxtext/run_maxtext_via_xpk.md
@@ -115,51 +115,76 @@ This guide focuses on submitting workloads to an existing cluster. Cluster creat
 
 1. **Set your configuration**
 
-   ```
-   export PROJECT_ID="your-gcp-project-id"
-   export ZONE="your-gcp-zone" # e.g., us-central1-a
-   export CLUSTER_NAME="your-existing-cluster-name"
-   export BASE_OUTPUT_DIR="gs://your-output-bucket/"
+   Set up the following environment variables to configure your training run. Replace
+   placeholders with your actual values.
+
+   ```bash
+   # -- Google Cloud Configuration --
+   # Your GCP project ID. Find it on the [Cloud Console Dashboard](https://console.cloud.google.com/home/dashboard).
+   # If you've already set it in your local config, you can retrieve it via:
+   # gcloud config get-value project
+   export PROJECT_ID=<GCP project ID>
+
+   # The GCP location (listed as "Location" in the UI) and name of your
+   # TPU-enabled (or GPU-enabled) GKE cluster. Both can be found on the
+   # [Cloud Console](https://console.cloud.google.com/kubernetes/list).
+   export ZONE=<GCP location> # e.g., 'us-central1' or 'us-central1-a'
+   export GKE_CLUSTER=<cluster name>
+
+   # -- Workload Configuration --
+   # An arbitrary string to identify this specific run.
+   # Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
+   export RUN_NAME="maxtext-run-$(date +%Y%m%d-%H%M%S)"
+
+   # Number of TPU slices (for TPU clusters) or number of nodes (for GPU clusters)
+   export NUM_SLICES=1
+
+   # -- MaxText & Storage Configuration --
+   # Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
+   # region as your TPUs to minimize latency and costs.
+   # You can list your buckets and their locations in the
+   # [Cloud Console](https://console.cloud.google.com/storage/browser).
+   export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
    export DATASET_PATH="gs://your-dataset-bucket/"
    ```
 
 2. **Configure gcloud CLI**
 
-   ```
+   ```bash
    gcloud config set project ${PROJECT_ID?}
    gcloud config set compute/zone ${ZONE?}
    ```
 
 ### A Note on multi-slice and multi-node runs
 
-The examples below run on a single TPU slice (`--num-slices=1`) or a small number of GPU nodes (`--num-nodes=2`). To scale your job to a larger, multi-host configuration, you simply increase these values.
+The examples below run on a single TPU slice (`--num-slices=1`) or a small number of GPU nodes (`--num-nodes=2`). To scale your job to a larger, multi-host configuration, you simply increase the `NUM_SLICES` value.
 
-For instance, to run a job across **four TPU slices**, you would change `--num-slices=1` to `--num-slices=4`. This tells XPK to allocate four `v5litepod-256` slices and orchestrate the training job across all of them as a single workload. Similarly, for GPUs, you would increase the `--num-nodes` value.
+For instance, to run a job across **four TPU slices**, you would change `export NUM_SLICES=1` to `export NUM_SLICES=4`. This tells XPK to allocate four `v5litepod-256` slices and orchestrate the training job across all of them as a single workload. Similarly, for GPUs, you would increase the value.
 
 3. **Create the workload (run the job)**
 
    - **On your TPU cluster:**
 
-     ```
-     xpk workload create\
-       --cluster ${CLUSTER_NAME?}\
-       --workload ${USER}-tpu-job\
-       --base-docker-image maxtext_base_image\
-       --tpu-type v5litepod-256\
-       --num-slices 1\
-       --command "python3 -m maxtext.trainers.pre_train.train run_name=${USER}-tpu-job base_output_directory=${BASE_OUTPUT_DIR?} dataset_path=${DATASET_PATH?} steps=100"
+     ```bash
+     xpk workload create \
+       --cluster ${GKE_CLUSTER?} \
+       --workload ${RUN_NAME?} \
+       --base-docker-image maxtext_base_image \
+       --tpu-type v5litepod-256 \
+       --num-slices ${NUM_SLICES?} \
+       --command "python3 -m maxtext.trainers.pre_train.train run_name=${RUN_NAME?} base_output_directory=${BASE_OUTPUT_DIRECTORY?} dataset_path=${DATASET_PATH?} steps=100"
      ```
 
    - **On your GPU cluster:**
 
-     ```
-     xpk workload create\
-       --cluster ${CLUSTER_NAME?}\
-       --workload ${USER}-gpu-job\
-       --base-docker-image maxtext_base_image\
-       --device-type h100-80gb-8\
-       --num-nodes 2\
-       --command "python3 -m maxtext.trainers.pre_train.train run_name=${USER}-gpu-job base_output_directory=${BASE_OUTPUT_DIR?} dataset_path=${DATASET_PATH?} steps=100"
+     ```bash
+     xpk workload create \
+       --cluster ${GKE_CLUSTER?} \
+       --workload ${RUN_NAME?} \
+       --base-docker-image maxtext_base_image \
+       --device-type h100-80gb-8 \
+       --num-nodes ${NUM_SLICES?} \
+       --command "python3 -m maxtext.trainers.pre_train.train run_name=${RUN_NAME?} base_output_directory=${BASE_OUTPUT_DIRECTORY?} dataset_path=${DATASET_PATH?} steps=100"
      ```
 
 ______________________________________________________________________
@@ -172,20 +197,20 @@ ______________________________________________________________________
 
   2. Go to **Workloads**.
 
-  3. Find your workload (e.g., `${USER}-tpu-job`) and click on it.
+  3. Find your workload (e.g., `${RUN_NAME?}`) and click on it.
 
   4. Select the **Logs** tab to view the container logs.
 
 - **List your jobs:**
 
-  ```
-  xpk workload list --cluster ${CLUSTER_NAME?}
+  ```bash
+  xpk workload list --cluster ${GKE_CLUSTER?}
   ```
 
-- **Analyze output:** Checkpoints and other artifacts will be saved to the Google Cloud Storage bucket you specified in `BASE_OUTPUT_DIR`.
+- **Analyze output:** Checkpoints and other artifacts will be saved to the Google Cloud Storage bucket you specified in `BASE_OUTPUT_DIRECTORY`.
 
 - **Delete a job:**
 
-  ```
-  xpk workload delete --cluster ${CLUSTER_NAME?} --workload <your-workload-name>
+  ```bash
+  xpk workload delete --cluster ${GKE_CLUSTER?} --workload ${RUN_NAME?}
   ```

--- a/docs/tutorials/posttraining/full_finetuning.md
+++ b/docs/tutorials/posttraining/full_finetuning.md
@@ -34,13 +34,26 @@ Login to Hugging Face. Provide your access token when prompted:
 hf auth login
 ```
 
-```sh
+Set up the following environment variables to configure your training run. Replace
+placeholders with your actual values.
+
+```bash
 # -- Model configuration --
-export MODEL=<model name> # e.g., 'llama3.1-8b-Instruct'
+# The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
+# full list of supported models.
+export MODEL=<MaxText Model> # e.g., 'llama3.1-8b-Instruct'
 
 # -- MaxText configuration --
-export BASE_OUTPUT_DIRECTORY=<output directory to store run logs> # e.g., gs://my-bucket/my-output-directory
-export RUN_NAME=<name for this run> # e.g., $(date +%Y-%m-%d-%H-%M-%S)
+# Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
+# region as your TPUs to minimize latency and costs.
+# You can list your buckets and their locations in the
+# [Cloud Console](https://console.cloud.google.com/storage/browser).
+export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
+
+# An arbitrary string to identify this specific run.
+# We recommend to include the model, user, and timestamp.
+# Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
+export RUN_NAME=<Name for this run>
 ```
 
 ## Hugging Face checkpoint to Maxtext checkpoint
@@ -77,10 +90,10 @@ Run these steps once per project prior to any local development or cluster exper
 MaxText assumes these GCS buckets are created in the same project and that it has permissions to read and write from them.
 
 ```sh
-export PROJECT=<Google Cloud Project ID>
+export PROJECT_ID=<Google Cloud Project ID>
 export DATASET_GCS_BUCKET=<GCS for dataset> # e.g., gs://my-bucket/my-dataset
 
-bash tools/data_generation/download_dataset.sh ${PROJECT?} ${DATASET_GCS_BUCKET?}
+bash tools/data_generation/download_dataset.sh ${PROJECT_ID?} ${DATASET_GCS_BUCKET?}
 ```
 
 The above will download the c4 dataset to the GCS BUCKET.

--- a/docs/tutorials/posttraining/knowledge_distillation.md
+++ b/docs/tutorials/posttraining/knowledge_distillation.md
@@ -92,12 +92,12 @@ sudo mkdir -p /mnt/hyperdisk
 sudo mount /dev/sdb /mnt/hyperdisk
 ```
 
-Update the BASE_DIRECTORY to point to the mounted disk and create the directory:
+Update the BASE_OUTPUT_DIRECTORY to point to the mounted disk and create the directory:
 
 ```bash
 export BASE_NAME=<your-base-directory>  # e.g., knowledge-distillation
-export BASE_DIRECTORY=/mnt/hyperdisk/${BASE_NAME?}
-mkdir -p ${BASE_DIRECTORY?}
+export BASE_OUTPUT_DIRECTORY=/mnt/hyperdisk/${BASE_NAME?}
+mkdir -p ${BASE_OUTPUT_DIRECTORY?}
 ```
 
 > **Note:** This tutorial uses a mounted Hyperdisk for performance and reproducibility, because writing large model files and many small I/O operations directly to `gs://` can be significantly slower.
@@ -110,7 +110,7 @@ You can simply download the model from Hugging Face to your local directory:
 
 ```bash
 huggingface-cli login --token ${HF_TOKEN?}
-huggingface-cli download Qwen/Qwen3-32B --repo-type model --local-dir ${BASE_DIRECTORY?}/qwen3-32b
+huggingface-cli download Qwen/Qwen3-32B --repo-type model --local-dir ${BASE_OUTPUT_DIRECTORY?}/qwen3-32b
 ```
 
 ### Obtain and prepare the student model
@@ -129,13 +129,13 @@ python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
 
 ```bash
 # Set the checkpoint directory
-export PRE_TRAINED_MODEL_CKPT_DIRECTORY=${BASE_DIRECTORY?}/llama3.1-8b-ckpt
+export MAXTEXT_CKPT_PATH=${BASE_OUTPUT_DIRECTORY?}/llama3.1-8b-ckpt
 
 # Convert to MaxText format
 python3 -m maxtext.checkpoint_conversion.to_maxtext \
     model_name=llama3.1-8b \
     hf_access_token=${HF_TOKEN?} \
-    base_output_directory=${PRE_TRAINED_MODEL_CKPT_DIRECTORY?} \
+    base_output_directory=${MAXTEXT_CKPT_PATH?} \
     scan_layers=True skip_jax_distributed_system=True
 ```
 
@@ -146,14 +146,14 @@ Use the provided script `generate_distillation_data_vllm.py` to generate the dat
 Run the generation script:
 
 ```bash
-export OUTPUT_DATASET=${BASE_DIRECTORY?}/datasets/distillation_data.parquet
+export OUTPUT_DATASET=${BASE_OUTPUT_DIRECTORY?}/datasets/distillation_data.parquet
 
 python3 -m tools.data_generation.generate_distillation_data_vllm \
   --dataset-path HuggingFaceH4/ultrachat_200k \
   --data-split train_sft \
   --data-columns messages \
   --hf-access-token ${HF_TOKEN?} \
-  --teacher-model ${BASE_DIRECTORY?}/qwen3-32b \
+  --teacher-model ${BASE_OUTPUT_DIRECTORY?}/qwen3-32b \
   --use-chat-template \
   --num-prompts 5120 \
   --num-generations 2 \
@@ -172,14 +172,14 @@ Example command to run fine-tuning on a TPU v6e-8:
 ```bash
 python3 -m maxtext.trainers.post_train.sft.train_sft_deprecated \
   run_name=${RUN_NAME?} \
-  base_output_directory=${BASE_DIRECTORY?}/distillation/qwen3-32b-distill-llama3.1-8b \
+  base_output_directory=${BASE_OUTPUT_DIRECTORY?}/distillation/qwen3-32b-distill-llama3.1-8b \
   tokenizer_path=meta-llama/Llama-3.1-8B-Instruct tokenizer_type=huggingface \
   dataset_type=hf \
   hf_path=parquet \
   hf_train_files=${OUTPUT_DATASET?} \
   train_split='train' \
   train_data_columns=['messages'] \
-  load_parameters_path=${PRE_TRAINED_MODEL_CKPT_DIRECTORY?}/0/items \
+  load_parameters_path=${MAXTEXT_CKPT_PATH?}/0/items \
   model_name=llama3.1-8b \
   per_device_batch_size=2 \
   steps=200 \
@@ -195,7 +195,7 @@ The checkpoint from the student model's fine-tuning (on the teacher-generated da
 
 ```bash
 # Get the latest checkpoint for fine-tuned student model
-CHECKPOINTS_PATH=${BASE_DIRECTORY?}/distillation/qwen3-32b-distill-llama3.1-8b/${RUN_NAME?}/checkpoints
+CHECKPOINTS_PATH=${BASE_OUTPUT_DIRECTORY?}/distillation/qwen3-32b-distill-llama3.1-8b/${RUN_NAME?}/checkpoints
 checkpoints=$(ls ${CHECKPOINTS_PATH?})
 integer_dirs=()
 for dir in $checkpoints; do
@@ -211,7 +211,7 @@ FINE_TUNED_MODEL_CKPT_PATH=${CHECKPOINTS_PATH?}/${largest_dir}/model_params
 # Fine-tune student model on original dataset
 python3 -m maxtext.trainers.post_train.sft.train_sft \
   run_name=${RUN_NAME?}_stage2 \
-  base_output_directory=${BASE_DIRECTORY?}/distillation/qwen3-32b-distill-llama3.1-8b \
+  base_output_directory=${BASE_OUTPUT_DIRECTORY?}/distillation/qwen3-32b-distill-llama3.1-8b \
   tokenizer_path=meta-llama/Llama-3.1-8B-Instruct tokenizer_type=huggingface \
   dataset_type=hf \
   hf_path='HuggingFaceH4/ultrachat_200k' \

--- a/docs/tutorials/posttraining/multimodal.md
+++ b/docs/tutorials/posttraining/multimodal.md
@@ -33,15 +33,17 @@ Install pytorch:
 python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
 ```
 
-Then use this command to convert an unscanned checkpoint from HuggingFace to MaxText, and save it to `MAXTEXT_CKPT_GCS_PATH`:
+Then use this command to convert an unscanned checkpoint from HuggingFace to MaxText, and save it to `MAXTEXT_CKPT_PATH`:
 
 ```shell
-export HF_ACCESS_TOKEN=hf_...
-export MAXTEXT_CKPT_GCS_PATH=gs://...
+# Your Hugging Face access token. Required to download gated models like Llama.
+# You can generate one at https://huggingface.co/settings/tokens.
+export HF_TOKEN=<Hugging Face access token>
+export MAXTEXT_CKPT_PATH=<Checkpoint GCS path> # gs://my-bucket/path
 python -m maxtext.checkpoint_conversion.to_maxtext \
     model_name=gemma3-4b \
-    hf_access_token=${HF_ACCESS_TOKEN?} \
-    base_output_directory=${MAXTEXT_CKPT_GCS_PATH?} \
+    hf_access_token=${HF_TOKEN?} \
+    base_output_directory=${MAXTEXT_CKPT_PATH?} \
     use_multimodal=true \
     scan_layers=false
 ```
@@ -50,12 +52,12 @@ For the Llama4 model family, we are using a separate checkpoint conversion scrip
 
 ```shell
 export LOCAL_HF_MODEL_PATH=...  # Need to pre-download the safetensors from HuggingFace
-export MAXTEXT_CKPT_GCS_PATH=gs://...
+export MAXTEXT_CKPT_PATH=<Checkpoint GCS path> # gs://my-bucket/path
 python -m maxtext.checkpoint_conversion.standalone_scripts.llama4_ckpt_unscanned \
     --model-size=llama4-17b-16e \
     --huggingface-checkpoint=True \
     --base-model-path=${LOCAL_HF_MODEL_PATH?} \
-    --maxtext-model-path=${MAXTEXT_CKPT_GCS_PATH?}
+    --maxtext-model-path=${MAXTEXT_CKPT_PATH?}
 ```
 
 ## Multimodal Decode
@@ -74,9 +76,9 @@ To run a forward pass and verify the model's output, use the following command:
 # Gemma3 decode
 python -m maxtext.inference.decode \
     model_name=gemma3-4b \
-    hf_access_token=${HF_ACCESS_TOKEN?} \
+    hf_access_token=${HF_TOKEN?} \
     tokenizer_path=src/maxtext/assets/tokenizers/tokenizer.gemma3 \
-    load_parameters_path=${MAXTEXT_CKPT_GCS_PATH?}/0/items \
+    load_parameters_path=${MAXTEXT_CKPT_PATH?}/0/items \
     per_device_batch_size=1 \
     run_name=ht_test \
     max_prefill_predict_length=272 \
@@ -122,18 +124,19 @@ For larger models such as Llama4-Scout/Maverick, we suggest to run the decoding 
 ## Supervised Fine-Tuning
 
 Supervised Fine-Tuning (SFT) of multimodal LLMs in MaxText focuses specifically on post-training; we don't yet support pre-training multimodal models from scratch. The SFT process typically involves training on Visual Question Answering (VQA) datasets where the model learns to generate accurate text responses based on both visual and textual inputs. During this fine-tuning phase, we recommend to freeze the pre-trained encoder layers (such as vision transformers) to preserve their learned visual representations, while the projection layers and LLM decoder components remain trainable. This selective training strategy allows the model to adapt the cross-modal alignment and text generation capabilities without disrupting the robust feature extraction abilities of the encoders, ultimately leading to improved performance on multimodal understanding and reasoning tasks while maintaining computational efficiency. This is achieved by setting `freeze_vision_encoder_params=True` in [sft-vision-chartqa.yml](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/post_train/sft-vision-chartqa.yml).
-
 Here, we use [ChartQA](https://huggingface.co/datasets/HuggingFaceM4/ChartQA) as an example to demonstrate SFT functionality:
 
 ```shell
-export UNSCANNED_CKPT_PATH=...  # either set to an already available MaxText ckpt or to the one we just converted in the previous step
+export MAXTEXT_CKPT_PATH=...  # either set to an already available MaxText ckpt or to the one we just converted in the previous step
+export BASE_OUTPUT_DIRECTORY=gs://...
+export STEPS=1000
 python -m maxtext.trainers.post_train.sft.train_sft_deprecated \
     src/maxtext/configs/post_train/sft-vision-chartqa.yml \
     run_name="chartqa-sft" \
     model_name=gemma3-4b \
     tokenizer_path="google/gemma-3-4b-it" \
-    hf_access_token=${HF_ACCESS_TOKEN?} \
-    load_parameters_path=${UNSCANNED_CKPT_PATH?} \
+    hf_access_token=${HF_TOKEN?} \
+    load_parameters_path=${MAXTEXT_CKPT_PATH?} \
     base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
     per_device_batch_size=1 \
     steps=${STEPS?} \

--- a/docs/tutorials/posttraining/rl.md
+++ b/docs/tutorials/posttraining/rl.md
@@ -51,30 +51,39 @@ For instructions on installing MaxText with post-training dependencies on your V
 ## Setup environment variables
 
 Login to Hugging Face. Provide your access token when prompted:
+You can generate one at https://huggingface.co/settings/tokens.
 
 ```bash
 hf auth login
 ```
 
-Setup following environment variables before running GRPO/GSPO:
+Set up the following environment variables to configure your training run. Replace
+placeholders with your actual values.
 
 ```bash
 # -- Model configuration --
+# The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
+# full list of supported models.
 export MODEL=<MaxText Model> # e.g. 'llama3.1-8b-Instruct'
 
 # -- MaxText configuration --
-export BASE_OUTPUT_DIRECTORY=<output directory to store run logs> # e.g., gs://my-bucket/my-output-directory
+# Use a GCS bucket you own to store logs and checkpoints.
+# You can list your buckets and their locations in the
+# [Cloud Console](https://console.cloud.google.com/storage/browser) or via
+# `gcloud storage buckets list --format="table(name, location)"`.
+export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
 
-export RUN_NAME=<name for this run> # e.g., $(date +%Y-%m-%d-%H-%M-%S)
+# An arbitrary string to identify this specific run.
+# We recommend to include the model, user, and timestamp.
+# Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
+export RUN_NAME=<Name for this run>
 
-export CHIPS_PER_VM=<the number of chips per VM> # depends on hardware, for v5p this is 4, for v6e this is 8
+# Number of accelerator chips per VM.
+# - TPU v5e (single host): 8
+# - TPU v5p (single host): 4
+# - TPU v6e (single host): 8
+export CHIPS_PER_VM=<the number of chips per VM>
 ```
-
-For the value of `CHIPS_PER_VM` on different TPU hardware, refer the official document
-
-- [TPU v5e](https://docs.cloud.google.com/tpu/docs/v5e) (single host, chips_per_vm=8)
-- [TPU v5p](https://docs.cloud.google.com/tpu/docs/v5p) (single host, chips_per_vm=4)
-- [TPU v6e](https://docs.cloud.google.com/tpu/docs/v6e) (single host, chips_per_vm=8)
 
 ## Get your model checkpoint
 

--- a/docs/tutorials/posttraining/rl_on_multi_host.md
+++ b/docs/tutorials/posttraining/rl_on_multi_host.md
@@ -68,24 +68,61 @@ For instructions on building and uploading the MaxText Docker image with post-tr
 
 ## Setup Environment Variables
 
-Set up the following environment variables. Replace placeholders with your
-actual values.
+Set up the following environment variables to configure your training run. Replace
+placeholders with your actual values.
 
 ```bash
 # -- Model configuration --
+# The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
+# full list of supported models.
 export MODEL=<MaxText Model> # e.g. 'llama3.1-70b-Instruct'
+
+# Your Hugging Face access token. Required to download gated models like Llama.
+# You can generate one at https://huggingface.co/settings/tokens.
 export HF_TOKEN=<Hugging Face access token>
 
 # -- MaxText configuration --
-export BASE_OUTPUT_DIRECTORY=<output directory to store run logs> # e.g., gs://my-bucket/my-output-directory
-export WORKLOAD=<Name for this run> # e.g., llama-3-70b-grpo
-export MAXTEXT_CKPT_PATH=${BASE_OUTPUT_DIRECTORY?}/${WORKLOAD?}/0/items
+# Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
+# region as your TPUs to minimize latency and costs.
+# You can list your buckets and their locations in the
+# [Cloud Console](https://console.cloud.google.com/storage/browser).
+export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
+
+# An arbitrary string to identify this specific run.
+# We recommend to include the model, user, and timestamp.
+# Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
+export RUN_NAME=<Name for this run>
+
+# The directory containing the MaxText-compatible model checkpoint.
+# If you are converting from a Hugging Face checkpoint, see:
+# [Checkpoint Conversion Guide](../../guides/checkpointing_solutions/convert_checkpoint.md)
+export MAXTEXT_CKPT_PATH=${BASE_OUTPUT_DIRECTORY?}/${RUN_NAME?}/0/items
 
 # -- Workload configuration --
-export TPU_TYPE=<TPU Type> # e.g., 'v5p-128'
-export TPU_CLUSTER=<cluster name>
+# Your GCP project ID. Find it on the [Cloud Console Dashboard](https://console.cloud.google.com/home/dashboard).
+# If you've already set it in your local config, you can retrieve it via:
+# gcloud config get-value project
 export PROJECT_ID=<GCP project ID>
-export ZONE=<GCP zone>
+
+# The GCP location (listed as "Location" in the UI) and name of your
+# TPU-enabled GKE cluster. Both can be found on the
+# [Cloud Console](https://console.cloud.google.com/kubernetes/list).
+export ZONE=<GCP location> # e.g., 'us-central1' or 'us-central1-a'
+export GKE_CLUSTER=<cluster name>
+
+# For a full list of MaxText-supported TPU types, see: `src/maxtext/utils/accelerator_to_spec_map.py`. To see the TPU type
+# of your cluster:
+
+# 1. Connect to the cluster (required for kubectl commands later):
+# gcloud container clusters get-credentials ${GKE_CLUSTER?} --location ${ZONE?} --project ${PROJECT_ID?}
+
+# 2. Find your TPU type (e.g., 'v5p-128') by checking the accelerator labels on your nodes:
+# kubectl get nodes -l cloud.google.com/gke-tpu-accelerator -o jsonpath='{.items[*].metadata.labels.cloud\.google\.com/gke-tpu-accelerator}' | tr ' ' '\n' | sort -u
+export TPU_TYPE=<TPU Type>
+
+# The Docker image you pushed in the prerequisite step
+export CLOUD_IMAGE_NAME=<image name>
+export DOCKER_IMAGE="gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?}"
 ```
 
 ## Get Your Model Checkpoint
@@ -101,7 +138,7 @@ export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucke
 
 ### Option 2: Converting from a Hugging Face checkpoint
 
-Refer the steps in [Hugging Face to MaxText](https://maxtext.readthedocs.io/en/maxtext-v0.2.1/guides/checkpointing_solutions/convert_checkpoint.html#hugging-face-to-maxtext) to convert a hugging face checkpoint to MaxText. Make sure you have correct checkpoint files converted and saved. Similar as Option 1, you can set the following environment and move on.
+Refer to the steps in [Hugging Face to MaxText](../../guides/checkpointing_solutions/convert_checkpoint.md) to convert a hugging face checkpoint to MaxText. Make sure you have correct checkpoint files converted and saved. Similar as Option 1, you can set the following environment and move on.
 
 ```bash
 export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
@@ -122,8 +159,8 @@ submit the `train_rl.py` script via XPK.
 ### Submit GRPO workload
 
 ```bash
-xpk workload create-pathways --workload ${WORKLOAD?} \
---docker-image gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?} --cluster ${TPU_CLUSTER?} \
+xpk workload create-pathways --workload ${RUN_NAME?} \
+--docker-image ${DOCKER_IMAGE?} --cluster ${GKE_CLUSTER?} \
 --tpu-type=${TPU_TYPE?} --num-slices=1 \
 --project=${PROJECT_ID?} --priority=high \
 --zone=${ZONE?} \
@@ -131,7 +168,7 @@ xpk workload create-pathways --workload ${WORKLOAD?} \
 python3 -m maxtext.trainers.post_train.rl.train_rl \
   model_name=${MODEL?} \
   load_parameters_path=${MAXTEXT_CKPT_PATH?} \
-  run_name=${WORKLOAD?} \
+  run_name=${RUN_NAME?} \
   base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
   hf_access_token=${HF_TOKEN?}"
 ```
@@ -139,8 +176,8 @@ python3 -m maxtext.trainers.post_train.rl.train_rl \
 ### Submit GSPO workload
 
 ```bash
-xpk workload create-pathways --workload ${WORKLOAD?} \
---docker-image gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?} --cluster ${TPU_CLUSTER?} \
+xpk workload create-pathways --workload ${RUN_NAME?} \
+--docker-image ${DOCKER_IMAGE?} --cluster ${GKE_CLUSTER?} \
 --tpu-type=${TPU_TYPE?} --num-slices=1 \
 --project=${PROJECT_ID?} --priority=high \
 --zone=${ZONE?} \
@@ -148,7 +185,7 @@ xpk workload create-pathways --workload ${WORKLOAD?} \
 python3 -m maxtext.trainers.post_train.rl.train_rl \
   model_name=${MODEL?} \
   load_parameters_path=${MAXTEXT_CKPT_PATH?} \
-  run_name=${WORKLOAD?} \
+  run_name=${RUN_NAME?} \
   base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
   hf_access_token=${HF_TOKEN?} \
   loss_algo=gspo-token"
@@ -160,8 +197,8 @@ python3 -m maxtext.trainers.post_train.rl.train_rl \
 - **Delete a workload**: To remove a failed or unwanted Pathways job, use XPK:
   ```bash
   xpk workload delete \
-      --workload ${WORKLOAD?} \
-      --cluster ${TPU_CLUSTER?} \
+      --workload ${RUN_NAME?} \
+      --cluster ${GKE_CLUSTER?} \
       --project ${PROJECT_ID?}
   ```
   In case the job still lingers on, you can use
@@ -178,12 +215,12 @@ python3 -m maxtext.trainers.post_train.rl.train_rl \
 - **Workload Failures**: Review the logs for specific error messages and
   ensure all environment variables are properly set.
 - **Workload retry / resume**:
-  - **Retry (fresh run)**: Use a unique workload name to avoid overwriting
-    outputs: `export WORKLOAD=${WORKLOAD}-retry1 export MAXTEXT_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/${WORKLOAD}/0/items`. Then
+  - **Retry (fresh run)**: Use a unique run name to avoid overwriting
+    outputs: `export RUN_NAME=${RUN_NAME?}-retry1 export MAXTEXT_CKPT_PATH=${BASE_OUTPUT_DIRECTORY?}/${RUN_NAME?}/0/items`. Then
     submit the XPK workload. If "workload already exists" error occurs, pick
     a new name or list jobs: `kubectl get pathwaysjob`.
-  - **Resume from checkpoint**: Keep the same `WORKLOAD` and set the
-    checkpoint path: `export load_parameters_path=${MAXTEXT_CKPT_PATH}/checkpoint-0000`. Then submit
+  - **Resume from checkpoint**: Keep the same `RUN_NAME` and set the
+    checkpoint path: `export load_parameters_path=${MAXTEXT_CKPT_PATH?}/checkpoint-0000`. Then submit
     the workload again.
   - **Tip**: Verify the checkpoint exists in GCS with read access before
     resuming.

--- a/docs/tutorials/posttraining/sft.md
+++ b/docs/tutorials/posttraining/sft.md
@@ -38,15 +38,27 @@ Login to Hugging Face. Provide your access token when prompted:
 hf auth login
 ```
 
-Set the following environment variables before running SFT.
+Set up the following environment variables to configure your training run. Replace
+placeholders with your actual values.
 
-```sh
+```bash
 # -- Model configuration --
+# The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
+# full list of supported models.
 export MODEL=<MaxText Model> # e.g., 'llama3.1-8b-Instruct'
 
 # -- MaxText configuration --
-export BASE_OUTPUT_DIRECTORY=<output directory to store run logs> # e.g., gs://my-bucket/my-output-directory
-export RUN_NAME=<name for this run> # e.g., $(date +%Y-%m-%d-%H-%M-%S)
+# Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
+# region as your TPUs to minimize latency and costs.
+# You can list your buckets and their locations in the
+# [Cloud Console](https://console.cloud.google.com/storage/browser).
+export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
+
+# An arbitrary string to identify this specific run.
+# We recommend to include the model, user, and timestamp.
+# Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
+export RUN_NAME=<Name for this run>
+
 export STEPS=<number of fine-tuning steps to run> # e.g., 1000
 export PER_DEVICE_BATCH_SIZE=<batch size per device> # e.g., 1
 

--- a/docs/tutorials/posttraining/sft_on_multi_host.md
+++ b/docs/tutorials/posttraining/sft_on_multi_host.md
@@ -45,24 +45,61 @@ Use a pathways ready GKE cluster as described [here](https://docs.cloud.google.c
 
 ## Environment configuration
 
+Set up the following environment variables to configure your training run. Replace
+placeholders with your actual values.
+
 ```bash
-# -- Google Cloud Configuration --
-export PROJECT=<Google Cloud Project ID>
-export CLUSTER_NAME=<Name of GKE Cluster>
-export ZONE=<GKE Cluster Zone>
+# -- Model configuration --
+# The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
+# full list of supported models.
+export MODEL=<MaxText Model> # e.g., deepseek3-671b
 
-# -- Workload Configuration --
-export WORKLOAD_NAME=<Name of Workload> # e.g., sft-$(date +%s)
-export TPU_TYPE=<TPU Type> # e.g., v6e-256
-export TPU_SLICE=<number of slices>
-
-# -- MaxText Configuration --
-export OUTPUT_PATH=<GCS Path for Output/Logs> # e.g., gs://my-bucket/my-output-directory
-export STEPS=<Fine-Tuning Steps> # e.g., 1000
+# Your Hugging Face access token. Required to download gated models like Llama.
+# You can generate one at https://huggingface.co/settings/tokens.
 export HF_TOKEN=<Hugging Face Access Token>
 
-# -- Model Configuration --
-export MODEL=<MaxText Model> # e.g., deepseek3-671b
+# -- MaxText configuration --
+# Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
+# region as your TPUs to minimize latency and costs.
+# You can list your buckets and their locations in the
+# [Cloud Console](https://console.cloud.google.com/storage/browser) or via
+# `gcloud storage buckets list --format="table(name, location)"`.
+export BASE_OUTPUT_DIRECTORY=<GCS Path for Output/Logs> # e.g., gs://my-bucket/maxtext-runs
+
+# An arbitrary string to identify this specific run.
+# We recommend to include the model, user, and timestamp.
+# Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
+export RUN_NAME=<Name for this run>
+
+# -- Workload configuration --
+# Your GCP project ID. Find it on the [Cloud Console Dashboard](https://console.cloud.google.com/home/dashboard).
+# If you've already set it in your local config, you can retrieve it via:
+# gcloud config get-value project
+export PROJECT_ID=<Google Cloud Project ID>
+
+# The GCP location (listed as "Location" in the UI) and name of your
+# TPU-enabled GKE cluster. Both can be found on the
+# [Cloud Console](https://console.cloud.google.com/kubernetes/list).
+export ZONE=<GKE Cluster Zone> # e.g., 'us-central1'
+export GKE_CLUSTER=<Name of GKE Cluster>
+
+# For a full list of MaxText-supported TPU types, see: `src/maxtext/utils/accelerator_to_spec_map.py`. To see the TPU type
+# of your cluster:
+
+# 1. Connect to the cluster (required for kubectl commands later):
+# gcloud container clusters get-credentials ${GKE_CLUSTER?} --location ${ZONE?} --project ${PROJECT_ID?}
+
+# 2. Find your TPU type (e.g., 'v5p-128') by checking the accelerator labels on your nodes:
+# kubectl get nodes -l cloud.google.com/gke-tpu-accelerator -o jsonpath='{.items[*].metadata.labels.cloud\.google\.com/gke-tpu-accelerator}' | tr ' ' '\n' | sort -u
+export TPU_TYPE=<TPU Type>
+export NUM_SLICES=<number of slices>
+
+# The Docker image you pushed in the prerequisite step
+export CLOUD_IMAGE_NAME=<image name>
+export DOCKER_IMAGE="gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?}"
+
+# -- Fine-Tuning configuration --
+export STEPS=<Fine-Tuning Steps> # e.g., 1000
 
 # -- Dataset configuration --
 export DATASET_NAME=<Hugging Face Dataset Name> # e.g., HuggingFaceH4/ultrachat_200k
@@ -106,17 +143,17 @@ This section provides the command to run SFT on a GKE cluster.
 
 ```bash
 xpk workload create \
---cluster=${CLUSTER_NAME?} \
---project=${PROJECT?} \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
 --zone=${ZONE?} \
---docker-image=gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?} \
---workload=${WORKLOAD_NAME?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload=${RUN_NAME?} \
 --tpu-type=${TPU_TYPE?} \
---num-slices=${TPU_SLICE?} \
---command "python3 -m maxtext.trainers.post_train.sft.train_sft run_name=${WORKLOAD_NAME?} base_output_directory=${OUTPUT_PATH?} model_name=${MODEL?} load_parameters_path=${MAXTEXT_CKPT_PATH?} hf_access_token=${HF_TOKEN?}  per_device_batch_size=1 steps=${STEPS?} profiler=xplane hf_path=${DATASET_NAME?} train_split=${TRAIN_SPLIT?} train_data_columns=${TRAIN_DATA_COLUMNS?}"
+--num-slices=${NUM_SLICES?} \
+--command "python3 -m maxtext.trainers.post_train.sft.train_sft run_name=${RUN_NAME?} base_output_directory=${BASE_OUTPUT_DIRECTORY?} model_name=${MODEL?} load_parameters_path=${MAXTEXT_CKPT_PATH?} hf_access_token=${HF_TOKEN?}  per_device_batch_size=1 steps=${STEPS?} profiler=xplane hf_path=${DATASET_NAME?} train_split=${TRAIN_SPLIT?} train_data_columns=${TRAIN_DATA_COLUMNS?}"
 ```
 
-Once the fine-tuning is completed, you can access your model checkpoints at `$OUTPUT_PATH/$WORKLOAD_NAME/checkpoints`.
+Once the fine-tuning is completed, you can access your model checkpoints at `${BASE_OUTPUT_DIRECTORY}/${RUN_NAME}/checkpoints`.
 
 ### SFT with Pathways
 
@@ -124,14 +161,14 @@ Once the fine-tuning is completed, you can access your model checkpoints at `$OU
 export USE_PATHWAYS=1
 
 xpk workload create-pathways \
---cluster=${CLUSTER_NAME?} \
---project=${PROJECT?} \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
 --zone=${ZONE?} \
---docker-image=gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?} \
---workload=${WORKLOAD_NAME?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload=${RUN_NAME?} \
 --tpu-type=${TPU_TYPE?} \
---num-slices=${TPU_SLICE?} \
---command="JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE=1 python3 -m maxtext.trainers.post_train.sft.train_sft run_name=${WORKLOAD_NAME?} base_output_directory=${OUTPUT_PATH?} model_name=${MODEL?} load_parameters_path=${MAXTEXT_CKPT_PATH?} hf_access_token=${HF_TOKEN?} per_device_batch_size=1 steps=${STEPS?} profiler=xplane checkpoint_storage_use_zarr3=$((1 - USE_PATHWAYS)) checkpoint_storage_use_ocdbt=$((1 - USE_PATHWAYS)) enable_single_controller=True"
+--num-slices=${NUM_SLICES?} \
+--command="JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE=1 python3 -m maxtext.trainers.post_train.sft.train_sft run_name=${RUN_NAME?} base_output_directory=${BASE_OUTPUT_DIRECTORY?} model_name=${MODEL?} load_parameters_path=${MAXTEXT_CKPT_PATH?} hf_access_token=${HF_TOKEN?} per_device_batch_size=1 steps=${STEPS?} profiler=xplane checkpoint_storage_use_zarr3=$((1 - USE_PATHWAYS)) checkpoint_storage_use_ocdbt=$((1 - USE_PATHWAYS)) enable_single_controller=True"
 ```
 
-Once the fine-tuning is completed, you can access your model checkpoints at `$OUTPUT_PATH/$WORKLOAD_NAME/checkpoints`.
+Once the fine-tuning is completed, you can access your model checkpoints at `${BASE_OUTPUT_DIRECTORY}/${RUN_NAME}/checkpoints`.

--- a/tests/post_training/unit/sft_data_processing_test.py
+++ b/tests/post_training/unit/sft_data_processing_test.py
@@ -496,7 +496,8 @@ class SFTChatTemplateLogicTest(unittest.TestCase):
     if not os.path.exists(cls.LLAMA_TOKENIZER_PATH):
       exit_code = subprocess.call(
           [
-              "gsutil",
+              "gcloud",
+              "storage",
               "cp",
               "-r",
               "gs://maxtext-dataset/hf/llama2-chat-tokenizer",


### PR DESCRIPTION
# Description

Per UXR study we need to better document how to set various environment variables.
I added comments to make it easier to find the values.
Additionally, I changed the environment variables to use consistent naming e.g. "PROJECT_ID" vs "PROJECT", or "RUN_NAME" vs. "WORKLOAD".

Additionally, I found a few remaining places where we use the deprecated "gsutil" instead of "gcloud storage". Updated them.

FIXES: b/497817148

# Tests

I asked Gemini-CLI to proof-read and find inconsistencies. Also manual review.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
