### PR TITLE
Fix AttributeError during Checkpoint Loading

### DIFF
--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -507,6 +507,16 @@ def from_pretrained(
 
         # Get the structure of checkpoint in `config.load_parameters_path`
         metadata = ckptr.metadata(config.load_parameters_path)
+        if metadata is None or metadata.item_metadata is None:
+          max_logging.log(
+              f"ERROR: No valid Orbax checkpoint found at '{config.load_parameters_path}'. "
+              "Please check your load_parameters_path, the path may be missing, empty, "
+              "or point to a parent directory rather than the checkpoint step directory "
+          )
+          raise ValueError(
+              f"No valid Orbax checkpoint found at '{config.load_parameters_path}'. "
+              "Please check your load_parameters_path."
+          )
 
         def _adjust_target_for_moe_fusion(target, meta_tree, is_nnx):
           if not hasattr(target, "items") or not hasattr(meta_tree, "items"):


### PR DESCRIPTION
# Description

A critical AttributeError occurs in the RL Trainer (train_rl.py) during GSPO/GRPO workload initialization when the Orbax checkpointer returns None metadata.

This change adds a null-check, raises an informative error and logs what to check.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/496324353

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
