### PR TITLE
[New Model Bringup] Initial Commit to enable Text-only architecture for Qwen3.5

### DIFF
--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -102,6 +102,7 @@ class DecoderBlockType(enum.Enum):
   QWEN3_MOE = "qwen3_moe"
   QWEN3_CUSTOM_MOE = "qwen3_custom_moe"
   QWEN3_NEXT = "qwen3_next"
+  QWEN3_5 = "qwen3_5"
   GPT3 = "gpt3"
   GPT_OSS = "gpt_oss"
   SIMPLE = "simple"

--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -101,6 +101,7 @@ class DecoderBlockType(enum.Enum):
   QWEN3_MOE = "qwen3_moe"
   QWEN3_CUSTOM_MOE = "qwen3_custom_moe"
   QWEN3_NEXT = "qwen3_next"
+  QWEN3_5 = "qwen3_5"
   GPT3 = "gpt3"
   GPT_OSS = "gpt_oss"
   SIMPLE = "simple"

--- a/src/maxtext/configs/models/qwen3.5-397b-a17b.yml
+++ b/src/maxtext/configs/models/qwen3.5-397b-a17b.yml
@@ -1,0 +1,51 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# maxtext/configs/models/qwen3.5-397b-a17b.yml
+
+decoder_block: "qwen3_5"
+
+# Core Architectural Parameters
+base_emb_dim: 4096
+base_num_decoder_layers: 60
+base_num_query_heads: 32
+base_num_kv_heads: 2
+head_dim: 256
+vocab_size: 248320
+normalization_layer_epsilon: 1.0e-6
+
+# MoE Specific Parameters
+# Set base_mlp_dim to match base_moe_mlp_dim to pass validation for fully MoE models.
+base_mlp_dim: 1024
+base_moe_mlp_dim: 1024
+num_experts: 512
+shared_experts: 1
+num_experts_per_tok: 10
+norm_topk_prob: True
+
+# GatedDeltaNet Specific Parameters for Linear Attention (GDN)
+inhomogeneous_layer_cycle_interval: 4
+gdn_conv_kernel_dim: 4
+gdn_key_head_dim: 128
+gdn_value_head_dim: 128
+gdn_num_key_heads: 16
+gdn_num_value_heads: 64
+gdn_chunk_size: 64
+
+# RoPE Settings
+rope_max_timescale: 10000000
+partial_rotary_factor: 0.25
+
+# General Model Settings
+enable_dropout: False

--- a/src/maxtext/configs/models/qwen3.5-397b-a17b.yml
+++ b/src/maxtext/configs/models/qwen3.5-397b-a17b.yml
@@ -1,0 +1,53 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# maxtext/configs/models/qwen3-next-80b-a3b.yml
+
+decoder_block: "qwen3_5"
+
+# Core Architectural Parameters
+base_emb_dim: 4096
+base_num_decoder_layers: 60
+base_num_query_heads: 32
+base_num_kv_heads: 2
+head_dim: 256
+vocab_size: 248320
+normalization_layer_epsilon: 1.0e-6
+
+# MoE Specific Parameters
+# Set base_mlp_dim to match base_moe_mlp_dim to pass validation for fully MoE models.
+base_mlp_dim: 1024
+base_moe_mlp_dim: 1024
+num_experts: 512
+shared_experts: 1
+num_experts_per_tok: 10
+norm_topk_prob: True
+
+# Qwen3-Next Specific Parameters for Linear Attention (Gated Delta Net)
+inhomogeneous_layer_cycle_interval: 4
+gdn_conv_kernel_dim: 4
+gdn_key_head_dim: 128
+gdn_value_head_dim: 128
+gdn_num_key_heads: 16
+gdn_num_value_heads: 64
+gdn_chunk_size: 64
+
+# RoPE Settings
+rope_max_timescale: 10000000
+partial_rotary_factor: 0.25
+
+# General Model Settings
+enable_dropout: False
+
+

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -259,6 +259,7 @@ ModelName = Literal[
     "qwen3-next-80b-a3b",
     "qwen3-omni-30b-a3b",
     "qwen3-custom-30b-a3b",
+    "qwen3.5-397b-a17b",
     "gpt3-175b",
     "gpt3-22b",
     "gpt3-6b",
@@ -2871,7 +2872,10 @@ class MaxTextConfig(
             f"The number of decoder layers ({self.base_num_decoder_layers}) must be divisible by interleave moe layer step "
             f"({self.interleave_moe_layer_step})"
         )
-    if self.decoder_block == DecoderBlockType.QWEN3_NEXT:
+    if self.decoder_block in (
+        DecoderBlockType.QWEN3_NEXT,
+        DecoderBlockType.QWEN3_5,
+    ):
       if int(self.gdn_num_value_heads) % int(self.gdn_num_key_heads) != 0:
         raise ValueError("gdn_num_value_heads must be divisible by gdn_num_key_heads")
       rotary_dim = int(self.head_dim * self.partial_rotary_factor)

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -257,6 +257,7 @@ ModelName = Literal[
     "qwen3-next-80b-a3b",
     "qwen3-omni-30b-a3b",
     "qwen3-custom-30b-a3b",
+    "qwen3.5-397b-a17b",
     "gpt3-175b",
     "gpt3-22b",
     "gpt3-6b",
@@ -2725,7 +2726,7 @@ class MaxTextConfig(
             f"The number of decoder layers ({self.base_num_decoder_layers}) must be divisible by interleave moe layer step "
             f"({self.interleave_moe_layer_step})"
         )
-    if self.decoder_block == DecoderBlockType.QWEN3_NEXT:
+    if self.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
       if int(self.gdn_num_value_heads) % int(self.gdn_num_key_heads) != 0:
         raise ValueError("gdn_num_value_heads must be divisible by gdn_num_key_heads")
       rotary_dim = int(self.head_dim * self.partial_rotary_factor)

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -424,7 +424,7 @@ class Attention(nnx.Module):
     self.partial_rotary_factor = partial_rotary_factor
 
     self.is_qwen2 = self.config.decoder_block == DecoderBlockType.QWEN2
-    self.is_qwen3_next = self.config.decoder_block == DecoderBlockType.QWEN3_NEXT
+    self.is_qwen3_hybrid = self.config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5)
 
     # Module attribute names must match names previously passed to Linen for checkpointing
     self.KVCache_0 = (
@@ -522,7 +522,7 @@ class Attention(nnx.Module):
           with_scale=with_scale,
           rngs=self.rngs,
       )
-    elif self.is_qwen3_next:
+    elif self.is_qwen3_hybrid:
       self.query_norm = Qwen3NextRMSNorm(
           num_features=self.config.head_dim,
           eps=self.config.normalization_layer_epsilon,
@@ -597,7 +597,7 @@ class Attention(nnx.Module):
     in_features = self.convert_dense_general_inputs_shape(inputs_q_shape)
     out_features = (self.num_query_heads, self.head_dim)
 
-    if self.is_qwen3_next:
+    if self.is_qwen3_hybrid:
       out_features = (self.num_query_heads, self.head_dim * 2)
 
     return DenseGeneral(
@@ -715,7 +715,7 @@ class Attention(nnx.Module):
     )
     axis = (-2, -1)
 
-    if self.is_qwen3_next:
+    if self.is_qwen3_hybrid:
       in_features = self.num_query_heads * self.out_head_dim
       out_kernel_axis = ("mlp", "embed")
       axis = (-1,)
@@ -824,7 +824,7 @@ class Attention(nnx.Module):
           shard_mode=self.config.shard_mode,
           rngs=self.rngs,
       )
-    elif self.is_qwen3_next:
+    elif self.is_qwen3_hybrid:
       rotary_embedding = PartialRotaryEmbedding(
           min_timescale=self.config.rope_min_timescale,
           max_timescale=self.rope_max_timescale,
@@ -1102,7 +1102,7 @@ class Attention(nnx.Module):
         value = self.kv_projection(inputs_kv, proj_name="value", out_sharding=qkv_sharding)
 
     gate = None
-    if self.is_qwen3_next:
+    if self.is_qwen3_hybrid:
       # Split query into query & gate.
       query, gate = jnp.split(query, 2, axis=-1)
       batch_size, seq_len, _, _ = gate.shape
@@ -1111,7 +1111,7 @@ class Attention(nnx.Module):
     is_llama4_decoder_block = self.config.decoder_block == DecoderBlockType.LLAMA4
     # NOTE: llama 4 does L2 normalization after RoPE
     # Apply Qwen3Next specific RMS Norm
-    if (self.use_qk_norm and not is_llama4_decoder_block) or self.is_qwen3_next:
+    if (self.use_qk_norm and not is_llama4_decoder_block) or self.is_qwen3_hybrid:
       query = self.query_norm(query)
       key = self.key_norm(key)
 
@@ -1199,7 +1199,7 @@ class Attention(nnx.Module):
       out = self._maybe_shard_with_logical(out, self.out_axis_names)
     else:
       out = self._maybe_shard_with_logical(out, self.decode_out_axis_names)
-    if self.is_qwen3_next:
+    if self.is_qwen3_hybrid:
       out = out.reshape(batch_size, seq_len, self.config.num_query_heads * self.config.head_dim)
       out = out * jax.nn.sigmoid(gate)
     out = self.out_projection(out, out_sharding=out_sharding)

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -424,7 +424,7 @@ class Attention(nnx.Module):
     self.partial_rotary_factor = partial_rotary_factor
 
     self.is_qwen2 = self.config.decoder_block == DecoderBlockType.QWEN2
-    self.is_qwen3_next = self.config.decoder_block == DecoderBlockType.QWEN3_NEXT
+    self.is_qwen3_hybrid = self.config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5)
 
     # Module attribute names must match names previously passed to Linen for checkpointing
     self.KVCache_0 = (
@@ -522,7 +522,7 @@ class Attention(nnx.Module):
           with_scale=with_scale,
           rngs=self.rngs,
       )
-    elif self.is_qwen3_next:
+    elif self.is_qwen3_hybrid:
       self.query_norm = Qwen3NextRMSNorm(
           num_features=self.config.head_dim,
           eps=self.config.normalization_layer_epsilon,
@@ -597,7 +597,7 @@ class Attention(nnx.Module):
     in_features = self.convert_dense_general_inputs_shape(inputs_q_shape)
     out_features = (self.num_query_heads, self.head_dim)
 
-    if self.is_qwen3_next:
+    if self.is_qwen3_hybrid:
       out_features = (self.num_query_heads, self.head_dim * 2)
 
     return DenseGeneral(
@@ -715,7 +715,7 @@ class Attention(nnx.Module):
     )
     axis = (-2, -1)
 
-    if self.is_qwen3_next:
+    if self.is_qwen3_hybrid:
       in_features = self.num_query_heads * self.out_head_dim
       out_kernel_axis = ("mlp", "embed")
       axis = (-1,)
@@ -824,7 +824,7 @@ class Attention(nnx.Module):
           shard_mode=self.config.shard_mode,
           rngs=self.rngs,
       )
-    elif self.is_qwen3_next:
+    elif self.is_qwen3_hybrid:
       rotary_embedding = PartialRotaryEmbedding(
           min_timescale=self.config.rope_min_timescale,
           max_timescale=self.rope_max_timescale,
@@ -1101,7 +1101,7 @@ class Attention(nnx.Module):
         value = self.kv_projection(inputs_kv, proj_name="value", out_sharding=qkv_sharding)
 
     gate = None
-    if self.is_qwen3_next:
+    if self.is_qwen3_hybrid:
       # Split query into query & gate.
       query, gate = jnp.split(query, 2, axis=-1)
       batch_size, seq_len, _, _ = gate.shape
@@ -1110,7 +1110,7 @@ class Attention(nnx.Module):
     is_llama4_decoder_block = self.config.decoder_block == DecoderBlockType.LLAMA4
     # NOTE: llama 4 does L2 normalization after RoPE
     # Apply Qwen3Next specific RMS Norm
-    if (self.use_qk_norm and not is_llama4_decoder_block) or self.is_qwen3_next:
+    if (self.use_qk_norm and not is_llama4_decoder_block) or self.is_qwen3_hybrid:
       query = self.query_norm(query)
       key = self.key_norm(key)
 
@@ -1198,7 +1198,7 @@ class Attention(nnx.Module):
       out = self._maybe_shard_with_logical(out, self.out_axis_names)
     else:
       out = self._maybe_shard_with_logical(out, self.decode_out_axis_names)
-    if self.is_qwen3_next:
+    if self.is_qwen3_hybrid:
       out = out.reshape(batch_size, seq_len, self.config.num_query_heads * self.config.head_dim)
       out = out * jax.nn.sigmoid(gate)
     out = self.out_projection(out, out_sharding=out_sharding)

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -57,6 +57,7 @@ from maxtext.models import (
     qwen2,
     qwen3,
     qwen3_custom,
+    qwen3_5,
     simple_layer,
 )
 from maxtext.multimodal import utils as mm_utils
@@ -483,6 +484,8 @@ class Decoder(nn.Module):
         return [qwen3_custom.Qwen3CustomMoeDecoderLayerToLinen]
       case DecoderBlockType.QWEN3_NEXT:
         return [qwen3.Qwen3NextScannableBlockToLinen] if self.config.scan_layers else [qwen3.Qwen3NextDecoderLayerToLinen]
+      case DecoderBlockType.QWEN3_5:
+        return [qwen3_5.Qwen3_5ScannableBlockToLinen] if self.config.scan_layers else [qwen3_5.Qwen3_5DecoderLayerToLinen]
       case DecoderBlockType.SIMPLE:
         return [simple_layer.SimpleDecoderLayerToLinen]
       case DecoderBlockType.SIMPLE_MLP:
@@ -550,7 +553,7 @@ class Decoder(nn.Module):
       return functools.partial(rms_norm, num_features=num_features, shard_mode=self.config.shard_mode)
     elif self.config.decoder_block == DecoderBlockType.GPT3:
       return functools.partial(gpt3.gpt3_layer_norm, num_features=num_features, reductions_in_fp32=False, use_bias=True)
-    elif self.config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+    elif self.config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
       return functools.partial(
           normalizations.Qwen3NextRMSNormLinen, num_features=num_features, shard_mode=self.config.shard_mode
       )
@@ -1104,13 +1107,13 @@ class Decoder(nn.Module):
                   "is_nope_layer": llama4.determine_is_nope_layer(lyr, self.config.nope_layer_interval),
                   "is_moe_layer": llama4.determine_is_moe_layer(lyr, self.config.interleave_moe_layer_step),
               }
-            if cfg.decoder_block == DecoderBlockType.QWEN3_NEXT:
+            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
               layer_kwargs = {"layer_idx": lyr}
             kv_cache = None
-            if kv_caches is not None and cfg.decoder_block != DecoderBlockType.QWEN3_NEXT:
+            if kv_caches is not None and cfg.decoder_block not in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
               kv_cache = kv_caches[lyr]
-            elif kv_caches is not None and cfg.decoder_block == DecoderBlockType.QWEN3_NEXT:
-              # For Qwen3Next, kv_caches is a dictionary of lists of caches.
+            elif kv_caches is not None and cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
+              # For Qwen3Next & Qwen3.5, kv_caches is a dictionary of lists of caches.
               if (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
                 kv_cache = (kv_caches["key_cache"][lyr], kv_caches["value_cache"][lyr])
 
@@ -1135,7 +1138,7 @@ class Decoder(nn.Module):
                 **layer_call_kwargs,
             )
             if kv_caches is not None and returned_cache is not None:
-              if cfg.decoder_block != DecoderBlockType.QWEN3_NEXT:
+              if cfg.decoder_block not in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
                 kv_caches[lyr] = returned_cache
               elif (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
                 kv_caches["key_cache"][lyr] = returned_cache[0]

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -57,6 +57,7 @@ from maxtext.models import (
     qwen2,
     qwen3,
     qwen3_custom,
+    qwen3_5,
     simple_layer,
 )
 from maxtext.multimodal import utils as mm_utils
@@ -481,6 +482,8 @@ class Decoder(nn.Module):
         return [qwen3_custom.Qwen3CustomMoeDecoderLayerToLinen]
       case DecoderBlockType.QWEN3_NEXT:
         return [qwen3.Qwen3NextScannableBlockToLinen] if self.config.scan_layers else [qwen3.Qwen3NextDecoderLayerToLinen]
+      case DecoderBlockType.QWEN3_5:
+        return [qwen3_5.Qwen3_5ScannableBlockToLinen] if self.config.scan_layers else [qwen3_5.Qwen3_5DecoderLayerToLinen]
       case DecoderBlockType.SIMPLE:
         return [simple_layer.SimpleDecoderLayerToLinen]
       case DecoderBlockType.SIMPLE_MLP:
@@ -547,7 +550,7 @@ class Decoder(nn.Module):
       return functools.partial(rms_norm, num_features=num_features, shard_mode=self.config.shard_mode)
     elif self.config.decoder_block == DecoderBlockType.GPT3:
       return functools.partial(gpt3.gpt3_layer_norm, num_features=num_features, reductions_in_fp32=False, use_bias=True)
-    elif self.config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+    elif self.config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
       return functools.partial(
           normalizations.Qwen3NextRMSNormLinen, num_features=num_features, shard_mode=self.config.shard_mode
       )
@@ -1055,13 +1058,13 @@ class Decoder(nn.Module):
                   "is_nope_layer": llama4.determine_is_nope_layer(lyr, self.config.nope_layer_interval),
                   "is_moe_layer": llama4.determine_is_moe_layer(lyr, self.config.interleave_moe_layer_step),
               }
-            if cfg.decoder_block == DecoderBlockType.QWEN3_NEXT:
+            if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
               layer_kwargs = {"layer_idx": lyr}
             kv_cache = None
-            if kv_caches is not None and cfg.decoder_block != DecoderBlockType.QWEN3_NEXT:
+            if kv_caches is not None and cfg.decoder_block not in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
               kv_cache = kv_caches[lyr]
-            elif kv_caches is not None and cfg.decoder_block == DecoderBlockType.QWEN3_NEXT:
-              # For Qwen3Next, kv_caches is a dictionary of lists of caches.
+            elif kv_caches is not None and cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
+              # For Qwen3Next & Qwen3.5, kv_caches is a dictionary of lists of caches.
               if (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
                 kv_cache = (kv_caches["key_cache"][lyr], kv_caches["value_cache"][lyr])
 
@@ -1086,7 +1089,7 @@ class Decoder(nn.Module):
                 **layer_call_kwargs,
             )
             if kv_caches is not None and returned_cache is not None:
-              if cfg.decoder_block != DecoderBlockType.QWEN3_NEXT:
+              if cfg.decoder_block not in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
                 kv_caches[lyr] = returned_cache
               elif (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
                 kv_caches["key_cache"][lyr] = returned_cache[0]

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -59,6 +59,7 @@ from maxtext.models import (
     mixtral,
     olmo3,
     qwen3,
+    qwen3_5,
     simple_layer,
 )
 from maxtext.multimodal import utils as mm_utils
@@ -426,7 +427,7 @@ class NNXDecoder(nnx.Module):
                 "is_nope_layer": llama4.determine_is_nope_layer(lyr, self.config.nope_layer_interval),
                 "is_moe_layer": llama4.determine_is_moe_layer(lyr, self.config.interleave_moe_layer_step),
             }
-          elif config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+          elif config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
             layer_kwargs = {"layer_idx": lyr}
           elif config.decoder_block == DecoderBlockType.GPT_OSS:
             layer_kwargs = {"attention_type": gpt_oss.get_attention_type(layer_id=lyr)}
@@ -688,6 +689,7 @@ class NNXDecoder(nnx.Module):
         DecoderBlockType.DEEPSEEK: get_deepseek(),
         DecoderBlockType.GPT_OSS: get_scannable(gpt_oss.GptOssDecoderLayer, gpt_oss.GptOssScannableBlock),
         DecoderBlockType.QWEN3_NEXT: get_scannable(qwen3.Qwen3NextDecoderLayer, qwen3.Qwen3NextScannableBlock),
+        DecoderBlockType.QWEN3_5: get_scannable(qwen3_5.Qwen3_5DecoderLayer, qwen3_5.Qwen3_5ScannableBlock),
         DecoderBlockType.LLAMA4: get_scannable(llama4.Llama4DecoderLayer, llama4.Llama4ScannableBlock),
         DecoderBlockType.OLMO3: get_scannable(olmo3.Olmo3DecoderLayer, olmo3.Olmo3ScannableBlock),
     }
@@ -841,7 +843,7 @@ class NNXDecoder(nnx.Module):
       return functools.partial(
           gpt3.Gpt3LayerNorm, num_features=num_features, reductions_in_fp32=False, use_bias=True, rngs=rngs
       )
-    elif self.config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+    elif self.config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
       return functools.partial(
           normalizations.RMSNorm, num_features=num_features, shard_mode=self.config.shard_mode, rngs=rngs
       )

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -57,6 +57,7 @@ from maxtext.models import (
     mixtral,
     olmo3,
     qwen3,
+    qwen3_5,
     simple_layer,
 )
 from maxtext.multimodal import utils as mm_utils
@@ -356,7 +357,7 @@ class NNXDecoder(nnx.Module):
                 "is_nope_layer": llama4.determine_is_nope_layer(lyr, self.config.nope_layer_interval),
                 "is_moe_layer": llama4.determine_is_moe_layer(lyr, self.config.interleave_moe_layer_step),
             }
-          elif config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+          elif config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
             layer_kwargs = {"layer_idx": lyr}
           elif config.decoder_block == DecoderBlockType.GPT_OSS:
             layer_kwargs = {"attention_type": gpt_oss.get_attention_type(layer_id=lyr)}
@@ -509,6 +510,7 @@ class NNXDecoder(nnx.Module):
         DecoderBlockType.DEEPSEEK: get_deepseek(),
         DecoderBlockType.GPT_OSS: get_scannable(gpt_oss.GptOssDecoderLayer, gpt_oss.GptOssScannableBlock),
         DecoderBlockType.QWEN3_NEXT: get_scannable(qwen3.Qwen3NextDecoderLayer, qwen3.Qwen3NextScannableBlock),
+        DecoderBlockType.QWEN3_5: get_scannable(qwen3_5.Qwen3_5DecoderLayer, qwen3_5.Qwen3_5ScannableBlock),
         DecoderBlockType.LLAMA4: get_scannable(llama4.Llama4DecoderLayer, llama4.Llama4ScannableBlock),
         DecoderBlockType.OLMO3: get_scannable(olmo3.Olmo3DecoderLayer, olmo3.Olmo3ScannableBlock),
     }
@@ -664,7 +666,7 @@ class NNXDecoder(nnx.Module):
       return functools.partial(
           gpt3.Gpt3LayerNorm, num_features=num_features, reductions_in_fp32=False, use_bias=True, rngs=rngs
       )
-    elif self.config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+    elif self.config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
       return functools.partial(
           normalizations.Qwen3NextRMSNorm, num_features=num_features, shard_mode=self.config.shard_mode, rngs=rngs
       )

--- a/src/maxtext/models/qwen3_5.py
+++ b/src/maxtext/models/qwen3_5.py
@@ -1,0 +1,255 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3.5 family of model decoder layers."""
+# pylint: disable=arguments-differ
+# pylint: disable=no-name-in-module
+
+from typing import Any, cast
+
+from jax.sharding import Mesh
+import jax.numpy as jnp
+
+from flax import linen as nn
+from flax import nnx
+
+from maxtext.common.common_types import Config, Array
+from maxtext.layers import initializers as max_initializers
+from maxtext.layers import nnx_wrappers
+from maxtext.layers.normalizations import Qwen3NextRMSNorm
+from maxtext.layers.quantizations import AqtQuantization as Quant
+
+from maxtext.inference import page_manager
+
+from maxtext.models.qwen3 import (
+    Qwen3NextGatedDeltaNet,
+    Qwen3NextFullAttention,
+    Qwen3NextSparseMoeBlock,
+)
+
+
+# -----------------------------------------
+# Qwen3.5 Layer Implementations
+# -----------------------------------------
+
+
+class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
+  """Qwen3.5 GatedDeltaNet layer that is identical to Qwen3-Next GatedDeltaNet"""
+
+
+class Qwen3_5FullAttention(Qwen3NextFullAttention):
+  """Qwen3.5 Gated Attention layer that is identical to Qwen3-Next"""
+
+
+class Qwen3_5SparseMoEBlock(Qwen3NextSparseMoeBlock):
+  """Shares same MoE code as Qwen3-Next"""
+
+
+class Qwen3_5ScannableBlock(nnx.Module):
+  """Scanned Structure for Text-only Architecture, explicitly invoking Qwen3_5 layers."""
+
+  def __init__(self, config: Config, mesh: Mesh, model_mode: str, quant=None, *, rngs: nnx.Rngs):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.quant = quant
+    self.rngs = rngs
+    cfg = self.config
+
+    # Explicitly instantiate Qwen3_5DecoderLayer here
+    for i in range(cfg.inhomogeneous_layer_cycle_interval):
+      layer_rngs = self.rngs.fork()
+      layer_name = f"layer_{i}"
+      layer = Qwen3_5DecoderLayer(
+          config=self.config,
+          mesh=self.mesh,
+          quant=self.quant,
+          model_mode=self.model_mode,
+          layer_idx=i,
+          rngs=layer_rngs,
+      )
+      setattr(self, layer_name, layer)
+
+  def __call__(
+      self,
+      carry: jnp.ndarray,
+      decoder_segment_ids: None | jnp.ndarray,
+      decoder_positions: None | jnp.ndarray,
+      deterministic: bool,
+      model_mode: str,
+      previous_chunk=None,
+      page_state: None | page_manager.PageState = None,
+      slot: None | int = None,
+  ) -> tuple[Array, None]:
+    cfg = self.config
+    x = carry
+
+    for i in range(cfg.inhomogeneous_layer_cycle_interval):
+      layer = getattr(self, f"layer_{i}")
+      x, _ = layer(
+          x,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          previous_chunk,
+          page_state,
+          slot,
+      )
+
+    return x, None
+
+
+class Qwen3_5DecoderLayer(nnx.Module):
+  """
+  This layer is a hybrid, capable of functioning as either:
+  1. A standard attention + MoE layer.
+  2. A linear attention + MoE layer.
+
+  Attributes:
+    config: The model configuration object.
+    mesh: The device mesh for sharding.
+    model_mode: The operational mode (e.g., 'train', 'prefill').
+    layer_idx: The index of the current layer in the transformer stack.
+    quant: Optional quantization configuration.
+  """
+
+  def __init__(
+      self, config: Config, mesh: Mesh, model_mode: str, layer_idx: int, quant: None | Quant = None, *, rngs: nnx.Rngs
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.layer_idx = layer_idx
+    self.quant = quant
+    cfg = self.config
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+    # First LayerNorm, applied before the attention block.
+    self.input_layernorm = Qwen3NextRMSNorm(
+        num_features=cfg.emb_dim,
+        eps=cfg.normalization_layer_epsilon,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        rngs=rngs,
+    )
+
+    # Determine the type of attention mechanism for the current layer.
+    is_full_attention_layer = (self.layer_idx + 1) % cfg.inhomogeneous_layer_cycle_interval == 0
+
+    # Conditionally instantiate either the Linear Attention or Full Attention block.
+    if is_full_attention_layer:
+      self.attention = Qwen3_5FullAttention(
+          config=cfg,
+          mesh=self.mesh,
+          quant=self.quant,
+          model_mode=model_mode,
+          layer_idx=self.layer_idx,
+          rngs=rngs,
+      )
+    else:
+      self.attention = Qwen3_5GatedDeltaNet(config=cfg, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs)
+
+    # Second LayerNorm, applied before the MoE block.
+    self.post_attention_layernorm = Qwen3NextRMSNorm(
+        num_features=cfg.emb_dim,
+        eps=cfg.normalization_layer_epsilon,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        rngs=rngs,
+    )
+
+    # Instantiate our `Qwen3_5SparseMoEBlock`.
+    self.mlp = Qwen3_5SparseMoEBlock(config=cfg, mesh=self.mesh, quant=self.quant, rngs=rngs)
+
+  def __call__(
+      self,
+      inputs: jnp.ndarray,
+      decoder_segment_ids: None | jnp.ndarray,
+      decoder_positions: None | jnp.ndarray,
+      deterministic: bool,
+      model_mode: str,
+      previous_chunk=None,
+      page_state: None | page_manager.PageState = None,
+      slot: None | int = None,
+      kv_cache: None | dict[str, Array] = None,
+      attention_metadata: None | dict[str, Any] = None,
+  ):
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
+    residual = inputs
+
+    # First LayerNorm, applied before the attention block.
+    hidden_states = self.input_layernorm(inputs)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+
+    # Conditionally apply either the Linear Attention or Full Attention block.
+    if isinstance(self.attention, Qwen3_5FullAttention):
+      attention_output, new_kv_cache = cast(Qwen3_5FullAttention, self.attention)(
+          hidden_states,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          kv_cache=kv_cache,
+          attention_metadata=attention_metadata,
+      )
+    else:
+      attention_output = cast(Qwen3_5GatedDeltaNet, self.attention)(
+          hidden_states,
+          model_mode=model_mode,
+          kv_cache=None,
+          decoder_segment_ids=decoder_segment_ids,
+      )
+      new_kv_cache = None
+
+    # First residual connection after attention
+    hidden_states = residual + attention_output
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+
+    # Prepare for the MoE block by capturing the new residual
+    residual = hidden_states
+
+    # Second LayerNorm, applied before the MoE block.
+    hidden_states = self.post_attention_layernorm(hidden_states)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+
+    # Instantiate and call our `Qwen3_5SparseMoEBlock`.
+    mlp_output, load_balance_loss = self.mlp(hidden_states, deterministic=deterministic)
+
+    # We sow the load balancing loss so it can be collected and added to the total loss
+    # during training.
+    if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
+      self.sow("intermediates", "moe_lb_loss", load_balance_loss)
+
+    # Final residual connection (after the MoE block)
+    layer_output = residual + mlp_output
+    layer_output = nn.with_logical_constraint(
+        layer_output,
+        self.activation_axis_names,
+    )
+    return layer_output, new_kv_cache
+
+
+Qwen3_5DecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Qwen3_5DecoderLayer,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+
+Qwen3_5ScannableBlockToLinen = nnx_wrappers.to_linen_class(
+    Qwen3_5ScannableBlock,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)

--- a/src/maxtext/models/qwen3_5.py
+++ b/src/maxtext/models/qwen3_5.py
@@ -1,0 +1,271 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3.5 family of model decoder layers."""
+# pylint: disable=arguments-differ
+# pylint: disable=no-name-in-module
+
+from typing import Any, cast
+import math
+
+import jax
+import jax.nn
+from jax import lax
+from jax.ad_checkpoint import checkpoint_name
+from jax.sharding import Mesh
+import jax.numpy as jnp
+
+from flax import linen as nn
+from flax import nnx
+
+from maxtext.common.common_types import AttentionType, Config, DType, Array, BATCH, EMBED, MODEL_MODE_TRAIN, LENGTH
+from maxtext.layers import attentions
+from maxtext.layers import initializers as max_initializers
+from maxtext.layers import moe
+from maxtext.layers import nnx_wrappers
+from maxtext.layers import quantizations
+from maxtext.layers.embeddings import Qwen3OmniMoeVisionPosEmbedInterpolate, PositionalEmbedding
+from maxtext.layers.normalizations import RMSNorm, l2norm, Qwen3NextRMSNorm, Qwen3NextRMSNormGated
+from maxtext.layers.quantizations import AqtQuantization as Quant
+from maxtext.layers.attentions import Attention
+from maxtext.layers.linears import DenseGeneral, MlpBlock
+from maxtext.layers.moe import RoutedMoE
+from maxtext.layers.initializers import nd_dense_init, variable_to_logically_partitioned
+
+from maxtext.utils import max_utils
+from maxtext.inference import page_manager, kvcache
+
+from maxtext.models.qwen3 import (
+  Qwen3NextGatedDeltaNet, 
+  Qwen3NextFullAttention, 
+  Qwen3NextSparseMoeBlock, 
+  Qwen3NextScannableBlock, 
+)
+
+
+# -----------------------------------------
+# Qwen3.5 Layer Implementations
+# -----------------------------------------
+
+class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
+  """Qwen3.5 GatedDeltaNet layer that is identical to Qwen3-Next GatedDeltaNet"""
+  pass
+
+
+class Qwen3_5FullAttention(Qwen3NextFullAttention):
+  """Qwen3.5 Gated Attention layer that is identical to Qwen3-Next"""
+  pass
+
+
+class Qwen3_5SparseMoEBlock(Qwen3NextSparseMoeBlock):
+  """Shares same MoE code as Qwen3-Next"""
+  pass
+
+class Qwen3_5ScannableBlock(nnx.Module):
+  """Scanned Structure for Text-only Architecture, explicitly invoking Qwen3_5 layers."""
+
+  def __init__(self, config: Config, mesh: Mesh, model_mode: str, quant=None, *, rngs: nnx.Rngs):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.quant = quant
+    self.rngs = rngs
+    cfg = self.config
+
+    # Explicitly instantiate Qwen3_5DecoderLayer here
+    for i in range(cfg.inhomogeneous_layer_cycle_interval):
+      layer_rngs = self.rngs.fork()
+      layer_name = f"layer_{i}"
+      layer = Qwen3_5DecoderLayer(
+          config=self.config,
+          mesh=self.mesh,
+          quant=self.quant,
+          model_mode=self.model_mode,
+          layer_idx=i,
+          rngs=layer_rngs,
+      )
+      setattr(self, layer_name, layer)
+
+  def __call__(
+      self,
+      carry: jnp.ndarray,
+      decoder_segment_ids: None | jnp.ndarray,
+      decoder_positions: None | jnp.ndarray,
+      deterministic: bool,
+      model_mode: str,
+      previous_chunk=None,
+      page_state: None | page_manager.PageState = None,
+      slot: None | int = None,
+  ) -> tuple[Array, None]:
+    cfg = self.config
+    x = carry
+
+    for i in range(cfg.inhomogeneous_layer_cycle_interval):
+      layer = getattr(self, f"layer_{i}")
+      x, _ = layer(
+          x,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          previous_chunk,
+          page_state,
+          slot,
+      )
+
+    return x, None
+
+
+class Qwen3_5DecoderLayer(nnx.Module):
+  """
+  This layer is a hybrid, capable of functioning as either:
+  1. A standard attention + MoE layer.
+  2. A linear attention + MoE layer.
+
+  Attributes:
+    config: The model configuration object.
+    mesh: The device mesh for sharding.
+    model_mode: The operational mode (e.g., 'train', 'prefill').
+    layer_idx: The index of the current layer in the transformer stack.
+    quant: Optional quantization configuration.
+  """
+
+  def __init__(
+      self, config: Config, mesh: Mesh, model_mode: str, layer_idx: int, quant: None | Quant = None, *, rngs: nnx.Rngs
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.model_mode = model_mode
+    self.layer_idx = layer_idx
+    self.quant = quant
+    cfg = self.config
+    self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+    # First LayerNorm, applied before the attention block.
+    self.input_layernorm = Qwen3NextRMSNorm(
+        num_features=cfg.emb_dim,
+        eps=cfg.normalization_layer_epsilon,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        rngs=rngs,
+    )
+
+    # Determine the type of attention mechanism for the current layer.
+    is_full_attention_layer = (self.layer_idx + 1) % cfg.inhomogeneous_layer_cycle_interval == 0
+
+    # Conditionally instantiate either the Linear Attention or Full Attention block.
+    if is_full_attention_layer:
+      self.attention = Qwen3_5FullAttention(
+          config=cfg,
+          mesh=self.mesh,
+          quant=self.quant,
+          model_mode=model_mode,
+          layer_idx=self.layer_idx,
+          rngs=rngs,
+      )
+    else:
+      self.attention = Qwen3_5GatedDeltaNet(config=cfg, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs)
+
+    # Second LayerNorm, applied before the MoE block.
+    self.post_attention_layernorm = Qwen3NextRMSNorm(
+        num_features=cfg.emb_dim,
+        eps=cfg.normalization_layer_epsilon,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        rngs=rngs,
+    )
+
+    # Instantiate our `Qwen3_5SparseMoEBlock`.
+    self.mlp = Qwen3_5SparseMoEBlock(config=cfg, mesh=self.mesh, quant=self.quant, rngs=rngs)
+
+  def __call__(
+      self,
+      inputs: jnp.ndarray,
+      decoder_segment_ids: None | jnp.ndarray,
+      decoder_positions: None | jnp.ndarray,
+      deterministic: bool,
+      model_mode: str,
+      previous_chunk=None,
+      page_state: None | page_manager.PageState = None,
+      slot: None | int = None,
+      kv_cache: None | dict[str, Array] = None,
+      attention_metadata: None | dict[str, Any] = None,
+  ):
+    # Unpack inputs if it's a tuple (e.g. from a previous layer returning (hidden_states, kv_cache))
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
+    residual = inputs
+
+    # First LayerNorm, applied before the attention block.
+    hidden_states = self.input_layernorm(inputs)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+
+    # Conditionally apply either the Linear Attention or Full Attention block.
+    if isinstance(self.attention, Qwen3_5FullAttention):
+      attention_output, new_kv_cache = cast(Qwen3_5FullAttention, self.attention)(
+          hidden_states,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          kv_cache=kv_cache,
+          attention_metadata=attention_metadata,
+      )
+    else:
+      attention_output = cast(Qwen3_5GatedDeltaNet, self.attention)(
+          hidden_states,
+          model_mode=model_mode,
+          kv_cache=None,
+          decoder_segment_ids=decoder_segment_ids,
+      )
+      new_kv_cache = None
+
+    # First residual connection after attention
+    hidden_states = residual + attention_output
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+
+    # Prepare for the MoE block by capturing the new residual
+    residual = hidden_states
+
+    # Second LayerNorm, applied before the MoE block.
+    hidden_states = self.post_attention_layernorm(hidden_states)
+    hidden_states = nn.with_logical_constraint(hidden_states, self.activation_axis_names)
+
+    # Instantiate and call our `Qwen3_5SparseMoEBlock`.
+    mlp_output, load_balance_loss = self.mlp(hidden_states, deterministic=deterministic)
+
+    # We sow the load balancing loss so it can be collected and added to the total loss
+    # during training.
+    if self.config.load_balance_loss_weight > 0.0 and load_balance_loss is not None:
+      self.sow("intermediates", "moe_lb_loss", load_balance_loss)
+
+    # Final residual connection (after the MoE block)
+    layer_output = residual + mlp_output
+    layer_output = nn.with_logical_constraint(
+        layer_output,
+        self.activation_axis_names,
+    )
+    return layer_output, new_kv_cache
+  
+
+Qwen3_5DecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Qwen3_5DecoderLayer,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)
+
+
+Qwen3_5ScannableBlockToLinen = nnx_wrappers.to_linen_class(
+    Qwen3_5ScannableBlock,
+    base_metadata_fn=max_initializers.variable_to_logically_partitioned,
+)

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -616,7 +616,7 @@ def get_dense_moe_layers(config):
     num_moe_layers = config.num_decoder_layers // config.interleave_moe_layer_step
     num_dense_layers = config.num_decoder_layers - num_moe_layers
     return num_dense_layers, num_moe_layers
-  elif config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+  elif config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
     return 0, config.num_decoder_layers
   elif config.decoder_block == DecoderBlockType.DEFAULT:
     raise ValueError("Unsupported decoder block for dense/MoE layer calculation")
@@ -862,6 +862,7 @@ def calculate_tflops_training_per_device(config, log=True):
         DecoderBlockType.DEEPSEEK,
         DecoderBlockType.LLAMA4,
         DecoderBlockType.QWEN3_NEXT,
+        DecoderBlockType.QWEN3_5,
         DecoderBlockType.GEMMA4,
     ):
       total_ffn_flops = calculate_routed_and_shared_ffn_tflops_per_device(config)
@@ -972,7 +973,10 @@ def calculate_tflops_training_per_device(config, log=True):
     total_weight_flops = total_ffn_flops_all_layers + per_layer_flops * config.num_decoder_layers + embedding_flops
     learnable_weight_tflops = total_weight_flops * 3 / 10**12
     attention_tflops = causal_attention_flops * config.num_decoder_layers * 3 / 10**12
-  elif config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+  elif config.decoder_block in (
+      DecoderBlockType.QWEN3_NEXT,
+      DecoderBlockType.QWEN3_5,
+  ):
     gdn_weight_flops_per_layer, gdn_attn_flops_per_layer = calculate_gated_delta_net_flops_per_device(config)
     cycle_interval = config.inhomogeneous_layer_cycle_interval
     num_full_attn_layers = config.num_decoder_layers // cycle_interval

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -611,7 +611,7 @@ def get_dense_moe_layers(config):
     num_moe_layers = config.num_decoder_layers // config.interleave_moe_layer_step
     num_dense_layers = config.num_decoder_layers - num_moe_layers
     return num_dense_layers, num_moe_layers
-  elif config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+  elif config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
     return 0, config.num_decoder_layers
   elif config.decoder_block == DecoderBlockType.DEFAULT:
     raise ValueError("Unsupported decoder block for dense/MoE layer calculation")
@@ -857,6 +857,7 @@ def calculate_tflops_training_per_device(config, log=True):
         DecoderBlockType.DEEPSEEK,
         DecoderBlockType.LLAMA4,
         DecoderBlockType.QWEN3_NEXT,
+        DecoderBlockType.QWEN3_5,
         DecoderBlockType.GEMMA4,
     ):
       total_ffn_flops = calculate_routed_and_shared_ffn_tflops_per_device(config)
@@ -941,7 +942,7 @@ def calculate_tflops_training_per_device(config, log=True):
         / 10**12
     )
     attention_tflops = causal_attention_flops * config.num_decoder_layers * 3 / 10**12
-  elif config.decoder_block == DecoderBlockType.QWEN3_NEXT:
+  elif config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
     gdn_weight_flops_per_layer, gdn_attn_flops_per_layer = calculate_gated_delta_net_flops_per_device(config)
     cycle_interval = config.inhomogeneous_layer_cycle_interval
     num_full_attn_layers = config.num_decoder_layers // cycle_interval

--- a/tests/unit/flop_calculation_test.py
+++ b/tests/unit/flop_calculation_test.py
@@ -894,7 +894,10 @@ class FlopCalculation(parameterized.TestCase):
       ) + config.kv_lora_rank * config.num_query_heads * (config.qk_nope_head_dim + config.v_head_dim)
       proj_params = config.emb_dim * config.num_query_heads * config.v_head_dim
       total_qkv_proj_params = (q_params + kv_params + proj_params) * config.num_decoder_layers
-    elif getattr(config, "decoder_block", None) == maxtext_utils.DecoderBlockType.QWEN3_NEXT:
+    elif getattr(config, "decoder_block", None) in (
+        maxtext_utils.DecoderBlockType.QWEN3_NEXT,
+        maxtext_utils.DecoderBlockType.QWEN3_5,
+    ):
       # Interleaved Full Attention and Gated Delta Net (Linear Attention)
       cycle_interval = config.inhomogeneous_layer_cycle_interval
       num_full_attn_layers = config.num_decoder_layers // cycle_interval

--- a/tests/unit/flop_calculation_test.py
+++ b/tests/unit/flop_calculation_test.py
@@ -871,7 +871,10 @@ class FlopCalculation(parameterized.TestCase):
       ) + config.kv_lora_rank * config.num_query_heads * (config.qk_nope_head_dim + config.v_head_dim)
       proj_params = config.emb_dim * config.num_query_heads * config.v_head_dim
       total_qkv_proj_params = (q_params + kv_params + proj_params) * config.num_decoder_layers
-    elif getattr(config, "decoder_block", None) == maxtext_utils.DecoderBlockType.QWEN3_NEXT:
+    elif getattr(config, "decoder_block", None) in (
+      maxtext_utils.DecoderBlockType.QWEN3_NEXT, 
+      maxtext_utils.DecoderBlockType.QWEN3_5
+    ):
       # Interleaved Full Attention and Gated Delta Net (Linear Attention)
       cycle_interval = config.inhomogeneous_layer_cycle_interval
       num_full_attn_layers = config.num_decoder_layers // cycle_interval

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -1244,6 +1244,12 @@ class TestGetDenseMoeLayers(unittest.TestCase):
     self.assertEqual(dense, 0)
     self.assertEqual(moe, 8)
 
+  def test_qwen3_5_block(self):
+    cfg = self._make_cfg(DecoderBlockType.QWEN3_5, num_decoder_layers=8)
+    dense, moe = maxtext_utils.get_dense_moe_layers(cfg)
+    self.assertEqual(dense, 0)
+    self.assertEqual(moe, 8)
+
   def test_unsupported_block_raises(self):
     cfg = self._make_cfg(DecoderBlockType.DEFAULT)
     with self.assertRaises(ValueError):

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -1032,3 +1032,24 @@ class TrainCompile(parameterized.TestCase):
             "weight_dtype=bfloat16",
         )
     )
+
+  @pytest.mark.cpu_only
+  def test_qwen3_5(self):
+    """AOT test for qwen3-5"""
+    compiled_trainstep_file = "/tmp/test_qwen3_5"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-512",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3.5-397b-a17b",
+            "per_device_batch_size=1.0",
+            "max_target_length=1024",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "use_tokamax_splash=True",
+        )
+    )

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -974,3 +974,25 @@ class TrainCompile(unittest.TestCase):
             "qk_clip_threshold=100",
         )
     )
+
+
+  @pytest.mark.cpu_only
+  def test_qwen3_5(self):
+    """AOT test for qwen3-5"""
+    compiled_trainstep_file = "/tmp/test_qwen3_5"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-512",
+            "compile_topology_num_slices=1",
+            "model_name=qwen3.5-397b-a17b",
+            "per_device_batch_size=1.0",
+            "max_target_length=1024",
+            "sparse_matmul=True",
+            "megablox=True",
+            "attention=flash",
+            "use_tokamax_splash=True",
+        )
+    )


### PR DESCRIPTION
# Description

This pr enables maxtext to run train workloads on the text only architecture of qwen3.5, which is identical to that of qwen3-next. This current pr enables the model configs for the largest MoE model in the family: qwen3.5-397b-a17b. Other models part of the family will be added later on.

# Tests

Will run a training workload and verify that the loss decreases correctly and will add a train_compile test for this new model

Update:

- Ran a train workload on a mini config: the 122b MoE model. The only differences within configs are as follows:
    - base_emb_dim: 4096 -> 3072
    - base_num_decoder_layers: 60 -> 48
    - num_experts: 512 -> 256
    - num_experts_per_tok: 10 ->  8
The loss decreases slowly and training is stable: 
Command: https://paste.googleplex.com/5762710475243520#l=15
Logs: https://paste.googleplex.com/5093482696933376

- Train compile test is passing


**Note:** Since Qwen3.5 reuses components from Qwen3-Next, we already have unit tests implemented for the text-only architecture i.e the GatedDeltaNet, GatedAttention, RMSNorm, SparseMoEBlock, etc. In upcoming PRs, we will add unit tests against ref transformers implementation for the multimodal part.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
