### PR TITLE
add dynamic versioning and conditional checkout instructions

### DIFF
--- a/docs/build_maxtext.md
+++ b/docs/build_maxtext.md
@@ -78,7 +78,25 @@ If you plan to contribute to MaxText or need the latest unreleased features, ins
 # Clone the repository
 git clone https://github.com/AI-Hypercomputer/maxtext.git
 cd maxtext
+```
 
+:::\{only} is_not_latest
+
+By default, cloning the repository provides the latest version (**HEAD**).
+If you wish to use the latest features, please follow the [latest guide](https://maxtext.readthedocs.io/en/latest/install_maxtext.html).
+If you want to ensure compatibility with the specific version of the documentation
+you are currently viewing, you must checkout the corresponding tag for that version
+before proceeding with the installation.
+
+```{eval-rst}
+.. parsed-literal::
+
+  git checkout |version|
+```
+
+:::
+
+```bash
 # Create virtual environment
 export VENV_NAME=<your virtual env name> # e.g., docker_venv
 uv venv --python 3.12 --seed ${VENV_NAME?}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ project = "MaxText"
 # pylint: disable=redefined-builtin
 copyright = "2023–2026, Google LLC"
 author = "MaxText developers"
+version = os.environ.get("READTHEDOCS_VERSION", "latest")
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -250,3 +251,6 @@ def setup(app):
   logger = logging.getLogger("sphinx")
   warning_handler, *_ = [h for h in logger.handlers if isinstance(h, sphinx_logging.WarningStreamHandler)]
   warning_handler.filters.insert(0, FilterSphinxWarnings(app))
+
+  if version != "latest":
+    app.tags.add("is_not_latest")

--- a/docs/install_maxtext.md
+++ b/docs/install_maxtext.md
@@ -112,6 +112,22 @@ environment to avoid dependency conflicts.
    cd maxtext
    ```
 
+:::\{only} is_not_latest
+
+By default, cloning the repository provides the latest version (**HEAD**).
+If you wish to use the latest features, please follow the [latest guide](https://maxtext.readthedocs.io/en/latest/install_maxtext.html).
+If you want to ensure compatibility with the specific version of the documentation
+you are currently viewing, you must checkout the corresponding tag for that version
+before proceeding with the installation.
+
+```{eval-rst}
+.. parsed-literal::
+
+  git checkout |version|
+```
+
+:::
+
 2. Create virtual environment:
 
    ```bash


### PR DESCRIPTION
# Description

- Updated `docs/conf.py` to read the `READTHEDOCS_VERSION` environment variable to dynamically set the Sphinx `version` variable.
- Configured a new Sphinx tag (`is_not_latest`) in `docs/conf.py` to identify when the documentation being built is for an older release rather than the latest.
- Modified `docs/install_maxtext.md` and `docs/build_maxtext.md` to conditionally display a warning when users are viewing older versions of the documentation.

# Tests

Locally build the docs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
