### PR TITLE
Add tokenizer support for Qwen3-30B-A3B-Base.

### DIFF
--- a/src/maxtext/utils/globals.py
+++ b/src/maxtext/utils/globals.py
@@ -67,6 +67,7 @@ HF_IDS = {
     "llama3.1-70b": "meta-llama/Llama-3.1-70B",
     "llama3.1-405b": "meta-llama/Llama-3.1-405B",
     "qwen3-30b-a3b": "Qwen/Qwen3-30B-A3B-Thinking-2507",
+    "qwen3-30b-a3b-base": "Qwen/Qwen3-30B-A3B-Base",
     "qwen3-235b-a22b": "Qwen/Qwen3-235B-A22B-Thinking-2507",
     "qwen3-480b-a35b": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
     "deepseek2-16b": "deepseek-ai/DeepSeek-V2-Lite",

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -110,6 +110,14 @@ class PyconfigTest(unittest.TestCase):
     self.assertEqual(config.base_emb_dim, 1024)  # override
     self.assertEqual(config.base_mlp_dim, 14336)  # unchanged
 
+  def test_tokenizer_path_resolution_for_qwen3_base(self):
+    config = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        model_name="qwen3-30b-a3b-base",
+    )
+    self.assertEqual(config.tokenizer_path, "Qwen/Qwen3-30B-A3B-Base")
+
   def test_resolve_config_path(self):
     self.assertEqual(resolve_config_path("foo"), os.path.join("src", "foo"))
     self.assertEqual(resolve_config_path(__file__), __file__)


### PR DESCRIPTION


# Description

Tokenizer defaults to the llama tokenizer without this change.

# Tests

Added a test and tried it out with a training run on a TPU cluster.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
