### PR TITLE
Pass data_sharding configuration to Tunix PeftTrainer in train_distill

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -542,6 +542,7 @@ def build_training_components(
       checkpoint_root_directory=None,  # Tunix should NOT checkpoint our ModelBundle. MaxTextCheckpointManager handles this.
       checkpointing_options=checkpointing_options,
       gradient_accumulation_steps=student_config.gradient_accumulation_steps,
+      data_sharding_axis=tuple(student_config.data_sharding),
   )
 
   return strategy, optimizer, train_config

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -41,6 +41,22 @@ from maxtext.configs import pyconfig
 from tests.utils.test_helpers import get_test_config_path
 
 
+DEFAULT_DATA_SHARDING = [
+    "data",
+    "stage",
+    "fsdp",
+    "fsdp_transpose",
+    "sequence",
+    "context",
+    "context_autoregressive",
+    "tensor",
+    "tensor_transpose",
+    "tensor_sequence",
+    "expert",
+    "autoregressive",
+]
+
+
 # pylint: disable=protected-access
 class TrainDistillTest(unittest.TestCase):
 
@@ -999,6 +1015,7 @@ class TrainDistillTest(unittest.TestCase):
     mock_student_cfg.vocab_size = 32000
     mock_student_cfg.mesh_axes = ("data",)
     mock_student_cfg.dataset_type = "grain"
+    mock_student_cfg.data_sharding = DEFAULT_DATA_SHARDING
 
     # Add dummy numbers for optimizer math
     mock_student_cfg.learning_rate = 1e-4
@@ -1079,6 +1096,7 @@ class TrainDistillTest(unittest.TestCase):
     mock_student_cfg.vocab_size = 32000
     mock_student_cfg.mesh_axes = ("data",)
     mock_student_cfg.dataset_type = "grain"
+    mock_student_cfg.data_sharding = DEFAULT_DATA_SHARDING
 
     # Add dummy numbers for optimizer math
     mock_student_cfg.learning_rate = 1e-4


### PR DESCRIPTION
# Description

This PR explicitly passes the `data_sharding` configuration to Tunix's `PeftTrainer` during distillation training and updates the corresponding unit tests.
  
Previously, `data_sharding_axis` relied on PeftTrainer's default value. This mismatch with MaxText's native dataset `PartitionSpec` caused Tunix to incorrectly attempt eager re-sharding of globally distributed arrays, throwing `ValueError: device_put's first argument must be a fully addressable array`.
  
Propagating the proper `data_sharding` config ensures the Tunix trainer leverages MaxText's upstream sharding and correctly bypasses eager re-sharding.

bugs: b/496590815
  
# Tests

- Checked that unit tests pass with the updated mocks.
- End-to-end distillation training to ensure the `ValueError` is fixed (TODO before submitting).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
