### PR TITLE
fix gemma4 dtype mismatch

### DIFF
--- a/src/maxtext/models/gemma4.py
+++ b/src/maxtext/models/gemma4.py
@@ -370,7 +370,7 @@ class Gemma4DecoderLayer(nnx.Module):
 
     next_layer_addition = mlp_lnx + residual
     layer_output = next_layer_addition
-    layer_output = layer_output * self.layer_scalar.value
+    layer_output = layer_output * jnp.asarray(self.layer_scalar.value, cfg.dtype)
 
     layer_output = nn.with_logical_constraint(layer_output, self.activation_axis_names)
 


### PR DESCRIPTION
# Description

When fixing another bug in #3727 , I changed to use config.weight_dtype from config.dtype to initialize layer_scalar because it's a weight, this requires casting layer_scalar back to dtype during use time, or it causes error `The input   
  carry component c[1] has type bfloat16[2048,4096,2816] but the corresponding output carry component has type float32[2048,4096,2816], so the dtypes do not match.` when `weight_dtype=float32, dtype=bfloat16`

# Tests
[log with error](https://cloudlogging.app.goo.gl/uUPxUg7qFrHu5eGC7)
[working log](https://cloudlogging.app.goo.gl/88g2Ebn3FKU1jPiP9)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
