### PR TITLE
Enable data mixture with expansion factor

### DIFF
--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -424,6 +424,7 @@ def make_grain_train_iterator(
         grain_num_threads=config.grain_num_threads,
         grain_prefetch_buffer_size=config.grain_prefetch_buffer_size,
         grain_data_source_max_workers=config.grain_data_source_max_workers,
+        mixture_config_path=config.grain_train_mixture_config_path,
     )
     if config.use_dpo:
       preprocessing_fn = functools.partial(


### PR DESCRIPTION
# Description

Customer trying to resume workload from 512 to chips to 256 chips, Their dataset is a mixture defined in data_mixture.json. Scaling down requires setting expansion_factor_real_data=0.5
Thread: https://chat.google.com/room/AAAA5hZCgEg/V99I-LqcWxA

This use case was not supported in MaxText, but only 1 line to add the support.

# Tests
[script](https://paste.googleplex.com/6333391034253312)
checkpoint_dir=`gs://aireenmei-multipod/grain/aireen-2026-04-28-23-56-55/checkpoints`
Run 1. 2 slices of v5e-32, use data_mixture.json. set steps=11, saved checkpoints at step 0, 5, 10, [log](https://cloudlogging.app.goo.gl/TETCA5m4qnXnyRdW6)
Run 2. 1 slice of v5e-32, use data_mixture.json and expansion_factor_real_data=0.5. set steps=21, saved checkpoints at step 15, 20, [log](https://cloudlogging.app.goo.gl/5xz3jsVEJKQBMM39A)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
