### PR TITLE
Add optional --skip-validation flag to benchmark recipes and XPK workload creation

### DIFF
--- a/benchmarks/maxtext_xpk_runner.py
+++ b/benchmarks/maxtext_xpk_runner.py
@@ -115,6 +115,7 @@ class WorkloadConfig:
   disruption_configs: DisruptionConfig = None
   xpk_storage: None | list[str] = None
   hlo_dump: None | bool = None
+  skip_validation: bool = False
 
   def __post_init__(self):
     """Initializes num_devices_per_slice and topology for recording the run into BigQuery"""
@@ -643,6 +644,9 @@ def generate_xpk_workload_cmd(
     docker_image_flag = f"--docker-image={pw_config.runner_image}"
   else:
     docker_image_flag = f'--base-docker-image="{wl_config.base_docker_image}"'
+
+  if wl_config.skip_validation:
+    workload_create_command += " --skip-validation"
 
   upload_metrics_to_bq_cmd = ""
   if wl_config.generate_metrics_and_upload_to_big_query and not is_pathways_headless_enabled:

--- a/benchmarks/recipes/parser_utils.py
+++ b/benchmarks/recipes/parser_utils.py
@@ -151,6 +151,13 @@ def add_arguments(parser: argparse.ArgumentParser):
       help="BigQuery dataset name where metrics will be written.",
   )
 
+  parser.add_argument(
+      "--skip-validation",
+      action="store_true",
+      default=False,
+      help="Skip xpk health checks and system dependency validation during workload execution",
+)
+
   # Other configurations
   parser.add_argument("--xpk_path", type=str, default="~/xpk", help="Path to xpk.")
   parser.add_argument("--delete", action="store_true", help="Delete the cluster workload")

--- a/benchmarks/recipes/runner_utils.py
+++ b/benchmarks/recipes/runner_utils.py
@@ -48,6 +48,7 @@ def _create_workload_config(
       "generate_metrics_and_upload_to_big_query": user_config.bq_enable,
       "db_project": user_config.bq_db_project,
       "db_dataset": user_config.bq_db_dataset,
+      "skip_validation": user_config.skip_validation,
   }
   # Add any extra arguments, like disruption_configs, if they exist
   config_args.update(kwargs)

--- a/benchmarks/recipes/user_configs.py
+++ b/benchmarks/recipes/user_configs.py
@@ -82,6 +82,7 @@ class UserConfig:
   max_restarts: int = 0
   temp_key: str = None
   workload_id: str = None
+  skip_validation: bool = False
 
   def __post_init__(self):
     """Automatically generate derived attributes after the object is created."""


### PR DESCRIPTION
# Description

**Context** 
Previously, benchmark recipe interfaces (e.g., `pw_mcjax_benchmark_recipe`) lacked a mechanism to propagate the` --skip-validation` intent to the underlying generated commands. This prevented users from bypassing validation steps during benchmark execution.

**Solution** 
Introduced an optional `--skip-validation` flag to the benchmark recipe interface. This flag is threaded down to the `xpk workload create` command to bypass system dependency checks (such as `docker` or `kubectl-kjob`) and resource validation. This is specifically required for Airflow/Composer integration, where these tools are not available or necessary for launching workloads, thus avoiding unnecessary environment complexity.

- Default Behavior: If the flag is omitted, the existing validation logic remains active, ensuring backward compatibility.

- New Behavior: When provided, it explicitly skips the validation phase in the workload creation.


# Tests

Validated the flag propagation by executing the `pw_mcjax_benchmark_recipe` with the new parameter:

**Execution Command:**
`python3 -m benchmarks.recipes.pw_mcjax_benchmark_recipe --user=root --cluster_name=pw-v6e-32x4 --project=cienet-cmcs --zone=us-central1-b --benchmark_steps=20 --num_slices_list=1 --server_image=[us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest](https://www.google.com/url?sa=D&q=http%3A%2F%2Fus-docker.pkg.dev%2Fcloud-tpu-v2-images%2Fpathways%2Fserver%3Alatest) --proxy_image=[us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest](https://www.google.com/url?sa=D&q=http%3A%2F%2Fus-docker.pkg.dev%2Fcloud-tpu-v2-images%2Fpathways%2Fproxy_server%3Alatest) --runner=[gcr.io/tpu-prod-env-multipod/skip_val:latest](https://www.google.com/url?sa=D&q=http%3A%2F%2Fgcr.io%2Ftpu-prod-env-multipod%2Fskip_val%3Alatest) --selected_model_framework=pathways --selected_model_names=default_basic_1 --priority=medium --max_restarts=1 --bq_enable=False --bq_db_project=cloud-tpu-multipod-dev --bq_db_dataset=chzheng_test_100steps --workload_id=roo-pw-default-1-ha5 --device_type=v6e-32 --skip-validation`

**Verification:**
[Execution logs ](https://paste.googleplex.com/6704503488380928) confirm that the flag was correctly parsed and passed to the xpk command.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
