### PR TITLE
Standardize placeholders in documentation and reduce list in editable…

### DIFF
--- a/docs/_static/js/editable_commands.js
+++ b/docs/_static/js/editable_commands.js
@@ -1,81 +1,44 @@
 /**
  * Handles inline editable commands in documentation.
- * Replaces placeholders in code blocks with inline input fields.
+ * Replaces placeholders in code blocks with inline editable spans.
+ * Using contenteditable spans avoids the "newline on copy" issue caused by inputs.
  */
 document.addEventListener('DOMContentLoaded', () => {
   const codeBlocks = document.querySelectorAll('div.highlight-sh pre, div.highlight-bash pre, div.highlight-default pre');
 
+  const placeholders = [
+    "<BATCH_SIZE_PER_DEVICE>",
+    "<CHIPS_PER_VM>",
+    "<CKPT_PATH>",
+    "<CLUSTER_NAME>",
+    "<DATA_COLUMNS>",
+    "<DATASET_NAME>",
+    "<DATASET_PATH>",
+    "<GCS_BUCKET>",
+    "<HF_CKPT_PATH>",
+    "<HF_MODEL>",
+    "<HF_TOKEN>",
+    "<IMAGE_NAME>",
+    "<LAZY_LOAD>",
+    "<MODEL_NAME>",
+    "<NUM_SLICES>",
+    "<POD_NAME>",
+    "<PROJECT_ID>",
+    "<RUN_NAME>",
+    "<STEPS>",
+    "<TPU_TYPE>",
+    "<TRAIN_SPLIT>",
+    "<VENV_NAME>",
+    "<ZONE>"
+  ];
+
   codeBlocks.forEach(block => {
-
     const originalHTML = block.innerHTML;
-
-    const placeholders = [
-      "<batch size per device>",
-      "<bucket>",
-      "<cluster name>",
-      "<data columns to train on>",
-      "<Data Columns to Train on>",
-      "<data split for train>",
-      "<Data Split for Train>",
-      "<dataset path>",
-      "<Docker Image Name>",
-      "<Fine-Tuning Steps>",
-      "<Flag to lazy load>",
-      "<Flag to use ocdbt>",
-      "<Flag to use zarr3>",
-      "<folder>",
-      "<gcs path for MaxText checkpoint>",
-      "<GCS Path for Output/Logs>",
-      "<GCS for dataset>",
-      "<GCP project ID>",
-      "<GCP zone>",
-      "<gke version>",
-      "<GKE Cluster Zone>",
-      "<Google Cloud Project ID>",
-      "<Hugging Face Access Token>",
-      "<Hugging Face access token>",
-      "<Hugging Face Dataset Name>",
-      "<Hugging Face dataset name>",
-      "<Hugging Face Model>",
-      "<Hugging Face Model to be converted to MaxText>",
-      "<MaxText Model>",
-      "<MaxText model name>",
-      "<Model Name>",
-      "<model name>",
-      "<Model Tokenizer>",
-      "<name for this run>",
-      "<Name for this run>",
-      "<Name of GKE Cluster>",
-      "<Name of Workload>",
-      "<number of fine-tuning steps to run>",
-      "<number of slices>",
-      "<output directory to store Hugging Face checkpoint>",
-      "<output directory to store MaxText checkpoint>",
-      "<output directory to store run logs>",
-      "<path to Hugging Face checkpoint>",
-      "<path/to/gcr.io>",
-      "<project id>",
-      "<project ID>",
-      "<project>",
-      "<ramdisk size>",
-      "<steps>",
-      "<the number of chips per VM>",
-      "<Tokenizer>",
-      "<tokenizer path>",
-      "<TPU Type>",
-      "<virtual env name>",
-      "<your virtual env name>",
-      "<your zone>",
-      "<YOUR WORKLOAD NAME>",
-      "<zone>",
-      "<zone name>"
-    ];
-
     let newHTML = originalHTML;
 
     placeholders.forEach(placeholder => {
-      // 1. create robust regex for this placeholder
-      // escape chars
+      // 1. Create robust regex for this placeholder
+      // Escape chars
       const escapeRegex = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
       const htmlEscapedKey = placeholder
@@ -86,16 +49,17 @@ document.addEventListener('DOMContentLoaded', () => {
       let pattern = '';
       for (let i = 0; i < htmlEscapedKey.length; i++) {
         const char = htmlEscapedKey[i];
-        pattern += escapeRegex(char) + '(?:<[^>]+>)*';
+        // FIX: Avoid matching across our inserted spans by ignoring tags with contenteditable
+        pattern += escapeRegex(char) + '(?:<(?!span[^>]*contenteditable)[^>]+>)*';
       }
 
       const regex = new RegExp(pattern, 'g');
 
-      // Replace with an input element
-      // We use the original placeholder text as placeholder for the input
-      const inputHTML = `<input class="inline-input" placeholder="${placeholder}" style="width: ${placeholder.length + 2}ch;" />`;
+      // Replace with a contenteditable span
+      // The styling mimics an input field but remains strictly inline
+      const spanHTML = `<span class="inline-input" contenteditable="true" spellcheck="false" data-placeholder="${placeholder}" style="border-bottom: 1px dashed #888; background: rgba(128, 128, 128, 0.15); padding: 0 4px; border-radius: 2px; outline: none;">${htmlEscapedKey}</span>`;
 
-      newHTML = newHTML.replace(regex, inputHTML);
+      newHTML = newHTML.replace(regex, spanHTML);
     });
 
     if (newHTML !== originalHTML) {
@@ -103,50 +67,33 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // Add event listeners to newly created inputs to auto-resize
-  document.querySelectorAll('.inline-input').forEach(input => {
-    input.addEventListener('input', function () {
-      this.style.width = Math.max(this.value.length, this.placeholder.length) + 2 + 'ch';
+  // Bind behavioral events to the newly created editable spans
+  document.querySelectorAll('.inline-input').forEach(span => {
+
+    // Auto-select the text when clicked, so the user can immediately type over the placeholder
+    span.addEventListener('focus', function () {
+      if (this.textContent === this.getAttribute('data-placeholder')) {
+        const range = document.createRange();
+        range.selectNodeContents(this);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }
+    });
+
+    // If the user deletes everything and clicks away, restore the original placeholder
+    span.addEventListener('blur', function () {
+      if (this.textContent.trim() === '') {
+        this.textContent = this.getAttribute('data-placeholder');
+      }
+    });
+
+    // Prevent 'Enter' from creating a messy multiline command block
+    span.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        this.blur(); // Drop focus instead of breaking to a new line
+      }
     });
   });
-
-  /**
-   * Intercept copy button clicks to include user input values.
-   * Runs in capture phase to precede sphinx-copybutton's listener.
-   */
-  document.addEventListener('click', (event) => {
-    // Check if the clicked element is a copy button or inside one
-    const button = event.target.closest('.copybtn');
-    if (!button) return;
-
-    // Find the associated code block
-    // Sphinx-copybutton places the button inside .highlight usually
-    const highlightDiv = button.closest('.highlight');
-    if (!highlightDiv) return;
-
-    const inputs = highlightDiv.querySelectorAll('input.inline-input');
-    if (inputs.length === 0) return;
-
-    const swaps = [];
-    inputs.forEach(input => {
-      // Create a temporary span with the input's current value
-      const span = document.createElement('span');
-      // If value is empty, fallback to placeholder to match original text behavior
-      const val = input.value;
-      span.textContent = val ? val : input.placeholder;
-
-      // Mimic input appearance slightly if needed, but plain text is what we want copied
-      span.style.color = val ? 'inherit' : 'gray';
-
-      input.replaceWith(span);
-      swaps.push({ input, span });
-    });
-
-    // Revert immediately after the current event loop
-    setTimeout(() => {
-      swaps.forEach(({ input, span }) => {
-        span.replaceWith(input);
-      });
-    }, 0);
-  }, true);
 });

--- a/docs/build_maxtext.md
+++ b/docs/build_maxtext.md
@@ -57,7 +57,7 @@ pip install uv
 # curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Create virtual environment
-export VENV_NAME=<your virtual env name> # e.g., docker_venv
+export VENV_NAME=<VENV_NAME> # e.g., docker_venv
 uv venv --python 3.12 --seed ${VENV_NAME?}
 source ${VENV_NAME?}/bin/activate
 
@@ -80,7 +80,7 @@ git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
 
 # Create virtual environment
-export VENV_NAME=<your virtual env name> # e.g., docker_venv
+export VENV_NAME=<VENV_NAME> # e.g., docker_venv
 uv venv --python 3.12 --seed ${VENV_NAME?}
 source ${VENV_NAME?}/bin/activate
 
@@ -137,7 +137,7 @@ build_maxtext_docker_image WORKFLOW=post-training
 
 ```bash
 # Make sure to set `CLOUD_IMAGE_NAME` with your desired image name.
-export CLOUD_IMAGE_NAME=<Docker Image Name>
+export CLOUD_IMAGE_NAME=<IMAGE_NAME>
 upload_maxtext_docker_image CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME?}
 ```
 

--- a/docs/guides/checkpointing_solutions/convert_checkpoint.md
+++ b/docs/guides/checkpointing_solutions/convert_checkpoint.md
@@ -40,10 +40,10 @@ Use the `to_maxtext.py` script to convert a Hugging Face model checkpoint into a
 python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
 
 # Setup environment variables
-export MODEL=<Hugging Face Model to be converted to MaxText> # e.g. 'llama3.1-8b-Instruct'
-export BASE_OUTPUT_DIRECTORY=<output directory to store MaxText checkpoint> # e.g., gs://my-bucket/my-checkpoint-directory
+export MODEL=<HF_MODEL> # e.g. 'llama3.1-8b-Instruct'
+export BASE_OUTPUT_DIRECTORY=<CKPT_PATH> # e.g., gs://my-bucket/my-checkpoint-directory
 export USE_PATHWAYS=0 # Set to 1 for Pathways, 0 for McJAX
-export LAZY_LOAD_TENSORS=<Flag to lazy load> # Set to True to save RAM
+export LAZY_LOAD_TENSORS=<LAZY_LOAD> # Set to True to save RAM
 ```
 
 ### Run Conversion
@@ -93,9 +93,9 @@ Use the `to_huggingface.py` script to convert a MaxText checkpoint into the Hugg
 python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
 
 # Setup environment variables
-export MODEL=<MaxText model name> # e.g. 'qwen3-4b'
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
-export BASE_OUTPUT_DIRECTORY=<output directory to store Hugging Face checkpoint> # e.g., gs://my-bucket/my-checkpoint-directory
+export MODEL=<MODEL_NAME> # e.g. 'qwen3-4b'
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+export BASE_OUTPUT_DIRECTORY=<HF_CKPT_PATH> # e.g., gs://my-bucket/my-checkpoint-directory
 ```
 
 ### Run Conversion
@@ -134,9 +134,9 @@ To ensure the conversion was successful, you can use the [test script](https://g
 
 ```bash
 # Setup environment variables
-export MODEL=<MaxText model name> # e.g. 'qwen3-4b'
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
-export HF_CKPT_PATH=<path to Hugging Face checkpoint> # e.g., gs://my-bucket/my-checkpoint-directory
+export MODEL=<MODEL_NAME> # e.g. 'qwen3-4b'
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+export HF_CKPT_PATH=<HF_CKPT_PATH> # e.g., gs://my-bucket/my-checkpoint-directory
 ```
 
 ### Run Correctness Test

--- a/docs/install_maxtext.md
+++ b/docs/install_maxtext.md
@@ -33,8 +33,8 @@ This is the easiest way to get started with the latest stable version.
 1. **Create a virtual environment:**
 
    ```bash
-   uv venv --python 3.12 --seed <virtual env name>
-   source <virtual env name>/bin/activate
+   uv venv --python 3.12 --seed <VENV_NAME>
+   source <VENV_NAME>/bin/activate
    ```
 
 2. **Install MaxText and its dependencies.**
@@ -115,8 +115,8 @@ environment to avoid dependency conflicts.
 2. Create virtual environment:
 
    ```bash
-   uv venv --python 3.12 --seed <virtual env name>
-   source <virtual env name>/bin/activate
+   uv venv --python 3.12 --seed <VENV_NAME>
+   source <VENV_NAME>/bin/activate
    ```
 
 3. Install dependencies in editable mode. Choose a single installation option

--- a/docs/tutorials/posttraining/full_finetuning.md
+++ b/docs/tutorials/posttraining/full_finetuning.md
@@ -41,19 +41,19 @@ placeholders with your actual values.
 # -- Model configuration --
 # The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
 # full list of supported models.
-export MODEL=<MaxText Model> # e.g., 'llama3.1-8b-Instruct'
+export MODEL=<MODEL_NAME> # e.g., 'llama3.1-8b-Instruct'
 
 # -- MaxText configuration --
 # Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
 # region as your TPUs to minimize latency and costs.
 # You can list your buckets and their locations in the
 # [Cloud Console](https://console.cloud.google.com/storage/browser).
-export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
+export BASE_OUTPUT_DIRECTORY=<GCS_BUCKET> # e.g., gs://my-bucket/maxtext-runs
 
 # An arbitrary string to identify this specific run.
 # We recommend to include the model, user, and timestamp.
 # Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
-export RUN_NAME=<Name for this run>
+export RUN_NAME=<RUN_NAME>
 ```
 
 ## Hugging Face checkpoint to Maxtext checkpoint
@@ -65,7 +65,7 @@ This section explains how to prepare your model checkpoint for use with MaxText.
 If you already have a MaxText-compatible model checkpoint, simply set the following environment variable and move on to the next section.
 
 ```sh
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
 ### Option 2: Converting a Hugging Face checkpoint
@@ -73,7 +73,7 @@ export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucke
 Refer the steps in [Hugging Face to MaxText](https://maxtext.readthedocs.io/en/maxtext-v0.2.1/guides/checkpointing_solutions/convert_checkpoint.html#hugging-face-to-maxtext) to convert a hugging face checkpoint to MaxText. Make sure you have correct checkpoint files converted and saved. Similar as Option 1, you can set the following environment and move on.
 
 ```bash
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # gs://my-bucket/my-checkpoint-directory/0/items
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # gs://my-bucket/my-checkpoint-directory/0/items
 ```
 
 ## Dataset
@@ -90,8 +90,8 @@ Run these steps once per project prior to any local development or cluster exper
 MaxText assumes these GCS buckets are created in the same project and that it has permissions to read and write from them.
 
 ```sh
-export PROJECT_ID=<Google Cloud Project ID>
-export DATASET_GCS_BUCKET=<GCS for dataset> # e.g., gs://my-bucket/my-dataset
+export PROJECT_ID=<PROJECT_ID>
+export DATASET_GCS_BUCKET=<DATASET_PATH> # e.g., gs://my-bucket/my-dataset
 
 bash tools/data_generation/download_dataset.sh ${PROJECT_ID?} ${DATASET_GCS_BUCKET?}
 ```

--- a/docs/tutorials/posttraining/rl.md
+++ b/docs/tutorials/posttraining/rl.md
@@ -64,25 +64,25 @@ placeholders with your actual values.
 # -- Model configuration --
 # The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
 # full list of supported models.
-export MODEL=<MaxText Model> # e.g. 'llama3.1-8b-Instruct'
+export MODEL=<MODEL_NAME> # e.g. 'llama3.1-8b-Instruct'
 
 # -- MaxText configuration --
 # Use a GCS bucket you own to store logs and checkpoints.
 # You can list your buckets and their locations in the
 # [Cloud Console](https://console.cloud.google.com/storage/browser) or via
 # `gcloud storage buckets list --format="table(name, location)"`.
-export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
+export BASE_OUTPUT_DIRECTORY=<GCS_BUCKET> # e.g., gs://my-bucket/maxtext-runs
 
 # An arbitrary string to identify this specific run.
 # We recommend to include the model, user, and timestamp.
 # Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
-export RUN_NAME=<Name for this run>
+export RUN_NAME=<RUN_NAME>
 
 # Number of accelerator chips per VM.
 # - TPU v5e (single host): 8
 # - TPU v5p (single host): 4
 # - TPU v6e (single host): 8
-export CHIPS_PER_VM=<the number of chips per VM>
+export CHIPS_PER_VM=<CHIPS_PER_VM>
 ```
 
 ## Get your model checkpoint
@@ -93,7 +93,7 @@ If you already have a MaxText-compatible model checkpoint, simply set the
 following environment variable and move on to the next section.
 
 ```bash
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
 ### Option 2: Converting from a Hugging Face checkpoint
@@ -101,7 +101,7 @@ export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucke
 Refer the steps in [Hugging Face to MaxText](https://maxtext.readthedocs.io/en/maxtext-v0.2.1/guides/checkpointing_solutions/convert_checkpoint.html#hugging-face-to-maxtext) to convert a hugging face checkpoint to MaxText. Make sure you have correct checkpoint files converted and saved. Similar as Option 1, you can set the following environment and move on.
 
 ```bash
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
 ## Run GRPO

--- a/docs/tutorials/posttraining/rl_on_multi_host.md
+++ b/docs/tutorials/posttraining/rl_on_multi_host.md
@@ -75,23 +75,23 @@ placeholders with your actual values.
 # -- Model configuration --
 # The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
 # full list of supported models.
-export MODEL=<MaxText Model> # e.g. 'llama3.1-70b-Instruct'
+export MODEL=<MODEL_NAME> # e.g. 'llama3.1-70b-Instruct'
 
 # Your Hugging Face access token. Required to download gated models like Llama.
 # You can generate one at https://huggingface.co/settings/tokens.
-export HF_TOKEN=<Hugging Face access token>
+export HF_TOKEN=<HF_TOKEN>
 
 # -- MaxText configuration --
 # Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
 # region as your TPUs to minimize latency and costs.
 # You can list your buckets and their locations in the
 # [Cloud Console](https://console.cloud.google.com/storage/browser).
-export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
+export BASE_OUTPUT_DIRECTORY=<GCS_BUCKET> # e.g., gs://my-bucket/maxtext-runs
 
 # An arbitrary string to identify this specific run.
 # We recommend to include the model, user, and timestamp.
 # Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
-export RUN_NAME=<Name for this run>
+export RUN_NAME=<RUN_NAME>
 
 # The directory containing the MaxText-compatible model checkpoint.
 # If you are converting from a Hugging Face checkpoint, see:
@@ -102,13 +102,13 @@ export MAXTEXT_CKPT_PATH=${BASE_OUTPUT_DIRECTORY?}/${RUN_NAME?}/0/items
 # Your GCP project ID. Find it on the [Cloud Console Dashboard](https://console.cloud.google.com/home/dashboard).
 # If you've already set it in your local config, you can retrieve it via:
 # gcloud config get-value project
-export PROJECT_ID=<GCP project ID>
+export PROJECT_ID=<PROJECT_ID>
 
 # The GCP location (listed as "Location" in the UI) and name of your
 # TPU-enabled GKE cluster. Both can be found on the
 # [Cloud Console](https://console.cloud.google.com/kubernetes/list).
-export ZONE=<GCP location> # e.g., 'us-central1' or 'us-central1-a'
-export GKE_CLUSTER=<cluster name>
+export ZONE=<ZONE> # e.g., 'us-central1' or 'us-central1-a'
+export GKE_CLUSTER=<CLUSTER_NAME>
 
 # For a full list of MaxText-supported TPU types, see: `src/maxtext/utils/accelerator_to_spec_map.py`. To see the TPU type
 # of your cluster:
@@ -118,10 +118,10 @@ export GKE_CLUSTER=<cluster name>
 
 # 2. Find your TPU type (e.g., 'v5p-128') by checking the accelerator labels on your nodes:
 # kubectl get nodes -l cloud.google.com/gke-tpu-accelerator -o jsonpath='{.items[*].metadata.labels.cloud\.google\.com/gke-tpu-accelerator}' | tr ' ' '\n' | sort -u
-export TPU_TYPE=<TPU Type>
+export TPU_TYPE=<TPU_TYPE>
 
 # The Docker image you pushed in the prerequisite step
-export CLOUD_IMAGE_NAME=<image name>
+export CLOUD_IMAGE_NAME=<IMAGE_NAME>
 export DOCKER_IMAGE="gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?}"
 ```
 
@@ -133,7 +133,7 @@ If you already have a MaxText-compatible model checkpoint, simply set the
 following environment variable and move on to the next section.
 
 ```bash
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
 ### Option 2: Converting from a Hugging Face checkpoint
@@ -141,7 +141,7 @@ export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucke
 Refer to the steps in [Hugging Face to MaxText](../../guides/checkpointing_solutions/convert_checkpoint.md) to convert a hugging face checkpoint to MaxText. Make sure you have correct checkpoint files converted and saved. Similar as Option 1, you can set the following environment and move on.
 
 ```bash
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
 ## Submit your RL workload via Pathways
@@ -154,7 +154,7 @@ submit the `train_rl.py` script via XPK.
 
 > **Note:** XPK v0.14.0+ automatically discovers your cluster's location from
 > GCP. You don't need to specify `--zone` in the commands below. If using an
-> older XPK version, add `--zone=<zone>` to the workload commands.
+> older XPK version, add `--zone=<ZONE>` to the workload commands.
 
 ### Submit GRPO workload
 
@@ -202,7 +202,7 @@ python3 -m maxtext.trainers.post_train.rl.train_rl \
       --project ${PROJECT_ID?}
   ```
   In case the job still lingers on, you can use
-  `kubectl get pods` to obtain the name of the pod and then run: `kubectl delete pod <pod-name>`.
+  `kubectl get pods` to obtain the name of the pod and then run: `kubectl delete pod <POD_NAME>`.
 
 ## Troubleshooting
 

--- a/docs/tutorials/posttraining/sft.md
+++ b/docs/tutorials/posttraining/sft.md
@@ -45,27 +45,27 @@ placeholders with your actual values.
 # -- Model configuration --
 # The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
 # full list of supported models.
-export MODEL=<MaxText Model> # e.g., 'llama3.1-8b-Instruct'
+export MODEL=<MODEL_NAME> # e.g., 'llama3.1-8b-Instruct'
 
 # -- MaxText configuration --
 # Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
 # region as your TPUs to minimize latency and costs.
 # You can list your buckets and their locations in the
 # [Cloud Console](https://console.cloud.google.com/storage/browser).
-export BASE_OUTPUT_DIRECTORY=<gcs bucket path> # e.g., gs://my-bucket/maxtext-runs
+export BASE_OUTPUT_DIRECTORY=<GCS_BUCKET> # e.g., gs://my-bucket/maxtext-runs
 
 # An arbitrary string to identify this specific run.
 # We recommend to include the model, user, and timestamp.
 # Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
-export RUN_NAME=<Name for this run>
+export RUN_NAME=<RUN_NAME>
 
-export STEPS=<number of fine-tuning steps to run> # e.g., 1000
-export PER_DEVICE_BATCH_SIZE=<batch size per device> # e.g., 1
+export STEPS=<STEPS> # e.g., 1000
+export PER_DEVICE_BATCH_SIZE=<BATCH_SIZE_PER_DEVICE> # e.g., 1
 
 # -- Dataset configuration --
-export DATASET_NAME=<Hugging Face dataset name> # e.g., HuggingFaceH4/ultrachat_200k
-export TRAIN_SPLIT=<data split for train> # e.g., train_sft
-export TRAIN_DATA_COLUMNS=<data columns to train on> # e.g., ['messages']
+export DATASET_NAME=<DATASET_NAME> # e.g., HuggingFaceH4/ultrachat_200k
+export TRAIN_SPLIT=<TRAIN_SPLIT> # e.g., train_sft
+export TRAIN_DATA_COLUMNS=<DATA_COLUMNS> # e.g., ['messages']
 ```
 
 ## Get your model checkpoint
@@ -77,7 +77,7 @@ This section explains how to prepare your model checkpoint for use with MaxText.
 If you already have a MaxText-compatible model checkpoint, simply set the following environment variable and move on to the next section.
 
 ```sh
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
 ### Option 2: Converting a Hugging Face checkpoint
@@ -85,7 +85,7 @@ export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucke
 Refer the steps in [Hugging Face to MaxText](https://maxtext.readthedocs.io/en/maxtext-v0.2.1/guides/checkpointing_solutions/convert_checkpoint.html#hugging-face-to-maxtext) to convert a hugging face checkpoint to MaxText. Make sure you have correct checkpoint files converted and saved. Similar as Option 1, you can set the following environment and move on.
 
 ```sh
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
 ## Run SFT on Hugging Face Dataset

--- a/docs/tutorials/posttraining/sft_on_multi_host.md
+++ b/docs/tutorials/posttraining/sft_on_multi_host.md
@@ -52,11 +52,11 @@ placeholders with your actual values.
 # -- Model configuration --
 # The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
 # full list of supported models.
-export MODEL=<MaxText Model> # e.g., deepseek3-671b
+export MODEL=<MODEL_NAME> # e.g., deepseek3-671b
 
 # Your Hugging Face access token. Required to download gated models like Llama.
 # You can generate one at https://huggingface.co/settings/tokens.
-export HF_TOKEN=<Hugging Face Access Token>
+export HF_TOKEN=<HF_TOKEN>
 
 # -- MaxText configuration --
 # Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
@@ -64,24 +64,24 @@ export HF_TOKEN=<Hugging Face Access Token>
 # You can list your buckets and their locations in the
 # [Cloud Console](https://console.cloud.google.com/storage/browser) or via
 # `gcloud storage buckets list --format="table(name, location)"`.
-export BASE_OUTPUT_DIRECTORY=<GCS Path for Output/Logs> # e.g., gs://my-bucket/maxtext-runs
+export BASE_OUTPUT_DIRECTORY=<GCS_BUCKET> # e.g., gs://my-bucket/maxtext-runs
 
 # An arbitrary string to identify this specific run.
 # We recommend to include the model, user, and timestamp.
 # Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
-export RUN_NAME=<Name for this run>
+export RUN_NAME=<RUN_NAME>
 
 # -- Workload configuration --
 # Your GCP project ID. Find it on the [Cloud Console Dashboard](https://console.cloud.google.com/home/dashboard).
 # If you've already set it in your local config, you can retrieve it via:
 # gcloud config get-value project
-export PROJECT_ID=<Google Cloud Project ID>
+export PROJECT_ID=<PROJECT_ID>
 
 # The GCP location (listed as "Location" in the UI) and name of your
 # TPU-enabled GKE cluster. Both can be found on the
 # [Cloud Console](https://console.cloud.google.com/kubernetes/list).
-export ZONE=<GKE Cluster Zone> # e.g., 'us-central1'
-export GKE_CLUSTER=<Name of GKE Cluster>
+export ZONE=<ZONE> # e.g., 'us-central1'
+export GKE_CLUSTER=<CLUSTER_NAME>
 
 # For a full list of MaxText-supported TPU types, see: `src/maxtext/utils/accelerator_to_spec_map.py`. To see the TPU type
 # of your cluster:
@@ -91,20 +91,20 @@ export GKE_CLUSTER=<Name of GKE Cluster>
 
 # 2. Find your TPU type (e.g., 'v5p-128') by checking the accelerator labels on your nodes:
 # kubectl get nodes -l cloud.google.com/gke-tpu-accelerator -o jsonpath='{.items[*].metadata.labels.cloud\.google\.com/gke-tpu-accelerator}' | tr ' ' '\n' | sort -u
-export TPU_TYPE=<TPU Type>
-export NUM_SLICES=<number of slices>
+export TPU_TYPE=<TPU_TYPE>
+export NUM_SLICES=<NUM_SLICES>
 
 # The Docker image you pushed in the prerequisite step
-export CLOUD_IMAGE_NAME=<image name>
+export CLOUD_IMAGE_NAME=<IMAGE_NAME>
 export DOCKER_IMAGE="gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?}"
 
 # -- Fine-Tuning configuration --
-export STEPS=<Fine-Tuning Steps> # e.g., 1000
+export STEPS=<STEPS> # e.g., 1000
 
 # -- Dataset configuration --
-export DATASET_NAME=<Hugging Face Dataset Name> # e.g., HuggingFaceH4/ultrachat_200k
-export TRAIN_SPLIT=<Data Split for Train> # e.g., train_sft
-export TRAIN_DATA_COLUMNS=<Data Columns to Train on> # e.g., ['messages']
+export DATASET_NAME=<DATASET_NAME> # e.g., HuggingFaceH4/ultrachat_200k
+export TRAIN_SPLIT=<TRAIN_SPLIT> # e.g., train_sft
+export TRAIN_DATA_COLUMNS=<DATA_COLUMNS> # e.g., ['messages']
 ```
 
 ## Get MaxText model checkpoint
@@ -116,7 +116,7 @@ This section explains how to prepare your model checkpoint for use with MaxText.
 If you already have a MaxText-compatible model checkpoint, simply set the following environment variable and move on to the next section.
 
 ```bash
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
 **Note:** Make sure that `MAXTEXT_CKPT_PATH` has the checkpoints created using the correct storage flags:
@@ -132,7 +132,7 @@ checkpoint_storage_use_ocdbt=$((1 - USE_PATHWAYS))
 Refer the steps in [Hugging Face to MaxText](https://maxtext.readthedocs.io/en/maxtext-v0.2.1/guides/checkpointing_solutions/convert_checkpoint.html#hugging-face-to-maxtext) to convert a hugging face checkpoint to MaxText. Make sure you have correct checkpoint files converted and saved. Similar as Option 1, you can set the following environment and move on.
 
 ```bash
-export MAXTEXT_CKPT_PATH=<gcs path for MaxText checkpoint> # gs://my-bucket/my-checkpoint-directory/0/items
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # gs://my-bucket/my-checkpoint-directory/0/items
 ```
 
 ## Submit workload on GKE cluster


### PR DESCRIPTION
# Description

This PR standardizes documentation placeholders across the repository and significantly reduces the number of placeholders tracked in docs/_static/js/editable_commands.js. Previously, the documentation used a wide variety of inconsistent placeholder formats (e.g., <MaxText Model>, <gcs bucket path>, <Name for this run>), and the JavaScript file maintained a list of over 60 entries. Now, all placeholders follow a consistent, all-caps, underscore-separated format (e.g., <MODEL_NAME>, <GCS_BUCKET>), and the list in editable_commands.js has been reduced to 23 standardized tokens. Additionally, this change ensures that users can directly copy and paste the editable commands without introducing unwanted line breaks, preserving shell-safe command integrity.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: https://b.corp.google.com/issues/497820805
FIXES: https://b.corp.google.com/issues/497810452

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
