### PR TITLE
feat: Add FLOPs calculation for Multi-Token Prediction (MTP) modules

### DIFF
--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -968,6 +968,45 @@ def calculate_tflops_training_per_device(config, log=True):
     )
     attention_tflops = causal_attention_flops * config.num_decoder_layers * 3 / 10**12
 
+  # MTP (Multi-Token Prediction) FLOPs Calculation
+  mtp_num_layers = getattr(config, "mtp_num_layers", 0)
+  if mtp_num_layers > 0:
+    # MTP modules act as structural replicas of the model's final decoder layer.
+    # To calculate accurately for mixed architectures (e.g., DeepSeek, Llama 4),
+    # we must explicitly reconstruct the FLOPs for the final layer rather than averaging.
+    if config.num_experts > 1:
+      # For MoE architectures, the final layer is always an MoE layer.
+      # Reconstruct the gate, shared expert (if applicable), and routed expert FLOPs.
+      gate_flops = 2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.num_experts
+      if config.decoder_block in (
+          DecoderBlockType.DEEPSEEK,
+          DecoderBlockType.LLAMA4,
+          DecoderBlockType.QWEN3_NEXT,
+          DecoderBlockType.GEMMA4,
+      ):
+        shared_flops = calculate_ffn_mamtul_tflops_per_device(config, config.moe_mlp_dim) * config.shared_experts
+        routed_flops = calculate_ffn_mamtul_tflops_per_device(config, config.moe_mlp_dim) * config.num_experts_per_tok
+        last_layer_ffn_flops = gate_flops + shared_flops + routed_flops
+      else:
+        routed_flops = calculate_ffn_mamtul_tflops_per_device(config, config.moe_mlp_dim) * config.num_experts_per_tok
+        last_layer_ffn_flops = gate_flops + routed_flops
+    else:
+      # For dense architectures, the final layer is a standard dense FFN.
+      last_layer_ffn_flops = calculate_ffn_mamtul_tflops_per_device(config, config.mlp_dim)
+
+    # Calculate total weight FLOPs per MTP module.
+    # Crucially, MTP shares the base model's vocabulary embeddings and final output
+    # projections, so we strictly add only the FFN, QKV, and standard projection FLOPs.
+    mtp_weight_flops = (last_layer_ffn_flops + qkv_flops + projection_flops) * mtp_num_layers
+
+    # Attention FLOPs scale linearly with the number of MTP modules.
+    mtp_attn_flops = causal_attention_flops * mtp_num_layers
+
+    # Convert to TFLOPs (multiply by 3 to account for 1 forward pass + 2 backward passes).
+    # Add directly to the running totals before Engram and Vision calculations.
+    learnable_weight_tflops += mtp_weight_flops * 3 / 10**12
+    attention_tflops += mtp_attn_flops * 3 / 10**12
+
   # Engram flops
   if config.engram_layers:
     engram_learnable_tflops, engram_attention_tflops = calculate_engram_tflops(config)

--- a/tests/unit/flop_calculation_test.py
+++ b/tests/unit/flop_calculation_test.py
@@ -682,6 +682,124 @@ class FlopCalculation(parameterized.TestCase):
 
     self.assertAlmostEqual(ffn_tflops, expected_total, places=5)
 
+  def test_mtp_dense_flops(self):
+    """Test model with MTP modules on a Dense architecture (Llama3)."""
+    # Inject MTP modules during initialization
+    cfg = self._initialize_model_config(
+        "llama3-8b",
+        max_target_length=2048,
+        per_device_batch_size=4,
+        mtp_num_layers=2,
+    )
+
+    kwargs = cfg.get_keys()
+    B = cfg.per_device_batch_size
+    S = cfg.max_target_length
+
+    # 1. Base Llama3-8b FLOPs
+    base_attention_flops = self.compute_regular_attention_flops_per_device(kwargs)
+    # LLaMA3-8b has ~7.50B active parameters with tied embeddings
+    golden_base_param_size = 7.50e9
+    golden_base_tflops = 6 * B * S * golden_base_param_size / 1e12 + base_attention_flops
+
+    # 2. MTP Module Active Params (Per Module) for Dense
+    # MTP acts as a final layer replica without vocab embeddings or output projections.
+    Hq = kwargs["base_num_query_heads"]
+    Hkv = kwargs["base_num_kv_heads"]
+    Hd = kwargs["head_dim"]
+    emb_dim = kwargs["base_emb_dim"]
+    mlp_dim = kwargs["base_mlp_dim"]
+
+    # Attention Params: Q, K, V, and Out projections
+    attn_params = (emb_dim * (Hq + 2 * Hkv) * Hd) + (Hq * Hd * emb_dim)
+
+    # FFN Params: Llama uses SwiGLU, which consists of 3 matrices (Gate, Up, Down)
+    ffn_params = 3 * emb_dim * mlp_dim
+
+    # Total MTP Params
+    mtp_active_params = (attn_params + ffn_params) * cfg.mtp_num_layers
+    mtp_weight_tflops = 6 * B * S * mtp_active_params / 1e12
+
+    # MTP Attention FLOPs (Causal)
+    # 2 for QK^T and SV operations. 3 for fwd + bwd passes.
+    mtp_attention_tflops = 2 * 3 * cfg.mtp_num_layers * B * (S**2) * Hq * Hd / 1e12
+
+    # Final Expected TFLOPs
+    golden_total_tflops = golden_base_tflops + mtp_weight_tflops + mtp_attention_tflops
+
+    # Run Calculation
+    calculated_tflops, _, _ = calculate_tflops_training_per_device(cfg)
+
+    self.assertFlopsAlmostEqual(calculated_tflops, golden_total_tflops)
+
+  def test_mtp_moe_flops(self):
+    """Test model with MTP modules on an MoE architecture (DeepSeek)."""
+    # Inject MTP modules during initialization
+    cfg = self._initialize_model_config(
+        "deepseek2-16b",
+        max_target_length=8192,
+        per_device_batch_size=4,
+        mtp_num_layers=2,
+    )
+
+    kwargs = cfg.get_keys()
+    B = cfg.per_device_batch_size
+    S = cfg.max_target_length
+
+    # 1. Base DeepSeek FLOPs
+    base_attention_flops = self.compute_deepseek_attention_flops_per_device(kwargs)
+    # deepseek2-16b has ~2.4B active parameters
+    golden_base_param_size = 2.4e9
+    golden_base_tflops = 6 * B * S * golden_base_param_size / 1e12 + base_attention_flops
+
+    # 2. MTP Module Active Params for MoE (DeepSeek style)
+    emb_dim = kwargs["base_emb_dim"]
+    num_experts = kwargs["num_experts"]
+    moe_mlp_dim = kwargs["base_moe_mlp_dim"]
+    shared_experts = kwargs.get("shared_experts", 1)
+    num_experts_per_tok = kwargs["num_experts_per_tok"]
+
+    # FFN Params (Gate + Shared + Routed)
+    # SwiGLU requires 3 matrices (Gate, Up, Down) per expert
+    gate_params = emb_dim * num_experts
+    shared_params = 3 * emb_dim * moe_mlp_dim * shared_experts
+    routed_params = 3 * emb_dim * moe_mlp_dim * num_experts_per_tok
+    ffn_params = gate_params + shared_params + routed_params
+
+    # MLA Attention Params (Q, KV, and Out Projections)
+    qk_nope_hd = kwargs["qk_nope_head_dim"]
+    qk_rope_hd = kwargs["qk_rope_head_dim"]
+    v_hd = kwargs["v_head_dim"]
+    H_q = kwargs["base_num_query_heads"]
+    q_lora_rank = kwargs.get("q_lora_rank", 0)
+    kv_lora_rank = kwargs.get("kv_lora_rank", 0)
+
+    qk_head_dim_sum = qk_nope_hd + qk_rope_hd
+    if q_lora_rank == 0:
+      q_params = emb_dim * H_q * qk_head_dim_sum
+    else:
+      q_params = emb_dim * q_lora_rank + q_lora_rank * H_q * qk_head_dim_sum
+
+    kv_params = emb_dim * (kv_lora_rank + qk_rope_hd) + kv_lora_rank * H_q * (qk_nope_hd + v_hd)
+    proj_params = emb_dim * H_q * v_hd
+    attn_params = q_params + kv_params + proj_params
+
+    # Total MTP Active Params
+    mtp_active_params = (attn_params + ffn_params) * cfg.mtp_num_layers
+    mtp_weight_tflops = 6 * B * S * mtp_active_params / 1e12
+
+    # 3. MTP Attention FLOPs
+    # Causal attention flops for MLA (3 for fwd + bwd pass)
+    mtp_attention_tflops = 3 * cfg.mtp_num_layers * B * (S**2) * H_q * (qk_nope_hd + qk_rope_hd + v_hd) / 1e12
+
+    # Final Expected TFLOPs
+    golden_total_tflops = golden_base_tflops + mtp_weight_tflops + mtp_attention_tflops
+
+    # Run Calculation
+    calculated_tflops, _, _ = calculate_tflops_training_per_device(cfg)
+
+    self.assertFlopsAlmostEqual(calculated_tflops, golden_total_tflops)
+
   # ========== Parameterized Tests for Multiple Standard Models ==========
 
   def _verify_flops(self, model_name, max_target_length=1):


### PR DESCRIPTION
# Description

Currently, if a model is configured to use Multi-Token Prediction (`mtp_num_layers > 0`), the computational cost of those extra modules is missing from the training TFLOPs calculation, leading to an underestimation of the model's actual footprint.

Since MTP modules act as independent replicas of the model's final decoder layer---but share the base model's vocabulary embeddings and final output projection---this PR adds the precise mathematical accounting for them.

**Specific Changes:**

-   **Explicit Final Layer Math:** Added logic to `maxtext_utils.py` to explicitly calculate the FLOPs of the final layer. It checks `config.num_experts > 1` to cleanly separate standard Dense architectures from MoE architectures (accurately handling gates, routed experts, and shared experts) instead of using inaccurate layer averages.

-   **Shared Layer Exclusion:** Ensures that embedding matrices and final projections are strictly excluded from the MTP module's active parameter calculations.

-   **Unit Tests:** Added two tests to `tests/unit/flop_calculation_test.py` (`test_mtp_dense_flops` using Llama 3 and `test_mtp_moe_flops` using DeepSeek2) to verify the FLOPs math matches the manual `6 * active_params * tokens` estimation rule.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/503354872

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

-   Ran `pytest tests/unit/flop_calculation_test.py -k "test_mtp" -v` (Passed)

-   Ran the full `tests/unit/flop_calculation_test.py` suite to ensure no regressions in base architectural FLOP calculations. (Passed)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
