### PR TITLE
Add MoE load balancing loss to distillation

### DIFF
--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -508,6 +508,8 @@ class Transformer(nnx.Module):
       mutable_collections.append("intermediates")
     if self.config.distill_beta > 0.0 and "intermediates" not in mutable_collections:
       mutable_collections.append("intermediates")
+    if self.config.load_balance_loss_weight > 0.0 and "intermediates" not in mutable_collections:
+      mutable_collections.append("intermediates")
 
     if self.config.pure_nnx_decoder:
       logits, hidden_state, kv_caches = self.decoder(

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1055,7 +1055,7 @@ class Qwen3NextDecoderLayer(nnx.Module):
     # We sow the load balancing loss so it can be collected and added to the total loss
     # during training.
     if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
-      self.sow("intermediates", "moe_lb_loss", load_balance_loss)
+      self.moe_lb_loss = nnx.Intermediate(load_balance_loss)
 
     # Final residual connection (after the MoE block)
     layer_output = residual + mlp_output
@@ -1299,7 +1299,7 @@ class Qwen3MoeDecoderLayer(AttentionWithNorm):
     mlp_lnx, load_balance_loss, _ = self.moe_block(hidden_states)
     mlp_lnx = nn.with_logical_constraint(mlp_lnx, self.activation_axis_names)
     if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
-      self.sow("intermediates", "moe_lb_loss", load_balance_loss)
+      self.moe_lb_loss = nnx.Intermediate(load_balance_loss)
 
     layer_output = intermediate_inputs + mlp_lnx
     layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)

--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -52,6 +52,8 @@ class DistillationForwardOutput:
   logits: jax.Array
   #: out_projection_activations
   out_projection_activations: jax.Array | None = None
+  #: moe load balance loss
+  moe_lb_loss: jax.Array | None = None
 
 
 @flax.struct.dataclass(frozen=True)
@@ -520,6 +522,17 @@ class CombinedDistillationStrategy(DistillationStrategy):
 
     total_loss = base_logit_loss + feature_loss
 
+    moe_lb_loss = jnp.array(0.0)
+    if student_output.moe_lb_loss is not None:
+      # The moe_lb_loss collected from the model is already scaled by load_balance_loss_weight
+      # within the MoE layer itself (see load_balance_loss in moe.py).
+      moe_lb_loss = student_output.moe_lb_loss
+      total_loss += moe_lb_loss
+
+    teacher_moe_lb_loss = jnp.array(0.0)
+    if teacher_output.moe_lb_loss is not None:
+      teacher_moe_lb_loss = teacher_output.moe_lb_loss
+
     # Per-step next-token perplexity. Note: this is mean(exp(per-step CE)), not
     # exp(window-CE-mean) — close to true perplexity in steady state. For the exact
     # perplexity over a logging window compute exp(distill/hard_loss) on the TB side.
@@ -545,6 +558,8 @@ class CombinedDistillationStrategy(DistillationStrategy):
         "distill/kl_div_T1": (kl_t1_sum, valid_count),
         # Per-step quantities: (value, 1.0) so the aggregator yields a simple mean over steps.
         "distill/out_proj_feature_loss": (feature_loss, one),
+        "distill/moe_lb_loss": (moe_lb_loss, one),
+        "distill/teacher_moe_lb_loss": (teacher_moe_lb_loss, one),
         "distill/total_loss": (total_loss, one),
         "distill/temperature": (temperature, one),
         "distill/alpha": (alpha, one),

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -151,8 +151,15 @@ def create_forward_fn(config: pyconfig.HyperParameters) -> Callable[..., distill
     if config.distill_beta > 0.0:
       out_projection_activations = maxtext_utils.get_intermediate_value(model, "out_projection_activations", clear=True)
 
+    moe_lb_loss = None
+    if config.num_experts > 1 and config.load_balance_loss_weight > 0.0:
+      intermediate_outputs = nnx.pop(model, nnx.Intermediate)
+      total_moe_lb_losses = maxtext_utils.collect_intermediates_by_suffix(intermediate_outputs, "moe_lb_loss")
+      if total_moe_lb_losses:
+        moe_lb_loss = jnp.mean(jnp.concatenate(total_moe_lb_losses))
+
     retval = distillation_utils.DistillationForwardOutput(
-        logits=logits, out_projection_activations=out_projection_activations
+        logits=logits, out_projection_activations=out_projection_activations, moe_lb_loss=moe_lb_loss
     )
     return retval
 
@@ -509,7 +516,7 @@ def build_training_components(
       max_steps=student_config.steps,
   )
 
-  # 4. Optimizer & Config
+  # Prepare optimizer
   optimizer = get_distillation_optimizer(student_config, student_config.steps)
 
   checkpointing_options = checkpoint.CheckpointManagerOptions(

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -439,6 +439,7 @@ class TrainDistillTest(unittest.TestCase):
         "distill/kl_div_T1",
         "distill/teacher_loss",
         "distill/out_proj_feature_loss",
+        "distill/moe_lb_loss",
         "distill/total_loss",
         "distill/temperature",
         "distill/alpha",


### PR DESCRIPTION
# Description

This PR introduces support for Mixture of Experts (MoE) load balancing loss during the distillation workflow.

Key Changes
   1. NNX Intermediate Extraction (maxtext_utils.py & qwen3.py): 
      - Replaced legacy Linen self.sow(...) calls with native nnx.Intermediate(load_balance_loss) inside
   2. Distillation Strategy Updates (distillation_utils.py & train_distill.py):
      - Upgraded DistillationForwardOutput to carry the collected moe_lb_loss.
      - Updated CombinedDistillationStrategy to actively add the moe_lb_loss to the total_loss so the optimizer
        minimizes it.
      - Surfaced "distill/moe_lb_loss" to the metrics dictionary for TensorBoard logging and visibility.
   3. Model Mutability (models.py):
      - Automatically appended "intermediates" to the mutable_collections list during the Transformer's forward pass
        whenever load_balance_loss_weight > 0.0 to ensure NNX variables can successfully write to the state.

# Tests
Added "distill/moe_lb_loss" to the expected metrics keys in the test suite to prevent regressions in train_distill_test.py.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
