### PR TITLE
Add lm_loss/perplexity metrics and fix MoE load balance loss extraction

### DIFF
--- a/src/maxtext/common/metric_logger.py
+++ b/src/maxtext/common/metric_logger.py
@@ -170,12 +170,23 @@ class MetricLogger:
           ]
       )
 
+    lm_loss = scalars.get("learning/lm_loss", 0.0)
+    perplexity = scalars.get("learning/perplexity", 0.0)
     log_parts.extend(
         [
             f"total_weights: {scalars['learning/total_weights']}",
             f"loss: {loss:.3f}",
+            f"lm_loss: {lm_loss:.3f}",
+            f"perplexity: {perplexity:.3f}",
         ]
     )
+    if self.config.use_dpo:
+      dpo_loss = scalars.get("learning/dpo_loss", 0.0)
+      log_parts.append(f"dpo_loss: {dpo_loss:.3f}")
+
+    if self.config.num_experts > 1:
+      moe_lb_loss = scalars.get("learning/moe_lb_loss", 0.0)
+      log_parts.append(f"moe_lb_loss: {moe_lb_loss:.3f}")
 
     if self.config.mtp_num_layers > 0:
       mtp_loss = scalars.get("learning/mtp_loss", 0.0)
@@ -190,6 +201,7 @@ class MetricLogger:
     log_parts = [
         f"eval metrics after step: {step}",
         f"loss={scalars['eval/avg_loss']:.3f}",
+        f"perplexity={scalars['eval/avg_perplexity']:.3f}",
         f"total_weights={scalars['eval/total_weights']}",
     ]
 
@@ -359,6 +371,7 @@ class MetricLogger:
       self.cumulative_eval_metrics["scalar"]["eval/mtp_acceptance_rate_percent"] += float(
           metrics["scalar"].get("evaluation/mtp_acceptance_rate_percent", 0.0)
       )
+      self.cumulative_eval_metrics["scalar"]["eval/z_loss"] += float(metrics["scalar"].get("evaluation/z_loss", 0.0))
       if self.config.use_dpo:
         self.cumulative_eval_metrics["scalar"]["eval/dpo_reward_accuracy"] += float(
             metrics["scalar"].get("evaluation/dpo_reward_accuracy", 0.0)
@@ -369,6 +382,7 @@ class MetricLogger:
           self.cumulative_eval_metrics["scalar"]["eval/total_weights"] + EPS
       )
       self.cumulative_eval_metrics["scalar"]["eval/avg_loss"] = eval_loss
+      self.cumulative_eval_metrics["scalar"]["eval/avg_perplexity"] = np.exp(eval_loss)
       self.cumulative_eval_metrics["scalar"]["eval/avg_moe_lb_loss"] = (
           self.cumulative_eval_metrics["scalar"]["eval/moe_lb_loss"] / eval_step_count
       )
@@ -380,6 +394,9 @@ class MetricLogger:
       )
       self.cumulative_eval_metrics["scalar"]["eval/avg_mtp_acceptance_rate_percent"] = (
           self.cumulative_eval_metrics["scalar"]["eval/mtp_acceptance_rate_percent"] / eval_step_count
+      )
+      self.cumulative_eval_metrics["scalar"]["eval/avg_z_loss"] = (
+          self.cumulative_eval_metrics["scalar"]["eval/z_loss"] / eval_step_count
       )
       if self.config.use_dpo:
         self.cumulative_eval_metrics["scalar"]["eval/dpo_reward_accuracy"] = (

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2530,6 +2530,12 @@ class MaxTextConfig(
         raise NotImplementedError(
             "Sparse indexer is only supported dot_product attention or flash attention with tokamax splash."
         )
+      if self.indexer_loss_scaling_factor > 0.0 and self.indexer_topk >= self.max_target_length:
+        raise ValueError(
+            f"`indexer_topk` ({self.indexer_topk}) must be < `max_target_length` ({self.max_target_length}) "
+            "when indexer loss is enabled (`indexer_loss_scaling_factor > 0.0`); otherwise the indexer "
+            "short-circuits to select all tokens and no indexer loss is produced."
+        )
     if self.attention_type == AttentionType.CHUNK.value and (
         not isinstance(self.chunk_attn_window_size, int) or self.chunk_attn_window_size <= 0
     ):

--- a/src/maxtext/input_pipeline/input_pipeline_interface.py
+++ b/src/maxtext/input_pipeline/input_pipeline_interface.py
@@ -64,7 +64,8 @@ def create_data_iterator(config: pyconfig.HyperParameters, mesh):
 
   # Return synthetic dataset if selected
   if config.dataset_type == "synthetic":
-    return SyntheticDataIterator(config, mesh), None
+    eval_iterator = SyntheticDataIterator(config, mesh) if config.eval_interval > 0 else None
+    return SyntheticDataIterator(config, mesh), eval_iterator
   dataset_type_to_train_eval_iterator = {
       "tfds": (make_tfds_train_iterator, make_tfds_eval_iterator),
       "grain": (make_grain_train_iterator, make_grain_eval_iterator),

--- a/src/maxtext/input_pipeline/synthetic_data_processing.py
+++ b/src/maxtext/input_pipeline/synthetic_data_processing.py
@@ -56,6 +56,9 @@ class SyntheticDataIterator:
     segmentation = jnp.ones((config.global_batch_size_to_load, config.max_target_length), dtype=jnp.int32)
     self.data = (tokens, batch_positions, segmentation)
 
+  def reset(self):
+    pass  # Synthetic data is stateless; nothing to reset.
+
   def __iter__(self):
     return self
 

--- a/src/maxtext/trainers/post_train/dpo/dpo_utils.py
+++ b/src/maxtext/trainers/post_train/dpo/dpo_utils.py
@@ -42,8 +42,14 @@ def dpo_loss_fn(model, config, data, dropout_rng, params, reference_params, is_t
     is_train: True for train_step and False for eval_step
 
   Returns:
-    loss: average loss
-    aux: a dictionary including intermediate_outputs, total_loss, and total_weights
+    loss: DPO preference loss + MoE load balance loss (if applicable)
+    aux: a dictionary with:
+      - intermediate_outputs: model intermediates from forward pass
+      - xent_sum: always 0.0 (DPO has no per-token cross-entropy)
+      - dpo_loss: pure preference loss before auxiliary losses
+      - total_weights: number of samples in the batch
+      - moe_lb_loss: MoE load balance loss (0.0 if num_experts <= 1)
+      - reward_accuracy: fraction of examples where chosen is preferred over rejected
   """
   # inputs, targets, segments, positions = apply_args
   rng1, aqt_rng = jax.random.split(dropout_rng)
@@ -130,14 +136,15 @@ def dpo_loss_fn(model, config, data, dropout_rng, params, reference_params, is_t
 
   moe_lb_loss = 0.0
   if config.num_experts > 1:
-    nested_key = ("intermediates", "decoder", "layers", "moe_lb_loss")
-    total_moe_lb_loss = maxtext_utils.get_nested_value(intermediate_outputs, nested_key, 0.0)
-    moe_lb_loss = jnp.mean(jnp.array(total_moe_lb_loss))
-    loss += moe_lb_loss
+    moe_lb_losses = maxtext_utils.collect_intermediates_by_suffix(intermediate_outputs, "moe_lb_loss")
+    if moe_lb_losses:
+      moe_lb_loss = jnp.mean(jnp.concatenate(moe_lb_losses))
+      loss += moe_lb_loss
   reward_accuracy = jnp.mean(chosen_logratios > rejected_logratios)
   aux = {
       "intermediate_outputs": intermediate_outputs,
-      "total_loss": total_loss,
+      "xent_sum": 0.0,  # DPO has no per-token cross-entropy sum; set to 0 for train_step compatibility
+      "dpo_loss": total_loss,  # pure preference loss before MoE lb, analogous to lm_loss in pre-training
       "total_weights": total_weights,
       "moe_lb_loss": moe_lb_loss,
       "reward_accuracy": reward_accuracy,

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -100,7 +100,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
 
   Returns:
     loss: average loss
-    aux: a dictionary including intermediate_outputs, total_loss, and total_weights
+    aux: a dictionary including intermediate_outputs, xent_sum, and total_weights
   """
   # decimate proportion of data when per_device_batch_size<1
   if is_train:
@@ -142,12 +142,12 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
     if (config.use_indexer and not config.indexer_sparse_training) and is_train:
       # In Dense Warm-up stage, we skip main model loss calculation for efficiency.
       # The main model parameters are frozen and only the indexer is trained via KL divergence.
-      total_loss = 0.0
+      xent_sum = 0.0
       total_z_loss = 0.0
     elif config.num_vocab_tiling > 1:
       hidden_state_key = ("intermediates", "decoder", "hidden_states")
       hidden_states = maxtext_utils.get_nested_value(intermediate_outputs, hidden_state_key)[0]
-      total_loss, total_z_loss = vocab_tiling_linen_loss(hidden_states, data, config, model, params, is_train)
+      xent_sum, total_z_loss = vocab_tiling_linen_loss(hidden_states, data, config, model, params, is_train)
     else:
       one_hot_targets = jax.nn.one_hot(data["targets"], config.vocab_size)
       xent, z_loss = max_utils.cross_entropy_with_logits(logits, one_hot_targets, z_loss=config.z_loss_multiplier)
@@ -171,7 +171,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
       xent = xent * (data["targets_segmentation"] != 0)
       z_loss = z_loss * (data["targets_segmentation"] != 0)
 
-      total_loss = jnp.sum(xent)
+      xent_sum = jnp.sum(xent)
       total_z_loss = jnp.sum(z_loss)
   else:
     # Flax NNX model
@@ -190,7 +190,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
     if (config.use_indexer and not config.indexer_sparse_training) and is_train:
       # In Dense Warm-up stage, we skip main model loss calculation for efficiency.
       # The main model parameters are frozen and only the indexer is trained via KL divergence.
-      total_loss = 0.0
+      xent_sum = 0.0
       total_z_loss = 0.0
     else:
       one_hot_targets = jax.nn.one_hot(data["targets"], config.vocab_size)
@@ -203,26 +203,26 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
       xent = xent * (data["targets_segmentation"] != 0)
       z_loss = z_loss * (data["targets_segmentation"] != 0)
 
-      total_loss = jnp.sum(xent)
+      xent_sum = jnp.sum(xent)
       total_z_loss = jnp.sum(z_loss)
 
   total_weights = jnp.sum(data["targets_segmentation"] != 0)
-  # If gradient accumulation is enabled, we don't need to divide total_loss
+  # If gradient accumulation is enabled, we don't need to divide xent_sum
   # by total_weights and then multiply the computed gradient by total_weights,
-  # since it's equivalent to computing the gradient from total_loss.
+  # since it's equivalent to computing the gradient from xent_sum.
   # This simplification reduces the number of operations and makes it easier
   # for XLA to move all-reduce out of the gradient accumulation loop when use
   # Zero1+GA to reduce communication overhead.
   # EPS was used to avoid division by zero, but it's not needed when gradient
   # accumulation is enabled since there's no division.
   if config.gradient_accumulation_steps > 1 and not config.use_tunix_gradient_accumulation:
-    loss = total_loss
+    loss = xent_sum
   else:
     # When using Tunix gradient accumulation, we revert to standard normalization.
     # Unlike the manual accumulation path above, Tunix (via optax.MultiSteps) expects
     # a normalized loss for each step. It handles the accumulation state
     # updates and scaling internally.
-    loss = total_loss / (total_weights + EPS)
+    loss = xent_sum / (total_weights + EPS)
 
   # We keep z-loss normalized by total_weights.
   total_z_loss = total_z_loss / (total_weights + EPS)
@@ -236,15 +236,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
   # get indexer loss
   indexer_loss = 0.0
   if config.use_indexer and config.indexer_loss_scaling_factor > 0.0:
-    indexer_losses = []
-    # Extract 'indexer_loss' from model intermediates.
-    # We check for paths ending in ('self_attention', 'indexer_loss').
-    # This handles varying paths caused by different layer names.
-    for path, val in jax.tree_util.tree_leaves_with_path(intermediate_outputs):
-      path_keys = tuple(k.key for k in path if hasattr(k, "key"))
-      if path_keys[-2:] == ("self_attention", "indexer_loss"):
-        indexer_losses.append(jnp.ravel(val))
-
+    indexer_losses = maxtext_utils.collect_intermediates_by_suffix(intermediate_outputs, "self_attention", "indexer_loss")
     if indexer_losses:
       indexer_loss = jnp.mean(jnp.concatenate(indexer_losses))
       loss += indexer_loss
@@ -254,25 +246,12 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
   # get MoE load balance loss
   moe_lb_loss = 0.0
   if config.num_experts > 1:
-    # Note: the key is affected by the model implementation
-    possible_keys = [
-        ("intermediates", "decoder", "layers", "moe_lb_loss"),
-        ("intermediates", "decoder", "moe_layers", "moe_lb_loss"),
-    ]
-
-    total_moe_lb_loss = 0.0
-    found_loss = False
-    for nested_key in possible_keys:
-      total_moe_lb_loss = maxtext_utils.get_nested_value(intermediate_outputs, nested_key, 0.0)
-      if total_moe_lb_loss != 0.0:
-        found_loss = True
-        break
-
-    if not found_loss:
+    moe_lb_losses = maxtext_utils.collect_intermediates_by_suffix(intermediate_outputs, "moe_lb_loss")
+    if moe_lb_losses:
+      moe_lb_loss = jnp.mean(jnp.concatenate(moe_lb_losses))
+      loss += moe_lb_loss
+    else:
       max_logging.debug("\nNo MoE load balance loss found. Defaulting to 0.0.")
-
-    moe_lb_loss = jnp.mean(jnp.array(total_moe_lb_loss))
-    loss += moe_lb_loss
 
   # get MoE routed bias term updates
   moe_bias_updates = None
@@ -286,7 +265,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
 
   aux = {
       "intermediate_outputs": intermediate_outputs,
-      "total_loss": total_loss,
+      "xent_sum": xent_sum,
       "z_loss": total_z_loss,
       "total_weights": total_weights,
       "moe_lb_loss": moe_lb_loss,
@@ -364,12 +343,13 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
         max_utils.with_memory_kind(params_shardings, "device"),
     )
   intermediate_outputs = aux["intermediate_outputs"]
+  xent_sum = aux["xent_sum"]
   total_weights = aux["total_weights"]
   moe_lb_loss = aux["moe_lb_loss"]
-  indexer_loss = aux["indexer_loss"]
-  z_loss = aux["z_loss"]
-  moe_bias_updates = aux["moe_bias_updates"]
-  mtp_loss = aux["mtp_loss"]
+  indexer_loss = aux.get("indexer_loss", 0.0)
+  z_loss = aux.get("z_loss", 0.0)
+  moe_bias_updates = aux.get("moe_bias_updates")
+  mtp_loss = aux.get("mtp_loss", 0.0)
 
   if config.gradient_clipping_threshold > 0:
     grads = maxtext_utils.apply_gradient_clipping(raw_grads, state, config.gradient_clipping_threshold)
@@ -422,8 +402,11 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
     moe_bias_updates = jnp.array(moe_bias_updates[0]).transpose()
     new_state = maxtext_utils.update_state_param(new_state, target_path, moe_bias_updates)
 
+  lm_loss = xent_sum / (total_weights + EPS)
   scalar_metrics = {
       "learning/loss": loss,
+      "learning/lm_loss": lm_loss,
+      "learning/perplexity": jnp.exp(lm_loss),
       "learning/z_loss": z_loss,
       "learning/moe_lb_loss": moe_lb_loss,
       "learning/indexer_loss": indexer_loss,
@@ -444,6 +427,7 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
     scalar_metrics["learning/raw_grad_norm"] = max_utils.l2norm_pytree(raw_grads)
     scalar_metrics["learning/param_norm"] = max_utils.l2norm_pytree(new_state.params)
   if config.use_dpo:
+    scalar_metrics["learning/dpo_loss"] = aux["dpo_loss"]
     scalar_metrics["learning/dpo_reward_accuracy"] = aux["reward_accuracy"]
   metrics = {
       "scalar": scalar_metrics,
@@ -475,17 +459,21 @@ def eval_step(model, config, state, data, dropout_rng):
   if config.mtp_eval_target_module > 0:
     mtp_acceptance_rate = calculate_mtp_acceptance_rate(aux["intermediate_outputs"], config)
 
-  total_loss = aux["total_loss"]
-  z_loss = aux["z_loss"]
+  xent_sum = aux["xent_sum"]
+  z_loss = aux.get("z_loss", 0.0)
   total_weights = aux["total_weights"]
   moe_lb_loss = aux["moe_lb_loss"]
-  indexer_loss = aux["indexer_loss"]
-  mtp_loss = aux["mtp_loss"]
+  indexer_loss = aux.get("indexer_loss", 0.0)
+  mtp_loss = aux.get("mtp_loss", 0.0)
+  # For DPO, report the unnormalized sum of per-sample preference losses so that
+  # MetricLogger (which divides eval/total_loss by eval/total_weights) recovers
+  # the correct mean DPO loss. xent_sum is always 0 for DPO and must not be used.
+  eval_total_loss = aux["dpo_loss"] * total_weights if config.use_dpo else xent_sum
   metrics = {
       "scalar": {
           "evaluation/loss": loss,
           "evaluation/z_loss": z_loss,
-          "evaluation/total_loss": total_loss,
+          "evaluation/total_loss": eval_total_loss,
           "evaluation/total_weights": total_weights,
           "evaluation/moe_lb_loss": moe_lb_loss,
           "evaluation/indexer_loss": indexer_loss,

--- a/src/maxtext/utils/gradient_accumulation.py
+++ b/src/maxtext/utils/gradient_accumulation.py
@@ -92,7 +92,7 @@ def gradient_accumulation_loss_and_grad(
   def accumulate_gradient(acc_grad_and_loss, data):
     ga_params = acc_grad_and_loss["ga_params"]
     (_, aux), cur_batch_gradient = grad_func(model, config, data, dropout_rng, ga_params, *extra_dpo_args, is_train=True)
-    acc_grad_and_loss["loss"] += aux["total_loss"]
+    acc_grad_and_loss["loss"] += aux["xent_sum"] + aux.get("dpo_loss", 0.0)
     acc_grad_and_loss["moe_lb_loss"] += aux["moe_lb_loss"]
     acc_grad_and_loss["indexer_loss"] += aux["indexer_loss"]
     acc_grad_and_loss["mtp_loss"] += aux["mtp_loss"]
@@ -111,7 +111,7 @@ def gradient_accumulation_loss_and_grad(
   init_grad = jax.tree_util.tree_map(jnp.zeros_like, ga_params)
   init_grad = jax.tree.map(_maybe_shard_with_name, init_grad, grad_shardings)
   init_grad_and_loss = {
-      "loss": 0.0,
+      "loss": 0.0,  # accumulates xent_sum across microbatches
       "grad": init_grad,
       "total_weights": 0,
       "moe_lb_loss": 0.0,

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -143,6 +143,13 @@ def get_shaped_batch(config):
   shaped_batch["targets"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
   shaped_batch["targets_position"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
   shaped_batch["targets_segmentation"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+  if config.use_dpo:
+    shaped_batch["chosen"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+    shaped_batch["chosen_position"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+    shaped_batch["chosen_segmentation"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+    shaped_batch["rejected"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+    shaped_batch["rejected_position"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+    shaped_batch["rejected_segmentation"] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
   if config.use_multimodal:
     image_shape = mm_processor.get_dummy_image_shape_for_init(
         config.model_name, batch_size=config.micro_batch_size_to_train_on
@@ -1058,6 +1065,30 @@ def get_nested_value(dictionary, nested_key, default=None):
       return default
     current_level = current_level[key]
   return current_level
+
+
+def collect_intermediates_by_suffix(intermediate_outputs, *suffix_keys: str) -> list:
+  """Collects intermediate leaf values whose dict-key path ends with suffix_keys.
+
+  Works regardless of model architecture (scanned, scannable blocks, or standard),
+  since it matches only the tail of the path rather than the full path.
+
+  Args:
+    intermediate_outputs: The intermediates dict returned by model.apply().
+    *suffix_keys: One or more key names forming the expected path suffix,
+      e.g. ``("moe_lb_loss",)`` or ``("self_attention", "indexer_loss")``.
+
+  Returns:
+    A list of 1-D JAX arrays, one per matching leaf (already ravelled).
+  """
+  suffix = tuple(suffix_keys)
+  n = len(suffix)
+  values = []
+  for path, val in jax.tree_util.tree_leaves_with_path(intermediate_outputs):
+    path_keys = tuple(k.key for k in path if hasattr(k, "key"))
+    if len(path_keys) >= n and path_keys[-n:] == suffix:
+      values.append(jnp.ravel(val))
+  return values
 
 
 def get_intermediate_value(model, nested_key, default=None, clear=False):


### PR DESCRIPTION
# Description

Adds `lm_loss` and `perplexity` metrics to pre-training, fixes MoE load
balance loss extraction for scanned architectures, and fixes eval with
synthetic data.

**Metric improvements:**
- Rename `aux["total_loss"]` → `aux["xent_sum"]` to clarify it is the
  unnormalized sum of per-token cross-entropies, distinct from the full
  training objective (`loss` includes MoE lb, indexer, MTP auxiliary losses)
- Add `learning/lm_loss` (= xent_sum / total_weights) and
  `learning/perplexity` (= exp(lm_loss)) to TensorBoard and console output
- Add `eval/avg_perplexity` and `eval/avg_z_loss` to cumulative eval metrics
- Log `moe_lb_loss` in console output when `num_experts > 1`

**MoE load balance loss fix:**
The previous implementation looked up MoE lb loss via a fixed set of hard-coded
intermediate paths. This broke for Gemma4 and other models (like Llama4) that use scanned
blocks, where the path includes dynamic layer indices. Replaced with
`collect_intermediates_by_suffix()`, a new `maxtext_utils` helper that matches
leaves by key-path suffix, working correctly across scanned, scannable-block,
and standard layer layouts. Same fix applied to indexer loss extraction.

**Synthetic eval fix:**
fixed synthetic evals work with `eval_interval > 0`.

# Tests

Verified a run on Gemma4-26B:

```
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml   model_name=gemma4-26b   base_output_directory=${BASE_OUTPUT_DIRECTORY?}   dataset_type=hf   hf_path=allenai/c4   hf_name=en   hf_eval_split=validation   tokenizer_type=huggingface   tokenizer_path=google/gemma-4-26b-a4b-it   per_device_batch_size=1   run_name=runner_finetune_gemma4_26b_2   steps=100   enable_checkpointing=false   sharding_tolerance=0.03   eval_interval=20   eval_steps=5   load_balance_loss_weight=0.1
```

output: https://paste.googleplex.com/5891139803676672

DPO test:

```
 python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/post_train/dpo.yml   run_name=dpo_smoke   base_emb_dim=256   base_num_query_heads=4   base_num_kv_heads=4   base_mlp_dim=512   base_num_decoder_layers=4   head_dim=64   per_device_batch_size=1   max_target_length=128   steps=10   eval_interval=5   eval_steps=2   enable_checkpointing=false
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
