### PR TITLE
Move cpu tests from n2-16 to n2-32 runners and jupyter notebook tests to v6e-8

### DIFF
--- a/.github/workflows/build_and_test_maxtext.yml
+++ b/.github/workflows/build_and_test_maxtext.yml
@@ -135,9 +135,9 @@ jobs:
         fail-fast: false
     with:
       device_type: tpu
-      device_name: v6e-4
+      device_name: v6e-8
       base_image: maxtext-unit-test-tpu:py312
-      cloud_runner: linux-x86-ct6e-180-4tpu
+      cloud_runner: linux-x86-ct6e-180-8tpu
       maxtext_sha: ${{ needs.build_and_upload_maxtext_package.outputs.maxtext_sha }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/run_jupyter_notebooks.yml
+++ b/.github/workflows/run_jupyter_notebooks.yml
@@ -109,7 +109,7 @@ jobs:
           for notebook in "$MAXTEXT_NOTEBOOKS_ROOT"/{sft,rl}*.ipynb; do
             filename=$(basename "$notebook")
             # TODO: Update runnner to v6e-8 as RL with LLama3.1-8b doesn't fit on v6e-4
-            if [[ "$filename" == "sft_llama3_demo_gpu.ipynb" || "$filename" == "maxtext_with_gepa.ipynb" || "$filename" == "rl_llama3_demo.ipynb" ]]; then
+            if [[ "$filename" == "sft_llama3_demo_gpu.ipynb" || "$filename" == "maxtext_with_gepa.ipynb" ]]; then
               echo "Skipping $filename"
               continue
             fi

--- a/.github/workflows/run_tests_coordinator.yml
+++ b/.github/workflows/run_tests_coordinator.yml
@@ -98,8 +98,8 @@ jobs:
           "tpu-post-training-integration": "linux-x86-ct6e-180-4tpu",
           "gpu-unit": "linux-x86-a2-48-a100-4gpu",
           "gpu-integration": "linux-x86-a2-48-a100-4gpu",
-          "cpu-unit": "linux-x86-n2-16",
-          "cpu-post-training-unit": "linux-x86-n2-16"
+          "cpu-unit": "linux-x86-n2-32",
+          "cpu-post-training-unit": "linux-x86-n2-32"
         }')[inputs.flavor] }}
       # Pytest Marker Mapping
       pytest_marker: >-

--- a/src/maxtext/examples/rl_llama3_demo.ipynb
+++ b/src/maxtext/examples/rl_llama3_demo.ipynb
@@ -247,6 +247,7 @@
     "    f\"chat_template_path={CHAT_TEMPLATE_PATH}\",\n",
     "    f\"load_parameters_path={MODEL_CHECKPOINT_PATH}\",\n",
     "    f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
+    "    \"rollout_tensor_parallelism=4\",\n",
     "    \"debug.rl=True\",\n",
     "    f\"rl.loss_algo={LOSS_ALGO}\",\n",
     "    \"use_pathways=False\",\n",


### PR DESCRIPTION
# Description

Migrate cpu tests from n2-16 to n2-32 runners and jupyter notebook tests to v6e-8

Fixes: [b/506143429](http://b/506143429)

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
