### PR TITLE
fix dtype mismatch when using vocab_tiling

### DIFF
--- a/src/maxtext/models/gemma4.py
+++ b/src/maxtext/models/gemma4.py
@@ -299,7 +299,7 @@ class Gemma4DecoderLayer(nnx.Module):
     else:
       self.post_ffw_norm = None
 
-    self.layer_scalar = nnx.Param(jnp.ones((1,), dtype=config.dtype), sharding=(None,))
+    self.layer_scalar = nnx.Param(jnp.ones((1,), dtype=config.weight_dtype), sharding=(None,))
 
     if model_mode == MODEL_MODE_PREFILL:
       self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")

--- a/src/maxtext/utils/vocabulary_tiling.py
+++ b/src/maxtext/utils/vocabulary_tiling.py
@@ -224,10 +224,10 @@ def vocab_tiling_linen_loss(
         _bwd_scan_body, initial_grad_params_acc, (reshaped_hidden_states, reshaped_labels, reshaped_segmentation)
     )
     grad_reshaped_hidden_states = _maybe_shard_with_name(grad_reshaped_hidden_states, reshaped_hidden_spec)
-    # TODO (chengnuojin): we may want to convert grad_params to bf16 to save memory
-    # grad_params = jax.tree_util.tree_map(lambda x, y: y.astype(x.dtype), gathered_params, grad_params)
     # Chain-rule to accumulate gradients
     grad_params = jax.tree_util.tree_map(lambda g: g * loss_cotangent, grad_params)
+    # Cast cotangents back to each primal's dtype; custom_vjp requires dtype match.
+    grad_params = jax.tree_util.tree_map(lambda x, y: y.astype(x.dtype), gathered_params, grad_params)
     # Give back sharding constraint
     grad_reshaped_hidden_states = _reshape(grad_reshaped_hidden_states, (batch_size, seq_len, emb_dim), hidden_spec)
     return (

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -974,3 +974,22 @@ class TrainCompile(unittest.TestCase):
             "qk_clip_threshold=100",
         )
     )
+
+  @pytest.mark.cpu_only
+  def test_vocab_tiling_bf16(self):
+    """test vocab_tiling when weight_dtype=bfloat16"""
+    compiled_trainstep_file = "/tmp/test_vocab_tiling_bf16.pickle"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "base_num_decoder_layers=2",
+            "per_device_batch_size=2",
+            "max_target_length=1024",
+            "num_vocab_tiling=4",
+            "weight_dtype=bfloat16",
+        )
+    )


### PR DESCRIPTION
# Description
Encountered [this error](https://paste.googleplex.com/6595822797062144) when testing gemma4 with bfloat16 and `num_vocab_tiling=8`.

The root cause is the incompatibility of weight_dtype=bfloat16 and vocab_tiling. In my test, I was using `weight_dtype=float32 dtype=bfloat16`,  but gemma4 has a bug that uses config.dtype (should use config.weight_dtype) to initiate layer scalar, resulting in a bfloat16 weight that causes this error.

This PR fix:
* add dtype cast to allow using weight_dtype=bfloat16 with vocab_tiling. Although weight_dtype=bfloat16 is not common, I see some test scripts use it, so it's still good to support
* gemma4 layer scalar initiate with config.weight_dtype

# Tests
* Added unit test and verified that test fail without the fix and pass after.
* [test script](https://paste.googleplex.com/5252416829259776) 
* [log with error](https://cloudlogging.app.goo.gl/R3YseuHvduWy6cbe6)
* [log after fix](https://cloudlogging.app.goo.gl/r46gq5pKdcZmaoYV8)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
