### PR TITLE
Track next token prediction loss in training workload

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -430,6 +430,7 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
       "learning/indexer_loss": indexer_loss,
       "learning/mtp_loss": mtp_loss,
       "learning/total_weights": total_weights,
+      "learning/loss_without_mtp": loss - mtp_loss,
   }
   if config.use_qk_clip:
     # Apply QK-Clip


### PR DESCRIPTION
# Description

We want to also track the immediate next token prediction loss when MTP is enabled. We can get this by doing total_loss - mtp_loss. The benefit of this is we can see if having mtp enabled is helping the model's loss converge at a faster rate.

# Tests

Unit tests should pass.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
