### PR TITLE
Fix megablox tile sizes

### DIFF
--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -1296,26 +1296,26 @@ class RoutedMoE(nnx.Module):
           expert_assignments=selected_experts,
       )
       wi_tile_size = (
-          self.config.wi_tile_fwd_batch_seq,
-          self.config.wi_tile_fwd_embed_dim,
-          self.config.wi_tile_fwd_mlp_dim,
-          self.config.wi_tile_dlhs_batch_seq,
-          self.config.wi_tile_dlhs_embed_dim,
-          self.config.wi_tile_dlhs_mlp_dim,
-          self.config.wi_tile_drhs_batch_seq,
-          self.config.wi_tile_drhs_embed_dim,
-          self.config.wi_tile_drhs_mlp_dim,
+          self.config.wi_tile_fwd_batch_seq,  # m (LHS batch)
+          self.config.wi_tile_fwd_embed_dim,  # k  (contracting)
+          self.config.wi_tile_fwd_mlp_dim,  # n (RHS batch)
+          self.config.wi_tile_dlhs_batch_seq,  # m (LHS batch)
+          self.config.wi_tile_dlhs_mlp_dim,  # k (contracting)
+          self.config.wi_tile_dlhs_embed_dim,  # n (RHS batch)
+          self.config.wi_tile_drhs_batch_seq,  # Called m in megablox, but this is contracting
+          self.config.wi_tile_drhs_embed_dim,  # Called k in megablox, but this is LHS batch dim
+          self.config.wi_tile_drhs_mlp_dim,  # Called n in megablox, and indeed is RHS batch dim
       )
       wo_tile_size = (
-          self.config.wo_tile_fwd_batch_seq,
-          self.config.wo_tile_fwd_embed_dim,
-          self.config.wo_tile_fwd_mlp_dim,
-          self.config.wo_tile_dlhs_batch_seq,
-          self.config.wo_tile_dlhs_embed_dim,
-          self.config.wo_tile_dlhs_mlp_dim,
-          self.config.wo_tile_drhs_batch_seq,
-          self.config.wo_tile_drhs_embed_dim,
-          self.config.wo_tile_drhs_mlp_dim,
+          self.config.wo_tile_fwd_batch_seq,  # m (LHS batch)
+          self.config.wo_tile_fwd_mlp_dim,  # k (contracting)
+          self.config.wo_tile_fwd_embed_dim,  # n (RHS batch)
+          self.config.wo_tile_dlhs_batch_seq,  # m (LHS batch)
+          self.config.wo_tile_dlhs_embed_dim,  # k (contracting)
+          self.config.wo_tile_dlhs_mlp_dim,  # n (RHS)
+          self.config.wo_tile_drhs_batch_seq,  # Called m in megablox, but this is contracting
+          self.config.wo_tile_drhs_mlp_dim,  # Called k in megablox, but this is LHS batch dim
+          self.config.wo_tile_drhs_embed_dim,  # Called n in megablox, and indeed is the RHS batch dim
       )
 
       layer_w0 = gmm_fn(

--- a/src/maxtext/models/deepseek_batchsplit_fp8.py
+++ b/src/maxtext/models/deepseek_batchsplit_fp8.py
@@ -977,26 +977,27 @@ def compute(x, w0, w1, wo, group_sizes, weights, *, config, mesh):
   wo_gather_axes = []
 
   wi_tile_size = (
-      config.wi_tile_fwd_batch_seq,
-      config.wi_tile_fwd_embed_dim,
-      config.wi_tile_fwd_mlp_dim,
-      config.wi_tile_dlhs_batch_seq,
-      config.wi_tile_dlhs_embed_dim,
-      config.wi_tile_dlhs_mlp_dim,
-      config.wi_tile_drhs_batch_seq,
-      config.wi_tile_drhs_embed_dim,
-      config.wi_tile_drhs_mlp_dim,
+      config.wi_tile_fwd_batch_seq,  # m (LHS batch)
+      config.wi_tile_fwd_embed_dim,  # k  (contracting)
+      config.wi_tile_fwd_mlp_dim,  # n (RHS batch)
+      config.wi_tile_dlhs_batch_seq,  # m (LHS batch)
+      config.wi_tile_dlhs_mlp_dim,  # k (contracting)
+      config.wi_tile_dlhs_embed_dim,  # n (RHS batch)
+      config.wi_tile_drhs_batch_seq,  # Called m in megablox, but this is contracting
+      config.wi_tile_drhs_embed_dim,  # Called k in megablox, but this is LHS batch dim
+      config.wi_tile_drhs_mlp_dim,  # Called n in megablox, and indeed is the RHS batch dim
   )
+
   wo_tile_size = (
-      config.wo_tile_fwd_batch_seq,
-      config.wo_tile_fwd_embed_dim,
-      config.wo_tile_fwd_mlp_dim,
-      config.wo_tile_dlhs_batch_seq,
-      config.wo_tile_dlhs_embed_dim,
-      config.wo_tile_dlhs_mlp_dim,
-      config.wo_tile_drhs_batch_seq,
-      config.wo_tile_drhs_embed_dim,
-      config.wo_tile_drhs_mlp_dim,
+      config.wo_tile_fwd_batch_seq,  # m (LHS batch)
+      config.wo_tile_fwd_mlp_dim,  # k (contracting)
+      config.wo_tile_fwd_embed_dim,  # n (RHS batch)
+      config.wo_tile_dlhs_batch_seq,  # m (LHS batch)
+      config.wo_tile_dlhs_embed_dim,  # k (contracting)
+      config.wo_tile_dlhs_mlp_dim,  # n (RHS)
+      config.wo_tile_drhs_batch_seq,  # Called m in megablox, but this is contracting
+      config.wo_tile_drhs_mlp_dim,  # Called k in megablox, but this is LHS batch dim
+      config.wo_tile_drhs_embed_dim,  # Called n in megablox, and indeed is the RHS batch dim
   )
 
   if config.use_qwix_quantization:


### PR DESCRIPTION
# Description

Tile sizes for megablox were being passed / being named inappropriately. E.g. before we were passing in wi_dlhs_embed as the fourth argument, but that will map to "k" of the dlhs which will actually be the model dimension.

Note this PR has the effect of mapping/permuting the tile sizes. You can see in existing tuned tile sizes like [here](http://google3/cloud/tpu/testing/tests/v2/helper/data/scripts/shell/jax-maxtext-tpu7x.sh;l=2030-2047;rcl=897908501) the optimal wi_mlp_dim is actually related to the embed dim, not the mlp dim

# Tests
* test irregular model shapes and tile sizes that batch [command](https://paste.googleplex.com/5103710054252544)
* [xprof](https://xprof.corp.google.com/trace_viewer/mattdavidow-5213476274991121192?view_start=553.081&view_end=565.087) (~66% MFU on gmms)
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
