### PR TITLE
Support grain data checkpoint for elastic training

### DIFF
--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -24,7 +24,7 @@ from flax.training import train_state
 import jax
 from maxtext.utils.globals import DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE
 from maxtext.input_pipeline.multihost_dataloading import MultiHostDataLoadIterator
-from maxtext.input_pipeline.multihost_dataloading import RemoteIterator
+from maxtext.input_pipeline.multihost_dataloading import RemoteIteratorWrapper
 from maxtext.input_pipeline.synthetic_data_processing import PlaceHolderDataIterator
 from maxtext.utils import exceptions
 from maxtext.utils import max_logging
@@ -43,6 +43,7 @@ import json
 
 import grain
 from grain.python import PyGrainCheckpointHandler
+from grain.experimental import ElasticIterator
 
 CheckpointManager = ocp.CheckpointManager
 CheckpointManagerOptions = ocp.CheckpointManagerOptions
@@ -67,6 +68,22 @@ class GrainCheckpointHandler(PyGrainCheckpointHandler, ocp.CheckpointHandler):
   ):
     """Saves the given iterator to the checkpoint in `directory`."""
     item = item or args.item  # pytype:disable=attribute-error
+
+    # RemoteIteratorWrapper handles checkpointing via colocated python
+    if isinstance(item, RemoteIteratorWrapper):
+      step = int(directory.parent.name)
+      item.save_state(step)
+      return
+
+    # ElasticIterator state is a single global scalar shared by all shards,
+    # so we write one fixed `process_0.json` from process 0 only. This file
+    # layout survives changes in `jax.process_count()`.
+    if isinstance(item, ElasticIterator):
+      if jax.process_index() == 0:
+        directory.mkdir(parents=True, exist_ok=True)
+        filename = directory / "process_0.json"
+        filename.write_text(json.dumps(item.get_state(), indent=4))
+      return
 
     def save_single_process(item, process_index, process_count):
       filename = directory / f"process_{process_index}-of-{process_count}.json"
@@ -93,6 +110,21 @@ class GrainCheckpointHandler(PyGrainCheckpointHandler, ocp.CheckpointHandler):
     item = item or args.item
     process_index = getattr(args, "process_index", None)
     process_count = getattr(args, "process_count", None)
+
+    # In Pathways + colocated_python environment, RemoteIteratorWrapper handles checkpointing
+    if isinstance(item, RemoteIteratorWrapper):
+      step = int(directory.parent.name)
+      item.restore_state(step)
+      return item
+
+    # McJax and Pathways through controller cases
+    # ElasticIterator: every process reads the same shared `process_0.json`.
+    if isinstance(item, ElasticIterator):
+      filename = directory / "process_0.json"
+      if not filename.exists():
+        raise ValueError(f"File {filename} does not exist.")
+      item.set_state(json.loads(filename.read_text()))
+      return item
 
     def restore_single_process(item, process_index, process_count):
       filename = directory / f"process_{process_index}-of-{process_count}.json"
@@ -129,15 +161,6 @@ class GrainCheckpointRestore(ocp.args.CheckpointArgs):
   item: Any
   process_index: Optional[int | list[int]] = None
   process_count: Optional[int] = None
-
-
-def _is_remote_iterator(data_iterator):
-  """Check if data_iterator is a RemoteIterator or contains RemoteIterator instances."""
-  if isinstance(data_iterator, RemoteIterator):
-    return True
-  if isinstance(data_iterator, list):
-    return any(isinstance(item, RemoteIterator) for item in data_iterator)
-  return False
 
 
 def _load_full_state_from_path(
@@ -481,6 +504,17 @@ def _restore_grain_iterator(
   This function dispatches to the correct restore strategy based on
   the number of stored checkpoint files vs. current JAX processes.
   """
+  if isinstance(data_iterator, RemoteIteratorWrapper):
+    grain_restore_args = GrainCheckpointRestore(item=data_iterator)
+    restored_state = checkpoint_manager.restore(step, args=Composite(items=checkpoint_args, iter=grain_restore_args))
+    return (restored_state, None)
+
+  # ElasticIterator: one shared `process_0.json` regardless of shard count.
+  if not isinstance(data_iterator, list) and isinstance(data_iterator.local_iterator, ElasticIterator):
+    grain_restore_args = GrainCheckpointRestore(item=data_iterator.local_iterator)
+    restored_state = checkpoint_manager.restore(step, args=Composite(items=checkpoint_args, iter=grain_restore_args))
+    return (restored_state, None)
+
   directory = checkpoint_manager.directory / str(step) / "iter"
   process_count_jax = jax.process_count()
 
@@ -620,13 +654,11 @@ def load_state_if_possible(
             (EmergencyCheckpointManager, EmergencyReplicatorCheckpointManager),
         ):
           return (
-              checkpoint_manager.restore(
-                  step, args=Composite(state=checkpoint_args)
-              ).state,
+              checkpoint_manager.restore(step, args=Composite(state=checkpoint_args)).state,
               None,
           )
         # Case 2: Matches if dataset type is "grain" and the data iterator is not a
-        # PlaceHolderDataIterator or RemoteIterator and a specific checkpoint file exists for the iterator
+        # PlaceHolderDataIterator and a specific checkpoint file exists for the iterator
         case (
             checkpoint_manager,
             dataset_type,
@@ -635,7 +667,6 @@ def load_state_if_possible(
             dataset_type == "grain"
             and data_iterator
             and not isinstance(data_iterator, PlaceHolderDataIterator)
-            and not _is_remote_iterator(data_iterator)
             and (checkpoint_manager.directory / str(step) / "iter").exists()
         ):
           return _restore_grain_iterator(
@@ -797,22 +828,24 @@ def save_checkpoint(checkpoint_manager, step, state, config=None, data_iterator=
   )
   save_args_composite = {"items": checkpoint_args}
 
-  if (
-      config
-      and config.dataset_type == "grain"
-      and not isinstance(data_iterator, PlaceHolderDataIterator)
-      and not _is_remote_iterator(data_iterator)
-  ):
-    if not isinstance(data_iterator, list):
-      data_iterator = [data_iterator]
-    grain_iters_to_save = []
-    process_count_total = jax.process_count() * len(data_iterator)
-    if config.expansion_factor_real_data > 1:
-      process_count_total = process_count_total // config.expansion_factor_real_data
-    for i, data_iter in enumerate(data_iterator):
-      process_index = jax.process_index() + i * jax.process_count()
-      grain_iters_to_save.append((data_iter.local_iterator, process_index, process_count_total))
-    save_args_composite["iter"] = GrainCheckpointSave(item=grain_iters_to_save)
+  if config and config.dataset_type == "grain" and not isinstance(data_iterator, PlaceHolderDataIterator):
+    if isinstance(data_iterator, RemoteIteratorWrapper):
+      # Pass the wrapper directly; GrainCheckpointHandler will call save_state with the step
+      save_args_composite["iter"] = GrainCheckpointSave(item=data_iterator)
+    elif not isinstance(data_iterator, list) and isinstance(data_iterator.local_iterator, ElasticIterator):
+      # ElasticIterator checkpoints a single global scalar shared by all shards.
+      save_args_composite["iter"] = GrainCheckpointSave(item=data_iterator.local_iterator)
+    else:
+      if not isinstance(data_iterator, list):
+        data_iterator = [data_iterator]
+      grain_iters_to_save = []
+      process_count_total = jax.process_count() * len(data_iterator)
+      if config.expansion_factor_real_data > 1:
+        process_count_total = process_count_total // config.expansion_factor_real_data
+      for i, data_iter in enumerate(data_iterator):
+        process_index = jax.process_index() + i * jax.process_count()
+        grain_iters_to_save.append((data_iter.local_iterator, process_index, process_count_total))
+      save_args_composite["iter"] = GrainCheckpointSave(item=grain_iters_to_save)
 
   match (checkpoint_manager, config, data_iterator):
     case (checkpoint_manager, _, _) if isinstance(

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -729,6 +729,7 @@ grain_num_threads_eval: 16
 grain_prefetch_buffer_size_eval: 500
 grain_data_source_max_workers: 16  # Max workers for ThreadPoolExecutor when mixing multiple Grain data sources.
 grain_shuffle_buffer_size: 100 # shuffle buffer when using sequential access formats such as Parquet, TFRecord.
+grain_use_elastic_iterator: False # For elastic training, set to this true and packing=False
 # for using pathways
 colocated_python_data_input: False  # experimental feature, under testing
 

--- a/src/maxtext/configs/post_train/dpo.yml
+++ b/src/maxtext/configs/post_train/dpo.yml
@@ -1,6 +1,7 @@
 base_config: "base.yml"
 
 use_dpo: true
+packing: false
 train_data_columns: ['chosen', 'rejected']
 eval_data_columns: ['chosen', 'rejected']
 base_output_directory: 'gs://maxtext-external/logs'

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1123,6 +1123,13 @@ class GrainDataset(BaseModel):
   grain_file_type: str = Field(
       "arrayrecord", description="File type for Grain data. Supported: arrayrecord, tfrecord, parquet."
   )
+  grain_use_elastic_iterator: bool = Field(
+      False,
+      description=(
+          "Whether to use grain's `ElasticIterator` for data loading. When True, the iterator"
+          "checkpoint can be restored after a change in the number of data-loading shards."
+      ),
+  )
   grain_worker_count: int = Field(1, description="Number of workers for Grain data loading.")
   grain_per_worker_buffer_size: int = Field(1, description="Per-worker buffer size for Grain train data loading.")
   grain_worker_count_eval: int = Field(1, description="Number of workers for Grain eval data loading.")
@@ -2620,6 +2627,31 @@ class MaxTextConfig(
       raise ValueError("At most one of `load_parameters_path` or `load_full_state_path` should be set.")
     if self.elastic_enabled and not self.enable_single_controller:
       raise ValueError("Elastic training is only supported with Pathways (`enable_single_controller=True`).")
+    if self.grain_use_elastic_iterator and self.grain_file_type != "arrayrecord":
+      raise ValueError(
+          "`grain_use_elastic_iterator=True` only supports `grain_file_type=arrayrecord`. "
+          "tfrecord and parquet pipelines use `InterleaveIterDataset` (a many-to-one "
+          "IterDataset transform), which `ElasticIterator` forbids. "
+          f"Got grain_file_type={self.grain_file_type}."
+      )
+    if self.grain_use_elastic_iterator and self.packing:
+      raise ValueError("`grain_use_elastic_iterator=True` requires `packing=False`.")
+    if self.use_dpo and self.packing:
+      raise ValueError("DPO does not support packing. Set `packing=False`.")
+    if self.grain_use_elastic_iterator and not self.use_truncation:
+      raise ValueError(
+          "`grain_use_elastic_iterator=True` requires `use_truncation=True`. "
+          "`TokenizeAndChunk` uses `apply`, which produces a many-to-one "
+          "IterDataset transform that `ElasticIterator` forbids."
+      )
+    if self.grain_use_elastic_iterator and (
+        self.grain_train_mixture_config_path or ";" in (self.grain_train_files or "")
+    ):
+      raise ValueError(
+          "`grain_use_elastic_iterator=True` does not support dataset mixtures. "
+          "Set `grain_train_mixture_config_path` to empty and use a single "
+          "`grain_train_files` pattern (no ';' separator)."
+      )
     if (self.load_parameters_path or self.load_full_state_path) and not self.enable_checkpointing:
       raise ValueError("You must set enable_checkpointing=True to load a checkpoint.")
     if self.enable_multi_tier_checkpointing:

--- a/src/maxtext/input_pipeline/data_processing_utils.py
+++ b/src/maxtext/input_pipeline/data_processing_utils.py
@@ -74,8 +74,16 @@ def get_local_batch_size(config):
   return batch_size
 
 
-def format_and_batch(dataset, config, batch_size, pad_id, data_columns, tokenizer_model):
-  """Packs or pads the dataset according to config and batches it."""
+def format_and_batch(dataset, config, batch_size, pad_id, data_columns, tokenizer_model, shift=True):
+  """Packs or pads the dataset, batches it, and optionally shifts tokens for next-token prediction.
+
+  When `config.grain_use_elastic_iterator` is True, batching is skipped
+  (ElasticIterator performs it internally) and, if `shift=True`, the shift is
+  applied pre-batch on axis 0, which is equivalent to a post-batch axis=1 shift.
+
+  `shift` should be False for pipelines that don't do next-token prediction
+  (e.g. DPO, which scores full sequences).
+  """
   if config.packing:
     length_struct = {col: config.max_target_length for col in data_columns}
     max_segments = config.max_segments_per_seq
@@ -113,23 +121,24 @@ def format_and_batch(dataset, config, batch_size, pad_id, data_columns, tokenize
   else:
     dataset = dataset.map(input_pipeline_utils.PadOrTrimToMaxLength(config.max_target_length, pad_id))
 
+  if config.grain_use_elastic_iterator:
+    # ElasticIterator batches internally, so return the pre-batch dataset.
+    if shift:
+      dataset = dataset.map(input_pipeline_utils.ShiftData(ignored_ids=[pad_id], axis=0))
+    return dataset
+
   batch_fn = functools.partial(grain.experimental.batch_and_pad, batch_size=batch_size, pad_value=pad_id)
   dataset = dataset.batch(batch_size, batch_fn=batch_fn)
+  if shift:
+    dataset = dataset.map(input_pipeline_utils.ShiftData(ignored_ids=[pad_id], axis=1))
   return dataset
-
-
-def shift_dataset(dataset, pad_id):
-  """Shift tokens to create inputs and targets for standard next-token prediction."""
-  return dataset.map(
-      input_pipeline_utils.ShiftData(
-          ignored_ids=[pad_id],
-          axis=1,
-      )
-  )
 
 
 def apply_multiprocessing_and_prefetch(dataset, config, grain_worker_count, grain_per_worker_buffer_size):
   """Applies multiprocessing and prefetching configurations to the dataset."""
+  if config.grain_use_elastic_iterator:
+    # ElasticIterator applies multiprocessing itself.
+    return dataset
   multiprocessing_options = (
       pick_performance_config(
           ds=dataset,

--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -24,6 +24,7 @@ import json
 import jax
 
 import grain.python as grain
+from grain.experimental import ElasticIterator
 
 from maxtext.input_pipeline import data_processing_utils
 from maxtext.input_pipeline import input_pipeline_utils
@@ -55,11 +56,19 @@ def _apply_mapdataset_transforms(
     dataloading_host_count,
     grain_num_threads,
     grain_prefetch_buffer_size,
+    elastic=False,
 ):
-  """Apply standard shuffle, repeat, shard, and iter conversion transforms."""
+  """Apply standard shuffle, repeat, shard, and iter conversion transforms.
+
+  When `elastic` is True, sharding and conversion to IterDataset are
+  skipped so that the resulting MapDataset can be fed to `ElasticIterator`,
+  which performs sharding and batching internally.
+  """
   if shuffle:
     dataset = dataset.shuffle(seed=shuffle_seed)
   dataset = dataset.repeat(num_epoch)
+  if elastic:
+    return dataset
   dataset = dataset[dataloading_host_index::dataloading_host_count]  # sharding
   dataset = dataset.to_iter_dataset(
       read_options=grain.ReadOptions(
@@ -84,6 +93,7 @@ def get_datasets(
     grain_prefetch_buffer_size,
     grain_data_source_max_workers,
     mixture_config_path=None,
+    elastic=False,
 ):
   """Load dataset from array_record files for using with grain"""
   if data_file_type == "arrayrecord":
@@ -165,6 +175,7 @@ def get_datasets(
           dataloading_host_count,
           grain_num_threads,
           grain_prefetch_buffer_size,
+          elastic=elastic,
       )
       return dataset
   elif data_file_type == "tfrecord":
@@ -213,7 +224,12 @@ def pretrain_preprocessing_pipeline(
     grain_worker_count,
     grain_per_worker_buffer_size,
 ):
-  """Use grain pipeline to pre-process the dataset and return iterators for pretrain"""
+  """Use grain pipeline to pre-process the dataset and return iterators for pretrain.
+
+  When `config.grain_use_elastic_iterator` is True, the pipeline stops before batching
+  and multiprocessing (which `ElasticIterator` performs itself) and applies
+  shift pre-batch on axis 0 rather than post-batch on axis 1.
+  """
   dataset = data_processing_utils.parse_and_keep_features(dataset, config, data_columns, tokenize)
 
   assert len(data_columns) == 1
@@ -233,8 +249,6 @@ def pretrain_preprocessing_pipeline(
 
   batch_size = data_processing_utils.get_local_batch_size(config)
   dataset = data_processing_utils.format_and_batch(dataset, config, batch_size, pad_id, data_columns, tokenizer_model)
-
-  dataset = data_processing_utils.shift_dataset(dataset, pad_id)
   dataset = data_processing_utils.apply_multiprocessing_and_prefetch(
       dataset, config, grain_worker_count, grain_per_worker_buffer_size
   )
@@ -256,10 +270,11 @@ def dpo_preprocessing_pipeline(
   if tokenize:
     dataset = dataset.map(grain_tokenizer.TokenizeAndTrim(data_columns, config.max_target_length, tokenizer_model))
 
-  dataset = dataset.map(input_pipeline_utils.PadOrTrimToMaxLength(config.max_target_length, pad_id))
   batch_size = config.global_batch_size_to_load // jax.process_count()
-  batch_fn = functools.partial(grain.experimental.batch_and_pad, batch_size=batch_size, pad_value=pad_id)
-  dataset = dataset.batch(batch_size, batch_fn=batch_fn)
+  # DPO scores full sequences, so no shift.
+  dataset = data_processing_utils.format_and_batch(
+      dataset, config, batch_size, pad_id, data_columns, tokenizer_model, shift=False
+  )
   dataset = data_processing_utils.apply_multiprocessing_and_prefetch(
       dataset, config, grain_worker_count, grain_per_worker_buffer_size
   )
@@ -345,12 +360,40 @@ def sft_preprocessing_pipeline(
   dataset = data_processing_utils.format_and_batch(
       dataset, config, batch_size, pad_id, data_columns, base_tokenizer_model
   )
-
-  dataset = data_processing_utils.shift_dataset(dataset, pad_id)
   dataset = data_processing_utils.apply_multiprocessing_and_prefetch(
       dataset, config, grain_worker_count, grain_per_worker_buffer_size
   )
   return dataset
+
+
+def _get_pipeline_fn(config):
+  """Returns the appropriate preprocessing pipeline function based on config."""
+  if config.use_dpo:
+    return dpo_preprocessing_pipeline
+  if config.use_sft:
+    return sft_preprocessing_pipeline
+  return pretrain_preprocessing_pipeline
+
+
+def _make_elastic_iterator(dataset, config, preprocessing_fn, shard_index=None, shard_count=None, mp_opts=None):
+  """Applies preprocessing_fn then wraps the result with ElasticIterator.
+
+  When shard_index/shard_count are None, defaults to jax.process_index()/jax.process_count().
+  """
+  ds = preprocessing_fn(dataset=dataset)
+  return ElasticIterator(
+      ds,
+      global_batch_size=config.global_batch_size_to_load,
+      shard_options=grain.ShardOptions(
+          shard_index=shard_index if shard_index is not None else jax.process_index(),
+          shard_count=shard_count if shard_count is not None else jax.process_count(),
+      ),
+      read_options=grain.ReadOptions(
+          num_threads=config.grain_num_threads,
+          prefetch_buffer_size=config.grain_prefetch_buffer_size,
+      ),
+      multiprocessing_options=mp_opts,
+  )
 
 
 def make_grain_train_iterator(
@@ -362,114 +405,96 @@ def make_grain_train_iterator(
   assert (
       config.global_batch_size_to_load % global_mesh.size == 0
   ), "Batch size should be divisible by number of global devices."
-  if not config.colocated_python_data_input and not 0 < config.expansion_factor_real_data < 1:
-    train_ds = get_datasets(
-        config.grain_train_files,
-        config.grain_file_type,
-        shuffle=config.enable_data_shuffling,
-        shuffle_seed=config.data_shuffle_seed,
-        shuffle_buffer_size=config.grain_shuffle_buffer_size,
-        num_epoch=config.num_epoch,
-        dataloading_host_index=process_indices.index(jax.process_index()),
-        dataloading_host_count=len(process_indices),
-        grain_worker_count=config.grain_worker_count,
-        grain_num_threads=config.grain_num_threads,
-        grain_prefetch_buffer_size=config.grain_prefetch_buffer_size,
-        grain_data_source_max_workers=config.grain_data_source_max_workers,
-        mixture_config_path=config.grain_train_mixture_config_path,
-    )
-    if config.use_dpo:
-      train_dataloader = dpo_preprocessing_pipeline(
-          train_ds,
-          config,
-          data_columns=config.train_data_columns,
-          tokenize=config.tokenize_train_data,
-          grain_worker_count=config.grain_worker_count,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size,
-      )
-    elif config.use_sft:
-      train_dataloader = sft_preprocessing_pipeline(
-          train_ds,
-          config,
-          data_columns=config.train_data_columns,
-          tokenize=config.tokenize_train_data,
-          grain_worker_count=config.grain_worker_count,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size,
-      )
-    else:
-      train_dataloader = pretrain_preprocessing_pipeline(
-          train_ds,
-          config,
-          data_columns=config.train_data_columns,
-          tokenize=config.tokenize_train_data,
-          grain_worker_count=config.grain_worker_count,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size,
-      )
-    return multihost_dataloading.MultiHostDataLoadIterator(
-        train_dataloader,
+
+  pipeline_fn = _get_pipeline_fn(config)
+
+  get_ds_fn = functools.partial(
+      get_datasets,
+      config.grain_train_files,
+      config.grain_file_type,
+      shuffle=config.enable_data_shuffling,
+      shuffle_seed=config.data_shuffle_seed,
+      shuffle_buffer_size=config.grain_shuffle_buffer_size,
+      num_epoch=config.num_epoch,
+      grain_worker_count=config.grain_worker_count,
+      grain_num_threads=config.grain_num_threads,
+      grain_prefetch_buffer_size=config.grain_prefetch_buffer_size,
+      grain_data_source_max_workers=config.grain_data_source_max_workers,
+      mixture_config_path=config.grain_train_mixture_config_path,
+      elastic=config.grain_use_elastic_iterator,
+  )
+
+  preprocessing_fn = functools.partial(
+      pipeline_fn,
+      config=config,
+      data_columns=config.train_data_columns,
+      tokenize=config.tokenize_train_data,
+      grain_worker_count=config.grain_worker_count,
+      grain_per_worker_buffer_size=config.grain_per_worker_buffer_size,
+  )
+
+  # In the case of using colocated python for data input, partial functions such as
+  # get_ds_fn (data initialization) and preprocessing_fn (data transformation)
+  # are passed to the RemoteIteratorWrapper, which will then be passed to RemoteIterator
+  # that runs in the colocated python environment.
+  # While in other cases, get_ds_fn and preprocessing_fn to produce a data iterator and
+  # pass to MultiHostDataLoadIterator
+  if config.colocated_python_data_input:
+    if config.grain_use_elastic_iterator:
+      preprocessing_fn = functools.partial(_make_elastic_iterator, config=config, preprocessing_fn=preprocessing_fn)
+
+    global_shape = (config.global_batch_size_to_load, config.max_target_length)
+    return multihost_dataloading.RemoteIteratorWrapper(
+        get_ds_fn,
+        preprocessing_fn,
         global_mesh,
-        config.generate_padding_batch_train,
-        expansion_loading_factor_for_grain=config.expansion_factor_real_data,
+        global_shape,
+        checkpoint_path=config.checkpoint_dir,
+        elastic=config.grain_use_elastic_iterator,
+    )
+
+  if 0 < config.expansion_factor_real_data < 1:
+    num_dataloader_to_restore = int(1 / config.expansion_factor_real_data)
+    train_dataloader_list = []
+    dataloading_host_count = len(process_indices) * num_dataloader_to_restore
+    for i in range(num_dataloader_to_restore):
+      dataloading_host_index = len(process_indices) * i + process_indices.index(jax.process_index())
+      train_ds = get_ds_fn(dataloading_host_index=dataloading_host_index, dataloading_host_count=dataloading_host_count)
+      train_dataloader = preprocessing_fn(dataset=train_ds)
+      train_dataloader_list.append(train_dataloader)
+    return [
+        multihost_dataloading.MultiHostDataLoadIterator(x, global_mesh, config.generate_padding_batch_train)
+        for x in train_dataloader_list
+    ]
+
+  # Default non-colocated, non-expansion path
+  shard_index = process_indices.index(jax.process_index())
+  shard_count = len(process_indices)
+  train_ds = get_ds_fn(
+      dataloading_host_index=shard_index,
+      dataloading_host_count=shard_count,
+  )
+  if config.grain_use_elastic_iterator:
+    mp_options = (
+        grain.MultiprocessingOptions(
+            num_workers=config.grain_worker_count,
+            per_worker_buffer_size=config.grain_per_worker_buffer_size,
+        )
+        if config.grain_worker_count > 0
+        else None
+    )
+    train_dataloader = _make_elastic_iterator(
+        train_ds, config, preprocessing_fn, shard_index=shard_index, shard_count=shard_count, mp_opts=mp_options
     )
   else:
-    get_ds_fn = functools.partial(
-        get_datasets,
-        config.grain_train_files,
-        config.grain_file_type,
-        shuffle=config.enable_data_shuffling,
-        shuffle_seed=config.data_shuffle_seed,
-        shuffle_buffer_size=config.grain_shuffle_buffer_size,
-        num_epoch=config.num_epoch,
-        grain_worker_count=config.grain_worker_count,
-        grain_num_threads=config.grain_num_threads,
-        grain_prefetch_buffer_size=config.grain_prefetch_buffer_size,
-        grain_data_source_max_workers=config.grain_data_source_max_workers,
-        mixture_config_path=config.grain_train_mixture_config_path,
-    )
-    if config.use_dpo:
-      preprocessing_fn = functools.partial(
-          dpo_preprocessing_pipeline,
-          config=config,
-          data_columns=config.train_data_columns,
-          tokenize=config.tokenize_train_data,
-          grain_worker_count=config.grain_worker_count,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size,
-      )
-    elif config.use_sft:
-      preprocessing_fn = functools.partial(
-          sft_preprocessing_pipeline,
-          config=config,
-          data_columns=config.train_data_columns,
-          tokenize=config.tokenize_train_data,
-          grain_worker_count=config.grain_worker_count,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size,
-      )
-    else:
-      preprocessing_fn = functools.partial(
-          pretrain_preprocessing_pipeline,
-          config=config,
-          data_columns=config.train_data_columns,
-          tokenize=config.tokenize_train_data,
-          grain_worker_count=config.grain_worker_count,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size,
-      )
-    if config.colocated_python_data_input:
-      global_shape = (config.global_batch_size_to_load, config.max_target_length)
-      return multihost_dataloading.RemoteIterator(get_ds_fn, preprocessing_fn, global_mesh, global_shape)
-    else:
-      # config.expansion_factor_real_data is between 0 and 1
-      num_dataloader_to_restore = int(1 / config.expansion_factor_real_data)
-      train_dataloader_list = []
-      dataloading_host_count = len(process_indices) * num_dataloader_to_restore
-      for i in range(num_dataloader_to_restore):
-        dataloading_host_index = len(process_indices) * i + process_indices.index(jax.process_index())
-        train_ds = get_ds_fn(dataloading_host_index=dataloading_host_index, dataloading_host_count=dataloading_host_count)
-        train_dataloader = preprocessing_fn(train_ds)
-        train_dataloader_list.append(train_dataloader)
-      return [
-          multihost_dataloading.MultiHostDataLoadIterator(x, global_mesh, config.generate_padding_batch_train)
-          for x in train_dataloader_list
-      ]
+    train_dataloader = preprocessing_fn(dataset=train_ds)
+
+  return multihost_dataloading.MultiHostDataLoadIterator(
+      train_dataloader,
+      global_mesh,
+      config.generate_padding_batch_train,
+      expansion_loading_factor_for_grain=config.expansion_factor_real_data,
+  )
 
 
 def make_grain_eval_iterator(
@@ -481,91 +506,48 @@ def make_grain_eval_iterator(
   assert (
       config.global_batch_size_to_load_eval % global_mesh.size == 0
   ), "Batch size should be divisible by number of global devices."
+
+  pipeline_fn = _get_pipeline_fn(config)
+
+  get_ds_fn = functools.partial(
+      get_datasets,
+      config.grain_eval_files,
+      config.grain_file_type,
+      shuffle=False,  # No shuffle for eval
+      shuffle_seed=config.data_shuffle_seed,
+      shuffle_buffer_size=config.grain_shuffle_buffer_size,
+      num_epoch=1,
+      grain_worker_count=config.grain_worker_count_eval,
+      grain_num_threads=config.grain_num_threads_eval,
+      grain_prefetch_buffer_size=config.grain_prefetch_buffer_size_eval,
+      grain_data_source_max_workers=config.grain_data_source_max_workers,
+  )
+
+  preprocessing_fn = functools.partial(
+      pipeline_fn,
+      config=config,
+      data_columns=config.eval_data_columns,
+      tokenize=config.tokenize_eval_data,
+      grain_worker_count=config.grain_worker_count_eval,
+      grain_per_worker_buffer_size=config.grain_per_worker_buffer_size_eval,
+  )
+
   if not config.colocated_python_data_input:
-    eval_ds = get_datasets(
-        config.grain_eval_files,
-        config.grain_file_type,
-        shuffle=False,
-        shuffle_seed=config.data_shuffle_seed,
-        shuffle_buffer_size=config.grain_shuffle_buffer_size,
-        num_epoch=1,
+    eval_ds = get_ds_fn(
         dataloading_host_index=process_indices.index(jax.process_index()),
         dataloading_host_count=len(process_indices),
-        grain_worker_count=config.grain_worker_count_eval,
-        grain_num_threads=config.grain_num_threads_eval,
-        grain_prefetch_buffer_size=config.grain_prefetch_buffer_size_eval,
-        grain_data_source_max_workers=config.grain_data_source_max_workers,
     )
-    if config.use_dpo:
-      eval_dataloader = dpo_preprocessing_pipeline(
-          eval_ds,
-          config,
-          data_columns=config.eval_data_columns,
-          tokenize=config.tokenize_eval_data,
-          grain_worker_count=config.grain_worker_count_eval,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size_eval,
-      )
-    elif config.use_sft:
-      eval_dataloader = sft_preprocessing_pipeline(
-          eval_ds,
-          config,
-          data_columns=config.eval_data_columns,
-          tokenize=config.tokenize_eval_data,
-          grain_worker_count=config.grain_worker_count_eval,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size_eval,
-      )
-    else:
-      eval_dataloader = pretrain_preprocessing_pipeline(
-          eval_ds,
-          config,
-          data_columns=config.eval_data_columns,
-          tokenize=config.tokenize_eval_data,
-          grain_worker_count=config.grain_worker_count_eval,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size_eval,
-      )
+    eval_dataloader = preprocessing_fn(dataset=eval_ds)
     return multihost_dataloading.MultiHostDataLoadIterator(
         eval_dataloader, global_mesh, config.generate_padding_batch_eval
     )
   else:
-    get_ds_fn = functools.partial(
-        get_datasets,
-        config.grain_eval_files,
-        config.grain_file_type,
-        shuffle=False,  # No shuffle for eval
-        shuffle_seed=config.data_shuffle_seed,
-        shuffle_buffer_size=config.grain_shuffle_buffer_size,
-        num_epoch=1,
-        grain_worker_count=config.grain_worker_count_eval,
-        grain_num_threads=config.grain_num_threads_eval,
-        grain_prefetch_buffer_size=config.grain_prefetch_buffer_size_eval,
-        grain_data_source_max_workers=config.grain_data_source_max_workers,
-    )
-    if config.use_dpo:
-      preprocessing_fn = functools.partial(
-          dpo_preprocessing_pipeline,
-          config=config,
-          data_columns=config.eval_data_columns,
-          tokenize=config.tokenize_eval_data,
-          grain_worker_count=config.grain_worker_count_eval,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size_eval,
-      )
-    elif config.use_sft:
-      preprocessing_fn = functools.partial(
-          sft_preprocessing_pipeline,
-          config=config,
-          data_columns=config.eval_data_columns,
-          tokenize=config.tokenize_eval_data,
-          grain_worker_count=config.grain_worker_count_eval,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size_eval,
-      )
-    else:
-      preprocessing_fn = functools.partial(
-          pretrain_preprocessing_pipeline,
-          config=config,
-          data_columns=config.eval_data_columns,
-          tokenize=config.tokenize_eval_data,
-          grain_worker_count=config.grain_worker_count_eval,
-          grain_per_worker_buffer_size=config.grain_per_worker_buffer_size_eval,
-      )
     global_shape = (config.global_batch_size_to_load, config.max_target_length)
-    return multihost_dataloading.RemoteIterator(get_ds_fn, preprocessing_fn, global_mesh, global_shape)
+    return multihost_dataloading.RemoteIteratorWrapper(
+        get_ds_fn,
+        preprocessing_fn,
+        global_mesh,
+        global_shape,
+        checkpoint_path=config.checkpoint_dir,
+        elastic=config.grain_use_elastic_iterator,
+    )

--- a/src/maxtext/input_pipeline/multihost_dataloading.py
+++ b/src/maxtext/input_pipeline/multihost_dataloading.py
@@ -22,7 +22,9 @@ from functools import partial
 from typing import Union, Sequence
 from collections.abc import Iterator, Iterable
 import time
+import json
 
+from etils import epath
 import tensorflow as tf  # pylint: disable=g-import-not-at-top
 
 import numpy as np
@@ -158,41 +160,6 @@ class MultiHostDataLoadIterator:
     return jtu.tree_map(lambda x: jnp.full_like(x, 0), self.last_local_data)
 
 
-@colocated_python.colocated_python
-def _get_next(dummy_array):
-  """get next batch from the iterator stored in the state of colocated python"""
-  if "iterator" not in colocated_python.__dict__:
-    raise ValueError("iterator not found in colocated_python.__dict__")
-  if "global_shape" not in colocated_python.__dict__:
-    raise ValueError("_global_shape not found in colocated_python.__dict__")
-  local_data = next(colocated_python.__dict__["iterator"])
-  global_shape = colocated_python.__dict__["global_shape"]
-  for k, v in local_data.items():
-    local_data[k] = jnp.asarray(v)
-
-  def form_global_array_colocated_python(path, array, devices, global_shape, sharding):
-    try:
-      device_arrays = np.split(array, len(devices), axis=0)
-    except ValueError as array_split_error:
-      raise ValueError(
-          f"Unable to put to devices shape {array.shape} with "
-          f"local device count {len(devices)} "
-          f"at {jtu.keystr(path)}"
-      ) from array_split_error
-    device_arrays = jax.device_put(device_arrays, devices)
-    return jax.make_array_from_single_device_arrays(shape=global_shape, sharding=sharding, arrays=device_arrays)
-
-  return jtu.tree_map_with_path(
-      partial(
-          form_global_array_colocated_python,
-          devices=list(dummy_array.sharding.addressable_devices),
-          global_shape=global_shape,
-          sharding=dummy_array.sharding,
-      ),
-      local_data,
-  )
-
-
 def _colocated_cpu_devices(
     devices: Sequence[jax.Device],
 ) -> Sequence[jax.Device]:
@@ -205,10 +172,91 @@ def _colocated_cpu_mesh(mesh: Mesh) -> Mesh:
   return colocated_python.colocated_cpu_devices(mesh)
 
 
+@colocated_python.colocated_python_class
 class RemoteIterator:
-  "iterator class for using colocated python, iterator is initiated remotely and stored in the state of colocated python"
+  "iterator class for using colocated python class"
 
-  def __init__(self, get_ds_fn, preprocessing_fn, global_mesh, global_shape):
+  def __init__(self, get_ds_fn, preprocessing_fn, global_shape, checkpoint_path, elastic=False):
+    self.get_ds_fn = get_ds_fn
+    self.preprocessing_fn = preprocessing_fn
+    self.global_shape = global_shape
+    self.checkpoint_path = checkpoint_path
+    self.elastic = elastic
+    self.reset()
+    max_logging.log("RemoteIterator initiated")
+
+  def reset(self):
+    ds = self.get_ds_fn(dataloading_host_index=jax.process_index(), dataloading_host_count=jax.process_count())
+    dataloader = self.preprocessing_fn(dataset=ds)
+    if isinstance(dataloader, tf.data.Dataset):
+      self.iterator = dataloader.as_numpy_iterator()
+    elif isinstance(dataloader, Iterable):
+      self.iterator = iter(dataloader)
+    else:
+      raise ValueError("Type error: dataloader should be Iterable.")
+
+  def get_next(self, dummy_array):
+    """Gets the next batch of data and forms a global array."""
+    local_data = next(self.iterator)
+
+    def form_global_array_colocated_python(path, array, devices, global_shape, sharding):
+      try:
+        device_arrays = np.split(array, len(devices), axis=0)
+      except ValueError as array_split_error:
+        raise ValueError(
+            f"Unable to put to devices shape {array.shape} with "
+            f"local device count {len(devices)} "
+            f"at {jtu.keystr(path)}"
+        ) from array_split_error
+      device_arrays = jax.device_put(device_arrays, devices)
+      return jax.make_array_from_single_device_arrays(shape=global_shape, sharding=sharding, arrays=device_arrays)
+
+    return jtu.tree_map_with_path(
+        partial(
+            form_global_array_colocated_python,
+            devices=list(dummy_array.sharding.addressable_devices),
+            global_shape=self.global_shape,
+            sharding=dummy_array.sharding,
+        ),
+        local_data,
+    )
+
+  def save_state(self, step_array):
+    """Saves the iterator state to a file."""
+    step = step_array.addressable_data(0).item()
+    directory = epath.Path(self.checkpoint_path) / str(step) / "iter"
+    if self.elastic:
+      # ElasticIterator state is a single global scalar shared by all shards,
+      # so we write one fixed file (from process 0 only) and every process
+      # reads the same file on restore — this survives elastic resizes that
+      # change `jax.process_count()`.
+      if jax.process_index() == 0:
+        directory.mkdir(parents=True, exist_ok=True)
+        filename = directory / "process_0.json"
+        filename.write_text(json.dumps(self.iterator.get_state(), indent=4))
+      return step_array
+    directory.mkdir(parents=True, exist_ok=True)
+    filename = directory / f"process_{jax.process_index()}-of-{jax.process_count()}.json"
+    state = json.dumps(self.iterator.get_state(), indent=4)
+    filename.write_text(state)
+    return step_array
+
+  def restore_state(self, step_array):
+    step = step_array.addressable_data(0).item()
+    directory = epath.Path(self.checkpoint_path) / str(step) / "iter"
+    if self.elastic:
+      filename = directory / "process_0.json"
+    else:
+      filename = directory / f"process_{jax.process_index()}-of-{jax.process_count()}.json"
+    state = json.loads(filename.read_text())
+    self.iterator.set_state(state)
+    return step_array
+
+
+class RemoteIteratorWrapper:
+  """Wrapper for RemoteIterator that handles device placement."""
+
+  def __init__(self, get_ds_fn, preprocessing_fn, global_mesh, global_shape, checkpoint_path="", elastic=False):
     self.cpu_devices = _colocated_cpu_devices(jax.local_devices())
     self.tpu_devices = jax.local_devices()
     self.cpu_mesh = _colocated_cpu_mesh(global_mesh)
@@ -216,42 +264,28 @@ class RemoteIterator:
     self.cpu_sharding = jax.sharding.NamedSharding(self.cpu_mesh, PartitionSpec(self.cpu_mesh.axis_names))
     self.dummy_array = jnp.zeros((len(self.cpu_devices)))
     self.dummy_array = jax.device_put(self.dummy_array, self.cpu_sharding)
-
-    @colocated_python.colocated_python
-    def init(dummy_array):
-      colocated_python.global_shape = global_shape
-      ds = get_ds_fn(dataloading_host_index=jax.process_index(), dataloading_host_count=jax.process_count())
-      dataloader = preprocessing_fn(dataset=ds)
-      if isinstance(dataloader, tf.data.Dataset):
-        colocated_python.iterator = dataloader.as_numpy_iterator()
-      elif isinstance(dataloader, Iterable):
-        colocated_python.iterator = iter(dataloader)
-      else:
-        raise ValueError("Type error: dataloader should be either tf.data.Dataset or grain.DataLoader.")
-      return dummy_array
-
-    max_logging.log("Initiating RemoteIterator")
-    try:
-      out = jax.device_get(init(self.dummy_array))
-      if out is not None:
-        max_logging.log(f"RemoteIterator initiated. Test output: {out}")
-    except Exception as e:
-      max_logging.log(f"RemoteIterator init FAILED with error: {type(e).__name__}: {e}")
-      raise
+    # This is a proxy to a RemoteIterator running in a colocated process,
+    # named "local_iterator" to match MultiHostDataLoadIterator's interface.
+    self.local_iterator = RemoteIterator(get_ds_fn, preprocessing_fn, global_shape, checkpoint_path, elastic=elastic)
+    max_logging.log("RemoteIteratorWrapper initiated")
 
   def __iter__(self):
     return self
 
+  def reset(self):
+    self.local_iterator.reset()
+
   def __next__(self):
-    out = _get_next(self.dummy_array)
+    out = self.local_iterator.get_next(self.dummy_array)
+    # use tree_map is out is a dict
+    return jax.device_put(out, self.tpu_sharding)
 
-    def put_to_tpu_devices(path, array, sharding):
-      try:
-        return jax.device_put(array, sharding)
-      except Exception as e:  # pylint: disable=broad-exception-caught
-        max_logging.log(f"Error putting data to TPU device path{path}, exception={e}")
-        raise
+  def save_state(self, step):
+    step_array = jnp.full(self.dummy_array.shape, step, dtype=jnp.int32)
+    step_array = jax.device_put(step_array, self.cpu_sharding)
+    self.local_iterator.save_state(step_array)
 
-    input_gdas = jtu.tree_map_with_path(partial(put_to_tpu_devices, sharding=self.tpu_sharding), out)
-
-    return input_gdas
+  def restore_state(self, step):
+    step_array = jnp.full(self.dummy_array.shape, step, dtype=jnp.int32)
+    step_array = jax.device_put(step_array, self.cpu_sharding)
+    self.local_iterator.restore_state(step_array)

--- a/src/maxtext/input_pipeline/tfds_data_processing.py
+++ b/src/maxtext/input_pipeline/tfds_data_processing.py
@@ -232,7 +232,9 @@ def make_tfds_train_iterator(
         hf_access_token=config.hf_access_token,
     )
     global_shape = (config.global_batch_size_to_load, config.max_target_length)
-    return multihost_dataloading.RemoteIterator(get_ds_fn, preprocessing_fn, global_mesh, global_shape)
+    return multihost_dataloading.RemoteIteratorWrapper(
+        get_ds_fn, preprocessing_fn, global_mesh, global_shape, checkpoint_path=config.checkpoint_dir
+    )
 
 
 def make_tfds_eval_iterator(
@@ -296,4 +298,6 @@ def make_tfds_eval_iterator(
         use_dpo=config.use_dpo,
         hf_access_token=config.hf_access_token,
     )
-    return multihost_dataloading.RemoteIterator(get_ds_fn, preprocessing_fn, config, global_mesh)
+    return multihost_dataloading.RemoteIteratorWrapper(
+        get_ds_fn, preprocessing_fn, config, global_mesh, checkpoint_path=config.checkpoint_dir
+    )


### PR DESCRIPTION
# Description

* migrate RemoteIterator to colocated python class
* Add checkpointing logic to RemoteIterator, so data iterator in the colocated sidecar writes checkpoint to the checkpoint path, prevent sending data iterator state to the controller
* Add grain.ElasticIterator support controlled by flag grain_use_elastic_iterator, can be used with or without elastic training, with or without colocated_python. This class allows recovering checkpoint with a dynamic scale (up or down), with the following limitations, future work will loose the limitations:  
  (1). Only arrayrecord files are supported, parquet or tfrecord are not supported
  (2). Does not support many-to-one transformations, including packing, filtering
  (3). Does not support mixing datasets

# Tests
Tested on Pathways saving and restoring data iterator checkpoints with different # of v5e-32 slices
[jobset.yaml](https://paste.googleplex.com/5278394871840768)

### With colocated_python
`colocated_python_data_input=true colocated_python_checkpointing=true grain_use_elastic_iterator=true`, checkpoints in `gs://aireenmei-multipod/pathways-v5e/20260424_grain_elastic_2/aireen-pathways-v5e/checkpoints`:
* Start with 1 slice, set steps=25, checkpoint at step 0, 10, 20, 24: [log](https://cloudlogging.app.goo.gl/M5mH66AiYWMLNKRn9) (log confirms Num devices: 32), 
* Resume with 2 slices, set steps=45, checkpoint at step 30, 40, 44: [log](https://cloudlogging.app.goo.gl/Vcq6SufE1zqjnk3g8)(log confirms Num devices: 64), 
* Resume with 1 slice, set steps=65, checkpoint at step 50, 60, 64: [log](https://cloudlogging.app.goo.gl/56MKkZdQPchypPKT7)(log confirms Num devices: 32)

### Without colocated_python
`colocated_python_data_input=false colocated_python_checkpointing=false grain_use_elastic_iterator=true`, checkpoints in `gs://aireenmei-multipod/pathways-v5e/20260424_grain_elastic_3/aireen-pathways-v5e/checkpoints`:
* Start with 1 slice, set steps=25, checkpoint at step 0, 10, 20, 24: [log](https://cloudlogging.app.goo.gl/F7AP1yD26P3HoGdb6) (log confirms Num devices: 32), 
* Resume with 2 slices, set steps=45, checkpoint at step 30, 40, 44: [log](https://cloudlogging.app.goo.gl/Rk4QgfZ7tW6wdVUQ6)(log confirms Num devices: 64), 
* Resume with 1 slice, set steps=65, checkpoint at step 50, 60, 64: [log](https://cloudlogging.app.goo.gl/uHbfdxs4E31VuGmP7)(log confirms Num devices: 32)

### Index verification
Inspecting the checkpoints in `gs://aireenmei-multipod/pathways-v5e/20260424_grain_elastic_2/aireen-pathways-v5e/checkpoints/{step}/iter/process_0.json`
* Step 20: `"global_next_index": 672`
* Step 24: `"global_next_index": 800`
* Step 30: `"global_next_index": 1184`
* Step 20-24 is on 1 slice, 32 devices, batch_size=32, matches `(800-672) / 32 = 4 steps`
* Step 24-30 is on 2 slices, 64 devices, batch_size=64, matches `(1184-800) / 64 = 6 steps`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
