### PR TITLE
Fix KeyError in MTP layer processing for DeepSeek ckpt conversion

### DIFF
--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_deepseek_family_ckpt.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_deepseek_family_ckpt.py
@@ -528,6 +528,38 @@ def _convert_huggingface_to_jax_weights(base_model_path, model_params, mem_info,
   if has_mtp:
     max_logging.log("Processing MTP Layer")
 
+    # Initialize the mtp_block dictionary structure
+    jax_weights["mtp_block"] = {
+        "mtp_layer_1": {
+            "mtp_1_embedding_norm": {"scale": None},
+            "mtp_1_hidden_state_norm": {"scale": None},
+            "mtp_1_projection": {"kernel": None},
+            "mtp_1_transformer_layer": {
+                "pre_self_attention_layer_norm": {"scale": None},
+                "post_self_attention_layer_norm": {"scale": None},
+                "self_attention": {
+                    "kv_norm": {"scale": None},
+                    "wkv_a": {"kernel": None},
+                    "wkv_b": {"kernel": None},
+                    "out": {"kernel": None},
+                },
+                "DeepSeekMoeBlock_0": {
+                    "MoeBlock_0": {
+                        "wi_0": None,
+                        "wi_1": None,
+                        "wo": None,
+                        "gate": {"kernel": None},
+                    },
+                    "shared_experts": {
+                        "wi_0": {"kernel": None},
+                        "wi_1": {"kernel": None},
+                        "wo": {"kernel": None},
+                    },
+                },
+            },
+        }
+    }
+
     # MTP unique components
     jax_weights["mtp_block"]["mtp_layer_1"]["mtp_1_embedding_norm"]["scale"] = (
         chkpt_vars["mtp_block.mtp_layer_1.mtp_1_embedding_norm.scale"].to(torch.float16).numpy()


### PR DESCRIPTION
Description
===========

Initializes the `mtp_block` dictionary structure conditionally during DeepSeek checkpoint conversion to resolve a `KeyError`.

**Context and Problem:** When passing the `--enable_mtp=true` flag to `convert_deepseek_family_ckpt.py` (specifically required for DeepSeek-V3 Multi-Token Prediction weights), the script attempts to assign parsed safetensor values directly to keys within `jax_weights["mtp_block"]`. Because this nested dictionary structure was omitted from the base `jax_weights` initialization schema, it results in a `KeyError: 'mtp_block'` during the MTP Layer Processing step.

**Implementation and Solution:** This PR explicitly initializes the nested `mtp_block` dictionary structure inside the `if has_mtp:` condition, immediately preceding the weight assignments.

This approach ensures the necessary keys exist before data population, resolving the crash. Furthermore, by isolating the initialization to the conditional block, it maintains a clean `jax_weights` schema without injecting empty `mtp_block` structures for models that do not utilize MTP (e.g., DeepSeek-V2) or runs where the user explicitly disables MTP conversion.

Tests
=====

Tested the conversion script on a local VM utilizing CPU offloading to convert Hugging Face DeepSeek-V3 BF16 safetensors into a MaxText-compatible checkpoint.

**Command to reproduce:**

Bash

```
JAX_PLATFORMS=cpu python3 -m maxtext.checkpoint_conversion.standalone_scripts.convert_deepseek_family_ckpt\
    --base_model_path /path/to/deepseek/hf-671b-bf16\
    --maxtext_model_path gs://<YOUR_BUCKET>/deepseek3/conversion/test_ckpt\
    --model_size deepseek3-671b\
    --enable_mtp=true

```

**Result:** The script successfully bypasses the previous `KeyError: 'mtp_block'` and proceeds to process and export the MTP layers correctly.

Checklist
=========

Before submitting this PR, please make sure (put X in square brackets):

-   [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.

-   [x] I have necessary comments in my code, particularly in hard-to-understand areas.

-   [x] I have run end-to-end tests tests and provided workload links above if applicable.

-   [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).