### PR TITLE
Add dynamic loss weight scheduling for distillation

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1223,6 +1223,14 @@ distill_beta: 0.0
 # distill_feature_loss_type is the type of loss to use for feature distillation ("cosine" or "l2").
 distill_feature_loss_type: "cosine"
 distill_layer_indices: None
+# Dynamic loss weight scheduling: set *_end to a target value and *_schedule to "linear" or "cosine".
+# When *_end is None (default), the corresponding weight stays fixed throughout training.
+distill_alpha_end: None
+distill_alpha_schedule: "constant"
+distill_temperature_end: None
+distill_temperature_schedule: "constant"
+distill_beta_end: None
+distill_beta_schedule: "constant"
 
 ##### Elastic training parameters
 # Elastic training is Pathways-specific and does not work on McJAX.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1160,6 +1160,22 @@ class Distillation(BaseModel):
       "cosine", description="The type of loss to use for feature distillation ('cosine' or 'l2')."
   )
   distill_layer_indices: None | list = Field(None, description="Feature indices for feature loss.")
+  distill_alpha_end: Optional[float] = Field(None, description="Target alpha at end of training. None keeps alpha fixed.")
+  distill_alpha_schedule: Literal["constant", "linear", "cosine"] = Field(
+      "constant", description="Schedule type for alpha annealing ('constant', 'linear', or 'cosine')."
+  )
+  distill_temperature_end: Optional[float] = Field(
+      None, description="Target temperature at end of training. None keeps temperature fixed."
+  )
+  distill_temperature_schedule: Literal["constant", "linear", "cosine"] = Field(
+      "constant", description="Schedule type for temperature annealing ('constant', 'linear', or 'cosine')."
+  )
+  distill_beta_end: Optional[float] = Field(
+      None, description="Target beta_feature at end of training. None keeps beta fixed."
+  )
+  distill_beta_schedule: Literal["constant", "linear", "cosine"] = Field(
+      "constant", description="Schedule type for beta annealing ('constant', 'linear', or 'cosine')."
+  )
 
   # --- Distillation freezing filter --
   student_params_to_update: None | list = Field(
@@ -2250,6 +2266,30 @@ class MaxTextConfig(
         raise ValueError("a value of self.distill_beta > 0.0 requires self.scan_layers = True")
       if not self.enable_nnx:
         raise ValueError("a value of self.distill_beta > 0.0 requires self.enable_nnx = True")
+
+    # Validate distillation schedule parameters
+    if self.distill_alpha_end is not None and not 0.0 <= self.distill_alpha_end <= 1.0:
+      raise ValueError(f"distill_alpha_end must be in [0, 1], got {self.distill_alpha_end}")
+    if self.distill_temperature_end is not None and self.distill_temperature_end <= 0.0:
+      raise ValueError(f"distill_temperature_end must be > 0, got {self.distill_temperature_end}")
+    if self.distill_beta_end is not None and self.distill_beta_end < 0.0:
+      raise ValueError(f"distill_beta_end must be >= 0, got {self.distill_beta_end}")
+    if self.distill_beta == 0.0 and self.distill_beta_end is not None and self.distill_beta_end > 0.0:
+      raise ValueError(
+          f"distill_beta=0.0 but distill_beta_end={self.distill_beta_end}. "
+          "Feature extraction is disabled when distill_beta starts at 0.0. "
+          "Set distill_beta to a small positive value (e.g., 1e-6) to enable feature extraction."
+      )
+    for param_name, schedule, end_value in [
+        ("distill_alpha", self.distill_alpha_schedule, self.distill_alpha_end),
+        ("distill_temperature", self.distill_temperature_schedule, self.distill_temperature_end),
+        ("distill_beta", self.distill_beta_schedule, self.distill_beta_end),
+    ]:
+      if schedule != "constant" and end_value is None:
+        raise ValueError(
+            f"{param_name}_schedule is '{schedule}' but {param_name}_end is None. "
+            f"Set {param_name}_end to a target value or use schedule='constant'."
+        )
 
     # D. CALCULATE MODEL DIMENSIONS from global_parameter_scale
     # This allows scaling the model size up or down easily with a single power-of-two factor.

--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -185,6 +185,38 @@ class MaxTextToTunixIterator:
 # -----------------------------------------------------------------------------
 
 
+def compute_schedule(
+    step: jax.Array,
+    max_steps: int,
+    start_value: float,
+    end_value: float | None,
+    schedule_type: str,
+) -> jax.Array:
+  """Computes a scheduled value based on training progress.
+
+  Args:
+    step: Current training step as a JAX array.
+    max_steps: Total number of training steps.
+    start_value: Value at the beginning of training.
+    end_value: Value at the end of training. If None, returns start_value.
+    schedule_type: One of "constant", "linear", or "cosine".
+
+  Returns:
+    The scheduled value as a JAX scalar.
+  """
+  if end_value is None or schedule_type == "constant":
+    return jnp.array(start_value, dtype=jnp.float32)
+
+  progress = jnp.clip(step.astype(jnp.float32) / max_steps, 0.0, 1.0)
+
+  if schedule_type == "linear":
+    return start_value + (end_value - start_value) * progress
+  elif schedule_type == "cosine":
+    return end_value + (start_value - end_value) * 0.5 * (1.0 + jnp.cos(jnp.pi * progress))
+  else:
+    raise ValueError(f"Unsupported schedule_type: {schedule_type!r}. Must be 'constant', 'linear', or 'cosine'.")
+
+
 class DistillationStrategy(abc.ABC):
   """Abstract base class for MaxText Distillation Strategies."""
 
@@ -210,6 +242,7 @@ class DistillationStrategy(abc.ABC):
       student_output: "DistillationForwardOutput",
       teacher_output: "DistillationForwardOutput",
       labels: jax.Array,
+      step: jax.Array | None = None,
   ) -> tuple[jax.Array, dict[str, jax.Array]]:
     """Computes the distillation loss.
 
@@ -217,6 +250,7 @@ class DistillationStrategy(abc.ABC):
         student_output: The forward pass output of the student model.
         teacher_output: The forward pass output of the frozen teacher model.
         labels: The masked one-hot encoded ground truth labels.
+        step: Current training step for dynamic scheduling. If None, uses fixed values.
 
     Returns:
         A tuple containing the scalar loss and a dictionary of auxiliary metrics
@@ -265,8 +299,15 @@ class CombinedDistillationStrategy(DistillationStrategy):
       feature_loss_type: Literal["cosine", "l2"] = "cosine",
       cosine_distance_axis: int | tuple[int, ...] = -1,
       vocab_size: int = 0,
+      alpha_end: float | None = None,
+      alpha_schedule: Literal["constant", "linear", "cosine"] = "constant",
+      temperature_end: float | None = None,
+      temperature_schedule: Literal["constant", "linear", "cosine"] = "constant",
+      beta_end: float | None = None,
+      beta_schedule: Literal["constant", "linear", "cosine"] = "constant",
+      max_steps: int = 1,
   ):
-    """Initializes the Combined strategy using tunix logit.LogitStrategy.
+    """Initializes the Combined distillation strategy.
 
     Args:
         student_forward_fn: Function to compute student model outputs.
@@ -282,6 +323,13 @@ class CombinedDistillationStrategy(DistillationStrategy):
           teacher_map) and returns a scalar loss. Defaults to Cosine Distance.
         cosine_distance_axis: The axis to use for cosine distance computation if
           feature_loss_fn is not provided. Defaults to -1.
+        alpha_end: Target alpha value at end of training. None keeps alpha fixed.
+        alpha_schedule: Schedule type for alpha annealing.
+        temperature_end: Target temperature at end of training. None keeps temperature fixed.
+        temperature_schedule: Schedule type for temperature annealing.
+        beta_end: Target beta_feature value at end of training. None keeps beta fixed.
+        beta_schedule: Schedule type for beta annealing.
+        max_steps: Total training steps, used for schedule computation.
     """
 
     super().__init__(
@@ -296,6 +344,39 @@ class CombinedDistillationStrategy(DistillationStrategy):
     self.beta_feature = beta_feature
     self.layer_indices = jnp.array(layer_indices) if layer_indices is not None else None
 
+    # Schedule parameters
+    self.alpha_end = alpha_end
+    self.alpha_schedule = alpha_schedule
+    self.temperature_end = temperature_end
+    self.temperature_schedule = temperature_schedule
+    self.beta_end = beta_end
+    self.beta_schedule = beta_schedule
+    self.max_steps = max_steps
+
+    # Validate schedule parameter ranges
+    if alpha_end is not None and not 0.0 <= alpha_end <= 1.0:
+      raise ValueError(f"alpha_end must be in [0, 1], got {alpha_end}")
+    if temperature_end is not None and temperature_end <= 0.0:
+      raise ValueError(f"temperature_end must be > 0, got {temperature_end}")
+    if beta_end is not None and beta_end < 0.0:
+      raise ValueError(f"beta_end must be >= 0, got {beta_end}")
+    if beta_feature == 0.0 and beta_end is not None and beta_end > 0.0:
+      raise ValueError(
+          f"distill_beta=0.0 but distill_beta_end={beta_end}. Feature extraction is disabled when "
+          "distill_beta starts at 0.0 (the model does not sow intermediate activations). "
+          "Set distill_beta to a small positive value (e.g., 1e-6) to enable feature extraction."
+      )
+    for param_name, schedule, end_value in [
+        ("alpha", alpha_schedule, alpha_end),
+        ("temperature", temperature_schedule, temperature_end),
+        ("beta", beta_schedule, beta_end),
+    ]:
+      if schedule != "constant" and end_value is None:
+        raise ValueError(
+            f"{param_name}_schedule is '{schedule}' but {param_name}_end is None. "
+            f"Set {param_name}_end to a target value or use schedule='constant'."
+        )
+
     self.feature_loss_fn = feature_loss_fn
     if feature_loss_fn is None:
       if feature_loss_type == "cosine":
@@ -309,13 +390,39 @@ class CombinedDistillationStrategy(DistillationStrategy):
       else:
         raise ValueError(f"Unsupported feature_loss_type: {feature_loss_type!r}")
 
+  def _get_scheduled_weights(self, step: jax.Array | None) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Resolves the current alpha, temperature, and beta values from schedules.
+
+    Args:
+      step: Current training step. If None, returns the fixed initial values.
+
+    Returns:
+      A tuple of (alpha, temperature, beta_feature) as JAX scalars.
+    """
+    if step is None:
+      return (
+          jnp.array(self.alpha, dtype=jnp.float32),
+          jnp.array(self.temperature, dtype=jnp.float32),
+          jnp.array(self.beta_feature, dtype=jnp.float32),
+      )
+    alpha = compute_schedule(step, self.max_steps, self.alpha, self.alpha_end, self.alpha_schedule)
+    temperature = compute_schedule(
+        step, self.max_steps, self.temperature, self.temperature_end, self.temperature_schedule
+    )
+    beta_feature = compute_schedule(step, self.max_steps, self.beta_feature, self.beta_end, self.beta_schedule)
+    return alpha, temperature, beta_feature
+
   def compute_loss(
       self,
       student_output: DistillationForwardOutput,
       teacher_output: DistillationForwardOutput,
       labels: jax.Array,
+      step: jax.Array | None = None,
   ) -> tuple[jax.Array, dict[str, jax.Array]]:
     """Computes Loss and Auxiliary Metrics."""
+    # Resolve scheduled weights for this step
+    alpha, temperature, beta_feature = self._get_scheduled_weights(step)
+
     # Calculate Distillation Loss (KL Divergence)
     # Scale logits by temperature T for soft targets
     # We use explicit float32 casting for stability in loss calculation
@@ -332,8 +439,8 @@ class CombinedDistillationStrategy(DistillationStrategy):
           "Ensure the model architecture supports feature extraction (e.g., 'out_projection_activations' is sowed)."
       )
 
-    log_student_probs_temp = jax.nn.log_softmax(s_logits / self.temperature, axis=-1)
-    teacher_probs_temp = jax.nn.softmax(t_logits / self.temperature, axis=-1)
+    log_student_probs_temp = jax.nn.log_softmax(s_logits / temperature, axis=-1)
+    teacher_probs_temp = jax.nn.softmax(t_logits / temperature, axis=-1)
     # labels are supposed to have all sft masks applied by this moment
     labels_mask = jnp.any(labels != 0, axis=-1, keepdims=True)
     mean_mask = jnp.squeeze(labels_mask, axis=-1)
@@ -342,7 +449,7 @@ class CombinedDistillationStrategy(DistillationStrategy):
     kl_div = optax.kl_divergence(log_student_probs_temp, teacher_probs_temp, where=labels_mask)
 
     # Scale gradients by T^2 (Hinton et al.)
-    soft_loss = jnp.mean(kl_div, where=mean_mask) * (self.temperature**2)
+    soft_loss = jnp.mean(kl_div, where=mean_mask) * (temperature**2)
 
     # 1. Student Hard Loss (Existing)
     ce_loss_student = optax.softmax_cross_entropy(logits=s_logits, labels=labels, where=labels_mask)
@@ -353,7 +460,7 @@ class CombinedDistillationStrategy(DistillationStrategy):
     teacher_hard_loss = jnp.mean(ce_loss_teacher, where=mean_mask)
 
     # 3. Combine losses
-    base_logit_loss = (self.alpha * soft_loss) + ((1.0 - self.alpha) * hard_loss)
+    base_logit_loss = (alpha * soft_loss) + ((1.0 - alpha) * hard_loss)
 
     feature_loss = jnp.array(0.0)
     if self.beta_feature > 0.0:
@@ -369,11 +476,11 @@ class CombinedDistillationStrategy(DistillationStrategy):
       s_features_sliced = s_features_sliced.astype(jnp.float32)
       t_features_sliced = t_features_sliced.astype(jnp.float32)
 
-      feature_loss = self.beta_feature * self.feature_loss_fn(s_features_sliced, t_features_sliced)
+      feature_loss = beta_feature * self.feature_loss_fn(s_features_sliced, t_features_sliced)
 
     total_loss = base_logit_loss + feature_loss
 
-    # 4. Return Loss AND Metrics
+    # 4. Return Loss AND Metrics (log dynamic values for TensorBoard verification)
     metrics = {
         "distill/soft_loss": soft_loss,
         "distill/hard_loss": hard_loss,
@@ -381,9 +488,9 @@ class CombinedDistillationStrategy(DistillationStrategy):
         "distill/teacher_loss": teacher_hard_loss,
         "distill/out_proj_feature_loss": feature_loss,
         "distill/total_loss": total_loss,
-        "distill/temperature": self.temperature,
-        "distill/alpha": self.alpha,
-        "distill/beta_feature": self.beta_feature,
+        "distill/temperature": temperature,
+        "distill/alpha": alpha,
+        "distill/beta_feature": beta_feature,
     }
     return total_loss, metrics
 

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -182,6 +182,7 @@ class ModelBundle(nnx.Module):
   def __init__(self, teacher_model: nnx.Module, student_model: nnx.Module):
     self.teacher_model = teacher_model
     self.student_model = student_model
+    self.training_step = nnx.Variable(jnp.zeros((), dtype=jnp.int32))
 
   def __call__(self, *args, **kwargs):
     raise NotImplementedError("Use `call_student` or `call_teacher` explicitly.")
@@ -269,6 +270,7 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
     """Overrides the main JIT block to natively handle ModelBundle module."""
 
     batch = self.gen_model_input_fn(inputs)
+    current_step = model.training_step.value
 
     def loss_wrapper(student, teacher, batch):
       if "teacher_output" in batch:
@@ -299,7 +301,7 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
       )
       # we should apply a mask for labels to disable segment-separator tokens
       labels = self.strategy.create_labels(batch["targets"], targets_segmentation=batch.get("targets_segmentation", None))
-      return self.strategy.compute_loss(student_output, teacher_output, labels)
+      return self.strategy.compute_loss(student_output, teacher_output, labels, step=current_step)
 
     # Because student is the 0th argument, argnums=0 guarantees
     # we only compute gradients for the student.
@@ -310,6 +312,9 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
     )
 
     out, grads = grad_fn(model.student_model, model.teacher_model, batch)
+
+    # Increment step counter after loss computation
+    model.training_step.value = current_step + 1
 
     tunix_expects_grad_norm = getattr(self, "_tunix_expects_grad_norm", True)
 
@@ -509,6 +514,13 @@ def build_training_components(
       layer_indices=student_config.distill_layer_indices,
       feature_loss_type=student_config.distill_feature_loss_type,
       vocab_size=student_config.vocab_size,
+      alpha_end=student_config.distill_alpha_end,
+      alpha_schedule=student_config.distill_alpha_schedule,
+      temperature_end=student_config.distill_temperature_end,
+      temperature_schedule=student_config.distill_temperature_schedule,
+      beta_end=student_config.distill_beta_end,
+      beta_schedule=student_config.distill_beta_schedule,
+      max_steps=student_config.steps,
   )
 
   # 4. Optimizer & Config
@@ -631,6 +643,10 @@ def train_distill(
     # 5. Input Pipeline Checkpointing & Restoration
     # Replace the default CheckpointManager with a Grain-aware one, which enables iterator checkpointing for grain datasets.
     raw_train_iter = trainer.setup_checkpoint_manager_and_restore(raw_train_iter, student_config)
+
+    # Sync the ModelBundle step counter with the restored training step so that
+    # loss weight schedules resume from the correct position after checkpoint restore.
+    model_bundle.training_step.set_value(jnp.array(trainer._train_steps, dtype=jnp.int32))  # pylint: disable=protected-access
 
     # 6. Configure Input Mapping
     def custom_gen_model_input_fn(batch):

--- a/tests/post_training/unit/distillation_scheduling_test.py
+++ b/tests/post_training/unit/distillation_scheduling_test.py
@@ -1,0 +1,622 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Unit tests for distillation dynamic loss weight scheduling."""
+
+import unittest
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("tunix")
+pytestmark = [pytest.mark.tpu_only, pytest.mark.post_training]
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import numpy as np
+from absl.testing import absltest
+
+from maxtext.trainers.post_train.distillation import train_distill
+from maxtext.trainers.post_train.distillation import distillation_utils
+
+
+# Reusable test fixtures
+def _make_dummy_outputs(vocab_size=4, seq_len=2, with_features=False, feature_shape=(2, 1, 2, 4)):
+  """Creates matching student/teacher DistillationForwardOutput pairs."""
+  logits = jnp.array([[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]]) * 10
+  features = jnp.ones(feature_shape) if with_features else None
+  student = distillation_utils.DistillationForwardOutput(logits=logits, out_projection_activations=features)
+  teacher = distillation_utils.DistillationForwardOutput(logits=logits, out_projection_activations=features)
+  return student, teacher
+
+
+def _make_divergent_outputs(vocab_size=4):
+  """Creates student/teacher outputs that disagree, making soft_loss != hard_loss."""
+  student = distillation_utils.DistillationForwardOutput(
+      logits=jnp.array([[[10.0, -10.0, -10.0, -10.0], [-10.0, 10.0, -10.0, -10.0]]]),
+      out_projection_activations=None,
+  )
+  teacher = distillation_utils.DistillationForwardOutput(
+      logits=jnp.array([[[-10.0, -10.0, 10.0, -10.0], [-10.0, -10.0, -10.0, 10.0]]]),
+      out_projection_activations=None,
+  )
+  return student, teacher
+
+
+def _make_labels(vocab_size=4):
+  return jax.nn.one_hot(jnp.array([[0, 1]]), vocab_size)
+
+
+# pylint: disable=protected-access
+class ComputeScheduleTest(unittest.TestCase):
+  """Tests for the compute_schedule utility function."""
+
+  def test_constant_returns_start_value(self):
+    """Constant schedule returns start_value regardless of step."""
+    result = distillation_utils.compute_schedule(
+        step=jnp.array(50), max_steps=100, start_value=0.5, end_value=0.1, schedule_type="constant"
+    )
+    np.testing.assert_allclose(result, 0.5)
+
+  def test_none_end_value_returns_start_value(self):
+    """When end_value is None, returns start_value even with a non-constant schedule type."""
+    result = distillation_utils.compute_schedule(
+        step=jnp.array(50), max_steps=100, start_value=0.5, end_value=None, schedule_type="linear"
+    )
+    np.testing.assert_allclose(result, 0.5)
+
+  def test_linear_at_boundaries(self):
+    """Linear schedule returns exact start/end values at step 0 and max_steps."""
+    result_start = distillation_utils.compute_schedule(
+        step=jnp.array(0), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="linear"
+    )
+    np.testing.assert_allclose(result_start, 1.0, atol=1e-6)
+
+    result_end = distillation_utils.compute_schedule(
+        step=jnp.array(100), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="linear"
+    )
+    np.testing.assert_allclose(result_end, 0.0, atol=1e-6)
+
+  def test_linear_midpoint(self):
+    """Linear schedule returns the arithmetic midpoint at 50% progress."""
+    result = distillation_utils.compute_schedule(
+        step=jnp.array(50), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="linear"
+    )
+    np.testing.assert_allclose(result, 0.5, atol=1e-6)
+
+  def test_cosine_at_boundaries(self):
+    """Cosine schedule returns exact start/end values at step 0 and max_steps."""
+    result_start = distillation_utils.compute_schedule(
+        step=jnp.array(0), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="cosine"
+    )
+    np.testing.assert_allclose(result_start, 1.0, atol=1e-6)
+
+    result_end = distillation_utils.compute_schedule(
+        step=jnp.array(100), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="cosine"
+    )
+    np.testing.assert_allclose(result_end, 0.0, atol=1e-6)
+
+  def test_cosine_midpoint(self):
+    """Cosine schedule returns the midpoint at 50% progress (same as linear at this point)."""
+    result = distillation_utils.compute_schedule(
+        step=jnp.array(50), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="cosine"
+    )
+    np.testing.assert_allclose(result, 0.5, atol=1e-6)
+
+  def test_cosine_differs_from_linear_at_non_boundary(self):
+    """At 25% and 75% progress, cosine values differ significantly from linear."""
+    # At 25%: linear=0.75, cosine≈0.854
+    result_25 = distillation_utils.compute_schedule(
+        step=jnp.array(25), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="cosine"
+    )
+    np.testing.assert_allclose(result_25, 0.8535533, atol=1e-4)
+    self.assertGreater(float(result_25), 0.80, "Cosine at 25% should be above 0.80, not linear 0.75")
+
+    # At 75%: linear=0.25, cosine≈0.146
+    result_75 = distillation_utils.compute_schedule(
+        step=jnp.array(75), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="cosine"
+    )
+    np.testing.assert_allclose(result_75, 0.1464466, atol=1e-4)
+    self.assertLess(float(result_75), 0.20, "Cosine at 75% should be below 0.20, not linear 0.25")
+
+  def test_clamps_beyond_max_steps(self):
+    """Step > max_steps clamps to end_value for both linear and cosine."""
+    result_linear = distillation_utils.compute_schedule(
+        step=jnp.array(200), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="linear"
+    )
+    np.testing.assert_allclose(result_linear, 0.0, atol=1e-6)
+
+    result_cosine = distillation_utils.compute_schedule(
+        step=jnp.array(200), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="cosine"
+    )
+    np.testing.assert_allclose(result_cosine, 0.0, atol=1e-6)
+
+  def test_increasing_direction_linear(self):
+    """Linear schedule works correctly when end_value > start_value (ramp up)."""
+    result_mid = distillation_utils.compute_schedule(
+        step=jnp.array(50), max_steps=100, start_value=0.0, end_value=1.0, schedule_type="linear"
+    )
+    np.testing.assert_allclose(result_mid, 0.5, atol=1e-6)
+
+    result_end = distillation_utils.compute_schedule(
+        step=jnp.array(100), max_steps=100, start_value=0.0, end_value=1.0, schedule_type="linear"
+    )
+    np.testing.assert_allclose(result_end, 1.0, atol=1e-6)
+
+  def test_increasing_direction_cosine(self):
+    """Cosine schedule works correctly when end_value > start_value (ramp up)."""
+    result_start = distillation_utils.compute_schedule(
+        step=jnp.array(0), max_steps=100, start_value=0.2, end_value=0.8, schedule_type="cosine"
+    )
+    np.testing.assert_allclose(result_start, 0.2, atol=1e-6)
+
+    result_end = distillation_utils.compute_schedule(
+        step=jnp.array(100), max_steps=100, start_value=0.2, end_value=0.8, schedule_type="cosine"
+    )
+    np.testing.assert_allclose(result_end, 0.8, atol=1e-6)
+
+  def test_invalid_schedule_type_raises(self):
+    """Unsupported schedule type raises ValueError."""
+    with self.assertRaises(ValueError):
+      distillation_utils.compute_schedule(
+          step=jnp.array(0), max_steps=100, start_value=1.0, end_value=0.0, schedule_type="exponential"
+      )
+
+
+class StrategySchedulingTest(unittest.TestCase):
+  """Tests for dynamic scheduling within CombinedDistillationStrategy."""
+
+  def test_alpha_and_temperature_linear_schedule(self):
+    """Alpha and temperature follow linear schedules at steps 0, 50, and 100."""
+    strategy = distillation_utils.CombinedDistillationStrategy(
+        student_forward_fn=lambda m, **k: None,
+        teacher_forward_fn=lambda m, **k: None,
+        vocab_size=4,
+        temperature=2.0,
+        alpha=0.8,
+        beta_feature=0.0,
+        alpha_end=0.2,
+        alpha_schedule="linear",
+        temperature_end=1.0,
+        temperature_schedule="linear",
+        max_steps=100,
+    )
+
+    student, teacher = _make_dummy_outputs()
+    labels = _make_labels()
+
+    # Step 0
+    _, m0 = strategy.compute_loss(student, teacher, labels, step=jnp.array(0))
+    np.testing.assert_allclose(m0["distill/alpha"], 0.8, atol=1e-5)
+    np.testing.assert_allclose(m0["distill/temperature"], 2.0, atol=1e-5)
+
+    # Step 50
+    _, m50 = strategy.compute_loss(student, teacher, labels, step=jnp.array(50))
+    np.testing.assert_allclose(m50["distill/alpha"], 0.5, atol=1e-5)
+    np.testing.assert_allclose(m50["distill/temperature"], 1.5, atol=1e-5)
+
+    # Step 100
+    _, m100 = strategy.compute_loss(student, teacher, labels, step=jnp.array(100))
+    np.testing.assert_allclose(m100["distill/alpha"], 0.2, atol=1e-5)
+    np.testing.assert_allclose(m100["distill/temperature"], 1.0, atol=1e-5)
+
+  def test_cosine_alpha_at_strategy_level(self):
+    """Cosine alpha at 25% matches the expected cosine value (not linear)."""
+    strategy = distillation_utils.CombinedDistillationStrategy(
+        student_forward_fn=lambda m, **k: None,
+        teacher_forward_fn=lambda m, **k: None,
+        vocab_size=4,
+        temperature=1.0,
+        alpha=1.0,
+        alpha_end=0.0,
+        alpha_schedule="cosine",
+        beta_feature=0.0,
+        max_steps=100,
+    )
+
+    student, teacher = _make_dummy_outputs()
+    labels = _make_labels()
+
+    _, metrics = strategy.compute_loss(student, teacher, labels, step=jnp.array(25))
+    np.testing.assert_allclose(metrics["distill/alpha"], 0.8535533, atol=1e-4)
+
+  def test_step_none_uses_fixed_values(self):
+    """When step is None, fixed initial values are used even if schedules are configured."""
+    strategy = distillation_utils.CombinedDistillationStrategy(
+        student_forward_fn=lambda m, **k: None,
+        teacher_forward_fn=lambda m, **k: None,
+        vocab_size=4,
+        temperature=2.0,
+        alpha=0.8,
+        beta_feature=0.0,
+        alpha_end=0.2,
+        alpha_schedule="linear",
+        max_steps=100,
+    )
+
+    student, teacher = _make_dummy_outputs()
+    labels = _make_labels()
+
+    _, metrics = strategy.compute_loss(student, teacher, labels)
+    np.testing.assert_allclose(metrics["distill/alpha"], 0.8, atol=1e-5)
+    np.testing.assert_allclose(metrics["distill/temperature"], 2.0, atol=1e-5)
+
+  def test_beta_schedule_with_feature_loss(self):
+    """Beta scheduling with actual L2 feature loss: feature_loss scales proportionally."""
+    strategy = distillation_utils.CombinedDistillationStrategy(
+        student_forward_fn=lambda m, **k: None,
+        teacher_forward_fn=lambda m, **k: None,
+        vocab_size=4,
+        temperature=1.0,
+        alpha=0.5,
+        beta_feature=1.0,
+        beta_end=0.0,
+        beta_schedule="linear",
+        feature_loss_type="l2",
+        max_steps=100,
+    )
+
+    # Divergent features so feature loss is non-trivial
+    student = distillation_utils.DistillationForwardOutput(
+        logits=jnp.array([[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]]) * 10,
+        out_projection_activations=jnp.zeros((2, 1, 2, 4)),
+    )
+    teacher = distillation_utils.DistillationForwardOutput(
+        logits=jnp.array([[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]]) * 10,
+        out_projection_activations=jnp.ones((2, 1, 2, 4)),
+    )
+    labels = _make_labels()
+
+    # Step 0: beta=1.0
+    _, m0 = strategy.compute_loss(student, teacher, labels, step=jnp.array(0))
+    self.assertGreater(float(m0["distill/out_proj_feature_loss"]), 0.0)
+    np.testing.assert_allclose(m0["distill/beta_feature"], 1.0, atol=1e-5)
+
+    # Step 50: beta=0.5, feature loss should be half
+    _, m50 = strategy.compute_loss(student, teacher, labels, step=jnp.array(50))
+    np.testing.assert_allclose(m50["distill/beta_feature"], 0.5, atol=1e-5)
+    np.testing.assert_allclose(
+        float(m50["distill/out_proj_feature_loss"]),
+        float(m0["distill/out_proj_feature_loss"]) * 0.5,
+        atol=1e-5,
+    )
+
+    # Step 100: beta=0.0, feature loss should be zero
+    _, m100 = strategy.compute_loss(student, teacher, labels, step=jnp.array(100))
+    np.testing.assert_allclose(m100["distill/beta_feature"], 0.0, atol=1e-5)
+    np.testing.assert_allclose(float(m100["distill/out_proj_feature_loss"]), 0.0, atol=1e-5)
+
+  def test_alpha_schedule_affects_total_loss(self):
+    """Alpha=1.0 gives pure soft_loss; alpha=0.0 gives pure hard_loss; they differ."""
+    strategy = distillation_utils.CombinedDistillationStrategy(
+        student_forward_fn=lambda m, **k: None,
+        teacher_forward_fn=lambda m, **k: None,
+        vocab_size=4,
+        temperature=1.0,
+        alpha=1.0,
+        alpha_end=0.0,
+        alpha_schedule="linear",
+        beta_feature=0.0,
+        max_steps=100,
+    )
+
+    student, teacher = _make_divergent_outputs()
+    labels = _make_labels()
+
+    # alpha=1.0 -> total = soft_loss
+    loss_start, m_start = strategy.compute_loss(student, teacher, labels, step=jnp.array(0))
+    np.testing.assert_allclose(float(loss_start), float(m_start["distill/soft_loss"]), atol=1e-5)
+
+    # alpha=0.0 -> total = hard_loss
+    loss_end, m_end = strategy.compute_loss(student, teacher, labels, step=jnp.array(100))
+    np.testing.assert_allclose(float(loss_end), float(m_end["distill/hard_loss"]), atol=1e-5)
+
+    # The two should differ
+    self.assertNotAlmostEqual(float(loss_start), float(loss_end), places=2)
+
+
+class StrategyValidationTest(unittest.TestCase):
+  """Tests for configuration validation in CombinedDistillationStrategy."""
+
+  def test_beta_zero_with_beta_end_raises(self):
+    """beta_feature=0 with beta_end>0 is a misconfiguration and raises ValueError."""
+    with self.assertRaisesRegex(ValueError, "distill_beta=0.0 but distill_beta_end="):
+      distillation_utils.CombinedDistillationStrategy(
+          student_forward_fn=lambda m, **k: None,
+          teacher_forward_fn=lambda m, **k: None,
+          vocab_size=4,
+          beta_feature=0.0,
+          beta_end=0.5,
+          beta_schedule="linear",
+          max_steps=100,
+      )
+
+  def test_beta_zero_with_beta_end_none_is_allowed(self):
+    """beta_feature=0 with beta_end=None (no schedule) is valid."""
+    strategy = distillation_utils.CombinedDistillationStrategy(
+        student_forward_fn=lambda m, **k: None,
+        teacher_forward_fn=lambda m, **k: None,
+        vocab_size=4,
+        beta_feature=0.0,
+        beta_end=None,
+        max_steps=100,
+    )
+    self.assertEqual(strategy.beta_feature, 0.0)
+
+  def test_beta_zero_with_beta_end_zero_is_allowed(self):
+    """beta_feature=0 with beta_end=0 is valid (both are zero)."""
+    strategy = distillation_utils.CombinedDistillationStrategy(
+        student_forward_fn=lambda m, **k: None,
+        teacher_forward_fn=lambda m, **k: None,
+        vocab_size=4,
+        beta_feature=0.0,
+        beta_end=0.0,
+        beta_schedule="linear",
+        max_steps=100,
+    )
+    self.assertEqual(strategy.beta_feature, 0.0)
+
+
+class TrainerStepCounterTest(unittest.TestCase):
+  """Tests for ModelBundle.training_step and its integration with _train_step."""
+
+  def test_model_bundle_initializes_step_to_zero(self):
+    """ModelBundle.training_step starts at 0."""
+
+    class DummyModel(nnx.Module):
+
+      def __init__(self):
+        self.linear = nnx.Linear(in_features=2, out_features=2, rngs=nnx.Rngs(0))
+
+      def __call__(self, x):
+        return self.linear(x)
+
+    bundle = train_distill.ModelBundle(teacher_model=DummyModel(), student_model=DummyModel())
+    self.assertEqual(int(bundle.training_step[...]), 0)
+
+  def test_model_bundle_step_increment(self):
+    """ModelBundle.training_step can be incremented."""
+
+    class DummyModel(nnx.Module):
+
+      def __init__(self):
+        self.linear = nnx.Linear(in_features=2, out_features=2, rngs=nnx.Rngs(0))
+
+      def __call__(self, x):
+        return self.linear(x)
+
+    bundle = train_distill.ModelBundle(teacher_model=DummyModel(), student_model=DummyModel())
+    bundle.training_step[...] = bundle.training_step[...] + 1
+    self.assertEqual(int(bundle.training_step[...]), 1)
+    bundle.training_step[...] = bundle.training_step[...] + 1
+    self.assertEqual(int(bundle.training_step[...]), 2)
+
+  @mock.patch("maxtext.trainers.post_train.distillation.train_distill.optax.global_norm")
+  @mock.patch("maxtext.trainers.post_train.distillation.train_distill.nnx.value_and_grad")
+  def test_train_step_increments_and_passes_step(self, mock_value_and_grad, mock_global_norm):
+    """_train_step passes pre-increment step to compute_loss and increments after."""
+    # pylint: disable=no-value-for-parameter
+    trainer = train_distill.MaxTextDistillationTrainer.__new__(train_distill.MaxTextDistillationTrainer)
+    trainer.strategy = mock.Mock()
+    trainer.wrt_filter = lambda path, x: True  # type: ignore
+
+    # Use a real DistillationForwardOutput so jax.tree.map(stop_gradient, ...) works
+    # when loss_wrapper is invoked manually below.
+    fake_teacher_output = distillation_utils.DistillationForwardOutput(
+        logits=jnp.zeros((1, 2, 4)), out_projection_activations=None
+    )
+    mock_batch = {
+        "input_tokens": mock.Mock(),
+        "positions": mock.Mock(),
+        "attention_mask": mock.Mock(),
+        "decoder_segment_ids": mock.Mock(),
+        "targets": mock.Mock(),
+        "teacher_output": fake_teacher_output,
+    }
+    trainer.gen_model_input_fn = mock.Mock(return_value=mock_batch)
+
+    teacher_model, student_model = mock.Mock(), mock.Mock()
+    model_bundle = train_distill.ModelBundle(teacher_model=teacher_model, student_model=student_model)
+    optimizer = mock.Mock()
+
+    # Simulate resume from step 5
+    model_bundle.training_step.set_value(jnp.array(5, dtype=jnp.int32))
+
+    mock_grad_fn = mock.Mock(return_value=((mock.Mock(), {}), mock.Mock()))
+    mock_value_and_grad.return_value = mock_grad_fn
+    mock_global_norm.return_value = mock.Mock()
+
+    trainer._train_step(model_bundle, optimizer, mock.Mock())
+
+    # Step should have incremented to 6
+    self.assertEqual(int(model_bundle.training_step[...]), 6)
+
+    # Trigger loss_wrapper to verify step=5 was passed to compute_loss
+    loss_wrapper = mock_value_and_grad.call_args[0][0]
+    loss_wrapper(student_model, teacher_model, mock_batch)
+
+    call_kwargs = trainer.strategy.compute_loss.call_args
+    self.assertIn("step", call_kwargs.kwargs)
+    self.assertEqual(int(call_kwargs.kwargs["step"]), 5)
+
+  @mock.patch("maxtext.trainers.post_train.distillation.train_distill.optax.global_norm")
+  @mock.patch("maxtext.trainers.post_train.distillation.train_distill.nnx.value_and_grad")
+  def test_consecutive_train_steps_increment(self, mock_value_and_grad, mock_global_norm):
+    """training_step increments 0→1→2→3 across consecutive _train_step calls."""
+    # pylint: disable=no-value-for-parameter
+    trainer = train_distill.MaxTextDistillationTrainer.__new__(train_distill.MaxTextDistillationTrainer)
+    trainer.strategy = mock.Mock()
+    trainer.wrt_filter = lambda path, x: True  # type: ignore
+
+    mock_batch = {
+        "input_tokens": mock.Mock(),
+        "positions": mock.Mock(),
+        "targets": mock.Mock(),
+        "teacher_output": mock.Mock(),
+    }
+    trainer.gen_model_input_fn = mock.Mock(return_value=mock_batch)
+
+    teacher_model, student_model = mock.Mock(), mock.Mock()
+    model_bundle = train_distill.ModelBundle(teacher_model=teacher_model, student_model=student_model)
+    optimizer = mock.Mock()
+
+    mock_grad_fn = mock.Mock(return_value=((mock.Mock(), {}), mock.Mock()))
+    mock_value_and_grad.return_value = mock_grad_fn
+    mock_global_norm.return_value = mock.Mock()
+
+    self.assertEqual(int(model_bundle.training_step[...]), 0)
+    trainer._train_step(model_bundle, optimizer, mock.Mock())
+    self.assertEqual(int(model_bundle.training_step[...]), 1)
+    trainer._train_step(model_bundle, optimizer, mock.Mock())
+    self.assertEqual(int(model_bundle.training_step[...]), 2)
+    trainer._train_step(model_bundle, optimizer, mock.Mock())
+    self.assertEqual(int(model_bundle.training_step[...]), 3)
+
+
+class GetScheduledWeightsTest(unittest.TestCase):
+  """Direct tests for _get_scheduled_weights dispatch logic."""
+
+  def _make_strategy(self, **kwargs):
+    """Create a CombinedDistillationStrategy with test defaults, overridden by kwargs."""
+    defaults = {
+        "student_forward_fn": lambda m, **k: None,
+        "teacher_forward_fn": lambda m, **k: None,
+        "vocab_size": 4,
+        "temperature": 2.0,
+        "alpha": 0.8,
+        "beta_feature": 0.0,
+        "max_steps": 100,
+    }
+    defaults.update(kwargs)
+    return distillation_utils.CombinedDistillationStrategy(**defaults)
+
+  def test_returns_fixed_when_step_is_none(self):
+    """_get_scheduled_weights returns initial values when step is None."""
+    strategy = self._make_strategy(alpha_end=0.0, alpha_schedule="linear")
+    alpha, temperature, beta = strategy._get_scheduled_weights(step=None)
+    np.testing.assert_allclose(float(alpha), 0.8)
+    np.testing.assert_allclose(float(temperature), 2.0)
+    np.testing.assert_allclose(float(beta), 0.0)
+
+  def test_each_param_scheduled_independently(self):
+    """Alpha uses cosine, temperature uses linear, beta stays constant — all in one strategy."""
+    strategy = self._make_strategy(
+        beta_feature=0.5,
+        alpha_end=0.0,
+        alpha_schedule="cosine",
+        temperature_end=1.0,
+        temperature_schedule="linear",
+        # beta: no schedule configured → constant
+    )
+    alpha, temperature, beta = strategy._get_scheduled_weights(step=jnp.array(50))
+
+    # alpha: cosine from 0.8 to 0.0 at 50% → 0.4
+    np.testing.assert_allclose(float(alpha), 0.4, atol=1e-5)
+    # temperature: linear from 2.0 to 1.0 at 50% → 1.5
+    np.testing.assert_allclose(float(temperature), 1.5, atol=1e-5)
+    # beta: no schedule → stays at 0.5
+    np.testing.assert_allclose(float(beta), 0.5, atol=1e-5)
+
+
+class ScheduleEdgeCasesTest(unittest.TestCase):
+  """Edge cases for compute_schedule."""
+
+  def test_max_steps_one(self):
+    """max_steps=1 should jump to end_value at step 1."""
+    result = distillation_utils.compute_schedule(
+        step=jnp.array(0), max_steps=1, start_value=1.0, end_value=0.0, schedule_type="linear"
+    )
+    np.testing.assert_allclose(result, 1.0, atol=1e-6)
+
+    result = distillation_utils.compute_schedule(
+        step=jnp.array(1), max_steps=1, start_value=1.0, end_value=0.0, schedule_type="linear"
+    )
+    np.testing.assert_allclose(result, 0.0, atol=1e-6)
+
+  def test_start_equals_end(self):
+    """start_value == end_value returns that value regardless of schedule type or step."""
+    for stype in ("linear", "cosine"):
+      result = distillation_utils.compute_schedule(
+          step=jnp.array(50), max_steps=100, start_value=0.5, end_value=0.5, schedule_type=stype
+      )
+      np.testing.assert_allclose(result, 0.5, atol=1e-6, err_msg=f"Failed for {stype}")
+
+  def test_step_zero_always_returns_start(self):
+    """Step 0 returns start_value for all schedule types."""
+    for stype in ("linear", "cosine"):
+      result = distillation_utils.compute_schedule(
+          step=jnp.array(0), max_steps=100, start_value=0.7, end_value=0.3, schedule_type=stype
+      )
+      np.testing.assert_allclose(result, 0.7, atol=1e-6, err_msg=f"Failed for {stype}")
+
+
+class TemperatureScheduleEffectTest(unittest.TestCase):
+  """Verifies temperature schedule actually affects loss values, not just metrics."""
+
+  def test_temperature_schedule_changes_soft_loss(self):
+    """Different temperatures produce different soft_loss values (not just metric logging)."""
+    strategy = distillation_utils.CombinedDistillationStrategy(
+        student_forward_fn=lambda m, **k: None,
+        teacher_forward_fn=lambda m, **k: None,
+        vocab_size=4,
+        temperature=4.0,
+        temperature_end=1.0,
+        temperature_schedule="linear",
+        alpha=1.0,  # pure soft loss
+        beta_feature=0.0,
+        max_steps=100,
+    )
+
+    # Student and teacher disagree so soft_loss is non-trivial
+    student, teacher = _make_divergent_outputs()
+    labels = _make_labels()
+
+    _, m_high_temp = strategy.compute_loss(student, teacher, labels, step=jnp.array(0))  # temp=4.0
+    _, m_low_temp = strategy.compute_loss(student, teacher, labels, step=jnp.array(100))  # temp=1.0
+
+    # Different temperatures must produce different soft_loss values
+    self.assertNotAlmostEqual(
+        float(m_high_temp["distill/soft_loss"]),
+        float(m_low_temp["distill/soft_loss"]),
+        places=1,
+        msg="Temperature schedule should change soft_loss, not just the metric value",
+    )
+
+
+class CheckpointStepSyncTest(unittest.TestCase):
+  """Verifies the step counter sync after checkpoint restore."""
+
+  def test_step_counter_sync_from_trainer(self):
+    """ModelBundle.training_step is synced from trainer._train_steps after restore."""
+    teacher_model, student_model = mock.Mock(), mock.Mock()
+    model_bundle = train_distill.ModelBundle(teacher_model=teacher_model, student_model=student_model)
+
+    # Simulate what train_distill() does after setup_checkpoint_manager_and_restore
+    restored_step = 42
+    model_bundle.training_step.set_value(jnp.array(restored_step, dtype=jnp.int32))
+
+    self.assertEqual(int(model_bundle.training_step[...]), 42)
+
+  def test_step_counter_defaults_to_zero_without_restore(self):
+    """Without restore, training_step stays at 0."""
+    teacher_model, student_model = mock.Mock(), mock.Mock()
+    model_bundle = train_distill.ModelBundle(teacher_model=teacher_model, student_model=student_model)
+
+    self.assertEqual(int(model_bundle.training_step[...]), 0)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -765,7 +765,7 @@ class TrainDistillTest(unittest.TestCase):
     mock_student_forward = mock.Mock(side_effect=lambda model, **kwargs: model(dummy_batch["input_tokens"]))
     trainer.strategy.student_forward_fn = mock_student_forward
 
-    trainer.strategy.compute_loss.side_effect = lambda s_out, t_out, labels: (jnp.sum(s_out), {"aux": 1.0})
+    trainer.strategy.compute_loss.side_effect = lambda s_out, t_out, labels, step=None: (jnp.sum(s_out), {"aux": 1.0})
 
     # --- EXECUTE PASS 1 ---
     trainer._train_step(model_bundle, nnx_opt, dummy_batch)
@@ -891,7 +891,7 @@ class TrainDistillTest(unittest.TestCase):
 
     # 2. Setup strategy and trainer config
     strategy = mock.Mock()
-    strategy.compute_loss.side_effect = lambda s_out, t_out, labels: (jnp.sum(s_out.logits), {"aux": 1.0})
+    strategy.compute_loss.side_effect = lambda s_out, t_out, labels, step=None: (jnp.sum(s_out.logits), {"aux": 1.0})
     strategy.labels_fn.return_value = None
     strategy.student_forward_fn = lambda model, **kw: distillation_utils.DistillationForwardOutput(
         logits=model(kw["input_tokens"])
@@ -1037,6 +1037,14 @@ class TrainDistillTest(unittest.TestCase):
     mock_student_cfg.use_sft = False
     mock_student_cfg.enable_dropout = False
 
+    # Add scheduling attributes
+    mock_student_cfg.distill_alpha_end = None
+    mock_student_cfg.distill_alpha_schedule = "constant"
+    mock_student_cfg.distill_temperature_end = None
+    mock_student_cfg.distill_temperature_schedule = "constant"
+    mock_student_cfg.distill_beta_end = None
+    mock_student_cfg.distill_beta_schedule = "constant"
+
     # Add dummy variables for Checkpointer and Logger
     mock_student_cfg.max_num_checkpoints_to_keep = 1
     mock_student_cfg.async_checkpointing = False
@@ -1118,6 +1126,14 @@ class TrainDistillTest(unittest.TestCase):
     mock_student_cfg.use_sft = False
     mock_student_cfg.enable_dropout = False
 
+    # Add scheduling attributes
+    mock_student_cfg.distill_alpha_end = None
+    mock_student_cfg.distill_alpha_schedule = "constant"
+    mock_student_cfg.distill_temperature_end = None
+    mock_student_cfg.distill_temperature_schedule = "constant"
+    mock_student_cfg.distill_beta_end = None
+    mock_student_cfg.distill_beta_schedule = "constant"
+
     # Add dummy variables for Checkpointer and Logger
     mock_student_cfg.max_num_checkpoints_to_keep = 1
     mock_student_cfg.async_checkpointing = False
@@ -1181,7 +1197,7 @@ class TrainDistillTest(unittest.TestCase):
 
     # 3. Setup Strategy and TrainingConfig
     strategy = mock.Mock()
-    strategy.compute_loss.side_effect = lambda s_out, t_out, labels: (jnp.sum(s_out.logits), {"aux": 1.0})
+    strategy.compute_loss.side_effect = lambda s_out, t_out, labels, step=None: (jnp.sum(s_out.logits), {"aux": 1.0})
     strategy.create_labels.return_value = None
     strategy.student_forward_fn = lambda model, **kw: distillation_utils.DistillationForwardOutput(
         logits=model(kw["input_tokens"])


### PR DESCRIPTION
# Description

Add dynamic scheduling (linear, cosine) for `distill_alpha`, `distill_temperature`, and `distill_beta` loss weights during distillation training. Currently these weights are fixed for the entire run. Annealing them improves distillation quality — e.g., decaying alpha lets the student gradually shift from teacher reliance to hard labels.

Changes:
- `compute_schedule()` utility with linear and cosine curves
- Six new config fields (`distill_alpha_end`, `distill_alpha_schedule`, etc.)
- Validation for invalid combinations (out-of-range values, schedule without end value, beta ramp-up from zero)
- `training_step` counter on `ModelBundle` as `nnx.Variable` (JIT-compatible), synced on checkpoint restore
- Fully backward compatible — all defaults preserve existing constant-weight behavior

Example:
```yaml
distill_alpha: 0.8
distill_alpha_end: 0.2
distill_alpha_schedule: "cosine"
```

# Tests

Unit tests

End to end test and making sure values are logged in Tensorboard:

https://screenshot.googleplex.com/6yHckBhLsZu3hDC

```
# --- Distillation Loss Scheduling ---
distill_alpha_end: 0.2
distill_alpha_schedule: "cosine"
distill_temperature_end: 1.0
distill_temperature_schedule: "cosine"
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
