### PR TITLE
Add TP support with vLLM FusedMoE kernel

### DIFF
--- a/src/maxtext/configs/inference/vllm.yml
+++ b/src/maxtext/configs/inference/vllm.yml
@@ -24,6 +24,8 @@ skip_jax_distributed_system: True
 scan_layers: False
 # Set weight dtype to bfloat16 as is done in vLLM
 weight_dtype: bfloat16
+# Allow model config to be overridden by CLI kwargs
+override_model_config: True
 
 
 # -------------- Logical Axis Rules --------------

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -672,6 +672,9 @@ class MoEGeneral(BaseModel):
       description="Dimension of tokens entering the MoE layer. If < 0, defaults to emb_dim.",
   )
   base_moe_mlp_dim: int = Field(-1, description="Intermediate dimension at MoE layer.")
+  padded_base_moe_mlp_dim: Optional[int] = Field(
+      None, description="Padded intermediate dimension at MoE layer for efficient GMM_v2 kernel execution."
+  )
   load_balance_loss_weight: NonNegativeFloat = Field(0.0, description="Weight for the load balancing auxiliary loss.")
   use_custom_sort_vjp: bool = Field(
       True,

--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -20,7 +20,9 @@ import jax
 from flax import nnx
 import flax.linen as nn
 from jax import numpy as jnp
+from jax.experimental.pallas import tpu as pltpu
 from jax.sharding import Mesh
+
 from maxtext.configs import pyconfig
 from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
 from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE
@@ -30,7 +32,6 @@ from maxtext.utils import model_creation_utils
 
 try:
   from tpu_inference.layers.common.attention_metadata import AttentionMetadata
-  from tpu_inference.layers.common.attention_interface import ShardingAxisName
 except ImportError:
   # Mock for documentation build or environments without tpu_inference
   class AttentionMetadata:
@@ -38,6 +39,21 @@ except ImportError:
 
 
 from vllm.config import VllmConfig
+
+
+def next_power_of_two(x: int) -> int:
+  """Finds the smallest power of 2 >= x using bit manipulation.
+
+  Args:
+    x: The input number (should be an integer).
+
+  Returns:
+    The smallest integer power of 2 that is >= x.
+  """
+  assert x > 0
+  if x == 1:
+    return 1
+  return 1 << (x - 1).bit_length()
 
 
 def generate_maxtext_config(vllm_config: VllmConfig, mesh: Mesh) -> pyconfig.HyperParameters:
@@ -75,21 +91,50 @@ def generate_maxtext_config(vllm_config: VllmConfig, mesh: Mesh) -> pyconfig.Hyp
   base_config_path = os.path.join(MAXTEXT_CONFIGS_DIR, "inference", "vllm.yml")
   argv_list = ["", str(base_config_path)]
 
-  # Pad the number of KV heads if its less than the TP / EP size
-  if isinstance(ShardingAxisName.ATTN_HEAD, tuple):
-    tp_sizes = [mesh.shape[axis_name] for axis_name in ShardingAxisName.ATTN_HEAD]
-    max_tp_size = max(tp_sizes)
-  else:
-    max_tp_size = mesh.shape[ShardingAxisName.ATTN_HEAD]
+  # Gather sharding information from vLLM config to determine transformations to apply
+  sharding_config = vllm_config.sharding_config
+  tp = sharding_config.tp_size
+  ep = sharding_config.expert_size
+  attn_dp = sharding_config.attn_dp_size
 
+  # Calculate the maximum TP size across attention and MLP dimensions
+  kv_tp_size = tp * ep
+  moe_mlp_tp_size = tp * attn_dp
+
+  # Gather information on the hidden size of MoE models to determine if padding is needed
+  # to meet MLP MoE requirements for tpu-inference GMM_v2 kernel.
+  hidden_size = getattr(vllm_config.model_config.hf_config, "moe_intermediate_size", None)
+  padded_hidden_size = hidden_size
+  num_lanes = pltpu.get_tpu_info().num_lanes
+
+  max_logging.log(
+      f"vLLM sharding config: hidden_size={hidden_size}, tp={tp}, "
+      f"attn_dp={attn_dp}, ep={ep}, moe_mlp_tp_size={moe_mlp_tp_size}"
+  )
+
+  # Replicate the number of KV heads if its less than the total degree of model parallelism
   if (
-      max_tp_size % vllm_config.model_config.get_total_num_kv_heads() == 0
-      and vllm_config.model_config.get_total_num_kv_heads() < max_tp_size
+      kv_tp_size % vllm_config.model_config.get_total_num_kv_heads() == 0
+      and vllm_config.model_config.get_total_num_kv_heads() < kv_tp_size
   ):
     max_logging.log(
-        f"Padding num_kv_heads from {vllm_config.model_config.get_total_num_kv_heads()} to {max_tp_size} to match tp_size."
+        f"Padding num_kv_heads from {vllm_config.model_config.get_total_num_kv_heads()} "
+        f"to {kv_tp_size} to match the degree of tensor parallelism."
     )
-    overrides["base_num_kv_heads"] = max_tp_size
+    overrides["base_num_kv_heads"] = kv_tp_size
+
+  # Pad the hidden size of MoE models if the MLP dimension is less than expected by the GMM_v2 kernel in tpu-inference.
+  # The GMM_v2 kernel requires the MLP dimension per expert to be at least 2x the number of TPU lanes
+  # to ensure efficient execution. See the validate_inputs() method in the following file for more details:
+  # https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/kernels/megablox/gmm_v2.py
+  if hidden_size is not None and tp > 1 and (hidden_size // moe_mlp_tp_size) % (2 * num_lanes) != 0:
+    while (padded_hidden_size // moe_mlp_tp_size) < (2 * num_lanes):
+      padded_hidden_size = next_power_of_two(padded_hidden_size)
+
+    max_logging.log(
+        f"Padding moe_intermediate_size from {hidden_size} " f"to {padded_hidden_size} to match MLP MoE requirements."
+    )
+    overrides["padded_base_moe_mlp_dim"] = padded_hidden_size
 
   maxtext_config = pyconfig.initialize(argv_list, **overrides)
   return maxtext_config

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -446,10 +446,16 @@ class RoutedMoE(nnx.Module):
       self.wi_1 = jnp.zeros((num_experts, self.moe_expert_input_dim, intermediate_dim))
       self.wo = jnp.zeros((num_experts, intermediate_dim, self.moe_expert_input_dim))
     elif self.config.prefuse_moe_weights and self.config.attention == "vllm_rpa":
+      # Pad model dimension in Fused MoE weight kernels for GMM_v2 execution.
+      moe_intermediate_dim = (
+          self.config.padded_base_moe_mlp_dim
+          if self.config.padded_base_moe_mlp_dim is not None
+          else self.intermediate_dim
+      )
       self.wi = nnx.Param(
           self.kernel_init(
               self.rngs.params(),
-              (num_experts, self.moe_expert_input_dim, intermediate_dim * 2),
+              (num_experts, self.moe_expert_input_dim, moe_intermediate_dim * 2),
               weight_dtype,
               kernel_in_axis,
               kernel_out_axis,
@@ -467,10 +473,16 @@ class RoutedMoE(nnx.Module):
           sharding=self.wo_kernel_axes,
       )
     else:
+      # Pad model dimension in Unfused MoE weight kernels for GMM_v2 execution.
+      moe_intermediate_dim = (
+          self.config.padded_base_moe_mlp_dim
+          if self.config.padded_base_moe_mlp_dim is not None
+          else self.intermediate_dim
+      )
       self.wi_0 = nnx.Param(
           self.kernel_init(
               self.rngs.params(),
-              (num_experts, self.moe_expert_input_dim, intermediate_dim),
+              (num_experts, self.moe_expert_input_dim, moe_intermediate_dim),
               weight_dtype,
               kernel_in_axis,
               kernel_out_axis,
@@ -480,7 +492,7 @@ class RoutedMoE(nnx.Module):
       self.wi_1 = nnx.Param(
           self.kernel_init(
               self.rngs.params(),
-              (num_experts, self.moe_expert_input_dim, intermediate_dim),
+              (num_experts, self.moe_expert_input_dim, moe_intermediate_dim),
               weight_dtype,
               kernel_in_axis,
               kernel_out_axis,

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -28,7 +28,6 @@ from flax import nnx
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
-import numpy as np
 from jax.sharding import Mesh
 from maxtext.configs import pyconfig
 from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN
@@ -51,18 +50,100 @@ except ImportError:
     return hasattr(x, "shape") and hasattr(x, "sharding") and hasattr(x, "dtype") and not isinstance(x, jax.Array)
 
 
-def _expand_checkpoint_to_model_shapes(ckpt_arr, model_arr):
-  """Expand ckpt_arr to model_arr's shape and re-shard to model_arr's sharding.
+# Logical axis names whose padding semantics are "replicate the existing values"
+# (e.g. KV-head replication for GQA with TP > num_kv_heads).
+_VLLM_REPEAT_AXES = frozenset({"kv_heads", ("expert", "model")})
 
-  Used to expand checkpoint KV-head (and similar) arrays that were saved with
-  fewer heads than the padded model shape requires (e.g. due to TP/EP padding
-  in adapter.py).  Each dimension must divide evenly into the corresponding
-  model dimension.
+# Logical axis names whose padding semantics are "append zeros at the end"
+# (e.g. MoE MLP-dim padding to satisfy the GMM_v2 kernel's per-shard size
+# constraint, set in src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py).
+_VLLM_ZERO_PAD_AXES = frozenset({"mlp_moe", "activation_mlp", ("attn_dp", "model")})
 
-  Uses jnp.repeat so that each original slice is placed adjacent to its copies.
-  For GQA with TP, device i needs KV head i//ratio from the original checkpoint,
-  so the correct layout is e.g. [h0, h0, h1, h1, h2, h2, h3, h3] rather than
-  [h0, h1, h2, h3, h0, h1, h2, h3].
+
+def _normalize_logical_axes(axes):
+  """Coerce an axes value (PartitionSpec / tuple / None / leaf marker) to a plain tuple or None.
+
+  ``nnx.get_partition_spec`` returns a tree of :class:`jax.sharding.PartitionSpec`
+  leaves whose entries are logical axis names, ``None`` (unsharded), or nested
+  tuples (multi-axis sharding).  PartitionSpec is iterable, so ``tuple(spec)``
+  yields the per-axis entries directly.
+  """
+  if axes is None:
+    return None
+  if isinstance(axes, jax.sharding.PartitionSpec):
+    return tuple(axes)
+  if isinstance(axes, (tuple, list)):
+    return tuple(axes)
+  return None
+
+
+def _zero_pad_axis(arr, axis, extra):
+  """Append ``extra`` zeros at the end of ``axis``.
+
+  When ``arr`` is sharded along ``axis`` with a NamedSharding, this pads each
+  *local* shard via ``shard_map`` so we never materialize the full replicated
+  tensor — critical for large MoE weights where the global pad would re-OOM.
+  The resulting layout has zeros interleaved at each shard's tail rather than
+  all at the global tail. Both layouts are mathematically equivalent for any
+  matmul along the padded axis with a matching pad on the consuming weight,
+  which is exactly the MoE wi/wo + GMM_v2 kernel case (the only consumer that
+  triggers ``_ZERO_PAD_AXES`` today).
+
+  When ``arr`` is unsharded (or sharded along a different axis), falls back to
+  ``jnp.pad`` — same as before this change.
+  """
+  if extra == 0:
+    return arr
+
+  sharding = getattr(arr, "sharding", None)
+  pad_width = [(0, 0)] * arr.ndim
+
+  if isinstance(sharding, jax.sharding.NamedSharding):
+    spec = sharding.spec
+    partition = spec[axis] if axis < len(spec) else None
+    shards_along_axis = _partition_size(partition, sharding.mesh)
+    if shards_along_axis > 1:
+      if extra % shards_along_axis != 0:
+        raise ValueError(
+            f"Cannot per-shard zero-pad axis {axis}: extra={extra} not divisible by "
+            f"shards_along_axis={shards_along_axis} (sharding spec entry {partition!r})."
+        )
+      per_shard_extra = extra // shards_along_axis
+      pad_width[axis] = (0, per_shard_extra)
+
+      def _pad_local(x):
+        return jnp.pad(x, pad_width)
+
+      return jax.shard_map(_pad_local, mesh=sharding.mesh, in_specs=spec, out_specs=spec, check_vma=False)(arr)
+
+  pad_width[axis] = (0, extra)
+  return jnp.pad(arr, pad_width)
+
+
+def _align_checkpoint_to_model_shapes(ckpt_arr, model_arr, logical_axes=None):
+  """Align ckpt_arr to model_arr's shape and re-shard to model_arr's sharding.
+
+  Per-axis dispatch (driven by ``logical_axes``, the tuple of logical axis names
+  for ``model_arr``):
+
+    - axis name in ``_VLLM_REPEAT_AXES`` (e.g. ``"kv_heads"``): replicate the
+      checkpoint values along that axis with ``jnp.repeat``. For GQA with TP,
+      device ``i`` needs KV head ``i // ratio``, so the correct layout is e.g.
+      ``[h0, h0, h1, h1]`` rather than ``[h0, h1, h0, h1]``. Requires the
+      model dim to be an integer multiple of the checkpoint dim.
+
+    - axis name in ``_VLLM_ZERO_PAD_AXES`` (e.g. ``"mlp_moe"``,
+      ``"activation_mlp"``): append zeros at the end of the axis with
+      ``jnp.pad``. This is the right semantics for MoE MLP-dim padding done by
+      the vLLM adapter to satisfy the GMM_v2 kernel's size constraint.
+
+    - any other axis name (or when ``logical_axes`` is None): fall back to
+      ``jnp.repeat`` if the model dim divides evenly (preserving prior
+      behavior), otherwise raise.
+
+  Logical axis names are defined by the rules in ``configs/base.yml``. New
+  axes that need a non-default expansion semantics must be registered in
+  ``_VLLM_REPEAT_AXES`` or ``_VLLM_ZERO_PAD_AXES`` above.
   """
   ckpt_shape = ckpt_arr.shape
   model_shape = model_arr.shape
@@ -74,27 +155,188 @@ def _expand_checkpoint_to_model_shapes(ckpt_arr, model_arr):
         "If the checkpoint was saved with scan_layers=True (stacked layers), convert it to "
         "unscanned format before loading with vLLM (vllm.yml sets scan_layers=False)."
     )
+  axes = _normalize_logical_axes(logical_axes)
+  if axes is None or len(axes) != len(model_shape):
+    axes = (None,) * len(model_shape)
+
   result = ckpt_arr
-  for axis, (ckpt_dim, model_dim) in enumerate(zip(ckpt_shape, model_shape)):
-    if model_dim % ckpt_dim != 0:
-      raise ValueError(
-          f"Model dimension {model_dim} is not evenly divisible by checkpoint dimension {ckpt_dim}."
-          f" Full shapes — checkpoint: {ckpt_shape}, model: {model_shape}"
-      )
-    if model_dim != ckpt_dim:
+  for axis, (ckpt_dim, model_dim, axis_name) in enumerate(zip(ckpt_shape, model_shape, axes)):
+    if model_dim == ckpt_dim:
+      continue
+    if axis_name in _VLLM_ZERO_PAD_AXES:
+      if model_dim < ckpt_dim:
+        raise ValueError(
+            f"axis {axis} (logical={axis_name!r}): model_dim={model_dim} smaller than "
+            f"ckpt_dim={ckpt_dim}; shapes ckpt={ckpt_shape} model={model_shape}"
+        )
+      result = _zero_pad_axis(result, axis, model_dim - ckpt_dim)
+    elif axis_name in _VLLM_REPEAT_AXES:
+      if model_dim % ckpt_dim != 0:
+        raise ValueError(
+            f"axis {axis} (logical={axis_name!r}): model_dim={model_dim} not divisible by "
+            f"ckpt_dim={ckpt_dim}; shapes ckpt={ckpt_shape} model={model_shape}"
+        )
+      result = jnp.repeat(result, model_dim // ckpt_dim, axis=axis)
+    else:
+      if model_dim % ckpt_dim != 0:
+        raise ValueError(
+            f"Cannot align axis {axis} (logical={axis_name!r}): model_dim={model_dim} not "
+            f"divisible by ckpt_dim={ckpt_dim}, and axis is not registered in _VLLM_REPEAT_AXES "
+            f"({sorted(str(x) for x in _VLLM_REPEAT_AXES)}) or "
+            f"_VLLM_ZERO_PAD_AXES ({sorted(str(x) for x in _VLLM_ZERO_PAD_AXES)}). "
+            f"Full shapes ckpt={ckpt_shape} model={model_shape}"
+        )
       result = jnp.repeat(result, model_dim // ckpt_dim, axis=axis)
   return jax.device_put(result, model_arr.sharding)
 
 
+def _fuse_moe_weights(ckpt_tree, model_arrays_tree):
+  """Fuse separate wi_0/wi_1 checkpoint entries into a single wi when model uses fused layout.
+
+  This properly interleaves the gate and up projections based on the target tensor
+  parallelism (TP) sharding, ensuring that each device receives its respective
+  slice of both wi_0 and wi_1. It also applies any necessary MLP-dim padding
+  on a per-shard basis to satisfy kernel constraints.
+  """
+
+  def _is_fusion_site(node):
+    """A ckpt-side dict that holds wi_0/wi_1 leaf siblings — the parent of a fusion."""
+    return (
+        isinstance(node, dict)
+        and "wi_0" in node
+        and "wi_1" in node
+        and not isinstance(node["wi_0"], dict)
+        and not isinstance(node["wi_1"], dict)
+    )
+
+  def _key_str(key):
+    if hasattr(key, "key"):
+      return key.key
+    if hasattr(key, "attr"):
+      return key.attr
+    return key
+
+  def _lookup_model(path):
+    node = model_arrays_tree
+    for key in path:
+      name = _key_str(key)
+      if isinstance(node, dict) and name in node:
+        node = node[name]
+      else:
+        return None
+    return node
+
+  def _maybe_fuse(path, ckpt_node):
+    if not _is_fusion_site(ckpt_node):
+      return ckpt_node
+    model_node = _lookup_model(path)
+    if not isinstance(model_node, dict) or "wi" not in model_node:
+      return ckpt_node
+
+    wi_model = model_node["wi"]
+    axis = wi_model.ndim - 1
+
+    # Determine the number of shards (TP degree) along the concatenated axis
+    n_shards = 1
+    sharding = getattr(wi_model, "sharding", None)
+    if isinstance(sharding, jax.sharding.NamedSharding):
+      spec = sharding.spec
+      partition = spec[axis] if axis < len(spec) else None
+      n_shards = _partition_size(partition, sharding.mesh)
+
+    # Target size for a single half (wi_0 or wi_1) AFTER padding
+    target_half_dim = wi_model.shape[-1] // 2
+
+    # Helper to pad per-shard and reshape for interleaving
+    def _pad_and_chunk(arr, target_total_size):
+      shape = arr.shape
+      current_total_size = shape[-1]
+
+      # Calculate per-shard chunk sizes
+      chunk_size = current_total_size // n_shards
+      target_chunk_size = target_total_size // n_shards
+      pad_amount = target_chunk_size - chunk_size
+
+      # Reshape to expose the per-shard chunk: (..., n_shards, chunk_size)
+      arr_reshaped = arr.reshape(*shape[:-1], n_shards, chunk_size)
+
+      # Pad each chunk individually if necessary
+      if pad_amount > 0:
+        pad_widths = [(0, 0)] * arr_reshaped.ndim
+        pad_widths[-1] = (0, pad_amount)
+        arr_reshaped = jnp.pad(arr_reshaped, pad_widths)
+
+      return arr_reshaped
+
+    # Apply per-shard padding and chunking
+    padded_chunked_wi_0 = _pad_and_chunk(ckpt_node["wi_0"], target_half_dim)
+    padded_chunked_wi_1 = _pad_and_chunk(ckpt_node["wi_1"], target_half_dim)
+
+    # Concatenate along the inner chunk dimension to interleave the shards
+    # Shape becomes: (..., n_shards, target_chunk_size * 2)
+    wi_interleaved = jnp.concatenate([padded_chunked_wi_0, padded_chunked_wi_1], axis=-1)
+
+    # Flatten the n_shards dimension back out to match the final model shape, drop wi_0/wi_1.
+    new_node = {k: v for k, v in ckpt_node.items() if k not in ("wi_0", "wi_1")}
+    new_node["wi"] = wi_interleaved.reshape(*wi_model.shape)
+    return new_node
+
+  return jax.tree_util.tree_map_with_path(_maybe_fuse, ckpt_tree, is_leaf=_is_fusion_site)
+
+
+def _partition_size(partition, mesh):
+  """Total mesh-axis size used to shard a single tensor axis.
+
+  ``partition`` is a single PartitionSpec entry: ``None`` (unsharded), a single
+  mesh-axis name (str), or a tuple of mesh-axis names.
+  """
+  if partition is None:
+    return 1
+  names = (partition,) if isinstance(partition, str) else tuple(partition)
+  size = 1
+  for n in names:
+    size *= mesh.shape[n]
+  return size
+
+
+def _stored_shape_evenly_shardable(restore_arg, stored_shape):
+  """Whether the restore_arg's NamedSharding evenly partitions the stored shape.
+
+  When True, we can load the checkpoint with the model's logical sharding intact
+  (each device receives only its local slice), avoiding the multi-GB replicated
+  fanout that fully-replicated loading produces for large MoE weights.
+  """
+  sharding = restore_arg.sharding
+  if not isinstance(sharding, jax.sharding.NamedSharding):
+    return False
+  spec = sharding.spec
+  for axis_idx, dim in enumerate(stored_shape):
+    partition = spec[axis_idx] if axis_idx < len(spec) else None
+    if dim % _partition_size(partition, sharding.mesh) != 0:
+      return False
+  return True
+
+
 def _fix_restore_args_for_shape_mismatch(restore_args, stored_metadata_tree, mesh):
-  """Use replicated sharding for arrays whose checkpoint shape differs from the model shape.
+  """Adjust restore_args for arrays whose checkpoint shape differs from the model shape.
 
   When the model is initialized with padded shapes (e.g. KV heads padded to match
-  TP size) but the checkpoint was saved with smaller shapes, Orbax will reject the
-  restore because the provided sharding is incompatible with the stored shape.
-  For those arrays we switch to a fully-replicated sharding and clear global_shape
-  so Orbax loads the array as-written.  _expand_checkpoint_to_model_shapes then
-  expands and re-shards the loaded arrays to match the model.
+  TP size, or MoE MLP dim padded for the GMM_v2 kernel) but the checkpoint was
+  saved with smaller shapes, Orbax will reject the restore because the provided
+  ``global_shape`` is incompatible with the stored shape.
+
+  Two cases:
+
+  1. **Stored shape divides evenly across the model's NamedSharding** (typical
+     for MoE MLP-dim padding: stored 768 / TP=4 = 192). Keep the model's
+     sharding and pass the stored shape so Orbax loads each device's local
+     slice directly — no replicated fanout.
+     ``_align_checkpoint_to_model_shapes`` then pads each local shard.
+
+  2. **Stored shape doesn't divide evenly** (typical for KV-head padding:
+     stored 2 KV heads / TP=8 = 0.25). Fall back to fully-replicated loading
+     and let alignment expand-then-reshard. This matches the original behavior
+     and is required for correctness when sharded loading is impossible.
 
   Uses tree_map_with_path so each ArrayRestoreArgs is looked up by path in the
   metadata dict — avoids ordering/count mismatches from flattening two trees with
@@ -121,7 +363,8 @@ def _fix_restore_args_for_shape_mismatch(restore_args, stored_metadata_tree, mes
         return None
     return node
 
-  mismatched_paths = []
+  mismatched_paths_sharded = []
+  mismatched_paths_replicated = []
   rank_mismatched_paths = []
   missing_paths = []  # paths in model that are absent from the checkpoint tree
   found_array_count = [0]
@@ -136,6 +379,7 @@ def _fix_restore_args_for_shape_mismatch(restore_args, stored_metadata_tree, mes
     if _is_orbax_array_metadata(stored_meta):
       stored_shape = tuple(stored_meta.shape)
       if restore_arg.global_shape is not None and restore_arg.global_shape != stored_shape:
+        # Check for scanned vs unscanned rank mismatch
         if len(stored_shape) != len(restore_arg.global_shape):
           rank_mismatched_paths.append(
               f"  {'.'.join(_key_str(k) for k in path)}: "
@@ -143,10 +387,14 @@ def _fix_restore_args_for_shape_mismatch(restore_args, stored_metadata_tree, mes
               f"vs model shape {restore_arg.global_shape} (rank {len(restore_arg.global_shape)})"
           )
         else:
-          mismatched_paths.append(
-              f"  {'.'.join(_key_str(k) for k in path)}: stored={stored_shape} -> model={restore_arg.global_shape}"
-          )
+          # Handle the shape mismatch logic for padding/sharding
           found_array_count[0] += 1
+          path_str = f"  {'.'.join(_key_str(k) for k in path)}: stored={stored_shape} -> model={restore_arg.global_shape}"
+          if _stored_shape_evenly_shardable(restore_arg, stored_shape):
+            mismatched_paths_sharded.append(path_str)
+            return dataclasses.replace(restore_arg, global_shape=stored_shape, shape=stored_shape)
+
+          mismatched_paths_replicated.append(path_str)
           return dataclasses.replace(
               restore_arg, global_shape=None, shape=None, sharding=replicated, mesh=None, mesh_axes=None
           )
@@ -155,6 +403,7 @@ def _fix_restore_args_for_shape_mismatch(restore_args, stored_metadata_tree, mes
     return restore_arg
 
   fixed = jax.tree_util.tree_map_with_path(_fix_one, restore_args, is_leaf=lambda x: isinstance(x, ocp.ArrayRestoreArgs))
+
   if rank_mismatched_paths:
     sample = "\n".join(rank_mismatched_paths[:5])
     more = f"\n  ... and {len(rank_mismatched_paths) - 5} more" if len(rank_mismatched_paths) > 5 else ""
@@ -181,10 +430,16 @@ def _fix_restore_args_for_shape_mismatch(restore_args, stored_metadata_tree, mes
         f"scan_layers setting.\nExample missing paths:\n{sample}{more}"
     )
 
-  if mismatched_paths:
+  if mismatched_paths_sharded:
     max_logging.log(
-        f"Checkpoint shape mismatches ({len(mismatched_paths)} arrays): loading with replicated "
-        "sharding and expanding to model shape after restore.\n" + "\n".join(mismatched_paths)
+        f"Checkpoint shape mismatches ({len(mismatched_paths_sharded)} arrays): loading sharded at "
+        "stored shape and padding each local shard after restore.\n" + "\n".join(mismatched_paths_sharded)
+    )
+  if mismatched_paths_replicated:
+    max_logging.log(
+        f"Checkpoint shape mismatches ({len(mismatched_paths_replicated)} arrays): loading with replicated "
+        "sharding (stored shape not evenly partitionable across mesh) and expanding after restore.\n"
+        + "\n".join(mismatched_paths_replicated)
     )
   return fixed
 
@@ -634,6 +889,20 @@ def from_pretrained(
           )
           restore_args = {"base": restore_args} if has_base_key else restore_args
 
+        # Free memory used by initial sharded_state before restore, to make room for the incoming checkpoint arrays.
+        def _free_device_memory(node):
+          if isinstance(node, nnx.Variable) and not isinstance(node, nnx.RngState):
+            val = node.value
+          else:
+            val = node
+
+          if isinstance(val, jax.Array) and not val.is_deleted():
+            val.delete()
+
+          return node
+
+        jax.tree_util.tree_map(_free_device_memory, sharded_state, is_leaf=lambda n: isinstance(n, nnx.Variable))
+
         restored = ckptr.restore(
             epath.Path(config.load_parameters_path),
             item=item_to_restore,
@@ -657,6 +926,18 @@ def from_pretrained(
               sharded_state,
               is_leaf=lambda n: isinstance(n, nnx.Variable),
           )
+          # ``specs`` (nnx.get_partition_spec(abstract_state) at the top of from_pretrained)
+          # is the source of truth for logical axis names — it's the input to
+          # nn.logical_to_mesh_sharding.  Each leaf is a PartitionSpec whose entries are
+          # logical axis names (or None / nested tuples).  Reuse it for repeat/zero-pad
+          # dispatch in _align_checkpoint_to_model_shapes.
+          # nnx.get_partition_spec returns Variables wrapping PartitionSpecs at the leaves;
+          # unwrap to raw PartitionSpecs so _normalize_logical_axes can read them.
+          logical_axes_tree = jax.tree.map(
+              lambda v: v.value,
+              specs,
+              is_leaf=lambda n: isinstance(n, nnx.Variable),
+          )
 
           def to_dict(tree):
             if hasattr(tree, "items"):
@@ -665,22 +946,7 @@ def from_pretrained(
 
           model_arrays = to_dict(model_arrays)
           checkpoint = to_dict(checkpoint)
-
-          def _fuse_moe_weights(ckpt_tree, model_arrays_tree):
-            if not hasattr(ckpt_tree, "items") or not hasattr(model_arrays_tree, "items"):
-              return ckpt_tree
-            new_ckpt = {}
-            for k, v in ckpt_tree.items():
-              if k in ("wi_0", "wi_1") and "wi" in model_arrays_tree:
-                continue
-              new_ckpt[k] = _fuse_moe_weights(v, model_arrays_tree.get(k, {}))
-
-            if "wi" in model_arrays_tree and "wi_0" in ckpt_tree and "wi_1" in ckpt_tree:
-              wi_0 = ckpt_tree["wi_0"]
-              wi_1 = ckpt_tree["wi_1"]
-              new_ckpt["wi"] = np.concatenate([wi_0, wi_1], axis=-1)
-
-            return new_ckpt
+          logical_axes_tree = to_dict(logical_axes_tree)
 
           checkpoint = _fuse_moe_weights(checkpoint, model_arrays)
           # Release the raw restored buffers now that wi_0/wi_1 have been fused (if needed).
@@ -694,7 +960,20 @@ def from_pretrained(
             return {k: _filter_to_model_keys(ckpt[k], model[k]) for k in model if k in ckpt}
 
           checkpoint = _filter_to_model_keys(checkpoint, model_arrays)
-          checkpoint = jax.tree.map(_expand_checkpoint_to_model_shapes, checkpoint, model_arrays)
+
+          def _walk_align(ckpt, model_arr, axes):
+            if isinstance(ckpt, dict):
+              return {
+                  k: _walk_align(
+                      v,
+                      model_arr[k],
+                      axes.get(k) if isinstance(axes, dict) else None,
+                  )
+                  for k, v in ckpt.items()
+              }
+            return _align_checkpoint_to_model_shapes(ckpt, model_arr, axes)
+
+          checkpoint = _walk_align(checkpoint, model_arrays, logical_axes_tree)
           nnx.update(model, checkpoint)
         else:
           raise ValueError(

--- a/tests/unit/model_creation_utils_test.py
+++ b/tests/unit/model_creation_utils_test.py
@@ -21,10 +21,12 @@ from unittest.mock import MagicMock, patch
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import flax.linen as nn
 from flax import nnx
 from jax.sharding import Mesh
 from orbax import checkpoint as ocp
+import pytest
 
 from flax.training import train_state
 from maxtext.configs import pyconfig
@@ -32,7 +34,13 @@ from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TR
 from maxtext.models import models
 from maxtext.utils import maxtext_utils
 from maxtext.utils import model_creation_utils
-from maxtext.utils.model_creation_utils import _fix_restore_args_for_shape_mismatch
+from maxtext.utils.model_creation_utils import (
+    _align_checkpoint_to_model_shapes,
+    _fix_restore_args_for_shape_mismatch,
+    _fuse_moe_weights,
+    _stored_shape_evenly_shardable,
+    _zero_pad_axis,
+)
 from tests.utils.test_helpers import get_test_config_path, get_decoupled_parallelism_overrides
 
 
@@ -95,35 +103,67 @@ def _make_mesh(config):
   return Mesh(devices_array, config.mesh_axes)
 
 
+@pytest.mark.tpu_only
 class FixRestoreArgsRankGuardTest(unittest.TestCase):
-  """_fix_restore_args_for_shape_mismatch must not touch args when stored rank != model rank."""
+  """_fix_restore_args_for_shape_mismatch must dispatch correctly on rank/divisibility.
+
+  Two distinct outcomes for a same-rank shape mismatch:
+    - stored shape divides evenly across the original NamedSharding's mesh axes:
+      keep the model's sharding and load at stored shape (Orbax sees each device's
+      local slice — no replicated fanout). global_shape becomes stored_shape.
+    - otherwise: fall back to fully-replicated load (global_shape cleared).
+  Rank mismatch is short-circuited unchanged regardless.
+  """
 
   def setUp(self):
     self.mesh = jax.sharding.Mesh(jax.local_devices()[:1], ("x",))
 
-  def _run_fix(self, stored_shape, model_shape):
-    restore_args = {"kernel": _make_restore_arg(model_shape)}
+  def _run_fix(self, stored_shape, model_shape, sharding=None):
+    arg = _make_restore_arg(model_shape)
+    if sharding is not None:
+      arg = dataclasses.replace(arg, sharding=sharding)
+    restore_args = {"kernel": arg}
     metadata_tree = {"kernel": _FakeArrayMetadata(shape=stored_shape)}
     return _fix_restore_args_for_shape_mismatch(restore_args, metadata_tree, self.mesh)
 
   def test_scanned_ckpt_unscanned_model_raises_error(self):
     """Rank mismatch (scanned ckpt rank 4 vs unscanned model rank 3): arg must be unchanged."""
-    # Simulates: scanned checkpoint key kernel (94, 4096, 4, 128) vs vLLM model (4096, 64, 128).
-    stored_shape = (94, 4096, 4, 128)
-    model_shape = (4096, 64, 128)
+    # Simulates: scanned checkpoint key kernel (94, 256, 4, 128) vs vLLM model (256, 64, 128).
+    stored_shape = (94, 256, 4, 128)
+    model_shape = (256, 64, 128)
     with self.assertRaises(ValueError) as cm:
       self._run_fix(stored_shape, model_shape)
     self.assertIn("Checkpoint rank mismatches detected", str(cm.exception))
 
-  def test_same_rank_shape_mismatch_is_modified(self):
-    """Same rank, shape mismatch (KV padding): arg should be switched to replicated."""
-    # Simulates: unscanned checkpoint (4096, 4, 128) vs padded model (4096, 64, 128).
-    stored_shape = (4096, 4, 128)
-    model_shape = (4096, 64, 128)
+  def test_same_rank_shape_mismatch_divisible_keeps_sharding(self):
+    """Same rank, shape mismatch, stored shape divisible by sharding: keep sharding at stored shape."""
+    # 1-device mesh trivially divides any stored shape, so this hits the sharded path.
+    stored_shape = (256, 4, 128)
+    model_shape = (256, 64, 128)
     fixed = self._run_fix(stored_shape, model_shape)
     arg = fixed["kernel"]
-    # global_shape must be cleared (set to None) so Orbax loads the stored shape as-is.
+    # New path: global_shape carries the stored shape; original sharding is preserved.
+    self.assertEqual(arg.global_shape, stored_shape)
+    self.assertIsInstance(arg.sharding, jax.sharding.NamedSharding)
+
+  def test_same_rank_shape_mismatch_indivisible_falls_back_to_replicated(self):
+    """Stored dim not divisible by mesh axis size: fall back to fully-replicated."""
+    if jax.device_count() < 2:
+      self.skipTest("Requires >=2 devices to construct an indivisible mesh axis.")
+    devices = jax.local_devices()[:2]
+    multi_mesh = jax.sharding.Mesh(devices, ("x",))
+    sharding = jax.sharding.NamedSharding(multi_mesh, jax.sharding.PartitionSpec(None, "x", None))
+    # stored axis 1 = 3, mesh "x" = 2 -> 3 % 2 != 0 -> can't shard, must replicate.
+    stored_shape = (256, 3, 128)
+    model_shape = (256, 4, 128)
+    arg = dataclasses.replace(_make_restore_arg(model_shape), sharding=sharding)
+    fixed = _fix_restore_args_for_shape_mismatch(
+        {"kernel": arg}, {"kernel": _FakeArrayMetadata(shape=stored_shape)}, multi_mesh
+    )
+    arg = fixed["kernel"]
+    # Replicated fallback: global_shape cleared, sharding swapped to fully-replicated.
     self.assertIsNone(arg.global_shape)
+    self.assertEqual(arg.sharding.spec, jax.sharding.PartitionSpec())
 
   def test_same_shape_no_modification(self):
     """Identical shapes: arg must be unchanged."""
@@ -132,13 +172,306 @@ class FixRestoreArgsRankGuardTest(unittest.TestCase):
     arg = fixed["kernel"]
     self.assertEqual(arg.global_shape, shape)
 
-  def test_scanned_both_same_rank_shape_mismatch_is_modified(self):
-    """Scanned ckpt + scanned model + KV padding (rank 4 both): arg must be modified."""
-    stored_shape = (94, 4096, 4, 128)
-    model_shape = (94, 4096, 64, 128)
+  def test_scanned_both_same_rank_shape_mismatch_divisible_keeps_sharding(self):
+    """Scanned ckpt + scanned model + KV padding, divisible stored shape: keep sharding."""
+    stored_shape = (94, 256, 4, 128)
+    model_shape = (94, 256, 64, 128)
     fixed = self._run_fix(stored_shape, model_shape)
     arg = fixed["kernel"]
-    self.assertIsNone(arg.global_shape)
+    self.assertEqual(arg.global_shape, stored_shape)
+
+
+@pytest.mark.tpu_only
+class TestAlignCheckpointToModelShapes(unittest.TestCase):
+  """_align_checkpoint_to_model_shapes must dispatch on logical axis names.
+
+  Two distinct semantics must be preserved:
+    - kv_heads → jnp.repeat (each KV head is replicated across query heads on TP shards).
+    - mlp_moe / activation_mlp → jnp.pad with zeros at the end (MoE GMM_v2 kernel padding).
+  """
+
+  def test_no_op_when_shapes_match(self):
+    """Identical shapes: arr is returned unchanged (modulo device_put)."""
+    ckpt = jnp.arange(8, dtype=jnp.float32).reshape(2, 4)
+    model = jnp.zeros((2, 4), dtype=jnp.float32)
+    out = _align_checkpoint_to_model_shapes(ckpt, model, ("a", "b"))
+    np.testing.assert_array_equal(np.asarray(out), np.asarray(ckpt))
+
+  def test_kv_heads_repeat_layout(self):
+    """KV-head axis must use jnp.repeat: [h0, h0, h1, h1], NOT [h0, h1, h0, h1]."""
+    # Distinguishable per-head values so the layout assertion is unambiguous.
+    ckpt = jnp.array(
+        [
+            [[1.0, 1.0], [2.0, 2.0]],  # embed=0: kv_head_0=[1,1], kv_head_1=[2,2]
+            [[3.0, 3.0], [4.0, 4.0]],  # embed=1: kv_head_0=[3,3], kv_head_1=[4,4]
+        ],
+        dtype=jnp.float32,
+    )
+    model = jnp.zeros((2, 4, 2), dtype=jnp.float32)
+    out = _align_checkpoint_to_model_shapes(ckpt, model, ("embed", "kv_heads", "kv_head_dim"))
+    out_np = np.asarray(out)
+    self.assertEqual(out_np.shape, (2, 4, 2))
+    # kv_heads axis layout for embed=0 must be [h0, h0, h1, h1]:
+    np.testing.assert_array_equal(out_np[0, 0], [1.0, 1.0])
+    np.testing.assert_array_equal(out_np[0, 1], [1.0, 1.0])
+    np.testing.assert_array_equal(out_np[0, 2], [2.0, 2.0])
+    np.testing.assert_array_equal(out_np[0, 3], [2.0, 2.0])
+
+  def test_mlp_moe_zero_pads_at_end_wi_0(self):
+    """mlp_moe axis must zero-pad at the end (not repeat) — wi_0/wi_1 last-axis case."""
+    ckpt = jnp.ones((2, 4, 6), dtype=jnp.float32)  # exp=2, embed=4, mlp=6
+    model = jnp.zeros((2, 4, 8), dtype=jnp.float32)  # mlp padded to 8
+    out = _align_checkpoint_to_model_shapes(ckpt, model, ("exp", "embed_moe", "mlp_moe"))
+    out_np = np.asarray(out)
+    self.assertEqual(out_np.shape, (2, 4, 8))
+    # First 6 cols preserved as ones; last 2 cols are zeros.
+    np.testing.assert_array_equal(out_np[..., :6], np.ones((2, 4, 6), dtype=np.float32))
+    np.testing.assert_array_equal(out_np[..., 6:], np.zeros((2, 4, 2), dtype=np.float32))
+
+  def test_mlp_moe_zero_pads_at_end_wo(self):
+    """wo has the MLP dim on axis 1 — zero-pad at the end of axis 1."""
+    ckpt = jnp.ones((2, 6, 4), dtype=jnp.float32)
+    model = jnp.zeros((2, 8, 4), dtype=jnp.float32)
+    out = _align_checkpoint_to_model_shapes(ckpt, model, ("exp", "mlp_moe", "embed_moe"))
+    out_np = np.asarray(out)
+    self.assertEqual(out_np.shape, (2, 8, 4))
+    np.testing.assert_array_equal(out_np[:, :6, :], np.ones((2, 6, 4), dtype=np.float32))
+    np.testing.assert_array_equal(out_np[:, 6:, :], np.zeros((2, 2, 4), dtype=np.float32))
+
+  def test_activation_mlp_zero_pads_bias(self):
+    """activation_mlp axis (bias arrays) must also zero-pad at the end."""
+    ckpt = jnp.ones((2, 6), dtype=jnp.float32)
+    model = jnp.zeros((2, 8), dtype=jnp.float32)
+    out = _align_checkpoint_to_model_shapes(ckpt, model, ("exp", "activation_mlp"))
+    out_np = np.asarray(out)
+    np.testing.assert_array_equal(out_np[:, :6], np.ones((2, 6), dtype=np.float32))
+    np.testing.assert_array_equal(out_np[:, 6:], np.zeros((2, 2), dtype=np.float32))
+
+  def test_unknown_axis_divisible_falls_back_to_repeat(self):
+    """Unknown axis with divisible dims preserves prior repeat behavior (backward compat)."""
+    ckpt = jnp.array([1.0, 2.0], dtype=jnp.float32)
+    model = jnp.zeros((4,), dtype=jnp.float32)
+    out = _align_checkpoint_to_model_shapes(ckpt, model, ("unknown_axis",))
+    np.testing.assert_array_equal(np.asarray(out), [1.0, 1.0, 2.0, 2.0])
+
+  def test_unknown_axis_non_divisible_raises(self):
+    """Unknown axis with non-divisible dims must raise a clear error pointing at the axis."""
+    ckpt = jnp.ones((3,), dtype=jnp.float32)
+    model = jnp.zeros((4,), dtype=jnp.float32)
+    with self.assertRaisesRegex(ValueError, "not registered in _VLLM_REPEAT_AXES"):
+      _align_checkpoint_to_model_shapes(ckpt, model, ("unknown_axis",))
+
+  def test_logical_axes_none_falls_back_to_repeat(self):
+    """When logical_axes is None, divisible dims default to repeat (legacy behavior)."""
+    ckpt = jnp.array([1.0, 2.0], dtype=jnp.float32)
+    model = jnp.zeros((4,), dtype=jnp.float32)
+    out = _align_checkpoint_to_model_shapes(ckpt, model, None)
+    np.testing.assert_array_equal(np.asarray(out), [1.0, 1.0, 2.0, 2.0])
+
+  def test_kv_heads_non_divisible_raises(self):
+    """kv_heads axis with non-divisible dims raises (jnp.repeat is undefined here)."""
+    ckpt = jnp.ones((4, 3, 2), dtype=jnp.float32)
+    model = jnp.zeros((4, 4, 2), dtype=jnp.float32)
+    with self.assertRaisesRegex(ValueError, "kv_heads"):
+      _align_checkpoint_to_model_shapes(ckpt, model, ("embed", "kv_heads", "kv_head_dim"))
+
+  def test_rank_mismatch_raises(self):
+    """Different ranks (scanned vs unscanned ckpt) must raise the helpful message."""
+    ckpt = jnp.ones((4, 4, 2), dtype=jnp.float32)
+    model = jnp.zeros((2, 4, 4, 2), dtype=jnp.float32)
+    with self.assertRaisesRegex(ValueError, "different ranks"):
+      _align_checkpoint_to_model_shapes(ckpt, model, ("scan", "embed", "kv_heads", "kv_head_dim"))
+
+
+@pytest.mark.tpu_only
+class TestFuseMoeWeights(unittest.TestCase):
+  """_fuse_moe_weights must zero-pad each half BEFORE concatenation when MLP-dim padding applies.
+
+  Otherwise zeros land between wi_0's data and wi_1's data, corrupting the boundary.
+  """
+
+  def test_no_op_when_model_has_unfused_wi(self):
+    """If model has wi_0/wi_1 (not fused), the helper returns the ckpt tree unchanged."""
+    ckpt = {"wi_0": np.ones((2, 4, 3), dtype=np.float32), "wi_1": 2 * np.ones((2, 4, 3), dtype=np.float32)}
+    model = {"wi_0": np.zeros((2, 4, 3), dtype=np.float32), "wi_1": np.zeros((2, 4, 3), dtype=np.float32)}
+    out = _fuse_moe_weights(ckpt, model)
+    self.assertIn("wi_0", out)
+    self.assertIn("wi_1", out)
+    self.assertNotIn("wi", out)
+
+  def test_fuse_without_mlp_padding(self):
+    """When ckpt and model halves match, simple concat (no padding inserted)."""
+    wi_0 = np.ones((2, 4, 3), dtype=np.float32)
+    wi_1 = 2 * np.ones((2, 4, 3), dtype=np.float32)
+    ckpt = {"wi_0": wi_0, "wi_1": wi_1}
+    # Model has fused wi of last-dim 6 = 2 * 3 (no MLP padding).
+    model = {"wi": np.zeros((2, 4, 6), dtype=np.float32)}
+    out = _fuse_moe_weights(ckpt, model)
+    self.assertEqual(out["wi"].shape, (2, 4, 6))
+    np.testing.assert_array_equal(out["wi"][..., :3], wi_0)
+    np.testing.assert_array_equal(out["wi"][..., 3:], wi_1)
+
+  def test_fuse_with_mlp_padding_pads_each_half(self):
+    """With MLP padding, each half must be zero-padded BEFORE concatenation.
+
+    Result must be ``[wi_0_data | 0 | wi_1_data | 0]`` (zeros at the end of each half),
+    NOT ``[wi_0_data | wi_1_data | 0 | 0]`` (zeros only at the very tail).
+    """
+    wi_0 = np.ones((2, 4, 3), dtype=np.float32)
+    wi_1 = 2 * np.ones((2, 4, 3), dtype=np.float32)
+    ckpt = {"wi_0": wi_0, "wi_1": wi_1}
+    # Model has fused wi of last-dim 8 = 2 * 4 (each half padded from 3 → 4).
+    model = {"wi": np.zeros((2, 4, 8), dtype=np.float32)}
+    out = _fuse_moe_weights(ckpt, model)
+    self.assertEqual(out["wi"].shape, (2, 4, 8))
+    # First half: wi_0_data (3 cols) then 1 col of zeros.
+    np.testing.assert_array_equal(out["wi"][..., :3], wi_0)
+    np.testing.assert_array_equal(out["wi"][..., 3:4], np.zeros((2, 4, 1), dtype=np.float32))
+    # Second half: wi_1_data (3 cols) then 1 col of zeros.
+    np.testing.assert_array_equal(out["wi"][..., 4:7], wi_1)
+    np.testing.assert_array_equal(out["wi"][..., 7:8], np.zeros((2, 4, 1), dtype=np.float32))
+
+  def test_recurses_through_nested_dicts(self):
+    """The helper should walk arbitrary nested dicts and only fuse at MoE blocks."""
+    wi_0 = np.ones((2, 4, 3), dtype=np.float32)
+    wi_1 = 2 * np.ones((2, 4, 3), dtype=np.float32)
+    other = np.full((2, 4), 7.0, dtype=np.float32)
+    ckpt = {"layers": {"0": {"moe": {"wi_0": wi_0, "wi_1": wi_1}, "other": other}}}
+    model = {"layers": {"0": {"moe": {"wi": np.zeros((2, 4, 6), dtype=np.float32)}, "other": other}}}
+    out = _fuse_moe_weights(ckpt, model)
+    self.assertEqual(out["layers"]["0"]["moe"]["wi"].shape, (2, 4, 6))
+    np.testing.assert_array_equal(out["layers"]["0"]["other"], other)
+
+
+@pytest.mark.tpu_only
+class TestShardedZeroPad(unittest.TestCase):
+  """Covers the per-shard zero-pad path that avoids the replicated-fanout OOM.
+
+  Without this path, large MoE checkpoints loaded through the shape-mismatch
+  fallback in ``_fix_restore_args_for_shape_mismatch`` were forced to land as
+  full replicas on every TP device. ``_stored_shape_evenly_shardable`` decides
+  when the model's NamedSharding can carry the stored shape directly (no
+  replication), and ``_zero_pad_axis`` then expands each local shard via
+  ``shard_map`` instead of materializing a global replicated tensor.
+  """
+
+  def test_evenly_shardable_true_when_stored_dim_divides_mesh_axis(self):
+    devices = jax.local_devices()[:1]
+    mesh = jax.sharding.Mesh(devices, ("model",))
+    sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None, "model", None))
+    restore_arg = _make_restore_arg((128, 1024, 2048))
+    restore_arg = dataclasses.replace(restore_arg, sharding=sharding)
+    # 1-device mesh: any stored dim trivially divides 1.
+    self.assertTrue(_stored_shape_evenly_shardable(restore_arg, (128, 768, 2048)))
+
+  def test_evenly_shardable_false_when_stored_dim_indivisible(self):
+    if jax.device_count() < 2:
+      self.skipTest("Requires >=2 devices to construct a non-trivial mesh size.")
+    devices = jax.local_devices()[:2]
+    mesh = jax.sharding.Mesh(devices, ("model",))
+    sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None, "model", None))
+    restore_arg = _make_restore_arg((128, 8, 2048))
+    restore_arg = dataclasses.replace(restore_arg, sharding=sharding)
+    # stored_shape[1]=3 is not divisible by mesh "model"=2 -> must fall back to replicated.
+    self.assertFalse(_stored_shape_evenly_shardable(restore_arg, (128, 3, 2048)))
+
+  def test_zero_pad_axis_no_op_when_extra_zero(self):
+    arr = jnp.ones((2, 4, 2), dtype=jnp.float32)
+    self.assertIs(_zero_pad_axis(arr, axis=1, extra=0), arr)
+
+  def test_zero_pad_axis_unsharded_falls_back_to_global_pad(self):
+    # Unsharded input -> jnp.pad (zeros at the global tail of the axis).
+    arr = jnp.ones((2, 4, 2), dtype=jnp.float32)
+    out = _zero_pad_axis(arr, axis=1, extra=2)
+    out_np = np.asarray(out)
+    self.assertEqual(out_np.shape, (2, 6, 2))
+    np.testing.assert_array_equal(out_np[:, :4, :], np.ones((2, 4, 2), dtype=np.float32))
+    np.testing.assert_array_equal(out_np[:, 4:, :], np.zeros((2, 2, 2), dtype=np.float32))
+
+  def test_zero_pad_axis_sharded_pads_each_local_shard(self):
+    """Per-shard layout: zeros land at the tail of *each* shard, not the global tail.
+
+    Mathematically equivalent to the global-tail layout under matmul along the
+    padded axis with a matching pad on the consuming weight (the MoE wi/wo + GMM_v2
+    case). The point of this test is to lock in the *layout invariant*: per-shard
+    tails are zero, per-shard heads preserve the original ckpt slice.
+    """
+    if jax.device_count() < 4:
+      self.skipTest("Requires >=4 devices to exercise the sharded pad path with TP=4.")
+    devices = jax.local_devices()[:4]
+    mesh = jax.sharding.Mesh(devices, ("model",))
+    spec = jax.sharding.PartitionSpec(None, "model", None)
+    sharding = jax.sharding.NamedSharding(mesh, spec)
+
+    ckpt_np = np.arange(2 * 8 * 2, dtype=np.float32).reshape(2, 8, 2)
+    arr = jax.device_put(jnp.asarray(ckpt_np), sharding)
+
+    out = _zero_pad_axis(arr, axis=1, extra=4)  # 8 -> 12, 4 shards -> +1 zero per shard
+    out_np = np.asarray(out)
+    self.assertEqual(out_np.shape, (2, 12, 2))
+
+    for s in range(4):
+      # Per-shard head holds the original ckpt slice [s*2:s*2+2].
+      for i in range(2):
+        np.testing.assert_array_equal(out_np[:, s * 3 + i, :], ckpt_np[:, s * 2 + i, :])
+      # Per-shard tail is zero.
+      np.testing.assert_array_equal(out_np[:, s * 3 + 2, :], np.zeros((2, 2), dtype=np.float32))
+
+
+@pytest.mark.tpu_only
+class TestPartitionSpecUnwrapForAlignment(unittest.TestCase):
+  """Locks in the runtime extraction path used by from_pretrained.
+
+  ``nnx.get_partition_spec`` returns a tree whose leaves are ``nnx.Variable``
+  objects wrapping ``PartitionSpec`` values, not raw ``PartitionSpec``s.
+  Without unwrapping, ``_normalize_logical_axes`` returns ``None`` for every
+  leaf, the per-axis dispatch falls back to divisibility-based repeat, and MoE
+  MLP-dim padding (e.g. ``mlp_moe`` 768 → 1024) raises because 1024 is not a
+  multiple of 768. This test fails on the unwrapped value path and asserts
+  ``_align_checkpoint_to_model_shapes`` then dispatches into ``_ZERO_PAD_AXES``.
+  """
+
+  def test_unwrap_yields_partition_spec_and_enables_zero_pad(self):
+    class _TinyMoE(nnx.Module):
+
+      def __init__(self, rngs: nnx.Rngs):
+        self.wo = nnx.Param(
+            jax.random.normal(rngs.params(), (2, 6, 4), dtype=jnp.float32),
+            sharding=("exp", "mlp_moe", "embed_moe"),
+        )
+
+    # flax >= 0.12 requires an active mesh + logical_axis_rules to construct
+    # a Variable annotated with logical sharding names.
+    devices = jax.local_devices()[:1]
+    mesh = jax.sharding.Mesh(devices, ("x",), axis_types=(jax.sharding.AxisType.Explicit,))
+    rules = (("exp", None), ("mlp_moe", None), ("embed_moe", None))
+    with jax.sharding.set_mesh(mesh), nn.logical_axis_rules(rules):
+      module = nnx.eval_shape(lambda: _TinyMoE(nnx.Rngs(params=0)))
+
+    _, abstract_state = nnx.split(module)
+    specs = nnx.get_partition_spec(abstract_state)
+
+    # Mirror the unwrap done in from_pretrained.
+    logical_axes_tree = jax.tree.map(
+        lambda v: v.value,
+        specs,
+        is_leaf=lambda n: isinstance(n, nnx.Variable),
+    )
+
+    # Walk to the wo leaf (nnx.State is dict-like).
+    wo_axes = logical_axes_tree["wo"]
+    self.assertIsInstance(wo_axes, jax.sharding.PartitionSpec)
+    self.assertNotIsInstance(wo_axes, nnx.Variable)
+    self.assertEqual(tuple(wo_axes), ("exp", "mlp_moe", "embed_moe"))
+
+    # End-to-end: leaf must drive zero-pad dispatch on axis 1 (mlp_moe).
+    ckpt = jnp.ones((2, 4, 4), dtype=jnp.float32)
+    model = jnp.zeros((2, 6, 4), dtype=jnp.float32)
+    out = _align_checkpoint_to_model_shapes(ckpt, model, wo_axes)
+    out_np = np.asarray(out)
+    self.assertEqual(out_np.shape, (2, 6, 4))
+    np.testing.assert_array_equal(out_np[:, :4, :], np.ones((2, 4, 4), dtype=np.float32))
+    np.testing.assert_array_equal(out_np[:, 4:, :], np.zeros((2, 2, 4), dtype=np.float32))
 
 
 class TestGetTransformerModel(unittest.TestCase):


### PR DESCRIPTION
This PR adds support for TP using `tpu-inference` GMM_V2 kernel. 

To do this, we add logic to pad the MLP dimension of MoE kernels to the closest power of 2 that satisfies the divisibility constraint of the GMM_V2 kernel. Additionally, we add logic to `model_creation_utils.py` to correctly handle the padding case when loading a model checkpoint for inference. 

# Tests

E2E runs with `vllm_decode.py`. E2E GRPO runs. New unit tests to validate the logic in `model_creation_utils.py`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
