### PR TITLE
distillation: resume + xpk launcher + metrics refactor

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -18,25 +18,25 @@ This module contains adapter classes that bridge MaxText's data loading and
 model structures with Tunix's training interfaces.
 """
 
-import pickle
-import tensorflow as tf
-from array_record.python import array_record_module
-
 import abc
-from typing import Any, Iterator, Optional, List, Callable, Literal
+import pickle
+from typing import Any, Callable, Iterator, List, Literal, Optional, Sequence
 
 import flax
 from flax import nnx
 import jax
 import jax.numpy as jnp
+import numpy as np
 import optax
+import tensorflow as tf
+from array_record.python import array_record_module
 from orbax import checkpoint
 
 from maxtext.utils import max_logging
 # Reuse MaxText's native checkpointing logic
 from maxtext.common.checkpointing import GrainCheckpointHandler, GrainCheckpointSave, GrainCheckpointRestore
-from tunix.sft import peft_trainer
 from tunix.sft import checkpoint_manager as tunix_checkpoint_manager
+from tunix.sft import peft_trainer
 
 
 # -----------------------------------------------------------------------------
@@ -184,6 +184,11 @@ class MaxTextToTunixIterator:
 # Distillation Strategy
 # -----------------------------------------------------------------------------
 
+# Clamp CE before exp() so a divergence spike doesn't poison PPL averages
+# with inf. 20 nats is well above plausible CE (Llama random-init ~11.76)
+# and far below fp32 exp overflow (~88).
+_PPL_CE_CAP = 20.0
+
 
 def compute_schedule(
     step: jax.Array,
@@ -215,6 +220,33 @@ def compute_schedule(
     return end_value + (start_value - end_value) * 0.5 * (1.0 + jnp.cos(jnp.pi * progress))
   else:
     raise ValueError(f"Unsupported schedule_type: {schedule_type!r}. Must be 'constant', 'linear', or 'cosine'.")
+
+
+def weighted_mean(sum_count_pairs: Sequence[tuple[Any, Any]] | np.ndarray) -> float:
+  """Aggregates `(sum, count)` pairs into a single token-weighted mean.
+
+  Used as the aggregation function for metrics emitted by `compute_loss` and
+  `compute_eval_loss`. Robust to per-host imbalance and to varying valid-token
+  counts across logging steps:
+    final_value = sum(sums) / sum(counts)
+
+  Accepts either a list of (sum, count) tuples or an ndarray of shape (N, 2).
+  Tunix's metrics writer can pass either form, so we normalize here.
+
+  Returns 0.0 for an empty input or when total count is non-positive.
+  """
+  arr = np.asarray(sum_count_pairs, dtype=np.float32)
+  if arr.size == 0:
+    return 0.0
+  # Normalize shape. Single pair -> (1, 2); list of pairs -> (N, 2).
+  if arr.ndim == 1:
+    arr = arr.reshape(1, -1)
+  if arr.ndim != 2 or arr.shape[1] != 2:
+    return 0.0
+  total = float(arr[:, 1].sum())
+  if total <= 0.0:
+    return 0.0
+  return float(arr[:, 0].sum() / total)
 
 
 class DistillationStrategy(abc.ABC):
@@ -312,15 +344,14 @@ class CombinedDistillationStrategy(DistillationStrategy):
     Args:
         student_forward_fn: Function to compute student model outputs.
         teacher_forward_fn: Function to compute teacher model outputs.
-        labels_fn: Function to compute labels from model inputs.
         temperature: Temperature for softening probabilities (> 0).
         alpha: Weight to balance distillation loss and task loss (0.0 to 1.0).
         beta_feature: Weight to balance feature loss (0.0 to 1.0). 0.0 disables feature loss.
         layer_indices: Layer indices to apply feature loss.
         feature_loss_type: The type of feature loss to use if `feature_loss_fn` is None.
           Can be "cosine" (default) or "l2".
-        feature_loss_fn: A function that takes two jax. Arrays (student_map,
-          teacher_map) and returns a scalar loss. Defaults to Cosine Distance.
+        feature_loss_fn: A function that takes two jax.Arrays (student_map,
+          teacher_map) and returns a scalar loss. Defaults to cosine distance.
         cosine_distance_axis: The axis to use for cosine distance computation if
           feature_loss_fn is not provided. Defaults to -1.
         alpha_end: Target alpha value at end of training. None keeps alpha fixed.
@@ -418,18 +449,19 @@ class CombinedDistillationStrategy(DistillationStrategy):
       teacher_output: DistillationForwardOutput,
       labels: jax.Array,
       step: jax.Array | None = None,
-  ) -> tuple[jax.Array, dict[str, jax.Array]]:
-    """Computes Loss and Auxiliary Metrics."""
+  ) -> tuple[jax.Array, dict[str, tuple[jax.Array, jax.Array]]]:
+    """Computes Loss and Auxiliary Metrics.
+
+    Metrics are emitted as (sum, count) pairs so that they can be aggregated
+    across hosts and across logging windows in a token-weighted (unbiased) way:
+    final_value = sum(sums) / sum(counts).
+    """
     # Resolve scheduled weights for this step
     alpha, temperature, beta_feature = self._get_scheduled_weights(step)
 
-    # Calculate Distillation Loss (KL Divergence)
-    # Scale logits by temperature T for soft targets
-    # We use explicit float32 casting for stability in loss calculation
     s_logits = student_output.logits.astype(jnp.float32)
     t_logits = teacher_output.logits.astype(jnp.float32)
 
-    # Shape: [num_layers, batch, seq, hidden_dim]
     s_features = student_output.out_projection_activations
     t_features = teacher_output.out_projection_activations
 
@@ -439,34 +471,42 @@ class CombinedDistillationStrategy(DistillationStrategy):
           "Ensure the model architecture supports feature extraction (e.g., 'out_projection_activations' is sowed)."
       )
 
-    log_student_probs_temp = jax.nn.log_softmax(s_logits / temperature, axis=-1)
-    teacher_probs_temp = jax.nn.softmax(t_logits / temperature, axis=-1)
-    # labels are supposed to have all sft masks applied by this moment
-    labels_mask = jnp.any(labels != 0, axis=-1, keepdims=True)
-    mean_mask = jnp.squeeze(labels_mask, axis=-1)
+    # Per-token validity mask, derived from the one-hot labels so we don't need
+    # a separate mask input. A padded (fully-zero) row yields `any != 0 == False`.
+    mask = jnp.any(labels != 0, axis=-1).astype(jnp.float32)  # [B, T]
+    valid_count = jnp.sum(mask)
+    safe_count = jnp.maximum(valid_count, 1.0)
 
-    # KL(Teacher || Student)
-    kl_div = optax.kl_divergence(log_student_probs_temp, teacher_probs_temp, where=labels_mask)
+    # --- Soft loss: KL on temperature-softened distributions ---
+    log_s_T = jax.nn.log_softmax(s_logits / temperature, axis=-1)
+    t_p_T = jax.nn.softmax(t_logits / temperature, axis=-1)
+    # KL(teacher || student) per position. optax.kl_divergence(log_pred, target) = KL(target || pred).
+    kl_softened_per_pos = optax.kl_divergence(log_s_T, t_p_T)  # [B, T]
+    kl_softened_sum = jnp.sum(kl_softened_per_pos * mask)
+    # Scale by T^2 (Hinton). Apply once at the loss; logged metric is the scaled sum too.
+    soft_loss_sum_scaled = kl_softened_sum * (temperature**2)
+    soft_loss_mean = soft_loss_sum_scaled / safe_count
 
-    # Scale gradients by T^2 (Hinton et al.)
-    soft_loss = jnp.mean(kl_div, where=mean_mask) * (temperature**2)
+    # --- Hard loss: student CE against ground-truth ---
+    ce_student_per_pos = optax.softmax_cross_entropy(logits=s_logits, labels=labels)
+    ce_student_sum = jnp.sum(ce_student_per_pos * mask)
+    hard_loss_mean = ce_student_sum / safe_count
 
-    # 1. Student Hard Loss (Existing)
-    ce_loss_student = optax.softmax_cross_entropy(logits=s_logits, labels=labels, where=labels_mask)
-    hard_loss = jnp.mean(ce_loss_student, where=mean_mask)
+    # --- Teacher CE (verification metric) ---
+    ce_teacher_per_pos = optax.softmax_cross_entropy(logits=t_logits, labels=labels)
+    ce_teacher_sum = jnp.sum(ce_teacher_per_pos * mask)
 
-    # 2. Teacher Hard Loss (For Verification)
-    ce_loss_teacher = optax.softmax_cross_entropy(logits=t_logits, labels=labels, where=labels_mask)
-    teacher_hard_loss = jnp.mean(ce_loss_teacher, where=mean_mask)
+    # --- Always-T=1 KL for cross-run / cross-anneal comparability ---
+    log_s_1 = jax.nn.log_softmax(s_logits, axis=-1)
+    t_p_1 = jax.nn.softmax(t_logits, axis=-1)
+    kl_t1_per_pos = optax.kl_divergence(log_s_1, t_p_1)
+    kl_t1_sum = jnp.sum(kl_t1_per_pos * mask)
 
-    # 3. Combine losses
-    base_logit_loss = (alpha * soft_loss) + ((1.0 - alpha) * hard_loss)
+    base_logit_loss = (alpha * soft_loss_mean) + ((1.0 - alpha) * hard_loss_mean)
 
-    feature_loss = jnp.array(0.0)
+    feature_loss = jnp.array(0.0, dtype=jnp.float32)
     if self.beta_feature > 0.0:
-
       if self.layer_indices is not None:
-        # jnp.take slices along axis=0 (the layer dimension)
         s_features_sliced = jnp.take(s_features, self.layer_indices, axis=0)
         t_features_sliced = jnp.take(t_features, self.layer_indices, axis=0)
       else:
@@ -480,17 +520,35 @@ class CombinedDistillationStrategy(DistillationStrategy):
 
     total_loss = base_logit_loss + feature_loss
 
-    # 4. Return Loss AND Metrics (log dynamic values for TensorBoard verification)
-    metrics = {
-        "distill/soft_loss": soft_loss,
-        "distill/hard_loss": hard_loss,
-        "distill/kl_div": jnp.mean(kl_div, where=mean_mask),
-        "distill/teacher_loss": teacher_hard_loss,
-        "distill/out_proj_feature_loss": feature_loss,
-        "distill/total_loss": total_loss,
-        "distill/temperature": temperature,
-        "distill/alpha": alpha,
-        "distill/beta_feature": beta_feature,
+    # Per-step next-token perplexity. Note: this is mean(exp(per-step CE)), not
+    # exp(window-CE-mean) — close to true perplexity in steady state. For the exact
+    # perplexity over a logging window compute exp(distill/hard_loss) on the TB side.
+    teacher_loss_mean = ce_teacher_sum / safe_count
+    student_perplexity_step = jnp.exp(jnp.minimum(hard_loss_mean, _PPL_CE_CAP))
+    teacher_perplexity_step = jnp.exp(jnp.minimum(teacher_loss_mean, _PPL_CE_CAP))
+
+    one = jnp.array(1.0, dtype=jnp.float32)
+    metrics: dict[str, tuple[jax.Array, jax.Array]] = {
+        # Token-weighted: emit (sum, valid_count) so multi-host averaging is unbiased.
+        "distill/soft_loss": (soft_loss_sum_scaled, valid_count),
+        "distill/hard_loss": (ce_student_sum, valid_count),
+        "distill/teacher_loss": (ce_teacher_sum, valid_count),
+        # Next-token prediction perplexity (per-step approximation of exp(hard_loss)).
+        # The headline `_train_perplexity` Tunix prints is exp(total_loss) which for
+        # distillation is exp(α·soft + (1-α)·hard + β·feature) and NOT next-token PPL.
+        "distill/student_perplexity": (student_perplexity_step, one),
+        "distill/teacher_perplexity": (teacher_perplexity_step, one),
+        # KL at the current (scheduled) temperature T, without the T^2 scaling
+        # that soft_loss applies. Pair with kl_div_T1 to compare T vs T=1.
+        "distill/kl_div_at_T": (kl_softened_sum, valid_count),
+        # KL at T=1: comparable across runs / annealing schedules.
+        "distill/kl_div_T1": (kl_t1_sum, valid_count),
+        # Per-step quantities: (value, 1.0) so the aggregator yields a simple mean over steps.
+        "distill/out_proj_feature_loss": (feature_loss, one),
+        "distill/total_loss": (total_loss, one),
+        "distill/temperature": (temperature, one),
+        "distill/alpha": (alpha, one),
+        "distill/beta_feature": (beta_feature, one),
     }
     return total_loss, metrics
 
@@ -498,19 +556,23 @@ class CombinedDistillationStrategy(DistillationStrategy):
       self,
       student_output: DistillationForwardOutput,
       labels: jax.Array,
-  ) -> tuple[jax.Array, dict[str, jax.Array]]:
-    """Computes Eval Loss and returns empty aux dict (required for consistency)."""
-    # Parent logic for task loss
-    # We re-implement simple CE here to ensure float32 casting
+  ) -> tuple[jax.Array, dict[str, tuple[jax.Array, jax.Array]]]:
+    """Computes Eval Loss. Returns (loss, metrics) with (sum, count) metric pairs."""
     s_logits = student_output.logits.astype(jnp.float32)
 
-    labels_mask = jnp.any(labels != 0, axis=-1, keepdims=True)
-    mean_mask = jnp.squeeze(labels_mask, axis=-1)
-    ce_loss = optax.softmax_cross_entropy(logits=s_logits, labels=labels, where=labels_mask)
-    task_loss = jnp.mean(ce_loss, where=mean_mask)
+    mask = jnp.any(labels != 0, axis=-1).astype(jnp.float32)
+    valid_count = jnp.sum(mask)
+    safe_count = jnp.maximum(valid_count, 1.0)
 
-    # Must return a tuple because _has_aux=True expects it
-    return task_loss, {}
+    ce_per_pos = optax.softmax_cross_entropy(logits=s_logits, labels=labels)
+    ce_sum = jnp.sum(ce_per_pos * mask)
+    task_loss = ce_sum / safe_count
+
+    metrics = {
+        "eval/hard_loss": (ce_sum, valid_count),
+        "eval/student_perplexity": (jnp.exp(jnp.minimum(task_loss, _PPL_CE_CAP)), jnp.array(1.0, dtype=jnp.float32)),
+    }
+    return task_loss, metrics
 
   def create_labels(self, targets, targets_segmentation=None, **kwargs):
     """Converts integer targets to masked one-hot vectors for hard label loss."""
@@ -574,11 +636,13 @@ class MaxTextCheckpointManager(tunix_checkpoint_manager.CheckpointManager):
     if not force and not self._checkpoint_manager.should_save(step):
       return False
 
-    # Standard Tunix Logic for Model/Optimizer
+    # Standard Tunix Logic for Model/Optimizer.
+    # Accept either a ModelBundle (common path) or a plain nnx module.
+    target_model = getattr(model, "student_model", model)
     if save_only_lora_params:
-      params = nnx.state(model.student_model, nnx.LoRAParam)
+      params = nnx.state(target_model, nnx.LoRAParam)
     else:
-      params = nnx.state(model.student_model)
+      params = nnx.state(target_model)
 
     # Define standard SaveArgs once to reuse
     default_save_args = checkpoint.SaveArgs()
@@ -625,71 +689,27 @@ class MaxTextCheckpointManager(tunix_checkpoint_manager.CheckpointManager):
       optimizer: Any = None,
       restore_only_lora_params: bool = False,
   ) -> tuple[int, dict[str, Any]]:
-    """Restores model and optimizer state if a checkpoint exists, using correct sharding specs.
+    """Restores model + optimizer by delegating to upstream Tunix.
 
-    This method checks for the latest available checkpoint. If found, it restores the
-    model parameters and optionally the optimizer state in-place. It automatically
-    maps the parameter's `sharding` attributes to Orbax restore arguments to ensure
-    the tensors are placed on the correct device meshes.
-
-    Args:
-      model: The model to restore. If a `ModelBundle` is provided, it automatically
-        extracts and restores only the `student_model`.
-      optimizer: The optimizer state to restore. If None, optimizer restoration is skipped.
-      restore_only_lora_params: If True, restricts restoration to parameters marked
-        as `nnx.LoRAParam`.
+    Unwraps `ModelBundle` if present (we only restore `student_model`).
 
     Returns:
-      A tuple containing the restored step number (0 if no checkpoint was found)
-      and a dictionary of custom metadata.
+      (restored step, custom_metadata dict). Step is 0 if no checkpoint exists.
     """
     if self._checkpoint_manager is None:
       return 0, {}
 
-    step = self._checkpoint_manager.latest_step()
-    if step is None:
-      return 0, {}
-
-    max_logging.log(f"Restoring from checkpoint step {step}...")
-
-    # Extract student model safely
     target_model = getattr(model, "student_model", model)
 
-    if restore_only_lora_params:
-      params = nnx.state(target_model, nnx.LoRAParam)
-    else:
-      params = nnx.state(target_model)
-
-    def map_to_pspec(data):
-      if hasattr(data, "sharding"):
-        return checkpoint.type_handlers.ArrayRestoreArgs(sharding=data.sharding)
-      return None
-
-    restore_args = jax.tree.map(map_to_pspec, params)
-
-    cp_restore_args = {
-        "model_params": checkpoint.args.PyTreeRestore(
-            item=params,
-            restore_args=restore_args,
-        )
-    }
-
-    if optimizer is not None:
-      optimizer_state = nnx.state(optimizer, nnx.optimizer.OptState)
-      opt_restore_args = jax.tree.map(map_to_pspec, optimizer_state)
-      cp_restore_args["optimizer_state"] = checkpoint.args.PyTreeRestore(
-          item=optimizer_state,
-          restore_args=opt_restore_args,
-      )
-
-    restored = self._checkpoint_manager.restore(
-        step,
-        args=checkpoint.args.Composite(**cp_restore_args),
+    step, _ = super().maybe_restore(
+        model=target_model,
+        optimizer=optimizer,
+        restore_only_lora_params=restore_only_lora_params,
     )
+    if step == 0:
+      return 0, {}
 
-    nnx.update(target_model, restored.model_params)
-    if optimizer is not None:
-      nnx.update(optimizer, restored.optimizer_state)
+    max_logging.log(f"Restored from checkpoint step {step}.")
 
     metadata = self._checkpoint_manager.metadata(step)
     if metadata and hasattr(metadata, "custom_metadata") and metadata.custom_metadata is not None:

--- a/src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh
+++ b/src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh
@@ -1,0 +1,359 @@
+#!/bin/bash
+#
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Reference launcher for MaxText distillation on a GKE TPU cluster via XPK.
+# Treat this as a starting template — copy it, adapt the env vars and
+# `--command` body for your cluster + run, and submit from CI / a tmux / screen.
+#
+# The script expects a base image at $XPK_BASE_IMAGE. Build the MaxText base
+# with:
+#   sudo bash src/dependencies/scripts/docker_build_dependency_image.sh \
+#     MODE=stable WORKFLOW=post-training
+#
+# Then layer tunix on top via `prep_image` (below). We install tunix WITH deps
+# (it needs google-metrax + kagglehub at runtime) and then force-reinstall
+# jax/jaxlib/libtpu back to versions compatible with the base image's libtpu.
+#
+# Usage:
+#   bash src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh prep_image          # one-time image layering
+#   bash src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh submit             # fire-and-forget; returns in ~60s
+#   bash src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh monitor            # stream logs for the last submit
+#   bash src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh resume_until_done  # auto-retry loop for long jobs
+#
+# Reading logs on-demand:
+#   - GCP Logs Explorer URL that XPK prints at submit time (best for searching/filtering).
+#   - `kubectl logs <pod> -c jax-tpu-1 --tail=100`  for a quick ad-hoc look.
+#   - `kubectl logs <pod> --previous`               for a crashed container's last lines.
+#
+# Watch pod state changes (restarts, failures) in the background:
+#   nohup kubectl get pods -l jobset.sigs.k8s.io/jobset-name=$XPK_WORKLOAD --watch \
+#       > ~/distill-events.log 2>&1 &
+#   disown
+#   # Then: grep -iE 'error|crashloop|restart' ~/distill-events.log
+#
+# Restart policy (three layers):
+#   L1 pod-level     GKE restarts a crashed pod automatically; the trainer resumes
+#                    from the latest checkpoint via `maybe_restore` — no action needed.
+#   L2 workload-level when the whole JobSet terminates, `resume_until_done` deletes + re-submits
+#                    with the same XPK_WORKLOAD/XPK_BASE_OUTPUT_DIR (checkpoint resume, again).
+#   L3 human          `resume_until_done` exits non-zero after MAX_RETRIES; page yourself from there.
+#
+# REQUIRED env vars (no defaults; the script exits with an error if unset):
+#   XPK_CLUSTER          GKE cluster name
+#   XPK_PROJECT          GCP project hosting the cluster
+#   XPK_ZONE             cluster zone (e.g. us-central1-a)
+#   XPK_DEVICE_TYPE      e.g. tpu7x-4x4x4, v5p-128
+#   XPK_BASE_OUTPUT_DIR  GCS prefix for run outputs (each run writes to
+#                        ${XPK_BASE_OUTPUT_DIR}/${XPK_WORKLOAD}/)
+#
+# OPTIONAL env vars (with defaults):
+#   XPK_BASE_IMAGE       default: maxtext_base_image
+#   XPK_WORKLOAD         default: distill-${USER}-${RANDOM}
+#   XPK_PRIORITY         default: medium
+#   XPK_NUM_SLICES       default: 1
+#   XPK_DISTILL_CONFIG   default: src/maxtext/configs/post_train/distillation.yml
+#   XPK_RUN_NAME         default: distill_run — passed as MaxText run_name; becomes
+#                        the subdir under base_output_directory where checkpoints
+#                        and TB logs land (...${OUTPUT_DIR}/${XPK_RUN_NAME}/...).
+#                        resume_until_done lists this subdir to find the latest step.
+#   XPK_USE_GCSFUSE      default: 0 — if 1, mount XPK_DATASET_BUCKET via gcsfuse
+#                        and override grain_train_files to the local mount path
+#                        (useful for ArrayRecord; gs:// paths are slower)
+#   XPK_DATASET_BUCKET   default: maxtext-dataset (only used when XPK_USE_GCSFUSE=1)
+#   XPK_DATASET_SUBPATH  default: array-record/climbmix/*.arrayrecord
+#                        (relative to the bucket; only used when XPK_USE_GCSFUSE=1)
+#   STEPS_OVERRIDE       default: empty — yml `steps` is used unless set
+#   CHECKPOINT_PERIOD_OVERRIDE  default: empty — yml `checkpoint_period` is used
+#   MAX_RETRIES          default: 10 — only used by resume_until_done
+#
+# Feature-mapping / distillation loss hyperparameters (always passed to the
+# trainer; override yml values). Defaults enable feature mapping on the first
+# 8 layers. Set DISTILL_BETA=0.0 to disable feature mapping.
+#   DISTILL_ALPHA          default: 0.5
+#   DISTILL_TEMPERATURE    default: 1.0
+#   DISTILL_BETA           default: 1.0   (>0 enables feature-map loss;
+#                          requires scan_layers=True and enable_nnx=True)
+#   DISTILL_LAYER_INDICES  default: [0,1,2,3,4,5,6,7]  (no spaces inside brackets)
+#
+# Image pinning (used by prep_image):
+#   TUNIX_SOURCE  pip-installable spec for tunix.
+#                 default: git+https://github.com/google/tunix@110932a8395086511228483312131841521695c1
+#                 Use "google-tunix==<ver>" once a pypi release ships with the
+#                 multi-host shard_input fix.
+#   JAX_PIN       default: 0.9.2  — version to pin back after tunix deps resolve.
+#   JAXLIB_PIN    default: 0.9.2
+#   LIBTPU_PIN    default: 0.0.37
+#
+# Resume on failure:
+#   `resume_until_done` reuses the same XPK_BASE_OUTPUT_DIR/XPK_WORKLOAD across
+#   restarts, so the trainer auto-restores from the latest checkpoint each time.
+
+set -euo pipefail
+MODE="${1:-submit}"
+
+# -------------------------- required env --------------------------
+# Collects all missing vars so the user fixes them in one pass, not N runs.
+# Not called for `prep_image` — that mode only needs XPK_BASE_IMAGE + TUNIX_SOURCE
+# + JAX_PIN family, all of which have defaults.
+require_env() {
+  local missing=()
+  for v in "$@"; do
+    [ -z "${!v:-}" ] && missing+=("$v")
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "ERROR: required env vars not set: ${missing[*]}" >&2
+    echo "See this script's header for descriptions and example values." >&2
+    exit 1
+  fi
+}
+
+# -------------------------- defaults --------------------------
+: "${XPK_BASE_IMAGE:=maxtext_base_image}"
+: "${XPK_WORKLOAD:=distill-${USER:-anon}-${RANDOM}}"
+: "${XPK_PRIORITY:=medium}"
+: "${XPK_NUM_SLICES:=1}"
+: "${XPK_DISTILL_CONFIG:=src/maxtext/configs/post_train/distillation.yml}"
+: "${XPK_RUN_NAME:=distill_run}"
+: "${XPK_USE_GCSFUSE:=0}"
+: "${XPK_DATASET_BUCKET:=maxtext-dataset}"
+: "${XPK_DATASET_SUBPATH:=array-record/climbmix/*.arrayrecord}"
+: "${MAX_RETRIES:=10}"
+
+# Feature-mapping / distillation loss hyperparameters.
+: "${DISTILL_ALPHA:=0.5}"
+: "${DISTILL_TEMPERATURE:=1.0}"
+: "${DISTILL_BETA:=1.0}"
+: "${DISTILL_LAYER_INDICES:=[0,1,2,3,4,5,6,7]}"
+
+# Image pinning (used by prep_image).
+: "${TUNIX_SOURCE:=git+https://github.com/google/tunix@110932a8395086511228483312131841521695c1}"
+: "${JAX_PIN:=0.9.2}"
+: "${JAXLIB_PIN:=0.9.2}"
+: "${LIBTPU_PIN:=0.0.37}"
+
+# Computed at top-level so both submit_workload and resume_until_done can read it.
+# `${:-}` keeps `set -u` happy for `prep_image`, which doesn't need XPK_BASE_OUTPUT_DIR.
+OUTPUT_DIR="${XPK_BASE_OUTPUT_DIR:-}"
+OUTPUT_DIR="${OUTPUT_DIR%/}/${XPK_WORKLOAD}"
+# Default to $HOME, not /tmp: when `submit` is invoked under `sudo -E` (needed
+# so xpk can reach the docker daemon), some environments refuse bash redirects
+# from root to pre-existing user-owned files in /tmp. $HOME avoids that class
+# of failure. Override XPK_LAST_WORKLOAD_FILE if you want a different path.
+LAST_WORKLOAD_FILE="${XPK_LAST_WORKLOAD_FILE:-${HOME}/.xpk_last_workload}"
+
+# CLI overrides for the trainer. The distillation hyperparameters always
+# flow through so the values in this script are the source of truth; the
+# step / checkpoint_period overrides only apply when the env var is set.
+extra_cli="distill_alpha=${DISTILL_ALPHA} \
+distill_temperature=${DISTILL_TEMPERATURE} \
+distill_beta=${DISTILL_BETA} \
+distill_layer_indices=${DISTILL_LAYER_INDICES} \
+enable_nnx=True"
+if [ -n "${STEPS_OVERRIDE:-}" ]; then
+  extra_cli="$extra_cli learning_rate_schedule_steps=${STEPS_OVERRIDE} steps=${STEPS_OVERRIDE}"
+fi
+if [ -n "${CHECKPOINT_PERIOD_OVERRIDE:-}" ]; then
+  extra_cli="$extra_cli checkpoint_period=${CHECKPOINT_PERIOD_OVERRIDE}"
+fi
+
+# Optional gcsfuse prelude — direct gs:// reads of ArrayRecord shards are slow,
+# so mounting the bucket and pointing grain at the local path is recommended.
+gcsfuse_prelude=""
+grain_files_override=""
+if [ "$XPK_USE_GCSFUSE" = "1" ]; then
+  gcsfuse_prelude="bash src/dependencies/scripts/setup_gcsfuse.sh \
+    DATASET_GCS_BUCKET=${XPK_DATASET_BUCKET} MOUNT_PATH=/tmp/gcsfuse;"
+  grain_files_override="grain_train_files=/tmp/gcsfuse/${XPK_DATASET_SUBPATH}"
+fi
+
+# -------------------------- prep_image --------------------------
+# Adds tunix and repins jax/libtpu on top of $XPK_BASE_IMAGE, then retags
+# the result as $XPK_BASE_IMAGE (the original tag is overwritten).
+# Safe to re-run: pins are force-reinstalled, but layers accumulate.
+# To reset to a clean base, rebuild via docker_build_dependency_image.sh.
+prep_image() {
+  echo "== layering on ${XPK_BASE_IMAGE} =="
+  echo "  tunix   : ${TUNIX_SOURCE}"
+  echo "  jax     : ${JAX_PIN}"
+  echo "  jaxlib  : ${JAXLIB_PIN}"
+  echo "  libtpu  : ${LIBTPU_PIN}"
+  if ! sudo docker image inspect "$XPK_BASE_IMAGE" >/dev/null 2>&1; then
+    echo "ERROR: base image $XPK_BASE_IMAGE not found locally. Build it first:" >&2
+    echo "  sudo bash src/dependencies/scripts/docker_build_dependency_image.sh MODE=stable WORKFLOW=post-training" >&2
+    exit 1
+  fi
+  local tmp; tmp=$(mktemp -d)
+  cat > "$tmp/Dockerfile" <<EOF
+FROM $XPK_BASE_IMAGE
+# 1. Install tunix WITH deps (google-metrax + kagglehub are runtime requirements).
+RUN pip install --no-cache-dir --force-reinstall "$TUNIX_SOURCE"
+# 2. Repin jax/libtpu so the image's libtpu and the installed jax stay compatible.
+RUN pip install --no-cache-dir --force-reinstall --no-deps \\
+      "jax==$JAX_PIN" "jaxlib==$JAXLIB_PIN" "libtpu==$LIBTPU_PIN"
+EOF
+  sudo docker build -t "$XPK_BASE_IMAGE" -f "$tmp/Dockerfile" "$tmp"
+  rm -rf "$tmp"
+  # Sanity check: verify the installed shard_input carries the upstream fix.
+  sudo docker run --rm "$XPK_BASE_IMAGE" python -c "
+import inspect, tunix
+from tunix.sft import sharding_utils
+src = inspect.getsource(sharding_utils.shard_input)
+assert 'is_fully_addressable' in src, 'tunix install does not contain the shard_input fix'
+print(f'tunix {tunix.__version__}: shard_input fix present.')
+"
+}
+
+# -------------------------- submit --------------------------
+submit_workload() {
+  echo "Workload:    $XPK_WORKLOAD"
+  echo "Cluster:     $XPK_CLUSTER ($XPK_PROJECT, $XPK_ZONE)"
+  echo "Device:      $XPK_DEVICE_TYPE x ${XPK_NUM_SLICES} slice(s)"
+  echo "Base image:  $XPK_BASE_IMAGE"
+  echo "Output dir:  $OUTPUT_DIR"
+  echo "Config:      $XPK_DISTILL_CONFIG"
+  [ -n "$extra_cli" ] && echo "Overrides:  $extra_cli"
+
+  xpk workload create \
+    --cluster "$XPK_CLUSTER" \
+    --workload "$XPK_WORKLOAD" \
+    --priority="$XPK_PRIORITY" \
+    --tpu-type="$XPK_DEVICE_TYPE" \
+    --num-slices="$XPK_NUM_SLICES" \
+    --project="$XPK_PROJECT" \
+    --zone="$XPK_ZONE" \
+    --base-docker-image="$XPK_BASE_IMAGE" \
+    --command "export PYTHONPATH=/app/src; \
+export BASE_OUTPUT_DIRECTORY=${OUTPUT_DIR}; \
+${gcsfuse_prelude} \
+python3 -m maxtext.trainers.post_train.distillation.train_distill ${XPK_DISTILL_CONFIG} \
+  run_name=${XPK_RUN_NAME} \
+  base_output_directory=\$BASE_OUTPUT_DIRECTORY \
+  ${grain_files_override} \
+  ${extra_cli} \
+  save_checkpoint_on_completion=True"
+
+  echo "$XPK_WORKLOAD" > "$LAST_WORKLOAD_FILE"
+}
+
+# -------------------------- monitor --------------------------
+# Streams kubectl logs for the most recently submitted workload (or pass
+# the workload name as the second arg).
+monitor_workload() {
+  local workload="${2:-$(cat "$LAST_WORKLOAD_FILE" 2>/dev/null || true)}"
+  if [ -z "$workload" ]; then
+    echo "ERROR: no workload to monitor (none recorded in $LAST_WORKLOAD_FILE)." >&2
+    exit 1
+  fi
+  echo "Monitoring $workload"
+
+  # Wait for any pod to reach Running, but bail if all pods finish without ever running.
+  while true; do
+    local phases
+    phases=$(kubectl get pods -l "jobset.sigs.k8s.io/jobset-name=${workload}" \
+              -o jsonpath='{.items[*].status.phase}' 2>/dev/null || echo "")
+    if echo "$phases" | grep -q Running; then break; fi
+    if [ -n "$phases" ] && ! echo "$phases" | grep -qE "Pending|ContainerCreating"; then
+      echo "No Running pod; phases: $phases"
+      local one
+      one=$(kubectl get pods -l "jobset.sigs.k8s.io/jobset-name=${workload}" \
+            -o name 2>/dev/null | head -1)
+      [ -n "$one" ] && kubectl logs "$one" --all-containers 2>&1 | tail -40
+      exit 1
+    fi
+    echo "waiting for Running (phases: ${phases:-none})..."; sleep 15
+  done
+
+  local n
+  n=$(kubectl get pods -l "jobset.sigs.k8s.io/jobset-name=${workload}" -o name | wc -l)
+  local max=$((n * 4))   # raise above 2 × num_pods (each pod has 2 containers)
+  local out_log="${HOME}/training-${workload}.log"
+  echo "Streaming logs from $n pods (--max-log-requests=${max}) → ${out_log}"
+  kubectl logs -f -l "jobset.sigs.k8s.io/jobset-name=${workload}" \
+    --all-containers --max-log-requests="$max" --prefix \
+    2>&1 | tee "$out_log"
+}
+
+# -------------------------- resume_until_done --------------------------
+# Auto-resubmit loop. Each iteration submits with the SAME XPK_WORKLOAD +
+# OUTPUT_DIR, so the trainer auto-restores from the latest checkpoint.
+# Exits when the latest checkpoint reaches STEPS_OVERRIDE or MAX_RETRIES.
+resume_until_done() {
+  if [ -z "${STEPS_OVERRIDE:-}" ]; then
+    echo "ERROR: STEPS_OVERRIDE must be set so the loop knows when to stop." >&2
+    exit 1
+  fi
+  local target="$STEPS_OVERRIDE"
+  local retry=0
+
+  while [ "$retry" -lt "$MAX_RETRIES" ]; do
+    echo "=== resume attempt $((retry + 1)) / $MAX_RETRIES (target steps: $target) ==="
+    submit_workload
+
+    while true; do
+      sleep 60
+      local terminal
+      terminal=$(kubectl get jobset "$XPK_WORKLOAD" \
+        -o jsonpath='{.status.terminalState}' 2>/dev/null || echo "")
+      if [ -n "$terminal" ]; then
+        echo "Workload $XPK_WORKLOAD reached terminal state: $terminal"
+        break
+      fi
+    done
+
+    # latest checkpoint step on disk (subdirs named after the step number)
+    local last_step
+    last_step=$(gcloud storage ls "${OUTPUT_DIR}/${XPK_RUN_NAME}/checkpoints/" 2>/dev/null \
+                 | grep -oE '/[0-9]+/$' | tr -d '/' | sort -n | tail -1)
+    last_step=${last_step:-0}
+    echo "Latest checkpoint step on disk: ${last_step}"
+
+    if [ "$last_step" -ge "$target" ]; then
+      echo "Reached target step ${target}. Done."
+      return 0
+    fi
+
+    # Free the workload name so we can resubmit with the same name.
+    xpk workload delete --workload="$XPK_WORKLOAD" \
+      --cluster="$XPK_CLUSTER" --project="$XPK_PROJECT" --zone="$XPK_ZONE" --force \
+      >/dev/null 2>&1 || true
+
+    retry=$((retry + 1))
+    echo "Resubmitting from step ${last_step} (attempt $((retry + 1))/${MAX_RETRIES}) in 60s..."
+    sleep 60
+  done
+
+  echo "ERROR: max_retries=${MAX_RETRIES} reached without completing ${target} steps." >&2
+  return 1
+}
+
+# -------------------------- dispatch --------------------------
+case "$MODE" in
+  prep_image)
+    prep_image
+    ;;
+  submit|monitor|resume_until_done)
+    require_env XPK_CLUSTER XPK_PROJECT XPK_ZONE XPK_DEVICE_TYPE XPK_BASE_OUTPUT_DIR
+    case "$MODE" in
+      submit)            submit_workload ;;
+      monitor)           monitor_workload "$@" ;;
+      resume_until_done) resume_until_done ;;
+    esac
+    ;;
+  *)
+    echo "Unknown mode: $MODE (use prep_image|submit|monitor|resume_until_done)" >&2
+    exit 1
+    ;;
+esac

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -41,7 +41,6 @@ from flax import nnx
 from flax.linen import partitioning as nn_partitioning
 import jax
 import jax.numpy as jnp
-import numpy as np
 import optax
 from orbax import checkpoint
 
@@ -247,24 +246,7 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
       # Fallback if source code is unavailable
       pass
 
-  def _shard_optimizer(self, mesh: jax.sharding.Mesh) -> None:
-    """Overrides base _shard_optimizer to safely shard restored scalars.
-
-    This is necessary because the optimizer state restored from checkpoints may contain unsharded
-    scalars (e.g., Adam moments).
-    """
-    if mesh.empty:
-      return
-    optimizer_state = nnx.state(self.optimizer, nnx.optimizer.OptState)
-    optimizer_pspecs = nnx.get_partition_spec(optimizer_state)
-
-    def _safe_shard(x, pspec):
-      if isinstance(pspec, jax.sharding.PartitionSpec):
-        return jax.device_put(x, jax.sharding.NamedSharding(mesh, pspec))
-      return x
-
-    optimizer_sharded_state = jax.tree.map(_safe_shard, optimizer_state, optimizer_pspecs)
-    nnx.update(self.optimizer, optimizer_sharded_state)
+  # Inherits _shard_optimizer from PeftTrainer.
 
   def _train_step(self, model, optimizer, inputs):
     """Overrides the main JIT block to natively handle ModelBundle module."""
@@ -368,18 +350,20 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
         top_k_indices=input_data.top_k_indices,
     )
 
-  def _post_process_train_step(self, aux: dict[str, jax.Array]) -> None:
-    """Extracts auxiliary metrics from the strategy and buffers them for logging."""
+  def _post_process_train_step(self, aux: dict[str, tuple[jax.Array, jax.Array]]) -> None:
+    """Buffers (sum, count) metrics from the strategy for token-weighted logging.
+
+    `compute_loss` returns each metric as a (sum, count) pair. We store the pair
+    in the metrics buffer and use `weighted_mean` as the aggregator so the final
+    logged value is `sum(sums) / sum(counts)` — unbiased across hosts and across
+    logging windows even when valid-token counts vary per step.
+    """
     if self._buffered_train_metrics is None:
       return
 
-    # 'aux' contains the dictionary we returned from compute_loss:
-    # {"distill/soft_loss": ..., "distill/hard_loss": ...}
     for name, value in aux.items():
-      # We accumulate these values. PeftTrainer handles the averaging.
-      # The structure expected is: dict[metric_name, (list_of_values, aggregation_fn)]
       if name not in self._buffered_train_metrics.additional_metrics:
-        self._buffered_train_metrics.additional_metrics[name] = ([], np.mean)
+        self._buffered_train_metrics.additional_metrics[name] = ([], distillation_utils.weighted_mean)
 
       self._buffered_train_metrics.additional_metrics[name][0].append(value)
 

--- a/tests/post_training/unit/distillation_metrics_test.py
+++ b/tests/post_training/unit/distillation_metrics_test.py
@@ -1,0 +1,434 @@
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Unit tests for distillation metrics.
+
+Covers:
+  - KL direction (forward KL = teacher || student)
+  - KL self-equivalence (KL(p || p) == 0 at any temperature)
+  - Cross-entropy / perplexity numerics
+  - (sum, count) aggregator is unbiased under uneven masks
+  - Sharded (multi-device) verification of the same property
+  - Label mask correctness for pad_id == 0 and pad_id != 0
+  - T^2 scaling of soft loss
+  - Feature-mapping loss (beta > 0 path) and layer_indices slicing
+"""
+
+import pytest
+
+pytest.importorskip("optax")
+pytest.importorskip("tunix")
+
+pytestmark = [pytest.mark.cpu_only, pytest.mark.post_training]
+
+import unittest
+from typing import List, Optional
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from absl.testing import absltest
+from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
+
+from maxtext.trainers.post_train.distillation import distillation_utils
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_strategy(
+    vocab_size: int,
+    pad_id: int = 0,
+    temperature: float = 1.0,
+    alpha: float = 0.5,
+    beta_feature: float = 0.0,
+    layer_indices: Optional[List[int]] = None,
+):
+  """Builds a CombinedDistillationStrategy with no-op forward fns (we feed outputs directly)."""
+
+  def noop(*_args, **_kwargs):
+    return None
+
+  return distillation_utils.CombinedDistillationStrategy(
+      student_forward_fn=noop,
+      teacher_forward_fn=noop,
+      pad_id=pad_id,
+      temperature=temperature,
+      alpha=alpha,
+      beta_feature=beta_feature,
+      layer_indices=layer_indices,
+      vocab_size=vocab_size,
+      max_steps=1,
+  )
+
+
+def _one_hot_labels(targets: jnp.ndarray, vocab_size: int, pad_id: int = 0) -> jnp.ndarray:
+  one_hot = jax.nn.one_hot(targets, vocab_size)
+  mask = jnp.not_equal(targets, pad_id).astype(one_hot.dtype)[..., None]
+  return one_hot * mask
+
+
+def _mean(pair):
+  """Unpacks a (sum, count) metric tuple into a mean value."""
+  s, c = pair
+  c_val = float(c)
+  return float(s) / c_val if c_val > 0 else float(s)
+
+
+def _has_4_devices() -> bool:
+  return len(jax.devices()) >= 4
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class DistillationMetricsTest(unittest.TestCase):
+  """Unit tests for CombinedDistillationStrategy metrics."""
+
+  # --- 1. KL direction --------------------------------------------------
+
+  def test_kl_direction_matches_forward_kl_teacher_student(self):
+    """optax.kl_divergence(log_pred, target) == KL(target || pred). We use it
+    with log_pred=log_student, target=teacher_probs => KL(teacher || student)."""
+    rng = np.random.default_rng(0)
+    vocab_size = 8
+    s_logits = jnp.asarray(rng.normal(size=(1, 1, vocab_size)).astype(np.float32))
+    t_logits = jnp.asarray(rng.normal(size=(1, 1, vocab_size)).astype(np.float32))
+
+    log_s = jax.nn.log_softmax(s_logits, axis=-1)
+    t_p = jax.nn.softmax(t_logits, axis=-1)
+    optax_kl = float(optax.kl_divergence(log_s, t_p)[0, 0])
+
+    # Reference: forward KL(teacher || student) = sum_i t_i (log t_i - log s_i)
+    log_t = np.log(np.asarray(t_p[0, 0]) + 1e-30)
+    ref_fwd = float(np.sum(np.asarray(t_p[0, 0]) * (log_t - np.asarray(log_s[0, 0]))))
+    np.testing.assert_allclose(optax_kl, ref_fwd, rtol=1e-5, atol=1e-6)
+
+    # Reverse KL(student || teacher) should NOT match — assert we didn't
+    # accidentally compute it in the wrong direction.
+    s_p = jax.nn.softmax(s_logits, axis=-1)
+    log_t_jax = jax.nn.log_softmax(t_logits, axis=-1)
+    ref_rev = float(np.sum(np.asarray(s_p[0, 0]) * (np.asarray(log_s[0, 0]) - np.asarray(log_t_jax[0, 0]))))
+    self.assertFalse(np.isclose(ref_fwd, ref_rev, atol=1e-3), "test logits chosen badly: fwd == rev KL")
+
+  def test_kl_self_distillation_is_zero_at_any_temperature(self):
+    """KL(p || p) == 0; with student==teacher logits, soft_loss must be 0 at any T."""
+    vocab_size, batch_size, seq_len = 8, 2, 3
+    rng = np.random.default_rng(1)
+    logits = jnp.asarray(rng.normal(size=(batch_size, seq_len, vocab_size)).astype(np.float32))
+    out = distillation_utils.DistillationForwardOutput(logits=logits, out_projection_activations=None)
+    targets = jnp.array([[1, 2, 3], [4, 5, 6]], dtype=jnp.int32)
+    labels = _one_hot_labels(targets, vocab_size)
+
+    for temperature in [0.5, 1.0, 2.0, 8.0]:
+      strategy = _make_strategy(vocab_size, temperature=temperature, alpha=1.0)  # alpha=1 -> total = soft only
+      total_loss, metrics = strategy.compute_loss(out, out, labels, step=None)
+      # Float32 KL on numerically equal log_softmax outputs is ~1e-5; allow a bit of slack.
+      np.testing.assert_allclose(float(total_loss), 0.0, atol=1e-4)
+      soft_sum, _ = metrics["distill/soft_loss"]
+      np.testing.assert_allclose(float(soft_sum), 0.0, atol=1e-3)
+
+  # --- 2. Perplexity / CE numerics --------------------------------------
+
+  def test_hard_loss_matches_manual_cross_entropy_and_perplexity_relation(self):
+    vocab_size = 4
+    s_logits = jnp.array([[[2.0, 1.0, 0.5, 0.1], [0.0, 3.0, 1.0, 0.5]]], dtype=jnp.float32)
+    # Target token 0 is the pad_id so it would be masked. Use non-zero targets.
+    targets = jnp.array([[3, 1]], dtype=jnp.int32)
+    labels = _one_hot_labels(targets, vocab_size, pad_id=0)
+    out = distillation_utils.DistillationForwardOutput(logits=s_logits, out_projection_activations=None)
+
+    strategy = _make_strategy(vocab_size, pad_id=0, alpha=0.0)  # alpha=0 -> total = hard only
+    total_loss, metrics = strategy.compute_loss(out, out, labels, step=None)
+
+    log_p = jax.nn.log_softmax(s_logits, axis=-1)
+    manual_ce = -float(log_p[0, 0, 3] + log_p[0, 1, 1]) / 2.0
+    np.testing.assert_allclose(float(total_loss), manual_ce, rtol=1e-5)
+
+    # Perplexity sanity: exp(hard_loss) finite and >= 1 for non-degenerate logits.
+    ppl = float(np.exp(_mean(metrics["distill/hard_loss"])))
+    self.assertGreaterEqual(ppl, 1.0)
+    self.assertTrue(np.isfinite(ppl))
+
+  # --- 3. Label mask: pad_id == 0 and pad_id != 0 -----------------------
+
+  def test_label_mask_excludes_pad_tokens_pad0(self):
+    self._run_label_mask_excludes_pad(pad_id=0)
+
+  def test_label_mask_excludes_pad_tokens_pad7(self):
+    self._run_label_mask_excludes_pad(pad_id=7)
+
+  def _run_label_mask_excludes_pad(self, pad_id):
+    """Asserts pad positions are zeroed in labels and excluded from hard loss."""
+    vocab_size = 8
+    strategy = _make_strategy(vocab_size, pad_id=pad_id, alpha=0.0)
+    # second token is padding
+    targets = jnp.array([[1, pad_id]], dtype=jnp.int32)
+    labels = strategy.create_labels(targets)
+    # the padded row must be all zeros
+    np.testing.assert_array_equal(np.asarray(labels[0, 1]), np.zeros(vocab_size))
+
+    s_logits = jnp.array([[[5.0, -5.0, 0, 0, 0, 0, 0, 0], [-5.0, 5.0, 0, 0, 0, 0, 0, 0]]], dtype=jnp.float32)
+    out = distillation_utils.DistillationForwardOutput(logits=s_logits, out_projection_activations=None)
+    total_loss, metrics = strategy.compute_loss(out, out, labels, step=None)
+
+    _, hard_cnt = metrics["distill/hard_loss"]
+    np.testing.assert_allclose(float(hard_cnt), 1.0, atol=1e-6)  # only 1 valid token
+    # Total loss must equal CE on token 0 only, ignoring padded position.
+    log_p = jax.nn.log_softmax(s_logits, axis=-1)
+    expected = -float(log_p[0, 0, 1])  # target = 1
+    np.testing.assert_allclose(float(total_loss), expected, rtol=1e-5)
+
+  # --- 4. Temperature^2 scaling of soft loss ----------------------------
+
+  def test_soft_loss_scales_with_temperature_squared_in_high_T_limit(self):
+    """As T grows, soft_loss = T^2 * KL(softmax(t/T) || softmax(s/T)) should
+    approach a finite non-zero value (Hinton scaling). Verify it doesn't collapse to 0."""
+    vocab_size, batch_size, seq_len = 16, 2, 4
+    rng = np.random.default_rng(2)
+    s_logits = jnp.asarray(rng.normal(size=(batch_size, seq_len, vocab_size)).astype(np.float32))
+    t_logits = jnp.asarray(rng.normal(size=(batch_size, seq_len, vocab_size)).astype(np.float32))
+    s_out = distillation_utils.DistillationForwardOutput(logits=s_logits, out_projection_activations=None)
+    t_out = distillation_utils.DistillationForwardOutput(logits=t_logits, out_projection_activations=None)
+    targets = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
+    labels = _one_hot_labels(targets, vocab_size)
+
+    losses = []
+    for temperature in [1.0, 4.0, 16.0]:
+      strategy = _make_strategy(vocab_size, temperature=temperature, alpha=1.0)
+      _, metrics = strategy.compute_loss(s_out, t_out, labels, step=None)
+      losses.append(_mean(metrics["distill/soft_loss"]))
+
+    # All positive and bounded; high-T value should not be drastically smaller than T=1.
+    for value in losses:
+      self.assertGreater(value, 0)
+      self.assertTrue(np.isfinite(value))
+    # T^2 scaling keeps high-T loss within an order of magnitude of T=1 in this regime.
+    self.assertGreater(losses[-1], 0.1 * losses[0])
+
+  def test_kl_T1_metric_is_temperature_invariant_when_logged(self):
+    """distill/kl_div_T1 should be the same regardless of self.temperature."""
+    vocab_size, batch_size, seq_len = 8, 1, 2
+    rng = np.random.default_rng(3)
+    s_logits = jnp.asarray(rng.normal(size=(batch_size, seq_len, vocab_size)).astype(np.float32))
+    t_logits = jnp.asarray(rng.normal(size=(batch_size, seq_len, vocab_size)).astype(np.float32))
+    s_out = distillation_utils.DistillationForwardOutput(logits=s_logits, out_projection_activations=None)
+    t_out = distillation_utils.DistillationForwardOutput(logits=t_logits, out_projection_activations=None)
+    targets = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
+    labels = _one_hot_labels(targets, vocab_size)
+
+    values = []
+    for temperature in [1.0, 4.0, 16.0]:
+      strategy = _make_strategy(vocab_size, temperature=temperature, alpha=1.0)
+      _, metrics = strategy.compute_loss(s_out, t_out, labels, step=None)
+      values.append(_mean(metrics["distill/kl_div_T1"]))
+    np.testing.assert_allclose(values[0], values[1], rtol=1e-5)
+    np.testing.assert_allclose(values[0], values[2], rtol=1e-5)
+
+  # --- 5. (sum, count) aggregator: unbiased under uneven masks ----------
+
+  def test_weighted_mean_aggregator_token_weighted(self):
+    """The aggregator should compute sum(sums) / sum(counts), not mean of per-step means."""
+    pairs = [
+        (jnp.array(8.0), jnp.array(8.0)),  # 8 valid tokens, mean 1.0
+        (jnp.array(5.0), jnp.array(1.0)),  # 1 valid token, value 5.0
+        (jnp.array(8.0), jnp.array(4.0)),  # 4 valid tokens, mean 2.0
+        (jnp.array(8.0), jnp.array(4.0)),  # 4 valid tokens, mean 2.0
+    ]
+    # mean-of-means would be (1+5+2+2)/4 = 2.5 (biased)
+    # token-weighted: 29/17 ≈ 1.7058 (correct)
+    np.testing.assert_allclose(distillation_utils.weighted_mean(pairs), 29.0 / 17.0, rtol=1e-6)
+
+  def test_weighted_mean_aggregator_handles_empty_and_zero_count(self):
+    self.assertEqual(distillation_utils.weighted_mean([]), 0.0)
+    self.assertEqual(distillation_utils.weighted_mean([(jnp.array(0.0), jnp.array(0.0))]), 0.0)
+
+  # --- 6. Multi-device sharded version ----------------------------------
+
+  @unittest.skipIf(not _has_4_devices(), "Requires ≥4 devices.")
+  def test_sum_count_unbiased_under_sharded_uneven_masks(self):
+    """Across 4 devices with wildly different valid-token counts,
+    mean-of-per-device-means is biased; token-weighted (sum/count) is correct."""
+    devices = np.array(jax.devices()[:4])
+    mesh = Mesh(devices, ("data",))
+
+    # Per-device (B=2, T=4). Layout: 4 shards along the data axis.
+    # Device 0: 8 valid tokens, value 1.0  -> per-device mean 1.0
+    # Device 1: 1 valid token,  value 5.0  -> per-device mean 5.0
+    # Device 2: 4 valid tokens, value 2.0  -> per-device mean 2.0
+    # Device 3: 4 valid tokens, value 2.0  -> per-device mean 2.0
+    losses = jnp.array(
+        [
+            [[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]],
+            [[5.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+            [[2.0, 2.0, 2.0, 2.0], [0.0, 0.0, 0.0, 0.0]],
+            [[2.0, 2.0, 2.0, 2.0], [0.0, 0.0, 0.0, 0.0]],
+        ],
+        dtype=jnp.float32,
+    )
+    masks = jnp.array(
+        [
+            [[1, 1, 1, 1], [1, 1, 1, 1]],
+            [[1, 0, 0, 0], [0, 0, 0, 0]],
+            [[1, 1, 1, 1], [0, 0, 0, 0]],
+            [[1, 1, 1, 1], [0, 0, 0, 0]],
+        ],
+        dtype=jnp.float32,
+    )
+
+    sharding = NamedSharding(mesh, P("data"))
+    losses = jax.device_put(losses, sharding)
+    masks = jax.device_put(masks, sharding)
+
+    @jax.jit
+    def biased_mean_of_means(losses, masks):
+      per_dev_sum = jnp.sum(losses * masks, axis=(1, 2))
+      per_dev_cnt = jnp.maximum(jnp.sum(masks, axis=(1, 2)), 1.0)
+      return jnp.mean(per_dev_sum / per_dev_cnt)
+
+    @jax.jit
+    def unbiased_token_weighted(losses, masks):
+      return jnp.sum(losses * masks) / jnp.sum(masks)
+
+    np.testing.assert_allclose(float(biased_mean_of_means(losses, masks)), 2.5, rtol=1e-5)
+    np.testing.assert_allclose(float(unbiased_token_weighted(losses, masks)), 29.0 / 17.0, rtol=1e-5)
+
+  @unittest.skipIf(not _has_4_devices(), "Requires ≥4 devices.")
+  def test_compute_loss_sums_aggregate_correctly_across_shards(self):
+    """Run compute_loss on a sharded batch; verify weighted_mean over per-shard
+    (sum, count) outputs matches the global mean computed on the full batch."""
+    devices = np.array(jax.devices()[:4])
+    mesh = Mesh(devices, ("data",))
+
+    vocab_size, batch_size, seq_len = 8, 4, 4  # B=4 so each shard gets one example
+    rng = np.random.default_rng(7)
+    s_logits = jnp.asarray(rng.normal(size=(batch_size, seq_len, vocab_size)).astype(np.float32))
+    t_logits = jnp.asarray(rng.normal(size=(batch_size, seq_len, vocab_size)).astype(np.float32))
+    # Different valid-token counts per row (shard) to exercise the bias path.
+    targets = jnp.array(
+        [
+            [1, 2, 3, 4],
+            [1, 0, 0, 0],
+            [1, 2, 0, 0],
+            [1, 2, 3, 0],
+        ],
+        dtype=jnp.int32,
+    )
+    labels = _one_hot_labels(targets, vocab_size, pad_id=0)
+
+    strategy = _make_strategy(vocab_size, alpha=0.0)  # hard-loss only for clarity
+    s_out = distillation_utils.DistillationForwardOutput(logits=s_logits, out_projection_activations=None)
+    t_out = distillation_utils.DistillationForwardOutput(logits=t_logits, out_projection_activations=None)
+
+    # Global reference (single-host).
+    _, global_metrics = strategy.compute_loss(s_out, t_out, labels, step=None)
+    global_mean = _mean(global_metrics["distill/hard_loss"])
+
+    # Sharded: compute per-shard (sum, count), aggregate via weighted_mean.
+    sharding = NamedSharding(mesh, P("data"))
+    s_sharded = jax.device_put(s_logits, sharding)
+    t_sharded = jax.device_put(t_logits, sharding)
+    l_sharded = jax.device_put(labels, sharding)
+
+    @jax.jit
+    def per_shard(s_l, t_l, lab):
+      s_o = distillation_utils.DistillationForwardOutput(logits=s_l, out_projection_activations=None)
+      t_o = distillation_utils.DistillationForwardOutput(logits=t_l, out_projection_activations=None)
+      _, m = strategy.compute_loss(s_o, t_o, lab, step=None)
+      return m["distill/hard_loss"]  # (sum, count) — sharded
+
+    shard_sum, shard_cnt = per_shard(s_sharded, t_sharded, l_sharded)
+    # Pull each shard's contribution as if it came from a different host.
+    per_shard_pairs = [
+        (jax.device_get(shard_sum.addressable_shards[i].data), jax.device_get(shard_cnt.addressable_shards[i].data))
+        for i in range(len(devices))
+    ]
+    np.testing.assert_allclose(distillation_utils.weighted_mean(per_shard_pairs), global_mean, rtol=1e-5)
+
+  # --- 7. Feature-mapping loss (beta > 0 path) --------------------------
+
+  def test_feature_loss_zero_when_student_features_match_teacher(self):
+    """With beta>0 and s_features == t_features, distill/out_proj_feature_loss
+    must be 0 (cosine distance of identical vectors). Total loss then equals the
+    base logit loss — verifies the feature path doesn't contribute spurious mass."""
+    vocab_size, batch_size, seq_len, hidden_dim = 4, 1, 2, 8
+    num_layers = 4
+    s_logits = jnp.array([[[2.0, 1.0, 0.5, 0.1], [0.0, 3.0, 1.0, 0.5]]], dtype=jnp.float32)
+    rng = np.random.default_rng(11)
+    features = jnp.asarray(rng.normal(size=(num_layers, batch_size, seq_len, hidden_dim)).astype(np.float32))
+    s_out = distillation_utils.DistillationForwardOutput(logits=s_logits, out_projection_activations=features)
+    t_out = distillation_utils.DistillationForwardOutput(logits=s_logits, out_projection_activations=features)
+
+    targets = jnp.array([[3, 1]], dtype=jnp.int32)
+    labels = _one_hot_labels(targets, vocab_size, pad_id=0)
+
+    strategy = _make_strategy(vocab_size, alpha=0.0, beta_feature=1.0, layer_indices=[0, 2])
+    total_loss, metrics = strategy.compute_loss(s_out, t_out, labels, step=None)
+
+    feat_sum, _ = metrics["distill/out_proj_feature_loss"]
+    np.testing.assert_allclose(float(feat_sum), 0.0, atol=1e-5)
+    # alpha=0 + identical logits + zero feature loss -> total_loss is just hard CE.
+    np.testing.assert_allclose(float(total_loss), _mean(metrics["distill/hard_loss"]), rtol=1e-5)
+
+  def test_feature_loss_positive_when_student_features_differ_and_respects_layer_indices(self):
+    """With beta>0 and s_features != t_features on the sliced layers, feature
+    loss must be > 0; and restricting layer_indices to a subset must yield a
+    different value than using all layers (slice is actually applied)."""
+    vocab_size, batch_size, seq_len, hidden_dim = 4, 1, 2, 8
+    num_layers = 4
+    s_logits = jnp.array([[[2.0, 1.0, 0.5, 0.1], [0.0, 3.0, 1.0, 0.5]]], dtype=jnp.float32)
+    rng = np.random.default_rng(12)
+    s_features = jnp.asarray(rng.normal(size=(num_layers, batch_size, seq_len, hidden_dim)).astype(np.float32))
+    # Teacher features differ on layers 1 and 3; match on layers 0 and 2.
+    t_features = s_features.at[1].set(s_features[1] + 1.0).at[3].set(s_features[3] - 1.0)
+    s_out = distillation_utils.DistillationForwardOutput(logits=s_logits, out_projection_activations=s_features)
+    t_out = distillation_utils.DistillationForwardOutput(logits=s_logits, out_projection_activations=t_features)
+
+    targets = jnp.array([[3, 1]], dtype=jnp.int32)
+    labels = _one_hot_labels(targets, vocab_size, pad_id=0)
+
+    # Case A: include only layers where features match -> feature loss == 0.
+    strategy_match = _make_strategy(vocab_size, alpha=0.0, beta_feature=1.0, layer_indices=[0, 2])
+    _, m_match = strategy_match.compute_loss(s_out, t_out, labels, step=None)
+    feat_match, _ = m_match["distill/out_proj_feature_loss"]
+    np.testing.assert_allclose(float(feat_match), 0.0, atol=1e-5)
+
+    # Case B: include the differing layers -> feature loss > 0.
+    strategy_diff = _make_strategy(vocab_size, alpha=0.0, beta_feature=1.0, layer_indices=[1, 3])
+    _, m_diff = strategy_diff.compute_loss(s_out, t_out, labels, step=None)
+    feat_diff, _ = m_diff["distill/out_proj_feature_loss"]
+    self.assertGreater(float(feat_diff), 0.0)
+
+  # --- 8. compute_eval_loss returns (sum, count) ------------------------
+
+  def test_compute_eval_loss_returns_sum_count_pair(self):
+    vocab_size = 4
+    s_logits = jnp.array([[[3.0, 0.0, 0.0, 0.0], [0.0, 3.0, 0.0, 0.0]]], dtype=jnp.float32)
+    targets = jnp.array([[0, 1]], dtype=jnp.int32)
+    labels = _one_hot_labels(targets, vocab_size)
+    s_out = distillation_utils.DistillationForwardOutput(logits=s_logits, out_projection_activations=None)
+    strategy = _make_strategy(vocab_size)
+    task_loss, metrics = strategy.compute_eval_loss(s_out, labels)
+    self.assertIn("eval/hard_loss", metrics)
+    np.testing.assert_allclose(_mean(metrics["eval/hard_loss"]), float(task_loss), rtol=1e-6)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/post_training/unit/distillation_scheduling_test.py
+++ b/tests/post_training/unit/distillation_scheduling_test.py
@@ -60,6 +60,13 @@ def _make_labels(vocab_size=4):
   return jax.nn.one_hot(jnp.array([[0, 1]]), vocab_size)
 
 
+def _mean(pair):
+  """Unpacks a (sum, count) metric tuple into a scalar mean value."""
+  s, c = pair
+  c_val = float(c)
+  return float(s) / c_val if c_val > 0 else float(s)
+
+
 # pylint: disable=protected-access
 class ComputeScheduleTest(unittest.TestCase):
   """Tests for the compute_schedule utility function."""
@@ -200,18 +207,18 @@ class StrategySchedulingTest(unittest.TestCase):
 
     # Step 0
     _, m0 = strategy.compute_loss(student, teacher, labels, step=jnp.array(0))
-    np.testing.assert_allclose(m0["distill/alpha"], 0.8, atol=1e-5)
-    np.testing.assert_allclose(m0["distill/temperature"], 2.0, atol=1e-5)
+    np.testing.assert_allclose(_mean(m0["distill/alpha"]), 0.8, atol=1e-5)
+    np.testing.assert_allclose(_mean(m0["distill/temperature"]), 2.0, atol=1e-5)
 
     # Step 50
     _, m50 = strategy.compute_loss(student, teacher, labels, step=jnp.array(50))
-    np.testing.assert_allclose(m50["distill/alpha"], 0.5, atol=1e-5)
-    np.testing.assert_allclose(m50["distill/temperature"], 1.5, atol=1e-5)
+    np.testing.assert_allclose(_mean(m50["distill/alpha"]), 0.5, atol=1e-5)
+    np.testing.assert_allclose(_mean(m50["distill/temperature"]), 1.5, atol=1e-5)
 
     # Step 100
     _, m100 = strategy.compute_loss(student, teacher, labels, step=jnp.array(100))
-    np.testing.assert_allclose(m100["distill/alpha"], 0.2, atol=1e-5)
-    np.testing.assert_allclose(m100["distill/temperature"], 1.0, atol=1e-5)
+    np.testing.assert_allclose(_mean(m100["distill/alpha"]), 0.2, atol=1e-5)
+    np.testing.assert_allclose(_mean(m100["distill/temperature"]), 1.0, atol=1e-5)
 
   def test_cosine_alpha_at_strategy_level(self):
     """Cosine alpha at 25% matches the expected cosine value (not linear)."""
@@ -231,7 +238,7 @@ class StrategySchedulingTest(unittest.TestCase):
     labels = _make_labels()
 
     _, metrics = strategy.compute_loss(student, teacher, labels, step=jnp.array(25))
-    np.testing.assert_allclose(metrics["distill/alpha"], 0.8535533, atol=1e-4)
+    np.testing.assert_allclose(_mean(metrics["distill/alpha"]), 0.8535533, atol=1e-4)
 
   def test_step_none_uses_fixed_values(self):
     """When step is None, fixed initial values are used even if schedules are configured."""
@@ -251,8 +258,8 @@ class StrategySchedulingTest(unittest.TestCase):
     labels = _make_labels()
 
     _, metrics = strategy.compute_loss(student, teacher, labels)
-    np.testing.assert_allclose(metrics["distill/alpha"], 0.8, atol=1e-5)
-    np.testing.assert_allclose(metrics["distill/temperature"], 2.0, atol=1e-5)
+    np.testing.assert_allclose(_mean(metrics["distill/alpha"]), 0.8, atol=1e-5)
+    np.testing.assert_allclose(_mean(metrics["distill/temperature"]), 2.0, atol=1e-5)
 
   def test_beta_schedule_with_feature_loss(self):
     """Beta scheduling with actual L2 feature loss: feature_loss scales proportionally."""
@@ -282,22 +289,22 @@ class StrategySchedulingTest(unittest.TestCase):
 
     # Step 0: beta=1.0
     _, m0 = strategy.compute_loss(student, teacher, labels, step=jnp.array(0))
-    self.assertGreater(float(m0["distill/out_proj_feature_loss"]), 0.0)
-    np.testing.assert_allclose(m0["distill/beta_feature"], 1.0, atol=1e-5)
+    self.assertGreater(_mean(m0["distill/out_proj_feature_loss"]), 0.0)
+    np.testing.assert_allclose(_mean(m0["distill/beta_feature"]), 1.0, atol=1e-5)
 
     # Step 50: beta=0.5, feature loss should be half
     _, m50 = strategy.compute_loss(student, teacher, labels, step=jnp.array(50))
-    np.testing.assert_allclose(m50["distill/beta_feature"], 0.5, atol=1e-5)
+    np.testing.assert_allclose(_mean(m50["distill/beta_feature"]), 0.5, atol=1e-5)
     np.testing.assert_allclose(
-        float(m50["distill/out_proj_feature_loss"]),
-        float(m0["distill/out_proj_feature_loss"]) * 0.5,
+        _mean(m50["distill/out_proj_feature_loss"]),
+        _mean(m0["distill/out_proj_feature_loss"]) * 0.5,
         atol=1e-5,
     )
 
     # Step 100: beta=0.0, feature loss should be zero
     _, m100 = strategy.compute_loss(student, teacher, labels, step=jnp.array(100))
-    np.testing.assert_allclose(m100["distill/beta_feature"], 0.0, atol=1e-5)
-    np.testing.assert_allclose(float(m100["distill/out_proj_feature_loss"]), 0.0, atol=1e-5)
+    np.testing.assert_allclose(_mean(m100["distill/beta_feature"]), 0.0, atol=1e-5)
+    np.testing.assert_allclose(_mean(m100["distill/out_proj_feature_loss"]), 0.0, atol=1e-5)
 
   def test_alpha_schedule_affects_total_loss(self):
     """Alpha=1.0 gives pure soft_loss; alpha=0.0 gives pure hard_loss; they differ."""
@@ -318,11 +325,11 @@ class StrategySchedulingTest(unittest.TestCase):
 
     # alpha=1.0 -> total = soft_loss
     loss_start, m_start = strategy.compute_loss(student, teacher, labels, step=jnp.array(0))
-    np.testing.assert_allclose(float(loss_start), float(m_start["distill/soft_loss"]), atol=1e-5)
+    np.testing.assert_allclose(float(loss_start), _mean(m_start["distill/soft_loss"]), atol=1e-5)
 
     # alpha=0.0 -> total = hard_loss
     loss_end, m_end = strategy.compute_loss(student, teacher, labels, step=jnp.array(100))
-    np.testing.assert_allclose(float(loss_end), float(m_end["distill/hard_loss"]), atol=1e-5)
+    np.testing.assert_allclose(float(loss_end), _mean(m_end["distill/hard_loss"]), atol=1e-5)
 
     # The two should differ
     self.assertNotAlmostEqual(float(loss_start), float(loss_end), places=2)
@@ -589,8 +596,8 @@ class TemperatureScheduleEffectTest(unittest.TestCase):
 
     # Different temperatures must produce different soft_loss values
     self.assertNotAlmostEqual(
-        float(m_high_temp["distill/soft_loss"]),
-        float(m_low_temp["distill/soft_loss"]),
+        _mean(m_high_temp["distill/soft_loss"]),
+        _mean(m_low_temp["distill/soft_loss"]),
         places=1,
         msg="Temperature schedule should change soft_loss, not just the metric value",
     )

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -430,11 +430,13 @@ class TrainDistillTest(unittest.TestCase):
     # Verify structure
     self.assertIsInstance(metrics, dict)
 
-    # Check keys required for TensorBoard
+    # Check keys required for TensorBoard. `distill/kl_div` was renamed
+    # to `distill/kl_div_at_T`; `distill/kl_div_T1` is an always-T=1 form.
     expected_keys = [
         "distill/soft_loss",
         "distill/hard_loss",
-        "distill/kl_div",
+        "distill/kl_div_at_T",
+        "distill/kl_div_T1",
         "distill/teacher_loss",
         "distill/out_proj_feature_loss",
         "distill/total_loss",
@@ -445,9 +447,15 @@ class TrainDistillTest(unittest.TestCase):
     for key in expected_keys:
       self.assertIn(key, metrics)
 
-    # Since inputs match perfectly, KL, feature loss should be near 0
-    self.assertLess(metrics["distill/kl_div"], 1e-5)
-    self.assertLess(metrics["distill/out_proj_feature_loss"], 1e-5)
+    # Metrics are now (sum, count) pairs; use the mean for value comparisons.
+    def _mean(pair):
+      s, c = pair
+      c_val = float(c)
+      return float(s) / c_val if c_val > 0 else float(s)
+
+    # Since inputs match perfectly, KL and feature loss should be near 0.
+    self.assertLess(_mean(metrics["distill/kl_div_at_T"]), 1e-5)
+    self.assertLess(_mean(metrics["distill/out_proj_feature_loss"]), 1e-5)
 
   def verify_strategy_compute_eval_loss(self):
     """Covers MonitoredLogitStrategy.compute_eval_loss."""
@@ -520,10 +528,15 @@ class TrainDistillTest(unittest.TestCase):
     # all tokens are predicted incorrect so the loss should be 10*2 since
     # token at position 1 should be excluded from the loss
     # mean kl_div should also be equal to 20
-    self.assertTrue(19.0 < metrics["distill/hard_loss"] < 21.0)
-    self.assertTrue(19.0 < metrics["distill/soft_loss"] < 21.0)
-    self.assertTrue(19.0 < metrics["distill/kl_div"] < 21.0)
-    self.assertTrue(metrics["distill/teacher_loss"] == 0.0)
+    def _mean(pair):
+      s, c = pair
+      c_val = float(c)
+      return float(s) / c_val if c_val > 0 else float(s)
+
+    self.assertTrue(19.0 < _mean(metrics["distill/hard_loss"]) < 21.0)
+    self.assertTrue(19.0 < _mean(metrics["distill/soft_loss"]) < 21.0)
+    self.assertTrue(19.0 < _mean(metrics["distill/kl_div_at_T"]) < 21.0)
+    self.assertTrue(_mean(metrics["distill/teacher_loss"]) == 0.0)
 
   def test_setup_pipeline_grain_enabled(self):
     """Covers setup_checkpoint_manager_and_restore when Grain IS detected."""
@@ -707,19 +720,24 @@ class TrainDistillTest(unittest.TestCase):
     mock_buffer.additional_metrics = {}
     trainer._buffered_train_metrics = mock_buffer
 
-    # Simulate auxiliary output from strategy
-    aux_metrics = {"distill/kl_div": jnp.array(0.5), "distill/soft_loss": jnp.array(1.2)}
+    # Simulate auxiliary output from strategy — now (sum, count) pairs.
+    aux_metrics = {
+        "distill/kl_div_at_T": (jnp.array(0.5), jnp.array(1.0)),
+        "distill/soft_loss": (jnp.array(1.2), jnp.array(2.0)),
+    }
 
     # Run Hook
     trainer._post_process_train_step(aux_metrics)
 
     # Verify buffer updated
-    self.assertIn("distill/kl_div", mock_buffer.additional_metrics)
+    self.assertIn("distill/kl_div_at_T", mock_buffer.additional_metrics)
     self.assertIn("distill/soft_loss", mock_buffer.additional_metrics)
 
-    # Verify value appended to list
-    values_list = mock_buffer.additional_metrics["distill/kl_div"][0]
-    self.assertEqual(values_list[0], 0.5)
+    # Verify value appended to list — stored as the (sum, count) tuple.
+    values_list = mock_buffer.additional_metrics["distill/kl_div_at_T"][0]
+    s, c = values_list[0]
+    self.assertEqual(float(s), 0.5)
+    self.assertEqual(float(c), 1.0)
 
   def test_gradient_accumulation_requires_k_passes_for_update(self):
     """Verifies that weights only update after k distinct forward passes."""


### PR DESCRIPTION
# Description

 Distillation trainer: token-weighted metrics, use Tunix checkpointing, XPK launcher.   

- **Metrics: token-weighted `(sum, count)` contract.** The old path emitted
scalars aggregated via `np.mean`, which biased logs under uneven masks /
multi-host shards. New `weighted_mean` aggregator computes
`sum(sums) / sum(counts)` — unbiased. Adds `student_perplexity`,
`teacher_perplexity`, `kl_div_T1`. Renames `distill/kl_div` →
`distill/kl_div_at_T`. Clamps CE before `exp()` so divergences don't
poison PPL averages.
- **Checkpointing: delegate to upstream Tunix.** `maybe_restore` now just
unwraps `ModelBundle → student_model`; the local `_shard_optimizer`
override is gone (upstream handles replicated scalars via
`with_sharding_constraint`).
- **New: `scripts/run_distill_xpk.sh`** — reference XPK launcher with
`prep_image` (layers Tunix branch + repins jax/libtpu), `submit`,
`monitor`, `resume_until_done`.

# Tests

- **New unit tests** (`tests/post_training/unit/distillation_metrics_test.py`,
`cpu_only`, 14 tests): KL direction + self-equivalence, CE/PPL numerics,
pad masking, T² scaling, T=1 KL invariance, aggregator single-host +
4-device sharded, feature-mapping (β>0) layer-indexing, eval contract.
- **Existing tests** (`train_distill_test.py`): updated for the renamed
metric and the `(sum, count)` tuple. 22/22 green.
- **E2E on `tpu7x-4x4x4`:** submit to step 150 (checkpoints 50/100/150,
loss 1.53 → 1.20), then resume to step 250 — restored at 150, no loss
regression.                                                                                                                                                                                                                                                                             


Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
