### PR TITLE
Add distillation reference guide and online-distillation recipe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,4 +60,4 @@ repos:
         args: ['--number']
         additional_dependencies: [mdformat-myst, mdformat-ruff]
         files: (docs/.)
-        exclude: docs/guides/checkpointing_solutions.md
+        exclude: docs/guides/checkpointing_solutions.md|docs/guides.md

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -62,6 +62,13 @@ Interactive development guides for running MaxText on Google Colab or local Jupy
 
 A step-by-step guide for the community to help expand MaxText's model library.
 :::
+
+:::{grid-item-card} 🎓 Distillation
+:link: guides/distillation
+:link-type: doc
+
+How online distillation works in MaxText: loss anatomy, α / β / temperature schedule tuning, layer indices, monitoring metrics, and troubleshooting.
+:::
 ::::
 
 ```{toctree}
@@ -75,4 +82,5 @@ guides/checkpointing_solutions.md
 guides/monitoring_and_debugging.md
 guides/run_python_notebook.md
 guides/model_bringup.md
+guides/distillation.md
 ```

--- a/docs/guides/distillation.md
+++ b/docs/guides/distillation.md
@@ -1,0 +1,285 @@
+<!--
+ Copyright 2023-2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+# Distillation
+
+This guide covers how MaxText's online distillation trainer works, the loss anatomy, the configuration surface, and how to tune the loss-weight schedules (α, β, temperature) for different scenarios.
+
+For step-by-step launch recipes (single-host and multi-host), see the [Knowledge Distillation tutorial](../tutorials/posttraining/knowledge_distillation.md).
+
+## Overview
+
+MaxText supports two flavors of knowledge distillation:
+
+1. **Offline distillation** — the teacher generates a dataset (or top-k logits) once; the student is trained on the cached output. Cheapest when teacher inference is expensive and you plan to run multiple student experiments.
+2. **Online distillation** — teacher and student share the same training loop and the teacher runs forward each step. Required when you want **feature-level alignment** (intermediate activations) and useful for same-family compression and pruning recovery.
+
+This guide focuses on the **online trainer**, [`maxtext.trainers.post_train.distillation.train_distill`](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/trainers/post_train/distillation/train_distill.py), which is built on [Tunix](https://github.com/google/tunix). Common use cases:
+
+- **Same-size pruning recovery** — recover quality after structural pruning by aligning logits (and optionally activations) to the unpruned teacher.
+- **Compression** — distill a larger teacher into a smaller student of the same family (e.g. Llama-3.1-70B → Llama-3.1-8B).
+- **Self-distillation** — improve a model by distilling it from itself with stronger regularization or a different data mix.
+
+### Online vs. offline at a glance
+
+|                        | Online                                              | Offline                                                      |
+| ---------------------- | --------------------------------------------------- | ------------------------------------------------------------ |
+| Teacher inference cost | Per training step                                   | One-time data generation                                     |
+| Storage cost           | None beyond checkpoints                             | Significant (full dataset of teacher outputs)                |
+| Hardware required      | Both teacher + student fit in mesh                  | Student only during training                                 |
+| Supports feature loss  | Yes (`distill_beta > 0`)                            | No (only logit-level)                                        |
+| Best for               | Same-family pruning recovery, small/medium teachers | Very large teachers, repeat student experiments on same data |
+
+A hybrid pattern — **cache top-k teacher logits offline, then run the trainer in offline mode** — is also supported via `save_top_k_teacher_logits.py` and the `offline_data_dir` flag. See the tutorial for the recipe.
+
+## Architecture
+
+The trainer initializes **two MaxText models** with isolated configurations:
+
+- **Student** — trainable; configured from the YAML plus `student_overrides`.
+- **Teacher** — frozen (`stop_gradient`); configured from the YAML plus `teacher_overrides`.
+
+This separation lets you use the same base config for both while still varying e.g. `model_name`, `num_decoder_layers`, or `load_parameters_path` per side. CLI overrides only apply to the **student** by default — the teacher is initialized from the YAML + `teacher_overrides` only, so flags like `num_query_heads=16` passed on the command line will not silently change the teacher.
+
+### Vocabulary requirement
+
+Student and teacher must share the same vocabulary. The trainer asserts `student_config.vocab_size == teacher_config.vocab_size` at startup.
+
+### Required architectural flags for feature loss
+
+If `distill_beta > 0`, the model `sow`s the attention `out_projection` activations at every layer so the loss can read them. This requires:
+
+- `scan_layers: True` — activations are stacked along the leading scan axis; the loss does `jnp.take(features, layer_indices, axis=0)` over that axis.
+- `enable_nnx: True` — `sow(nnx.Intermediate, ...)` is an NNX-specific call.
+
+The trainer validates both at config initialization. Logit-only runs (`distill_beta = 0`) have no such constraint.
+
+## Loss anatomy
+
+The total per-step loss is:
+
+```
+L_total = α · KL(teacher_T || student_T) · T²   ←  soft loss
+        + (1 − α) · CE(student, labels)         ←  hard loss
+        + β · feature_loss(student_acts, teacher_acts[layer_indices])
+```
+
+Where `T` is the temperature, KL is over softmax-with-temperature distributions, and `feature_loss` is mean cosine distance (default) or L2.
+
+The Hinton T² scaling is applied automatically inside `compute_loss`, so the soft-loss magnitude stays comparable as you change T.
+
+Per-token validity is derived from the one-hot labels — padded positions (fully-zero rows) are excluded from the loss. All token-weighted metrics are emitted as `(sum, count)` pairs and aggregated as `sum(sums) / sum(counts)`, so the values are unbiased across multi-host averaging and across logging windows with varying valid-token counts.
+
+## Configuration surface
+
+The starter config is [`src/maxtext/configs/post_train/distillation.yml`](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/post_train/distillation.yml). Its key sections:
+
+```yaml
+base_config: "base.yml"
+
+# Student and teacher are configured separately; CLI args only flow into the student.
+student_overrides:
+  model_name: "llama3.1-8b"
+
+teacher_overrides:
+  model_name: "llama3.1-8b"
+  load_parameters_path: "/path/to/teacher/checkpoint/0/items"   # required for online runs
+
+# --- Logit distillation ---
+distill_alpha: 0.5             # weight on KL(teacher||student)
+distill_temperature: 1.0       # softmax temperature applied before KL
+
+# --- Feature distillation (optional; 0.0 disables) ---
+distill_beta: 0.0
+distill_feature_loss_type: "cosine"   # or "l2"
+distill_layer_indices: None           # which scanned layers to align
+
+# --- Schedules — when *_end is None, the value stays fixed ---
+distill_alpha_end: None
+distill_alpha_schedule: "constant"    # constant | linear | cosine
+distill_temperature_end: None
+distill_temperature_schedule: "constant"
+distill_beta_end: None
+distill_beta_schedule: "constant"
+```
+
+### Schedule semantics
+
+`progress = clip(step / max_steps, 0, 1)`. Past `max_steps`, the value freezes at `end_value`.
+
+- `constant` — fixed at `start_value`; `end_value` ignored.
+- `linear` — `start + (end − start) · progress`.
+- `cosine` — `end + (start − end) · 0.5 · (1 + cos(π · progress))`. Holds near `start` longer than linear before transitioning.
+
+## α (alpha) schedule guide
+
+α weights the **soft KL loss** against the **hard CE loss**:
+
+- `α = 1.0` → pure teacher mimicry (KL only)
+- `α = 0.0` → pure SFT (CE only)
+- α weights how much you trust the **teacher's distribution** vs the **one-hot label**
+
+### Why decay high → low
+
+| Phase             | What's happening                                                                    | Right α            |
+| ----------------- | ----------------------------------------------------------------------------------- | ------------------ |
+| Recovery (early)  | Student damaged by pruning; teacher's full softmax is dense, info-rich, low-noise   | High (0.8–1.0)     |
+| Refinement (late) | Student close to teacher; KL diminishing returns; teacher's errors start to bake in | Moderate (0.3–0.5) |
+
+### Recommended α schedules
+
+| Scenario                                                                | start | end | schedule |
+| ----------------------------------------------------------------------- | ----- | --- | -------- |
+| Large teacher → small student (e.g. 70B → 8B)                           | 1.0   | —   | constant |
+| Same-size pruning recovery (default recommendation)                     | 0.9   | 0.5 | cosine   |
+| Same-size, clean labels, want student > teacher on label-grounded tasks | 0.9   | 0.3 | cosine   |
+| Reasoning / code (label is gospel)                                      | 0.8   | 0.2 | cosine   |
+| Offline top-k logits (narrow teacher support)                           | 0.7   | 0.3 | cosine   |
+| Conservative baseline (current default)                                 | 0.5   | —   | constant |
+
+Prefer `cosine` over `linear` when decaying — cosine holds near `start_value` longer before transitioning, which better matches recovery dynamics.
+
+## β (beta) schedule guide
+
+β scales an **additive** feature-loss term — unlike α, it doesn't trade off against another loss. Increasing β just adds more pressure to align the student's attention out-projection activations to the teacher's at the chosen layers.
+
+Because it's additive, β's *absolute* magnitude matters relative to the logit losses:
+
+- The cosine-distance feature loss is bounded in `[0, 2]` per element → `β` of order **0.1–2.0** is typical.
+- L2 is unbounded → use `β` of order **0.01–0.1**.
+
+**Decay β high → low**: high β early forces the student's internals to match the teacher (strongest recovery signal); decay it as the student converges so the rigid same-shape activation match doesn't become a ceiling.
+
+### Recommended β schedules
+
+| Scenario                                                    | feature_loss_type | start | end   | schedule |
+| ----------------------------------------------------------- | ----------------- | ----- | ----- | -------- |
+| Off (logit-only distillation)                               | —                 | 0.0   | —     | constant |
+| Same-size pruning recovery (default)                        | cosine            | 1.0   | 0.1   | cosine   |
+| Aggressive recovery (heavy pruning)                         | cosine            | 2.0   | 0.5   | cosine   |
+| L2 variant                                                  | l2                | 0.05  | 0.005 | cosine   |
+| Constant feature pressure (architecturally similar student) | cosine            | 0.5   | —     | constant |
+
+> **Note:** `distill_beta = 0.0` disables feature *extraction* entirely (the `sow` is skipped), so you cannot start at 0 and ramp up. To "ramp on" feature loss, start at a tiny positive value (e.g. `1e-6`) and set `distill_beta_end` to your target.
+
+### Layer indices for feature loss
+
+`distill_layer_indices` selects which scanned-layer slices contribute to `feature_loss`. The XPK launcher's default is `[0,1,2,...,7]` — the first 8 layers, irrespective of model depth. Better defaults usually exist:
+
+| Goal                                        | Llama-8B (32 layers)                        | Llama-70B (80 layers)      |
+| ------------------------------------------- | ------------------------------------------- | -------------------------- |
+| Anchor low-level (current launcher default) | `[0,1,2,3,4,5,6,7]`                         | `[0,1,2,3,4,5,6,7]`        |
+| Cover full depth (recommended)              | `[3,7,11,15,19,23,27,31]`                   | `[9,19,29,39,49,59,69,79]` |
+| Top-heavy (semantic layers matter most)     | `[16,20,24,28,30,31]`                       | `[60,65,70,75,78,79]`      |
+| Bracket pruned region                       | layers immediately before/after pruned ones | same                       |
+
+If you have pruned specific layers, the most useful targets are usually the layers **straddling the pruned region** — those representations are the most disturbed.
+
+## Temperature schedule
+
+Higher T softens the distributions and transfers more "dark knowledge" (relative ordering of non-top tokens).
+
+| T                     | Effect                                                     |
+| --------------------- | ---------------------------------------------------------- |
+| 1                     | Raw softmax; fastest convergence on the dominant token     |
+| 2 (recommended start) | Meaningful contribution from non-top tokens                |
+| 4+                    | Very flat; soft-loss gradient shrinks even with T² scaling |
+
+Common pattern: anneal T from 2.0 → 1.0 alongside α decay.
+
+## Starter configurations
+
+### Same-size pruning recovery (default recommendation)
+
+```yaml
+# logits
+distill_alpha: 0.9
+distill_alpha_end: 0.5
+distill_alpha_schedule: cosine
+distill_temperature: 2.0
+distill_temperature_end: 1.0
+distill_temperature_schedule: cosine
+
+# features
+distill_beta: 1.0
+distill_beta_end: 0.1
+distill_beta_schedule: cosine
+distill_feature_loss_type: cosine
+distill_layer_indices: [3, 7, 11, 15, 19, 23, 27, 31]   # for 32-layer student
+
+scan_layers: True
+enable_nnx: True
+```
+
+### Logit-only baseline (cheapest; no feature extraction overhead)
+
+```yaml
+distill_alpha: 0.9
+distill_alpha_end: 0.5
+distill_alpha_schedule: cosine
+distill_temperature: 2.0
+distill_beta: 0.0            # disables sow; no extra memory or compute
+```
+
+For other shapes (large teacher → small student, aggressive recovery, etc.), adjust `distill_alpha`/`distill_beta` per the [α](#recommended-%CE%B1-schedules) and [β](#recommended-%CE%B2-schedules) schedule tables above.
+
+## Monitoring
+
+The trainer logs the following to TensorBoard (configured by `tensorboard_dir`, defaulting to a path under `base_output_directory`):
+
+| Metric                                                         | What it tells you                                                                                                                |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `distill/soft_loss`                                            | KL on temperature-softened distributions, scaled by T². The soft-loss component of the gradient.                                 |
+| `distill/hard_loss`                                            | Student CE on labels. Should track the teacher's after recovery.                                                                 |
+| `distill/teacher_loss`                                         | Teacher CE on labels — sanity check; should be ~constant. Jumping means the batch composition changed or the teacher mis-loaded. |
+| `distill/student_perplexity`, `distill/teacher_perplexity`     | Per-step next-token perplexity. The convergence gap is the student↔teacher quality gap.                                          |
+| `distill/kl_div_at_T`                                          | KL at the current (scheduled) temperature, without the T² scaling.                                                               |
+| `distill/kl_div_T1`                                            | KL at T=1. Comparable across runs / different temperature schedules. **Best metric for cross-run quality comparison.**           |
+| `distill/out_proj_feature_loss`                                | The feature-loss term (already β-scaled). Should drop early then plateau.                                                        |
+| `distill/total_loss`                                           | The full optimization target.                                                                                                    |
+| `distill/alpha`, `distill/beta_feature`, `distill/temperature` | Confirms the schedulers are firing as intended.                                                                                  |
+
+> **Note:** The headline `_train_perplexity` Tunix prints is `exp(total_loss)` which for distillation is `exp(α·soft + (1-α)·hard + β·feature)` — **not** next-token perplexity. Use `distill/student_perplexity` or compute `exp(distill/hard_loss)` for the comparable quality number.
+
+## Troubleshooting
+
+| Symptom                                                                             | Likely cause                                                                                           | Fix                                                                                                                           |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `ValueError: a value of self.distill_beta > 0.0 requires self.scan_layers = True`   | Feature loss enabled without scanned layers.                                                           | Add `scan_layers=True enable_nnx=True` to your CLI / yml.                                                                     |
+| `Vocab size mismatch! Student: X, Teacher: Y`                                       | Different tokenizers.                                                                                  | Use teacher and student with the same vocab; the trainer cannot match logits across vocabularies.                             |
+| `Teacher model path is missing`                                                     | `teacher_overrides.load_parameters_path` not set in non-offline mode.                                  | Set it in `teacher_overrides` in the yml or pass via CLI.                                                                     |
+| `Features extracted from student or teacher model are None, but distill_beta > 0.0` | Model architecture doesn't sow `out_projection_activations` (e.g. uses an unsupported attention path). | Verify the attention layer in use sets `self.sow(nnx.Intermediate, "out_projection_activations", out)` (see `attentions.py`). |
+| `distill_beta=0.0 but distill_beta_end=...`                                         | Trying to ramp β up from zero, but `0.0` disables the `sow` so there's nothing to ramp.                | Start at a small positive value (e.g. `distill_beta=1e-6`) and set `distill_beta_end` to the target.                          |
+| `hard_loss` keeps rising while `soft_loss` drops                                    | α is locking the student into teacher behavior that's bad against labels.                              | Decay α faster (lower `distill_alpha_end`), or decrease the alpha curve mid-training.                                         |
+| `out_proj_feature_loss` plateaus high and won't drop                                | Wrong layer indices for the pruning pattern, or β too high (numerically dominating gradients).         | Re-examine `distill_layer_indices`; lower starting β or its end value.                                                        |
+| `kl_div_T1` plateaus quickly then nothing improves                                  | Student capacity-bound on those layers; or teacher distribution too narrow.                            | Raise β to push deeper alignment; revisit the prune; or raise temperature.                                                    |
+| Teacher OOMs at startup                                                             | Teacher is too large for the mesh + student.                                                           | Use the offline top-k variant; or reduce `per_device_batch_size`; or move to a larger slice.                                  |
+
+## Ablation priority
+
+When tuning a new run, ablate in this order — each is a config-only change with no code edits:
+
+1. **`distill_alpha_end`** — try {0.3, 0.5, 0.7} with `start=0.9`, `schedule=cosine`. Highest-leverage knob.
+2. **`distill_layer_indices`** *(only if `distill_beta > 0`)* — evenly-spaced vs first-8 vs straddling pruned layers. Often as impactful as β value.
+3. **`distill_beta_end`** *(only if `distill_beta > 0`)* — {0.01, 0.1, 0.5} from `start=1.0`. Low end = "let internals drift", high end = "enforce alignment".
+4. **`distill_temperature`** — {1.0, 2.0, 4.0} starting values. T=2 is usually safe.
+5. **Schedule shape** — `cosine` vs `linear` for α. Cosine usually wins.
+6. **`distill_feature_loss_type`** — `cosine` vs `l2`. Cosine is more forgiving; L2 punishes magnitude drift too.
+
+## Related
+
+- [Knowledge Distillation tutorial](../tutorials/posttraining/knowledge_distillation.md) — step-by-step launch recipes.
+- [Optimization guide](optimization.md) — sharding strategies and performance tuning that apply to the distillation trainer too.

--- a/docs/tutorials/posttraining/knowledge_distillation.md
+++ b/docs/tutorials/posttraining/knowledge_distillation.md
@@ -18,9 +18,9 @@
 
 ## Overview
 
-Knowledge Distillation is a compression technique that transfers knowledge from a larger (teacher) model to a smaller (student) model. This allows the smaller model to achieve performance levels closer to the larger one, but with significantly fewer parameters and computational resources.
+Knowledge Distillation transfers knowledge from a teacher model to a student model. This allows the student to achieve performance levels closer to the teacher's, typically with significantly fewer parameters and computational resources.
 
-This tutorial focuses on **response-based knowledge distillation**, a technique where the student model is trained to replicate the outputs and behaviors of the teacher model. Within response-based knowledge distillation, two primary methods are often employed:
+This tutorial focuses on **response-based knowledge distillation**, a technique where the student model is trained to replicate the outputs and behaviors of the teacher model. Within response-based knowledge distillation, two primary methods are often employed, both covered below:
 
 1. **Offline Distillation (Dataset Generation):**
 
@@ -226,3 +226,198 @@ python3 -m maxtext.trainers.post_train.sft.train_sft \
   hf_access_token=${HF_TOKEN?} \
   profiler=xplane
 ```
+
+## Running Online Distillation with MaxText
+
+Online distillation runs the teacher and student in the same training process. Each step, both models do a forward pass on the same batch and the student is updated to match a combination of:
+
+1. The teacher's softened logit distribution (KL-divergence soft loss).
+2. The ground-truth labels (cross-entropy hard loss).
+3. (Optional) The teacher's intermediate attention activations (feature loss).
+
+The trainer entry point is [`maxtext.trainers.post_train.distillation.train_distill`](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/trainers/post_train/distillation/train_distill.py), built on [Tunix](https://github.com/google/tunix). For a deeper reference on how the trainer is structured, the loss anatomy, and how to tune the α / β / temperature schedules for different scenarios, see the dedicated [Distillation guide](../../guides/distillation.md).
+
+### Prerequisites
+
+#### a. Convert both teacher and student to MaxText format
+
+Online distillation runs the teacher inside MaxText (not vLLM), so both checkpoints must be in MaxText/Orbax format. Convert them with the same script used for the student in the offline section:
+
+```bash
+# Student
+python3 -m maxtext.checkpoint_conversion.to_maxtext \
+    model_name=llama3.1-8b \
+    hf_access_token=${HF_TOKEN?} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY?}/llama3.1-8b-ckpt \
+    scan_layers=True skip_jax_distributed_system=True
+
+# Teacher (example: same family, larger)
+python3 -m maxtext.checkpoint_conversion.to_maxtext \
+    model_name=llama3.1-70b \
+    hf_access_token=${HF_TOKEN?} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY?}/llama3.1-70b-ckpt \
+    scan_layers=True skip_jax_distributed_system=True
+```
+
+> **Note:** Student and teacher must share the same vocabulary. The trainer asserts `student_config.vocab_size == teacher_config.vocab_size` at startup.
+
+#### b. Install Tunix
+
+The online distillation trainer depends on Tunix. The XPK launcher script ([`scripts/run_distill_xpk.sh`](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh)) contains a `prep_image` step that layers Tunix on top of the MaxText base image. For local runs, install the same pin used by the launcher — the default `TUNIX_SOURCE` in `run_distill_xpk.sh` is the source of truth. As of this writing:
+
+```bash
+pip install "git+https://github.com/google/tunix@110932a8395086511228483312131841521695c1"
+```
+
+> **Note:** The commit pin above will drift as the launcher is updated. Before installing, check the `TUNIX_SOURCE` default in [`run_distill_xpk.sh`](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh) and use that spec. Once a Tunix PyPI release ships, this will become a versioned `google-tunix==<ver>` install.
+
+### Configuration
+
+The starter config is [`src/maxtext/configs/post_train/distillation.yml`](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/post_train/distillation.yml). The trainer initializes **two MaxText models** with isolated configurations applied via `student_overrides` and `teacher_overrides`. CLI overrides only apply to the student by default — the teacher is initialized from the YAML + `teacher_overrides` only.
+
+Key knobs (see the [Distillation guide](../../guides/distillation.md) for the full configuration surface and tuning advice):
+
+```yaml
+distill_alpha: 0.5             # weight on KL(teacher||student)
+distill_temperature: 1.0
+distill_beta: 0.0              # >0 enables feature distillation; requires scan_layers=True, enable_nnx=True
+distill_layer_indices: None
+```
+
+The student and teacher are configured separately via `student_overrides` and `teacher_overrides`. Two patterns cover most use cases:
+
+#### Pattern A — Compression (large teacher, smaller student)
+
+The headline use case: distill a larger teacher into a smaller student that shares its tokenizer. The trainer asserts `student_config.vocab_size == teacher_config.vocab_size` at startup, so the simplest path is to stay within a single family (Llama-3.1-70B → Llama-3.1-8B, Qwen → Qwen, Gemma → Gemma) where the vocabulary is guaranteed to match.
+
+```yaml
+student_overrides:
+  model_name: "llama3.1-8b"
+  load_parameters_path: "/path/to/llama3.1-8b-ckpt/0/items"
+
+teacher_overrides:
+  model_name: "llama3.1-70b"
+  load_parameters_path: "/path/to/llama3.1-70b-ckpt/0/items"
+```
+
+#### Pattern B — Pruning recovery (same model name, student is structurally smaller)
+
+What `train_distill.py` was originally built for: recover quality after structural pruning by aligning the pruned student to the unpruned teacher. The student overrides architectural keys (e.g. `base_num_decoder_layers`) to match its pruned shape.
+
+```yaml
+student_overrides:
+  model_name: "llama3.1-8b"
+  base_num_decoder_layers: 24    # 8b has 32 layers; this student is pruned down to 24
+  load_parameters_path: "/path/to/pruned-llama3.1-8b/0/items"
+
+teacher_overrides:
+  model_name: "llama3.1-8b"
+  load_parameters_path: "/path/to/full-llama3.1-8b/0/items"
+```
+
+> **Note:** Producing the pruned checkpoint is out of scope. This trainer recovers quality from any pruned student you bring; the pruning step itself lives in your own pipeline.
+
+### Launching online distillation
+
+#### Single-host (TPU v6e-8)
+
+The example below demonstrates **Pattern B** (pruning recovery): the student is a depth-pruned Llama-3.1-8B (24 of 32 layers) being aligned to the unpruned 32-layer teacher, with feature loss enabled. For **Pattern A** (compression) substitute the `teacher_overrides` with a larger model and set `distill_beta=0` — see the note on layer indices below.
+
+```bash
+python3 -m maxtext.trainers.post_train.distillation.train_distill \
+  src/maxtext/configs/post_train/distillation.yml \
+  run_name=${RUN_NAME?} \
+  base_output_directory=${BASE_OUTPUT_DIRECTORY?}/distillation/online \
+  tokenizer_path=meta-llama/Llama-3.1-8B tokenizer_type=huggingface \
+  hf_access_token=${HF_TOKEN?} \
+  student_overrides.model_name=llama3.1-8b \
+  student_overrides.base_num_decoder_layers=24 \
+  student_overrides.load_parameters_path=${BASE_OUTPUT_DIRECTORY?}/pruned-llama3.1-8b-24L/0/items \
+  teacher_overrides.model_name=llama3.1-8b \
+  teacher_overrides.load_parameters_path=${BASE_OUTPUT_DIRECTORY?}/llama3.1-8b-ckpt/0/items \
+  per_device_batch_size=2 \
+  gradient_accumulation_steps=8 \
+  ici_fsdp_parallelism=4 \
+  max_target_length=2048 \
+  steps=10000 \
+  distill_alpha=0.9 distill_alpha_end=0.5 distill_alpha_schedule=cosine \
+  distill_temperature=2.0 \
+  distill_beta=1.0 distill_beta_end=0.1 distill_beta_schedule=cosine \
+  distill_layer_indices=[2,5,8,11,14,17,20,23] \
+  scan_layers=True enable_nnx=True \
+  profiler=xplane
+```
+
+The schedule values above are a strong default for same-size pruning recovery. See [α and β schedule guide](../../guides/distillation.md#alpha-schedule-guide) for other scenarios (large teacher → small student, logit-only, aggressive recovery, etc.).
+
+> **Note:** `distill_layer_indices` is applied to **both** student and teacher activations identically. When the two have different depths (Pattern A or a depth-pruned Pattern B), every index must be valid on the *smaller* side, and same-numbered layers are aligned across the two models. The trainer cannot map student layer *i* to teacher layer *f(i)* for arbitrary *f*. If the depths differ significantly, prefer logit-only distillation (`distill_beta=0`).
+
+#### Multi-host on GKE via XPK
+
+A reference launcher is provided at `src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh`. It handles image preparation (`prep_image` layers Tunix on top of the MaxText base image), workload submission, log streaming, and an auto-resume loop for long-running jobs.
+
+Minimum environment variables:
+
+```bash
+export XPK_CLUSTER=<your-gke-cluster>
+export XPK_PROJECT=<your-gcp-project>
+export XPK_ZONE=<cluster-zone>             # e.g. us-central1-a
+export XPK_DEVICE_TYPE=<tpu-type>          # e.g. tpu7x-4x4x4, v5p-128
+export XPK_BASE_OUTPUT_DIR=gs://<bucket>/distill-runs
+
+# Distillation hyperparameters (always passed; override yml values)
+export DISTILL_ALPHA=0.9
+export DISTILL_TEMPERATURE=2.0
+export DISTILL_BETA=1.0
+# Layer indices for feature loss. Every index must be valid on the smaller side
+# (student for Pattern A, both for Pattern B). Values below assume a 32-layer
+# student; adjust for other depths — see the Distillation guide's layer-index table.
+export DISTILL_LAYER_INDICES=[3,7,11,15,19,23,27,31]   # no spaces inside brackets
+```
+
+Then:
+
+```bash
+# One-time: layer Tunix on top of the MaxText base image
+bash src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh prep_image
+
+# Submit a workload
+bash src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh submit
+
+# Stream logs
+bash src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh monitor
+
+# Auto-resume on failure (uses the same workload + base output dir, so checkpoint resume works)
+bash src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh resume_until_done
+```
+
+The script's header comment lists every supported environment variable.
+
+### Offline top-k logits variant
+
+If running the teacher every step is too expensive (for very large teachers), you can cache its top-k logits once and stream them to the trainer. **Feature loss is unavailable in this mode** — only `distill_alpha` / `distill_temperature` are active.
+
+1. Save top-k teacher logits to ArrayRecord files:
+
+   ```bash
+   python3 src/maxtext/trainers/post_train/distillation/save_top_k_teacher_logits.py \
+     src/maxtext/configs/post_train/distillation.yml \
+     --local_tmp_dir=/tmp/teacher_topk \
+     --steps_per_file=10 \
+     --top_k=64
+   ```
+
+2. Run the trainer with `offline_data_dir` pointing at the cached files:
+
+   ```bash
+   python3 -m maxtext.trainers.post_train.distillation.train_distill \
+     src/maxtext/configs/post_train/distillation.yml \
+     offline_data_dir=/tmp/teacher_topk \
+     ...other-args...
+   ```
+
+Bias α slightly lower (e.g. `0.7 → 0.3`) since the reconstructed distribution has narrow, hard-cut support — see the schedule guide for details.
+
+### Next steps
+
+- [Distillation guide](../../guides/distillation.md) — loss anatomy, α / β / temperature schedule tuning, layer-index selection, monitoring metrics, troubleshooting, and ablation priority.


### PR DESCRIPTION
# Description

Adds a new reference guide (docs/guides/distillation.md) covering the online distillation trainer — loss anatomy, α/β/temperature schedules, layer-index selection, monitoring, and troubleshooting — and extends  the knowledge-distillation tutorial with an Online Distillation section (Pattern A compression, Pattern B depth-pruning recovery, XPK multi-host,  and the offline top-k logits variant). The new guide is linked from  docs/guides.md.

# Tests

Run most of commands.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
