### PR TITLE
Migrate tpu tests to v6-8 and cpu tests to n2-32

### DIFF
--- a/.github/workflows/build_and_test_maxtext.yml
+++ b/.github/workflows/build_and_test_maxtext.yml
@@ -135,9 +135,9 @@ jobs:
         fail-fast: false
     with:
       device_type: tpu
-      device_name: v6e-4
+      device_name: v6e-8
       base_image: maxtext-unit-test-tpu:py312
-      cloud_runner: linux-x86-ct6e-180-4tpu
+      cloud_runner: linux-x86-ct6e-180-8tpu
       maxtext_sha: ${{ needs.build_and_upload_maxtext_package.outputs.maxtext_sha }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -195,9 +195,9 @@ jobs:
         fail-fast: false
     with:
       device_type: tpu
-      device_name: v6e-4
+      device_name: v6e-8
       base_image: maxtext-unit-test-tpu:py312
-      cloud_runner: linux-x86-ct6e-180-4tpu
+      cloud_runner: linux-x86-ct6e-180-8tpu
       pytest_marker: 'not cpu_only and not gpu_only and not integration_test and not post_training'
       pytest_addopts: '--ignore=tests/post_training'
       xla_python_client_mem_fraction: 0.75
@@ -214,9 +214,9 @@ jobs:
         fail-fast: false
     with:
       device_type: tpu
-      device_name: v6e-4
+      device_name: v6e-8
       base_image: maxtext-unit-test-tpu:py312
-      cloud_runner: linux-x86-ct6e-180-4tpu
+      cloud_runner: linux-x86-ct6e-180-8tpu
       pytest_marker: 'not cpu_only and not gpu_only and integration_test and not post_training'
       pytest_addopts: '--ignore=tests/post_training --ignore=tests/integration/hlo_diff_test.py'
       xla_python_client_mem_fraction: 0.75

--- a/.github/workflows/run_jupyter_notebooks.yml
+++ b/.github/workflows/run_jupyter_notebooks.yml
@@ -108,8 +108,7 @@ jobs:
 
           for notebook in "$MAXTEXT_NOTEBOOKS_ROOT"/{sft,rl}*.ipynb; do
             filename=$(basename "$notebook")
-            # TODO: Update runnner to v6e-8 as RL with LLama3.1-8b doesn't fit on v6e-4
-            if [[ "$filename" == "sft_llama3_demo_gpu.ipynb" || "$filename" == "maxtext_with_gepa.ipynb" || "$filename" == "rl_llama3_demo.ipynb" ]]; then
+            if [[ "$filename" == "sft_llama3_demo_gpu.ipynb" || "$filename" == "maxtext_with_gepa.ipynb" ]]; then
               echo "Skipping $filename"
               continue
             fi

--- a/.github/workflows/run_tests_coordinator.yml
+++ b/.github/workflows/run_tests_coordinator.yml
@@ -80,10 +80,10 @@ jobs:
 
       device_name: >-
         ${{ fromJSON('{
-          "tpu-unit": "v6e-4",
-          "tpu-integration": "v6e-4",
-          "tpu-post-training-unit": "v6e-4",
-          "tpu-post-training-integration": "v6e-4",
+          "tpu-unit": "v6e-8",
+          "tpu-integration": "v6e-8",
+          "tpu-post-training-unit": "v6e-8",
+          "tpu-post-training-integration": "v6e-8",
           "gpu-unit": "a100-40gb-4",
           "gpu-integration": "a100-40gb-4",
           "cpu-unit": "X64",
@@ -92,14 +92,14 @@ jobs:
 
       cloud_runner: >-
         ${{ fromJSON('{
-          "tpu-unit": "linux-x86-ct6e-180-4tpu",
-          "tpu-integration": "linux-x86-ct6e-180-4tpu",
-          "tpu-post-training-unit": "linux-x86-ct6e-180-4tpu",
-          "tpu-post-training-integration": "linux-x86-ct6e-180-4tpu",
+          "tpu-unit": "linux-x86-ct6e-180-8tpu",
+          "tpu-integration": "linux-x86-ct6e-180-8tpu",
+          "tpu-post-training-unit": "linux-x86-ct6e-180-8tpu",
+          "tpu-post-training-integration": "linux-x86-ct6e-180-8tpu",
           "gpu-unit": "linux-x86-a2-48-a100-4gpu",
           "gpu-integration": "linux-x86-a2-48-a100-4gpu",
-          "cpu-unit": "linux-x86-n2-16",
-          "cpu-post-training-unit": "linux-x86-n2-16"
+          "cpu-unit": "linux-x86-n2-32",
+          "cpu-post-training-unit": "linux-x86-n2-32"
         }')[inputs.flavor] }}
       # Pytest Marker Mapping
       pytest_marker: >-

--- a/src/maxtext/examples/rl_llama3_demo.ipynb
+++ b/src/maxtext/examples/rl_llama3_demo.ipynb
@@ -247,6 +247,7 @@
     "    f\"chat_template_path={CHAT_TEMPLATE_PATH}\",\n",
     "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}\",\n",
     "    f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
+    "    \"rollout_tensor_parallelism=4\",\n",
     "    \"debug.rl=True\",\n",
     "    f\"rl.loss_algo={LOSS_ALGO}\",\n",
     "    \"use_pathways=False\",\n",

--- a/tests/unit/context_parallelism_test.py
+++ b/tests/unit/context_parallelism_test.py
@@ -105,14 +105,18 @@ class ContextParallelismTest(unittest.TestCase):
     # Create a mapping from the expected device (in logical mesh order) to its expected properties
     # current_test_devices defines the logical order of devices in the mesh
     current_test_devices = self.mesh_cp.devices.flatten()
+    context_axis_idx = list(self.cfg_cp.mesh_axes).index("context")
+    device_to_context_idx = {
+        self.mesh_cp.devices[idx]: idx[context_axis_idx] for idx in np.ndindex(self.mesh_cp.devices.shape)
+    }
 
     expected_map = {
-        current_test_devices[i]: {
-            "index": expected_indices_per_logical_device[i],
+        device: {
+            "index": expected_indices_per_logical_device[ctx_idx],
             "shape": expected_shard_shape_2d,
-            "data": global_data_2d[expected_indices_per_logical_device[i]],
+            "data": global_data_2d[expected_indices_per_logical_device[ctx_idx]],
         }
-        for i in range(len(current_test_devices))
+        for device, ctx_idx in device_to_context_idx.items()
     }
 
     found_devices_in_shards = set()

--- a/tests/unit/mhc_test.py
+++ b/tests/unit/mhc_test.py
@@ -98,7 +98,7 @@ class TestMHC(unittest.TestCase):
         run_name="test_mhc",
         enable_checkpointing=False,
         model_name="deepseek-custom",
-        per_device_batch_size=4,
+        per_device_batch_size=jax.device_count(),
         max_target_length=7,
         max_prefill_predict_length=7,
         attention="dot_product",

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -403,7 +403,7 @@ class RoutedMoeTest(unittest.TestCase):
     )
     variables = model.init(
         {"params": rng, "dropout": rng},
-        jax.random.normal(rng, (int(cfg.per_device_batch_size), cfg.max_target_length, cfg.base_emb_dim)),
+        jax.random.normal(rng, hidden_states.shape),
     )
 
     output = jax.jit(model.apply)(variables, hidden_states)  # pylint: disable=not-callable
@@ -614,7 +614,7 @@ class RoutedMoeTest(unittest.TestCase):
         megablox=True,
         sparse_matmul=True,
         per_device_batch_size=4,  # TODO(b/450900273): sharding error if pdbs=1
-        ici_fsdp_parallelism=2,
+        ici_fsdp_parallelism=4,
         ici_fsdp_transpose_parallelism=2,
         moe_fsdp_use_two_stage_all_gather=True,
         max_target_length=128,

--- a/tests/unit/multihost_dataloading_test.py
+++ b/tests/unit/multihost_dataloading_test.py
@@ -39,7 +39,7 @@ class MultihostDataloadingTest(unittest.TestCase):
     # Note: this test uses gs://max-experiments/ (not gs://runner-maxtext-logs) in cloud mode
     base_output_directory = get_test_base_output_directory(cloud_path="gs://max-experiments/")
     dataset_path = get_test_dataset_path(cloud_path="gs://maxtext-dataset/")
-    batch_size = 4
+    batch_size = len(jax.devices())
     config = pyconfig.initialize(
         [sys.argv[0], get_test_config_path()],
         base_output_directory=base_output_directory,

--- a/tests/unit/pipeline_parallelism_test.py
+++ b/tests/unit/pipeline_parallelism_test.py
@@ -277,6 +277,11 @@ class PipelineParallelismTest(unittest.TestCase):
         num_pipeline_microbatches=8,
         per_device_batch_size=4,
         pipeline_fsdp_ag_once=True,
+        # Force FP32 to eliminate bfloat16 non-associative rounding noise
+        dtype="float32",
+        weight_dtype="float32",
+        # Use dot_product to avoid Flash Attention precision loss on unaligned dims
+        attention="dot_product"
     )
     self.assert_pipeline_same_output_and_grad(config)
 
@@ -295,6 +300,11 @@ class PipelineParallelismTest(unittest.TestCase):
         num_pipeline_microbatches=8,
         per_device_batch_size=4,
         pipeline_fsdp_ag_per_repeat=True,
+        # Force FP32 to eliminate bfloat16 non-associative rounding noise
+        dtype="float32",
+        weight_dtype="float32",
+        # Use dot_product to avoid Flash Attention precision loss on unaligned dims
+        attention="dot_product"
     )
     self.assert_pipeline_same_output_and_grad(config)
 


### PR DESCRIPTION
# Description

* Migrate TPU tests to v6e-8 runners
* Migrate CPU tests to n2-32 runners

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
