### PR TITLE
Remove undocumented fp8 NaN sanitization from train_step

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -356,31 +356,6 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
   else:
     grads = raw_grads
 
-  # fp8 fix: sanitize NaN OWG (overwrite-with-gradient) stats before apply_gradients.
-  # Under FSDP, the fp8 output gradient amax can be NaN at step 0, which propagates into
-  # amax_history and corrupts future steps. Replace NaN OWG entries with the current state
-  # values (skip the amax update for that step) instead of letting NaN flow through.
-  # Also restore OWG values after apply_gradients to bypass optimizer corruption
-  # (Adam should not update fp8 scale/amax_history).
-  fp8_stats = dict(grads).get(maxtext_utils.OVERWRITE_WITH_GRADIENT, None)
-  if fp8_stats is not None:
-    if maxtext_utils.OVERWRITE_WITH_GRADIENT in state.params:
-      current_fp8 = state.params[maxtext_utils.OVERWRITE_WITH_GRADIENT]
-      fp8_stats = jax.tree_util.tree_map(
-          lambda new, cur: jnp.where(jnp.isnan(new), cur, new),
-          fp8_stats,
-          current_fp8,
-      )
-    else:
-      fp8_stats = jax.tree_util.tree_map(lambda x: jnp.nan_to_num(x, nan=0.0), fp8_stats)
-    grads = dict(grads)
-    grads[maxtext_utils.OVERWRITE_WITH_GRADIENT] = fp8_stats
-  # Zero out any remaining NaN in float gradients to prevent param corruption
-  grads = jax.tree_util.tree_map(
-      lambda x: jnp.nan_to_num(x, nan=0.0) if jnp.issubdtype(x.dtype, jnp.floating) else x,
-      grads,
-  )
-
   if config.optimizer_memory_host_offload:
     state = state.replace(
         opt_state=jax.device_put(
@@ -419,12 +394,6 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
     )
   else:
     new_state = state.apply_gradients(grads=grads)
-
-  # fp8 fix: restore sanitized OWG values, bypassing any optimizer update to fp8 stats.
-  if fp8_stats is not None:
-    new_params = dict(new_state.params)
-    new_params[maxtext_utils.OVERWRITE_WITH_GRADIENT] = fp8_stats
-    new_state = new_state.replace(params=new_params)
 
   # Apply updates for Auxiliary-Loss-Free load balancing for DeepSeek family
   if config.routed_bias and config.routed_bias_update_rate > 0.0 and moe_bias_updates is not None:


### PR DESCRIPTION
# Description

The `train_step` in `src/maxtext/trainers/pre_train/train.py` contained an fp8-specific NaN handling block with two parts:

1. An **OWG-specific correction** — replaces NaN entries in the `OVERWRITE_WITH_GRADIENT` bucket (AQT's fp8 `amax_history` / `scale`) with the previous step's values before `apply_gradients`, then restores them after to "bypass optimizer corruption."
2. A **blanket `jnp.nan_to_num`** over every float gradient in the tree — zeroes any NaN in any parameter gradient unconditionally.

This PR removes both.

## Why

The logic was introduced in commit `6a0f895c3` ("NNX migration: NNX utils") as a drive-by addition inside an unrelated migration commit. The commit message mentions sharding utilities, not fp8, not NaN, not `amax_history`. No accompanying test, no repro config, no reference to a failure-mode bug report. I tried to find the workload that justified it — searched the `anfals/fp8_*` branches and the full commit history for `amax_history` — and came up empty. If a repro exists, it was never checked in.

Flagged the blanket `nan_to_num` as a concern: it silently zeroes parameter-gradient NaN, which hides convergence bugs behind the appearance of stable training. I agreed and ran an A/B on V6e-8, 10 steps, FSDP=8, synthetic data:

| Config | Original | OWG removed, mask kept | Both removed |
|---|---|---|---|
| bf16 `gpt3-52k` | stable | stable | stable (bit-identical) |
| fp8 `gpt3-52k` | stable | stable (bit-identical) | stable (bit-identical) |
| fp8 `llama2-7b` | ~~stable~~ (*was hidden by mask*) | NaN at step 2 | NaN at step 2 |

The llama2-7b fp8 run exposes a pre-existing convergence issue that the blanket mask was silently hiding. The OWG block has no observable effect on any of these configs. On every workload we can actually test, the entire block is dead code.

## Behavior change

- Non-fp8 recipes: no change in behavior. Code path is simply removed.
- fp8 recipes that were previously stable: no change — the OWG correction never fired on those anyway.
- fp8 recipes that *appeared* stable but had real gradient NaN being zeroed by the blanket mask: will now surface NaN loss and trigger `abort_on_nan_loss`. This is the intended behavior change — silent masking should not be the default.

If a specific fp8 config genuinely relies on the OWG correction, that should be demonstrated with a repro and fixed properly (ideally upstream in AQT / the fp8 backward pass rather than in the trainer).

# Tests

A/B on V6e-8, 10 steps, FSDP=8, synthetic data, `attention=dot_product`.

- `gpt3-52k` bf16 — loss 14.411 → 14.405, stable, no NaN.
- `gpt3-52k` fp8 (`quantization=fp8 sharding_tolerance=0.10`) — loss 14.317 → 14.320, stable, no NaN.
- `llama2-7b` fp8 — NaN at step 2, `abort_on_nan_loss` fires as expected.

Bit-identical results compared to runs with the blocks still present (for configs where the old code was dead); the only behavioral delta is fp8 NaN now surfacing instead of being zeroed.

**Repros:**
```bash
# Non-fp8
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
  model_name=gpt3-52k per_device_batch_size=1 ici_fsdp_parallelism=8 \
  steps=10 dataset_type=synthetic override_model_config=True attention=dot_product

# fp8 (gpt3-52k — stable regardless)
# ...same, plus quantization=fp8 sharding_tolerance=0.10

# fp8 (llama2-7b — surfaces pre-existing NaN)
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
  model_name=llama2-7b per_device_batch_size=1 ici_fsdp_parallelism=8 \
  steps=10 dataset_type=synthetic attention=dot_product \
  quantization=fp8 sharding_tolerance=0.10 max_target_length=1024
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).