### PR TITLE
update muon test and format doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,25 +118,25 @@ MaxText aims to provide you with the best OSS models, whether as a reference imp
   * Gemma 2 (2B, 9B, 27B)
   * Gemma 1 (2B, 7B)
 * Alibaba
-  * Qwen 2.5 (1.5B, 7B, 14B)
-  * Qwen 3 MoE 2507 (235B, 480B)
-  * Qwen 3 MoE (30B, 235B)
+  * Qwen 3 Next (80B)
+  * Qwen 3 MoE (30B, 235B), Qwen 3 MoE 2507 (235B, 480B)
   * Qwen 3 Dense (0.6B, 1.7B, 4B, 8B, 14B, 32B)
-* DeepSeek
+  * Qwen 2.5 (1.5B, 7B, 14B)  
+* DeepSeek AI
   * DeepSeek V3.2 (671B)  
   * DeepSeek V3.1 (671B)
-  * DeepSeek V3 0324 (671B) & DeepSeek R1 0528 (671B)
+  * DeepSeek V3 0324 (671B), DeepSeek R1 0528 (671B)
   * DeepSeek V2 (16B, 236B)
-* Kimi
-  * Kimi K2
+* Moonshot AI
+  * Kimi K2 (1T)
 * Meta
   * Llama 4 Scout (109B) & Maverick (400B)
-  * Llama 3.3 70B, 3.1 (8B, 70B, 405B), 3.0 (8B, 70B, 405B)
+  * Llama 3.3 (70B), 3.1 (8B, 70B, 405B), 3.0 (8B, 70B, 405B)
   * Llama 2 (7B, 13B, 70B)
-* Open AI
+* OpenAI
   * GPT-OSS (20B, 120B)
   * GPT3 (52K, 6B, 22B, 175B)
-* Mistral
+* Mistral AI
   * Mixtral (8x7B, 8x22B)
   * Mistral (7B)
 * Diffusion Models

--- a/src/maxtext/configs/pyconfig.py
+++ b/src/maxtext/configs/pyconfig.py
@@ -256,16 +256,6 @@ def _prepare_for_pydantic(raw_keys: dict[str, Any]) -> dict[str, Any]:
           Please pass tokenizer_path in your command if this is not intended."
         )
 
-    # Preprocess muon_consistent_rms to be None or float
-    if key == "muon_consistent_rms":
-      if value in ["None", "none"]:
-        new_value = None
-      else:
-        try:
-          new_value = float(value)
-        except ValueError as e:
-          raise ValueError("muon_consistent_rms should be None or float") from e
-
     pydantic_kwargs[key] = new_value
 
   return pydantic_kwargs

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1384,7 +1384,7 @@ class Muon(BaseModel):
       0,
       description="Strength of the weight decay regularization. This is multiplied with the learning rate.",
   )
-  muon_consistent_rms: None | float = Field(
+  muon_consistent_rms: float | None = Field(
       None,
       description="If None, apply width scaling to updates. If float, apply consistent rms scaling (recommend 0.2).",
   )

--- a/tests/end_to_end/tpu/deepseek/Run_DeepSeek.md
+++ b/tests/end_to_end/tpu/deepseek/Run_DeepSeek.md
@@ -170,7 +170,10 @@ python3 -m maxtext.trainers.post_train.sft.train_sft_deprecated src/maxtext/conf
 ```
 
 ## Continued pre-training for V3.2 Sparse Attention
-**DeepSeek Sparse Attention (DSA)** enhances the Multi-Head Latent Attention (MLA) architecture by introducing a **Lightning Indexer**, which selects the top-k tokens for attention. DeepSeek-V3.2 is instantiated from DeepSeek-V3.1 and undergoes continued pre-training to adapt this indexer via a two-stage strategy: **Dense Warm-up** and **Sparse Training**.  
+
+**DeepSeek Sparse Attention (DSA)** enhances the Multi-Head Latent Attention (MLA) architecture by introducing a **Lightning Indexer**, which selects the top-k tokens for attention. Note that Indexer is activated only if `max_target_length` > `indexer_topk` (2048).
+
+DeepSeek-V3.2 is instantiated from DeepSeek-V3.1 and undergoes continued pre-training to adapt this indexer via a two-stage strategy: **Dense Warm-up** and **Sparse Training**.
 
 1. **Dense Warmup Stage**
 The indexer is trained exclusively using dense indexer loss while all other model parameters remain frozen.  
@@ -186,6 +189,7 @@ python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
     async_checkpointing=false \
     ici_fsdp_parallelism=128 \
     steps=5 \
+    # Indexer is activated only if max_target_length > indexer_topk (2048)
     max_target_length=4096 \
     attention=flash \
     dtype=bfloat16 \
@@ -212,6 +216,7 @@ python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
     async_checkpointing=false \
     ici_fsdp_parallelism=128 \
     steps=5 \
+    # Indexer is activated only if max_target_length > indexer_topk (2048)
     max_target_length=4096 \
     attention=flash \
     dtype=bfloat16 \

--- a/tests/end_to_end/tpu/kimi/Run_Kimi.md
+++ b/tests/end_to_end/tpu/kimi/Run_Kimi.md
@@ -19,7 +19,7 @@
 Kimi is a family of high-performance, open-weights sparse MoE models by Moonshot AI designed for agentic intelligence. The currently supported models are **Kimi K2 (1T)**.
 
 * **[Kimi K2](https://arxiv.org/pdf/2507.20534)** features a massive 1.04 trillion total parameters with 32 billion activated parameters. The architecture is similar to DeepSeek-V3. It utilizes **Multi-Head Latent Attention (MLA)** and an ultra-sparse MoE with **384 experts**, optimized for long-context and agentic tasks.
-* **MuonClip Optimizer**: Kimi K2 was trained using the token-efficient [Muon](https://kellerjordan.github.io/posts/muon) optimizer combined with a novel **QK-clip** technique to ensure training stability and eliminate loss spikes during large-scale pre-training.
+* **MuonClip Optimizer**: Kimi K2 was trained using the token-efficient **[Muon optimizer](https://kellerjordan.github.io/posts/muon)** combined with a novel **QK-clip** technique to ensure training stability and eliminate loss spikes during large-scale pre-training.
 * **Agentic Excellence**: K2 is specifically post-trained using a large-scale agentic data synthesis pipeline and Reinforcement Learning (RL), achieving state-of-the-art performance on benchmarks like Tau2-Bench and SWE-Bench.
 
 ## Checkpoint Conversion
@@ -46,7 +46,7 @@ python3 -m maxtext.checkpoint_conversion.standalone_scripts.convert_deepseek_fam
 ```
 
 ## Pre-training
-You can train from scratch to generate a new checkpoint. One example command to run pre-training with Kimi K2 on tpu7x-512 (adjust parallelism for the 1T parameter scale). To use MuonClip optimizer, you need `optax>=0.2.7` and `tokamax>=0.0.11`.
+You can train from scratch to generate a new checkpoint. One example command to run pre-training with Kimi K2 on tpu7x-512 with 256 chips. To use **MuonClip optimizer**, you need `optax>=0.2.7` and `tokamax>=0.0.11`.
 
 ```sh
 python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
@@ -72,9 +72,11 @@ python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
     dataset_type=synthetic \
     scan_layers=True \
     use_ring_of_experts=True \
+    # muon optimizer
     opt_type=muon \
     muon_consistent_rms=0.2 \
     muon_weight_decay=0.1 \
+    # qk clip
     use_qk_clip=True \
     qk_clip_threshold=100
 ```
@@ -109,9 +111,11 @@ python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
     scan_layers=True \
     load_parameters_path=${SCANNED_CHECKPOINT?} \
     use_ring_of_experts=True \
+    # muon optimizer
     opt_type=muon \
     muon_consistent_rms=0.2 \
     muon_weight_decay=0.1 \
+    # qk clip
     use_qk_clip=True \
     qk_clip_threshold=100
 ```
@@ -122,18 +126,21 @@ Example command to run decoding with Kimi K2. Given its 1T size, high tensor par
 ```sh
 python3 -m maxtext.inference.decode src/maxtext/configs/base.yml \
     base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
-    load_parameters_path=${CONVERTED_CHECKPOINT?} \
     run_name=kimi_decode \
-    per_device_batch_size=1 \
     model_name=kimi-k2-1t \
-    max_target_length=2048 \
     tokenizer_type=huggingface \
     tokenizer_path=moonshotai/Kimi-K2-Instruct \
+    hf_access_token=${HF_TOKEN?} \
+    load_parameters_path=${UNSCANNED_CKPT_PATH?} \
+    scan_layers=False \
+    enable_checkpointing=true \
+    async_checkpointing=false \
+    per_device_batch_size=1 \
+    max_target_length=2048 \
     attention=dot_product \
     ici_tensor_parallelism=128 \
     ici_fsdp_parallelism=1 \
-    prompt="The primary goal of agentic intelligence is to " \
-    scan_layers=False
+    prompt="The primary goal of agentic intelligence is to "
 ```
 
 ## Correctness
@@ -157,6 +164,8 @@ python3 -m tests.assets.logits_generation.generate_hf_golden_logits \
   --hf-load-dtype=bfloat16 \  
   --trust-remote-code=True  
 ```
+
+Run command below to compare logits between MaxText and HuggingFace.
 
 ```sh
 JAX_PLATFORMS=cpu python3 -m tests.forward_pass_logit_checker \  

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -19,7 +19,7 @@ model configurations and parallelism strategies can be successfully compiled
 for different hardware topologies.
 """
 
-import unittest
+from absl.testing import parameterized
 import os.path
 from tempfile import gettempdir
 
@@ -32,7 +32,7 @@ from tests.utils.test_helpers import get_test_config_path
 
 
 @pytest.mark.tpu_backend
-class TrainCompile(unittest.TestCase):
+class TrainCompile(parameterized.TestCase):
   """Tests for the Ahead of Time Compilation functionality, train_compile.py"""
 
   @pytest.mark.cpu_only
@@ -550,7 +550,6 @@ class TrainCompile(unittest.TestCase):
         )
     )
 
-  @pytest.mark.skip(reason="Fix sharding issue of all layers of DeepSeek")
   @pytest.mark.cpu_only
   def test_moe_deepseek_unscanned_bf16(self):
     temp_dir = gettempdir()
@@ -715,7 +714,7 @@ class TrainCompile(unittest.TestCase):
             "",
             get_test_config_path(),
             f"compiled_trainstep_file={compiled_trainstep_file}",
-            "compile_topology=v5p-256",
+            "compile_topology=v5p-8",
             "compile_topology_num_slices=1",
             "model_name=gpt3-6b",
             "per_device_batch_size=1",
@@ -747,7 +746,7 @@ class TrainCompile(unittest.TestCase):
             "",
             get_test_config_path(),
             f"compiled_trainstep_file={compiled_trainstep_file}",
-            "compile_topology=v5p-256",
+            "compile_topology=v5p-64",
             "compile_topology_num_slices=1",
             "model_name=qwen3-next-80b-a3b",
             "per_device_batch_size=1",
@@ -777,9 +776,6 @@ class TrainCompile(unittest.TestCase):
             "use_tokamax_splash=True",
             "dtype=bfloat16",
             "weight_dtype=bfloat16",
-            # without_device_limit
-            "n_routing_groups=-1",
-            "topk_routing_group=-1",
         )
     )
 
@@ -929,8 +925,12 @@ class TrainCompile(unittest.TestCase):
     )
 
   @pytest.mark.cpu_only
-  def test_qk_clip(self):
-    """AOT test for qk-clip with DeepSeek3 Tiny model"""
+  @parameterized.named_parameters(
+      {"testcase_name": "dot_product", "attention": "dot_product"},
+      {"testcase_name": "tokamax_splash", "attention": "flash"},
+  )
+  def test_qk_clip(self, attention):
+    """AOT test for AdamW optimizer with QK clip for DeepSeek3 Tiny model"""
     compiled_trainstep_file = "/tmp/test_qk_clip.pickle"
     train_compile_main(
         (
@@ -944,15 +944,51 @@ class TrainCompile(unittest.TestCase):
             "sparse_matmul=True",
             "megablox=True",
             "use_tokamax_gmm=False",
-            # TODO(agagik): update to flash after support
-            "attention=dot_product",
-            "use_tokamax_splash=True",
             "max_target_length=128",
             "per_device_batch_size=1",
             "dtype=bfloat16",
             "weight_dtype=float32",
+            # attention
+            f"attention={attention}",
+            "use_tokamax_splash=True",
+            # qk clip
             "use_qk_clip=true",
             "qk_clip_threshold=100",
+        )
+    )
+
+  @pytest.mark.cpu_only
+  @parameterized.named_parameters(
+      {"testcase_name": "consistent_rms_scaling", "muon_consistent_rms": 0.2},
+      {"testcase_name": "width_scaling", "muon_consistent_rms": None},
+  )
+  def test_muon(self, muon_consistent_rms):
+    """AOT test for Muon optimizer for DeepSeek3 Tiny model"""
+    compiled_trainstep_file = "/tmp/test_muon.pickle"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "model_name=deepseek3-tiny",
+            "scan_layers=True",
+            "sparse_matmul=True",
+            "megablox=True",
+            "use_tokamax_gmm=False",
+            "max_target_length=128",
+            "per_device_batch_size=1",
+            "dtype=bfloat16",
+            "weight_dtype=float32",
+            # tokamax splash attention
+            "attention=flash",
+            "use_tokamax_splash=True",
+            # muon optimizer
+            "opt_type=muon",
+            "muon_beta=0.95",
+            "muon_weight_decay=0.1",
+            f"muon_consistent_rms={muon_consistent_rms}",
         )
     )
 


### PR DESCRIPTION
# Description

train_compile_test
- **Add muon test** (as optax is upgraded to >=0.2.7)
- Update qk clip with splash (as tokamax is upgraded to >=0.0.11)
- scale down some test for speedup

pyconfig
- Remove redundant preprocessing for **muon_consistent_rms** (None or float). The logic is already handled by [this](https://github.com/AI-Hypercomputer/maxtext/blob/c9df820b1e98b6c07b06d652e7f87cd3597c3111/src/maxtext/configs/pyconfig.py#L215-L216), which applies to other [similar args](https://github.com/AI-Hypercomputer/maxtext/blob/c9df820b1e98b6c07b06d652e7f87cd3597c3111/src/maxtext/configs/base.yml#L1229-L1239) with optional None values.

docs
- Minor formatting


# Tests

Train compile test pass in unit test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
