### PR TITLE
Remove HF_TOKEN from jupyter notebooks

### DIFF
--- a/.github/workflows/run_jupyter_notebooks.yml
+++ b/.github/workflows/run_jupyter_notebooks.yml
@@ -103,6 +103,9 @@ jobs:
           # Register maxtext_venv as a selectable kernel in Jupyter
           $PYTHON_EXE -m ipykernel install --user --name maxtext_venv
 
+          # Run Hugging Face authentication
+          hf auth login --token "$HF_TOKEN"
+
           for notebook in "$MAXTEXT_NOTEBOOKS_ROOT"/{sft,rl}*.ipynb; do
             filename=$(basename "$notebook")
             # TODO: Update runnner to v6e-8 as RL with LLama3.1-8b doesn't fit on v6e-4

--- a/docs/guides/run_python_notebook.md
+++ b/docs/guides/run_python_notebook.md
@@ -1,6 +1,6 @@
 # Run MaxText Python Notebooks on TPUs
 
-This guide provides clear, step-by-step instructions for getting started with python notebooks on the two most popular platforms: Google Colab and a local JupyterLab environment.
+This guide provides clear, step-by-step instructions for running MaxText Python notebooks on TPUs using three supported methods: Google Colab, Visual Studio Code, and a local JupyterLab environment.
 
 ## 📑 Table of Contents
 
@@ -10,21 +10,18 @@ This guide provides clear, step-by-step instructions for getting started with py
 - [Method 3: Local Jupyter Lab with TPU (Recommended)](#method-3-local-jupyter-lab-with-tpu-recommended)
 - [Common Pitfalls & Debugging](#common-pitfalls--debugging)
 - [Support & Resources](#support-and-resources)
-- [Contributing](#contributing)
 
 ## Prerequisites
 
-Before starting, make sure you have:
+### Get Hugging Face Token
 
-- ✅ Basic familiarity with Jupyter, Python, and Git
+To access model checkpoint from the Hugging Face Hub, you need to authenticate with a personal access token. Follow these steps to get your token:
 
-**For Method 2 (Visual Studio Code) and Method 3 (Local Jupyter Lab) only:**
+- **Navigate to the Access Tokens page** in your Hugging Face account settings. You can go there directly by visiting [this url](https://huggingface.co/settings/tokens).
 
-- ✅ A Google Cloud Platform (GCP) account with billing enabled
-- ✅ TPU quota available in your region (check under IAM & Admin → Quotas)
-- ✅ `tpu.nodes.create` permission to create a TPU VM
-- ✅ gcloud CLI installed locally
-- ✅ Firewall rules open for port 8888 (Jupyter) if accessing directly
+- **Create a new token** by clicking the **"+ Create new token"** button.
+
+- **Give your token a name** and assign it a **`read` role**. The `read` role is sufficient for downloading models.
 
 ## Method 1: Google Colab with TPU
 
@@ -33,39 +30,37 @@ This is the fastest way to run MaxText python notebooks without managing infrast
 **⚠️ IMPORTANT NOTE ⚠️**
 The free tier of Google Colab provides access to `v5e-1 TPU`, but this access is not guaranteed and is subject to availability and usage limits.
 
-Currently, this method only supports the **`sft_qwen3_demo.ipynb`** notebook, which demonstrates Qwen3-0.6B SFT training and evaluation on [OpenAI's GSM8K dataset](https://huggingface.co/datasets/openai/gsm8k). If you want to run other notebooks, please use the local Jupyter Lab setup method.
+Currently, this method only supports the **`sft_qwen3_demo.ipynb`** notebook, which demonstrates Qwen3-0.6B SFT training and evaluation on [OpenAI's GSM8K dataset](https://huggingface.co/datasets/openai/gsm8k). If you want to run other notebooks, please use the other methods below.
 
 Before proceeding, please verify that the specific notebook you are running works reliably on the free-tier TPU resources. If you encounter frequent disconnections or resource limitations, you may need to:
 
 - Upgrade to a Colab Pro or Pro+ subscription for more stable and powerful TPU access.
 
-- Move to local Jupyter Lab setup method with access to a powerful TPU machine.
+- Try [Method 2](#method-2-visual-studio-code-with-tpu-recommended) or [Method 3](#method-3-local-jupyter-lab-with-tpu-recommended) with access to a more powerful TPU machine.
 
-### Step 1: Choose an Example
+### Step 1: Import Notebook into Google Colab
 
-1.a. Visit the [MaxText examples directory](https://github.com/AI-Hypercomputer/maxtext/tree/main/src/maxtext/examples) on Github.
+- Visit the [MaxText examples directory](https://github.com/AI-Hypercomputer/maxtext/tree/main/src/maxtext/examples) on Github.
 
-1.b. Find the notebook you want to run (e.g., `sft_qwen3_demo.ipynb`) and copy its URL.
+- Find the notebook you want to run (e.g., `sft_qwen3_demo.ipynb`) and copy its URL.
 
-### Step 2: Import into Colab
+- Go to [Google Colab](https://colab.research.google.com/) and sign in.
 
-2.a. Go to [Google Colab](https://colab.research.google.com/) and sign in.
+- Go to **File** -> **Open Notebook**.
 
-2.b. Select **File** -> **Open Notebook**.
+- Select the **GitHub** tab.
 
-2.c. Select the **GitHub** tab.
+- Paste the target `.ipynb` link you copied and press Enter.
 
-2.d. Paste the target `.ipynb` link you copied in step 1.b and press Enter.
+### Step 2: Enable TPU Runtime
 
-### Step 3: Enable TPU Runtime
+- Go to **Runtime** → **Change runtime type**.
 
-3.a. **Runtime** → **Change runtime type**
+- Select your desired **TPU** under **Hardware accelerator**.
 
-3.b. Select your desired **TPU** under **Hardware accelerator**
+- Click **Save**.
 
-3.c. Click **Save**
-
-### Step 4: Run the Notebook
+### Step 3: Run the Notebook
 
 Follow the instructions within the notebook cells to install dependencies and run the training/inference.
 
@@ -73,25 +68,13 @@ Follow the instructions within the notebook cells to install dependencies and ru
 
 Running Jupyter notebooks in Visual Studio Code (VS Code) provides a powerful, interactive environment that combines the flexibility of notebooks with the robust features of a code editor. Follow these steps to get your environment up and running.
 
-### Step 1: Set Up TPU VM
+### Step 1: SSH to TPU-VM via VS Code
 
-In Google Cloud Console, create a standalone TPU VM:
+- Install the [Remote - SSH extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) in VS Code.
 
-1.a. **Compute Engine** → **TPUs** → **Create TPU**
+- Follow [Connect to a remote host](https://code.visualstudio.com/docs/remote/ssh#_connect-to-a-remote-host) guide to connect to your TPU-VM via VS Code.
 
-1.b. Example config:
-
-- **Name:** `maxtext-tpu-node`
-- **TPU type:** Choose your desired TPU type
-- **Runtime Version:** `tpu-ubuntu2204-base` (or other compatible runtime)
-
-### Step 2: SSH to TPU-VM via VS Code
-
-2.a. Install the [Remote - SSH extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) in VS Code.
-
-2.b. Follow [Connect to a remote host](https://code.visualstudio.com/docs/remote/ssh#_connect-to-a-remote-host) guide to connect to your TPU-VM via VS Code.
-
-### Step 3. Install Necessary Extensions on VS Code
+### Step 2: Install Necessary Extensions on VS Code
 
 To enable notebook support, you must install two official extensions from the VS Code Marketplace:
 
@@ -101,13 +84,19 @@ To enable notebook support, you must install two official extensions from the VS
 
 To install, click the `Extensions` icon on the left sidebar (or press `Ctrl+Shift+X` or `Cmd+Shift+X`), search for `Jupyter` and `Python`, and click `Install`.
 
-### Step 4: Install MaxText and Dependencies
+### Step 3: Install MaxText and Dependencies
 
 To execute post-training notebooks on your TPU-VM, follow the official [MaxText installation guides](https://maxtext.readthedocs.io/en/latest/install_maxtext.html#from-source) and specifically follow `Option 3: Installing [tpu-post-train]`. This will ensure all post-training dependencies are installed inside your virtual environment.
 
 > **Note:** If you have previously installed MaxText with a different option (e.g., `maxtext[tpu]`), we strongly recommend using a fresh virtual environment for `maxtext[tpu-post-train]` to avoid potential library version conflicts.
 
-### Step 5: Install the necessary library for Jupyter
+Login to Hugging Face and provide your access token when prompted:
+
+```bash
+hf auth login
+```
+
+### Step 4: Install the necessary library for Jupyter
 
 Jupyter requires a kernel to execute code. This kernel is tied to a specific Python environment. Open your terminal inside VS Code and run:
 
@@ -115,44 +104,30 @@ Jupyter requires a kernel to execute code. This kernel is tied to a specific Pyt
 uv pip install ipykernel
 ```
 
-### Step 6: Select Kernel in VS Code & Run Notebook
+### Step 5: Select Kernel in VS Code & Run Notebook
 
 Before you can run the notebook, you must tell VS Code which Python environment to use.
 
 1. Look at the top-right corner of the notebook editor.
 2. Click `Select Kernel`.
-3. Choose Python Environments and select the virtual environment you created in Step 4.
+3. Choose Python Environments and select the virtual environment you created in Step 3.
 4. Open [available post-training notebooks in MaxText](#available-examples) inside VS Code and run the jupyter notebook cells.
 
 ## Method 3: Local Jupyter Lab with TPU (Recommended)
 
 You can run all of our Python notebooks on a local JupyterLab environment, giving you full control over your computing resources.
 
-### Step 1: Set Up TPU VM
-
-In Google Cloud Console, create a standalone TPU VM:
-
-1.a. **Compute Engine** → **TPUs** → **Create TPU**
-
-1.b. Example config:
-
-- **Name:** `maxtext-tpu-node`
-- **TPU type:** Choose your desired TPU type
-- **Runtime Version:** `tpu-ubuntu2204-base` (or other compatible runtime)
-
-### Step 2: Connect with Port Forwarding
+### Step 1: SSH to TPU-VM with Port Forwarding
 
 Run the following command on your local machine:
 
-> **Note**: The `--` separator before the `-L` flag is required. This tunnels the remote port 8888 to your local machine securely.
-
 ```bash
-gcloud compute tpus tpu-vm ssh maxtext-tpu-node --zone=YOUR_ZONE -- -L 8888:localhost:8888
+gcloud compute tpus tpu-vm ssh <TPU_VM_NAME> --zone=<ZONE> -- -L 8888:localhost:8888
 ```
 
 > **Note**: If you get a "bind: Address already in use" error, it means port 8888 is busy on your local computer. Change the first number to a different port, e.g., -L 9999:localhost:8888. You will then access Jupyter at localhost:9999.
 
-### Step 3: Install JupyterLab
+### Step 2: Install JupyterLab
 
 Run the following commands on your TPU-VM:
 
@@ -162,21 +137,27 @@ sudo apt install python3-pip python3-dev git -y
 pip3 install jupyterlab
 ```
 
-### Step 4: Install MaxText and Dependencies
+### Step 3: Install MaxText and Dependencies
 
 To execute post-training notebooks on your TPU-VM, follow the official [MaxText installation guides](https://maxtext.readthedocs.io/en/latest/install_maxtext.html#from-source) and specifically follow `Option 3: Installing [tpu-post-train]`. This will ensure all post-training dependencies are installed inside your virtual environment.
 
 > **Note:** If you have previously installed MaxText with a different option (e.g., `maxtext[tpu]`), we strongly recommend using a fresh virtual environment for `maxtext[tpu-post-train]` to avoid potential library version conflicts.
 
-### Step 5: Register virtual environment as a Jupyter Kernel
-
-Once the environment is set up, you need to register it so JupyterLab can see it as an available kernel. Run the following command on your TPU-VM, replacing <virtual env name> with the actual name to your virtual environment:
+Login to Hugging Face and provide your access token when prompted:
 
 ```bash
-python3 -m ipykernel install --user --name <virtual env name> --display-name "Python3 (MaxText Venv)"
+hf auth login
 ```
 
-### Step 6: Start JupyterLab
+### Step 4: Register virtual environment as a Jupyter Kernel
+
+Once the environment is set up, you need to register it so JupyterLab can see it as an available kernel. Run the following command on your TPU-VM:
+
+```bash
+python3 -m ipykernel install --user --name <VENV_NAME> --display-name "Python3 (MaxText Venv)"
+```
+
+### Step 5: Start JupyterLab
 
 Start the Jupyter server on your TPU-VM by running:
 
@@ -184,43 +165,38 @@ Start the Jupyter server on your TPU-VM by running:
 jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root
 ```
 
-### Step 7: Access the Notebook
+### Step 6: Access the Notebook
 
-7.a. Look at the terminal output for a URL that looks like: `http://127.0.0.1:8888/lab?token=...`.
+- Look at the terminal output for a URL that looks like: `http://127.0.0.1:8888/lab?token=...` and copy it.
 
-7.b. Copy that URL.
+- Paste it into your **local computer's browser**.
 
-7.c. Paste it into your **local computer's browser**.
+- **Important:** If you changed the port in Step 1 (e.g., to `9999`), you must manually replace `8888` in the URL with `9999`. Example: `http://127.0.0.1:9999/lab?token=...`.
 
-- **Important:** If you changed the port in Step 2 (e.g., to `9999`), you must manually replace `8888` in the URL with `9999`.
-- *Example:* `http://127.0.0.1:9999/lab?token=...`
+- Once the interface opens in your browser, click on the current kernel name (e.g., `Python 3 (ipykernel)`).
 
-7.d. Once the interface opens in your browser, Click on the current kernel name (e.g., `Python 3 (ipykernel)`).
+- In the dropdown menu, select the new kernel you just created: `Python3 (MaxText Venv)`.
 
-7.e. In the dropdown menu, select the new kernel you just created: `Python3 (MaxText Venv)`.
-
-7.f. Open [available post-training notebooks in MaxText](#available-examples) and run the jupyter notebook cells.
+- Open [available post-training notebooks in MaxText](#available-examples) and run the jupyter notebook cells.
 
 ## Available Examples
 
 ### Supervised Fine-Tuning (SFT)
 
 - **`sft_qwen3_demo.ipynb`** → Qwen3-0.6B SFT training and evaluation on [OpenAI's GSM8K dataset](https://huggingface.co/datasets/openai/gsm8k). This notebook is friendly for beginners and runs successfully on Google Colab's free-tier v5e-1 TPU runtime.
-- **`sft_llama3_demo_tpu.ipynb`** → Llama3.1-8B SFT training on [Hugging Face ultrachat_200k dataset](https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k). We recommend running this on a v5p-8 TPU VM using the port-forwarding method.
+- **`sft_llama3_demo_tpu.ipynb`** → Llama3.1-8B SFT training on [Hugging Face ultrachat_200k dataset](https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k). We recommend running this on a v5p-8 TPU VM using [Method 2](#method-2-visual-studio-code-with-tpu-recommended) or [Method 3](#method-3-local-jupyter-lab-with-tpu-recommended).
 
 ### Reinforcement Learning (GRPO/GSPO) Training
 
-- **`rl_llama3_demo.ipynb`** → GRPO/GSPO training on [OpenAI's GSM8K dataset](https://huggingface.co/datasets/openai/gsm8k). We recommend running this on a v5p-8 TPU VM using the port-forwarding method.
+- **`rl_llama3_demo.ipynb`** → GRPO/GSPO training on [OpenAI's GSM8K dataset](https://huggingface.co/datasets/openai/gsm8k). We recommend running this on a v5p-8 TPU VM using [Method 2](#method-2-visual-studio-code-with-tpu-recommended) or [Method 3](#method-3-local-jupyter-lab-with-tpu-recommended).
 
 ## Common Pitfalls & Debugging
 
-| Issue                          | Solution                                                   |
-| ------------------------------ | ---------------------------------------------------------- |
-| ❌ TPU runtime mismatch        | Check TPU runtime version matches VM image                 |
-| ❌ Colab disconnects           | Save checkpoints to GCS or Drive regularly                 |
-| ❌ "RESOURCE_EXHAUSTED" errors | Use smaller batch size or v5e-8 instead of v5e-1           |
-| ❌ Firewall blocked            | Ensure port 8888 open, or always use SSH tunneling         |
-| ❌ Path confusion              | In Colab use `/content/maxtext`; in TPU VM use `~/maxtext` |
+| Issue                          | Solution                                                     |
+| ------------------------------ | ------------------------------------------------------------ |
+| ❌ Colab disconnects           | Save checkpoints to GCS regularly                            |
+| ❌ "RESOURCE_EXHAUSTED" errors | Use smaller batch size or change BASE_OUTPUTDIRECTORY to GCS |
+| ❌ Firewall blocked            | Ensure port 8888 open, or always use SSH tunneling           |
 
 ## Support and Resources
 
@@ -228,15 +204,3 @@ jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root
 - 💻 [Google Colab](https://colab.research.google.com)
 - ⚡ [Cloud TPU Docs](https://cloud.google.com/tpu/docs)
 - 🧩 [Jupyter Lab](https://jupyterlab.readthedocs.io)
-
-## Contributing
-
-If you encounter issues or have improvements for this guide, please:
-
-1. Open an issue on the MaxText repository
-2. Submit a pull request with your improvements
-3. Share your experience in the discussions
-
-______________________________________________________________________
-
-**Happy Training! 🚀**

--- a/src/maxtext/examples/rl_llama3_demo.ipynb
+++ b/src/maxtext/examples/rl_llama3_demo.ipynb
@@ -26,46 +26,9 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "### Change Runtime Type (only if running on Google Colab)\n",
+    "Before running this notebook, make sure your environment is set up for the method you are using. Follow the [Run MaxText Python Notebooks on TPUs](https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html) guide and complete all steps for your chosen method (Google Colab, VS Code, or Local Jupyter Lab) before proceeding.\n",
     "\n",
-    "**Instructions:**\n",
-    "1.  Navigate to the menu at the top of the screen.\n",
-    "2.  Click on **Runtime**.\n",
-    "3.  Select **Change runtime type** from the dropdown menu.\n",
-    "4.  Select **v6e-8** or **v5p-8 TPU** as the **Hardware accelerator**.\n",
-    "5. Click on **Save**."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Get Your Hugging Face Token\n",
-    "\n",
-    "To access model checkpoint from the Hugging Face Hub, you need to authenticate with a personal access token.\n",
-    "\n",
-    "**Follow these steps to get your token:**\n",
-    "\n",
-    "1.  **Navigate to the Access Tokens page** in your Hugging Face account settings. You can go there directly by visiting this URL:\n",
-    "    *   [https://huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)\n",
-    "\n",
-    "2.  **Create a new token** by clicking the **\"+ Create new token\"** button.\n",
-    "\n",
-    "3.  **Give your token a name** and assign it a **`read` role**. The `read` role is sufficient for downloading models.\n",
-    "\n",
-    "4.  **Copy the generated token**. You will need this in the later steps.\n",
-    "\n",
-    "**Follow these steps to store your token (only if running on Google Colab):**\n",
-    "\n",
-    "1. On the left sidebar of your Colab window, click the key icon (the Secrets tab).\n",
-    "\n",
-    "2. Click **\"+ Add new secret\"**.\n",
-    "\n",
-    "3. Set the Name as **HF_TOKEN**.\n",
-    "\n",
-    "4. Paste your token into the Value field.\n",
-    "\n",
-    "5. Ensure the Notebook access toggle is turned On."
+    "If you run into issues, refer to the [Common Pitfalls & Debugging](https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html#common-pitfalls-debugging) section of the guide."
    ]
   },
   {
@@ -75,7 +38,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "  from google.colab import userdata\n",
+    "  import google.colab\n",
     "  print(\"Running the notebook on Google Colab\")\n",
     "  IN_COLAB = True\n",
     "except ImportError:\n",
@@ -140,8 +103,6 @@
     "import os\n",
     "import sys\n",
     "import subprocess\n",
-    "from pathlib import Path\n",
-    "from huggingface_hub import login\n",
     "from etils import epath\n",
     "import jax\n",
     "\n",
@@ -176,24 +137,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    from google.colab import userdata\n",
-    "    HF_TOKEN = userdata.get(\"HF_TOKEN\")\n",
-    "except ImportError:\n",
-    "    HF_TOKEN = os.environ.get(\"HF_TOKEN\", \"\")\n",
-    "\n",
-    "# If not found in the environment, prompt the user for input securely\n",
-    "# getpass function ensures the token is hidden while you type\n",
-    "if not HF_TOKEN:\n",
-    "    from getpass import getpass\n",
-    "    HF_TOKEN = getpass(\"Hugging Face token not found in environment. Please enter it here: \")\n",
-    "\n",
-    "if HF_TOKEN:\n",
-    "    os.environ[\"HF_TOKEN\"] = HF_TOKEN\n",
-    "    login(token=HF_TOKEN)\n",
-    "    print(\"Authenticated with Hugging Face successfully!\")\n",
+    "if IN_COLAB:\n",
+    "    from huggingface_hub import notebook_login\n",
+    "    notebook_login()\n",
     "else:\n",
-    "    print(\"Authentication failed: Hugging Face token is not set.\")"
+    "    from huggingface_hub import login\n",
+    "    login()"
    ]
   },
   {
@@ -217,14 +166,14 @@
     "if not epath.Path(CHAT_TEMPLATE_PATH).exists():\n",
     "    raise FileNotFoundError(f\"Chat template not found: {CHAT_TEMPLATE_PATH}\")\n",
     "\n",
-    "# set the path to the model checkpoint (excluding `/0/items`) or leave empty to download from HuggingFace\n",
+    "BASE_OUTPUT_DIRECTORY = f\"{MAXTEXT_PKG_DIR}/rl_llama3_output\"\n",
+    "\n",
+    "# set the path to the model checkpoint (including `/0/items`) or leave empty to download from HuggingFace\n",
     "MODEL_CHECKPOINT_PATH = \"\"\n",
     "if not MODEL_CHECKPOINT_PATH:\n",
-    "   MODEL_CHECKPOINT_PATH = f\"{MAXTEXT_PKG_DIR}/llama_checkpoint\"\n",
+    "   MODEL_CHECKPOINT_PATH = f\"{BASE_OUTPUT_DIRECTORY}/llama3_checkpoint\"\n",
     "   print(\"Model checkpoint will be downloaded from HuggingFace at: \",  MODEL_CHECKPOINT_PATH)\n",
-    "   print(\"Set MODEL_CHECKPOINT_PATH if you do not wish to download the checkpoint.\")\n",
-    "    \n",
-    "OUTPUT_DIRECTORY = f\"{MAXTEXT_PKG_DIR}/rl_llama3_output\""
+    "   print(\"Set MODEL_CHECKPOINT_PATH if you do not wish to download the checkpoint.\")"
    ]
   },
   {
@@ -241,7 +190,6 @@
    "outputs": [],
    "source": [
     "if not epath.Path(MODEL_CHECKPOINT_PATH).exists():\n",
-    "\n",
     "    # Install torch for the conversion script\n",
     "    print(\"Installing torch...\")\n",
     "    subprocess.run(\n",
@@ -264,7 +212,6 @@
     "            f\"{MAXTEXT_PKG_DIR}/configs/base.yml\",\n",
     "            f\"model_name={MODEL_NAME}\",\n",
     "            f\"base_output_directory={MODEL_CHECKPOINT_PATH}\",\n",
-    "            f\"hf_access_token={HF_TOKEN}\",\n",
     "            \"use_multimodal=false\",\n",
     "            \"scan_layers=true\",\n",
     "            \"skip_jax_distributed_system=True\",\n",
@@ -272,9 +219,10 @@
     "        check=True,\n",
     "        env=env\n",
     "    )\n",
-    "\n",
-    "    if not epath.Path(MODEL_CHECKPOINT_PATH).exists():\n",
-    "        raise ValueError(\"Model checkpoint conversion failed. Check the logs above.\")"
+    "    \n",
+    "    MODEL_CHECKPOINT_PATH = os.path.join(MODEL_CHECKPOINT_PATH, \"0/items\")\n",
+    "else:\n",
+    "    print(f\"Model checkpoint exists at {MODEL_CHECKPOINT_PATH}\")"
    ]
   },
   {
@@ -297,17 +245,16 @@
     "    f\"model_name={MODEL_NAME}\",\n",
     "    f\"run_name={RUN_NAME}\",\n",
     "    f\"chat_template_path={CHAT_TEMPLATE_PATH}\",\n",
-    "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}/0/items\",\n",
-    "    f\"base_output_directory={OUTPUT_DIRECTORY}\",\n",
-    "    f\"hf_access_token={HF_TOKEN}\",\n",
-    "    \"debug.rl=False\",\n",
+    "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}\",\n",
+    "    f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
+    "    \"debug.rl=True\",\n",
     "    f\"rl.loss_algo={LOSS_ALGO}\",\n",
     "    \"use_pathways=False\",\n",
     "    \"log_config=False\",\n",
     "]\n",
     "\n",
     "print(\"✓ Configuration initialized successfully\")\n",
-    "print(f\"📁 Output directory: {OUTPUT_DIRECTORY}\")\n",
+    "print(f\"📁 Output directory: {BASE_OUTPUT_DIRECTORY}\")\n",
     "print(f\"🤖 Model: {MODEL_NAME}\")"
    ]
   },
@@ -339,6 +286,8 @@
     "    print(\"❌Training Failed!\")\n",
     "    print(\"=\" * 80)\n",
     "    traceback.print_exc()\n",
+    "    print(\"\\nFor troubleshooting, refer to the Common Pitfalls & Debugging section:\")\n",
+    "    print(\"https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html#common-pitfalls-debugging\")\n",
     "    sys.exit(1)"
    ]
   },
@@ -356,7 +305,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python (3.12.11)",
    "language": "python",
    "name": "python3"
   },

--- a/src/maxtext/examples/sft_llama3_demo_tpu.ipynb
+++ b/src/maxtext/examples/sft_llama3_demo_tpu.ipynb
@@ -32,48 +32,9 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "### Change Runtime Type (only if running on Google Colab)\n",
+    "Before running this notebook, make sure your environment is set up for the method you are using. Follow the [Run MaxText Python Notebooks on TPUs](https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html) guide and complete all steps for your chosen method (Google Colab, VS Code, or Local Jupyter Lab) before proceeding.\n",
     "\n",
-    "**Instructions:**\n",
-    "1.  Navigate to the menu at the top of the screen.\n",
-    "2.  Click on **Runtime**.\n",
-    "3.  Select **Change runtime type** from the dropdown menu.\n",
-    "4.  Select **v6e-8** or **v5p-8 TPU** as the **Hardware accelerator**.\n",
-    "5. Click on **Save**."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Du2WAe9JKgv4"
-   },
-   "source": [
-    "### Get Your Hugging Face Token\n",
-    "\n",
-    "To access model checkpoint from the Hugging Face Hub, you need to authenticate with a personal access token.\n",
-    "\n",
-    "**Follow these steps to get your token:**\n",
-    "\n",
-    "1.  **Navigate to the Access Tokens page** in your Hugging Face account settings. You can go there directly by visiting this URL:\n",
-    "    *   [https://huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)\n",
-    "\n",
-    "2.  **Create a new token** by clicking the **\"+ Create new token\"** button.\n",
-    "\n",
-    "3.  **Give your token a name** and assign it a **`read` role**. The `read` role is sufficient for downloading models.\n",
-    "\n",
-    "4.  **Copy the generated token**. You will need this in the later steps.\n",
-    "\n",
-    "**Follow these steps to store your token (only if running on Google Colab):**\n",
-    "\n",
-    "1. On the left sidebar of your Colab window, click the key icon (the Secrets tab).\n",
-    "\n",
-    "2. Click **\"+ Add new secret\"**.\n",
-    "\n",
-    "3. Set the Name as **HF_TOKEN**.\n",
-    "\n",
-    "4. Paste your token into the Value field.\n",
-    "\n",
-    "5. Ensure the Notebook access toggle is turned On."
+    "If you run into issues, refer to the [Common Pitfalls & Debugging](https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html#common-pitfalls-debugging) section of the guide."
    ]
   },
   {
@@ -85,7 +46,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "  from google.colab import userdata\n",
+    "  import google.colab\n",
     "  print(\"Running the notebook on Google Colab\")\n",
     "  IN_COLAB = True\n",
     "except ImportError:\n",
@@ -161,7 +122,7 @@
     "from maxtext.configs import pyconfig\n",
     "from maxtext.utils.globals import MAXTEXT_PKG_DIR\n",
     "from maxtext.trainers.post_train.sft import train_sft\n",
-    "from huggingface_hub import login\n",
+    "from etils import epath\n",
     "\n",
     "\n",
     "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")"
@@ -187,23 +148,12 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    from google.colab import userdata\n",
-    "    HF_TOKEN = userdata.get(\"HF_TOKEN\")\n",
-    "except ImportError:\n",
-    "    HF_TOKEN = os.environ.get(\"HF_TOKEN\", \"\")\n",
-    "\n",
-    "# If not found in the environment, prompt the user for input securely\n",
-    "# getpass function ensures the token is hidden while you type\n",
-    "if not HF_TOKEN:\n",
-    "    from getpass import getpass\n",
-    "    HF_TOKEN = getpass(\"Hugging Face token not found in environment. Please enter it here: \")\n",
-    "\n",
-    "if HF_TOKEN:\n",
-    "    login(token=HF_TOKEN)\n",
-    "    print(\"Authenticated with Hugging Face successfully!\")\n",
+    "if IN_COLAB:\n",
+    "    from huggingface_hub import notebook_login\n",
+    "    notebook_login()\n",
     "else:\n",
-    "    print(\"Authentication failed: Hugging Face token is not set.\")"
+    "    from huggingface_hub import login\n",
+    "    login()"
    ]
   },
   {
@@ -225,14 +175,15 @@
    "source": [
     "MODEL_NAME = \"llama3.1-8b-Instruct\"\n",
     "\n",
-    "# set the path to the model checkpoint (excluding `/0/items`) or leave empty to download from HuggingFace\n",
+    "BASE_OUTPUT_DIRECTORY = f\"{MAXTEXT_PKG_DIR}/sft_llama3_output\"\n",
+    "\n",
+    "# set the path to the model checkpoint (including `/0/items`) or leave empty to download from HuggingFace\n",
     "MODEL_CHECKPOINT_PATH = \"\"\n",
     "if not MODEL_CHECKPOINT_PATH:\n",
-    "   MODEL_CHECKPOINT_PATH = f\"{MAXTEXT_PKG_DIR}/llama_checkpoint\"\n",
+    "   MODEL_CHECKPOINT_PATH = f\"{BASE_OUTPUT_DIRECTORY}/llama3_checkpoint\"\n",
     "   print(\"Model checkpoint will be downloaded from HuggingFace at: \",  MODEL_CHECKPOINT_PATH)\n",
     "   print(\"Set MODEL_CHECKPOINT_PATH if you do not wish to download the checkpoint.\")\n",
     "\n",
-    "BASE_OUTPUT_DIRECTORY = f\"{MAXTEXT_PKG_DIR}/sft_llama3_output\"\n",
     "RUN_NAME = datetime.datetime.now().strftime(\"%Y-%m-%d-%H-%M-%S\")"
    ]
   },
@@ -253,7 +204,7 @@
    },
    "outputs": [],
    "source": [
-    "if not os.path.exists(MODEL_CHECKPOINT_PATH):\n",
+    "if not epath.Path(MODEL_CHECKPOINT_PATH).exists():\n",
     "    # Install torch for the conversion script\n",
     "    print(\"Installing torch...\")\n",
     "    subprocess.run(\n",
@@ -276,7 +227,6 @@
     "            f\"{MAXTEXT_PKG_DIR}/configs/base.yml\",\n",
     "            f\"model_name={MODEL_NAME}\",\n",
     "            f\"base_output_directory={MODEL_CHECKPOINT_PATH}\",\n",
-    "            f\"hf_access_token={HF_TOKEN}\",\n",
     "            \"use_multimodal=false\",\n",
     "            \"scan_layers=true\",\n",
     "            \"skip_jax_distributed_system=True\",\n",
@@ -285,8 +235,9 @@
     "        env=env\n",
     "    )\n",
     "\n",
-    "if not os.path.exists(MODEL_CHECKPOINT_PATH):\n",
-    "    raise ValueError(\"Model checkpoint conversion failed. Check the logs above.\")"
+    "    MODEL_CHECKPOINT_PATH = os.path.join(MODEL_CHECKPOINT_PATH, \"0/items\")\n",
+    "else:\n",
+    "    print(f\"Model checkpoint exists at {MODEL_CHECKPOINT_PATH}\")"
    ]
   },
   {
@@ -310,7 +261,7 @@
     "config_argv = [\n",
     "    \"\",\n",
     "    f\"{MAXTEXT_PKG_DIR}/configs/post_train/sft.yml\",\n",
-    "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}/0/items\",\n",
+    "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}\",\n",
     "    f\"model_name={MODEL_NAME}\",\n",
     "    \"steps=100\",\n",
     "    \"per_device_batch_size=1\",\n",
@@ -319,7 +270,6 @@
     "    \"weight_dtype=bfloat16\",\n",
     "    \"dtype=bfloat16\",\n",
     "    \"hf_path=HuggingFaceH4/ultrachat_200k\",\n",
-    "    f\"hf_access_token={HF_TOKEN}\",\n",
     "    f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
     "    f\"run_name={RUN_NAME}\",\n",
     "    \"profiler=xplane\",\n",
@@ -358,7 +308,6 @@
     "\n",
     "try:\n",
     "    trainer, mesh = train_sft.train(config)\n",
-    "\n",
     "    print(\"\\n\" + \"=\" * 60)\n",
     "    print(\"✅ Training Completed Successfully!\")\n",
     "    print(\"=\" * 60)\n",
@@ -368,6 +317,8 @@
     "    print(\"❌Training Failed!\")\n",
     "    print(\"=\" * 60)\n",
     "    traceback.print_exc()\n",
+    "    print(\"\\nFor troubleshooting, refer to the Common Pitfalls & Debugging section:\")\n",
+    "    print(\"https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html#common-pitfalls-debugging\")\n",
     "    sys.exit(1)"
    ]
   },
@@ -392,7 +343,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python (3.12.11)",
    "language": "python",
    "name": "python3"
   },

--- a/src/maxtext/examples/sft_qwen3_demo.ipynb
+++ b/src/maxtext/examples/sft_qwen3_demo.ipynb
@@ -36,48 +36,9 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "### Change Runtime Type (only if running on Google Colab)\n",
+    "Before running this notebook, make sure your environment is set up for the method you are using. Follow the [Run MaxText Python Notebooks on TPUs](https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html) guide and complete all steps for your chosen method (Google Colab, VS Code, or Local Jupyter Lab) before proceeding.\n",
     "\n",
-    "**Instructions:**\n",
-    "1.  Navigate to the menu at the top of the screen.\n",
-    "2.  Click on **Runtime**.\n",
-    "3.  Select **Change runtime type** from the dropdown menu.\n",
-    "4.  Select **v5e-1 TPU** as the **Hardware accelerator**.\n",
-    "5. Click on **Save**."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Rk_QpVVuZUQL"
-   },
-   "source": [
-    "### Get Your Hugging Face Token\n",
-    "\n",
-    "To access model checkpoint from the Hugging Face Hub, you need to authenticate with a personal access token.\n",
-    "\n",
-    "**Follow these steps to get your token:**\n",
-    "\n",
-    "1.  **Navigate to the Access Tokens page** in your Hugging Face account settings. You can go there directly by visiting this URL:\n",
-    "    *   [https://huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)\n",
-    "\n",
-    "2.  **Create a new token** by clicking the **\"+ Create new token\"** button.\n",
-    "\n",
-    "3.  **Give your token a name** and assign it a **`read` role**. The `read` role is sufficient for downloading models.\n",
-    "\n",
-    "4.  **Copy the generated token**. You will need this in the later steps.\n",
-    "\n",
-    "**Follow these steps to store your token (only if running on Google Colab):**\n",
-    "\n",
-    "1. On the left sidebar of your Colab window, click the key icon (the Secrets tab).\n",
-    "\n",
-    "2. Click **\"+ Add new secret\"**.\n",
-    "\n",
-    "3. Set the Name as **HF_TOKEN**.\n",
-    "\n",
-    "4. Paste your token into the Value field.\n",
-    "\n",
-    "5. Ensure the Notebook access toggle is turned On."
+    "If you run into issues, refer to the [Common Pitfalls & Debugging](https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html#common-pitfalls-debugging) section of the guide."
    ]
   },
   {
@@ -89,7 +50,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "  from google.colab import userdata\n",
+    "  import google.colab\n",
     "  print(\"Running the notebook on Google Colab\")\n",
     "  IN_COLAB = True\n",
     "except ImportError:\n",
@@ -179,7 +140,7 @@
     "\n",
     "from datetime import datetime\n",
     "from flax import nnx\n",
-    "from huggingface_hub import login\n",
+    "from etils import epath\n",
     "\n",
     "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")"
    ]
@@ -206,23 +167,12 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    from google.colab import userdata\n",
-    "    HF_TOKEN = userdata.get(\"HF_TOKEN\")\n",
-    "except ImportError:\n",
-    "    HF_TOKEN = os.environ.get(\"HF_TOKEN\", \"\")\n",
-    "\n",
-    "# If not found in the environment, prompt the user for input securely\n",
-    "# getpass function ensures the token is hidden while you type\n",
-    "if not HF_TOKEN:\n",
-    "    from getpass import getpass\n",
-    "    HF_TOKEN = getpass(\"Hugging Face token not found in environment. Please enter it here: \")\n",
-    "\n",
-    "if HF_TOKEN:\n",
-    "    login(token=HF_TOKEN)\n",
-    "    print(\"Authenticated with Hugging Face successfully!\")\n",
+    "if IN_COLAB:\n",
+    "    from huggingface_hub import notebook_login\n",
+    "    notebook_login()\n",
     "else:\n",
-    "    print(\"Authentication failed: Hugging Face token is not set.\")"
+    "    from huggingface_hub import login\n",
+    "    login()"
    ]
   },
   {
@@ -244,23 +194,19 @@
    "source": [
     "MODEL_NAME = \"qwen3-0.6b\"\n",
     "TOKENIZER_PATH = \"Qwen/Qwen3-0.6B\"\n",
-    "tokenizer = transformers.AutoTokenizer.from_pretrained(\n",
-    "    TOKENIZER_PATH,\n",
-    "    token=HF_TOKEN,\n",
-    ")\n",
+    "tokenizer = transformers.AutoTokenizer.from_pretrained(TOKENIZER_PATH)\n",
     "\n",
-    "# set the path to the model checkpoint (excluding `/0/items`) or leave empty to download from HuggingFace\n",
+    "# This is the directory where the fine-tuned model checkpoint will be saved\n",
+    "BASE_OUTPUT_DIRECTORY = f\"{MAXTEXT_PKG_DIR}/sft_qwen06_output\"\n",
+    "\n",
+    "# set the path to the model checkpoint (including `/0/items`) or leave empty to download from HuggingFace\n",
     "MODEL_CHECKPOINT_PATH = \"\"\n",
     "if not MODEL_CHECKPOINT_PATH:\n",
-    "   MODEL_CHECKPOINT_PATH = f\"{MAXTEXT_PKG_DIR}/qwen_checkpoint\"\n",
+    "   MODEL_CHECKPOINT_PATH = f\"{BASE_OUTPUT_DIRECTORY}/qwen06_checkpoint\"\n",
     "   print(\"Model checkpoint will be downloaded from HuggingFace at: \",  MODEL_CHECKPOINT_PATH)\n",
     "   print(\"Set MODEL_CHECKPOINT_PATH if you do not wish to download the checkpoint.\")\n",
     "\n",
-    "\n",
-    "RUN_NAME = datetime.now().strftime(\"%Y-%m-%d-%H-%m-%S\")\n",
-    "\n",
-    "# This is the directory where the fine-tuned model checkpoint will be saved\n",
-    "BASE_OUTPUT_DIRECTORY = f\"{MAXTEXT_PKG_DIR}/maxtext_qwen06_output\""
+    "RUN_NAME = datetime.now().strftime(\"%Y-%m-%d-%H-%m-%S\")"
    ]
   },
   {
@@ -280,7 +226,7 @@
    },
    "outputs": [],
    "source": [
-    "if not os.path.exists(MODEL_CHECKPOINT_PATH):\n",
+    "if not epath.Path(MODEL_CHECKPOINT_PATH).exists():\n",
     "    # Install torch for the conversion script\n",
     "    print(\"Installing torch...\")\n",
     "    subprocess.run(\n",
@@ -302,7 +248,6 @@
     "            f\"{MAXTEXT_PKG_DIR}/configs/base.yml\",\n",
     "            f\"model_name={MODEL_NAME}\",\n",
     "            f\"base_output_directory={MODEL_CHECKPOINT_PATH}\",\n",
-    "            f\"hf_access_token={HF_TOKEN}\",\n",
     "            \"use_multimodal=false\",\n",
     "            \"scan_layers=true\",\n",
     "            \"skip_jax_distributed_system=True\",\n",
@@ -310,9 +255,10 @@
     "        check=True,\n",
     "        env=env\n",
     "    )\n",
-    "\n",
-    "if not os.path.exists(MODEL_CHECKPOINT_PATH):\n",
-    "    raise ValueError(\"Model checkpoint conversion failed. Check the logs above.\")"
+    "    \n",
+    "    MODEL_CHECKPOINT_PATH = os.path.join(MODEL_CHECKPOINT_PATH, \"0/items\")\n",
+    "else:\n",
+    "    print(f\"Model checkpoint exists at {MODEL_CHECKPOINT_PATH}\")"
    ]
   },
   {
@@ -368,9 +314,8 @@
     "    [\n",
     "        \"\",\n",
     "        f\"{MAXTEXT_PKG_DIR}/configs/post_train/sft.yml\",\n",
-    "        f\"load_parameters_path={MODEL_CHECKPOINT_PATH}/0/items\",\n",
+    "        f\"load_parameters_path={MODEL_CHECKPOINT_PATH}\",\n",
     "        f\"model_name={MODEL_NAME}\",\n",
-    "        f\"hf_access_token={HF_TOKEN}\",\n",
     "        f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
     "        f\"run_name={RUN_NAME}\",\n",
     "        f\"tokenizer_path={TOKENIZER_PATH}\",\n",
@@ -612,7 +557,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "maxtext_sft (3.12.11)",
+   "display_name": "Python (3.12.11)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
# Description

This PR improves the user experience of MaxText post-training Jupyter notebooks by transitioning away from manual `HF_TOKEN` environment variable management in favor of standard Hugging Face authentication practices.

Key Changes:
* Notebook Cleanup: Removed hardcoded `HF_TOKEN` setup and environment variable prompts from multiple post-training notebooks (e.g., SFT and RL demos for Llama 3 and Qwen).
* Authentication Update: Updated documentation to recommend `hf auth login` for authenticating with Hugging Face. This aligns with recent changes in the project that favor the hf CLI tool over huggingface-cli for better "out of the box" compatibility.

Bug Fixes:
* Addresses [b/493987161](https://b.corp.google.com/issues/493987161) by removing hf_token from notebook documentation.
* Addresses [b/493987246](https://b.corp.google.com/issues/493987246) by adding instructions for `hf auth login`.

# Tests

* Validated that the updated notebooks run successfully in VSCode
* Confirmed that CI tests pass
* Verified that `hf auth login` correctly authenticates the environment for gated model access

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
