### PR TITLE
Update Tunix version

### DIFF
--- a/src/dependencies/extra_deps/post_train_base_deps.txt
+++ b/src/dependencies/extra_deps/post_train_base_deps.txt
@@ -1,1 +1,1 @@
-google-tunix @ https://github.com/google/tunix/archive/f0102a7b0dccc0020503c0617869883f16b3b4ed.zip
+google-tunix @ https://github.com/google/tunix/archive/9d25e2647520b205ef43e5182ded030d20f3f52b.zip


### PR DESCRIPTION
This is required to support fused moe in MaxText. See Tunix PR: https://github.com/google/tunix/pull/1385.

# Description

Fused moe in Maxtext requires a feature in Tunix that is only available after the pinned commit.

# Tests

Ran GRPO training and it was able to start successfully with various fused moe params set.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
