### PR TITLE
Fix validation for model config override

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -21,7 +21,7 @@
 run_name: ""
 
 model_name: "default" # override config settings to match a specific model. other than the override, nothing should use this!
-override_model_config: False # When set to true allows overriding model parameters via CLI for the purpose of debugging/testing.
+override_model_config: False # When set to true allows overriding model parameters via CLI (or kwargs or env vars) for the purpose of debugging/testing.
 override_logical_axis_rules: False # When set overrides logical axis rules instead of merging them.
 debug:
   rl: False # RL-specific debugging

--- a/src/maxtext/configs/pyconfig.py
+++ b/src/maxtext/configs/pyconfig.py
@@ -93,6 +93,15 @@ def yaml_key_to_env_key(s: str) -> str:
   return _MAX_PREFIX + s.upper()
 
 
+def validate_no_keys_overridden_twice(keys1: list[str], keys2: list[str]):
+  overridden_keys = [k for k in keys1 if k in keys2]
+  if overridden_keys:
+    raise ValueError(
+        f"Keys {overridden_keys} are overridden by both model config and CLI/kwargs."
+        "This is not allowed, unless setting `override_model_config=True`."
+    )
+
+
 def resolve_config_path(param: str) -> str:
   """Resolve config path to auto rewrite to use new src folder."""
   if os.path.isfile(param):
@@ -330,6 +339,8 @@ def initialize_pydantic(argv: list[str], **kwargs) -> MaxTextConfig:
         model_cfg = {k: v for k, v in model_loaded_cfg.items() if k not in overrides_cfg}
       else:
         model_cfg = model_loaded_cfg
+        # Validate that no keys are overridden by both model config and CLI/kwargs
+        validate_no_keys_overridden_twice(model_loaded_cfg.keys(), overrides_cfg.keys())
     else:
       logger.warning("Model config for '%s' not found at %s", model_name, model_config_path)
 
@@ -368,9 +379,16 @@ def initialize_pydantic(argv: list[str], **kwargs) -> MaxTextConfig:
   for k in tuple(raw_keys_dict.keys()):
     env_key = yaml_key_to_env_key(k)
     if env_key in os.environ:
+      # Validate that no keys are overridden by both CLI/kwargs and environment variable
       if k in cli_keys or k in kwargs_keys:
         raise ValueError(
             f"Key '{k}' is overridden by both CLI/kwargs and environment variable '{env_key}'. This is not allowed."
+        )
+      # Validate that no keys are overridden by both model config and environment variable
+      if not temp_cfg.get("override_model_config") and k in model_cfg.keys():
+        raise ValueError(
+            f"Key '{k}' is overridden by both model config and environment variable '{env_key}'."
+            "This is not allowed, unless setting `override_model_config=True`."
         )
 
       new_proposal = os.environ.get(env_key)

--- a/tests/unit/mhc_test.py
+++ b/tests/unit/mhc_test.py
@@ -101,13 +101,15 @@ class TestMHC(unittest.TestCase):
         per_device_batch_size=4,
         max_target_length=7,
         max_prefill_predict_length=7,
+        attention="dot_product",
+        routed_bias_update_rate=0.01,
+        load_balance_loss_weight=0.02,
+        # override
+        override_model_config=True,
         base_emb_dim=self.dim,
         mhc_expansion_rate=3,
         num_experts=4,
         num_experts_per_tok=2,
-        attention="dot_product",
-        routed_bias_update_rate=0.01,
-        load_balance_loss_weight=0.02,
         engram_layers=[],
     )
     devices_array = maxtext_utils.create_device_mesh(self.config)

--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -70,6 +70,7 @@ def _make_config(**overrides):
       **_BASE_CONFIG,
       **extra_args,
       **overrides,
+      override_model_config=True,
   )
 
 

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -83,8 +83,19 @@ class PyconfigTest(unittest.TestCase):
         base_emb_dim=1024,  # Defined as 3072 in gemma-7b
     )
 
-    self.assertEqual(config.base_emb_dim, 1024)
-    self.assertEqual(config.base_mlp_dim, 24576)
+    self.assertEqual(config.base_emb_dim, 1024)  # override
+    self.assertEqual(config.base_mlp_dim, 24576)  # unchanged
+
+  def test_overriding_model_raises_error(self):
+    """Test that overriding a model config with override_model_config=False raises an error."""
+    with self.assertRaises(ValueError):
+      pyconfig.initialize(
+          [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+          skip_jax_distributed_system=True,
+          model_name="gemma-7b",
+          override_model_config=False,
+          base_emb_dim=1024,  # Defined as 3072 in gemma-7b
+      )
 
   def test_overriding_model_in_sft(self):
     # TODO: Update MAXTEXT_PKG_DIR after repo restructuring is complete.
@@ -93,10 +104,11 @@ class PyconfigTest(unittest.TestCase):
         skip_jax_distributed_system=True,
         model_name="llama3.1-8b",
         override_model_config=True,
+        base_emb_dim=1024,  # Defined as 4096 in llama3.1-8b
     )
 
-    self.assertEqual(config.base_emb_dim, 4096)
-    self.assertEqual(config.base_mlp_dim, 14336)
+    self.assertEqual(config.base_emb_dim, 1024)  # override
+    self.assertEqual(config.base_mlp_dim, 14336)  # unchanged
 
   def test_resolve_config_path(self):
     self.assertEqual(resolve_config_path("foo"), os.path.join("src", "foo"))
@@ -121,7 +133,7 @@ class PyconfigTest(unittest.TestCase):
       self.assertTrue(os.path.isfile(full_path), f"Default config for '{module}' not found at {full_path}")
 
   def test_module_from_path(self):
-    import maxtext.trainers.pre_train.train as train_module
+    import maxtext.trainers.pre_train.train as train_module  # pylint: disable=import-outside-toplevel
 
     module_file = train_module.__file__
     result = _module_from_path(module_file)

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -817,6 +817,8 @@ class TrainCompile(unittest.TestCase):
             "max_target_length=1024",
             "attention=flash",
             "use_tokamax_splash=True",
+            # override
+            "override_model_config=True",
             "engram_layers=[]",
             # dense warmup
             "indexer_sparse_training=False",
@@ -842,6 +844,8 @@ class TrainCompile(unittest.TestCase):
             "max_target_length=1024",
             "attention=flash",
             "use_tokamax_splash=True",
+            # override
+            "override_model_config=True",
             "engram_layers=[]",
             # sparse training
             "indexer_sparse_training=True",
@@ -869,7 +873,7 @@ class TrainCompile(unittest.TestCase):
 
   @pytest.mark.cpu_only
   def test_mhc_integration(self):
-    """AOT test for Manifold-onstrained Hyper Connection implementation"""
+    """AOT test for Manifold-constrained Hyper Connection implementation"""
     compiled_trainstep_file = "/tmp/test_mhc_integration"
     train_compile_main(
         (
@@ -881,10 +885,12 @@ class TrainCompile(unittest.TestCase):
             "model_name=deepseek-custom",
             "per_device_batch_size=4",
             "scan_layers=True",
-            "max_target_length=1024",
-            "mhc_expansion_rate=4",
             "attention=flash",
             "use_tokamax_splash=True",
+            "max_target_length=1024",
+            # override
+            "override_model_config=True",
+            "mhc_expansion_rate=4",
             "engram_layers=[]",
         )
     )


### PR DESCRIPTION
# Description

Fix validation for flag `override_model_config`, b/502052235

## Issue

Flag: [override_model_config](https://github.com/AI-Hypercomputer/maxtext/blob/b7dbba73c99f5f0dd4ec40ab7d92905315817bc7/src/maxtext/configs/base.yml#L24)

Previous behavior: 
- **(expected) override with CLI/kwargs/env gives error, when `override_model_config=False`**
- override with CLI/kwargs/env successfully, when `override_model_config=True`

Current behavior:
- **(unexpected) override with CLI/kwargs/env successfully, when `override_model_config=False`**
- override with CLI/kwargs/env successfully, when `override_model_config=True`

Cause: We previously had **validation to check model config vs. CLI/kwargs/env**, in [`pyconfig_deprecated.py`](https://github.com/AI-Hypercomputer/maxtext/blob/7e5ef3e86a423e6fc1b4a6a1cac3a02b46b4180b/src/maxtext/configs/pyconfig_deprecated.py#L658-L659). It is now bypassed with `pyconfig.py` and `types.py`.

## Change

`pyconfig.py`: Add validation to check model config vs. CLI/kwargs/env, when `override_model_config=True`

`tests/unit`: add `override_model_config=True` to fix validation error in unit test

`tests/unit/pyconfig_test`
- (existing) [`test_overriding_model`](https://github.com/AI-Hypercomputer/maxtext/blob/9ba1f47470559cd6ff9dad04c78780f29ed927bc/tests/unit/pyconfig_test.py#L77-L84) : check successful update when `override_model_config=True`
- (newly added) `test_overriding_model_raises_error`: check ValueError when `override_model_config=False`

# Tests

## Before

**CLI, override_model_config=false -> can override, which is wrong**
```
git rev-parse HEAD
# base_emb_dim: 2048 in deepseek2-16b.yml
OVERRIDE="base_emb_dim=1024"
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=gs://runner-maxtext-logs run_name=megablox_pre_training model_name=deepseek2-16b tokenizer_type=huggingface tokenizer_path=deepseek-ai/DeepSeek-V2-Lite dataset_type=synthetic enable_checkpointing=false attention=flash sparse_matmul=True use_tokamax_gmm=False dtype=bfloat16 weight_dtype=bfloat16 per_device_batch_size=1 steps=5 max_target_length=1024 ici_fsdp_parallelism=-1 ${OVERRIDE}
```

https://paste.googleplex.com/5135739043053568

```
Config param base_emb_dim: 1024
completed step: 4, seconds: 0.488, TFLOP/s/device: 16.695, Tokens/s/device: 2100.384, total_weights: 4096, loss: 11.135
```

**environment variable, override_model_config=false -> can override, which is wrong**
```
git rev-parse HEAD
# base_emb_dim: 2048 in deepseek2-16b.yml
OVERRIDE=""
M_BASE_EMB_DIM=1024 \
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=gs://runner-maxtext-logs run_name=megablox_pre_training model_name=deepseek2-16b tokenizer_type=huggingface tokenizer_path=deepseek-ai/DeepSeek-V2-Lite dataset_type=synthetic enable_checkpointing=false attention=flash sparse_matmul=True use_tokamax_gmm=False dtype=bfloat16 weight_dtype=bfloat16 per_device_batch_size=1 steps=5 max_target_length=1024 ici_fsdp_parallelism=-1 ${OVERRIDE}
```

https://paste.googleplex.com/5933592896208896


## After


**1. CLI, override_model_config=false -> prevent ok**
```
# base_emb_dim: 2048 in deepseek2-16b.yml
OVERRIDE="base_emb_dim=1024"
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=gs://runner-maxtext-logs run_name=megablox_pre_training model_name=deepseek2-16b tokenizer_type=huggingface tokenizer_path=deepseek-ai/DeepSeek-V2-Lite dataset_type=synthetic enable_checkpointing=false attention=flash sparse_matmul=True use_tokamax_gmm=False dtype=bfloat16 weight_dtype=bfloat16 per_device_batch_size=1 steps=5 max_target_length=1024 ici_fsdp_parallelism=-1 ${OVERRIDE}
```

https://paste.googleplex.com/5025033308209152

```
ValueError: Keys ['base_emb_dim'] are overridden by both model config and CLI/kwargs.This is not allowed, unless setting `override_model_config=True`.
```


2. CLI, override_model_config=true -> override ok
```
# base_emb_dim: 2048 in deepseek2-16b.yml
OVERRIDE="base_emb_dim=1024 override_model_config=true"
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=gs://runner-maxtext-logs run_name=megablox_pre_training model_name=deepseek2-16b tokenizer_type=huggingface tokenizer_path=deepseek-ai/DeepSeek-V2-Lite dataset_type=synthetic enable_checkpointing=false attention=flash sparse_matmul=True use_tokamax_gmm=False dtype=bfloat16 weight_dtype=bfloat16 per_device_batch_size=1 steps=5 max_target_length=1024 ici_fsdp_parallelism=-1 ${OVERRIDE}
```

https://paste.googleplex.com/5895284967211008

```
Config param base_emb_dim: 1024
completed step: 4, seconds: 0.486, TFLOP/s/device: 16.735, Tokens/s/device: 2105.397, total_weights: 4096, loss: 11.135
```

**3. environment variable, override_model_config=false -> prevent ok**
```
# base_emb_dim: 2048 in deepseek2-16b.yml
OVERRIDE=""
M_BASE_EMB_DIM=1024 \
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=gs://runner-maxtext-logs run_name=megablox_pre_training model_name=deepseek2-16b tokenizer_type=huggingface tokenizer_path=deepseek-ai/DeepSeek-V2-Lite dataset_type=synthetic enable_checkpointing=false attention=flash sparse_matmul=True use_tokamax_gmm=False dtype=bfloat16 weight_dtype=bfloat16 per_device_batch_size=1 steps=5 max_target_length=1024 ici_fsdp_parallelism=-1 ${OVERRIDE}
```

https://paste.googleplex.com/6540298005118976

```
ValueError: Key 'base_emb_dim' is overridden by both model config and environment variable 'M_BASE_EMB_DIM'.This is not allowed, unless setting `override_model_config=True`.
```

4. environment variable, override_model_config=true  -> override ok
```
# base_emb_dim: 2048 in deepseek2-16b.yml
OVERRIDE="override_model_config=true"
M_BASE_EMB_DIM=1024 \
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=gs://runner-maxtext-logs run_name=megablox_pre_training model_name=deepseek2-16b tokenizer_type=huggingface tokenizer_path=deepseek-ai/DeepSeek-V2-Lite dataset_type=synthetic enable_checkpointing=false attention=flash sparse_matmul=True use_tokamax_gmm=False dtype=bfloat16 weight_dtype=bfloat16 per_device_batch_size=1 steps=5 max_target_length=1024 ici_fsdp_parallelism=-1 ${OVERRIDE}
```

https://paste.googleplex.com/5443039960104960

```
Config param base_emb_dim: 1024
completed step: 4, seconds: 0.488, TFLOP/s/device: 16.685, Tokens/s/device: 2099.148, total_weights: 4096, loss: 11.135
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
