### PR TITLE
RL with vllm-native support (qwen3 converter)

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1820,6 +1820,7 @@ class VLLM(BaseModel):
       description="Overrides for HuggingFace model config for MaxText model.",
   )
   vllm_hf_config_path: str = Field("", description="Path to HuggingFace model config for MaxText model.")
+  use_standalone_converter: bool = Field(False, description="Use the standalone MaxText->torchax vLLM converter")
 
 
 class RL(BaseModel):

--- a/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
@@ -1,0 +1,209 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MaxText-specific VllmSampler and VllmRollout subclasses.
+
+These replace the Tunix built-in key-mapping path with model-specific
+MaxText to vLLM converters, which handle:
+  - QKV fusion with GQA interleaving (attention)
+  - MoE expert gate+up fusion (w13_weight chunk-interleaved for TP)
+  - MoE gate / down transpose
+  - Layer-norm and LM-head transposes
+"""
+
+from typing import Any, Optional, Tuple
+
+import gc
+import logging
+import time
+import jax
+from flax import nnx
+from pathwaysutils.experimental import reshard as _experimental_reshard
+from tunix.generate import mappings
+from tunix.generate.vllm_sampler import VllmConfig, VllmSampler
+from tunix.rl.rollout import base_rollout, vllm_rollout
+
+from maxtext.integration.vllm.torchax_converter.qwen3_moe import Qwen3MaxTextToVLLMConverter
+
+
+def _create_model_converter(model_name: str, config: Any, mesh: jax.sharding.Mesh):
+  """Instantiate the converter for a MaxText model name."""
+  if model_name in {"qwen3-30b-a3b", "qwen3-30b-a3b-base", "qwen3-235b-a22b"}:
+    return Qwen3MaxTextToVLLMConverter(config=config, mesh=mesh)
+
+  raise ValueError(f"No MaxText->vLLM converter registered for model {model_name!r}.")
+
+
+class MaxTextVllmSampler(VllmSampler):
+  """VllmSampler that delegates weight updates to a MaxText to vLLM converter.
+
+  When a converter is supplied, update_params bypasses transfer_state_with_mappings
+  entirely and instead runs converter.convert() followed by a direct device_put
+  into the vLLM model-runner state dict.  If no converter is supplied the base-class
+  behaviour is preserved, so this class is safe to use as a drop-in replacement.
+  """
+
+  def __init__(
+      self,
+      tokenizer: Any,
+      config: VllmConfig,
+      converter: Any = None,
+  ):
+    super().__init__(tokenizer=tokenizer, config=config)
+    self._converter = converter
+
+  def update_params(
+      self,
+      updated_weights,
+      filter_types: Optional[Tuple[Any, ...]] = None,
+  ):
+    """Update the vLLM runner weights from a MaxText state tree."""
+    if self._converter is None:
+      super().update_params(updated_weights, filter_types)
+      return None
+
+    del filter_types
+
+    # delete kv_cache
+    if self.llm is not None:
+      self.llm.reset_prefix_cache()
+      self.llm.collective_rpc("delete_kv_cache")  # will free hbm
+    elif self._driver is not None:
+      self._driver.llm_engine.reset_prefix_cache()
+      self._driver.llm_engine.collective_rpc("delete_kv_cache")
+
+    # Perform explicit garbage collection and synchronization to free up HBM memory before loading new weights
+    gc.collect()
+    jax.effects_barrier()
+
+    logging.info("MaxTextVllmSampler.update_params: starting converter.convert()...")
+    vllm_state = self._converter.convert(updated_weights)
+    jax.block_until_ready(vllm_state)
+
+    logging.info("MaxTextVllmSampler.update_params: converter.convert() done, %d weights to assign", len(vllm_state))
+    model_runner_state = self.transformer_state
+
+    logging.info("Weight sync: using pathwaysutils experimental_reshard")
+
+    keys = list(vllm_state.keys())
+    start_time = time.time()
+    for i, key in enumerate(keys):
+      weight = vllm_state.pop(key)  # free immediately to avoid accumulating all weights in RAM
+      weight_array = (
+          weight.value if hasattr(weight, "value") else weight
+      )  # handle both jnp arrays and ShardedDeviceArrays
+      weight_shape_matches = weight_array.shape == model_runner_state[key].shape
+      assert (
+          weight_shape_matches
+      ), f"Shape mismatch for {key}: converter produced {weight_array.shape}, expected {model_runner_state[key].shape}"
+      # logging.info(f"{key}: mt {weight_array.shape} -> vllm {model_runner_state[key].shape}: {weight_shape_matches}")
+      target_sharding = model_runner_state[key].sharding
+      model_runner_state[key] = _experimental_reshard.reshard(
+          weight_array,
+          target_sharding,
+          donate=True,
+          may_alias=None,
+          cache_resharding_plans=True,
+      )
+      del weight, weight_array  # release TPU buffer before pushing back to device
+      # Periodically flush async ops and GC to prevent host RAM accumulation.
+      if i % 16 == 15:
+        jax.effects_barrier()
+        gc.collect()
+    jax.effects_barrier()
+    gc.collect()
+    end_time = time.time()
+    logging.info("MaxTextVllmSampler.update_params: all weights assigned in %.4f seconds", end_time - start_time)
+
+    # reinitialize kv_cache
+    if self.llm is not None:
+      self.llm.collective_rpc("reinitialize_kv_cache")
+    elif self._driver is not None:
+      self._driver.llm_engine.collective_rpc("reinitialize_kv_cache")
+
+    return None
+
+
+class MaxTextVllmRollout(vllm_rollout.VllmRollout):
+  """VllmRollout that uses MaxTextVllmSampler for weight synchronisation.
+
+  The extra `maxtext_config` argument is forwarded to the model-specific converter
+  together with `mesh`.  All other arguments mirror VllmRollout.__init__.
+
+  Usage (direct):
+      rollout = MaxTextVllmRollout(
+          rollout_actor=tunix_model,
+          tokenizer=tokenizer,
+          mesh=mesh,
+          rollout_config=rollout_config,
+          maxtext_config=maxtext_config,   # <-- new
+      )
+
+  Usage via RLCluster (recommended):
+      cluster_config = ClusterConfig(
+          ...
+          rollout_engine=functools.partial(MaxTextVllmRollout, maxtext_config=maxtext_config),
+          ...
+      )
+  """
+
+  def __init__(
+      self,
+      rollout_actor: Any,
+      tokenizer: Any,
+      mesh: jax.sharding.Mesh,
+      rollout_config: base_rollout.RolloutConfig,
+      maxtext_config: Any,
+      cache_config_or_size: base_rollout.CacheConfig | int = None,
+  ):  # pylint: disable=super-init-not-called,too-many-positional-arguments
+    # RLCluster's custom-class path doesn't pass cache_config_or_size; fall
+    # back to the value embedded in rollout_config.
+    if cache_config_or_size is None:
+      cache_config_or_size = rollout_config.kv_cache_size
+
+    converter = _create_model_converter(maxtext_config.model_name, config=maxtext_config, mesh=mesh)
+
+    mapping_config = mappings.MappingConfig.build(
+        mapping_obj=rollout_config.rollout_mapping_config,
+        model=rollout_actor,
+        backend="vllm_jax",
+    )
+    self._sampler = MaxTextVllmSampler(
+        tokenizer=tokenizer,
+        config=VllmConfig(  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+            mesh=mesh,
+            hbm_utilization=rollout_config.rollout_vllm_hbm_utilization,
+            init_with_random_weights=rollout_config.rollout_vllm_init_with_random_weights,
+            tpu_backend_type=rollout_config.rollout_vllm_tpu_backend_type,
+            mapping_config=mapping_config,
+            lora_config=rollout_config.rollout_vllm_lora_config,
+            server_mode=rollout_config.rollout_vllm_server_mode,
+            tensor_parallel_size=rollout_config.tensor_parallel_size,
+            data_parallel_size=rollout_config.data_parallel_size,
+            enable_dp_attention=rollout_config.rollout_vllm_enable_dp_attention,
+            engine_kwargs={
+                "max_model_len": cache_config_or_size,
+                "model": rollout_config.rollout_vllm_model_version,
+                "swap_space": rollout_config.rollout_vllm_swap_space_size_gb,
+                # Async scheduling causes KeyError in dp_scheduler on slow models
+                # (30B+) where inference latency exceeds the scheduler's window.
+                "async_scheduling": rollout_config.rollout_vllm_async_scheduling,
+            },
+        ),
+        converter=converter,
+    )
+
+    # Initial weight sync: run the converter so vLLM starts with real weights.
+    state = nnx.state(rollout_actor)
+    self._sampler.load_checkpoint(state)

--- a/src/maxtext/integration/vllm/torchax_converter/__init__.py
+++ b/src/maxtext/integration/vllm/torchax_converter/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/maxtext/integration/vllm/torchax_converter/base.py
+++ b/src/maxtext/integration/vllm/torchax_converter/base.py
@@ -1,0 +1,70 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared base classes for MaxText to vLLM converters."""
+
+import logging
+import time
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+
+GREEN = "\033[92m"
+RESET = "\033[0m"
+
+
+@contextmanager
+def timer(name):
+  start = time.perf_counter()
+  yield
+  end = time.perf_counter()
+  print(f"{name} took {end - start:.4f} seconds")
+
+
+class BaseMaxTextToVLLMConverter(ABC):
+  """Shared converter contract for MaxText to vLLM weight conversion."""
+
+  def __init__(self, config, mesh):
+    self.config = config
+    self.mesh = mesh
+    self.num_layers = config.base_num_decoder_layers
+    self.vllm_tp = self.config.rollout_tensor_parallelism
+    self.vllm_state = {}
+
+  def convert(self, model_state: dict):
+    """Convert a MaxText model state into vLLM weight tensors."""
+    logging.info("\n%sStarting Conversion...%s", GREEN, RESET)
+    self.vllm_state = {}
+
+    with timer("Convert Global Weights"):
+      self._convert_global(model_state)
+
+    with timer("Convert Attention Weights"):
+      self._convert_attn(model_state)
+
+    with timer("Convert MoE Weights"):
+      self._convert_moe(model_state)
+
+    return self.vllm_state
+
+  @abstractmethod
+  def _convert_global(self, params):
+    """Convert non-layered weights."""
+
+  @abstractmethod
+  def _convert_attn(self, params):
+    """Convert attention weights."""
+
+  @abstractmethod
+  def _convert_moe(self, params):
+    """Convert MLP/MoE weights."""

--- a/src/maxtext/integration/vllm/torchax_converter/qwen3_moe.py
+++ b/src/maxtext/integration/vllm/torchax_converter/qwen3_moe.py
@@ -1,0 +1,240 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3 MaxText to vLLM weight converters."""
+
+import functools
+import gc
+import logging
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import PyTree
+
+from maxtext.integration.vllm.torchax_converter.base import BaseMaxTextToVLLMConverter
+
+
+class Qwen3MaxTextToVLLMConverter(BaseMaxTextToVLLMConverter):
+  """Qwen3-specific MaxText to vLLM converter."""
+
+  def _convert_global(self, params):
+    logging.info("_convert_global: embed_tokens...")
+    self._to_embed_tokens(params)
+    logging.info("_convert_global: final_norm...")
+    self._to_final_norm(params)
+    logging.info("_convert_global: lm_head...")
+    self._to_lm_head(params)
+    logging.info("_convert_global: done")
+
+  def _convert_attn(self, params):
+    logging.info("_convert_attn: pre_self_attention_layer_norm...")
+    pre_ln = params["base"]["decoder"]["layers"]["pre_self_attention_layer_norm"]["scale"]
+    convert_pre_ln = self._transpose_unstack(pre_ln)
+    assert len(convert_pre_ln) == self.num_layers, f"Expected {self.num_layers} layers, got {len(convert_pre_ln)}"
+    for i, layer in enumerate(convert_pre_ln):
+      self.vllm_state[f"vllm_model.model.layers.{i}.input_layernorm.weight"] = layer
+    del convert_pre_ln
+
+    logging.info("_convert_attn: post_self_attention_layer_norm...")
+    post_ln = params["base"]["decoder"]["layers"]["post_self_attention_layer_norm"]["scale"]
+    converted_post_ln = self._transpose_unstack(post_ln)
+    assert len(converted_post_ln) == self.num_layers, f"Expected {self.num_layers} layers, got {len(converted_post_ln)}"
+    for i, layer in enumerate(converted_post_ln):
+      self.vllm_state[f"vllm_model.model.layers.{i}.post_attention_layernorm.weight"] = layer
+    del post_ln, converted_post_ln
+
+    logging.info("_convert_attn: self_attention (qkv/o/norms)...")
+    attn = params["base"]["decoder"]["layers"]["self_attention"]
+    self_attn = self._to_attn(attn)
+    for key, layers in self_attn.items():
+      self.vllm_state.update({f"vllm_model.model.layers.{i}.{key}": layer for i, layer in enumerate(layers)})
+    del attn, self_attn
+    logging.info("_convert_attn: done")
+    gc.collect()
+
+  def _convert_moe(self, params):
+    logging.info("_convert_moe: extracting moe_block...")
+    moe = params["base"]["decoder"]["layers"]["moe_block"].to_pure_dict()
+    prefix = "vllm_model.model.layers"
+
+    logging.info("_convert_moe: gate weights...")
+    self.vllm_state.update(
+        {f"{prefix}.{i}.mlp.gate.weight": weight for i, weight in enumerate(self._to_mlp_gate(moe["gate"]["kernel"]))}
+    )
+    del moe["gate"]
+    gc.collect()
+
+    logging.info("_convert_moe: expert down (w2) weights...")
+    self.vllm_state.update(
+        {f"{prefix}.{i}.mlp.experts.w2_weight": weight for i, weight in enumerate(self._to_mlp_expert_down(moe["wo"]))}
+    )
+    del moe["wo"]
+    gc.collect()
+
+    logging.info("_convert_moe: expert gate+up (w13) weights (fuse_all jit+vmap)...")
+    self._to_mlp_expert_gate_up(
+        moe["wi_0"],
+        moe["wi_1"],
+        prefix,
+        "mlp.experts.w13_weight",
+    )
+    del moe["wi_0"], moe["wi_1"], moe
+    logging.info("_convert_moe: done")
+    gc.collect()
+
+  def _to_final_norm(self, params):
+    self.vllm_state["vllm_model.model.norm.weight"] = jnp.array(params["base"]["decoder"]["decoder_norm"]["scale"])
+
+  def _to_embed_tokens(self, params):
+    self.vllm_state["vllm_model.model.embed_tokens.weight"] = jnp.array(params["base"]["token_embedder"]["embedding"])
+
+  def _to_lm_head(self, params):
+    self.vllm_state["vllm_model.lm_head.weight"] = self._transpose_2d(params["base"]["decoder"]["logits_dense"]["kernel"])
+
+  def _to_attn(self, attn: PyTree) -> dict[str, jax.Array]:
+    """Convert MaxText attention parameters into per-layer vLLM weights."""
+    tp = min(self.vllm_tp, self.config.base_num_kv_heads)
+    compute = self._make_attn_compute(tp)
+    return compute(attn)
+
+  @staticmethod
+  @functools.lru_cache(maxsize=8)
+  def _make_attn_compute(tp: int):
+    """Build the cached JIT that packs QKV and output projections for a TP size."""
+
+    @jax.jit
+    def _compute(attn):
+      q = jnp.transpose(attn["query"]["kernel"], (1, 0, 2, 3))
+      k = jnp.transpose(attn["key"]["kernel"], (1, 0, 2, 3))
+      v = jnp.transpose(attn["value"]["kernel"], (1, 0, 2, 3))
+
+      num_q_heads = q.shape[2]
+      num_kv_heads = k.shape[2]
+      head_dim = q.shape[3]
+      num_layers, d_model = q.shape[0], q.shape[1]
+
+      kv_per_tp = num_kv_heads // tp
+      q_per_tp = num_q_heads // tp
+
+      q_by_tp = q.reshape(num_layers, d_model, tp, q_per_tp, head_dim)
+      k_by_tp = k.reshape(num_layers, d_model, tp, kv_per_tp, head_dim)
+      v_by_tp = v.reshape(num_layers, d_model, tp, kv_per_tp, head_dim)
+
+      qkv_by_tp = jnp.concatenate([q_by_tp, k_by_tp, v_by_tp], axis=3)
+      qkv_flat = qkv_by_tp.reshape(num_layers, d_model, -1)
+      qkv_proj = jnp.transpose(qkv_flat, (0, 2, 1))
+
+      o = jnp.transpose(attn["out"]["kernel"], (1, 3, 0, 2))
+      o_proj = o.reshape(o.shape[0], o.shape[1], -1)
+
+      q_norm = jnp.transpose(attn["query_norm"]["scale"], (1, 0))
+      k_norm = jnp.transpose(attn["key_norm"]["scale"], (1, 0))
+
+      return {
+          "self_attn.qkv_proj.weight": jnp.unstack(qkv_proj),
+          "self_attn.o_proj.weight": jnp.unstack(o_proj),
+          "self_attn.q_norm.weight": jnp.unstack(q_norm),
+          "self_attn.k_norm.weight": jnp.unstack(k_norm),
+      }
+
+    return _compute
+
+  def _to_mlp_gate(self, param):
+    param = self._transpose_gate(param)
+    return self._unstack_layer(param)
+
+  def _to_mlp_expert_down(self, param):
+    param = self._transpose_expert_down(param)
+    param = jnp.transpose(param, (0, 1, 3, 2))
+    return self._unstack_layer(param)
+
+  def _to_mlp_expert_gate_up(self, wi_0, wi_1, layer_key_prefix, layer_key_suffix):
+    """Fuse MoE gate and up projections into the vLLM `w13` layout."""
+    fuse_all = self._make_fuse_all(self.vllm_tp)
+
+    logging.info("_to_mlp_expert_gate_up: dispatching _fuse_all (single JIT+vmap)...")
+    fused = fuse_all(wi_0, wi_1)
+    logging.info(
+        "_to_mlp_expert_gate_up: _fuse_all complete, shape=%s, unstacking layers...",
+        fused.shape,
+    )
+    del wi_0, wi_1
+    gc.collect()
+
+    for i, layer_i in enumerate(jnp.unstack(fused, axis=0)):
+      layer_i = jnp.transpose(layer_i, (0, 2, 1))
+      self.vllm_state[f"{layer_key_prefix}.{i}.{layer_key_suffix}"] = layer_i
+      if i % 8 == 7:
+        gc.collect()
+    del fused
+    gc.collect()
+
+  @staticmethod
+  @functools.lru_cache(maxsize=8)
+  def _make_fuse_all(tp: int):
+    """Build the cached JIT that fuses all expert gate and up weights."""
+
+    @jax.jit
+    def _fuse_all(wi_0, wi_1):
+      wi_0 = jnp.transpose(wi_0, (1, 0, 2, 3))
+      wi_1 = jnp.transpose(wi_1, (1, 0, 2, 3))
+
+      def _fuse_single(w0, w1):
+        # [e, d_model, d_inner] -> [e, 2*padded_chunk_size*tp, d_model]
+        w0 = jnp.transpose(w0, (0, 2, 1))
+        w1 = jnp.transpose(w1, (0, 2, 1))
+        num_experts, d_inner, d_model = w0.shape
+        chunk_size = d_inner // tp
+        # Pad each TP chunk to the next multiple of 128 for TPU GMM alignment,
+        # matching process_w13_for_gmm in tpu_inference.
+        # Example: d_inner=768 gives chunk=192 -> 256 with tp=4, or 96 -> 128 with tp=8.
+        padded_chunk_size = ((chunk_size + 127) // 128) * 128
+        pad_amount = padded_chunk_size - chunk_size
+        gate_chunks = w0.reshape(num_experts, tp, chunk_size, d_model)
+        up_chunks = w1.reshape(num_experts, tp, chunk_size, d_model)
+        if pad_amount > 0:
+          gate_chunks = jnp.pad(gate_chunks, ((0, 0), (0, 0), (0, pad_amount), (0, 0)))
+          up_chunks = jnp.pad(up_chunks, ((0, 0), (0, 0), (0, pad_amount), (0, 0)))
+        combined = jnp.stack([gate_chunks, up_chunks], axis=2)
+        return combined.reshape(num_experts, 2 * padded_chunk_size * tp, d_model)
+
+      return jax.vmap(_fuse_single)(wi_0, wi_1)
+
+    return _fuse_all
+
+  @staticmethod
+  @jax.jit
+  def _unstack_layer(param):
+    """Split a stacked layer tensor into a tuple of per-layer tensors."""
+    return jnp.unstack(param, axis=0)
+
+  @staticmethod
+  @jax.jit
+  def _transpose_unstack(x):
+    return jnp.unstack(jnp.transpose(x, (1, 0)))
+
+  @staticmethod
+  @jax.jit
+  def _transpose_2d(x):
+    return jnp.transpose(x, (1, 0))
+
+  @staticmethod
+  @jax.jit
+  def _transpose_gate(param):
+    return jnp.transpose(param, (1, 2, 0))
+
+  @staticmethod
+  @jax.jit
+  def _transpose_expert_down(param):
+    return jnp.transpose(param, (1, 0, 3, 2))

--- a/src/maxtext/integration/vllm/torchax_converter/validate_converter.py
+++ b/src/maxtext/integration/vllm/torchax_converter/validate_converter.py
@@ -1,0 +1,185 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate MaxText to vLLM weight conversion for supported models.
+
+This module provides a config-driven validation entrypoint that:
+1. loads a MaxText model from a standard MaxText config,
+2. converts its weights into the vLLM layout,
+3. loads the matching vLLM model, and
+4. assigns the converted weights before running a short generation check.
+
+	python -m maxtext.integration.vllm.torchax_converter.validate_converter \
+			src/maxtext/configs/base.yml model_name=qwen3-30b-a3b \
+			tokenizer_type=huggingface tokenizer_path=Qwen/Qwen3-30B-A3B \
+			load_parameters_path=<your_maxtext_checkpoint_path> run_name=qwen3_converter_validation \
+			per_device_batch_size=1 max_prefill_predict_length=8 max_target_length=16 steps=1 \
+			scan_layers=true skip_jax_distributed_system=true weight_dtype=bfloat16 \
+			attention=dot_product remat_policy=custom decoder_layer_input=offload \
+			query_proj=offload key_proj=offload value_proj=offload \
+			rollout_tensor_parallelism=4 hbm_utilization_vllm=0.6 async_scheduling=false \
+			prompt="Paris is" hf_access_token=<token>
+
+Currently this validator supports qwen3 converter flows.
+"""
+
+import functools
+import gc
+import logging
+import os
+from typing import Sequence
+
+from absl import app
+import jax
+from flax import nnx
+from vllm import LLM
+from vllm import SamplingParams
+
+from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE
+from maxtext.configs import pyconfig
+from maxtext.integration.vllm.torchax_converter.base import GREEN
+from maxtext.integration.vllm.torchax_converter.base import RESET
+from maxtext.integration.vllm.torchax_converter.base import timer
+from maxtext.integration.vllm.torchax_converter.qwen3_moe import Qwen3MaxTextToVLLMConverter
+from maxtext.utils import model_creation_utils
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+
+_JAX_COMPILATION_CACHE_DIR = "/tmp/jax_cache"
+
+vllm_model_name_mapping = {
+    "qwen3-30b-a3b": "Qwen/Qwen3-30B-A3B",
+    "qwen3-30b-a3b-base": "Qwen/Qwen3-30B-A3B",
+    "qwen3-235b-a22b": "Qwen/Qwen3-235B-A22B",
+    # Add more mappings as needed
+}
+
+
+def _setup_jax_compilation_cache():
+  jax.config.update("jax_compilation_cache_dir", _JAX_COMPILATION_CACHE_DIR)
+  jax.config.update("jax_persistent_cache_min_entry_size_bytes", -1)
+  jax.config.update("jax_persistent_cache_min_compile_time_secs", 0)
+  jax.config.update("jax_enable_compilation_cache", True)
+
+
+def _setup_vllm_environment():
+  os.environ["SKIP_JAX_PRECOMPILE"] = "1"
+  os.environ["JAX_RANDOM_WEIGHTS"] = "False"
+  os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+
+
+def _clean_device_memory():
+  logging.info("Cleaning JAX device memory...")
+  gc.collect()
+  for array in jax.live_arrays():
+    array.delete()
+  logging.info("Device memory cleanup complete.")
+
+
+def _get_maxtext_model(config):
+  logging.info("Creating model with config: %s", config)
+  model, mesh = model_creation_utils.from_pretrained(
+      config,
+      model_mode=MODEL_MODE_AUTOREGRESSIVE,
+  )
+  return model, mesh
+
+
+def validate_converter(config) -> None:
+  """Run end-to-end validation for MaxText to vLLM weight conversion."""
+  if not config.model_name.startswith("qwen3"):
+    raise ValueError("validate_converter.py currently supports qwen3 models only. " f"Got {config.model_name}.")
+
+  model, mesh = _get_maxtext_model(config)
+  print(f"{GREEN}MaxText model loaded successfully{RESET}")
+  print(f"Model: {config.model_name}")
+  print(f"Mesh: {mesh}")
+
+  print("=" * 80)
+  print("Converting weights to vLLM format")
+  print("=" * 80)
+  model_state = {"base": nnx.state(model)}
+  for path, leaf in jax.tree_util.tree_flatten_with_path(model_state)[0]:
+    if hasattr(leaf, "shape") and hasattr(leaf, "sharding"):
+      path_str = jax.tree_util.keystr(path)
+      logging.info("Name: %s, shape: %s", path_str, leaf.shape)
+      logging.info("\tSharding: %s", leaf.sharding)
+
+  converter = Qwen3MaxTextToVLLMConverter(config, mesh)
+  with timer("Overall Conversion"):
+    vllm_state = converter.convert(model_state)
+  del model_state
+  gc.collect()
+
+  print("=" * 80)
+  print("Loading vLLM model for generation test...")
+  print("=" * 80)
+  llm = LLM(
+      model=vllm_model_name_mapping[config.model_name],
+      max_model_len=config.max_target_length,
+      tensor_parallel_size=config.rollout_tensor_parallelism,
+      gpu_memory_utilization=getattr(config, "hbm_utilization_vllm", 0.5),
+      async_scheduling=getattr(config, "async_scheduling", False),
+  )
+  print("\n" + "=" * 80)
+  llm_state = llm.llm_engine.model_executor.driver_worker.model_runner.state
+
+  any_src = next(iter(vllm_state.values()))
+  any_src_arr = any_src.value if hasattr(any_src, "value") else any_src
+  any_dst = next(iter(llm_state.values()))
+  same_devices = frozenset(device.id for device in any_src_arr.sharding.mesh.devices.flat) == frozenset(
+      device.id for device in any_dst.sharding.mesh.devices.flat
+  )
+  logging.info(
+      "Weight sync: same_devices=%s (jit=%s, device_put=%s)",
+      same_devices,
+      same_devices,
+      not same_devices,
+  )
+
+  @functools.lru_cache(maxsize=None)
+  def _get_reshard_fn(dst_sharding):
+    if same_devices:
+      return jax.jit(lambda x: x, out_shardings=dst_sharding)
+    return functools.partial(jax.device_put, device=dst_sharding)
+
+  with timer(f"Assigning {len(vllm_state)} weights to vLLM model"):
+    for key, weight in vllm_state.items():
+      weight_array = weight.value if hasattr(weight, "value") else weight
+      dst_sharding = llm_state[key].sharding
+      assert (
+          llm_state[key].shape == weight_array.shape
+      ), f"Shape mismatch for {key}: expected {llm_state[key].shape}, got {weight_array.shape}"
+      llm_state[key] = _get_reshard_fn(dst_sharding)(weight_array)
+
+  sampling_params = SamplingParams(temperature=0.0, max_tokens=10)
+  prompt = getattr(config, "prompt", "Paris is")
+  print("\n" + "=" * 80)
+  print("Generation test after weight transfer:")
+  with timer("Generation"):
+    print(llm.generate(prompt, sampling_params=sampling_params))
+
+
+def main(argv: Sequence[str]) -> None:
+  print(f"JAX devices: {jax.devices()}")
+  _setup_jax_compilation_cache()
+  _setup_vllm_environment()
+  _clean_device_memory()
+
+  config = pyconfig.initialize(argv)
+  validate_converter(config)
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -62,6 +62,7 @@ from flax import nnx
 from orbax import checkpoint as ocp
 from pprint import pprint
 from transformers import AutoTokenizer
+import functools
 from tunix.rl import rl_cluster as rl_cluster_lib
 from tunix.rl.rollout import base_rollout
 from tunix.rl.grpo.grpo_learner import GrpoConfig, GrpoLearner
@@ -71,6 +72,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "0"
 
 from maxtext.configs import pyconfig
 from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.integration.vllm.maxtext_vllm_rollout import MaxTextVllmRollout
 from maxtext.trainers.post_train.rl.evaluate_rl import evaluate
 from maxtext.trainers.post_train.rl import utils_rl
 from maxtext.input_pipeline.instruction_data_processing import load_data_template_from_file
@@ -362,6 +364,12 @@ def create_rl_components(
   argv_list = ["", str(vllm_config_path), "log_config=False"]
   vllm_config = pyconfig.initialize(argv_list)
 
+  rl_rollout_engine = (
+      functools.partial(MaxTextVllmRollout, maxtext_config=trainer_config)
+      if trainer_config.use_standalone_converter
+      else "vllm"
+  )
+
   cluster_config = rl_cluster_lib.ClusterConfig(
       role_to_mesh={
           rl_cluster_lib.Role.ACTOR: actor_mesh,
@@ -373,7 +381,7 @@ def create_rl_components(
           rl_cluster_lib.Role.REFERENCE: trainer_config.logical_axis_rules,
           rl_cluster_lib.Role.ROLLOUT: vllm_config.logical_axis_rules,
       },
-      rollout_engine="vllm",
+      rollout_engine=rl_rollout_engine,
       offload_to_cpu=False,
       training_config=rl_cluster_lib.RLTrainingConfig(
           actor_optimizer=optimizer,


### PR DESCRIPTION
# Description

Implement/refactor MaxText to vLLM weight conversion into a reusable converter style:

- Introduce `BaseMaxTextToVLLMConverter` as the shared converter class, and isolate the Qwen3-MOE implementation into `torchax_converter/qwen3_moe.py`.
- Add a standalone, config-driven validator module at `maxtext.integration.vllm.torchax_converter.validate_converter` for VM testing and generation-based weight-transfer checks.
- Add a `use_standalone_converter` config flag so RL rollout can explicitly opt into the standalone MaxText to vLLM converter path.
- Update rollout integration to use `MaxTextVllmRollout` with model-specific converter creation instead of importing converter logic from the bench script.
- TP-aware padding to 128x is also added in qwen3 converter `_make_fuse_all`.


# Tests
[requirements](https://paste.googleplex.com/5240747596054528) (tpu-inference/vllm are critical)
[logs](https://paste.googleplex.com/4819117233274880)

Standalone weight sync and decode on a v5p-8 VM:
```
python -m maxtext.integration.vllm.torchax_converter.validate_converter src/maxtext/configs/base.yml model_name=qwen3-30b-a3b tokenizer_type=huggingface tokenizer_path=Qwen/Qwen3-30B-A3B  load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-30b-a3b/scanned/2026-01-23-14-00/0/items/0/items run_name=qwen3_converter_validation per_device_batch_size=1 max_prefill_predict_length=8 max_target_length=16 steps=1 scan_layers=true skip_jax_distributed_system=true weight_dtype=bfloat16 attention=dot_product remat_policy=custom decoder_layer_input=offload query_proj=offload key_proj=offload value_proj=offload rollout_tensor_parallelism=4 hbm_utilization_vllm=0.6 async_scheduling=false prompt=Paris\ is hf_access_token=xxx
```

```
Assigning 435 weights to vLLM model took 0.1711 seconds

================================================================================
Generation test after weight transfer:
Rendering prompts: 100%|█| 1/1 [00:00<00:
Processed prompts:   0%| | 0/1 [00:00<?, /home/hengtaoguo_google_com/projects/venv2/lib/python3.12/site-packages/torchax/tensor.py:167: UserWarning: Explicitly requested dtype int64 requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/jax-ml/jax#current-gotchas for more.
  res = jax_function(self._elem, *args, **kwargs)
WARNING 04-30 04:23:44 [tuned_block_sizes.py:4368] Couldn`t find tuned sizes for the RPA v3 kernel with ('TPU v5', 16, 'q_bfloat16_kv_bfloat16', 'q_head-8_kv_head-1_head-128', 'max_model_len-16-sw-None')
INFO 04-30 04:23:44 [tuned_block_sizes.py:4389] RPA v3 kernel tuned block sizes for ('TPU v5', 16, 'q_bfloat16_kv_bfloat16', 'q_head-8_kv_head-1_head-128', 'max_model_len-16-sw-None'): bkv_p=1, bq=16
Processed prompts: 100%|█| 1/1 [00:06<00:
[RequestOutput(request_id=0, prompt='Paris is', prompt_token_ids=[59604, 374], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text=' the capital of France. It is also the city', token_ids=[279, 6722, 315, 9625, 13, 1084, 374, 1083, 279, 3283], routed_experts=None, cumulative_logprob=None, logprobs=None, finish_reason=length, stop_reason=None)], finished=True, metrics=None, lora_request=None, num_cached_tokens=0)]
Generation took 6.9421 seconds
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
