### PR TITLE
[Distillation] base learn-to-init llama attention for distillation

### DIFF
--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -109,6 +109,8 @@ class DecoderBlockType(enum.Enum):
   LLAMA4 = "llama4"
   OLMO3 = "olmo3"
 
+  LLAMA2LTI = "llama2_learn_to_init"
+
 
 class AttentionType(enum.Enum):
   GLOBAL = "global"  # default, with causality

--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -32,8 +32,9 @@ AxisNames = tuple[str, ...]
 AxisIdxes = tuple[int, ...]
 
 BATCH = "activation_batch"
+BATCH_ATTN = "activation_batch_attn"
 
-ATTN_LENGTH = "activation_attn_length"
+ATTN_LENGTH = "activation_length_attn"
 
 LENGTH = "activation_length"
 PREFILL_LENGTH = "prefill_activation_length"
@@ -41,7 +42,7 @@ Q_LENGTH = "activation_q_length"
 Q_LORA_UP_PROJ = "q_lora_up_proj"
 KV_LENGTH = "activation_kv_length"
 KV_LORA_UP_PROJ = "kv_lora_up_proj"
-ATTN_EMBED = "activation_attn_embed"
+ATTN_EMBED = "activation_embed_attn"
 EMBED = "activation_embed"
 HEAD = "activation_heads"
 PREFILL_KV_BATCH = "activation_prefill_kv_batch"

--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -32,9 +32,8 @@ AxisNames = tuple[str, ...]
 AxisIdxes = tuple[int, ...]
 
 BATCH = "activation_batch"
-BATCH_ATTN = "activation_batch_attn"
 
-ATTN_LENGTH = "activation_length_attn"
+ATTN_LENGTH = "activation_attn_length"
 
 LENGTH = "activation_length"
 PREFILL_LENGTH = "prefill_activation_length"
@@ -42,7 +41,7 @@ Q_LENGTH = "activation_q_length"
 Q_LORA_UP_PROJ = "q_lora_up_proj"
 KV_LENGTH = "activation_kv_length"
 KV_LORA_UP_PROJ = "kv_lora_up_proj"
-ATTN_EMBED = "activation_embed_attn"
+ATTN_EMBED = "activation_attn_embed"
 EMBED = "activation_embed"
 HEAD = "activation_heads"
 PREFILL_KV_BATCH = "activation_prefill_kv_batch"
@@ -108,6 +107,8 @@ class DecoderBlockType(enum.Enum):
   SIMPLE_MLP = "simple_mlp"
   LLAMA4 = "llama4"
   OLMO3 = "olmo3"
+
+  LLAMA2LTI = "llama2_learn_to_init"
 
 
 class AttentionType(enum.Enum):

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1207,6 +1207,26 @@ class Distillation(BaseModel):
       "constant", description="Schedule type for beta annealing ('constant', 'linear', or 'cosine')."
   )
 
+  # --- Learn to init related parameters --
+  learn_to_init_mode: bool = Field(False, description="Runs in the learn-to-init mode only")
+
+  lti_use_general_linear_map: bool = Field(
+      False,
+      description="enable general map (i.e. single learnable projection instead of the bi-linear mapping. "
+      "Needs much more HBM.",
+  )
+
+  distill_weights_copy_map: dict[str, Any] = Field(
+      default_factory=dict,
+      description="Dictionary of copying original teacher weights to the student model.",
+  )
+
+  distill_student_weights_share_map: dict[str, Any] = Field(
+      default_factory=dict,
+      description="Experimental weight sharing map inside the student model for learn-to-init phase",
+  )
+  # ---------------------------------------
+
   # --- Distillation freezing filter --
   student_params_to_update: None | list = Field(
       None,

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -434,6 +434,19 @@ class Quantization(BaseModel):
       "absmax",
       description="Quantization calibration method used for gradients.",
   )
+  weight_sparsity_n: int | None = Field(
+      None,
+      description=("The 'N' in N:M sparsity, representing the maximum number of non-zero" " values in each block."),
+  )
+  weight_sparsity_m: int | None = Field(
+      None,
+      description=("The 'M' in N:M sparsity, representing the number of values in each" " block."),
+  )
+  weight_sparsity_update_step: int = Field(10, description="The step size for updating weight sparsity masks.")
+  weight_sparsity_start_step: int = Field(
+      50,
+      description=("The first number of steps before updating the sparsity masks."),
+  )
 
 
 class ModelArchitecture(BaseModel):
@@ -1819,6 +1832,13 @@ class RL(BaseModel):
   epsilon_high: Optional[float] = Field(
       None, description="Upper-bound clipping epsilon for GRPO loss. Defaults to epsilon when None (agentic only)."
   )
+  reshard_chunk_size: Optional[int] = Field(
+      None,
+      description=(
+          "Number of model keys to chunk for resharding tensors between trainer and rollout devices."
+          "If None, no chunking is applied, which may lead to OOM errors if tensors are too large."
+      ),
+  )
 
 
 class RLDataset(BaseModel):
@@ -1850,6 +1870,10 @@ class RLEvaluation(BaseModel):
       False,
       description="If True, return a list of (question, answer, responses) during evaluation.",
   )
+  eval_mode: Literal["pass", "maj", "pass_at_1"] = Field(
+      "pass",
+      description="Evaluation mode to use ('pass' for pass@K, 'maj' for maj@K, 'pass_at_1' for pass@1 estimation).",
+  )
 
 
 class Reward(BaseModel):
@@ -1867,6 +1891,11 @@ class Reward(BaseModel):
   )
   penalty_incorrect_format: float = Field(-0.5, description="Penalty for an incorrect format.")
   penalty_incorrect_answer: float = Field(-1.0, description="Penalty for an incorrect answer.")
+  math_verify_timeout: int = Field(300, description="Global timeout (seconds) for math_verify calls per batch.")
+  math_verify_num_procs: int | None = Field(
+      None,
+      description=("Max worker processes for the math_verify pool. None ⇒ " "min(batch_size, cpu_count())."),
+  )
 
 
 class SpecialTokens(BaseModel):
@@ -2616,7 +2645,7 @@ class MaxTextConfig(
       supports_flash_splash = self.attention == "flash" and self.use_tokamax_splash
       if not (supports_dot_product or supports_flash_splash):
         raise NotImplementedError(
-            "Sparse indexer is only supported dot_product attention or flash attention with tokamax splash."
+            "Sparse indexer is only supported with dot_product attention or flash attention with tokamax splash."
         )
       if self.indexer_loss_scaling_factor > 0.0 and self.indexer_topk >= self.max_target_length:
         raise ValueError(

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -434,19 +434,6 @@ class Quantization(BaseModel):
       "absmax",
       description="Quantization calibration method used for gradients.",
   )
-  weight_sparsity_n: int | None = Field(
-      None,
-      description=("The 'N' in N:M sparsity, representing the maximum number of non-zero" " values in each block."),
-  )
-  weight_sparsity_m: int | None = Field(
-      None,
-      description=("The 'M' in N:M sparsity, representing the number of values in each" " block."),
-  )
-  weight_sparsity_update_step: int = Field(10, description="The step size for updating weight sparsity masks.")
-  weight_sparsity_start_step: int = Field(
-      50,
-      description=("The first number of steps before updating the sparsity masks."),
-  )
 
 
 class ModelArchitecture(BaseModel):
@@ -1207,6 +1194,26 @@ class Distillation(BaseModel):
       "constant", description="Schedule type for beta annealing ('constant', 'linear', or 'cosine')."
   )
 
+  # --- Learn to init related parameters --
+  learn_to_init_mode: bool = Field(False, description="Runs in the learn-to-init mode only")
+
+  lti_use_general_linear_map: bool = Field(
+      False,
+      description="enable general map (i.e. single learnable projection instead of the bi-linear mapping. "
+      "Needs much more HBM.",
+  )
+
+  distill_weights_copy_map: dict[str, Any] = Field(
+      default_factory=dict,
+      description="Dictionary of copying original teacher weights to the student model.",
+  )
+
+  distill_student_weights_share_map: dict[str, Any] = Field(
+      default_factory=dict,
+      description="Experimental weight sharing map inside the student model for learn-to-init phase",
+  )
+  # ---------------------------------------
+
   # --- Distillation freezing filter --
   student_params_to_update: None | list = Field(
       None,
@@ -1812,13 +1819,6 @@ class RL(BaseModel):
   epsilon_high: Optional[float] = Field(
       None, description="Upper-bound clipping epsilon for GRPO loss. Defaults to epsilon when None (agentic only)."
   )
-  reshard_chunk_size: Optional[int] = Field(
-      None,
-      description=(
-          "Number of model keys to chunk for resharding tensors between trainer and rollout devices."
-          "If None, no chunking is applied, which may lead to OOM errors if tensors are too large."
-      ),
-  )
 
 
 class RLDataset(BaseModel):
@@ -1850,10 +1850,6 @@ class RLEvaluation(BaseModel):
       False,
       description="If True, return a list of (question, answer, responses) during evaluation.",
   )
-  eval_mode: Literal["pass", "maj", "pass_at_1"] = Field(
-      "pass",
-      description="Evaluation mode to use ('pass' for pass@K, 'maj' for maj@K, 'pass_at_1' for pass@1 estimation).",
-  )
 
 
 class Reward(BaseModel):
@@ -1871,11 +1867,6 @@ class Reward(BaseModel):
   )
   penalty_incorrect_format: float = Field(-0.5, description="Penalty for an incorrect format.")
   penalty_incorrect_answer: float = Field(-1.0, description="Penalty for an incorrect answer.")
-  math_verify_timeout: int = Field(300, description="Global timeout (seconds) for math_verify calls per batch.")
-  math_verify_num_procs: int | None = Field(
-      None,
-      description=("Max worker processes for the math_verify pool. None ⇒ " "min(batch_size, cpu_count())."),
-  )
 
 
 class SpecialTokens(BaseModel):
@@ -2625,7 +2616,7 @@ class MaxTextConfig(
       supports_flash_splash = self.attention == "flash" and self.use_tokamax_splash
       if not (supports_dot_product or supports_flash_splash):
         raise NotImplementedError(
-            "Sparse indexer is only supported with dot_product attention or flash attention with tokamax splash."
+            "Sparse indexer is only supported dot_product attention or flash attention with tokamax splash."
         )
       if self.indexer_loss_scaling_factor > 0.0 and self.indexer_topk >= self.max_target_length:
         raise ValueError(

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -569,6 +569,7 @@ class Decoder(nn.Module):
             "cache": cache_spec,
             "intermediates": 0,
             "aqt": 0,
+            "batch_stats": 0,
             "_overwrite_with_gradient": 0,
         },
         split_rngs={

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -449,6 +449,8 @@ class Decoder(nn.Module):
         return [DecoderLayer]
       case DecoderBlockType.LLAMA2:
         return [llama2.LlamaDecoderLayerToLinen]
+      case DecoderBlockType.LLAMA2LTI:
+        return [llama2.LlamaLTIDecoderLayerToLinen]
       case DecoderBlockType.MISTRAL:
         # TODO(ranran): update to Mistral with sliding window attention
         return [mistral.MistralDecoderLayerToLinen]
@@ -543,6 +545,7 @@ class Decoder(nn.Module):
         DecoderBlockType.SIMPLE_MLP,
         DecoderBlockType.LLAMA4,
         DecoderBlockType.OLMO3,
+        DecoderBlockType.LLAMA2LTI,
     ):
       return functools.partial(rms_norm, num_features=num_features, shard_mode=self.config.shard_mode)
     elif self.config.decoder_block == DecoderBlockType.GPT3:

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -449,6 +449,8 @@ class Decoder(nn.Module):
         return [DecoderLayer]
       case DecoderBlockType.LLAMA2:
         return [llama2.LlamaDecoderLayerToLinen]
+      case DecoderBlockType.LLAMA2LTI:
+        return [llama2.LlamaLTIDecoderLayerToLinen]
       case DecoderBlockType.MISTRAL:
         # TODO(ranran): update to Mistral with sliding window attention
         return [mistral.MistralDecoderLayerToLinen]
@@ -543,6 +545,7 @@ class Decoder(nn.Module):
         DecoderBlockType.SIMPLE_MLP,
         DecoderBlockType.LLAMA4,
         DecoderBlockType.OLMO3,
+        DecoderBlockType.LLAMA2LTI,
     ):
       return functools.partial(rms_norm, num_features=num_features, shard_mode=self.config.shard_mode)
     elif self.config.decoder_block == DecoderBlockType.GPT3:
@@ -566,7 +569,6 @@ class Decoder(nn.Module):
             "cache": cache_spec,
             "intermediates": 0,
             "aqt": 0,
-            "batch_stats": 0,
             "_overwrite_with_gradient": 0,
         },
         split_rngs={

--- a/src/maxtext/layers/learn_to_init_layer.py
+++ b/src/maxtext/layers/learn_to_init_layer.py
@@ -1,0 +1,441 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""nxx module overrides and utility methods for LTI distillation"""
+
+import jax
+from flax import nnx
+from maxtext.layers import linears, initializers
+from maxtext.common.common_types import Config
+from jax.sharding import Mesh, NamedSharding
+import jax.numpy as jnp
+from typing import Iterable, Optional
+
+from maxtext.common.common_types import DType, ShardMode, Array
+from maxtext.layers.nnx_wrappers import ToNNX
+from maxtext.layers.quantizations import AqtQuantization as Quant
+from maxtext.layers.initializers import NdInitializer, nd_dense_init
+from maxtext.utils import max_logging, max_utils
+
+
+class LearnToInitDecoderLayer(nnx.Module):
+  """
+  A generic wrapper that initializes a base decoder layer and dynamically swaps
+  its DenseGeneral modules for learn-to-init distillation.
+
+  This class instantiates a standard base decoder layer (e.g., LlamaDecoderLayer)
+  and replaces specific attention projection sub-modules ("query", "key", "value",
+  "out") with customized `LearnToInitDense` modules.
+
+  Attributes:
+      learn_to_init_wrapper: The instantiated base decoder layer containing the mutable NNX graph.
+      config: The model configuration parameters.
+      rngs: The random number generator state used for initialization.
+      self_attention_module_name: The target name of the attention module to customize.
+  """
+
+  def __init__(
+      self,
+      base_layer_cls,
+      config: Config,
+      model_mode: str,
+      mesh: Mesh,
+      rngs: nnx.Rngs,
+      quant=None,
+      **kwargs,
+  ):
+    # Instantiate the original layer (e.g., LlamaDecoderLayer)
+    self.learn_to_init_wrapper = base_layer_cls(
+        config=config, model_mode=model_mode, mesh=mesh, rngs=rngs, quant=quant, **kwargs
+    )
+
+    self.config = config
+    self.rngs = rngs
+
+    self.self_attention_module_name = "self_attention"
+
+    # replace relevant nnx modules with customized LearnToInit modules
+    self._customize_attention_modules(self.learn_to_init_wrapper)
+
+  def _customize_attention_modules(self, module: nnx.Module):
+    """Replaces specific DenseGeneral modules (q, k, v projections) in the attention module."""
+    attention_module = getattr(module, self.self_attention_module_name, None)
+    if attention_module is None:
+      return
+
+    # Target Q, K, V projections sub module names
+    target_names = ["query", "key", "value", "out"]
+
+    use_general_linear_map = self.config.lti_use_general_linear_map
+    teacher_config = self.config.teacher_config
+
+    for name in target_names:
+      child = getattr(attention_module, name, None)
+      if isinstance(child, linears.DenseGeneral):
+        orig_proj_shape = child.kernel.shape
+        assert len(orig_proj_shape) == 3
+        if name in ("query", "key", "value"):
+          teacher_heads_num = teacher_config.base_num_query_heads if name == "query" else teacher_config.base_num_kv_heads
+          teacher_shape = (orig_proj_shape[0], teacher_heads_num, teacher_config.head_dim)
+        elif name == "out":
+          teacher_shape = (teacher_config.base_num_query_heads, teacher_config.head_dim, orig_proj_shape[2])
+        else:
+          max_logging.warning(f"Non handled LTI projection type {name}")
+          continue
+        new_module = LearnToInitDense(
+            in_features_shape=child.in_features_shape,
+            out_features_shape=child.out_features_shape,
+            C=jnp.empty(teacher_shape),
+            axis=child.axis,
+            weight_dtype=child.weight_dtype,
+            dtype=child.dtype,
+            kernel_init=child.kernel_init,
+            kernel_axes=child.kernel_axes,
+            quant=child.quant,
+            use_bias=child.use_bias,
+            shard_mode=child.shard_mode,
+            matmul_precision=child.matmul_precision,
+            is_output_projection=(name == "out"),
+            use_general_linear_map=use_general_linear_map,
+            rngs=self.rngs,  # Reuse the layer's RNG stream
+        )
+        # Swap the module in the mutable NNX graph
+        setattr(attention_module, name, new_module)
+
+  def __call__(self, *args, **kwargs):
+    # Just forward the forward pass arguments to the base layer
+    return self.learn_to_init_wrapper(*args, **kwargs)
+
+
+class LearnToInitDense(nnx.Module):
+  """
+  A customized Dense layer used exclusively during the learn-to-init phase of distillation.
+
+  This module replaces standard `DenseGeneral` projections within the attention mechanism.
+  Instead of a single standard kernel, it computes the effective projection weights
+  dynamically during the forward pass by combining learnable student parameters
+  (either A and B matrices, or a general linear map W) with frozen teacher weights (C).
+
+  The projection math adapts automatically based on whether the layer is used for
+  Q/K/V projections or the final output projection.
+
+  Attributes:
+      C: The frozen, pre-trained teacher tensor.
+      A: The first learnable projection matrix (used if use_general_linear_map is False).
+      B: The second learnable projection matrix (used if use_general_linear_map is False).
+      W: A single, general learnable linear map (used if use_general_linear_map is True).
+      bias: An optional learnable bias parameter.
+  """
+
+  TENSOR_A = "A"
+  TENSOR_B = "B"
+  TENSOR_C = "C"
+  TENSOR_W = "W"
+
+  def __init__(
+      self,
+      in_features_shape: Iterable[int] | int,
+      out_features_shape: Iterable[int] | int,
+      C: Optional[jax.Array] = None,  # C is assumed to be the teacher tensor
+      axis: Iterable[int] | int = -1,
+      weight_dtype: DType = jnp.float32,
+      is_output_projection: bool = False,
+      use_general_linear_map: bool = False,
+      dtype: DType = jnp.float32,
+      kernel_init: NdInitializer = nd_dense_init(1.0, "fan_in", "truncated_normal"),
+      kernel_axes: tuple[None | str, ...] = (),
+      quant: None | Quant = None,
+      use_bias: bool = False,
+      shard_mode: ShardMode = ShardMode.AUTO,
+      matmul_precision: str = "default",
+      parameter_memory_host_offload: bool = False,
+      *,  # Following arguments are keyword-only
+      rngs: nnx.Rngs = None,
+  ):
+    self.in_features_shape = linears.canonicalize_tuple(in_features_shape)
+    self.out_features_shape = linears.canonicalize_tuple(out_features_shape)
+    self.axis = linears.canonicalize_tuple(axis)
+    self.weight_dtype = weight_dtype
+    self.is_output_projection = is_output_projection
+    self.dtype = dtype
+    self.kernel_init = kernel_init
+    self.kernel_axes = kernel_axes
+    self.quant = quant
+    self.use_bias = use_bias
+    self.shard_mode = shard_mode
+    self.matmul_precision = matmul_precision
+    self.parameter_memory_host_offload = parameter_memory_host_offload
+    self.use_general_linear_map = use_general_linear_map
+
+    self.C = nnx.Param(C, sharding=self.kernel_axes)
+
+    kernel_shape = self.in_features_shape + self.out_features_shape
+    assert len(kernel_shape) == 3, "LearnToInitDense currently only supports 3D kernels for attention."
+    assert len(self.C.value.shape) == 3, "The teacher tensor C must be 3D."
+
+    if self.is_output_projection:
+      # For output projection: student(u,v,b_s), teacher(x,y,b_t)
+      u, v, b_s = kernel_shape
+      x, y, b_t = self.C.value.shape
+      assert b_s == b_t, f"Embedding dimension mismatch for output projection: {b_s} != {b_t}"
+      if self.use_general_linear_map:
+        self.W = nnx.Param(
+            nnx.initializers.lecun_normal()(rngs.params(), (x, y, u, v), self.weight_dtype),
+            sharding=(None, None, None, None),
+        )
+      else:
+        self.A = nnx.Param(
+            nnx.initializers.lecun_normal()(rngs.params(), (x, u), self.weight_dtype),
+            sharding=(None, None),
+        )
+        self.B = nnx.Param(
+            nnx.initializers.lecun_normal()(rngs.params(), (v, y), self.weight_dtype),
+            sharding=(None, None),
+        )
+    else:
+      # For Q,K,V projections: student(b_s,u,v), teacher(b_t,x,y)
+      b_s, u, v = kernel_shape
+      b_t, x, y = self.C.value.shape
+
+      assert b_s == b_t, f"Dimension mismatch for QKV projection: {b_s} != {b_t}"
+      if self.use_general_linear_map:
+        self.W = nnx.Param(
+            nnx.initializers.lecun_normal()(rngs.params(), (x, y, u, v), self.weight_dtype),
+            sharding=(None, None, None, None),
+        )
+      else:
+        self.A = nnx.Param(
+            nnx.initializers.lecun_normal()(rngs.params(), (x, u), self.weight_dtype),
+            sharding=(None, None),
+        )
+        self.B = nnx.Param(
+            nnx.initializers.lecun_normal()(rngs.params(), (y, v), self.weight_dtype),
+            sharding=(None, None),
+        )
+
+    if self.use_bias:
+      bias_axes = self.kernel_axes[-len(self.out_features_shape) :]
+      bias_shape = self.out_features_shape
+      self.bias = nnx.Param(
+          initializers.default_bias_init(rngs.params(), bias_shape, self.weight_dtype),
+          sharding=bias_axes,
+      )
+    else:
+      self.bias = None
+
+  def __call__(self, inputs: Array, _initializing: bool = False, out_sharding: NamedSharding | None = None) -> Array:
+    inputs = jnp.asarray(inputs, self.dtype)
+    norm_axis = linears.normalize_axes(self.axis, inputs.ndim)
+
+    for i, ax in enumerate(norm_axis):
+      if inputs.shape[ax] != self.in_features_shape[i]:
+        raise ValueError(
+            f"Input dimension {inputs.shape[ax]} at axis {ax} "
+            f"does not match expected input feature size {self.in_features_shape[i]}"
+        )
+
+    if self.C.value.shape[0] == 0:
+      raise ValueError(
+          "The 'C' tensor in LearnToInitDense has not been initialized. "
+          "Please inject the teacher weights before training."
+      )
+
+    if self.use_general_linear_map:
+      kernel = _calc_attn_weight(
+          None,
+          None,
+          self.C,
+          general_map=self.W,
+          is_output_projection=self.is_output_projection,
+          matmul_precision=self.matmul_precision,
+      )
+    else:
+      kernel = _calc_attn_weight(
+          self.A, self.B, self.C, is_output_projection=self.is_output_projection, matmul_precision=self.matmul_precision
+      )
+
+    if self.parameter_memory_host_offload:
+      max_logging.log("linear.py: Moving parameter logits_dense kernel to device")
+      kernel = jax.device_put(kernel, max_utils.device_space())
+    kernel = jnp.asarray(kernel, self.dtype)
+
+    # out_sharding should be None for auto mesh axis
+    if self.shard_mode != ShardMode.EXPLICIT:
+      out_sharding = None
+
+    contract_ind = tuple(range(0, len(self.axis)))
+    output = linears._compute_dot_general_nnx(
+        inputs,
+        kernel,
+        norm_axis,
+        contract_ind,
+        self.matmul_precision,
+        None,
+        _initializing,
+        out_sharding,
+    )
+
+    if self.bias is not None:
+      bias = jnp.asarray(self.bias[...], self.dtype)
+      output += bias
+    return output
+
+
+def _calc_attn_weight(
+    A: jax.Array | nnx.Param | None,
+    B: jax.Array | nnx.Param | None,
+    C: jax.Array | nnx.Param | None,
+    general_map: Optional[jax.Array | nnx.Param] = None,
+    is_output_projection: bool = False,
+    matmul_precision: str = "default",
+    scan_dim: str = "",
+):
+  """Computes the effective attention weights from teacher weight and learnable projection(s).
+  See the description of calculate_attn_weight() below for details.
+  """
+  if general_map is not None:
+    if is_output_projection:
+      kernel = jnp.einsum(f"x{scan_dim}yb,x{scan_dim}yuv->u{scan_dim}vb", C, general_map, precision=matmul_precision)
+    else:
+      kernel = jnp.einsum(f"b{scan_dim}xy,x{scan_dim}yuv->b{scan_dim}uv", C, general_map, precision=matmul_precision)
+    return kernel
+
+  if is_output_projection:
+    intermediate = jnp.einsum(f"x{scan_dim}yb,x{scan_dim}u->y{scan_dim}ub", C, A, precision=matmul_precision)
+    kernel = jnp.einsum(f"y{scan_dim}ub,v{scan_dim}y->u{scan_dim}vb", intermediate, B, precision=matmul_precision)
+  else:
+    intermediate = jnp.einsum(f"b{scan_dim}xy,x{scan_dim}u->b{scan_dim}uy", C, A, precision=matmul_precision)
+    kernel = jnp.einsum(f"b{scan_dim}uy,y{scan_dim}v->b{scan_dim}uv", intermediate, B, precision=matmul_precision)
+  return kernel
+
+
+def calculate_attn_weight(
+    A: jax.Array | None,
+    B: jax.Array | None,
+    C: jax.Array,
+    general_map: Optional[jax.Array] = None,
+    is_output_projection: bool = False,
+    matmul_precision: str = "default",
+) -> jax.Array:
+  """
+  Helper function to dynamically compute the effective attention weights using `jnp.einsum`.
+
+  Computes the kernel by contracting the frozen teacher tensor (C) with the learnable
+  student representations. It handles both factorized maps (A and B) and general linear
+  maps (general_map/W), adjusting the tensor contractions based on whether the module
+  is an output projection or a Q/K/V projection.
+
+  Args:
+      A: The first learned factorized matrix.
+      B: The second learned factorized matrix.
+      C: The frozen teacher tensor.
+      general_map: An optional unified learnable projection tensor used instead of A and B.
+      is_output_projection: Boolean flag indicating if this computes the output projection weight.
+      matmul_precision: The precision for the einsum matrix multiplications.
+      scan_dim: A string representing the scan dimension for einsum (e.g., "l" for scanned layers, or "").
+
+  Returns:
+      The computed effective kernel tensor.
+  """
+
+  # In scan mode, tensors have an extra 2-nd dimension for the layer.
+  # We add 'l' to the einsum string to handle this batch dimension.
+  scan_dim = "l" if C.ndim == 4 else ""
+  return _calc_attn_weight(
+      A,
+      B,
+      C,
+      general_map=general_map,
+      is_output_projection=is_output_projection,
+      matmul_precision=matmul_precision,
+      scan_dim=scan_dim,
+  )
+
+
+def apply_lti_model_update(student_model, student_config):
+  """
+  Applies the finalized learn-to-init weights to the student model and cleans up the NNX graph.
+
+  This function iterates over the `LearnToInitDense` layers in the trained student model,
+  calculates their final, static effective kernels using `calculate_attn_weight`, and
+  replaces the dynamically-computed LTI modules with standard kernel representations.
+  It effectively collapses the learn-to-init parameterization back into a standard
+  decoder architecture, modifying the `student_model` in-place.
+
+  NOTE: works for ToNXX decoder model and layer-scan mode only
+
+  Args:
+      student_model: The trained student model to be updated in-place.
+      student_config: The configuration of the student model containing parameters like `matmul_precision`.
+  """
+
+  # Access the nested ToNNX dictionary directly
+  assert isinstance(student_model.decoder, ToNNX), "LTI now only supports ToNNX as the student_model's decoder type"
+  lti_wrapped_node = student_model.decoder.layers["learn_to_init_wrapper"]
+  attn_state_dict = lti_wrapped_node["self_attention"]
+
+  # Iterate through known projections and compute final weights
+  for proj_name in ["query", "key", "value", "out"]:
+    if proj_name not in attn_state_dict:
+      raise ValueError("Unsupported structure of LTI-augmented Attention module.")
+
+    proj_params = attn_state_dict[proj_name]
+    is_output_proj = proj_name == "out"
+
+    C_param = proj_params.get(LearnToInitDense.TENSOR_C)
+
+    if C_param is None:
+      raise ValueError("Attention LTI-augmented module has no C parameter.")
+
+    if LearnToInitDense.TENSOR_W in proj_params:
+      max_logging.log(f"Computing final learn-to-init weight (general map) for: {proj_name}")
+      W_param = proj_params[LearnToInitDense.TENSOR_W]
+      final_kernel = calculate_attn_weight(
+          A=None,
+          B=None,
+          C=C_param,
+          general_map=W_param,
+          is_output_projection=is_output_proj,
+          matmul_precision=student_config.matmul_precision,
+      )
+    elif LearnToInitDense.TENSOR_A in proj_params and LearnToInitDense.TENSOR_B in proj_params:
+      max_logging.log(f"Computing final learn-to-init weight for: {proj_name}")
+      A_param = proj_params[LearnToInitDense.TENSOR_A]
+      B_param = proj_params[LearnToInitDense.TENSOR_B]
+      final_kernel = calculate_attn_weight(
+          A=A_param,
+          B=B_param,
+          C=C_param,
+          is_output_projection=is_output_proj,
+          matmul_precision=student_config.matmul_precision,
+      )
+    else:
+      continue
+
+    # 3. Overwrite C with the final computed kernel
+    C_param.set_value(final_kernel)
+
+    # 4. Standardize the structure by placing it under the 'kernel' key
+    proj_params["kernel"] = C_param
+
+    # 5. Clean up the LTI-specific parameters using .pop()
+    # Using pop(key, None) avoids KeyErrors if a tensor was omitted or already shared/deleted
+    proj_params.pop(LearnToInitDense.TENSOR_W, None)
+    proj_params.pop(LearnToInitDense.TENSOR_A, None)
+    proj_params.pop(LearnToInitDense.TENSOR_B, None)
+    proj_params.pop(LearnToInitDense.TENSOR_C, None)
+
+  # unpack the learn_to_init_wrapper to match the standard model structure
+  del student_model.decoder.layers["learn_to_init_wrapper"]
+  student_model.decoder.layers.update(lti_wrapped_node)

--- a/src/maxtext/layers/nnx_wrappers.py
+++ b/src/maxtext/layers/nnx_wrappers.py
@@ -614,7 +614,10 @@ def to_linen_class(
 
   # Set the class name correctly to avoid issues like ScanToLinenPartial_0
   # Instead of ToLinenPartial_0, we can use the base class name + 'ToLinen'
-  class_name = f"{base_nnx_class.__name__}ToLinen"
+  if isinstance(base_nnx_class, partial):
+    class_name = f"{base_nnx_class.func.__name__}ToLinen"
+  else:
+    class_name = f"{base_nnx_class.__name__}ToLinen"
 
   class ToLinenPartial(ToLinen):
     """A dynamically created Linen Module that wraps a specific NNX Module."""

--- a/src/maxtext/models/llama2.py
+++ b/src/maxtext/models/llama2.py
@@ -33,6 +33,7 @@ from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_utils
 from maxtext.utils.sharding import create_sharding, maybe_shard_with_logical
+from maxtext.layers.learn_to_init_layer import LearnToInitDecoderLayer
 
 # -----------------------------------------
 # The Decoder Layer specific for Llama2
@@ -211,6 +212,13 @@ class LlamaDecoderLayer(nnx.Module):
     else:
       return layer_output, kv_cache
 
+
+LlamaLTIDecoderLayer = functools.partial(LearnToInitDecoderLayer, base_layer_cls=LlamaDecoderLayer)
+
+LlamaLTIDecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    LlamaLTIDecoderLayer,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)
 
 LlamaDecoderLayerToLinen = nnx_wrappers.to_linen_class(
     LlamaDecoderLayer,

--- a/src/maxtext/models/llama2.py
+++ b/src/maxtext/models/llama2.py
@@ -33,6 +33,7 @@ from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.utils import max_utils
 from maxtext.utils.sharding import create_sharding, maybe_shard_with_logical
+from maxtext.layers.learn_to_init_layer import LearnToInitDecoderLayer
 
 # -----------------------------------------
 # The Decoder Layer specific for Llama2
@@ -50,7 +51,6 @@ class LlamaDecoderLayer(nnx.Module):
       rngs: nnx.Rngs,
       quant: None | Quant = None,
   ):
-
     self.config = config
     self.mesh = mesh
     self.quant = quant
@@ -211,6 +211,13 @@ class LlamaDecoderLayer(nnx.Module):
     else:
       return layer_output, kv_cache
 
+
+LlamaLTIDecoderLayer = functools.partial(LearnToInitDecoderLayer, base_layer_cls=LlamaDecoderLayer)
+
+LlamaLTIDecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    LlamaLTIDecoderLayer,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)
 
 LlamaDecoderLayerToLinen = nnx_wrappers.to_linen_class(
     LlamaDecoderLayer,

--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -52,6 +52,8 @@ class DistillationForwardOutput:
   logits: jax.Array
   #: out_projection_activations
   out_projection_activations: jax.Array | None = None
+  #: moe load balance loss
+  moe_lb_loss: jax.Array | None = None
 
 
 @flax.struct.dataclass(frozen=True)
@@ -327,7 +329,7 @@ class CombinedDistillationStrategy(DistillationStrategy):
       alpha: float = 0.5,
       beta_feature: float = 0.0,
       layer_indices: Optional[List[int]] = None,
-      feature_loss_fn: Callable[[jax.Array, jax.Array], jax.Array] | None = None,
+      feature_loss_fn: Callable[[jax.Array, jax.Array, jax.Array], jax.Array] | None = None,
       feature_loss_type: Literal["cosine", "l2"] = "cosine",
       cosine_distance_axis: int | tuple[int, ...] = -1,
       vocab_size: int = 0,
@@ -350,8 +352,9 @@ class CombinedDistillationStrategy(DistillationStrategy):
         layer_indices: Layer indices to apply feature loss.
         feature_loss_type: The type of feature loss to use if `feature_loss_fn` is None.
           Can be "cosine" (default) or "l2".
-        feature_loss_fn: A function that takes two jax.Arrays (student_map,
-          teacher_map) and returns a scalar loss. Defaults to cosine distance.
+        feature_loss_fn: A function (student_features, teacher_features, mask) -> scalar
+          where features are [L, B, T, D] and mask is [B, T] (1.0 for valid tokens).
+          Defaults to a masked cosine distance with epsilon-floored safe-norm.
         cosine_distance_axis: The axis to use for cosine distance computation if
           feature_loss_fn is not provided. Defaults to -1.
         alpha_end: Target alpha value at end of training. None keeps alpha fixed.
@@ -408,16 +411,30 @@ class CombinedDistillationStrategy(DistillationStrategy):
             f"Set {param_name}_end to a target value or use schedule='constant'."
         )
 
+    # Mask keeps zero-norm pad activations out of the cosine denominator to avoid 0/0 NaN.
     self.feature_loss_fn = feature_loss_fn
     if feature_loss_fn is None:
       if feature_loss_type == "cosine":
-        self.feature_loss_fn = lambda student_features, teacher_features: jnp.mean(
-            optax.cosine_distance(student_features, teacher_features, axis=cosine_distance_axis)
-        )
+
+        def _masked_cosine(student_features, teacher_features, mask):
+          # epsilon>0 floors the safe-norm so an all-zero row can't divide by zero.
+          cd = optax.cosine_distance(
+              student_features, teacher_features, axis=cosine_distance_axis, epsilon=1e-6
+          )  # [L, B, T]
+          mask_b = mask.astype(cd.dtype)
+          num_valid_terms = jnp.maximum(jnp.sum(mask_b), 1.0) * cd.shape[0]
+          return jnp.sum(cd * mask_b[None, :, :]) / num_valid_terms
+
+        self.feature_loss_fn = _masked_cosine
       elif feature_loss_type == "l2":
-        self.feature_loss_fn = lambda student_features, teacher_features: jnp.mean(
-            optax.l2_loss(student_features, teacher_features)
-        )
+
+        def _masked_l2(student_features, teacher_features, mask):
+          sq = jnp.mean(jnp.square(student_features - teacher_features), axis=-1)  # [L, B, T]
+          mask_b = mask.astype(sq.dtype)
+          num_valid_terms = jnp.maximum(jnp.sum(mask_b), 1.0) * sq.shape[0]
+          return jnp.sum(sq * mask_b[None, :, :]) / num_valid_terms
+
+        self.feature_loss_fn = _masked_l2
       else:
         raise ValueError(f"Unsupported feature_loss_type: {feature_loss_type!r}")
 
@@ -516,9 +533,20 @@ class CombinedDistillationStrategy(DistillationStrategy):
       s_features_sliced = s_features_sliced.astype(jnp.float32)
       t_features_sliced = t_features_sliced.astype(jnp.float32)
 
-      feature_loss = beta_feature * self.feature_loss_fn(s_features_sliced, t_features_sliced)
+      feature_loss = beta_feature * self.feature_loss_fn(s_features_sliced, t_features_sliced, mask)
 
     total_loss = base_logit_loss + feature_loss
+
+    moe_lb_loss = jnp.array(0.0)
+    if student_output.moe_lb_loss is not None:
+      # The moe_lb_loss collected from the model is already scaled by load_balance_loss_weight
+      # within the MoE layer itself (see load_balance_loss in moe.py).
+      moe_lb_loss = student_output.moe_lb_loss
+      total_loss += moe_lb_loss
+
+    teacher_moe_lb_loss = jnp.array(0.0)
+    if teacher_output.moe_lb_loss is not None:
+      teacher_moe_lb_loss = teacher_output.moe_lb_loss
 
     # Per-step next-token perplexity. Note: this is mean(exp(per-step CE)), not
     # exp(window-CE-mean) — close to true perplexity in steady state. For the exact
@@ -545,6 +573,8 @@ class CombinedDistillationStrategy(DistillationStrategy):
         "distill/kl_div_T1": (kl_t1_sum, valid_count),
         # Per-step quantities: (value, 1.0) so the aggregator yields a simple mean over steps.
         "distill/out_proj_feature_loss": (feature_loss, one),
+        "distill/moe_lb_loss": (moe_lb_loss, one),
+        "distill/teacher_moe_lb_loss": (teacher_moe_lb_loss, one),
         "distill/total_loss": (total_loss, one),
         "distill/temperature": (temperature, one),
         "distill/alpha": (alpha, one),

--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -52,8 +52,6 @@ class DistillationForwardOutput:
   logits: jax.Array
   #: out_projection_activations
   out_projection_activations: jax.Array | None = None
-  #: moe load balance loss
-  moe_lb_loss: jax.Array | None = None
 
 
 @flax.struct.dataclass(frozen=True)
@@ -329,7 +327,7 @@ class CombinedDistillationStrategy(DistillationStrategy):
       alpha: float = 0.5,
       beta_feature: float = 0.0,
       layer_indices: Optional[List[int]] = None,
-      feature_loss_fn: Callable[[jax.Array, jax.Array, jax.Array], jax.Array] | None = None,
+      feature_loss_fn: Callable[[jax.Array, jax.Array], jax.Array] | None = None,
       feature_loss_type: Literal["cosine", "l2"] = "cosine",
       cosine_distance_axis: int | tuple[int, ...] = -1,
       vocab_size: int = 0,
@@ -352,9 +350,8 @@ class CombinedDistillationStrategy(DistillationStrategy):
         layer_indices: Layer indices to apply feature loss.
         feature_loss_type: The type of feature loss to use if `feature_loss_fn` is None.
           Can be "cosine" (default) or "l2".
-        feature_loss_fn: A function (student_features, teacher_features, mask) -> scalar
-          where features are [L, B, T, D] and mask is [B, T] (1.0 for valid tokens).
-          Defaults to a masked cosine distance with epsilon-floored safe-norm.
+        feature_loss_fn: A function that takes two jax.Arrays (student_map,
+          teacher_map) and returns a scalar loss. Defaults to cosine distance.
         cosine_distance_axis: The axis to use for cosine distance computation if
           feature_loss_fn is not provided. Defaults to -1.
         alpha_end: Target alpha value at end of training. None keeps alpha fixed.
@@ -411,30 +408,16 @@ class CombinedDistillationStrategy(DistillationStrategy):
             f"Set {param_name}_end to a target value or use schedule='constant'."
         )
 
-    # Mask keeps zero-norm pad activations out of the cosine denominator to avoid 0/0 NaN.
     self.feature_loss_fn = feature_loss_fn
     if feature_loss_fn is None:
       if feature_loss_type == "cosine":
-
-        def _masked_cosine(student_features, teacher_features, mask):
-          # epsilon>0 floors the safe-norm so an all-zero row can't divide by zero.
-          cd = optax.cosine_distance(
-              student_features, teacher_features, axis=cosine_distance_axis, epsilon=1e-6
-          )  # [L, B, T]
-          mask_b = mask.astype(cd.dtype)
-          num_valid_terms = jnp.maximum(jnp.sum(mask_b), 1.0) * cd.shape[0]
-          return jnp.sum(cd * mask_b[None, :, :]) / num_valid_terms
-
-        self.feature_loss_fn = _masked_cosine
+        self.feature_loss_fn = lambda student_features, teacher_features: jnp.mean(
+            optax.cosine_distance(student_features, teacher_features, axis=cosine_distance_axis)
+        )
       elif feature_loss_type == "l2":
-
-        def _masked_l2(student_features, teacher_features, mask):
-          sq = jnp.mean(jnp.square(student_features - teacher_features), axis=-1)  # [L, B, T]
-          mask_b = mask.astype(sq.dtype)
-          num_valid_terms = jnp.maximum(jnp.sum(mask_b), 1.0) * sq.shape[0]
-          return jnp.sum(sq * mask_b[None, :, :]) / num_valid_terms
-
-        self.feature_loss_fn = _masked_l2
+        self.feature_loss_fn = lambda student_features, teacher_features: jnp.mean(
+            optax.l2_loss(student_features, teacher_features)
+        )
       else:
         raise ValueError(f"Unsupported feature_loss_type: {feature_loss_type!r}")
 
@@ -533,20 +516,9 @@ class CombinedDistillationStrategy(DistillationStrategy):
       s_features_sliced = s_features_sliced.astype(jnp.float32)
       t_features_sliced = t_features_sliced.astype(jnp.float32)
 
-      feature_loss = beta_feature * self.feature_loss_fn(s_features_sliced, t_features_sliced, mask)
+      feature_loss = beta_feature * self.feature_loss_fn(s_features_sliced, t_features_sliced)
 
     total_loss = base_logit_loss + feature_loss
-
-    moe_lb_loss = jnp.array(0.0)
-    if student_output.moe_lb_loss is not None:
-      # The moe_lb_loss collected from the model is already scaled by load_balance_loss_weight
-      # within the MoE layer itself (see load_balance_loss in moe.py).
-      moe_lb_loss = student_output.moe_lb_loss
-      total_loss += moe_lb_loss
-
-    teacher_moe_lb_loss = jnp.array(0.0)
-    if teacher_output.moe_lb_loss is not None:
-      teacher_moe_lb_loss = teacher_output.moe_lb_loss
 
     # Per-step next-token perplexity. Note: this is mean(exp(per-step CE)), not
     # exp(window-CE-mean) — close to true perplexity in steady state. For the exact
@@ -573,8 +545,6 @@ class CombinedDistillationStrategy(DistillationStrategy):
         "distill/kl_div_T1": (kl_t1_sum, valid_count),
         # Per-step quantities: (value, 1.0) so the aggregator yields a simple mean over steps.
         "distill/out_proj_feature_loss": (feature_loss, one),
-        "distill/moe_lb_loss": (moe_lb_loss, one),
-        "distill/teacher_moe_lb_loss": (teacher_moe_lb_loss, one),
         "distill/total_loss": (total_loss, one),
         "distill/temperature": (temperature, one),
         "distill/alpha": (alpha, one),
@@ -629,10 +599,12 @@ class MaxTextCheckpointManager(tunix_checkpoint_manager.CheckpointManager):
   def __init__(
       self,
       raw_iterator: Any | None,
-      root_directory: str | None = None,
+      root_directory: str | None,
+      student_config: Any | None,
       options: checkpoint.CheckpointManagerOptions | None = None,
   ):
     super().__init__(root_directory=root_directory, options=options)
+    self.student_config = student_config
     self._iterator = raw_iterator
 
     # Re-initialize internal Orbax manager with MaxText's Grain handler
@@ -659,7 +631,15 @@ class MaxTextCheckpointManager(tunix_checkpoint_manager.CheckpointManager):
       )
     # pylint: enable=access-member-before-definition
 
-  def save(self, step, model, optimizer=None, save_only_lora_params=False, force=False, custom_metadata=None):
+  def save(
+      self,
+      step,
+      model,
+      optimizer=None,
+      save_only_lora_params=False,
+      force=False,
+      custom_metadata=None,
+  ):
     """Saves the checkpoint including the input pipeline state (if available)."""
     if self._checkpoint_manager is None:
       return False
@@ -681,7 +661,10 @@ class MaxTextCheckpointManager(tunix_checkpoint_manager.CheckpointManager):
             item=params, save_args=jax.tree.map(lambda _: default_save_args, params)
         ),
     }
-    if optimizer is not None:
+    # Exclude optimizer state if the flag is set OR if learn_to_init_mode is active.
+    exclude_opt = self.student_config.learn_to_init_mode
+
+    if optimizer is not None and not exclude_opt:
       optimizer_state = nnx.state(optimizer, nnx.optimizer.OptState)
       cp_save_args["optimizer_state"] = checkpoint.args.PyTreeSave(
           item=optimizer_state, save_args=jax.tree.map(lambda _: default_save_args, optimizer_state)

--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -629,10 +629,12 @@ class MaxTextCheckpointManager(tunix_checkpoint_manager.CheckpointManager):
   def __init__(
       self,
       raw_iterator: Any | None,
-      root_directory: str | None = None,
+      root_directory: str | None,
+      student_config: Any | None,
       options: checkpoint.CheckpointManagerOptions | None = None,
   ):
     super().__init__(root_directory=root_directory, options=options)
+    self.student_config = student_config
     self._iterator = raw_iterator
 
     # Re-initialize internal Orbax manager with MaxText's Grain handler
@@ -659,7 +661,15 @@ class MaxTextCheckpointManager(tunix_checkpoint_manager.CheckpointManager):
       )
     # pylint: enable=access-member-before-definition
 
-  def save(self, step, model, optimizer=None, save_only_lora_params=False, force=False, custom_metadata=None):
+  def save(
+      self,
+      step,
+      model,
+      optimizer=None,
+      save_only_lora_params=False,
+      force=False,
+      custom_metadata=None,
+  ):
     """Saves the checkpoint including the input pipeline state (if available)."""
     if self._checkpoint_manager is None:
       return False
@@ -681,7 +691,10 @@ class MaxTextCheckpointManager(tunix_checkpoint_manager.CheckpointManager):
             item=params, save_args=jax.tree.map(lambda _: default_save_args, params)
         ),
     }
-    if optimizer is not None:
+    # Exclude optimizer state if the flag is set OR if learn_to_init_mode is active.
+    exclude_opt = self.student_config.learn_to_init_mode
+
+    if optimizer is not None and not exclude_opt:
       optimizer_state = nnx.state(optimizer, nnx.optimizer.OptState)
       cp_save_args["optimizer_state"] = checkpoint.args.PyTreeSave(
           item=optimizer_state, save_args=jax.tree.map(lambda _: default_save_args, optimizer_state)

--- a/src/maxtext/trainers/post_train/distillation/lti_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/lti_utils.py
@@ -1,0 +1,117 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for Learn-to-Init phase of the distillation"""
+
+from flax import nnx
+from maxtext.utils import max_logging
+
+
+def _nav_to_attr(root, parts):
+  """Walk `root.parts[0].parts[1]...` and return the terminal Python object.
+
+  Handles both attribute access and mapping/sequence access (integer-looking
+  components are tried as sequence indices as a last resort) so string paths
+  from `nnx.graph.iter_graph` round-trip across scanned and unscanned models.
+  """
+  obj = root
+  for p in parts:
+    if hasattr(obj, p):
+      obj = getattr(obj, p)
+      continue
+    try:
+      obj = obj[p]
+      continue
+    except (KeyError, TypeError, IndexError):
+      pass
+    try:
+      obj = obj[int(p)]
+      continue
+    except (ValueError, TypeError, KeyError, IndexError):
+      pass
+    raise AttributeError(
+        f"prepare_student_weights: cannot resolve path component {p!r} on "
+        f"{type(obj).__name__}. Make sure copy/share map paths match "
+        f"nnx.graph.iter_graph output for this model."
+    )
+  return obj
+
+
+def prepare_student_weights(
+    student_model: nnx.Module,
+    teacher_model: nnx.Module,
+    teacher_weights_copy_map: dict[str, str],
+    student_weights_share_map: dict[str, str],
+):
+  """Injects weights from a teacher model into a student model in-place as well as
+  shares specific pairs of weights inside the student model - might be useful for learn-to-init experiments.
+
+  This function iterates through the provided mapping dictionaries and
+  copies the corresponding weights from the teacher.
+
+  It works by matching the graph path of a module in the student to the same
+  path in the teacher.
+
+  Args:
+    student_model: The student model (NNX Module), which will be modified.
+    teacher_model: The teacher model (NNX Module), used as the source.
+    teacher_weights_copy_map: A dictionary mapping teacher parameter paths (as strings)
+      to student parameter paths.
+    student_weights_share_map: A dictionary mapping student parameter paths to be shared.
+  """
+  max_logging.log("Starting teacher weight injection...")
+
+  # Get a dictionary view of the teacher graph for efficient lookups
+  teacher_graph = {"/".join(map(str, path)): node for path, node in nnx.graph.iter_graph(teacher_model)}
+  student_graph = {"/".join(map(str, path)): node for path, node in nnx.graph.iter_graph(student_model)}
+
+  # --- Weight sharing (alias destination -> source Variable) ---
+  for source_path, dest_path in student_weights_share_map.items():
+    source_node = student_graph.get(source_path)
+    dest_node = student_graph.get(dest_path)
+    assert (
+        source_node is not None
+    ), f"Student parameter sharing: Could not find source_node model parameter at path: {source_path}"
+    assert (
+        dest_node is not None
+    ), f"Student parameter sharing: Could not find dest_node model parameter at path: {dest_path}"
+
+    assert source_node.value.shape == dest_node.value.shape, (
+        f"Shape mismatch for sharing parameter between {source_path} and {dest_path}: "
+        f"{source_node.value.shape} vs {dest_node.value.shape}"
+    )
+
+    max_logging.info(f"Sharing parameter {source_path} with {dest_path}")
+    dest_parts = dest_path.split("/")
+
+    dest_parent = _nav_to_attr(student_model, dest_parts[:-1])
+    dest_attr = dest_parts[-1]
+
+    if hasattr(dest_parent, dest_attr):
+      setattr(dest_parent, dest_attr, source_node)
+    else:
+      dest_parent[dest_attr] = source_node
+
+  for teacher_path, student_path in teacher_weights_copy_map.items():
+    teacher_node = teacher_graph.get(teacher_path)
+    student_node = student_graph.get(student_path)
+    assert teacher_node is not None, f"Could not find teacher model parameter at path: {teacher_path}"
+    assert student_node is not None, f"Could not find student model parameter at path: {student_path}"
+    assert (
+        student_node.value.shape == teacher_node.value.shape
+    ), f"Shape mismatch for {teacher_path}. Teacher: {teacher_node.value.shape}, Student: {student_node.value.shape}"
+    student_node.value = teacher_node.value
+    max_logging.info(f"Inserted teacher weight parameter {teacher_path} to the student at {student_path}")
+
+  max_logging.info("Teacher weight injection complete.")

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -50,8 +50,9 @@ from orbax import checkpoint
 from maxtext.configs import pyconfig
 from maxtext.input_pipeline import tokenizer
 from maxtext.input_pipeline import input_pipeline_interface
+from maxtext.layers.learn_to_init_layer import apply_lti_model_update
 from maxtext.optimizers import optimizers
-from maxtext.trainers.post_train.distillation import distillation_utils
+from maxtext.trainers.post_train.distillation import distillation_utils, lti_utils
 from maxtext.utils import max_logging
 from maxtext.utils import maxtext_utils
 from maxtext.utils import model_creation_utils
@@ -187,7 +188,7 @@ def _log_config_details(config: pyconfig.HyperParameters, label: str) -> None:
 class ModelBundle(nnx.Module):
   """Wrapper for teacher and student modules."""
 
-  def __init__(self, teacher_model: nnx.Module, student_model: nnx.Module):
+  def __init__(self, teacher_model: nnx.Module | None, student_model: nnx.Module):
     self.teacher_model = teacher_model
     self.student_model = student_model
     self.training_step = nnx.Variable(jnp.zeros((), dtype=jnp.int32))
@@ -375,6 +376,7 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
         self._buffered_train_metrics.additional_metrics[name] = ([], distillation_utils.weighted_mean)
 
       self._buffered_train_metrics.additional_metrics[name][0].append(value)
+    max_logging.log(f"Distillation metrics: {aux}")
 
   def setup_checkpoint_manager_and_restore(self, raw_train_iter, config):
     """Configures the trainer's CheckpointManager and restores states.
@@ -419,6 +421,7 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
     self.checkpoint_manager = distillation_utils.MaxTextCheckpointManager(
         raw_iterator=iterator_to_manage,
         root_directory=config.checkpoint_dir,
+        student_config=config,  # Pass the config here
         options=self.config.checkpointing_options,
     )
 
@@ -590,16 +593,6 @@ def train_distill(
   with mesh, nn_partitioning.axis_rules(student_config.logical_axis_rules):
 
     # 2. Load Models
-    max_logging.log(f"Loading Student from {student_config.load_parameters_path}...")
-    _log_config_details(student_config, "Student")
-    student_model = get_maxtext_model(student_config, mesh)
-
-    student_params_to_update = getattr(student_config, "student_params_to_update", [])
-
-    def student_freeze_param_fn(path) -> bool:
-      path_str = "/".join(str(p) for p in path)
-      return not any(template in path_str for template in student_params_to_update)
-
     if is_offline:
       max_logging.log("Offline Distillation: Skipping Teacher Model loading.")
       teacher_model = None
@@ -608,6 +601,27 @@ def train_distill(
       _log_config_details(teacher_config, "Teacher")
       teacher_model = get_maxtext_model(teacher_config, mesh)
       teacher_model.eval()
+
+    # LTI phase needs the student initialization step to know about the teacher configuration
+    student_config.get_keys()["teacher_config"] = teacher_config
+
+    max_logging.log(f"Loading Student from {student_config.load_parameters_path}...")
+    _log_config_details(student_config, "Student")
+    student_model = get_maxtext_model(student_config, mesh)
+    student_params_to_update = getattr(student_config, "student_params_to_update", [])
+
+    def student_freeze_param_fn(path) -> bool:
+      path_str = "/".join(str(p) for p in path)
+      return not any(template in path_str for template in student_params_to_update)
+
+    # Inject the teacher's frozen weights into the student model
+    if teacher_model:
+      lti_utils.prepare_student_weights(
+          student_model,
+          teacher_model,
+          teacher_weights_copy_map=getattr(student_config, "distill_weights_copy_map", {}),
+          student_weights_share_map=getattr(student_config, "distill_student_weights_share_map", {}),
+      )
 
     student_model.train()
     model_bundle = ModelBundle(teacher_model, student_model)
@@ -685,6 +699,11 @@ def train_distill(
     # Pass both iterators to the trainer
     trainer.train(train_iter, eval_iter)
 
+  if student_config.learn_to_init_mode:
+    # If learn_to_init_mode is enabled, generate the final weights and update the model structure
+    max_logging.log("Learn-to-init mode enabled. Finalizing student model...")
+    apply_lti_model_update(student_model, student_config)
+
   # 9. Final Save (Conditional)
   if student_config.save_checkpoint_on_completion:
     should_save = student_config.steps % student_config.checkpoint_period
@@ -692,8 +711,12 @@ def train_distill(
     if should_save:
       max_logging.log(f"Saving final checkpoint to {student_config.checkpoint_dir}...")
       try:
+        # TODO: tmp solution for learn_to_init_mode - we need to save the changed model checkpoint,
+        # force=True doesn't work and orbax can keep skip saving the most recent model
+        # temporal hack is to simply bump the step number
+        # you are supppsed to run regular distillation from scratch afterwards anyway
         saved = trainer.checkpoint_manager.save(
-            trainer.train_steps,
+            trainer.train_steps + (1 if student_config.learn_to_init_mode else 0),
             trainer.model,
             optimizer=trainer.optimizer,
             save_only_lora_params=getattr(trainer, "_lora_enabled", False),

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -35,8 +35,10 @@ Architecture Overview:
 
 import inspect
 import logging
+import shlex
 from typing import Sequence, Callable, Any
 from absl import app
+from etils import epath
 from flax import nnx
 from flax.linen import partitioning as nn_partitioning
 import jax
@@ -150,8 +152,15 @@ def create_forward_fn(config: pyconfig.HyperParameters) -> Callable[..., distill
     if config.distill_beta > 0.0:
       out_projection_activations = maxtext_utils.get_intermediate_value(model, "out_projection_activations", clear=True)
 
+    moe_lb_loss = None
+    if config.num_experts > 1 and config.load_balance_loss_weight > 0.0:
+      intermediate_outputs = nnx.pop(model, nnx.Intermediate)
+      total_moe_lb_losses = maxtext_utils.collect_intermediates_by_suffix(intermediate_outputs, "moe_lb_loss")
+      if total_moe_lb_losses:
+        moe_lb_loss = jnp.mean(jnp.concatenate(total_moe_lb_losses))
+
     retval = distillation_utils.DistillationForwardOutput(
-        logits=logits, out_projection_activations=out_projection_activations
+        logits=logits, out_projection_activations=out_projection_activations, moe_lb_loss=moe_lb_loss
     )
     return retval
 
@@ -510,7 +519,7 @@ def build_training_components(
       max_steps=student_config.steps,
   )
 
-  # 4. Optimizer & Config
+  # Prepare optimizer
   optimizer = get_distillation_optimizer(student_config, student_config.steps)
 
   checkpointing_options = checkpoint.CheckpointManagerOptions(
@@ -729,6 +738,35 @@ def train_distill(
   max_logging.log("Distillation Complete.")
 
 
+def _save_run_manifest(argv: Sequence[str], config: pyconfig.HyperParameters) -> None:
+  """Writes the source YAML and a shell-pasteable command to the output dir.
+
+  Saves `distillation.yml` (verbatim copy of the user's config file) and
+  `command.sh` (the CLI overrides) so a run can be reproduced by copying the
+  YAML and re-running the saved command.
+  """
+  if jax.process_index() != 0:
+    return
+  if not (config.base_output_directory and config.run_name):
+    return
+  if len(argv) < 2:
+    return
+
+  try:
+    out_dir = epath.Path(config.base_output_directory) / config.run_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    source_yml = epath.Path(pyconfig.resolve_config_path(argv[1]))
+    source_yml.copy(out_dir / "distillation.yml", overwrite=True)
+
+    cli_args = shlex.join(argv[2:])
+    command = "python3 -m maxtext.trainers.post_train.distillation.train_distill " f"distillation.yml {cli_args}\n"
+    (out_dir / "command.sh").write_text(command)
+    max_logging.log(f"Saved run manifest (distillation.yml, command.sh) to {out_dir}")
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    max_logging.log(f"Warning: could not save run manifest: {e}")
+
+
 def main(argv: Sequence[str]) -> None:
   """Entry point for the script.
 
@@ -740,6 +778,7 @@ def main(argv: Sequence[str]) -> None:
   """
   # 1. Parse Global Config to extract Overrides
   global_config = pyconfig.initialize(argv)
+  _save_run_manifest(argv, global_config)
 
   # 2. Initialize STUDENT Config
   # Order of precedence: YAML < CLI < kwargs (student_overrides).

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -35,10 +35,8 @@ Architecture Overview:
 
 import inspect
 import logging
-import shlex
 from typing import Sequence, Callable, Any
 from absl import app
-from etils import epath
 from flax import nnx
 from flax.linen import partitioning as nn_partitioning
 import jax
@@ -50,8 +48,9 @@ from orbax import checkpoint
 from maxtext.configs import pyconfig
 from maxtext.input_pipeline import tokenizer
 from maxtext.input_pipeline import input_pipeline_interface
+from maxtext.layers.learn_to_init_layer import apply_lti_model_update
 from maxtext.optimizers import optimizers
-from maxtext.trainers.post_train.distillation import distillation_utils
+from maxtext.trainers.post_train.distillation import distillation_utils, lti_utils
 from maxtext.utils import max_logging
 from maxtext.utils import maxtext_utils
 from maxtext.utils import model_creation_utils
@@ -151,15 +150,8 @@ def create_forward_fn(config: pyconfig.HyperParameters) -> Callable[..., distill
     if config.distill_beta > 0.0:
       out_projection_activations = maxtext_utils.get_intermediate_value(model, "out_projection_activations", clear=True)
 
-    moe_lb_loss = None
-    if config.num_experts > 1 and config.load_balance_loss_weight > 0.0:
-      intermediate_outputs = nnx.pop(model, nnx.Intermediate)
-      total_moe_lb_losses = maxtext_utils.collect_intermediates_by_suffix(intermediate_outputs, "moe_lb_loss")
-      if total_moe_lb_losses:
-        moe_lb_loss = jnp.mean(jnp.concatenate(total_moe_lb_losses))
-
     retval = distillation_utils.DistillationForwardOutput(
-        logits=logits, out_projection_activations=out_projection_activations, moe_lb_loss=moe_lb_loss
+        logits=logits, out_projection_activations=out_projection_activations
     )
     return retval
 
@@ -187,7 +179,7 @@ def _log_config_details(config: pyconfig.HyperParameters, label: str) -> None:
 class ModelBundle(nnx.Module):
   """Wrapper for teacher and student modules."""
 
-  def __init__(self, teacher_model: nnx.Module, student_model: nnx.Module):
+  def __init__(self, teacher_model: nnx.Module | None, student_model: nnx.Module):
     self.teacher_model = teacher_model
     self.student_model = student_model
     self.training_step = nnx.Variable(jnp.zeros((), dtype=jnp.int32))
@@ -375,6 +367,7 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
         self._buffered_train_metrics.additional_metrics[name] = ([], distillation_utils.weighted_mean)
 
       self._buffered_train_metrics.additional_metrics[name][0].append(value)
+    max_logging.log(f"Distillation metrics: {aux}")
 
   def setup_checkpoint_manager_and_restore(self, raw_train_iter, config):
     """Configures the trainer's CheckpointManager and restores states.
@@ -419,6 +412,7 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
     self.checkpoint_manager = distillation_utils.MaxTextCheckpointManager(
         raw_iterator=iterator_to_manage,
         root_directory=config.checkpoint_dir,
+        student_config=config,  # Pass the config here
         options=self.config.checkpointing_options,
     )
 
@@ -516,7 +510,7 @@ def build_training_components(
       max_steps=student_config.steps,
   )
 
-  # Prepare optimizer
+  # 4. Optimizer & Config
   optimizer = get_distillation_optimizer(student_config, student_config.steps)
 
   checkpointing_options = checkpoint.CheckpointManagerOptions(
@@ -590,16 +584,6 @@ def train_distill(
   with mesh, nn_partitioning.axis_rules(student_config.logical_axis_rules):
 
     # 2. Load Models
-    max_logging.log(f"Loading Student from {student_config.load_parameters_path}...")
-    _log_config_details(student_config, "Student")
-    student_model = get_maxtext_model(student_config, mesh)
-
-    student_params_to_update = getattr(student_config, "student_params_to_update", [])
-
-    def student_freeze_param_fn(path) -> bool:
-      path_str = "/".join(str(p) for p in path)
-      return not any(template in path_str for template in student_params_to_update)
-
     if is_offline:
       max_logging.log("Offline Distillation: Skipping Teacher Model loading.")
       teacher_model = None
@@ -608,6 +592,27 @@ def train_distill(
       _log_config_details(teacher_config, "Teacher")
       teacher_model = get_maxtext_model(teacher_config, mesh)
       teacher_model.eval()
+
+    # LTI phase needs the student initialization step to know about the teacher configuration
+    student_config.get_keys()["teacher_config"] = teacher_config
+
+    max_logging.log(f"Loading Student from {student_config.load_parameters_path}...")
+    _log_config_details(student_config, "Student")
+    student_model = get_maxtext_model(student_config, mesh)
+    student_params_to_update = getattr(student_config, "student_params_to_update", [])
+
+    def student_freeze_param_fn(path) -> bool:
+      path_str = "/".join(str(p) for p in path)
+      return not any(template in path_str for template in student_params_to_update)
+
+    # Inject the teacher's frozen weights into the student model
+    if teacher_model:
+      lti_utils.prepare_student_weights(
+          student_model,
+          teacher_model,
+          teacher_weights_copy_map=getattr(student_config, "distill_weights_copy_map", {}),
+          student_weights_share_map=getattr(student_config, "distill_student_weights_share_map", {}),
+      )
 
     student_model.train()
     model_bundle = ModelBundle(teacher_model, student_model)
@@ -685,6 +690,11 @@ def train_distill(
     # Pass both iterators to the trainer
     trainer.train(train_iter, eval_iter)
 
+  if student_config.learn_to_init_mode:
+    # If learn_to_init_mode is enabled, generate the final weights and update the model structure
+    max_logging.log("Learn-to-init mode enabled. Finalizing student model...")
+    apply_lti_model_update(student_model, student_config)
+
   # 9. Final Save (Conditional)
   if student_config.save_checkpoint_on_completion:
     should_save = student_config.steps % student_config.checkpoint_period
@@ -692,8 +702,12 @@ def train_distill(
     if should_save:
       max_logging.log(f"Saving final checkpoint to {student_config.checkpoint_dir}...")
       try:
+        # TODO: tmp solution for learn_to_init_mode - we need to save the changed model checkpoint,
+        # force=True doesn't work and orbax can keep skip saving the most recent model
+        # temporal hack is to simply bump the step number
+        # you are supppsed to run regular distillation from scratch afterwards anyway
         saved = trainer.checkpoint_manager.save(
-            trainer.train_steps,
+            trainer.train_steps + (1 if student_config.learn_to_init_mode else 0),
             trainer.model,
             optimizer=trainer.optimizer,
             save_only_lora_params=getattr(trainer, "_lora_enabled", False),
@@ -715,35 +729,6 @@ def train_distill(
   max_logging.log("Distillation Complete.")
 
 
-def _save_run_manifest(argv: Sequence[str], config: pyconfig.HyperParameters) -> None:
-  """Writes the source YAML and a shell-pasteable command to the output dir.
-
-  Saves `distillation.yml` (verbatim copy of the user's config file) and
-  `command.sh` (the CLI overrides) so a run can be reproduced by copying the
-  YAML and re-running the saved command.
-  """
-  if jax.process_index() != 0:
-    return
-  if not (config.base_output_directory and config.run_name):
-    return
-  if len(argv) < 2:
-    return
-
-  try:
-    out_dir = epath.Path(config.base_output_directory) / config.run_name
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    source_yml = epath.Path(pyconfig.resolve_config_path(argv[1]))
-    source_yml.copy(out_dir / "distillation.yml", overwrite=True)
-
-    cli_args = shlex.join(argv[2:])
-    command = "python3 -m maxtext.trainers.post_train.distillation.train_distill " f"distillation.yml {cli_args}\n"
-    (out_dir / "command.sh").write_text(command)
-    max_logging.log(f"Saved run manifest (distillation.yml, command.sh) to {out_dir}")
-  except Exception as e:  # pylint: disable=broad-exception-caught
-    max_logging.log(f"Warning: could not save run manifest: {e}")
-
-
 def main(argv: Sequence[str]) -> None:
   """Entry point for the script.
 
@@ -755,7 +740,6 @@ def main(argv: Sequence[str]) -> None:
   """
   # 1. Parse Global Config to extract Overrides
   global_config = pyconfig.initialize(argv)
-  _save_run_manifest(argv, global_config)
 
   # 2. Initialize STUDENT Config
   # Order of precedence: YAML < CLI < kwargs (student_overrides).

--- a/tests/post_training/unit/distillation_checkpointing_test.py
+++ b/tests/post_training/unit/distillation_checkpointing_test.py
@@ -86,8 +86,10 @@ class MaxTextCheckpointManagerTest(absltest.TestCase):
     self.assertEqual(iterator.counter, 10)
 
     # 2. Save Checkpoint
+    mock_student_config = mock.Mock()
+    mock_student_config.learn_to_init_mode = False
     manager = distillation_utils.MaxTextCheckpointManager(
-        raw_iterator=iterator, root_directory=self.test_dir, options=self.options
+        raw_iterator=iterator, root_directory=self.test_dir, student_config=mock_student_config, options=self.options
     )
 
     # Create dummy model so 'model_params' is not empty
@@ -115,8 +117,13 @@ class MaxTextCheckpointManagerTest(absltest.TestCase):
     new_iterator = FakeGrainIterator()
     self.assertEqual(new_iterator.counter, 0)
 
+    mock_student_config_restore = mock.Mock()
+    mock_student_config_restore.learn_to_init_mode = False
     restore_manager = distillation_utils.MaxTextCheckpointManager(
-        raw_iterator=new_iterator, root_directory=self.test_dir, options=self.options
+        raw_iterator=new_iterator,
+        root_directory=self.test_dir,
+        student_config=mock_student_config_restore,
+        options=self.options,
     )
 
     with mock.patch.object(jax, "process_index", return_value=0), mock.patch.object(jax, "process_count", return_value=1):
@@ -128,8 +135,13 @@ class MaxTextCheckpointManagerTest(absltest.TestCase):
   def test_restore_returns_none_if_no_checkpoint(self):
     """Verifies restore_iterator returns None gracefully if no checkpoint exists."""
     iterator = FakeGrainIterator()
+    mock_student_config_restore = mock.Mock()
+    mock_student_config_restore.learn_to_init_mode = False
     manager = distillation_utils.MaxTextCheckpointManager(
-        raw_iterator=iterator, root_directory=self.test_dir, options=self.options
+        raw_iterator=iterator,
+        root_directory=self.test_dir,
+        student_config=mock_student_config_restore,
+        options=self.options,
     )
 
     # No save called

--- a/tests/post_training/unit/learn_to_init_test.py
+++ b/tests/post_training/unit/learn_to_init_test.py
@@ -1,0 +1,307 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the LearnToInitDense layer in Learn-To-Init (LTI) distillation."""
+
+import unittest
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from absl.testing import absltest
+
+# Import the module under test
+from maxtext.layers.learn_to_init_layer import LearnToInitDense
+from maxtext.trainers.post_train.distillation.lti_utils import prepare_student_weights
+from unittest import mock
+from maxtext.models.llama2 import LlamaDecoderLayer
+from maxtext.layers.learn_to_init_layer import LearnToInitDecoderLayer
+
+
+# Minimal dummy models for testing
+class DummyLayer(nnx.Module):
+
+  def __init__(self, rngs: nnx.Rngs):
+    # A simple linear kernel initialized with random normal distribution
+    self.kernel = nnx.Param(jax.random.normal(rngs.params(), (4, 4)))
+
+
+class DummyModel(nnx.Module):
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.layer1 = DummyLayer(rngs)
+    self.layer2 = DummyLayer(rngs)
+
+
+class PrepareStudentWeightsTest(unittest.TestCase):
+
+  def test_prepare_student_weights_copy_only(self):
+    """Verifies that teacher weights are correctly copied into the student model."""
+    teacher = DummyModel(nnx.Rngs(0))
+    student = DummyModel(nnx.Rngs(1))
+
+    # Ensure the initialized kernels are initially different
+    self.assertFalse(jnp.array_equal(teacher.layer1.kernel.value, student.layer1.kernel.value))
+    self.assertFalse(jnp.array_equal(teacher.layer2.kernel.value, student.layer2.kernel.value))
+
+    # Map teacher's layer1 to student's layer1
+    copy_map = {"layer1/kernel": "layer1/kernel"}
+
+    prepare_student_weights(
+        student_model=student, teacher_model=teacher, teacher_weights_copy_map=copy_map, student_weights_share_map={}
+    )
+
+    # Verify that layer1 was copied over
+    self.assertTrue(jnp.array_equal(student.layer1.kernel.value, teacher.layer1.kernel.value))
+
+    # Verify that layer2 remained untouched
+    self.assertFalse(jnp.array_equal(student.layer2.kernel.value, teacher.layer2.kernel.value))
+
+  def test_prepare_student_weights_share_and_copy(self):
+    """Verifies the behavior when using the experimental weight sharing map."""
+    teacher = DummyModel(nnx.Rngs(0))
+    student = DummyModel(nnx.Rngs(1))
+
+    # We share layer1's node to layer2's path in the local dictionary.
+    # This means any subsequent copy targeted at "layer2/kernel" will actually write
+    # into the student's layer1 node.
+    share_map = {"layer1/kernel": "layer2/kernel"}
+
+    # We copy the teacher's layer2 into the student's layer2 path
+    copy_map = {"layer2/kernel": "layer2/kernel"}
+
+    prepare_student_weights(
+        student_model=student,
+        teacher_model=teacher,
+        teacher_weights_copy_map=copy_map,
+        student_weights_share_map=share_map,
+    )
+
+    # Since student's layer2 was "shared" from layer1, the copy operation
+    # overwrites student's layer1.
+    self.assertTrue(jnp.array_equal(student.layer1.kernel.value, teacher.layer2.kernel.value))
+
+    # The actual layer2 of the student remains unchanged because the dictionary
+    # reference was rerouted. We verify it still has its original initialization.
+    student_original_layer2 = DummyModel(nnx.Rngs(1)).layer2.kernel.value
+    self.assertTrue(jnp.array_equal(student.layer2.kernel.value, student_original_layer2))
+
+  def test_prepare_student_weights_shape_mismatch(self):
+    """Verifies that an error is raised when trying to copy misaligned shapes."""
+    teacher = DummyModel(nnx.Rngs(0))
+    student = DummyModel(nnx.Rngs(1))
+
+    # Modify student shape manually to force a mismatch
+    student.layer1.kernel.value = jnp.zeros((8, 8))
+
+    copy_map = {"layer1/kernel": "layer1/kernel"}
+
+    with self.assertRaisesRegex(AssertionError, "Shape mismatch for layer1/kernel"):
+      prepare_student_weights(
+          student_model=student, teacher_model=teacher, teacher_weights_copy_map=copy_map, student_weights_share_map={}
+      )
+
+
+class LearnToInitDenseTest(unittest.TestCase):
+
+  def test_qkv_projection_standard_map(self):
+    """Verifies parameter shapes and forward pass for QKV-like projection (is_output_projection=False)."""
+    embed_dim = 16
+    teacher_heads = 4
+    teacher_head_dim = 8
+
+    # C shape for Q,K,V projections: (embed_dim, teacher_heads, teacher_head_dim)
+    C = jnp.ones((embed_dim, teacher_heads, teacher_head_dim))
+
+    student_heads = 2
+    student_head_dim = 16
+
+    layer = LearnToInitDense(
+        in_features_shape=(embed_dim,),
+        out_features_shape=(student_heads, student_head_dim),
+        C=C,
+        is_output_projection=False,
+        use_general_linear_map=False,
+        rngs=nnx.Rngs(0),
+    )
+
+    # Verify initialized parameters
+    # A maps teacher_heads -> student_heads
+    self.assertEqual(layer.A.value.shape, (teacher_heads, student_heads))
+    # B maps teacher_head_dim -> student_head_dim
+    self.assertEqual(layer.B.value.shape, (teacher_head_dim, student_head_dim))
+    self.assertEqual(layer.C.value.shape, (embed_dim, teacher_heads, teacher_head_dim))
+
+    # Verify forward pass shape
+    batch_size = 2
+    seq_len = 5
+    x = jnp.ones((batch_size, seq_len, embed_dim))
+    out = layer(x)
+    self.assertEqual(out.shape, (batch_size, seq_len, student_heads, student_head_dim))
+
+  def test_out_projection_standard_map(self):
+    """Verifies parameter shapes and forward pass for Output projection (is_output_projection=True)."""
+    embed_dim = 16
+    teacher_heads = 4
+    teacher_head_dim = 8
+
+    # C shape for Output projection: (teacher_heads, teacher_head_dim, embed_dim)
+    C = jnp.ones((teacher_heads, teacher_head_dim, embed_dim))
+
+    student_heads = 2
+    student_head_dim = 16
+
+    layer = LearnToInitDense(
+        in_features_shape=(student_heads, student_head_dim),
+        out_features_shape=(embed_dim,),
+        C=C,
+        axis=(-2, -1),  # Reduce over the student heads and head_dim
+        is_output_projection=True,
+        use_general_linear_map=False,
+        rngs=nnx.Rngs(0),
+    )
+
+    # Verify initialized parameters
+    # A maps teacher_heads -> student_heads
+    self.assertEqual(layer.A.value.shape, (teacher_heads, student_heads))
+    # B maps student_head_dim -> teacher_head_dim
+    self.assertEqual(layer.B.value.shape, (student_head_dim, teacher_head_dim))
+
+    # Verify forward pass shape
+    batch_size = 2
+    seq_len = 5
+    x = jnp.ones((batch_size, seq_len, student_heads, student_head_dim))
+    out = layer(x)
+    self.assertEqual(out.shape, (batch_size, seq_len, embed_dim))
+
+  def test_qkv_projection_general_map(self):
+    """Verifies parameter shapes and forward pass for QKV-like projection with a general map (W)."""
+    embed_dim = 16
+    teacher_heads = 4
+    teacher_head_dim = 8
+    C = jnp.ones((embed_dim, teacher_heads, teacher_head_dim))
+
+    student_heads = 2
+    student_head_dim = 16
+
+    layer = LearnToInitDense(
+        in_features_shape=(embed_dim,),
+        out_features_shape=(student_heads, student_head_dim),
+        C=C,
+        is_output_projection=False,
+        use_general_linear_map=True,
+        rngs=nnx.Rngs(0),
+    )
+
+    # Verify W tensor shape is correctly formatted as (x, y, u, v)
+    self.assertEqual(layer.W.value.shape, (teacher_heads, teacher_head_dim, student_heads, student_head_dim))
+
+    # Verify forward pass shape
+    batch_size = 2
+    seq_len = 5
+    x = jnp.ones((batch_size, seq_len, embed_dim))
+    out = layer(x)
+    self.assertEqual(out.shape, (batch_size, seq_len, student_heads, student_head_dim))
+
+
+class LearnToInitDecoderLayerTest(unittest.TestCase):
+
+  def test_llama_lti_decoder_layer_initialization(self):
+    """Verifies LearnToInitDecoderLayer initializes and modifies LlamaDecoderLayer correctly."""
+
+    # 1. Setup mock teacher config
+    mock_teacher_config = mock.MagicMock()
+    mock_teacher_config.base_num_query_heads = 4
+    mock_teacher_config.base_num_kv_heads = 2
+    mock_teacher_config.head_dim = 16
+
+    # 2. Setup mock student config
+    mock_config = mock.MagicMock()
+    mock_config.lti_use_general_linear_map = False
+    mock_config.teacher_config = mock_teacher_config
+
+    # Add attributes strictly required by LlamaDecoderLayer and Attention sub-layers
+    mock_config.emb_dim = 64
+    mock_config.dtype = jnp.float32
+    mock_config.weight_dtype = jnp.float32
+    mock_config.shard_mode = "auto"
+    mock_config.normalization_layer_epsilon = 1e-6
+    mock_config.num_query_heads = 4
+    mock_config.num_kv_heads = 2
+    mock_config.head_dim = 16
+    mock_config.max_target_length = 32
+    mock_config.max_prefill_predict_length = 32
+    mock_config.attention = "dot_product"
+    mock_config.dropout_rate = 0.0
+    mock_config.float32_qk_product = False
+    mock_config.float32_logits = False
+    mock_config.prefill_cache_axis_order = "0,1,2,3"
+    mock_config.ar_cache_axis_order = "0,1,2,3"
+    mock_config.compute_axis_order = "0,1,2,3"
+    mock_config.reshape_q = False
+    mock_config.use_ragged_attention = False
+    mock_config.ragged_block_size = 16
+    mock_config.attn_logits_soft_cap = 0.0
+    mock_config.mlp_dim = 128
+    mock_config.mlp_activations = ["silu", "linear"]
+    mock_config.debug_sharding = False
+    mock_config.record_internal_nn_metrics = False
+    mock_config.scan_layers = False
+    mock_config.ici_context_autoregressive_parallelism = 1
+    mock_config.fused_qkv = False
+
+    # 3. Dummy Jax sharding mesh and NNX Rngs
+    mesh = jax.sharding.Mesh(jax.devices(), ("data",))
+    rngs = nnx.Rngs(0)
+
+    # Patch utility functions to isolate the test from deeper external dependencies
+    with (
+        mock.patch("maxtext.utils.max_utils.get_batch_seq_len_for_mode", return_value=(2, 32)),
+        mock.patch("maxtext.layers.quantizations.configure_kv_quant", return_value=None),
+    ):
+
+      # This effectively initializes LlamaLTIDecoderLayer and implicitly calls _customize_attention_modules
+      layer = LearnToInitDecoderLayer(
+          base_layer_cls=LlamaDecoderLayer,
+          config=mock_config,
+          model_mode="train",
+          mesh=mesh,
+          rngs=rngs,
+      )
+
+    # 4. Verify initialization result
+    self.assertIsInstance(layer.learn_to_init_wrapper, LlamaDecoderLayer)
+    self.assertEqual(layer.self_attention_module_name, "self_attention")
+
+    # 5. Verify the behavior of _customize_attention_modules
+    # It should correctly replace query, key, value, and out with LearnToInitDense
+    attention_module = layer.learn_to_init_wrapper.self_attention
+
+    for proj_name in ["query", "key", "value", "out"]:
+      child = getattr(attention_module, proj_name)
+      self.assertIsInstance(child, LearnToInitDense, f"{proj_name} was not swapped to LearnToInitDense")
+
+      # Validate that the dummy Teacher Tensor C is dimensioned correctly
+      if proj_name == "query":
+        # (emb_dim, teacher_heads, head_dim) -> (64, 4, 16)
+        self.assertEqual(child.C.value.shape, (64, 4, 16))
+      elif proj_name in ("key", "value"):
+        # (emb_dim, teacher_kv_heads, head_dim) -> (64, 2, 16)
+        self.assertEqual(child.C.value.shape, (64, 2, 16))
+      elif proj_name == "out":
+        # (teacher_heads, head_dim, emb_dim) -> (4, 16, 64)
+        self.assertEqual(child.C.value.shape, (4, 16, 64))
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -1059,6 +1059,12 @@ class TrainDistillTest(unittest.TestCase):
     mock_student_cfg.use_sft = False
     mock_student_cfg.enable_dropout = False
 
+    # LTI related attributes
+    mock_student_cfg.learn_to_init_mode = False
+    mock_student_cfg.distill_weights_copy_map = {}
+    mock_student_cfg.distill_student_weights_share_map = {}
+    mock_student_cfg.get_keys.return_value = {}
+
     # Add scheduling attributes
     mock_student_cfg.distill_alpha_end = None
     mock_student_cfg.distill_alpha_schedule = "constant"
@@ -1151,6 +1157,12 @@ class TrainDistillTest(unittest.TestCase):
     mock_student_cfg.use_sft = False
     mock_student_cfg.enable_dropout = False
 
+    # LTI-attributes
+    mock_student_cfg.learn_to_init_mode = False
+    mock_student_cfg.distill_weights_copy_map = {}
+    mock_student_cfg.distill_student_weights_share_map = {}
+    mock_student_cfg.get_keys.return_value = {}
+
     # Add scheduling attributes
     mock_student_cfg.distill_alpha_end = None
     mock_student_cfg.distill_alpha_schedule = "constant"
@@ -1175,7 +1187,8 @@ class TrainDistillTest(unittest.TestCase):
 
     mock_student_model = mock.Mock()
     mock_teacher_model = mock.Mock()
-    mock_get_model.side_effect = [mock_student_model, mock_teacher_model]
+    # The teacher is loaded before the student in online mode
+    mock_get_model.side_effect = [mock_teacher_model, mock_student_model]
 
     mock_build_tokenizer.return_value = mock.Mock(pad_id=0)
     mock_create_iterator.return_value = (mock.Mock(), mock.Mock())

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -439,6 +439,7 @@ class TrainDistillTest(unittest.TestCase):
         "distill/kl_div_T1",
         "distill/teacher_loss",
         "distill/out_proj_feature_loss",
+        "distill/moe_lb_loss",
         "distill/total_loss",
         "distill/temperature",
         "distill/alpha",
@@ -1028,6 +1029,8 @@ class TrainDistillTest(unittest.TestCase):
     mock_global.student_overrides = {}
     mock_global.teacher_overrides = {}  # No checkpoint needed
     mock_global.offline_data_dir = "gs://bucket/data"  # Triggers offline mode
+    mock_global.base_output_directory = ""
+    mock_global.run_name = ""
 
     mock_student_cfg = mock.Mock()
     mock_student_cfg.vocab_size = 32000
@@ -1124,6 +1127,8 @@ class TrainDistillTest(unittest.TestCase):
     mock_global.student_overrides = {}
     mock_global.teacher_overrides = {"load_parameters_path": "gs://ckpt"}
     mock_global.offline_data_dir = None  # Triggers online mode
+    mock_global.base_output_directory = ""
+    mock_global.run_name = ""
 
     mock_student_cfg = mock.Mock()
     mock_student_cfg.vocab_size = 32000
@@ -1286,6 +1291,43 @@ class TrainDistillTest(unittest.TestCase):
     # Verify layer2 has changed (trained)
     is_layer2_unchanged = np.allclose(student.layer2.kernel.get_value(), initial_layer2_weights)
     self.assertFalse(is_layer2_unchanged, msg="layer2 weights should have updated.")
+
+  def test_save_run_manifest_writes_files(self):
+    """Verifies _save_run_manifest copies the source YAML and writes command.sh."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      source_yml = os.path.join(tmp_dir, "my_distill.yml")
+      with open(source_yml, "w", encoding="utf-8") as f:
+        f.write("# example config\nsteps: 10\n")
+
+      config = mock.Mock()
+      config.base_output_directory = tmp_dir
+      config.run_name = "test_run"
+      argv = ["train_distill.py", source_yml, "steps=20", "learning_rate=1e-4"]
+
+      train_distill._save_run_manifest(argv, config)  # pylint: disable=protected-access
+
+      out_dir = os.path.join(tmp_dir, "test_run")
+      saved_yml = os.path.join(out_dir, "distillation.yml")
+      saved_cmd = os.path.join(out_dir, "command.sh")
+      self.assertTrue(os.path.exists(saved_yml))
+      self.assertTrue(os.path.exists(saved_cmd))
+      with open(saved_yml, encoding="utf-8") as f:
+        self.assertIn("steps: 10", f.read())
+      with open(saved_cmd, encoding="utf-8") as f:
+        command = f.read()
+      self.assertIn("distillation.yml", command)
+      self.assertIn("steps=20", command)
+      self.assertIn("learning_rate=1e-4", command)
+
+  def test_save_run_manifest_swallows_errors(self):
+    """Verifies _save_run_manifest does not raise if the source YAML is missing."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      config = mock.Mock()
+      config.base_output_directory = tmp_dir
+      config.run_name = "test_run"
+      argv = ["train_distill.py", "/does/not/exist.yml"]
+      # Must not raise — failures here should not kill training.
+      train_distill._save_run_manifest(argv, config)  # pylint: disable=protected-access
 
 
 if __name__ == "__main__":

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -439,7 +439,6 @@ class TrainDistillTest(unittest.TestCase):
         "distill/kl_div_T1",
         "distill/teacher_loss",
         "distill/out_proj_feature_loss",
-        "distill/moe_lb_loss",
         "distill/total_loss",
         "distill/temperature",
         "distill/alpha",
@@ -1029,8 +1028,6 @@ class TrainDistillTest(unittest.TestCase):
     mock_global.student_overrides = {}
     mock_global.teacher_overrides = {}  # No checkpoint needed
     mock_global.offline_data_dir = "gs://bucket/data"  # Triggers offline mode
-    mock_global.base_output_directory = ""
-    mock_global.run_name = ""
 
     mock_student_cfg = mock.Mock()
     mock_student_cfg.vocab_size = 32000
@@ -1058,6 +1055,12 @@ class TrainDistillTest(unittest.TestCase):
     mock_student_cfg.distill_feature_loss_type = "cosine"
     mock_student_cfg.use_sft = False
     mock_student_cfg.enable_dropout = False
+
+    # LTI related attributes
+    mock_student_cfg.learn_to_init_mode = False
+    mock_student_cfg.distill_weights_copy_map = {}
+    mock_student_cfg.distill_student_weights_share_map = {}
+    mock_student_cfg.get_keys.return_value = {}
 
     # Add scheduling attributes
     mock_student_cfg.distill_alpha_end = None
@@ -1121,8 +1124,6 @@ class TrainDistillTest(unittest.TestCase):
     mock_global.student_overrides = {}
     mock_global.teacher_overrides = {"load_parameters_path": "gs://ckpt"}
     mock_global.offline_data_dir = None  # Triggers online mode
-    mock_global.base_output_directory = ""
-    mock_global.run_name = ""
 
     mock_student_cfg = mock.Mock()
     mock_student_cfg.vocab_size = 32000
@@ -1151,6 +1152,12 @@ class TrainDistillTest(unittest.TestCase):
     mock_student_cfg.use_sft = False
     mock_student_cfg.enable_dropout = False
 
+    # LTI-attributes
+    mock_student_cfg.learn_to_init_mode = False
+    mock_student_cfg.distill_weights_copy_map = {}
+    mock_student_cfg.distill_student_weights_share_map = {}
+    mock_student_cfg.get_keys.return_value = {}
+
     # Add scheduling attributes
     mock_student_cfg.distill_alpha_end = None
     mock_student_cfg.distill_alpha_schedule = "constant"
@@ -1175,7 +1182,8 @@ class TrainDistillTest(unittest.TestCase):
 
     mock_student_model = mock.Mock()
     mock_teacher_model = mock.Mock()
-    mock_get_model.side_effect = [mock_student_model, mock_teacher_model]
+    # The teacher is loaded before the student in online mode
+    mock_get_model.side_effect = [mock_teacher_model, mock_student_model]
 
     mock_build_tokenizer.return_value = mock.Mock(pad_id=0)
     mock_create_iterator.return_value = (mock.Mock(), mock.Mock())
@@ -1278,43 +1286,6 @@ class TrainDistillTest(unittest.TestCase):
     # Verify layer2 has changed (trained)
     is_layer2_unchanged = np.allclose(student.layer2.kernel.get_value(), initial_layer2_weights)
     self.assertFalse(is_layer2_unchanged, msg="layer2 weights should have updated.")
-
-  def test_save_run_manifest_writes_files(self):
-    """Verifies _save_run_manifest copies the source YAML and writes command.sh."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-      source_yml = os.path.join(tmp_dir, "my_distill.yml")
-      with open(source_yml, "w", encoding="utf-8") as f:
-        f.write("# example config\nsteps: 10\n")
-
-      config = mock.Mock()
-      config.base_output_directory = tmp_dir
-      config.run_name = "test_run"
-      argv = ["train_distill.py", source_yml, "steps=20", "learning_rate=1e-4"]
-
-      train_distill._save_run_manifest(argv, config)  # pylint: disable=protected-access
-
-      out_dir = os.path.join(tmp_dir, "test_run")
-      saved_yml = os.path.join(out_dir, "distillation.yml")
-      saved_cmd = os.path.join(out_dir, "command.sh")
-      self.assertTrue(os.path.exists(saved_yml))
-      self.assertTrue(os.path.exists(saved_cmd))
-      with open(saved_yml, encoding="utf-8") as f:
-        self.assertIn("steps: 10", f.read())
-      with open(saved_cmd, encoding="utf-8") as f:
-        command = f.read()
-      self.assertIn("distillation.yml", command)
-      self.assertIn("steps=20", command)
-      self.assertIn("learning_rate=1e-4", command)
-
-  def test_save_run_manifest_swallows_errors(self):
-    """Verifies _save_run_manifest does not raise if the source YAML is missing."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-      config = mock.Mock()
-      config.base_output_directory = tmp_dir
-      config.run_name = "test_run"
-      argv = ["train_distill.py", "/does/not/exist.yml"]
-      # Must not raise — failures here should not kill training.
-      train_distill._save_run_manifest(argv, config)  # pylint: disable=protected-access
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR introduces the base implementation for Learn-to-Init (LTI) attention for distillation (llama only be can easily be generalized). 

Relevant details and context:
- **Problem being solved:** Setting up the foundational LTI components required for effective attention distillation of LLaMA models.
- **Implementation details:** 
  - Adds the core LTI logic in a new `learn_to_init_layer.py` module.
  - Updates the distillation pipeline (`distillation_utils.py` and `train_distill.py`) and decoders to support the new attention layer.
  - 2 LTI implementation for GQA - using bi-linear and global linear map options.
  - Configures the system to get LTI student init-time teacher shapes directly from the configuration.

# Tests
- Added a new unit test for LearnToInitDense as well as teacher to student weight injection logic.
src/maxtext/tests/post_training/unit/learn-to-init_test.py

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
