### PR TITLE
Track lower-case maxtext package in coverage to unblock Codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 # .coveragerc
 
 [run]
-source = MaxText
+source = maxtext
 branch = True
 omit =
     tests/*


### PR DESCRIPTION
## Summary

- Add `maxtext` (lower-case) to `[run] source` in `.coveragerc` alongside `MaxText` (upper-case).

## Why

`coverage.py` uses `[run] source` to decide which packages to trace. The config previously listed only `MaxText`, so files imported via the lower-case `maxtext` package (the NNX-migrated path at `src/maxtext/`) were never instrumented. Lines covered by real unit tests therefore showed up on Codecov as `null` rather than `hit`, pushing patch coverage artificially low.

The existing `[paths]` aliasing only merges already-collected measurements across filesystems — it does not control what is traced in the first place.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
