### PR TITLE
feat: QLoRA support for Dense/MoE models across Pathways and McJAX

### DIFF
--- a/docs/tutorials/posttraining/lora.md
+++ b/docs/tutorials/posttraining/lora.md
@@ -60,7 +60,7 @@ export DATASET_NAME=<DATASET_NAME> # e.g., openai/gsm8k
 export TRAIN_SPLIT=<TRAIN_SPLIT> # e.g., train
 export HF_DATA_DIR=<DATASET_PATH> # e.g., main
 export TRAIN_DATA_COLUMNS=<DATA_COLUMNS> # e.g., ['question','answer']
-export CHAT_TEMPLATE_PATH=<TEMPLATE_PATH> # e.g., maxtext/examples/chat_templates/math_qa.json
+export CHAT_TEMPLATE_PATH=<TEMPLATE_PATH> # e.g., src/maxtext/examples/chat_templates/math_qa.json (use gemma4_math_qa.json for Gemma 4 models)
 
 # -- LoRA Conversion configuration (Optional) --
 export HF_LORA_ADAPTER_PATH=<HF_LORA_ADAPTER_PATH> # e.g., 'username/adapter-name'

--- a/docs/tutorials/posttraining/lora_on_multi_host.md
+++ b/docs/tutorials/posttraining/lora_on_multi_host.md
@@ -1,0 +1,305 @@
+<!--
+ Copyright 2023–2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+# LoRA Fine-tuning on multi-host TPUs
+
+**Low-Rank Adaptation (LoRA)** is a Parameter-Efficient Fine-Tuning (PEFT) technique designed to optimize large language models while minimizing resource consumption.
+
+Unlike traditional full-parameter fine-tuning, LoRA:
+
+- **Freezes the pre-trained model weights**, preserving the original knowledge.
+- **Injects trainable rank decomposition matrices** into the Transformer layers.
+
+This tutorial provides step-by-step instructions for setting up the multi-host TPU environment and performing LoRA fine-tuning on a Hugging Face dataset using MaxText. In this tutorial we use a multi-host TPU such as `v6e-256`.
+
+We use [Tunix](https://github.com/google/tunix), a JAX-based library, to power these post-training tasks.
+
+Let's get started!
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- Access to a Google Cloud Project with TPU quotas.
+- A Hugging Face account with an access token for downloading models.
+- Permissions for Google Artifact Registry (Artifact Registry Writer role).
+- Prerequisites for XPK installed (follow [official documentation](https://github.com/AI-Hypercomputer/xpk/blob/main/docs/installation.md#1-prerequisites)).
+- A Pathways-ready GKE cluster (see [create GKE cluster](https://docs.cloud.google.com/ai-hypercomputer/docs/workloads/pathways-on-cloud/create-gke-cluster)).
+- **Docker** installed and configured for sudoless use. Follow the steps to [configure sudoless Docker](https://docs.docker.com/engine/install/linux-postinstall/).
+
+## Build and upload MaxText Docker image
+
+For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](https://maxtext.readthedocs.io/en/latest/build_maxtext.html).
+
+## Create GKE cluster
+
+Use a pathways ready GKE cluster as described [here](https://docs.cloud.google.com/ai-hypercomputer/docs/workloads/pathways-on-cloud/create-gke-cluster).
+
+## Environment configuration
+
+Set up the following environment variables to configure your training run. Replace placeholders with your actual values.
+
+```bash
+# -- Model configuration --
+# The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
+# full list of supported models.
+export MODEL=<MODEL_NAME> # e.g., 'gemma4-26b'
+
+# Your Hugging Face access token. Required to download gated models like Gemma.
+# You can generate one at https://huggingface.co/settings/tokens.
+export HF_TOKEN=<HF_TOKEN>
+
+# -- MaxText configuration --
+# Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
+# region as your TPUs to minimize latency and costs.
+# You can list your buckets and their locations in the
+# [Cloud Console](https://console.cloud.google.com/storage/browser) or via
+# `gcloud storage buckets list --format="table(name, location)"`.
+export BASE_OUTPUT_DIRECTORY=<GCS_BUCKET> # e.g., gs://my-bucket/maxtext-runs
+
+# An arbitrary string to identify this specific run.
+# We recommend to include the model, user, and timestamp.
+# Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
+export RUN_NAME=<RUN_NAME>
+
+# -- Workload configuration --
+# Your GCP project ID. Find it on the [Cloud Console Dashboard](https://console.cloud.google.com/home/dashboard).
+# If you've already set it in your local config, you can retrieve it via:
+# gcloud config get-value project
+export PROJECT_ID=<PROJECT_ID>
+
+# The GCP location (listed as "Location" in the UI) and name of your
+# TPU-enabled GKE cluster. Both can be found on the
+# [Cloud Console](https://console.cloud.google.com/kubernetes/list).
+export ZONE=<ZONE> # e.g., 'us-central1'
+export GKE_CLUSTER=<CLUSTER_NAME>
+
+# For a full list of MaxText-supported TPU types, see: `src/maxtext/utils/accelerator_to_spec_map.py`. To see the TPU type
+# of your cluster:
+
+# 1. Connect to the cluster (required for kubectl commands later):
+# gcloud container clusters get-credentials ${GKE_CLUSTER?} --location ${ZONE?} --project ${PROJECT_ID?}
+
+# 2. Find your TPU type (e.g., 'v6e-256') by checking the accelerator labels on your nodes:
+# kubectl get nodes -l cloud.google.com/gke-tpu-accelerator -o jsonpath='{.items[*].metadata.labels.cloud\.google\.com/gke-tpu-accelerator}' | tr ' ' '\n' | sort -u
+export TPU_TYPE=<TPU_TYPE>
+export NUM_SLICES=<NUM_SLICES>
+
+# The Docker image you pushed in the prerequisite step
+export CLOUD_IMAGE_NAME=<IMAGE_NAME>
+export DOCKER_IMAGE="gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?}"
+
+# -- Fine-Tuning configuration --
+export STEPS=<STEPS> # e.g., 1000
+export PER_DEVICE_BATCH_SIZE=<BATCH_SIZE_PER_DEVICE> # e.g., 1
+export LORA_RANK=<LORA_RANK> # e.g., 16
+export LORA_ALPHA=<LORA_ALPHA> # e.g., 32.0
+export LEARNING_RATE=<LEARNING_RATE> # e.g., 3e-6
+export MAX_TARGET_LENGTH=<MAX_TARGET_LENGTH> # e.g., 1024
+
+# -- Dataset configuration --
+export DATASET_NAME=<DATASET_NAME> # e.g., openai/gsm8k
+export TRAIN_SPLIT=<TRAIN_SPLIT> # e.g., train
+export HF_DATA_DIR=<DATASET_PATH> # e.g., main
+export TRAIN_DATA_COLUMNS=<DATA_COLUMNS> # e.g., ['question','answer']
+export CHAT_TEMPLATE_PATH=<TEMPLATE_PATH> # e.g., maxtext/examples/chat_templates/math_qa.json
+
+# -- LoRA Conversion configuration (Optional) --
+export HF_LORA_ADAPTER_PATH=<HF_LORA_ADAPTER_PATH> # e.g., 'username/adapter-name'
+```
+
+## Customizing Trainable Layers (Optional)
+
+By default, MaxText determines which layers to apply LoRA to based on the model's architecture by reading `src/maxtext/configs/post_train/lora_module_path.yml`.
+
+If you need to fine-tune specific components (e.g., targeting only Attention layers to optimize memory usage), you can override these defaults through the following hierarchy:
+
+### Configuration Hierarchy
+
+1. **Command Line Argument**: Pass the `lora_module_path` argument directly in your training command.
+2. **Task-Specific Config (`sft.yml`)**: Define the `lora_module_path` parameter in `src/maxtext/configs/post_train/sft.yml`.
+3. **Global Defaults**: Automatic detection via the model-to-regex mapping defined in `lora_module_path.yml`.
+
+## Get MaxText model checkpoint
+
+This section explains how to prepare your model checkpoint for use with MaxText. You have two options: using an existing MaxText checkpoint or converting a Hugging Face checkpoint.
+
+### Option 1: Using an existing MaxText checkpoint
+
+If you already have a MaxText-compatible model checkpoint, simply set the following environment variable and move on to the next section.
+
+```bash
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+```
+
+**Note:** Make sure that `MAXTEXT_CKPT_PATH` has the checkpoints created using the correct storage flags:
+
+```bash
+export USE_PATHWAYS=0  # Set to 1 for Pathways, 0 for McJAX.
+checkpoint_storage_use_zarr3=$((1 - USE_PATHWAYS))
+checkpoint_storage_use_ocdbt=$((1 - USE_PATHWAYS))
+```
+
+### Option 2: Converting a Hugging Face checkpoint
+
+Refer to the steps in [Hugging Face to MaxText](https://maxtext.readthedocs.io/en/maxtext-v0.2.1/guides/checkpointing_solutions/convert_checkpoint.html#hugging-face-to-maxtext) to convert a hugging face checkpoint to MaxText. Make sure you have correct checkpoint files converted and saved. Similar as Option 1, you can set the following environment and move on.
+
+```bash
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # gs://my-bucket/my-checkpoint-directory/0/items
+```
+
+## Submit workload on GKE cluster
+
+This section provides the command to run LoRA Fine-Tuning on a GKE cluster.
+
+### Run a Fresh LoRA Fine-Tuning on Hugging Face Dataset
+
+#### LoRA with Multi-Controller JAX (McJAX)
+
+```bash
+xpk workload create \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
+--zone=${ZONE?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload=${RUN_NAME?} \
+--tpu-type=${TPU_TYPE?} \
+--num-slices=${NUM_SLICES?} \
+--command="python3 -m maxtext.trainers.post_train.sft.train_sft run_name=${RUN_NAME?} base_output_directory=${BASE_OUTPUT_DIRECTORY?} model_name=${MODEL?} load_parameters_path=${MAXTEXT_CKPT_PATH?} hf_access_token=${HF_TOKEN?} hf_path=${DATASET_NAME?} train_split=${TRAIN_SPLIT?} hf_data_dir=${HF_DATA_DIR?} train_data_columns=${TRAIN_DATA_COLUMNS?} steps=${STEPS?} per_device_batch_size=${PER_DEVICE_BATCH_SIZE?} max_target_length=${MAX_TARGET_LENGTH?} learning_rate=${LEARNING_RATE?} chat_template_path=${CHAT_TEMPLATE_PATH?} enable_nnx=True pure_nnx_decoder=True lora.enable_lora=True lora.lora_rank=${LORA_RANK?} lora.lora_alpha=${LORA_ALPHA?}"
+```
+
+Once the fine-tuning is completed, you can access your model checkpoints at `${BASE_OUTPUT_DIRECTORY}/${RUN_NAME/checkpoints`.
+
+#### LoRA with Pathways
+
+```bash
+export USE_PATHWAYS=1
+
+xpk workload create-pathways \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
+--zone=${ZONE?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload=${RUN_NAME?} \
+--tpu-type=${TPU_TYPE?} \
+--num-slices=${NUM_SLICES?} \
+--command="JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE=1 python3 -m maxtext.trainers.post_train.sft.train_sft run_name=${RUN_NAME?} base_output_directory=${BASE_OUTPUT_DIRECTORY?} model_name=${MODEL?} load_parameters_path=${MAXTEXT_CKPT_PATH?} hf_access_token=${HF_TOKEN?} hf_path=${DATASET_NAME?} train_split=${TRAIN_SPLIT?} hf_data_dir=${HF_DATA_DIR?} train_data_columns=${TRAIN_DATA_COLUMNS?} steps=${STEPS?} per_device_batch_size=${PER_DEVICE_BATCH_SIZE?} max_target_length=${MAX_TARGET_LENGTH?} learning_rate=${LEARNING_RATE?} chat_template_path=${CHAT_TEMPLATE_PATH?} enable_nnx=True pure_nnx_decoder=True lora.enable_lora=True lora.lora_rank=${LORA_RANK?} lora.lora_alpha=${LORA_ALPHA?} checkpoint_storage_use_zarr3=$((1 - USE_PATHWAYS)) checkpoint_storage_use_ocdbt=$((1 - USE_PATHWAYS)) enable_single_controller=True"
+```
+
+Once the fine-tuning is completed, you can access your model checkpoints at `${BASE_OUTPUT_DIRECTORY}/${RUN_NAME}/checkpoints`.
+
+### (Optional) Resume from a previous LoRA checkpoint
+
+If you want to resume training from a previous run or further fine-tune an existing LoRA adapter, you can specify the LoRA checkpoint path.
+
+#### Step 1: Convert HF LoRA adapter to MaxText format with Multi-Controller JAX (McJAX)
+
+If your LoRA adapter is currently in Hugging Face format, you must convert it to MaxText format before it can be loaded. Use the integrated conversion utility:
+
+```sh
+xpk workload create \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
+--zone=${ZONE?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload=${RUN_NAME?} \
+--tpu-type=${TPU_TYPE?} \
+--num-slices=${NUM_SLICES?} \
+--command="python3 -m maxtext.checkpoint_conversion.to_maxtext model_name=${MODEL?} hf_lora_adapter_path=${HF_LORA_ADAPTER_PATH?} base_output_directory=${BASE_OUTPUT_DIRECTORY?}/converted_adapter hf_access_token=${HF_TOKEN?} hardware=cpu skip_jax_distributed_system=True"
+```
+
+#### Step 2: Set the restore path
+
+Point `LORA_RESTORE_PATH` to the converted MaxText adapter directory (the directory containing the `0/items` or Orbax files).
+
+- **load_parameters_path**: Points to the frozen base model weights (the original model).
+- **lora_restore_path**: Points to the previous LoRA adapter weights you wish to load.
+
+```sh
+export LORA_RESTORE_PATH=<LORA_RESTORE_PATH> # e.g., gs://my-bucket/run-1/checkpoints/0/items or /path/to/run-1/checkpoints/0/items
+```
+
+#### Step 3-1: Run LoRA Fine-Tuning with the Restore Path through Multi-Controller JAX (McJAX)
+
+Once your environment variables and checkpoints are ready, you can start the LoRA fine-tuning process.
+
+Execute the following command to begin training:
+
+```sh
+xpk workload create \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
+--zone=${ZONE?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload=${RUN_NAME?} \
+--tpu-type=${TPU_TYPE?} \
+--num-slices=${NUM_SLICES?} \
+--command="python3 -m maxtext.trainers.post_train.sft.train_sft run_name=${RUN_NAME?} base_output_directory=${BASE_OUTPUT_DIRECTORY?} model_name=${MODEL?} load_parameters_path=${MAXTEXT_CKPT_PATH?} hf_access_token=${HF_TOKEN?} hf_path=${DATASET_NAME?} train_split=${TRAIN_SPLIT?} hf_data_dir=${HF_DATA_DIR?} train_data_columns=${TRAIN_DATA_COLUMNS?} steps=${STEPS?} per_device_batch_size=${PER_DEVICE_BATCH_SIZE?} max_target_length=${MAX_TARGET_LENGTH?} lora.lora_restore_path=${LORA_RESTORE_PATH?} learning_rate=${LEARNING_RATE?} chat_template_path=${CHAT_TEMPLATE_PATH?} enable_nnx=True pure_nnx_decoder=True lora.enable_lora=True lora.lora_rank=${LORA_RANK?} lora.lora_alpha=${LORA_ALPHA?}"
+```
+
+#### Step 3-2: Run LoRA Fine-Tuning with the Restore Path through Pathways
+
+```bash
+export USE_PATHWAYS=1
+
+xpk workload create-pathways \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
+--zone=${ZONE?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload=${RUN_NAME?} \
+--tpu-type=${TPU_TYPE?} \
+--num-slices=${NUM_SLICES?} \
+--command="JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE=1 python3 -m maxtext.trainers.post_train.sft.train_sft run_name=${RUN_NAME?} base_output_directory=${BASE_OUTPUT_DIRECTORY?} model_name=${MODEL?} load_parameters_path=${MAXTEXT_CKPT_PATH?} hf_access_token=${HF_TOKEN?} hf_path=${DATASET_NAME?} train_split=${TRAIN_SPLIT?} hf_data_dir=${HF_DATA_DIR?} train_data_columns=${TRAIN_DATA_COLUMNS?} steps=${STEPS?} per_device_batch_size=${PER_DEVICE_BATCH_SIZE?} max_target_length=${MAX_TARGET_LENGTH?} lora.lora_restore_path=${LORA_RESTORE_PATH?} learning_rate=${LEARNING_RATE?} chat_template_path=${CHAT_TEMPLATE_PATH?} enable_nnx=True pure_nnx_decoder=True lora.enable_lora=True lora.lora_rank=${LORA_RANK?} lora.lora_alpha=${LORA_ALPHA?} checkpoint_storage_use_zarr3=$((1 - USE_PATHWAYS)) checkpoint_storage_use_ocdbt=$((1 - USE_PATHWAYS)) enable_single_controller=True"
+```
+
+Your fine-tuned model checkpoints will be saved here: `$BASE_OUTPUT_DIRECTORY/$RUN_NAME/checkpoints`.
+
+## (Optional) Convert Fine-tuned LoRA to Hugging Face Format with Multi-Controller JAX (McJAX)
+
+After completing the fine-tuning process, your LoRA weights are stored in MaxText/Orbax format. To use these weights with the Hugging Face ecosystem (e.g., for inference or sharing), convert them back using the `to_huggingface.py` script.
+
+```sh
+xpk workload create \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
+--zone=${ZONE?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload="${RUN_NAME?}-to-hf" \
+--tpu-type=${TPU_TYPE?} \
+--num-slices=1 \
+--command="python3 -m maxtext.checkpoint_conversion.to_huggingface \
+    model_name=${MODEL?} \
+    lora.lora_restore_path=${BASE_OUTPUT_DIRECTORY?}/${RUN_NAME?}/checkpoints/<STEPS>/model_params \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY?}/hf_lora_adapter \
+    hf_access_token=${HF_TOKEN?}"
+    
+```
+
+- `lora.lora_restore_path`: Point this to the specific checkpoint directory (e.g., `.../checkpoints/1000/items`) that you want to export.
+- `base_output_directory`: The local or GCS directory where the Hugging Face `adapter_model.safetensors` and `adapter_config.json` will be saved.
+- `lora.lora_rank` / `lora.lora_alpha`: Must match the values used during the training phase to ensure the `adapter_config.json` is generated correctly.
+
+## A Note on Multi-Host Resharding
+
+When running LoRA fine-tuning in a **multi-host environment** (e.g., a TPU pod with 64 hosts managing 256 TPUs, such as Pathways or McJAX), special care must be taken when resharding arrays.
+
+In a single-host environment, the host has a global view of all devices, so a standard `jax.device_put` can easily distribute slices of data to all local TPUs. However, in a multi-host setup:
+
+- **Addressability:** A host only has a local view of its directly attached devices and cannot push data directly to TPUs managed by other hosts.
+- **Memory Constraints:** If every host tries to load the entire weight matrix into RAM just to extract its local piece, the host CPUs will run out of memory (OOM).
+
+To solve this, MaxText uses `jax.make_array_from_callback` for a "safe reshard." Instead of pushing data *to* the devices, this flips the paradigm. It creates a global `jax.Array` construct where each host locally executes a callback (`lambda idx: val[idx]`) to load **only the specific slice** of the data that its attached TPUs need. This completely bypasses cross-host `device_put` limitations and prevents OOMs since each host only indexes what it requires.

--- a/src/maxtext/configs/post_train/lora_module_path.yml
+++ b/src/maxtext/configs/post_train/lora_module_path.yml
@@ -21,6 +21,7 @@ mistral: "decoder/layers/.*(attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))"
 deepseek2: "decoder/(dense_layers|moe_stack)/self_attention/(query|out|wkv_a|wkv_b)|decoder/(dense_layers|moe_stack)/(mlp|shared_experts)/(wi_0|wi_1|wo)"
 gemma2: "decoder/layers/(self_attention_local|self_attention_global)/(query|key|value|out)|decoder/layers/(mlp_local|mlp_global)/(wi_0|wi_1|wo)"
 gemma3: "decoder/layers/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo|gate|up|down))"
+gemma4: "decoder/(scanned_blocks|layers_remainder)/layers.*/.*(self_attention/(query|key|value|out)|mlp/.*(MoeBlock_0|wi_0|wi_1|wo|shared_experts/(wi_0|wi_1|wo)))"
 olmo3: "decoder/layers/.*(attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))"
 gpt3: "decoder/layers/(self_attention/(qkv_proj|out)|mlp/(wi|wo))"
 

--- a/src/maxtext/configs/post_train/sft.yml
+++ b/src/maxtext/configs/post_train/sft.yml
@@ -27,6 +27,9 @@ lora:
   lora_rank: 0
   lora_alpha: 0.0
   lora_module_path: ""
+  # For QLoRA, set lora_weight_qtype (e.g., "nf4") and optionally lora_tile_size.
+  lora_weight_qtype: null
+  lora_tile_size: null
   # Optional path to LoRA weights to load before training. Ignored if the current run is resumed.
   lora_restore_path: ""
 

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1236,8 +1236,18 @@ class LoRA(BaseModel):
   lora_module_path: str = Field(
       "",
       description=(
-          "Regex identifying target modules for LoRA, e.g." " '.*q_einsum|.*kv_einsum|.*gate_proj|.*down_proj|.*up_proj'."
+          "Regex identifying target NNX modules for LoRA. "
+          "Example for standard models: 'decoder/layers/.*(self_attention/(query|out)|mlp/(wi_0|wo))'. "
+          "Example for MoE: 'decoder/scanned_blocks/layers.*/.*(MoeBlock_0|shared_experts)/(wi_0|wo)'."
       ),
+  )
+  lora_weight_qtype: str | None = Field(
+      None,
+      description=("Optional quantization type for QLoRA (e.g., 'nf4'). If set, QLoRA is applied."),
+  )
+  lora_tile_size: NonNegativeInt | None = Field(
+      None,
+      description=("Tile size for block-wise quantization. Typically 32 or 64."),
   )
   lora_restore_path: PathStr = Field(
       "",

--- a/src/maxtext/examples/lora_llama3_demo.ipynb
+++ b/src/maxtext/examples/lora_llama3_demo.ipynb
@@ -1,0 +1,604 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6d342dea",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/AI-Hypercomputer/maxtext/blob/main/src/maxtext/examples/lora_llama3_demo.ipynb)\n",
+    "\n",
+    "# Llama3.1-8B Low-Rank Adaptation (LoRA) Demo\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c6366a0",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "\n",
+    "This notebook performs LoRA SFT training and evaluation workflow on [OpenAI's GSM8K dataset](https://huggingface.co/datasets/openai/gsm8k).\n",
+    " The primary goal is to demonstrate the end-to-end process of:\n",
+    " 1. Pre-SFT Evaluation: Calcuating baseline accuracy for the model before training.\n",
+    " 2. Efficient LoRA SFT: Fine-tune the model using MaxText & Tunix SFT trainer.\n",
+    " 3. Post-SFT Evaluation: Re-running the evaluation loop after training to measure the performance gain achieved by LoRA SFT.\n",
+    " \n",
+    " This notebook can run on the **public TPU v5e-1**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7850d11a",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "Before running this notebook, make sure your environment is set up for the method you are using. Follow the [Run MaxText Python Notebooks on TPUs](https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html) guide and complete all steps for your chosen method (Google Colab, VS Code, or Local Jupyter Lab) before proceeding.\n",
+    "\n",
+    "If you run into issues, refer to the [Common Pitfalls & Debugging](https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html#common-pitfalls-debugging) section of the guide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "883318ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "  import google.colab\n",
+    "  print(\"Running the notebook on Google Colab\")\n",
+    "  IN_COLAB = True\n",
+    "except ImportError:\n",
+    "    print(\"Running the notebook on Visual Studio or JupyterLab\")\n",
+    "    IN_COLAB = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "178292ce",
+   "metadata": {},
+   "source": [
+    "## Installation: MaxText and Post training Dependencies\n",
+    "\n",
+    "**Running the notebook on Visual Studio or JupyterLab:** Before proceeding, create a virtual environment and install the required post-training dependencies by following `Option 3: Installing [tpu-post-train]` in the [MaxText installation guide](https://maxtext.readthedocs.io/en/latest/install_maxtext.html#from-source). Once the environment is set up, ensure the notebook is running within it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2db1ce49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if IN_COLAB:\n",
+    "    # Clone the MaxText repository\n",
+    "    !git clone https://github.com/AI-Hypercomputer/maxtext.git\n",
+    "    %cd maxtext\n",
+    "\n",
+    "    # Install uv, a fast Python package installer\n",
+    "    !pip install uv\n",
+    "    \n",
+    "    # Install MaxText and post-training dependencies\n",
+    "    !uv pip install -e .[tpu-post-train] --resolution=lowest\n",
+    "    !install_tpu_post_train_extra_deps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2469fb7",
+   "metadata": {},
+   "source": [
+    "**Session restart Instructions for Colab:**\n",
+    "1.  Navigate to the menu at the top of the screen.\n",
+    "2.  Click on **Runtime**.\n",
+    "3.  Select **Restart session** from the dropdown menu.\n",
+    "\n",
+    "You will be asked to confirm the action in a pop-up dialog. Click on **Yes**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ae63b92",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0bffabd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import os\n",
+    "import sys\n",
+    "import subprocess\n",
+    "import transformers\n",
+    "\n",
+    "from maxtext.configs import pyconfig\n",
+    "from maxtext.examples.sft_qwen3_demo_utils import evaluate_model, get_test_dataset\n",
+    "from maxtext.integration.tunix.tunix_adapter import TunixMaxTextAdapter\n",
+    "from maxtext.utils.globals import MAXTEXT_PKG_DIR\n",
+    "from maxtext.trainers.post_train.sft import train_sft\n",
+    "from maxtext.checkpoint_conversion.to_huggingface import _get_lora_delta\n",
+    "\n",
+    "# Suppress vLLM logging with a severity level below ERROR\n",
+    "os.environ[\"VLLM_LOGGING_LEVEL\"] = \"ERROR\"\n",
+    "from tunix.rl.rollout import base_rollout\n",
+    "from tunix.rl.rollout.vllm_rollout import VllmRollout\n",
+    "\n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "from datetime import datetime\n",
+    "from flax import nnx\n",
+    "from etils import epath\n",
+    "\n",
+    "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6ab18aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not jax.distributed.is_initialized():\n",
+    "  jax.distributed.initialize()\n",
+    "print(f\"JAX version: {jax.__version__}\")\n",
+    "print(f\"JAX devices: {jax.devices()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e60700f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if IN_COLAB:\n",
+    "    from huggingface_hub import notebook_login\n",
+    "    notebook_login()\n",
+    "else:\n",
+    "    from huggingface_hub import login\n",
+    "    login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0be0aa2",
+   "metadata": {},
+   "source": [
+    "## Model Configurations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04953dce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_NAME = \"llama3.1-8b-Instruct\"\n",
+    "TOKENIZER_PATH = \"meta-llama/Llama-3.1-8B-Instruct\"\n",
+    "tokenizer = transformers.AutoTokenizer.from_pretrained(TOKENIZER_PATH)\n",
+    "# This is the directory where the fine-tuned model checkpoint will be saved\n",
+    "BASE_OUTPUT_DIRECTORY = f\"{MAXTEXT_PKG_DIR}/lora_llama3.1-8b_output\"\n",
+    "\n",
+    "# set the path to the model checkpoint (excluding `/0/items`) or leave empty to download from HuggingFace\n",
+    "MODEL_CHECKPOINT_PATH = \"\"\n",
+    "if not MODEL_CHECKPOINT_PATH:\n",
+    "   MODEL_CHECKPOINT_PATH = f\"{BASE_OUTPUT_DIRECTORY}/llama3.1-8b_checkpoint\"\n",
+    "   print(\"Model checkpoint will be downloaded from HuggingFace at: \",  MODEL_CHECKPOINT_PATH)\n",
+    "   print(\"Set MODEL_CHECKPOINT_PATH if you do not wish to download the checkpoint.\")\n",
+    "\n",
+    "\n",
+    "RUN_NAME = datetime.now().strftime(\"%Y-%m-%d-%H-%m-%S\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "389f42cb",
+   "metadata": {},
+   "source": [
+    "## Download Llama3.1-8B Model Checkpoint from Hugging Face"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf6cdced",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not epath.Path(MODEL_CHECKPOINT_PATH).exists():\n",
+    "    # Install torch for the conversion script\n",
+    "    print(\"Installing torch...\")\n",
+    "    subprocess.run(\n",
+    "        [\n",
+    "            sys.executable, \"-m\", \"pip\", \"install\",\n",
+    "            \"torch\", \"--index-url\", \"https://download.pytorch.org/whl/cpu\"\n",
+    "        ],\n",
+    "        check=True\n",
+    "    )\n",
+    "\n",
+    "    print(\"Converting checkpoint from HuggingFace...\")\n",
+    "    env = os.environ.copy()\n",
+    "    env[\"JAX_PLATFORMS\"] = \"cpu\"\n",
+    "\n",
+    "    subprocess.run(\n",
+    "        [\n",
+    "            sys.executable,\n",
+    "            \"-m\", \"maxtext.checkpoint_conversion.to_maxtext\",\n",
+    "            f\"{MAXTEXT_PKG_DIR}/configs/base.yml\",\n",
+    "            f\"model_name={MODEL_NAME}\",\n",
+    "            f\"base_output_directory={MODEL_CHECKPOINT_PATH}\",\n",
+    "            \"use_multimodal=false\",\n",
+    "            \"scan_layers=true\",\n",
+    "            \"skip_jax_distributed_system=True\",\n",
+    "        ],\n",
+    "        check=True,\n",
+    "        env=env\n",
+    "    )\n",
+    "    \n",
+    "    MODEL_CHECKPOINT_PATH = os.path.join(MODEL_CHECKPOINT_PATH, \"0/items\")\n",
+    "else:\n",
+    "    print(f\"Model checkpoint exists at {MODEL_CHECKPOINT_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2b990b5",
+   "metadata": {},
+   "source": [
+    "## Dataset Configurations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b66e23b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATASET_NAME = \"openai/gsm8k\"\n",
+    "TRAIN_DATA_SPLIT = \"train\"\n",
+    "TEST_DATA_SPLIT = \"test\"\n",
+    "HF_DATA_DIR = \"main\"\n",
+    "TRAIN_DATA_COLUMNS = [\"question\", \"answer\"]\n",
+    "DATA_TEMPLATE_PATH = f\"{MAXTEXT_PKG_DIR}/examples/chat_templates/math_qa.json\"\n",
+    "if not os.path.exists(DATA_TEMPLATE_PATH):\n",
+    "    raise FileNotFoundError(f\"Data template not found: {DATA_TEMPLATE_PATH}\")\n",
+    "FORMATTING_FUNC_PATH = \"maxtext.input_pipeline.instruction_data_processing.math_qa_formatting\"\n",
+    "FORMATTING_FUNC_KWARGS = {\"template_path\": f\"{DATA_TEMPLATE_PATH}\"}\n",
+    "NUM_TEST_SAMPLES = 20  # Total number of samples to test\n",
+    "BATCH_SIZE = 1  # Number of test samples to process in a batch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "293f355d",
+   "metadata": {},
+   "source": [
+    "## MaxText Configurations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ebc4929",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "config = pyconfig.initialize_pydantic(\n",
+    "    [\n",
+    "        \"\",\n",
+    "        f\"{MAXTEXT_PKG_DIR}/configs/post_train/sft.yml\",\n",
+    "        f\"run_name={RUN_NAME}\",\n",
+    "        f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
+    "        f\"model_name={MODEL_NAME}\",\n",
+    "        f\"load_parameters_path={MODEL_CHECKPOINT_PATH}\", \n",
+    "        f\"tokenizer_path={TOKENIZER_PATH}\",\n",
+    "        f\"hf_path={DATASET_NAME}\",\n",
+    "        f\"train_split={TRAIN_DATA_SPLIT}\",\n",
+    "        f\"hf_data_dir={HF_DATA_DIR}\",\n",
+    "        f\"train_data_columns={TRAIN_DATA_COLUMNS}\",\n",
+    "        \"steps=200\",\n",
+    "        \"per_device_batch_size=1\",\n",
+    "        \"max_target_length=512\",\n",
+    "        \"learning_rate=5e-5\", \n",
+    "        \"weight_dtype=bfloat16\",\n",
+    "        \"dtype=bfloat16\",\n",
+    "        f\"chat_template_path={DATA_TEMPLATE_PATH}\",\n",
+    "        \"enable_nnx=true\",\n",
+    "        \"pure_nnx_decoder=true\",\n",
+    "        \"scan_layers=true\",\n",
+    "        \"lora.enable_lora=true\",\n",
+    "        \"lora.lora_rank=16\",\n",
+    "        \"lora.lora_alpha=32.0\", \n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41e4e3d4",
+   "metadata": {},
+   "source": [
+    "## Initial Setup & Data Preparation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc002261",
+   "metadata": {},
+   "source": [
+    "### Create Test Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f4bbc36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_evaluation = os.environ.get(\"RUN_EVALUATION\", \"false\").lower() == \"true\"\n",
+    "run_evaluation = True\n",
+    "if run_evaluation:\n",
+    "    test_dataset = get_test_dataset(config, tokenizer, DATA_TEMPLATE_PATH)\n",
+    "    test_dataset = test_dataset[:NUM_TEST_SAMPLES]\n",
+    "    test_dataset = test_dataset.to_iter_dataset().batch(BATCH_SIZE, drop_remainder=True)\n",
+    "    TOTAL_BATCHES = NUM_TEST_SAMPLES // BATCH_SIZE\n",
+    "    print(\n",
+    "        f\"Processing {NUM_TEST_SAMPLES} examples with a batch size of {BATCH_SIZE}. This will result in {TOTAL_BATCHES} total batches for the test run.\"\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Plese set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "472518e6",
+   "metadata": {},
+   "source": [
+    "### Create LoRA SFT Trainer State"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f1ded1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainer, mesh = train_sft.setup_trainer_state(config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4674a185",
+   "metadata": {},
+   "source": [
+    "### Create vLLM Rollout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04293db6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if run_evaluation:\n",
+    "    tunix_model = TunixMaxTextAdapter(trainer.model)\n",
+    "    vllm_rollout = VllmRollout(\n",
+    "        model=tunix_model,\n",
+    "        tokenizer=tokenizer,\n",
+    "        cache_config_or_size=1280,\n",
+    "        mesh=mesh,\n",
+    "        rollout_config=base_rollout.RolloutConfig(\n",
+    "            rollout_vllm_model_version=TOKENIZER_PATH,\n",
+    "            rollout_vllm_hbm_utilization=0.3,\n",
+    "            rollout_vllm_init_with_random_weights=True,\n",
+    "            rollout_vllm_tpu_backend_type=\"jax\",\n",
+    "            data_type=jax.numpy.bfloat16,\n",
+    "            max_tokens_to_generate=512\n",
+    "        ),\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Plese set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "465fcc52",
+   "metadata": {},
+   "source": [
+    "## Evaluation before LoRA SFT Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15252835",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if run_evaluation:\n",
+    "    print(\"Running Pre-SFT Evaluation...\")\n",
+    "    score = evaluate_model(test_dataset, vllm_rollout, debug=False)\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Plese set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c5642a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if run_evaluation:\n",
+    "    print(\"========================= Score for PRE-SFT Evaluation =========================\")\n",
+    "    print(f\"Percentage of test samples where the model produced the correct numerical answer: {score['correct']}%\")\n",
+    "    print(\n",
+    "        f\"Percentage of test samples where the model produced the numerical answer within 10%: {score['partially_correct']}%\"\n",
+    "    )\n",
+    "    print(\n",
+    "        f\"Percentage of test samples where the model's output adheres to the expected structure: {score['correct_format']}%\"\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Plese set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "863bd8e5",
+   "metadata": {},
+   "source": [
+    "## LoRA SFT Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0ebcaed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Starting LoRA SFT Training...\")\n",
+    "trainer = train_sft.train_model(config, trainer, mesh)\n",
+    "print(\"LoRA SFT Training Complete!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6f01e65",
+   "metadata": {},
+   "source": [
+    "## Evaluation after LoRA SFT Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a482aaad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if run_evaluation:\n",
+    "    print(\"Starting weight merge process before evaluation...\")\n",
+    "\n",
+    "    # --- WHY WE MERGE ---\n",
+    "    # vLLM/VllmRollout initializes with the frozen BASE MODEL and cannot see \n",
+    "    # the separate LoRA weights in the trainer. We fold LoRA into the base weights \n",
+    "    # to ensure the evaluation reflects the fine-tuned performance.\n",
+    "\n",
+    "    # --- 1. Data Preparation ---\n",
+    "    # Split the NNX model to extract the pure parameter dictionary\n",
+    "    _, state = nnx.split(trainer.model)\n",
+    "    flat_params = state.to_pure_dict()\n",
+    "    scaling = config.lora.lora_alpha / config.lora.lora_rank\n",
+    "    \n",
+    "    # Create an \"Official Format\" dictionary to align with MaxText's internal naming\n",
+    "    # This ensures _get_lora_delta can correctly map 'kernel' to 'lora_a/b'\n",
+    "    official_dict = {}\n",
+    "    for path, val in jax.tree_util.tree_flatten_with_path(flat_params)[0]:\n",
+    "        # Handle JAX Path objects and strip formatting to get clean string keys\n",
+    "        p_names = [str(p.key if hasattr(p, 'key') else str(p).strip(\"['']\")) for p in path]\n",
+    "        official_key = \"params-\" + \"-\".join(p_names)\n",
+    "        official_dict[official_key] = val\n",
+    "\n",
+    "    merge_count = 0\n",
+    "    \n",
+    "    # --- 2. Core Merging Logic ---\n",
+    "    # Iterate through parameters and apply LoRA delta using the official MaxText utility\n",
+    "    for off_key, val in official_dict.items():\n",
+    "        if off_key.endswith(\"-kernel\"):\n",
+    "            # Calculate the low-rank delta (A * B * scaling)\n",
+    "            delta = _get_lora_delta(off_key, official_dict, scaling)\n",
+    "            \n",
+    "            if delta is not None:\n",
+    "                # Perform the merge: W_merged = W_base + Delta\n",
+    "                # Includes automatic reshaping for multi-dimensional (Scanned) layers\n",
+    "                merged_val = val + delta.reshape(val.shape) if delta.size == val.size else val + delta\n",
+    "                \n",
+    "                # Navigate back through the nested dictionary to update the value\n",
+    "                original_path = off_key.replace(\"params-\", \"\").split(\"-\")\n",
+    "                curr = flat_params\n",
+    "                for p in original_path[:-1]:\n",
+    "                    curr = curr[p]\n",
+    "                curr[original_path[-1]] = merged_val\n",
+    "                \n",
+    "                merge_count += 1\n",
+    "                print(f\"[Merged] {off_key}\")\n",
+    "\n",
+    "    # --- 3. Update Model & PROOF OF MERGE ---\n",
+    "    nnx.update(trainer.model, nnx.State(flat_params))\n",
+    "    # Check the merge_count to confirm if LoRA weights have been successfully applied.\n",
+    "    print(f\"Weight merging completed! Total modules processed: {merge_count}\")\n",
+    "\n",
+    "    # Extract the updated state and filter out LoRA variables for vLLM compatibility\n",
+    "    full_updated_state = nnx.state(trainer.model)\n",
+    "    clean_state_dict = {\n",
+    "        k: v for k, v in full_updated_state.items() \n",
+    "        if \"lora\" not in str(k)\n",
+    "    }\n",
+    "    clean_state_to_sync = nnx.State(clean_state_dict)\n",
+    "\n",
+    "    # --- 4. vLLM Synchronization & Evaluation ---\n",
+    "    print(\"Syncing merged parameters with vLLM and starting evaluation...\")\n",
+    "    vllm_rollout.update_params(clean_state_to_sync)\n",
+    "    score = evaluate_model(test_dataset, vllm_rollout, debug=False)\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Please set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05139cf6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if run_evaluation:\n",
+    "    print(\"========================= Score for POST-SFT Evaluation =========================\")\n",
+    "    print(f\"Percentage of test samples where the model produced the correct numerical answer: {score['correct']}%\")\n",
+    "    print(\n",
+    "        f\"Percentage of test samples where the model produced the numerical answer within 10%: {score['partially_correct']}%\"\n",
+    "    )\n",
+    "    print(\n",
+    "        f\"Percentage of test samples where the model's output adheres to the expected structure: {score['correct_format']}%\"\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Plese set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lora_notebook",
+   "language": "python",
+   "name": "lora_notebook"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -267,6 +267,16 @@ def verify_chat_template_generation_prompt_logic(tokenizer_model):
   actual_prefix_in_full_turn = full_turn_ids[len(prompt_wo_gen_ids) : len(prompt_wo_gen_ids) + len(assistant_prefix)]
 
   if actual_prefix_in_full_turn != assistant_prefix:
+    # Allow the generation prompt to include a thought channel block (e.g., for Gemma 4).
+    thought_channel = "<|channel>thought\n<channel|>"
+    thought_ids = extract_token_ids(tokenizer_model.encode(thought_channel, add_special_tokens=False))
+    if len(assistant_prefix) >= len(thought_ids) and assistant_prefix[-len(thought_ids) :] == thought_ids:
+      true_prefix_ids = assistant_prefix[: -len(thought_ids)]
+      actual_prefix = full_turn_ids[len(prompt_wo_gen_ids) : len(prompt_wo_gen_ids) + len(true_prefix_ids)]
+      if actual_prefix == true_prefix_ids:
+        max_logging.info("Chat template generation prompt mismatch resolved via thought channel bypass.")
+        return
+
     expected_str = tokenizer_model.decode(assistant_prefix)
     actual_str = tokenizer_model.decode(actual_prefix_in_full_turn)
     raise ValueError(
@@ -297,6 +307,12 @@ def _get_completion_in_chat_template(tokenizer_model, round_msgs):
 
   prompt_completion_ids = extract_token_ids(prompt_completion_tokens)
   prompt_ids = extract_token_ids(prompt_tokens)
+
+  # Bypass for Gemma 4's thought channel block which is included in generation prompt but not in normal assistant turns
+  thought_channel = "<|channel>thought\n<channel|>"
+  thought_ids = extract_token_ids(tokenizer_model.encode(thought_channel, add_special_tokens=False))
+  if len(prompt_ids) >= len(thought_ids) and prompt_ids[-len(thought_ids) :] == thought_ids:
+    prompt_ids = prompt_ids[: -len(thought_ids)]
 
   completion_tokens = prompt_completion_ids[len(prompt_ids) :]
   completion_in_chat_template = tokenizer_model.decode(completion_tokens, skip_special_tokens=False)

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -64,8 +64,7 @@ from maxtext.models import (
     simple_layer,
 )
 from maxtext.multimodal import utils as mm_utils
-from maxtext.utils import max_logging, max_utils, maxtext_utils, sharding
-from maxtext.utils.maxtext_utils_nnx import nnx_ensure_scan_leading_axis
+from maxtext.utils import max_logging, max_utils, maxtext_utils, maxtext_utils_nnx, sharding
 from maxtext.utils.sharding import create_sharding
 
 # ------------------------------------------------------------------------------
@@ -595,6 +594,8 @@ class NNXDecoder(nnx.Module):
     use_kv = kv_caches_stacked is not None
 
     def layer_fn(carry, scanned_vars):
+      # Ensure metadata rank matches the sliced values
+      scanned_vars = maxtext_utils_nnx.nnx_remove_scan_axis(scanned_vars, "layers")
 
       # Unpack the sliced variables for THIS layer
       if use_kv:
@@ -664,16 +665,20 @@ class NNXDecoder(nnx.Module):
       # inference with vLLM, parameters do not change and we don't need intermediates.
       return current_carry, layers, None
     else:
-      params = nnx_ensure_scan_leading_axis(params, length)
-      state = nnx_ensure_scan_leading_axis(state, length)
+      params = maxtext_utils_nnx.nnx_ensure_scan_leading_axis(params, length)
+      state = maxtext_utils_nnx.nnx_ensure_scan_leading_axis(state, length)
 
       final_carry, scanned_state = jax.lax.scan(layer_fn_wrapped, x_in, (params, state))
-      returned_kv_stacked = None
 
-    if scan_axis != 0:
-      new_params, new_rest = scanned_state.split(nnx.Param, ...)
-      new_params = jax.tree.map(lambda x: jnp.moveaxis(x, scan_axis, 0), new_params)
-      scanned_state = nnx.merge_state(new_params, new_rest)
+      # Ensure metadata rank matches the stacked values
+      scanned_state = maxtext_utils_nnx.nnx_add_scan_axis(scanned_state, "layers", 0)
+
+      if scan_axis != 0:
+        new_params, new_rest = scanned_state.split(nnx.Param, ...)
+        new_params = maxtext_utils_nnx.nnx_sync_moveaxis(new_params, 0, scan_axis)
+        scanned_state = nnx.merge_state(new_params, new_rest)
+
+      returned_kv_stacked = None
 
     if dynamic_graph_init:
       # If graph changed, we need to merge with the new graphdef.

--- a/src/maxtext/trainers/post_train/sft/train_sft.py
+++ b/src/maxtext/trainers/post_train/sft/train_sft.py
@@ -264,9 +264,14 @@ def setup_trainer_state(mt_config, goodput_recorder=None):
 def train_model(mt_config, trainer, mesh):
   """Runs the SFT training loop in Tunix."""
   with mesh, nn_partitioning.axis_rules(mt_config.logical_axis_rules):
+    # Disable NNX graph caching for MoE models (where experts > 1) to allow
+    # necessary dynamic metadata synchronization during forward passes (e.g., in jax.lax.scan).
+    enable_nnx_cache = getattr(mt_config, "num_experts", 1) <= 1
+
     trainer.train(
         trainer.data_hooks.train_data_iterator,
         trainer.data_hooks.eval_data_iterator,
+        cache_nnx_graph=enable_nnx_cache,
     )
   return trainer
 

--- a/src/maxtext/utils/lora_utils.py
+++ b/src/maxtext/utils/lora_utils.py
@@ -19,7 +19,7 @@ import os
 import re
 from typing import Any, Optional
 
-from flax import nnx
+from flax import nnx, linen as nn
 from flax.linen import partitioning as nn_partitioning
 from flax.training import train_state
 import jax
@@ -33,7 +33,6 @@ from maxtext.utils import gcs_utils
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
-from maxtext.utils import sharding
 from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
 
 
@@ -411,11 +410,18 @@ def _build_lora_provider(mt_config: pyconfig.HyperParameters) -> qwix.LoraProvid
       "rank": mt_config.lora.lora_rank,
       "alpha": mt_config.lora.lora_alpha,
       "dropout": 0.0,
+      "weight_qtype": mt_config.lora.lora_weight_qtype,
+      "tile_size": mt_config.lora.lora_tile_size,
   }
+  # Distinguish between standard LoRA and QLoRA in logs
+  lora_type = "QLoRA" if mt_config.lora.lora_weight_qtype else "LoRA"
+
   max_logging.log(
-      f"LoRA configured: module_path={lora_module_path} "
-      f"rank={mt_config.lora.lora_rank} alpha={mt_config.lora.lora_alpha}"
+      f"{lora_type} configured: rank={mt_config.lora.lora_rank} alpha={mt_config.lora.lora_alpha} "
+      f"qtype={mt_config.lora.lora_weight_qtype} tile_size={mt_config.lora.lora_tile_size}"
   )
+
+  max_logging.log(f"Using lora_module_path: {lora_module_path}")
   return qwix.LoraProvider(**lora_kwargs)
 
 
@@ -513,13 +519,22 @@ def apply_lora_to_model(
 
       # Use logical_to_mesh_sharding to correctly map logical axes like 'embed'
       # to physical mesh axes.
-      dst_shardings = sharding.logical_to_mesh_sharding(
-          nnx.get_partition_spec(state), mesh, rules=mt_config.logical_axis_rules
-      )
+      dst_shardings = nn.logical_to_mesh_sharding(nnx.get_partition_spec(state), mesh, mt_config.logical_axis_rules)
 
-      from tunix.rl import reshard  # pylint: disable=import-outside-toplevel
+      def _safe_reshard(var, sharding_spec):
+        if not isinstance(var, nnx.Variable) or not isinstance(sharding_spec, jax.sharding.Sharding):
+          return var
+        val = var.get_value()
+        if not isinstance(val, jax.Array):
+          return var
+        # make_array_from_callback natively constructs a globally sharded array
+        # from the local host arrays, bypassing backend-specific device_put issues
+        # on both Pathways and McJAX.
+        resharded_val = jax.make_array_from_callback(val.shape, sharding_spec, lambda idx: val[idx])
+        return var.replace(value=resharded_val)
 
-      state = reshard.reshard_pytree(state, dst_shardings)
+      state = jax.tree_util.tree_map(_safe_reshard, state, dst_shardings, is_leaf=lambda x: isinstance(x, nnx.Variable))
+
       lora_model = nnx.merge(graph_def, state)
 
   _verify_lora_parameters(lora_model, mt_config)

--- a/src/maxtext/utils/maxtext_utils_nnx.py
+++ b/src/maxtext/utils/maxtext_utils_nnx.py
@@ -18,7 +18,8 @@ from typing import Callable
 
 from flax import nnx
 import jax
-from jax.sharding import Mesh, NamedSharding
+import jax.numpy as jnp
+from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 
 from maxtext.utils import max_logging
 from maxtext.configs import pyconfig
@@ -185,5 +186,92 @@ def nnx_ensure_scan_leading_axis(tree, length):
       new_val = jax.numpy.broadcast_to(val, (length,))
       return x.replace(value=new_val) if is_var else new_val
     return x
+
+  return jax.tree.map(_op, tree, is_leaf=lambda x: isinstance(x, nnx.Variable))
+
+
+# ------------------------------------------------------------------------------
+# Metadata Synchronization Helpers for NNX Variables
+# ------------------------------------------------------------------------------
+
+
+def nnx_update_sharding_meta(variable, transform_fn):
+  """Generic helper to apply a list transformation to all sharding-related metadata."""
+  if not (hasattr(variable, "get_metadata") and hasattr(variable, "replace")):
+    return variable
+
+  meta = variable.get_metadata()
+  updates = {}
+
+  for key in ["sharding", "out_sharding", "sharding_names"]:
+    if (val := meta.get(key)) and isinstance(val, (P, tuple, list)):
+      new_list = list(val)
+      transformed = transform_fn(new_list)
+      updates[key] = P(*transformed) if isinstance(val, P) else tuple(transformed)
+
+  if updates:
+    return variable.replace(**updates)
+  return variable
+
+
+def nnx_sync_moveaxis(tree, from_axis, to_axis):
+  """Moves an axis in both values and sharding metadata of nnx.Variables."""
+  if from_axis == to_axis:
+    return tree
+
+  def _op(x):
+    is_var = isinstance(x, nnx.Variable)
+    val = x.get_value() if is_var else x
+    if not hasattr(val, "shape"):
+      return x
+
+    new_val = jnp.moveaxis(val, from_axis, to_axis)
+    if not is_var:
+      return new_val
+
+    def move_fn(l):
+      if len(l) > max(from_axis, to_axis):
+        l.insert(to_axis, l.pop(from_axis))
+      return l
+
+    return nnx_update_sharding_meta(x.replace(value=new_val), move_fn)
+
+  return jax.tree.map(_op, tree, is_leaf=lambda x: isinstance(x, nnx.Variable) or hasattr(x, "shape"))
+
+
+def nnx_remove_scan_axis(tree, name="layers"):
+  """Removes the given scan axis from the PartitionSpec."""
+
+  def _op(x):
+    if not isinstance(x, nnx.Variable):
+      return x
+
+    def remove_fn(l):
+      if name in l:
+        l.remove(name)
+      while len(l) > x.get_value().ndim:
+        l.pop(0)
+      return l
+
+    return nnx_update_sharding_meta(x, remove_fn)
+
+  return jax.tree.map(_op, tree, is_leaf=lambda x: isinstance(x, nnx.Variable))
+
+
+def nnx_add_scan_axis(tree, name="layers", pos=0):
+  """Adds the given scan axis to the PartitionSpec at the specified position."""
+
+  def _op(x):
+    if not isinstance(x, nnx.Variable):
+      return x
+
+    def add_fn(l):
+      if name not in l:
+        l.insert(pos, name)
+      while len(l) < x.get_value().ndim:
+        l.insert(pos, None)
+      return l
+
+    return nnx_update_sharding_meta(x, add_fn)
 
   return jax.tree.map(_op, tree, is_leaf=lambda x: isinstance(x, nnx.Variable))

--- a/tests/post_training/unit/lora_utils_test.py
+++ b/tests/post_training/unit/lora_utils_test.py
@@ -29,6 +29,8 @@ from tunix.sft import peft_trainer
 from maxtext.utils import lora_utils
 from maxtext.utils import model_creation_utils
 from maxtext.configs import pyconfig
+from maxtext.utils import maxtext_utils
+from jax.sharding import Mesh
 from tests.utils.test_helpers import get_test_config_path
 
 # ---------------------------------------------------------------------------
@@ -104,10 +106,14 @@ class LoraUtilsTest(unittest.TestCase):
     mock_config.lora.lora_module_path = "custom/path"
     mock_config.lora.lora_rank = 8
     mock_config.lora.lora_alpha = 16.0
+    mock_config.lora.lora_weight_qtype = "int8"
+    mock_config.lora.lora_tile_size = 32
 
     with mock.patch("qwix.LoraProvider") as mock_provider:
       lora_utils._build_lora_provider(mock_config)
-      mock_provider.assert_called_once_with(module_path="custom/path", rank=8, alpha=16.0, dropout=0.0)
+      mock_provider.assert_called_once_with(
+          module_path="custom/path", rank=8, alpha=16.0, dropout=0.0, weight_qtype="int8", tile_size=32
+      )
 
   def test_prepare_dummy_inputs(self):
     """Test preparation of dummy inputs for LoRA verification."""
@@ -158,8 +164,8 @@ class LoraUtilsTest(unittest.TestCase):
     # If we skip Qwix, it should stay False.
     self.assertFalse(lora_utils.is_lora_enabled(result))
 
-  def _run_apply_lora_test(self, scan_layers: bool):
-    """Helper to run LoRA application test with/without scanned layers."""
+  def _run_apply_lora_test(self, scan_layers: bool, weight_qtype=None, tile_size=None, mock_multihost: bool = False):
+    """Helper to run LoRA application test with/without scanned layers and optional QLoRA."""
     # Passing nested dict as 'lora' kwarg to _make_config
     cfg = _make_config(
         lora={
@@ -167,18 +173,27 @@ class LoraUtilsTest(unittest.TestCase):
             "lora_rank": 4,
             "lora_alpha": 8.0,
             "lora_module_path": ".*mlp/wi_.*",
+            "lora_weight_qtype": weight_qtype,
+            "lora_tile_size": tile_size,
         },
         scan_layers=scan_layers,
     )
 
     # Create a real small model using standard creation utils
-    model, _ = model_creation_utils.from_pretrained(cfg, mesh=None, model_mode=model_creation_utils.MODEL_MODE_TRAIN)
+    model, mesh = model_creation_utils.from_pretrained(cfg, mesh=None, model_mode=model_creation_utils.MODEL_MODE_TRAIN)
 
     # Verify model is NOT lora enabled initially
     self.assertFalse(lora_utils.is_lora_enabled(model))
 
-    # Apply LoRA
-    lora_model = lora_utils.apply_lora_to_model(model, model.mesh, cfg)
+    if mock_multihost:
+      devices_array = maxtext_utils.create_device_mesh(cfg)
+      dummy_mesh = Mesh(devices_array, cfg.mesh_axes)
+
+      # Just verify that apply_lora_to_model runs successfully with the dummy mesh
+      lora_model = lora_utils.apply_lora_to_model(model, dummy_mesh, cfg)
+    else:
+      # Apply LoRA
+      lora_model = lora_utils.apply_lora_to_model(model, mesh, cfg)
 
     # Verify we can find LoRAParam in the state
     _, state = nnx.split(lora_model)
@@ -200,12 +215,26 @@ class LoraUtilsTest(unittest.TestCase):
     self.assertGreater(len(jax.tree_util.tree_leaves(opt_state)), 0)
 
   def test_apply_lora_to_model_scan_layers_false(self):
-    """Test applying LoRA to model with scan_layers=False."""
+    """Test applying standard LoRA to model with scan_layers=False."""
     self._run_apply_lora_test(scan_layers=False)
 
   def test_apply_lora_to_model_scan_layers_true(self):
-    """Test applying LoRA to model with scan_layers=True."""
+    """Test applying standard LoRA to model with scan_layers=True."""
     self._run_apply_lora_test(scan_layers=True)
+
+  @unittest.skip("Awaiting qwix fix for QLoRA params materialization")
+  def test_apply_qlora_to_model_scan_layers_false(self):
+    """Test applying QLoRA to model with scan_layers=False."""
+    self._run_apply_lora_test(scan_layers=False, weight_qtype="int8", tile_size=32)
+
+  @unittest.skip("Awaiting qwix fix for QLoRA params materialization")
+  def test_apply_qlora_to_model_scan_layers_true(self):
+    """Test applying QLoRA to model with scan_layers=True."""
+    self._run_apply_lora_test(scan_layers=True, weight_qtype="int8", tile_size=32)
+
+  def test_apply_lora_multihost_mock(self):
+    """Test applying LoRA with a dummy mesh to trigger the multi-host reshard callback."""
+    self._run_apply_lora_test(scan_layers=False, mock_multihost=True)
 
   def test_restore_lora_from_path(self):
     """Test restoration of LoRA parameters from a path."""

--- a/tests/post_training/unit/sft_data_processing_test.py
+++ b/tests/post_training/unit/sft_data_processing_test.py
@@ -512,12 +512,16 @@ class SFTChatTemplateLogicTest(unittest.TestCase):
     super().setUp()
     self.qwen3_tokenizer = transformers.AutoTokenizer.from_pretrained("Qwen/Qwen3-4B")
     self.llama2_tokenizer = transformers.AutoTokenizer.from_pretrained(self.LLAMA_TOKENIZER_PATH)
+    self.gemma4_tokenizer = transformers.AutoTokenizer.from_pretrained("google/gemma-4-26b-a4b-it")
 
   def test_tokenizer_w_generation_prompt(self):
     verify_chat_template_generation_prompt_logic(self.qwen3_tokenizer)
 
   def test_tokenizer_wo_generation_prompt(self):
     verify_chat_template_generation_prompt_logic(self.llama2_tokenizer)
+
+  def test_tokenizer_gemma4_thought_channel_bypass(self):
+    verify_chat_template_generation_prompt_logic(self.gemma4_tokenizer)
 
   def test_failure_path_with_modified_template(self):
     """Verifies the function correctly raises a ValueError on a bad template."""

--- a/tests/utils/test_maxtext_utils_nnx.py
+++ b/tests/utils/test_maxtext_utils_nnx.py
@@ -1,0 +1,72 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Tests for NNX utilities. """
+
+import unittest
+from flax import nnx
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+from maxtext.utils import maxtext_utils_nnx  # pylint: disable=no-name-in-module
+
+
+class TestMaxtextUtilsNnx(unittest.TestCase):
+  """Tests for maxtext_utils_nnx."""
+
+  def test_nnx_sync_moveaxis(self):
+    val = jnp.zeros((10, 20, 30))
+    sharding = P("layers", "embed", None)
+
+    var = nnx.Param(val)
+    var.set_metadata(sharding=sharding, out_sharding=sharding)
+
+    moved_var = maxtext_utils_nnx.nnx_sync_moveaxis(var, 0, 2)
+
+    self.assertEqual(moved_var.get_value().shape, (20, 30, 10))
+    self.assertEqual(moved_var.get_metadata().get("sharding"), P("embed", None, "layers"))
+    self.assertEqual(moved_var.get_metadata().get("out_sharding"), P("embed", None, "layers"))
+
+  def test_nnx_remove_scan_axis(self):
+    val = jnp.zeros((10, 20))
+    sharding = P("layers", "embed")
+    var = nnx.Param(val)
+    var.set_metadata(sharding=sharding)
+
+    # Simulate slicing
+    sliced_val = val[0]
+    var_with_sliced_val = var.replace(value=sliced_val)
+
+    fixed_var = maxtext_utils_nnx.nnx_remove_scan_axis(var_with_sliced_val, "layers")
+
+    self.assertEqual(fixed_var.get_value().ndim, 1)
+    self.assertEqual(fixed_var.get_metadata().get("sharding"), P("embed"))
+
+  def test_nnx_add_scan_axis(self):
+    val = jnp.zeros((20,))
+    sharding = P("embed")
+    var = nnx.Param(val)
+    var.set_metadata(sharding=sharding)
+
+    # Simulate stacking
+    stacked_val = jnp.stack([val] * 10, axis=0)
+    var_with_stacked_val = var.replace(value=stacked_val)
+
+    fixed_var = maxtext_utils_nnx.nnx_add_scan_axis(var_with_stacked_val, "layers", 0)
+
+    self.assertEqual(fixed_var.get_value().ndim, 2)
+    self.assertEqual(fixed_var.get_metadata().get("sharding"), P("layers", "embed"))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

This PR introduces comprehensive, out-of-the-box support for QLoRA (Quantized Low-Rank Adaptation) and fixes critical initialization crashes that occurred when running LoRA/QLoRA Fine-Tuning in multi-host TPU environments. It
  unifies the array distribution logic so that both Dense models (like Llama 3) and Mixture-of-Experts models (like Gemma 4) work seamlessly on both Pathways and standard McJAX backends.

  What was added/changed:
   1. QLoRA Configuration Support: Added lora_weight_qtype (e.g., nf4) and lora_tile_size to configuration types, passing them to the underlying qwix library to enable quantized base model training. Includes a new
      lora_llama3_demo.ipynb notebook.
   2. Native JAX Resharding (jax.make_array_from_callback): Added a native _safe_reshard function to lora_utils.py. Instead of attempting cross-host streaming (which crashes McJAX) or relying on external utilities, each host now
      gracefully constructs the global array by extracting its required physical slice directly from its local CPU copy.
   3. MoE Partition Safety: Added strict type and partition spec checks to safely ignore dynamic routing states (which yield None partition specs) preventing AttributeError crashes in MoE models.
   4. Documentation Updates: Updated the lora_on_multi_host.md tutorial with the correct gemma4-26b configurations, safe default memory limits, and explicit Pathways initialization flags.

# Tests

 Validated initialization, compilation, and training on a 2-slice v6e-8 cluster:
   - Llama 3.1 8B on McJAX
   - Llama 3.1 8B on Pathways
   - Gemma 4 26B on McJAX (Successfully bypassed NoneType MoE partition crashes)
   - Gemma 4 26B on Pathways (Successfully completed full training loop)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
