### PR TITLE
fix(mtp): resolve parameter scoping in Multi-Token Prediction block

### DIFF
--- a/src/maxtext/layers/multi_token_prediction.py
+++ b/src/maxtext/layers/multi_token_prediction.py
@@ -79,7 +79,6 @@ class MultiTokenPredictionLayer(nnx.Module):
     self.layer_number = layer_number
     self.transformer_layer_module = transformer_layer_module
     self.rngs = rngs
-    k = layer_number
     cfg = self.config
 
     self.embedding_norm = RMSNorm(
@@ -112,7 +111,6 @@ class MultiTokenPredictionLayer(nnx.Module):
         config=cfg,
         mesh=mesh,
         model_mode=MODEL_MODE_TRAIN,
-        name=f"mtp_{k}_transformer_layer",
         rngs=rngs,
     )
 

--- a/src/maxtext/layers/nnx_wrappers.py
+++ b/src/maxtext/layers/nnx_wrappers.py
@@ -627,5 +627,6 @@ def to_linen_class(
   ToLinenPartial.__qualname__ = class_name
 
   ToLinenPartial.__init__ = __init__
+  ToLinenPartial.module_class = base_nnx_class
 
   return ToLinenPartial

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -93,14 +93,17 @@ class TransformerLinenPure(nn.Module):
     # If MTP is enabled via config, set up the MTP block.
     if self.config.mtp_num_layers > 0:
       # Get the list of layer blueprints for the current model.
-      layer_types = self.decoder.get_decoder_layers()
       # For MTP, we use the DecoderLayer blueprint to ensure architectural consistency.
       # By convention, this is the last layer in the list.
-      mtp_layer = layer_types[-1]
+      layer_types = self.decoder.get_decoder_layers()
+      mtp_layer_linen = layer_types[-1]
+      # UNWRAP: The MTP block is pure NNX. If the decoder returned a Linen wrapper,
+      # extract the native NNX class to preserve parameter tracing/scoping.
+      mtp_layer_nnx = getattr(mtp_layer_linen, "module_class", mtp_layer_linen)
       self.mtp_block = multi_token_prediction_block_as_linen(
           config=self.config,
           mesh=self.mesh,
-          transformer_layer_module=mtp_layer,
+          transformer_layer_module=mtp_layer_nnx,
           decoder=self.decoder,
           rngs=self.make_rng("mtp_block"),
       )


### PR DESCRIPTION
# Description

The MTP transformer layer parameters were incorrectly attaching to the top-level Linen scope (`mtp_block`) instead of the nested NNX scope (`mtp_layer_1`). This occurred because the parent model passed `ToLinen` wrappers into the MTP block, causing the Flax NNX tracer to ignore the nested layers and default to Linen's automatic scoping.

Changes:
* src/maxtext/layers/nnx_wrappers.py: Exposed the underlying native NNX class in the `to_linen_class` factory via a new `module_class` attribute.
* src/maxtext/models/models.py: Dynamically unwrapped the transformer layer using `getattr(mtp_layer_linen, "module_class")` before injecting it into the MTP block to preserve NNX tracing.
* src/maxtext/layers/multi_token_prediction.py: Removed the legacy Linen `name=` argument from the transformer.

FIXES: b/502806272

# Tests

Printed the param tree 

```
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_embedding_norm']['scale']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_hidden_state_norm']['scale']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_projection']['kernel']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['DeepSeekMoeBlock_0']['MoeBlock_0']['gate']['bias']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['DeepSeekMoeBlock_0']['MoeBlock_0']['gate']['kernel']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['DeepSeekMoeBlock_0']['MoeBlock_0']['wi_0']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['DeepSeekMoeBlock_0']['MoeBlock_0']['wi_1']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['DeepSeekMoeBlock_0']['MoeBlock_0']['wo']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['DeepSeekMoeBlock_0']['shared_experts']['wi_0']['kernel']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['DeepSeekMoeBlock_0']['shared_experts']['wi_1']['kernel']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['DeepSeekMoeBlock_0']['shared_experts']['wo']['kernel']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['post_self_attention_layer_norm']['scale']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['pre_self_attention_layer_norm']['scale']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['self_attention']['kv_norm']['scale']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['self_attention']['out']['kernel']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['self_attention']['q_norm']['scale']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['self_attention']['wkv_a']['kernel']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['self_attention']['wkv_b']['kernel']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['self_attention']['wq_a']['kernel']
['params']['params']['mtp_block']['mtp_layer_1']['mtp_1_transformer_layer']['self_attention']['wq_b']['kernel']
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
