### PR TITLE
Mark sparsity_test as tpu_only in CI

### DIFF
--- a/tests/sparsity_test.py
+++ b/tests/sparsity_test.py
@@ -18,6 +18,7 @@ import os
 import tempfile
 from absl.testing import absltest
 from absl.testing import parameterized
+import pytest
 from maxtext.trainers.pre_train import train
 from tests.utils.test_helpers import get_test_config_path
 
@@ -45,9 +46,8 @@ class Train(parameterized.TestCase):
           "use_sparsity": True,
       },
   )
-  def test_different_quant_sparsity_configs(
-      self, quantization: str, use_sparsity: bool
-  ):
+  @pytest.mark.tpu_only
+  def test_different_quant_sparsity_configs(self, quantization: str, use_sparsity: bool):
     test_tmpdir = os.environ.get("TEST_TMPDIR", gettempdir())
     outputs_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", test_tmpdir)
     args = [
@@ -81,11 +81,13 @@ class Train(parameterized.TestCase):
         f"metrics_file={os.path.join(outputs_dir, 'metrics.json')}",
     ]
     if use_sparsity:
-      args.extend([
-          "weight_sparsity_n=2",
-          "weight_sparsity_m=4",
-          "weight_sparsity_update_step=1",
-      ])
+      args.extend(
+          [
+              "weight_sparsity_n=2",
+              "weight_sparsity_m=4",
+              "weight_sparsity_update_step=1",
+          ]
+      )
     train_main(args)
 
 


### PR DESCRIPTION
# Description

The latest `sparsity_test.py` failure is block the CI:

https://github.com/AI-Hypercomputer/maxtext/actions/runs/24909800193/job/72948409059

Reported bug: [b/506257265](https://b.corp.google.com/issues/506257265)

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
