### PR TITLE
Add embed_vocab in 2dfsdp and batch split logical rule

### DIFF
--- a/src/maxtext/configs/models/deepseek3-671b-2dfsdp.yml
+++ b/src/maxtext/configs/models/deepseek3-671b-2dfsdp.yml
@@ -70,6 +70,7 @@ logical_axis_rules: [
     ['activation_stage', 'stage'],
     ['embed', ['fsdp']],
     ['embed_moe', ['fsdp']],
+    ['embed_vocab', ['fsdp']],
     ['embed_no_exp', ['fsdp']],
     ['embed_no_exp_moe', ['fsdp']],
     ['q_lora', ['fsdp']],

--- a/src/maxtext/configs/models/deepseek3-671b-batchsplit.yml
+++ b/src/maxtext/configs/models/deepseek3-671b-batchsplit.yml
@@ -71,6 +71,7 @@ logical_axis_rules: [
     ['activation_heads', []],
     ['embed', ['fsdp']],
     ['embed_moe', ['fsdp']],
+    ['embed_vocab', ['fsdp']],
     ['embed_no_exp', ['fsdp']],
     ['embed_no_exp_moe', ['fsdp']],
     ['q_lora', ['fsdp']],


### PR DESCRIPTION
# Description

Resolves improper embedding table sharding for the `deepseek3-671b-2dfsdp` and `deepseek3-671b-batchsplit` models caused by #3607.

# Tests

Before vs. after #3607: https://diff.googleplex.com/#key=qM70IpQO9Mve

This PR fixes the OOM, see https://paste.googleplex.com/6590529920958464.

It also passes the explicit shard mode: https://paste.googleplex.com/5400133865963520.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
