### PR TITLE
Save run manifest for distillation reproducibility.

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -35,8 +35,10 @@ Architecture Overview:
 
 import inspect
 import logging
+import shlex
 from typing import Sequence, Callable, Any
 from absl import app
+from etils import epath
 from flax import nnx
 from flax.linen import partitioning as nn_partitioning
 import jax
@@ -722,6 +724,35 @@ def train_distill(
   max_logging.log("Distillation Complete.")
 
 
+def _save_run_manifest(argv: Sequence[str], config: pyconfig.HyperParameters) -> None:
+  """Writes the source YAML and a shell-pasteable command to the output dir.
+
+  Saves `distillation.yml` (verbatim copy of the user's config file) and
+  `command.sh` (the CLI overrides) so a run can be reproduced by copying the
+  YAML and re-running the saved command.
+  """
+  if jax.process_index() != 0:
+    return
+  if not (config.base_output_directory and config.run_name):
+    return
+  if len(argv) < 2:
+    return
+
+  try:
+    out_dir = epath.Path(config.base_output_directory) / config.run_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    source_yml = epath.Path(pyconfig.resolve_config_path(argv[1]))
+    source_yml.copy(out_dir / "distillation.yml", overwrite=True)
+
+    cli_args = shlex.join(argv[2:])
+    command = "python3 -m maxtext.trainers.post_train.distillation.train_distill " f"distillation.yml {cli_args}\n"
+    (out_dir / "command.sh").write_text(command)
+    max_logging.log(f"Saved run manifest (distillation.yml, command.sh) to {out_dir}")
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    max_logging.log(f"Warning: could not save run manifest: {e}")
+
+
 def main(argv: Sequence[str]) -> None:
   """Entry point for the script.
 
@@ -733,6 +764,7 @@ def main(argv: Sequence[str]) -> None:
   """
   # 1. Parse Global Config to extract Overrides
   global_config = pyconfig.initialize(argv)
+  _save_run_manifest(argv, global_config)
 
   # 2. Initialize STUDENT Config
   # Order of precedence: YAML < CLI < kwargs (student_overrides).

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -1010,6 +1010,8 @@ class TrainDistillTest(unittest.TestCase):
     mock_global.student_overrides = {}
     mock_global.teacher_overrides = {}  # No checkpoint needed
     mock_global.offline_data_dir = "gs://bucket/data"  # Triggers offline mode
+    mock_global.base_output_directory = ""
+    mock_global.run_name = ""
 
     mock_student_cfg = mock.Mock()
     mock_student_cfg.vocab_size = 32000
@@ -1100,6 +1102,8 @@ class TrainDistillTest(unittest.TestCase):
     mock_global.student_overrides = {}
     mock_global.teacher_overrides = {"load_parameters_path": "gs://ckpt"}
     mock_global.offline_data_dir = None  # Triggers online mode
+    mock_global.base_output_directory = ""
+    mock_global.run_name = ""
 
     mock_student_cfg = mock.Mock()
     mock_student_cfg.vocab_size = 32000
@@ -1255,6 +1259,43 @@ class TrainDistillTest(unittest.TestCase):
     # Verify layer2 has changed (trained)
     is_layer2_unchanged = np.allclose(student.layer2.kernel.get_value(), initial_layer2_weights)
     self.assertFalse(is_layer2_unchanged, msg="layer2 weights should have updated.")
+
+  def test_save_run_manifest_writes_files(self):
+    """Verifies _save_run_manifest copies the source YAML and writes command.sh."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      source_yml = os.path.join(tmp_dir, "my_distill.yml")
+      with open(source_yml, "w", encoding="utf-8") as f:
+        f.write("# example config\nsteps: 10\n")
+
+      config = mock.Mock()
+      config.base_output_directory = tmp_dir
+      config.run_name = "test_run"
+      argv = ["train_distill.py", source_yml, "steps=20", "learning_rate=1e-4"]
+
+      train_distill._save_run_manifest(argv, config)  # pylint: disable=protected-access
+
+      out_dir = os.path.join(tmp_dir, "test_run")
+      saved_yml = os.path.join(out_dir, "distillation.yml")
+      saved_cmd = os.path.join(out_dir, "command.sh")
+      self.assertTrue(os.path.exists(saved_yml))
+      self.assertTrue(os.path.exists(saved_cmd))
+      with open(saved_yml, encoding="utf-8") as f:
+        self.assertIn("steps: 10", f.read())
+      with open(saved_cmd, encoding="utf-8") as f:
+        command = f.read()
+      self.assertIn("distillation.yml", command)
+      self.assertIn("steps=20", command)
+      self.assertIn("learning_rate=1e-4", command)
+
+  def test_save_run_manifest_swallows_errors(self):
+    """Verifies _save_run_manifest does not raise if the source YAML is missing."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      config = mock.Mock()
+      config.base_output_directory = tmp_dir
+      config.run_name = "test_run"
+      argv = ["train_distill.py", "/does/not/exist.yml"]
+      # Must not raise — failures here should not kill training.
+      train_distill._save_run_manifest(argv, config)  # pylint: disable=protected-access
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
                                                                                                         
Save `distillation.yml`  and `command.sh` (CLI overrides) to the run's output directory at startup, so a run can be reproduced by copying the YAML and re-running the saved command.
  - Works for local and GCS paths via `etils.epath`. Host-0 only.                                     
  - Failures in the helper are caught and logged as a warning — they do not abort the training run.

# Tests

Unit test and end to end test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
