### PR TITLE
Update config correcting rule and log_config

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -479,7 +479,7 @@ logical_axis_rules: [
                       ['activation_mlp_moe', ['tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['activation_kv', ['tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['activation_prefill_kv_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
-                      ['activation_kv_batch', ['data', 'fsdp', 'fsdp_transpose']],
+                      ['activation_kv_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_kv_head_dim', ['tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['activation_vocab', ['tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['activation_vocab', ['tensor', 'tensor_transpose']],
@@ -969,7 +969,7 @@ xprof_e2e_enable_fw_power_level_event: False
 xprof_e2e_enable_fw_thermal_event: False
 profile_power_events: False # Set to True to enable TPU-specific power/thermal profiling events. Defaults to False to avoid breaking GPU xplane tracing.
 
-log_config: False # Prints the config (after defaults have been set by pyconfig logic)
+log_config: True # Prints the config (after defaults have been set by pyconfig logic)
 debug_sharding: False # Prints model weights sharding info
 
 # Checkpoint Structured logging

--- a/src/maxtext/configs/custom_mesh_and_rule/pipeline-large-moe.yml
+++ b/src/maxtext/configs/custom_mesh_and_rule/pipeline-large-moe.yml
@@ -46,7 +46,7 @@ logical_axis_rules: [
                       ['activation_mlp', ['tensor']],
                       ['activation_mlp_moe', ['tensor']],
                       ['activation_kv', ['tensor']],
-                      ['activation_kv_batch', ['data', 'fsdp']],
+                      ['activation_kv_batch', ['data', 'fsdp', 'expert']],
                       ['activation_kv_head_dim', ['tensor']],
                       ['activation_vocab', ['tensor']],
                       ['activation_stage', 'stage'],


### PR DESCRIPTION
# Description

Update `activation_kv_batch` in logical rule to include expert and correct `log_config` as `True`.

# Tests

This PR successfully recover ds2 performance back to ~80TFLOPs/s, see https://paste.googleplex.com/5815349401485312.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
