### PR TITLE
Introduce cp-as-ep rule supporting more flexible fractional batch size

### DIFF
--- a/docs/guides/optimization/custom_mesh_and_rule.md
+++ b/docs/guides/optimization/custom_mesh_and_rule.md
@@ -1,0 +1,64 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+# Customizing mesh and rule for advanced sharding features in MaxText
+
+## How `custom_mesh_and_rule` Works
+
+In MaxText, the `custom_mesh_and_rule` configuration allows you to completely override the default device mesh and logical axis rules used for sharding. Instead of relying on the standard rules defined in the main configuration (`base.yml`), you can point this parameter to a specific YAML file located in the `src/maxtext/configs/custom_mesh_and_rule/` directory.
+
+When you specify a rule name (e.g., `custom_mesh_and_rule=pure-fsdp`), MaxText loads the corresponding YAML file and applies its specific:
+
+- `mesh_axes`: The physical layout of the devices.
+- `data_sharding`: Axes used for sharding input data.
+- `context_sharding`: Which physical axis plays the role of context parallelism.
+- `logical_axis_rules`: The precise mapping of logical tensor axes to physical device mesh axes.
+
+## When to Use Custom Meshes and Rules
+
+While MaxText's default sharding strategies handle most standard models and configurations effectively, you may need to define custom meshes and rules in the following scenarios:
+
+- **Simplifying logical rules:** If you are training on a smaller cluster where only one or two axes are necessary, a simplified, custom logical rule focusing exclusively on those axes can significantly streamline the sharding debugging process.
+- **Managing large-scale training:** At scale, you must carefully dictate how specific tensors are sharded or replicated to respect HBM and sharding dimension limits. For example, if a `q_lora` tensor with a dimension of 512 is sharded across FSDP, Expert, and Context axes, an error will occur if the product of these axes exceeds 512. A custom rule allows you to drop conflicting axes to prevent these dimension overflows.
+- **Implementing advanced sharding features:** To maximize performance, you might want to repurpose specific axes dynamically based on the layer. For instance, you could configure the Expert axis to handle Context parallelism outside of Mixture of Experts (MoE) layers. Achieving this level of granular flexibility requires custom sharding rules.
+
+## Pre-Defined Sharding Configurations
+
+MaxText currently provides several ready-to-use custom mesh and rule configurations:
+
+### `pure-fsdp.yml`
+
+This rule relies entirely on Fully Sharded Data Parallelism (FSDP). It maps all activations and weights directly to the `fsdp` mesh axis. This is the recommended sharding strategy for small-scale training, as it simplifies the overall configuration and makes debugging significantly easier.
+
+### `ep-as-cp.yml`
+
+This rule utilizes the `data`, `stage`, `fsdp`, and `expert` axes. Its defining feature is that it repurposes the `expert` axis to handle context parallelism in all components *except* for the core dense Mixture of Experts (MoE) layers (i.e., the computations between Expert Parallelism all-to-all communications). By reusing the expert dimension to shard the sequence length in non-MoE layers, it enables fractional batch size to reduce HBM usage.
+
+### `cp-as-ep.yml`
+
+Similar in philosophy to `ep-as-cp.yml`, this configuration explicitly includes the `context` axis in the mesh layout alongside `data`, `stage`, `fsdp`, and `expert`. While context sharding is mapped to the `context` axis globally, within MoE components, this `context` axis dynamically shifts to perform expert parallelism instead of FSDP. This custom rule supports using CP and EP together.
+
+### `pipeline-large-moe.yml`
+
+Designed specifically to optimize pipeline parallelism for extremely large-scale MoE jobs (such as DeepSeek models). It defines the physical axes: `data`, `stage`, `fsdp`, `tensor`, `context`, and `expert`. To prevent dimension limit errors, it intentionally disables expert weight sharding on the (typically small) `q_lora` dimension. Furthermore, tensor and expert parallelism are strictly preserved to support advanced pipelining features like `pipeline_fsdp_ag_one` and `pipeline_fsdp_ag_per_repeat`.
+
+## Protecting Configurations with Sharding Dump
+
+Because custom sharding rules are highly specific and sensitive to changes in model architecture, MaxText uses an automated **Sharding Dump** mechanism to protect them against regressions.
+
+1. **Dumping State:** The `tests/utils/sharding_dump.py` tool generates an abstract state representation of how tensors are sharded across the mesh for a given model, topology, and `custom_mesh_and_rule`. It outputs this layout into a JSON file.
+2. **Comparison Testing:** In `tests/unit/sharding_compare_test.py`, test cases instantiate models with specific custom mesh rules and compare the generated sharding JSON against known-good "golden" files stored in `tests/utils/sharding_info/`.
+3. **Regression Prevention:** If a code change inadvertently alters the sharding layout (for example, causing an activation to un-shard and run out of memory), the comparison test will fail, alerting developers before the issue affects actual large-scale training jobs.

--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -139,3 +139,11 @@ class HyperConnectionType(enum.Enum):
   ATTENTION = "attention"
   MLP_MOE = "mlp_moe"
   MLP_DENSE = "mlp_dense"
+
+
+class CustomRule(enum.Enum):
+  DEFAULT = ""
+  PURE_FSDP = "pure-fsdp"
+  CP_AS_EP = "cp-as-ep"  # Support CP and EP together
+  EP_AS_CP = "ep-as-cp"  # Support EP only
+  PIPELINE_LARGE_MOE = "pipeline-large-moe"

--- a/src/maxtext/configs/custom_mesh_and_rule/cp-as-ep.yml
+++ b/src/maxtext/configs/custom_mesh_and_rule/cp-as-ep.yml
@@ -1,0 +1,78 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This rule uses data, stage, FSDP, context, and expert. Context axis acts as expert
+# parallelism in core MoE part (between EP all2all).
+mesh_axes: ['data', 'stage', 'fsdp', 'context', 'expert']
+data_sharding: [['data', 'stage', 'fsdp', 'context', 'expert']]
+context_sharding: 'context'
+logical_axis_rules: [
+                      # ==========================================
+                      # Vocabulary Embedding
+                      # ==========================================
+                      # Vocab Activations
+                      ['activation_embed_and_logits_batch', ['data', 'stage', 'fsdp', 'expert']],
+                      ['activation_embed_and_logits_batch_sequence', ['data', 'stage', 'fsdp', 'expert']],
+                      # Vocab Weights
+                      ['vocab', []],
+                      ['embed_vocab', ['fsdp', 'context', 'expert']],
+                      # ==========================================
+                      # Attention
+                      # ==========================================
+                      # Attention Activations
+                      ['activation_batch_attn', ['data', 'fsdp', 'expert']],
+                      ['activation_heads', []],
+                      ['activation_kv_heads', []],
+                      ['activation_length_attn', ['context']],
+                      ['activation_q_length', ['context']],
+                      ['activation_kv_length', []],
+                      ['activation_embed_attn', []],
+                      ['activation_kv', []],
+                      ['activation_kv_batch', ['data', 'fsdp', 'expert']],
+                      ['activation_kv_head_dim', []],
+                      # Attention Weights
+                      ['heads', []],
+                      ['q_heads', []],
+                      ['kv_heads', []],
+                      ['qkv', []],
+                      ['kv', []],
+                      ['kv_head_dim', []],
+                      ['q_lora', ['fsdp', 'context', 'expert']],
+                      ["q_lora_up_proj", []],
+                      ['kv_lora', ['fsdp', 'context', 'expert']],
+                      ["kv_lora_up_proj", []],
+                      # ==========================================
+                      # Mixture of Experts (MoE)
+                      # ==========================================
+                      # MoE Activations
+                      ['activation_batch_moe', ['data', 'fsdp']],
+                      ['activation_exp', ['context', 'expert']],
+                      # MoE Weights
+                      ['exp', ['context', 'expert']],
+                      ['embed_moe', ['fsdp']],
+                      # ==========================================
+                      # Standard MLP / Dense Layers / Model Structure
+                      # ==========================================
+                      # Dense Activations
+                      ['activation_mlp', []],
+                      ['activation_batch', ['data', 'fsdp', 'expert']],
+                      ['activation_length', ['context']],
+                      ['activation_norm_length', ['context']],
+                      ['activation_embed', []],
+                      ['activation_stage', 'stage'],
+                      # General Weights
+                      ['mlp', []],
+                      ['layers', 'stage'],
+                      ['embed', ['fsdp', 'context', 'expert']],
+                  ]

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -29,7 +29,7 @@ import yaml
 from typing import Any, Literal, NewType, Optional
 
 import jax
-from maxtext.common.common_types import AttentionType, DecoderBlockType, ReorderStrategy, ShardMode
+from maxtext.common.common_types import AttentionType, DecoderBlockType, ReorderStrategy, ShardMode, CustomRule
 from maxtext.utils import gcs_utils
 from maxtext.utils import max_utils
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
@@ -844,7 +844,9 @@ class HardwareAndMesh(BaseModel):
       description="Reorder strategy for load-balanced context parallelism.",
   )
   custom_mesh: str = Field("", description="Available options: ['hybrid_ring_64x4', 'hybrid_ring_32x8']")
-  custom_mesh_and_rule: str = Field("", description="Customized mesh and logical rules for granularity.")
+  custom_mesh_and_rule: CustomRule = Field(
+      CustomRule.DEFAULT, description="Customized mesh and logical rules for granularity."
+  )
   allow_split_physical_axes: bool = Field(False, description="Allow splitting physical axes for device mesh creation.")
   enable_nnx: bool = Field(False, description="Whether to use NNX for model definition.")
   optimize_mesh_for_tpu_v6e: bool = Field(False, description="Apply transformations to the mesh for TPU v6e.")
@@ -2193,11 +2195,11 @@ class MaxTextConfig(
     Computes all derived values and runs all cross-field validations after initial parsing.
     This logic is ported from the legacy pyconfig_deprecated.py system and adapted for Pydantic.
     """
-    if self.custom_mesh_and_rule:
+    if self.custom_mesh_and_rule is not CustomRule.DEFAULT:
       custom_mesh_path = os.path.join(
           os.path.dirname(os.path.abspath(__file__)),
           "custom_mesh_and_rule",
-          f"{self.custom_mesh_and_rule}.yml",
+          f"{self.custom_mesh_and_rule.value}.yml",
       )
       if os.path.exists(custom_mesh_path):
         with open(custom_mesh_path, "r") as f:  # pylint: disable=unspecified-encoding

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -376,6 +376,9 @@ class RoutedMoE(nnx.Module):
 
     if self.config.attention == "vllm_rpa" and self.config.enable_dp_attention:
       self._expert_parallelism_name = "attn_dp_expert"
+    elif self.config.custom_mesh_and_rule == ctypes.CustomRule.CP_AS_EP:
+      # when custom mesh and rule is cp-as-ep, context axis is same with expert in MoE component
+      self._expert_parallelism_name = ("context", "expert")
     else:
       self._expert_parallelism_name = "expert"
 
@@ -550,6 +553,9 @@ class RoutedMoE(nnx.Module):
     )
 
   def get_expert_parallelism_size(self):
+    # When expert parallelism has more than one physical axes, take product of their shapes
+    if isinstance(self._expert_parallelism_name, tuple):
+      return math.prod(self.mesh.shape.get(name, 1) for name in self._expert_parallelism_name)
     return self.mesh.shape.get(self._expert_parallelism_name, 1)
 
   def get_tensor_parallelism_size(self):

--- a/tests/utils/sharding_dump.py
+++ b/tests/utils/sharding_dump.py
@@ -55,6 +55,13 @@ TEST_CASES = [
         "ep-as-cp",
         ("ici_fsdp_parallelism=-1", "ici_expert_parallelism=2"),
     ),
+    (
+        "deepseek2-16b",
+        "tpu7x-8",
+        1,
+        "cp-as-ep",
+        ("ici_fsdp_parallelism=-1", "ici_context_parallelism=2", "ici_expert_parallelism=2"),
+    ),
     ("qwen3-0.6b", "tpu7x-16", 1, "", ()),
     ("gpt-oss-20b", "tpu7x-16", 1, "", ()),
     ("gpt-oss-20b", "tpu7x-16", 1, "", ("ici_fsdp_parallelism=-1", "ici_expert_parallelism=2")),

--- a/tests/utils/sharding_info/deepseek2-16b/tpu7x-8/slice_1/rule_cp-as-ep_ici_fsdp_parallelism=-1_ici_context_parallelism=2_ici_expert_parallelism=2/input_shardings.json
+++ b/tests/utils/sharding_info/deepseek2-16b/tpu7x-8/slice_1/rule_cp-as-ep_ici_fsdp_parallelism=-1_ici_context_parallelism=2_ici_expert_parallelism=2/input_shardings.json
@@ -1,0 +1,178 @@
+{
+  "Activation Sharding Dump": [
+    {
+      "deepseek/inputs: bfloat16[96,2048,2048]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "deepseek/pre_attention_norm: bfloat16[96,2048,2048]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "attention_mla/inputs_q: bfloat16[96,2048,2048]": {
+        "logic_axes": "('activation_batch_attn', 'activation_length', 'activation_embed')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "attention_mla/inputs_kv: bfloat16[96,2048,2048]": {
+        "logic_axes": "('activation_batch_attn', 'activation_length', 'activation_embed')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "attention_mla/q_nope: bfloat16[96,2048,16,128]": {
+        "logic_axes": "('activation_kv_batch', 'activation_length', 'activation_kv_heads', 'activation_kv_head_dim')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None, None)"
+      }
+    },
+    {
+      "attention_mla/q_pe: bfloat16[96,2048,16,64]": {
+        "logic_axes": "('activation_kv_batch', 'activation_length', 'activation_kv_heads', 'activation_kv_head_dim')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None, None)"
+      }
+    },
+    {
+      "attention_mla/query: bfloat16[96,2048,16,192]": {
+        "logic_axes": "('activation_kv_batch', 'activation_length', 'activation_kv_heads', 'activation_kv_head_dim')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None, None)"
+      }
+    },
+    {
+      "attention_mla/key_nope: bfloat16[96,2048,16,128]": {
+        "logic_axes": "('activation_kv_batch', 'activation_length', 'activation_kv_heads', 'activation_kv_head_dim')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None, None)"
+      }
+    },
+    {
+      "attention_mla/key_rope: bfloat16[96,2048,16,64]": {
+        "logic_axes": "('activation_kv_batch', 'activation_length', 'activation_kv_heads', 'activation_kv_head_dim')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None, None)"
+      }
+    },
+    {
+      "attention_mla/key: bfloat16[96,2048,16,192]": {
+        "logic_axes": "('activation_kv_batch', 'activation_length', 'activation_kv_heads', 'activation_kv_head_dim')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None, None)"
+      }
+    },
+    {
+      "attention_mla/value: bfloat16[96,2048,16,128]": {
+        "logic_axes": "('activation_kv_batch', 'activation_length', 'activation_kv_heads', 'activation_kv_head_dim')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None, None)"
+      }
+    },
+    {
+      "attention_op/arr: int8[1,4,4]": {
+        "logic_axes": "Unknown",
+        "PartitionSpec": "P(None, 'context')"
+      }
+    },
+    {
+      "attention_op/arr: int32[2048]": {
+        "logic_axes": "Unknown",
+        "PartitionSpec": "P('context',)"
+      }
+    },
+    {
+      "attention_op/query: bfloat16[96,16,2048,192]": {
+        "logic_axes": "Unknown",
+        "PartitionSpec": "P(('fsdp', 'expert'), None, 'context', None)"
+      }
+    },
+    {
+      "attention_op/key: bfloat16[96,16,2048,192]": {
+        "logic_axes": "Unknown",
+        "PartitionSpec": "P(('fsdp', 'expert'), None, None, None)"
+      }
+    },
+    {
+      "attention_op/value: bfloat16[96,16,2048,128]": {
+        "logic_axes": "Unknown",
+        "PartitionSpec": "P(('fsdp', 'expert'), None, None, None)"
+      }
+    },
+    {
+      "attention_mla/out: bfloat16[96,2048,16,128]": {
+        "logic_axes": "('activation_batch_attn', 'activation_length', 'activation_heads', 'activation_kv')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None, None)"
+      }
+    },
+    {
+      "deepseek/attention_result: bfloat16[96,2048,2048]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "deepseek/post_attention_norm: bfloat16[96,2048,2048]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "linears/x: bfloat16[96,2048,10944]": {
+        "logic_axes": "('activation_batch', 'activation_length', 'activation_mlp')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "deepseek/mlp: bfloat16[96,2048,2048]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "deepseek/x: bfloat16[96,2048,2048]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "moe/inputs: bfloat16[96,2048,2048]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', None)",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "moe/gate_logits: bfloat16[96,2048,64]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', None)",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "moe/w0_kernel: bfloat16[64,2048,1408]": {
+        "logic_axes": "Unknown",
+        "PartitionSpec": "P(('context', 'expert'), None, None)"
+      }
+    },
+    {
+      "moe/w1_kernel: bfloat16[64,2048,1408]": {
+        "logic_axes": "Unknown",
+        "PartitionSpec": "P(('context', 'expert'), None, None)"
+      }
+    },
+    {
+      "moe/wo_kernel: bfloat16[64,1408,2048]": {
+        "logic_axes": "Unknown",
+        "PartitionSpec": "P(('context', 'expert'), None, None)"
+      }
+    },
+    {
+      "linears/x: bfloat16[96,2048,2816]": {
+        "logic_axes": "('activation_batch', 'activation_length', 'activation_mlp')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    },
+    {
+      "deepseek/mlp_lnx: bfloat16[96,2048,2048]": {
+        "logic_axes": "('activation_batch', 'activation_norm_length', 'activation_embed')",
+        "PartitionSpec": "P(('fsdp', 'expert'), 'context', None)"
+      }
+    }
+  ]
+}

--- a/tests/utils/sharding_info/deepseek2-16b/tpu7x-8/slice_1/rule_cp-as-ep_ici_fsdp_parallelism=-1_ici_context_parallelism=2_ici_expert_parallelism=2/logical_shardings.json
+++ b/tests/utils/sharding_info/deepseek2-16b/tpu7x-8/slice_1/rule_cp-as-ep_ici_fsdp_parallelism=-1_ici_context_parallelism=2_ici_expert_parallelism=2/logical_shardings.json
@@ -1,0 +1,980 @@
+{
+  ".step": {
+    "partition_spec": [],
+    "shape": []
+  },
+  ".params/['params']/['decoder']/['decoder_norm']/['scale']": {
+    "partition_spec": [
+      "norm"
+    ],
+    "shape": [
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['mlp']/['wi_0']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['mlp']/['wi_1']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['mlp']/['wo']/['kernel']": {
+    "partition_spec": [
+      "mlp",
+      "dense_layers",
+      "embed"
+    ],
+    "shape": [
+      10944,
+      1,
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "dense_layers"
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "dense_layers"
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "dense_layers"
+    ],
+    "shape": [
+      512,
+      1
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['self_attention']/['out']/['kernel']": {
+    "partition_spec": [
+      "heads",
+      "dense_layers",
+      "kv",
+      "embed"
+    ],
+    "shape": [
+      16,
+      1,
+      128,
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['self_attention']/['query']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "q_heads",
+      "kv"
+    ],
+    "shape": [
+      2048,
+      1,
+      16,
+      192
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "kv_lora_up_proj"
+    ],
+    "shape": [
+      2048,
+      1,
+      576
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "partition_spec": [
+      "kv_lora",
+      "dense_layers",
+      "kv_heads",
+      "kv_head_dim"
+    ],
+    "shape": [
+      512,
+      1,
+      16,
+      256
+    ]
+  },
+  ".params/['params']/['decoder']/['logits_dense']/['kernel']": {
+    "partition_spec": [
+      "embed_vocab",
+      "vocab"
+    ],
+    "shape": [
+      2048,
+      102400
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['gate']/['kernel']": {
+    "partition_spec": [
+      "embed_moe",
+      "moe_layers",
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      64
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_0']": {
+    "partition_spec": [
+      "exp",
+      "moe_layers",
+      "embed_moe",
+      "mlp_moe"
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_1']": {
+    "partition_spec": [
+      "exp",
+      "moe_layers",
+      "embed_moe",
+      "mlp_moe"
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wo']": {
+    "partition_spec": [
+      "exp",
+      "moe_layers",
+      "mlp_moe",
+      "embed_moe"
+    ],
+    "shape": [
+      64,
+      26,
+      1408,
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_0']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_1']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wo']/['kernel']": {
+    "partition_spec": [
+      "mlp",
+      "moe_layers",
+      "embed"
+    ],
+    "shape": [
+      2816,
+      26,
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "moe_layers"
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "moe_layers"
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "moe_layers"
+    ],
+    "shape": [
+      512,
+      26
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['self_attention']/['out']/['kernel']": {
+    "partition_spec": [
+      "heads",
+      "moe_layers",
+      "kv",
+      "embed"
+    ],
+    "shape": [
+      16,
+      26,
+      128,
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['self_attention']/['query']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "q_heads",
+      "kv"
+    ],
+    "shape": [
+      2048,
+      26,
+      16,
+      192
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "kv_lora_up_proj"
+    ],
+    "shape": [
+      2048,
+      26,
+      576
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "partition_spec": [
+      "kv_lora",
+      "moe_layers",
+      "kv_heads",
+      "kv_head_dim"
+    ],
+    "shape": [
+      512,
+      26,
+      16,
+      256
+    ]
+  },
+  ".params/['params']/['token_embedder']/['embedding']": {
+    "partition_spec": [
+      "vocab",
+      "embed_vocab"
+    ],
+    "shape": [
+      102400,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.count": {
+    "partition_spec": [],
+    "shape": []
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['decoder_norm']/['scale']": {
+    "partition_spec": [
+      "norm"
+    ],
+    "shape": [
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['mlp']/['wi_0']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['mlp']/['wi_1']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['mlp']/['wo']/['kernel']": {
+    "partition_spec": [
+      "mlp",
+      "dense_layers",
+      "embed"
+    ],
+    "shape": [
+      10944,
+      1,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "dense_layers"
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "dense_layers"
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "dense_layers"
+    ],
+    "shape": [
+      512,
+      1
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['self_attention']/['out']/['kernel']": {
+    "partition_spec": [
+      "heads",
+      "dense_layers",
+      "kv",
+      "embed"
+    ],
+    "shape": [
+      16,
+      1,
+      128,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['self_attention']/['query']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "q_heads",
+      "kv"
+    ],
+    "shape": [
+      2048,
+      1,
+      16,
+      192
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "kv_lora_up_proj"
+    ],
+    "shape": [
+      2048,
+      1,
+      576
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "partition_spec": [
+      "kv_lora",
+      "dense_layers",
+      "kv_heads",
+      "kv_head_dim"
+    ],
+    "shape": [
+      512,
+      1,
+      16,
+      256
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['logits_dense']/['kernel']": {
+    "partition_spec": [
+      "embed_vocab",
+      "vocab"
+    ],
+    "shape": [
+      2048,
+      102400
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['gate']/['kernel']": {
+    "partition_spec": [
+      "embed_moe",
+      "moe_layers",
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      64
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_0']": {
+    "partition_spec": [
+      "exp",
+      "moe_layers",
+      "embed_moe",
+      "mlp_moe"
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_1']": {
+    "partition_spec": [
+      "exp",
+      "moe_layers",
+      "embed_moe",
+      "mlp_moe"
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wo']": {
+    "partition_spec": [
+      "exp",
+      "moe_layers",
+      "mlp_moe",
+      "embed_moe"
+    ],
+    "shape": [
+      64,
+      26,
+      1408,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_0']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_1']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wo']/['kernel']": {
+    "partition_spec": [
+      "mlp",
+      "moe_layers",
+      "embed"
+    ],
+    "shape": [
+      2816,
+      26,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "moe_layers"
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "moe_layers"
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "moe_layers"
+    ],
+    "shape": [
+      512,
+      26
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['self_attention']/['out']/['kernel']": {
+    "partition_spec": [
+      "heads",
+      "moe_layers",
+      "kv",
+      "embed"
+    ],
+    "shape": [
+      16,
+      26,
+      128,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['self_attention']/['query']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "q_heads",
+      "kv"
+    ],
+    "shape": [
+      2048,
+      26,
+      16,
+      192
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "kv_lora_up_proj"
+    ],
+    "shape": [
+      2048,
+      26,
+      576
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "partition_spec": [
+      "kv_lora",
+      "moe_layers",
+      "kv_heads",
+      "kv_head_dim"
+    ],
+    "shape": [
+      512,
+      26,
+      16,
+      256
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['token_embedder']/['embedding']": {
+    "partition_spec": [
+      "vocab",
+      "embed_vocab"
+    ],
+    "shape": [
+      102400,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['decoder_norm']/['scale']": {
+    "partition_spec": [
+      "norm"
+    ],
+    "shape": [
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['mlp']/['wi_0']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['mlp']/['wi_1']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['mlp']/['wo']/['kernel']": {
+    "partition_spec": [
+      "mlp",
+      "dense_layers",
+      "embed"
+    ],
+    "shape": [
+      10944,
+      1,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "dense_layers"
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "dense_layers"
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "dense_layers"
+    ],
+    "shape": [
+      512,
+      1
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['self_attention']/['out']/['kernel']": {
+    "partition_spec": [
+      "heads",
+      "dense_layers",
+      "kv",
+      "embed"
+    ],
+    "shape": [
+      16,
+      1,
+      128,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['self_attention']/['query']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "q_heads",
+      "kv"
+    ],
+    "shape": [
+      2048,
+      1,
+      16,
+      192
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "dense_layers",
+      "kv_lora_up_proj"
+    ],
+    "shape": [
+      2048,
+      1,
+      576
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "partition_spec": [
+      "kv_lora",
+      "dense_layers",
+      "kv_heads",
+      "kv_head_dim"
+    ],
+    "shape": [
+      512,
+      1,
+      16,
+      256
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['logits_dense']/['kernel']": {
+    "partition_spec": [
+      "embed_vocab",
+      "vocab"
+    ],
+    "shape": [
+      2048,
+      102400
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['gate']/['kernel']": {
+    "partition_spec": [
+      "embed_moe",
+      "moe_layers",
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      64
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_0']": {
+    "partition_spec": [
+      "exp",
+      "moe_layers",
+      "embed_moe",
+      "mlp_moe"
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_1']": {
+    "partition_spec": [
+      "exp",
+      "moe_layers",
+      "embed_moe",
+      "mlp_moe"
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wo']": {
+    "partition_spec": [
+      "exp",
+      "moe_layers",
+      "mlp_moe",
+      "embed_moe"
+    ],
+    "shape": [
+      64,
+      26,
+      1408,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_0']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_1']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "mlp"
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wo']/['kernel']": {
+    "partition_spec": [
+      "mlp",
+      "moe_layers",
+      "embed"
+    ],
+    "shape": [
+      2816,
+      26,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "moe_layers"
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "moe_layers"
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "partition_spec": [
+      "norm",
+      "moe_layers"
+    ],
+    "shape": [
+      512,
+      26
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['self_attention']/['out']/['kernel']": {
+    "partition_spec": [
+      "heads",
+      "moe_layers",
+      "kv",
+      "embed"
+    ],
+    "shape": [
+      16,
+      26,
+      128,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['self_attention']/['query']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "q_heads",
+      "kv"
+    ],
+    "shape": [
+      2048,
+      26,
+      16,
+      192
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "partition_spec": [
+      "embed",
+      "moe_layers",
+      "kv_lora_up_proj"
+    ],
+    "shape": [
+      2048,
+      26,
+      576
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "partition_spec": [
+      "kv_lora",
+      "moe_layers",
+      "kv_heads",
+      "kv_head_dim"
+    ],
+    "shape": [
+      512,
+      26,
+      16,
+      256
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['token_embedder']/['embedding']": {
+    "partition_spec": [
+      "vocab",
+      "embed_vocab"
+    ],
+    "shape": [
+      102400,
+      2048
+    ]
+  },
+  ".opt_state/[2]/.count": {
+    "partition_spec": [],
+    "shape": []
+  }
+}

--- a/tests/utils/sharding_info/deepseek2-16b/tpu7x-8/slice_1/rule_cp-as-ep_ici_fsdp_parallelism=-1_ici_context_parallelism=2_ici_expert_parallelism=2/named_shardings.json
+++ b/tests/utils/sharding_info/deepseek2-16b/tpu7x-8/slice_1/rule_cp-as-ep_ici_fsdp_parallelism=-1_ici_context_parallelism=2_ici_expert_parallelism=2/named_shardings.json
@@ -1,0 +1,2543 @@
+{
+  ".step": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [],
+    "shape": []
+  },
+  ".params/['params']/['decoder']/['decoder_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null
+    ],
+    "shape": [
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['mlp']/['wi_0']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['mlp']/['wi_1']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['mlp']/['wo']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      10944,
+      1,
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      1
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['self_attention']/['out']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      16,
+      1,
+      128,
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['self_attention']/['query']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      16,
+      192
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      576
+    ]
+  },
+  ".params/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      1,
+      16,
+      256
+    ]
+  },
+  ".params/['params']/['decoder']/['logits_dense']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null
+    ],
+    "shape": [
+      2048,
+      102400
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['gate']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      "fsdp",
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      64
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_0']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "context",
+        "expert"
+      ],
+      null,
+      "fsdp",
+      null
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_1']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "context",
+        "expert"
+      ],
+      null,
+      "fsdp",
+      null
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wo']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      "fsdp"
+    ],
+    "shape": [
+      64,
+      26,
+      1408,
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_0']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_1']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wo']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      2816,
+      26,
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      26
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['self_attention']/['out']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      16,
+      26,
+      128,
+      2048
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['self_attention']/['query']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      16,
+      192
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      576
+    ]
+  },
+  ".params/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      26,
+      16,
+      256
+    ]
+  },
+  ".params/['params']/['token_embedder']/['embedding']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      102400,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.count": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [],
+    "shape": []
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['decoder_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null
+    ],
+    "shape": [
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['mlp']/['wi_0']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['mlp']/['wi_1']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['mlp']/['wo']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      10944,
+      1,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      1
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['self_attention']/['out']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      16,
+      1,
+      128,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['self_attention']/['query']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      16,
+      192
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      576
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      1,
+      16,
+      256
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['logits_dense']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null
+    ],
+    "shape": [
+      2048,
+      102400
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['gate']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      "fsdp",
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      64
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_0']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "context",
+        "expert"
+      ],
+      null,
+      "fsdp",
+      null
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_1']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "context",
+        "expert"
+      ],
+      null,
+      "fsdp",
+      null
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wo']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      "fsdp"
+    ],
+    "shape": [
+      64,
+      26,
+      1408,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_0']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_1']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wo']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      2816,
+      26,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      26
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['self_attention']/['out']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      16,
+      26,
+      128,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['self_attention']/['query']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      16,
+      192
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      576
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      26,
+      16,
+      256
+    ]
+  },
+  ".opt_state/[0]/.mu/['params']/['token_embedder']/['embedding']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      102400,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['decoder_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null
+    ],
+    "shape": [
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['mlp']/['wi_0']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['mlp']/['wi_1']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      10944
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['mlp']/['wo']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      10944,
+      1,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      1
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['self_attention']/['out']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      16,
+      1,
+      128,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['self_attention']/['query']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      16,
+      192
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      1,
+      576
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['dense_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      1,
+      16,
+      256
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['logits_dense']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null
+    ],
+    "shape": [
+      2048,
+      102400
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['gate']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      "fsdp",
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      64
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_0']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "context",
+        "expert"
+      ],
+      null,
+      "fsdp",
+      null
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wi_1']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "context",
+        "expert"
+      ],
+      null,
+      "fsdp",
+      null
+    ],
+    "shape": [
+      64,
+      26,
+      2048,
+      1408
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['MoeBlock_0']/['wo']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      "fsdp"
+    ],
+    "shape": [
+      64,
+      26,
+      1408,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_0']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wi_1']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      2816
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['DeepSeekMoeBlock_0']/['shared_experts']/['wo']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      2816,
+      26,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['post_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['pre_self_attention_layer_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['self_attention']/['kv_norm']/['scale']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      26
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['self_attention']/['out']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      null,
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      16,
+      26,
+      128,
+      2048
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['self_attention']/['query']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      16,
+      192
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_a']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null
+    ],
+    "shape": [
+      2048,
+      26,
+      576
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['decoder']/['moe_layers']/['self_attention']/['wkv_b']/['kernel']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      null,
+      null,
+      null
+    ],
+    "shape": [
+      512,
+      26,
+      16,
+      256
+    ]
+  },
+  ".opt_state/[0]/.nu/['params']/['token_embedder']/['embedding']": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [
+      null,
+      [
+        "fsdp",
+        "context",
+        "expert"
+      ]
+    ],
+    "shape": [
+      102400,
+      2048
+    ]
+  },
+  ".opt_state/[2]/.count": {
+    "mesh": {
+      "axis_names": [
+        "data",
+        "stage",
+        "fsdp",
+        "context",
+        "expert"
+      ],
+      "shape": {
+        "data": 1,
+        "stage": 1,
+        "fsdp": 2,
+        "context": 2,
+        "expert": 2
+      }
+    },
+    "partition_spec": [],
+    "shape": []
+  }
+}


### PR DESCRIPTION
# Description

The new `cp-as-ep` sharding rule supports five mesh axes: data, stage, fsdp, context, and expert. All axes follow the default sharding rules, **except** for the context axis, which applies the Expert Parallelism (EP) rule within the MoE layers.

Compared to the `ep-as-cp` rule introduced in #3656, this new rule is particularly beneficial when `per_device_batch_size` × `ici_expert_parallelism` >> 1 and context parallelism (CP) is needed. Instead of converting all EP to CP—which can degrade performance—this approach allows us to map only a subset of EP to CP in non-MoE components. For example, when training an MoE model with `per_device_batch_size=0.5` where a total EP of 8 is desired, setting EP=4 and CP=2 should yield better performance than simply using EP=8.

This PR also adds a doc explaining the custom mesh and rule feature.

# Tests

In the following test we show that the new custom mesh demonstrates the ideal sharding feature and shows performance advantages over regular CP for MoE model training.

## Functionality test

1. CP + EP with cp_as_ep, `use_ring_of_experts=False`: https://paste.googleplex.com/4643477766930432
2. CP + EP with cp_as_ep, `use_ring_of_experts=True`: https://paste.googleplex.com/5879502447181824
3. CP + EP with cp_as_ep large size compilation: https://paste.googleplex.com/6589777362157568

## Correctness test
Losses match for both cases.

1. Compare FSDP+EP vs. FSDP+CP+cp-as-ep, ragged a2a: https://diff.googleplex.com/#key=6uGMjMG0dDtA
2. Compare FSDP+EP vs. FSDP+CP+cp-as-ep, ring of experts: https://diff.googleplex.com/#key=ef9R3qEOY4x8

## Performance test
For both cases `cp-as-ep` shows performance advantages.

1. Compare FSDP+CP vs. FSDP+CP+cp-as-ep: https://diff.googleplex.com/#key=f8hfz3RRQCgS
2. Compare FSDP+EP+ep-as-cp vs. FSDP+CP+cp-as-ep: https://diff.googleplex.com/#key=nkwbnj8eVfhV

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
