### PR TITLE
Enable Qwen3-Omni vision decode

### DIFF
--- a/src/maxtext/inference/decode.py
+++ b/src/maxtext/inference/decode.py
@@ -113,7 +113,7 @@ def main(argv: Sequence[str]) -> None:
         video_placeholder=config.video_placeholder,
         model_name=config.model_name,
         num_images=processor_outputs.num_images,
-        num_videos=getattr(processor_outputs, 'num_videos', 0),
+        num_videos=getattr(processor_outputs, "num_videos", 0),
     )
 
   metadata = engine.get_tokenizer()
@@ -131,7 +131,8 @@ def main(argv: Sequence[str]) -> None:
     has_chat_template = getattr(tokenizer_model.tokenizer, "chat_template", False)  # pytype: disable=attribute-error
   except AttributeError as _:
     has_chat_template = False
-  tokens, true_length = tokenizer_model.encode(text, is_bos=not has_chat_template, prefill_lengths=[prefill_length])
+  is_bos = config.add_bos and not has_chat_template
+  tokens, true_length = tokenizer_model.encode(text, is_bos=is_bos, prefill_lengths=[prefill_length])
 
   position_ids = None
   mrope_position_deltas = None
@@ -144,11 +145,11 @@ def main(argv: Sequence[str]) -> None:
       from maxtext.multimodal import processor_qwen3_omni  # pylint: disable=import-outside-toplevel
 
       position_ids, mrope_position_deltas = processor_qwen3_omni.get_rope_index(
-          input_ids=tokens,
+          input_ids=tokens[np.newaxis, :],  # Add batch dimension for processing
           image_grid_thw=processor_outputs.pixel_grid_thw,  # pytype: disable=attribute-error
           video_grid_thw=processor_outputs.video_grid_thw,  # pytype: disable=attribute-error
-          attention_mask=np.ones_like(tokens),
-          use_audio_in_video=config.use_audio and getattr(processor_outputs, 'num_videos', 0) > 0,
+          attention_mask=np.ones_like(tokens)[np.newaxis, :],
+          use_audio_in_video=config.use_audio and getattr(processor_outputs, "num_videos", 0) > 0,
           audio_lengths=processor_outputs.audio_lengths,  # pytype: disable=attribute-error
           second_per_grids=processor_outputs.video_second_per_grid,  # pytype: disable=attribute-error
           spatial_merge_size=config.spatial_merge_size_for_vit,  # pytype: disable=attribute-error

--- a/src/maxtext/inference/maxengine/maxengine.py
+++ b/src/maxtext/inference/maxengine/maxengine.py
@@ -1320,7 +1320,9 @@ class MaxEngine(_BaseEngine):
       )
 
     inserted_logits = jax.lax.dynamic_update_index_in_dim(decode_state["logits"], unboxed_prefix["logits"], slot, 0)
-    inserted_next_pos = jax.lax.dynamic_update_index_in_dim(decode_state["next_pos"], unboxed_prefix["next_pos"], slot, 0)
+    inserted_next_pos = jax.lax.dynamic_update_index_in_dim(
+        decode_state["next_pos"], jnp.asarray(unboxed_prefix["next_pos"], dtype=decode_state["next_pos"].dtype), slot, 0
+    )
     inserted_generated_tokens = jax.lax.dynamic_update_index_in_dim(
         decode_state["generated_tokens"],
         unboxed_prefix["generated_tokens"],

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -403,16 +403,9 @@ class RoutedMoE(nnx.Module):
     if rule is not None:
       if not isinstance(rule, qwix.QtRule):
         raise ValueError("Expect a QtRule for quantized training.")
-      if (
-          rule.additional_qt_config
-          and "sparsity_rule" in rule.additional_qt_config
-      ):
+      if rule.additional_qt_config and "sparsity_rule" in rule.additional_qt_config:
         q_s_rule = rule.additional_qt_config["sparsity_rule"]
-        if (
-            q_s_rule
-            and q_s_rule.weight_sparsity_n
-            and q_s_rule.weight_sparsity_m
-        ):
+        if q_s_rule and q_s_rule.weight_sparsity_n and q_s_rule.weight_sparsity_m:
           sparsity_rule = q_s_rule
 
     if sparsity_rule is not None:
@@ -1064,14 +1057,16 @@ class RoutedMoE(nnx.Module):
     def get_tokamax_group_sizes(group_sizes, inputs, kernel):
       # TODO (b/491979205) pipeline fsdp ag per repeat fails tokamax gmm
       if self.config.use_qwix_quantization or (
-          self.config.using_pipeline_parallelism
-          and self.config.pipeline_fsdp_ag_per_repeat
+          self.config.using_pipeline_parallelism and self.config.pipeline_fsdp_ag_per_repeat
       ):
         return group_sizes
       elif self.config.attention == "vllm_rpa":
         return group_sizes
       else:
-        return tokamax.RaggedDotGroupSizes(group_sizes, len(inputs))
+        return tokamax.RaggedDotGroupSizes(
+            group_sizes,
+            (inputs.shape[0] // kernel.shape[0],) * kernel.shape[0],
+        )
 
     def get_quantization_dtypes():
       lhs_quantize_dtype, rhs_quantize_dtype = None, None
@@ -2194,15 +2189,9 @@ class RoutedMoE(nnx.Module):
       wo_kernel = wo_kernel * jnp.asarray(self.per_expert_scale[...], self.dtype)[:, None, None]
 
     if self.wi_0_sparsity_module is not None:
-      _, w0_kernel = self.wi_0_sparsity_module(
-          jnp.zeros_like(w0_kernel), w0_kernel
-      )
-      _, w1_kernel = self.wi_1_sparsity_module(
-          jnp.zeros_like(w1_kernel), w1_kernel
-      )
-      _, wo_kernel = self.wo_sparsity_module(
-          jnp.zeros_like(wo_kernel), wo_kernel
-      )
+      _, w0_kernel = self.wi_0_sparsity_module(jnp.zeros_like(w0_kernel), w0_kernel)
+      _, w1_kernel = self.wi_1_sparsity_module(jnp.zeros_like(w1_kernel), w1_kernel)
+      _, wo_kernel = self.wo_sparsity_module(jnp.zeros_like(wo_kernel), wo_kernel)
     if cfg.mlp_bias:
       w0_bias = jnp.asarray(self.wi_0_bias[...], self.dtype)
       w1_bias = jnp.asarray(self.wi_1_bias[...], self.dtype)

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1781,12 +1781,20 @@ class Qwen3OmniMoeVisionEncoder(nnx.Module):
         - encoder_output: shape (batch, T*H*W, hidden_size_for_vit)
         - deep_features: List of intermediate features, each of shape (batch, T*H*W, out_hidden_size)
     """
-    _, _, num_frames, height, width = hidden_states.shape
+    batch_size, _, num_frames, height, width = hidden_states.shape
     num_frames = num_frames // self.config.temporal_patch_size_for_vit
     height = height // self.config.patch_size_for_vit
     width = width // self.config.patch_size_for_vit
+    hidden_states = hidden_states.reshape(
+        -1,
+        self.config.num_channels_for_vit,
+        self.config.temporal_patch_size_for_vit,
+        self.config.patch_size_for_vit,
+        self.config.patch_size_for_vit,
+    )
 
     x = self.patch_embed(hidden_states)
+    x = x.reshape(batch_size, -1, self.config.hidden_size_for_vit)
     pos = self.pos_embed_interpolate(num_frames, height, width)
 
     pos = pos[jnp.newaxis, :, :]

--- a/src/maxtext/multimodal/processor_qwen3_omni.py
+++ b/src/maxtext/multimodal/processor_qwen3_omni.py
@@ -481,6 +481,17 @@ def preprocess_mm_data_qwen3_omni(config):
   if config.image_path:
     images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
     pixel_values, pixel_grid_thw = pre_process_qwen3_image(images, config)
+    # Reshape to align with current Qwen3OmniMoeVisionEncoder, which carries grid_thw information
+    pixel_values = np.reshape(
+        pixel_values,
+        (
+            1,
+            config.num_channels_for_vit,
+            config.temporal_patch_size_for_vit * pixel_grid_thw[0, 0],
+            config.patch_size_for_vit * pixel_grid_thw[0, 1],
+            config.patch_size_for_vit * pixel_grid_thw[0, 2],
+        ),
+    )
     processor_outputs.pixel_values = pixel_values
     processor_outputs.pixel_grid_thw = pixel_grid_thw
     processor_outputs.num_images = len(images)

--- a/tests/unit/qwen3_omni_layers_test.py
+++ b/tests/unit/qwen3_omni_layers_test.py
@@ -60,7 +60,6 @@ from tests.utils.multimodal_test_utils import (
     copy_vision_encoder_weights,
     create_block_diagonal_attention_mask,
     create_random_jax_torch,
-    split_into_patches,
 )
 import numpy as np
 import torch
@@ -535,15 +534,18 @@ class TestQwen3OmniMoeVisionEncoderEndToEnd(BaseVisionTestCaseWithMesh):
     in_channels = self.config.num_channels_for_vit
     h, w = 8, 8  # 8x8 patches
 
-    total_elements = 1 * in_channels * temporal_patch_size * (h * patch_size) * (w * patch_size)
-    jax_hidden_states, _ = create_random_jax_torch(total_elements)
+    n_patches = h * w
+    total_elements = n_patches * in_channels * temporal_patch_size * patch_size * patch_size
+    flat_data, _ = create_random_jax_torch(total_elements)
 
-    jax_hidden_states = jax_hidden_states.reshape(1, in_channels, temporal_patch_size, h * patch_size, w * patch_size)
+    # JAX encoder expects preprocessor format: (1, C, tps*T, ps*H, ps*W) where the underlying
+    # memory is patch-first (T*H*W, C*tps*ps*ps). Simple reshape in the encoder then recovers
+    # each patch correctly, matching the end-to-end preprocessing pipeline.
+    jax_hidden_states = flat_data.reshape(1, in_channels, temporal_patch_size, h * patch_size, w * patch_size)
 
-    torch_hidden_states = split_into_patches(
-        torch.from_numpy(np.array(jax_hidden_states)),
-        temporal_patch_size,
-        patch_size,
+    # PyTorch encoder expects patches directly in (N, C, tps, ps, ps) format.
+    torch_hidden_states = torch.from_numpy(
+        np.array(flat_data).reshape((n_patches, in_channels, temporal_patch_size, patch_size, patch_size))
     )
 
     grid_thw = np.array([[1, h, w]], dtype=np.int64)
@@ -673,7 +675,6 @@ class TestQwen3OmniPreprocessing(unittest.TestCase):
         model_name="qwen3-omni-30b-a3b",
         tokenizer_type="huggingface",
         tokenizer_path="Qwen/Qwen3-Omni-30B-A3B-Instruct",
-        use_multimodal=True,
         image_path=self.image_path,
         video_path=self.video_path,
         use_audio_in_video=True,
@@ -739,9 +740,12 @@ class TestQwen3OmniPreprocessing(unittest.TestCase):
     # Check the tokenized IDs are the same (with multimodal paddings)
     assert np.array_equal(mt_input_ids[: hf_input_ids.shape[0]], hf_input_ids)
     # Check the image/video/audio values are close (allow some tolerance due to preprocessing differences)
+    hf_pixel_values = np.array(hf_processor_outputs["pixel_values"]).astype(np.float32)
+    # MaxText pixel_values are reshaped to (1, C, T, H, W); flatten to patch format for comparison.
+    mt_pixel_values = np.array(mt_processor_outputs.pixel_values).reshape(hf_pixel_values.shape)
     assert np.allclose(
-        mt_processor_outputs.pixel_values,
-        np.array(hf_processor_outputs["pixel_values"]).astype(np.float32),
+        mt_pixel_values,
+        hf_pixel_values,
         rtol=1e-2,
         atol=1e-2,
     )


### PR DESCRIPTION
# Description

Fixes inference for Qwen3-Omni multimodal (image) decode:
- `moe.py`: Fix `RaggedDotGroupSizes` representative value: commit `083293fc3` (https://github.com/AI-Hypercomputer/maxtext/pull/3434) regressed `len(inputs)` (an `int`) where a `tuple[int, ...]` is required. Restored as `(inputs.shape[0] // kernel.shape[0],) * kernel.shape[0]`. Also minor formatting cleanup from the sparsity PR.
- `decode.py`: Respect `config.add_bos` flag instead of hardcoding `not has_chat_template`. Add batch dimension when calling `get_rope_index` for `input_ids`/`attention_mask`.
- `maxengine.py`: Cast `next_pos` to the decode state's dtype before `dynamic_update_index_in_dim` to avoid dtype mismatch when MRoPE position IDs are float vs int.
- `qwen3.py`: Fix `Qwen3OmniMoeVisionEncoder.__call__`: explicitly reshape `hidden_states` to patch-level layout before `patch_embed`, then reshape output back to `(batch, seq, hidden)`. Previously assumed a flattened input that didn't account for batch size.
- `processor_qwen3_omni.py`: Reshape preprocessed image pixel values to `(1, C, T*t, H*h, W*w)` to match the updated vision encoder's expected input layout, carrying explicit grid-thw information.

**Note**: Video decoding is working too but pending an input interface refactor. To manage the growing number of model-specific inputs (video_values, mask, grid_thw), we are planning a follow-up PR to standardize the interface.
# Tests

Unit tests passing:
```
python -m pytest tests/unit/qwen3_omni_layers_test.py -vv -s

= 28 passed, 2119 warnings in 91.25s (0:01:31) =
```

Decode with a test image:

```
python -m maxtext.inference.decode maxtext/configs/base.yml model_name=qwen3-omni-30b-a3b tokenizer_path=Qwen/Qwen3-Omni-30B-A3B-Instruct tokenizer_type=huggingface load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-omni-30b-a3b/unscanned/001/0/items per_device_batch_size=1 run_name=ht_test steps=1 async_checkpointing=false scan_layers=false use_multimodal=true prompt=\'What\ can\ you\ see\?\ Answer\ in\ one\ short\ sentence.\' image_path=\'tests/assets/test_image.jpg\' max_prefill_predict_length=361 max_target_length=391 attention=\'dot_product\' hf_access_token=<hf_access_token> ici_tensor_parallelism=4 add_bos=False override_model_config=True
```

```
Input `<|im_start|>user
<|vision_start|><|image_pad|><|vision_end|>What can you see? Answer in one short sentence.<|im_end|>
<|im_start|>assistant
` -> `A city skyline with a prominent space needle, snow-capped mountains in the distance, and a clear blue sky.
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
