### PR TITLE
Implement Tunix-based DPO/ORPO integration.

### DIFF
--- a/docs/tutorials/post_training_index.md
+++ b/docs/tutorials/post_training_index.md
@@ -28,6 +28,8 @@ MaxText was co-designed with key Google led innovations to provide a unified pos
   - [SFT on Multi-Host TPUs](../tutorials/posttraining/sft_on_multi_host.md)
 - **LoRA (Low-Rank Adaptation)**
   - [LoRA on Single-Host TPUs](../tutorials/posttraining/lora.md)
+- **DPO (Direct Preference Optimization) and ORPO (Odds-Ratio Policy Optimization)**
+  - [DPO/ORPO on Single-Host TPUs](../tutorials/posttraining/dpo.md)
 - **Multimodal SFT**
   - [Multimodal Support](../tutorials/posttraining/multimodal.md)
 - **Reinforcement Learning (RL)**
@@ -68,6 +70,7 @@ maxdepth: 1
 ---
 posttraining/sft.md
 posttraining/sft_on_multi_host.md
+posttraining/dpo.md
 posttraining/rl.md
 posttraining/rl_on_multi_host.md
 posttraining/rl_qwen3_30b.md

--- a/docs/tutorials/posttraining/dpo.md
+++ b/docs/tutorials/posttraining/dpo.md
@@ -1,0 +1,131 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+# Preference Optimization (DPO & ORPO) on Single-Host TPUs
+
+MaxText supports two primary methods for aligning models with human preferences: **Direct Preference Optimization (DPO)** and **Odds Ratio Preference Optimization (ORPO)**. Both methods avoid the complexity of traditional Reinforcement Learning from Human Feedback (RLHF) by optimizing directly on preference data.
+
+## DPO vs. ORPO
+
+- **Direct Preference Optimization (DPO):** Optimizes the policy by maximizing the relative log-probability of preferred responses over rejected ones. DPO requires a **reference model** (a frozen copy of the base model) to regularize the training and ensure the policy does not drift too far from the original model's distribution.
+- **Odds Ratio Preference Optimization (ORPO):** A newer, reference-free alignment method that integrates the preference loss directly into the supervised fine-tuning objective using an odds ratio. Because it **does not require a reference model**, ORPO is more memory-efficient and faster than DPO.
+
+## Data Requirements
+
+Both methods consume preference data in a **triplet format** consisting of a Prompt, a Chosen response, and a Rejected response. MaxText supports two ways to provide this data via the `train_data_columns` configuration:
+
+1. **Explicit Triplets (3 Columns):** The dataset provides three distinct columns for the prompt, chosen response, and rejected response.
+2. **Shared Prefix (2 Columns):** For datasets like `Anthropic/hh-rlhf`, where the prompt is embedded at the beginning of the responses, you can provide just two columns (e.g., `chosen` and `rejected`). MaxText will automatically extract the shared common prefix as the **Prompt** and treat the differing suffixes as the responses.
+
+During the input pipeline, prompts are left-padded and responses are right-padded to maintain optimal context for the model.
+
+## Prerequisites
+
+For instructions on installing MaxText with post-training dependencies on your VM, please refer to the [official documentation](../../install_maxtext.md) and use the `maxtext[tpu-post-train]` installation path.
+
+## Local run on a single-host TPU VM
+
+### Setup environment variables
+
+Login to Hugging Face. Provide your access token when prompted:
+
+```bash
+hf auth login
+```
+
+Set up the following environment variables to configure your training run. Replace placeholders with your actual values.
+
+```bash
+# -- Model configuration --
+# The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
+# full list of supported models.
+export MODEL=<MODEL_NAME>  # e.g., "qwen3-0.6b"
+
+# -- MaxText configuration --
+# Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
+# region as your TPUs to minimize latency and costs.
+# You can list your buckets and their locations in the
+# [Cloud Console](https://console.cloud.google.com/storage/browser).
+export BASE_OUTPUT_DIRECTORY=<GCS_BUCKET> # e.g., gs://my-bucket/maxtext-runs
+
+# An arbitrary string to identify this specific run.
+# We recommend to include the model, user, and timestamp.
+# Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
+export RUN_NAME=<RUN_NAME>
+
+export STEPS=<STEPS> # e.g., 1000
+export PER_DEVICE_BATCH_SIZE=<BATCH_SIZE_PER_DEVICE> # e.g., 1
+
+export ALGORITHM=<"dpo" or "orpo">  # Set to either "orpo" or "dpo"
+
+# -- Dataset configuration --
+export DATASET_NAME=<DATASET_NAME> # e.g., "argilla/distilabel-intel-orca-dpo-pairs"
+export TRAIN_SPLIT=<TRAIN_SPLIT> # e.g., train
+
+# Map your dataset columns to [Prompt, Chosen, Rejected]
+# For 3-column datasets:
+export TRAIN_DATA_COLUMNS="['input', 'chosen', 'rejected']"
+
+# For 2-column datasets (Prefix Extraction):
+# export TRAIN_DATA_COLUMNS="['chosen', 'rejected']"
+```
+
+## Get your model checkpoint
+
+This section explains how to prepare your model checkpoint for use with MaxText. You have two options: using an existing MaxText checkpoint or converting a Hugging Face checkpoint.
+
+### Option 1: Using an existing MaxText checkpoint
+
+If you already have a MaxText-compatible model checkpoint, simply set the following environment variable and move on to the next section.
+
+```sh
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+```
+
+### Option 2: Converting a Hugging Face checkpoint
+
+Refer to the steps in [Hugging Face to MaxText](../../guides/checkpointing_solutions/convert_checkpoint.md#hugging-face-to-maxtext) to convert a hugging face checkpoint to MaxText. Make sure you have correct checkpoint files converted and saved. Similar as Option 1, you can set the following environment and move on.
+
+```sh
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+```
+
+## Running DPO Training
+
+You can run the DPO training using the specialized post-training script:
+
+```{note}
+The script below uses `eval_interval=0` because the default "argilla/distilabel-intel-orca-dpo-pairs" dataset only has a "train" split.
+To use the same split for eval you can set a non-zero value and add `hf_eval_split=train`.
+```
+
+```bash
+python3 -m maxtext.trainers.post_train.dpo.train_dpo \
+    run_name=${RUN_NAME?} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
+    model_name=${MODEL?} \
+    load_parameters_path=${MAXTEXT_CKPT_PATH?} \
+    dataset_type=hf \
+    hf_path=${DATASET_NAME?} \
+    train_split=${TRAIN_SPLIT?} \
+    train_data_columns="${TRAIN_DATA_COLUMNS?}" \
+    steps=${STEPS?} \
+    eval_interval=0 \
+    per_device_batch_size=1 \
+    max_target_length=1024 \
+    use_dpo=1 \
+    dpo.algo=${ALGORITHM?}
+```

--- a/src/maxtext/common/metric_logger.py
+++ b/src/maxtext/common/metric_logger.py
@@ -190,9 +190,10 @@ class MetricLogger:
             f"perplexity: {perplexity:.3f}",
         ]
     )
-    if self.config.use_dpo:
-      dpo_loss = scalars.get("learning/dpo_loss", 0.0)
-      log_parts.append(f"dpo_loss: {dpo_loss:.3f}")
+    if "learning/dpo_loss" in scalars:
+      log_parts.append(f"dpo_loss: {scalars['learning/dpo_loss']:.3f}")
+    if "learning/reward_accuracy" in scalars:
+      log_parts.append(f"reward_accuracy: {scalars['learning/reward_accuracy']:.3f}")
 
     if self.config.num_experts > 1:
       moe_lb_loss = scalars.get("learning/moe_lb_loss", 0.0)

--- a/src/maxtext/configs/pyconfig.py
+++ b/src/maxtext/configs/pyconfig.py
@@ -52,6 +52,7 @@ _CONFIG_FILE_MAPPING: dict[str, str] = {
     "maxtext.trainers.pre_train.train": "base.yml",
     "maxtext.trainers.pre_train.train_compile": "base.yml",
     "maxtext.trainers.post_train.distillation.train_distill": "post_train/distillation.yml",
+    "maxtext.trainers.post_train.dpo.train_dpo": "post_train/dpo.yml",
     "maxtext.trainers.post_train.rl.train_rl": "post_train/rl.yml",
     "maxtext.trainers.post_train.sft.train_sft": "post_train/sft.yml",
     "maxtext.trainers.post_train.sft.train_sft_deprecated": "post_train/sft.yml",

--- a/src/maxtext/trainers/post_train/dpo/train_dpo.py
+++ b/src/maxtext/trainers/post_train/dpo/train_dpo.py
@@ -1,0 +1,189 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DPO Training script that uses Tunix DPOTrainer on a MaxText model.
+
+Example command:
+Training & Evaluation:
+  python3 -m maxtext.trainers.post_train.dpo.train_dpo \
+    run_name=${WORKLOAD?} base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
+    tokenizer_path="google/gemma-2-2b-it" tokenizer_type=huggingface \
+    dataset_type="hf" hf_path="Anthropic/hh-rlhf" hf_eval_split="test" \
+    train_data_columns="['chosen', 'rejected']" eval_data_columns="['chosen', 'rejected']" \
+    model_name=${MODEL?} load_parameters_path=${MAXTEXT_CONVERTED_CHECKPOINT?}/0/items \
+    hf_access_token=${HF_TOKEN?} per_device_batch_size=1 max_target_length=1024 \
+    eval_interval=2 eval_steps=2 steps=10 profiler=xplane weight_dtype=bfloat16
+"""
+
+from absl import app
+import jax
+import optax
+from orbax import checkpoint as ocp
+import pathwaysutils
+
+from flax import nnx
+from flax.linen import partitioning as nn_partitioning
+
+from tunix.sft import metrics_logger, profiler
+from tunix.sft.dpo.dpo_trainer import DPOTrainer, DPOTrainingConfig
+
+from maxtext.common.goodput import (
+    GoodputEvent,
+    RECORD_JOB_END_TIME,
+    RECORD_JOB_START_TIME,
+    create_goodput_recorder,
+    maybe_monitor_goodput,
+    maybe_record_goodput,
+    record_goodput,
+)
+from maxtext.configs import pyconfig
+from maxtext.configs.types import MaxTextConfig
+from maxtext.optimizers import optimizers
+from maxtext.trainers.post_train.dpo import hooks
+from maxtext.utils import max_logging
+from maxtext.utils import max_utils
+from maxtext.utils import maxtext_utils
+from maxtext.utils import model_creation_utils
+
+
+def get_tunix_config(mt_config: MaxTextConfig) -> DPOTrainingConfig:
+  """Gets the Tunix training configurations from the MaxText config.
+
+  Args:
+    mt_config: MaxText config.
+
+  Returns:
+    A Tunix `DPOTrainingConfig` object.
+  """
+  # Checkpointing configurations
+  checkpointing_options = ocp.CheckpointManagerOptions(
+      save_interval_steps=mt_config.checkpoint_period,
+      enable_async_checkpointing=mt_config.async_checkpointing,
+  )
+
+  # Metrics configurations
+  metrics_logging_options = metrics_logger.MetricsLoggerOptions(log_dir=mt_config.tensorboard_dir)
+
+  # Profiler configurations
+  profiler_options = None
+  if mt_config.profiler:
+    set_profile_options = True
+    platform_version = jax.extend.backend.get_backend().platform_version.strip()
+    if platform_version.startswith("Pathways"):
+      max_logging.log("Pathways backend detected. Disabling setting profile options.")
+      set_profile_options = False
+    profiler_options = profiler.ProfilerOptions(
+        log_dir=mt_config.tensorboard_dir,
+        skip_first_n_steps=mt_config.skip_first_n_steps_for_profiler,
+        profiler_steps=mt_config.profiler_steps,
+        set_profile_options=set_profile_options,
+    )
+
+  max_prompt_length = mt_config.max_target_length // 2
+  return DPOTrainingConfig(
+      eval_every_n_steps=mt_config.eval_interval,
+      max_steps=mt_config.steps,
+      gradient_accumulation_steps=mt_config.gradient_accumulation_steps,
+      checkpoint_root_directory=mt_config.checkpoint_dir,
+      checkpointing_options=checkpointing_options,
+      metrics_logging_options=metrics_logging_options,
+      profiler_options=profiler_options,
+      algorithm=mt_config.dpo.algo,
+      lambda_orpo=mt_config.dpo.orpo_lambda,
+      beta=mt_config.dpo.dpo_beta,
+      label_smoothing=mt_config.dpo.dpo_label_smoothing,
+      max_prompt_length=max_prompt_length,
+      max_response_length=mt_config.max_target_length - max_prompt_length,
+  )
+
+
+def setup_trainer_state(mt_config, goodput_recorder=None):
+  """Set up prerequisites for training loop."""
+  tunix_config = get_tunix_config(mt_config)
+
+  with maybe_record_goodput(goodput_recorder, GoodputEvent.TPU_INIT):
+    model, mesh = model_creation_utils.from_pretrained(mt_config, wrap_with_tunix_adapter=True)
+
+    learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(mt_config)
+    # pass in model for muon
+    optimizer = optimizers.get_optimizer(mt_config, learning_rate_schedule, model)
+
+    if mt_config.gradient_clipping_threshold > 0:
+      optimizer = optax.chain(
+          optax.clip_by_global_norm(max_norm=mt_config.gradient_clipping_threshold),
+          optimizer,
+      )
+
+  # ORPO does not require a reference model.
+  ref_model = nnx.clone(model) if mt_config.dpo.algo == "dpo" else None
+
+  with maybe_record_goodput(goodput_recorder, GoodputEvent.TRAINING_PREPARATION):
+    training_hooks = hooks.DPOTrainingHooks(mt_config, mesh, learning_rate_schedule, goodput_recorder)
+    data_hooks = hooks.DPODataHooks(mt_config, mesh, goodput_recorder)
+
+    # Provide rules context so logical axes (e.g. 'norm') are translated to mesh axes during maybe_restore
+    with nn_partitioning.axis_rules(mt_config.logical_axis_rules):
+      trainer = DPOTrainer(
+          model=model, ref_model=ref_model, optimizer=optimizer, training_config=tunix_config, tokenizer=None
+      )
+      trainer.with_training_hooks(training_hooks)
+      trainer.with_data_hooks(data_hooks)
+
+  return trainer, mesh
+
+
+def train_model(mt_config: MaxTextConfig, trainer, mesh):
+  """Runs the DPO training loop in Tunix."""
+  with mesh, nn_partitioning.axis_rules(mt_config.logical_axis_rules):
+    trainer.train(trainer.data_hooks.train_data_iterator, trainer.data_hooks.eval_data_iterator)
+  return trainer
+
+
+def train(mt_config, goodput_recorder=None):
+  """Main method for DPO training.
+
+  Args:
+    mt_config: MaxText config.
+    goodput_recorder: An optional GoodputRecorder to record performance metrics.
+  """
+  trainer, mesh = setup_trainer_state(mt_config, goodput_recorder)
+  _job_completed_gracefully = False
+  try:
+    trainer = train_model(mt_config, trainer, mesh)
+    _job_completed_gracefully = True
+  finally:
+    if _job_completed_gracefully:
+      record_goodput(goodput_recorder, RECORD_JOB_END_TIME)
+  return trainer, mesh
+
+
+def main(argv: list[str]) -> None:
+  """Main function to run DPO training.
+
+  Args:
+    argv: Command-line arguments.
+  """
+  pathwaysutils.initialize()
+
+  mt_config = pyconfig.initialize_pydantic(argv)
+  max_utils.print_system_information()
+
+  goodput_recorder = create_goodput_recorder(mt_config)
+  record_goodput(goodput_recorder, RECORD_JOB_START_TIME)
+  with maybe_monitor_goodput(mt_config):
+    train(mt_config, goodput_recorder)
+
+
+if __name__ == "__main__":
+  app.run(main)


### PR DESCRIPTION
# Description

Tunix-based DPO/ORPO implementation.

This DPO implementation is based on `train_sft.py`. The hooks are shared with SFT (see #3862).

Only HF datasets are currently supported (no grain and TFDS) yet.

After this PR I plan to follow up with:
* Additional documentation in the form of Jupyter notebooks
* End-to-end tests.
* Delete of the legacy DPO implementation.
* Add support of grain and TFDS datasets.

FIXES: b/485626968

# Tests

The DPO and ORPO integration was verified on a single-node TPU v5-8 VM using `Qwen2.5-1.5B-Instruct` as the base model and the `argilla/distilabel-intel-orca-dpo-pairs` dataset. 

* **E2E Functional Correctness:** Verified that the training loop runs to completion without error using the provided `train_dpo.py` script.
* **Instruction-Following Improvements (IFEval):** Evaluation over the IFEval dataset shows measurable alignment improvements:
  * **Strict Instruction Accuracy:** Improved by **+1.44%** (53.24% DPO vs. 51.80% baseline).
  * **Strict Prompt Accuracy:** Improved by **+0.37%** (41.77% DPO vs. 41.40% baseline).
* **General Knowledge Stability (MMLU):** Evaluation over the full 3,511 sharded MMLU test set confirms that general reasoning and knowledge capacity are mostly preserved post-alignment:
  * **Baseline:** 60.51%
  * **DPO Aligned:** 60.38% (99.7% knowledge retention; negligible -0.13% delta)
 
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
