### PR TITLE
fix: Vertex TensorBoard uploader stops immediately after starting

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -649,8 +649,12 @@ def train_loop(config, recorder, state=None):
   return state
 
 
-def initialize(argv: Sequence[str]) -> tuple[pyconfig.HyperParameters, Any, Any]:
-  """Initialization of hyperparameters and utilities"""
+def initialize(argv: Sequence[str]) -> tuple[pyconfig.HyperParameters, Any, Any, Any]:
+  """Initialization of hyperparameters and utilities.
+
+  Returns ``vertex_tensorboard_manager`` so the caller can keep it alive for
+  the full training lifetime (its uploader thread is stopped on GC).
+  """
   pathwaysutils.initialize()
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
   # TF allocates extraneous GPU memory when using TFDS data
@@ -684,7 +688,7 @@ def initialize(argv: Sequence[str]) -> tuple[pyconfig.HyperParameters, Any, Any]
       )
   )
   diagnostic_config = diagnostic_configuration.DiagnosticConfig(debug_config)
-  return config, recorder, diagnostic_config
+  return config, recorder, diagnostic_config, vertex_tensorboard_manager
 
 
 def run(config, recorder, diagnostic_config):
@@ -716,7 +720,8 @@ def get_train_func(config, recorder, diagnostic_config, argv):
 
     def elastic_train_wrapper(argv: Sequence[str]) -> None:
       """Wrapper for elastic training initializes variables and runs the train loop."""
-      elastic_config, elastic_recorder, elastic_diagnostic_config = initialize(argv)
+      # Hold the manager so its uploader thread is stopped on scope exit.
+      elastic_config, elastic_recorder, elastic_diagnostic_config, unused_vertex_tensorboard_manager = initialize(argv)
       run(
           elastic_config,
           elastic_recorder,
@@ -733,7 +738,8 @@ def get_train_func(config, recorder, diagnostic_config, argv):
 
 
 def main(argv: Sequence[str]) -> None:
-  config, recorder, diagnostic_config = initialize(argv)
+  # Hold the manager so its uploader thread is stopped on scope exit.
+  config, recorder, diagnostic_config, unused_vertex_tensorboard_manager = initialize(argv)
   record_goodput(recorder, RECORD_JOB_START_TIME)
   train_func = get_train_func(config, recorder, diagnostic_config, argv)
   with maybe_monitor_goodput(config):


### PR DESCRIPTION
# Description

- The `VertexTensorboardManager` was a local variable in `initialize()`, so Python GC triggered `__del__()` → `stop_upload_to_tensorboard()` as soon as `initialize()` returned — before any metrics were written.
- Declare it as `global` to keep the uploader thread alive for the lifetime of the process.

# Tests

Log evidence (before fix)
```
uploader.py:118] Starting uploading of logs to Tensorboard.
uploader.py:242] Setting experiment to ...
uploader.py:106] Logs will no longer be uploaded to Tensorboard.
```
The uploader starts then immediately stops because `__del__` is called when the local variable goes out of scope.

After
```
I0412 07:58:03.489995 132784166402944 tensorboard.py:125] Creating Experiment for Tensorboard instance id: foo
I0412 07:58:03.642194 132784166402944 vertex_tensorboard.py:123] View your Vertex AI Tensorboard at: https://foo
I0412 07:58:03.642300 132784166402944 vertex_tensorboard.py:87] Data will be uploaded to Vertex Tensorboard instance: foo and Experiment: bar in us-central1.
I0412 07:58:03.814826 132784166402944 uploader.py:118] Starting uploading of logs to Tensorboard.
View your Tensorboard at https://foo
```
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
