### PR TITLE
Add new RL argument for reshard chunk size.

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -68,6 +68,9 @@ rl:
   degenerate_group_masking: True
   # Upper-bound clipping epsilon for GRPO loss; defaults to grpo_epsilon when null.
   epsilon_high: null
+  # Number of model keys to chunk for resharding tensors between trainer and rollout devices.
+  # If null, the entire model is resharded at once.
+  reshard_chunk_size: null
 
 
 # ====== Models ======

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -436,26 +436,16 @@ class Quantization(BaseModel):
   )
   weight_sparsity_n: int | None = Field(
       None,
-      description=(
-          "The 'N' in N:M sparsity, representing the maximum number of non-zero"
-          " values in each block."
-      ),
+      description=("The 'N' in N:M sparsity, representing the maximum number of non-zero" " values in each block."),
   )
   weight_sparsity_m: int | None = Field(
       None,
-      description=(
-          "The 'M' in N:M sparsity, representing the number of values in each"
-          " block."
-      ),
+      description=("The 'M' in N:M sparsity, representing the number of values in each" " block."),
   )
-  weight_sparsity_update_step: int = Field(
-      10, description="The step size for updating weight sparsity masks."
-  )
+  weight_sparsity_update_step: int = Field(10, description="The step size for updating weight sparsity masks.")
   weight_sparsity_start_step: int = Field(
       50,
-      description=(
-          "The first number of steps before updating the sparsity masks."
-      ),
+      description=("The first number of steps before updating the sparsity masks."),
   )
 
 
@@ -1821,6 +1811,13 @@ class RL(BaseModel):
   )
   epsilon_high: Optional[float] = Field(
       None, description="Upper-bound clipping epsilon for GRPO loss. Defaults to epsilon when None (agentic only)."
+  )
+  reshard_chunk_size: Optional[int] = Field(
+      None,
+      description=(
+          "Number of model keys to chunk for resharding tensors between trainer and rollout devices."
+          "If None, no chunking is applied, which may lead to OOM errors if tensors are too large."
+      ),
   )
 
 

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -405,6 +405,7 @@ def create_rl_components(
           rollout_vllm_max_num_seqs=trainer_config.max_num_seqs,
           rollout_vllm_async_scheduling=trainer_config.async_scheduling,
           rollout_vllm_server_mode=trainer_config.rl.use_agentic_rollout,
+          rollout_vllm_reshard_chunk_size=trainer_config.rl.reshard_chunk_size,
           rollout_vllm_kwargs={
               "hf_overrides": trainer_config.vllm_hf_overrides,
               "enable_expert_parallel": sampler_config.enable_expert_parallel,


### PR DESCRIPTION
# Description

This PR adds support for the new `rollout_vllm_reshard_chunk_size` argument from Tunix, which controls how many keys to reshard at a time when performing weight sync between trainer and sampler models. This is helpful for resharding larger models as it reduces the peak HBM utilization of the reshard function. 

# Tests

E2E GRPO run.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
