### PR TITLE
Add fused_moe_mlp: fuse wi_0 and wi_1 into one grouped GEMM for MoE FFN1

### DIFF
--- a/docs/reference/core_concepts/moe_configuration.md
+++ b/docs/reference/core_concepts/moe_configuration.md
@@ -99,6 +99,8 @@ Dropping:
 
 `mlp_bias`: If enabled, add learnable bias terms for MLP matmul. Originally implemented to support the GPT-OSS model architecture.
 
+`prefuse_moe_weights`: If enabled alongside `sparse_matmul=True`, fuses the two FFN1 grouped GEMMs (wi\_0 and wi\_1) into a single grouped GEMM call. Expert weights are stored in a concatenated `(num_experts, embed_dim, 2 * mlp_dim)` shape, so input activations are loaded from HBM once per forward pass instead of twice. Backend-agnostic (works with Megablox, JAX Ragged Dot, and Tokamax). When used with `attention=vllm_rpa`, the fused weight tensor is passed directly to the vLLM-TPU serving kernel without splitting.
+
 `use_batch_split_schedule` (experimental): If enabled, split batch into micro-batches to hide communications that yields performance benefits.
 
 ## 2. Sharding

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -813,7 +813,7 @@ class MoEGeneral(BaseModel):
   prefuse_moe_weights: bool = Field(
       False,
       description="Whether to pre-fuse MoE weights (w0 and w1) during initialization. "
-      "This is useful for inference performance in vllm_rpa mode.",
+      "This enables a single FFN1 grouped GEMM in sparse MoE paths and passes fused weights directly in vllm_rpa mode.",
   )
   fuse_expert_scales: bool = Field(
       False,

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -496,6 +496,12 @@ class RoutedMoE(nnx.Module):
 
     kernel_in_axis = np.arange(1)
     kernel_out_axis = np.arange(1, 2)
+    # Pad the MoE input weight kernels for GMM_v2 execution when configured.
+    moe_intermediate_dim = (
+        self.config.padded_base_moe_mlp_dim
+        if self.config.padded_base_moe_mlp_dim is not None
+        else self.intermediate_dim
+    )
 
     if quantizations.in_serve_mode(self.quant):
       # During aqt convert state we delete kernel weight from params to save
@@ -504,13 +510,7 @@ class RoutedMoE(nnx.Module):
       self.wi_0 = jnp.zeros((num_experts, self.moe_expert_input_dim, intermediate_dim))
       self.wi_1 = jnp.zeros((num_experts, self.moe_expert_input_dim, intermediate_dim))
       self.wo = jnp.zeros((num_experts, intermediate_dim, self.moe_expert_input_dim))
-    elif self.config.prefuse_moe_weights and self.config.attention == "vllm_rpa":
-      # Pad model dimension in Fused MoE weight kernels for GMM_v2 execution.
-      moe_intermediate_dim = (
-          self.config.padded_base_moe_mlp_dim
-          if self.config.padded_base_moe_mlp_dim is not None
-          else self.intermediate_dim
-      )
+    elif self.config.prefuse_moe_weights:
       self.wi = nnx.Param(
           self.kernel_init(
               self.rngs.params(),
@@ -532,12 +532,6 @@ class RoutedMoE(nnx.Module):
           out_sharding=self.wo_kernel_axes,
       )
     else:
-      # Pad model dimension in Unfused MoE weight kernels for GMM_v2 execution.
-      moe_intermediate_dim = (
-          self.config.padded_base_moe_mlp_dim
-          if self.config.padded_base_moe_mlp_dim is not None
-          else self.intermediate_dim
-      )
       self.wi_0 = nnx.Param(
           self.kernel_init(
               self.rngs.params(),
@@ -1665,19 +1659,44 @@ class RoutedMoE(nnx.Module):
     def gmm_up(x, w0, w1, w0_bias, w1_bias, gmm_fn, weight_gather):
       """Run the two up-projections (gate + up) and apply the FFN activation."""
       wi_gather_axes, wi_tile_size = get_wi_gmm_params()
-      layer_w0 = gmm_fn(x, w0, tiling=wi_tile_size, weight_gather_axes=wi_gather_axes)
-      if self.get_tensor_transpose_parallelism_size() > 1:
-        layer_w0 = jax.lax.psum(layer_w0, "tensor_transpose")
-      if self.config.mlp_bias:
-        layer_w0 = layer_w0 + w0_bias
-      layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
+      if self.config.prefuse_moe_weights:
+        # Weights are stored as (G,K,2N); w0/w1 are adjacent slices so XLA elides this concat.
+        w_fused = jnp.concatenate([w0, w1], axis=-1)
+        out = gmm_fn(x, w_fused, tiling=wi_tile_size, weight_gather_axes=wi_gather_axes)
+        n = out.shape[-1] // 2
+        layer_w0, layer_w1 = out[:, :n], out[:, n:]
+        if self.get_tensor_transpose_parallelism_size() > 1:
+          layer_w0 = jax.lax.psum(layer_w0, "tensor_transpose")
+          layer_w1 = jax.lax.psum(layer_w1, "tensor_transpose")
+        if self.config.mlp_bias:
+          layer_w0 = layer_w0 + w0_bias
+          layer_w1 = layer_w1 + w1_bias
+        layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
+        layer_w1 = adc.checkpoint_name(layer_w1, "moe_mlpwi_1")
+      else:
+        layer_w0 = gmm_fn(
+            x,
+            w0,
+            tiling=wi_tile_size,
+            weight_gather_axes=wi_gather_axes,
+        )
+        if self.get_tensor_transpose_parallelism_size() > 1:
+          layer_w0 = jax.lax.psum(layer_w0, "tensor_transpose")
+        if self.config.mlp_bias:
+          layer_w0 = layer_w0 + w0_bias
+        layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
 
-      layer_w1 = gmm_fn(x, w1, tiling=wi_tile_size, weight_gather_axes=wi_gather_axes)
-      if self.get_tensor_transpose_parallelism_size() > 1:
-        layer_w1 = jax.lax.psum(layer_w1, "tensor_transpose")
-      if self.config.mlp_bias:
-        layer_w1 = layer_w1 + w1_bias
-      layer_w1 = adc.checkpoint_name(layer_w1, "moe_mlpwi_1")
+        layer_w1 = gmm_fn(
+            x,
+            w1,
+            tiling=wi_tile_size,
+            weight_gather_axes=wi_gather_axes,
+        )
+        if self.get_tensor_transpose_parallelism_size() > 1:
+          layer_w1 = jax.lax.psum(layer_w1, "tensor_transpose")
+        if self.config.mlp_bias:
+          layer_w1 = layer_w1 + w1_bias
+        layer_w1 = adc.checkpoint_name(layer_w1, "moe_mlpwi_1")
       return self.apply_ffn_activation(layer_w0, layer_w1)
 
     def get_gmm_for_local_experts(x, routing, route_metadata):
@@ -2588,6 +2607,11 @@ class RoutedMoE(nnx.Module):
     w1_kernel = None
     if cfg.prefuse_moe_weights and cfg.attention == "vllm_rpa" and not self.is_hash_routing:
       fused_kernel = jnp.asarray(self.wi[...], self.dtype)
+    elif cfg.prefuse_moe_weights:
+      wi = jnp.asarray(self.wi[...], self.dtype)
+      n = wi.shape[-1] // 2
+      w0_kernel = wi[..., :n]
+      w1_kernel = wi[..., n:]
     else:
       w0_kernel = jnp.asarray(self.wi_0[...], self.dtype)
       w1_kernel = jnp.asarray(self.wi_1[...], self.dtype)

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -1643,5 +1643,69 @@ def test_moe_dispatch_no_expert_sharding_dense_forward():
   assert out.shape == inputs.shape
 
 
+@pytest.mark.tpu_only
+class FusedMlpMoETest(unittest.TestCase):
+  """Tests that prefuse_moe_weights=True and prefuse_moe_weights=False produce identical outputs for MoE."""
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self._B = 1
+    self._S = 16
+
+  def setUp(self):
+    super().setUp()
+    self.rng = jax.random.PRNGKey(0)
+    self.ref_cfg = pyconfig.initialize(
+        [None, get_test_config_path()],
+        run_name="fused_mlp_moe_ref",
+        enable_checkpointing=False,
+        model_name="mixtral-8x7b",
+        dtype="bfloat16",
+        sparse_matmul=True,
+        megablox=True,
+        prefuse_moe_weights=False,
+        ici_expert_parallelism=jax.device_count(),
+        max_target_length=self._S,
+        per_device_batch_size=self._B,
+    )
+    ref_devices = maxtext_utils.create_device_mesh(self.ref_cfg)
+    self.ref_mesh = Mesh(ref_devices, self.ref_cfg.mesh_axes)
+    self.ref_model = make_moe(self.ref_cfg, self.ref_mesh)
+
+  def _inputs(self):
+    return jax.random.normal(self.rng, (self._B, self._S, self.ref_cfg.base_emb_dim), dtype=jnp.bfloat16)
+
+  def test_prefuse_moe_weights_matches_unfused(self):
+    """prefuse_moe_weights=True output matches prefuse_moe_weights=False with sparse_matmul (Megablox)."""
+    fused_cfg = pyconfig.initialize(
+        [None, get_test_config_path()],
+        run_name="fused_mlp_moe_fused",
+        enable_checkpointing=False,
+        model_name="mixtral-8x7b",
+        dtype="bfloat16",
+        sparse_matmul=True,
+        megablox=True,
+        prefuse_moe_weights=True,
+        ici_expert_parallelism=jax.device_count(),
+        max_target_length=self._S,
+        per_device_batch_size=self._B,
+    )
+    fused_devices = maxtext_utils.create_device_mesh(fused_cfg)
+    fused_mesh = Mesh(fused_devices, fused_cfg.mesh_axes)
+    fused_model = make_moe(fused_cfg, fused_mesh)
+    copy_weights_prefused(self.ref_model, fused_model)
+
+    inputs = self._inputs()
+    ref_out, _, _ = self.ref_model(inputs)
+    fused_out, _, _ = fused_model(inputs)
+
+    np.testing.assert_allclose(
+        np.array(ref_out, dtype=np.float32),
+        np.array(fused_out, dtype=np.float32),
+        rtol=1e-2,
+        atol=1e-2,
+    )
+
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Analogous to the existing fused_mlp flag for dense models. When enabled, concatenates the wi_0 and wi_1 expert weight matrices along the output dimension ([G,K,N] + [G,K,N] -> [G,K,2N]), issues a single grouped GEMM call, then splits the result. This halves FFN1 kernel launches and reads the input activations from HBM once instead of twice.

Works with all grouped GEMM backends (megablox, tokamax, ragged_dot). Off by default; requires sparse_matmul=True.

# Description

Adds a `fused_moe_mlp` boolean config flag (default `false`) for MoE models, analogous to the existing `fused_mlp` flag for dense models. When enabled, the two FFN1 input projections (`wi_0` gate and `wi_1` up) are fused into a single grouped GEMM call instead of two separate   
  ones.                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                         
  **Why this change:**                                      
  In a gated MoE FFN, `wi_0` and `wi_1` share the same input `x` but are currently dispatched as two independent grouped GEMMs. This means `x` is loaded from HBM twice and two kernel launches are issued back-to-back for every MoE layer.
                                                                                                                                                                                                                                                                                         
  **How it works:**
  The two expert weight matrices (`[G, K, N]` each) are concatenated along the output dimension to form a single fused weight `[G, K, 2N]`. One grouped GEMM call produces `[M, 2N]`, which is then split into `layer_w0` and `layer_w1`. This is the same approach `fused_mlp` uses for 
  dense models (stacking `wi_0`/`wi_1` into a single `dot_general`), extended to the grouped GEMM case.                                                                                                                                                                                  
   
  **Benefits:**                                                                                                                                                                                                                                                                          
  - Halves FFN1 kernel launches (2 → 1) per MoE layer       
  - Reads input activations `x` from HBM once instead of twice
  - Presents the accelerator with a wider `N = 2 × mlp_dim` GEMM, which typically achieves better hardware utilization than two narrower back-to-back GEMMs                                                                                                                              
  - Backend-agnostic: works with megablox, tokamax, and `jax.lax.ragged_dot`
                                                                                                                                                                                                                                                                                         
  **Implementation:**                                       
  The change is entirely in `sparse_matmul` in `moe.py` — a conditional branch on `config.fused_moe_mlp` wraps the existing `gmm_fn` calls. The unfused path is unchanged. A config-load-time validation ensures `sparse_matmul=True` (the dense `einsum` path does not use `gmm_fn` and 
  is unaffected). Off by default (`fused_moe_mlp: false`).                                                                                                                                                                                                                               
   
  # Tests                                                                                                                                                                                                                                                                                
                                                            
  Forward-pass correctness: run with `fused_moe_mlp=false` and `fused_moe_mlp=true` on identical synthetic inputs and verify `intermediate_layer` outputs match numerically. Gradient correctness: verify gradients w.r.t. `wi_0` and `wi_1` match the unfused path (JAX AD traces       
  cleanly through `jnp.concatenate` + slicing with no custom VJP needed). Validation: confirm `fused_moe_mlp=true` with `sparse_matmul=false` raises `ValueError` at config load.
              
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
