### PR TITLE
[NNX] NNX migration prep (6/N): NNX-native DPO

### DIFF
--- a/src/maxtext/layers/train_state_nnx.py
+++ b/src/maxtext/layers/train_state_nnx.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" The NNX Unified TrainState. """
+"""The NNX Unified TrainState."""
 
 from typing import Any
 
@@ -25,20 +25,34 @@ class TrainStateNNX(nnx.Module):
   This replaces Linen's TrainState for checkpointing.
 
   Linen TrainState pytree:
-    {“params”: {...}, “opt_state”: {}...}
+    {"params": {...}, "opt_state": {}...}
   TrainStateNNX state pytree:
-    {“model”: {...}, “optimizer”: {“opt_state”: {...}}
+    {"model": {...}, "optimizer": {"opt_state": {...}}}
+
+  For DPO (Direct Preference Optimization), an optional `reference_model`
+  carries a frozen copy of the same architecture used to compute reference
+  log-probabilities. Only `model` is updated by `apply_gradients`; the
+  reference is held alongside so it is sharded, jit-traced, and checkpointed
+  with the rest of the train state.
   """
 
-  def __init__(self, model: nnx.Module, optimizer: nnx.Optimizer | None):
+  def __init__(
+      self,
+      model: nnx.Module,
+      optimizer: nnx.Optimizer | None,
+      reference_model: nnx.Module | None = None,
+  ):
     self.model = model
     self.optimizer = optimizer
+    if reference_model is not None:
+      self.reference_model = reference_model
 
   def apply_gradients(self, grads: Any):
     """
     Mimics the Linen apply_gradients function.
     Updates the optimizer state, applies updates to parameters,
-    and increments the step counter.
+    and increments the step counter. Only updates `self.model`;
+    `self.reference_model` (if present) is left untouched.
     """
     if self.optimizer is None:
       raise RuntimeError(

--- a/src/maxtext/trainers/post_train/dpo/dpo_utils.py
+++ b/src/maxtext/trainers/post_train/dpo/dpo_utils.py
@@ -19,6 +19,8 @@ limitations under the License.
 import jax
 import jax.numpy as jnp
 
+from flax import nnx
+
 from maxtext.utils import maxtext_utils
 
 
@@ -132,7 +134,14 @@ def dpo_loss_fn(model, config, data, dropout_rng, params, reference_params, is_t
       - jax.nn.log_sigmoid(-BETA * logratios_delta) * LABEL_SMOOTHING
   )
   total_loss, total_weights = jnp.mean(losses), losses.shape[0]
-  loss = total_loss
+  # Under manual gradient accumulation, return the unnormalized sum: the accumulator
+  # sums per-microbatch grads then divides once by total_weights, so a pre-normalized
+  # mean would scale the gradient down by an extra microbatch-size factor. Tunix GA
+  # expects a normalized per-step loss. Mirrors loss_fn in train.py.
+  if config.gradient_accumulation_steps > 1 and not config.use_tunix_gradient_accumulation:
+    loss = jnp.sum(losses)
+  else:
+    loss = total_loss
 
   moe_lb_loss = 0.0
   if config.num_experts > 1:
@@ -148,6 +157,8 @@ def dpo_loss_fn(model, config, data, dropout_rng, params, reference_params, is_t
       "total_weights": total_weights,
       "moe_lb_loss": moe_lb_loss,
       "reward_accuracy": reward_accuracy,
+      "indexer_loss": 0.0,  # for gradient_accumulation aux pytree compatibility
+      "mtp_loss": 0.0,  # for gradient_accumulation aux pytree compatibility
   }
   return loss, aux
 
@@ -155,3 +166,148 @@ def dpo_loss_fn(model, config, data, dropout_rng, params, reference_params, is_t
 def _merge_dpo_state(state, reference_params):
   """Merge reference parameters back into DPO state."""
   return state.replace(params=dict(state.params, reference_params=reference_params))
+
+
+# NNX DPO has no split/merge counterpart: the Linen path overlays
+# `reference_params` inside `state.params`, so it must be peeled off and
+# reattached around `apply_gradients`. The NNX path holds the reference as a
+# sibling field `TrainStateNNX.reference_model`; `apply_gradients` already
+# only touches `self.model`, so no split/merge is needed.
+
+
+def dpo_loss_fn_nnx(policy_model, config, data, dropout_rng, params, reference_model, is_train=True):
+  """NNX DPO loss_fn for both train and eval.
+
+  Signature mirrors the Linen `dpo_loss_fn` so it slots into the same
+  dispatcher in `gradient_accumulation_loss_and_grad`:
+    `(model, config, data, dropout_rng, params, *extra_dpo_args, is_train=True)`
+
+  Differences from the Linen `dpo_loss_fn`:
+    * `policy_model` is an `nnx.Module` (carries its own params + RNG state).
+    * `dropout_rng` and `params` are unused for NNX (kept positional for
+      signature parity; NNX models manage these internally).
+    * The 6th arg (the `extra_dpo_args[0]`) is a frozen reference
+      `nnx.Module`, not a `reference_params` pytree.
+    * Reference forward is wrapped in `jax.lax.stop_gradient`; combined with
+      `nnx.value_and_grad(..., argnums=0)` over the policy, no gradient flows
+      to the reference's `nnx.Param` leaves.
+
+  Args:
+    policy_model: Policy `nnx.Module` (the model being trained).
+    config: Config of parameters.
+    data: Batch of preference data with `chosen` / `rejected` fields.
+    dropout_rng: Unused for NNX (kept for signature parity with Linen).
+    params: Unused for NNX (kept for signature parity with Linen).
+    reference_model: Frozen reference `nnx.Module` for DPO logratio computation.
+    is_train: True for train_step and False for eval_step.
+
+  Returns:
+    loss: DPO preference loss + MoE load balance loss (if applicable).
+    aux: dict with intermediate_outputs, xent_sum (always 0.0), dpo_loss,
+      total_weights, moe_lb_loss, reward_accuracy.
+  """
+  del dropout_rng, params  # unused for NNX
+  # decimate proportion of data when per_device_batch_size<1
+  if is_train:
+    for k, v in data.items():
+      data[k] = v[: config.micro_batch_size_to_train_on, :]
+
+  # for DPO we don't support packed sequences (they shouldn't be present in the first place)
+  data["chosen_segmentation"] = (data["chosen_segmentation"] == 1).astype(jnp.int32)
+  data["rejected_segmentation"] = (data["rejected_segmentation"] == 1).astype(jnp.int32)
+  data["chosen_position"] = data["chosen_position"] * (data["chosen_segmentation"] == 1)
+  data["rejected_position"] = data["rejected_position"] * (data["rejected_segmentation"] == 1)
+
+  # concatenated policy/reference forward pass
+  inputs = jnp.concatenate([data["chosen"], data["rejected"]], 0)
+  inputs_position = jnp.concatenate([data["chosen_position"], data["rejected_position"]], 0)
+  inputs_segmentation = jnp.concatenate([data["chosen_segmentation"], data["rejected_segmentation"]], 0)
+
+  logits = policy_model(
+      decoder_input_tokens=inputs,
+      decoder_positions=inputs_position,
+      decoder_segment_ids=inputs_segmentation,
+      enable_dropout=config.enable_dropout if is_train else False,
+  )
+  # pop (not snapshot) so sown Intermediates don't persist on the model across
+  # microbatches during gradient accumulation; matches loss_fn in train.py.
+  intermediates = nnx.pop(policy_model, nnx.Intermediate)
+  intermediate_outputs = intermediates.to_pure_dict()
+
+  ref_logits = reference_model(
+      decoder_input_tokens=inputs,
+      decoder_positions=inputs_position,
+      decoder_segment_ids=inputs_segmentation,
+      enable_dropout=False,
+  )
+  ref_logits = jax.lax.stop_gradient(ref_logits)
+
+  # extract token ids, segmentation and logits for chosen and rejected sequences
+  chosen_ids = data["chosen"][..., 1:]
+  rejected_ids = data["rejected"][..., 1:]
+  chosen_segmentation = data["chosen_segmentation"][..., 1:]
+  rejected_segmentation = data["rejected_segmentation"][..., 1:]
+  n_logits = logits.shape[-3] // 2  # [B, S, E] - [batch, sequence, embedding/vocab]
+  chosen_logits, rejected_logits = logits[:n_logits, :, :], logits[n_logits:, :, :]
+  chosen_ref_logits, rejected_ref_logits = ref_logits[:n_logits, :, :], ref_logits[n_logits:, :, :]
+
+  # common subsequence and padding mask
+  common_prefix_mask = jnp.cumsum(chosen_ids != rejected_ids, axis=-1) == 0  # [B, S]
+  valid_seq_mask = (chosen_segmentation != 0) & (rejected_segmentation != 0) & ~common_prefix_mask  # [B, S]
+
+  # compute logratios from the sequence-reduced observed token log-probability
+  chosen_logps_seq = jnp.take_along_axis(  # [B, S]
+      jax.nn.log_softmax(chosen_logits[..., :-1, :], axis=-1), chosen_ids[..., None], axis=-1
+  )[..., 0]
+  chosen_logps = jnp.sum(chosen_logps_seq * valid_seq_mask, axis=-1)  # [B]
+  chosen_ref_logps_seq = jnp.take_along_axis(  # [B, S]
+      jax.nn.log_softmax(chosen_ref_logits[..., :-1, :], axis=-1), chosen_ids[..., None], axis=-1
+  )[..., 0]
+  chosen_ref_logps = jnp.sum(chosen_ref_logps_seq * valid_seq_mask, axis=-1)  # [B]
+  chosen_logratios = chosen_logps - chosen_ref_logps  # [B]
+
+  rejected_logps_seq = jnp.take_along_axis(  # [B, S]
+      jax.nn.log_softmax(rejected_logits[..., :-1, :], axis=-1), rejected_ids[..., None], axis=-1
+  )[..., 0]
+  rejected_logps = jnp.sum(rejected_logps_seq * valid_seq_mask, axis=-1)  # [B]
+  rejected_ref_logps_seq = jnp.take_along_axis(  # [B, S]
+      jax.nn.log_softmax(rejected_ref_logits[..., :-1, :], axis=-1), rejected_ids[..., None], axis=-1
+  )[..., 0]
+  rejected_ref_logps = jnp.sum(rejected_ref_logps_seq * valid_seq_mask, axis=-1)  # [B]
+  rejected_logratios = rejected_logps - rejected_ref_logps  # [B]
+
+  # DPO loss from chosen and rejected logratios
+  LABEL_SMOOTHING, BETA = config.dpo_label_smoothing, config.dpo_beta
+  logratios_delta = BETA * (chosen_logratios - rejected_logratios)  # [B]
+  losses = (  # [B]
+      -jax.nn.log_sigmoid(BETA * logratios_delta) * (1 - LABEL_SMOOTHING)
+      - jax.nn.log_sigmoid(-BETA * logratios_delta) * LABEL_SMOOTHING
+  )
+  total_loss, total_weights = jnp.mean(losses), losses.shape[0]
+  # Under manual gradient accumulation, return the unnormalized sum: the accumulator
+  # sums per-microbatch grads then divides once by total_weights, so a pre-normalized
+  # mean would scale the gradient down by an extra microbatch-size factor. Tunix GA
+  # expects a normalized per-step loss. Mirrors loss_fn in train.py.
+  if config.gradient_accumulation_steps > 1 and not config.use_tunix_gradient_accumulation:
+    loss = jnp.sum(losses)
+  else:
+    loss = total_loss
+
+  moe_lb_loss = 0.0
+  if config.num_experts > 1:
+    moe_lb_losses = maxtext_utils.collect_intermediates_by_suffix(intermediate_outputs, "moe_lb_loss")
+    if moe_lb_losses:
+      moe_lb_loss = jnp.mean(jnp.concatenate(moe_lb_losses))
+      loss += moe_lb_loss
+  reward_accuracy = jnp.mean(chosen_logratios > rejected_logratios)
+  aux = {
+      "intermediate_outputs": intermediate_outputs,
+      "xent_sum": 0.0,  # DPO has no per-token cross-entropy sum; set to 0 for train_step compatibility
+      "dpo_loss": total_loss,  # pure preference loss before MoE lb, analogous to lm_loss in pre-training
+      "total_weights": total_weights,
+      "moe_lb_loss": moe_lb_loss,
+      "reward_accuracy": reward_accuracy,
+      "indexer_loss": 0.0,  # for gradient_accumulation aux pytree compatibility
+      "mtp_loss": 0.0,  # for gradient_accumulation aux pytree compatibility
+  }
+  return loss, aux

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -59,7 +59,7 @@ from maxtext.common.goodput import (
 from maxtext.common.gcloud_stub import vertex_tensorboard_modules
 from maxtext.common import metric_logger
 from maxtext.common.metric_logger import record_activation_metrics
-from maxtext.trainers.post_train.dpo.dpo_utils import _merge_dpo_state, _split_dpo_state, dpo_loss_fn
+from maxtext.trainers.post_train.dpo.dpo_utils import _merge_dpo_state, _split_dpo_state, dpo_loss_fn, dpo_loss_fn_nnx
 from maxtext.utils import exceptions
 from maxtext.utils import gcs_utils
 from maxtext.utils import max_logging
@@ -319,15 +319,15 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
     params = state.params
     ga_fn, ga_model, ga_params, ga_rng, ga_dpo = _loss_fn, model, params, dropout_rng, extra_dpo_args
   else:
-    if config.use_dpo:
-      raise NotImplementedError(
-          "DPO is not yet supported for NNX modules. DPO requires a reference model "
-          "stored alongside the policy model (Linen path uses state.params['reference_params']); "
-          "the NNX TrainState equivalent has not been wired up. As a workaround, set "
-          "pure_nnx=False for DPO runs."
-      )
     state = nnx.merge(model, state)  # reconstruct TrainStateNNX
-    ga_fn, ga_model, ga_params, ga_rng, ga_dpo = loss_fn, state.model, None, None, []
+    if config.use_dpo:
+      # NNX DPO: reference_model is a sibling field on TrainStateNNX (set up by
+      # init_initial_state when config.use_dpo=True). dpo_loss_fn_nnx mirrors
+      # the Linen dpo_loss_fn signature, so it slots into the same dispatcher
+      # with reference_model passed as the single extra_dpo_args entry.
+      ga_fn, ga_model, ga_params, ga_rng, ga_dpo = (dpo_loss_fn_nnx, state.model, None, None, [state.reference_model])
+    else:
+      ga_fn, ga_model, ga_params, ga_rng, ga_dpo = loss_fn, state.model, None, None, []
 
   # --- Gradient computation ---
   if config.gradient_accumulation_steps > 1:
@@ -393,9 +393,14 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
         )
         nnx.update(state.model, curr_params)
 
+      # `ga_fn` and `ga_dpo` were set up earlier (loss_fn vs dpo_loss_fn_nnx;
+      # ga_dpo carries the frozen reference_model when use_dpo, else empty).
+      _nnx_loss_fn = ga_fn
+      _nnx_extra_dpo_args = ga_dpo
+
       def diff_wrapper(param, rest, config, data):
         local_model = nnx.merge(model_graphdef, param, rest, copy=True)
-        loss, aux = loss_fn(local_model, config, data, None, None, is_train=True)
+        loss, aux = _nnx_loss_fn(local_model, config, data, None, None, *_nnx_extra_dpo_args, is_train=True)
         _, _, new_rest = nnx.split(local_model, nnx.Param, ...)
         return loss, (aux, new_rest)
 
@@ -581,7 +586,10 @@ def eval_step(model, config, state, data, dropout_rng=None):
     loss, aux = eval_loss_fn(pure_params, *extra_dpo_args, sparsity_state=batch_stats)
   else:
     state = nnx.merge(model, state)  # reconstruct TrainStateNNX
-    loss, aux = loss_fn(state.model, config, data, None, None, is_train=False)
+    if config.use_dpo:
+      loss, aux = dpo_loss_fn_nnx(state.model, config, data, None, None, state.reference_model, is_train=False)
+    else:
+      loss, aux = loss_fn(state.model, config, data, None, None, is_train=False)
 
   mtp_acceptance_rate = 0.0
   if config.mtp_eval_target_module > 0:
@@ -639,8 +647,8 @@ def train_loop(config, recorder, state=None):
       state_mesh_shardings = _merge_dpo_state(state_mesh_shardings, state_mesh_shardings.params["params"])
     jit_model = model
   else:
-    if config.use_dpo:
-      raise NotImplementedError("DPO is not supported for NNX models.")
+    # NNX keeps the DPO reference model as a sibling field on TrainStateNNX
+    # (set up in init_state_fn), so no reference-param merge is needed here.
     jit_model, state = nnx.split(state)
 
   params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
@@ -709,7 +717,7 @@ def train_loop(config, recorder, state=None):
 
         step_time_delta = datetime.datetime.now() - last_step_completion
 
-        state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]
+        state_to_save = state if not (config.use_dpo and not config.pure_nnx) else _split_dpo_state(state)[0]
         checkpointing.maybe_save_checkpoint(checkpoint_manager, state_to_save, config, data_iterator, step)
 
         if config.dump_hlo and step == (config.dump_step if config.dump_step >= 0 else start_step):
@@ -756,7 +764,7 @@ def train_loop(config, recorder, state=None):
         metric_logger_instance.buffer_and_write_metrics(metrics, step, step_time_delta)
 
     if config.save_checkpoint_on_completion:
-      state_to_save = state if not config.use_dpo else _split_dpo_state(state)[0]
+      state_to_save = state if not (config.use_dpo and not config.pure_nnx) else _split_dpo_state(state)[0]
       checkpointing.maybe_save_checkpoint(checkpoint_manager, state_to_save, config, data_iterator)
     if checkpoint_manager is not None:
       # in case the last checkpoint_period checkpoint is still in progress

--- a/src/maxtext/utils/train_utils.py
+++ b/src/maxtext/utils/train_utils.py
@@ -225,10 +225,16 @@ def setup_train_loop(config, recorder, devices=None):
 
     if config.pure_nnx:
       # For NNX, the train state is wrapped in the TrainStateNNX module.
+      # When DPO is enabled, also materialize a frozen reference model alongside
+      # the policy. Both are constructed by `_create_model_partial()` (which uses
+      # `config.init_weights_seed`), so the reference starts identical to the
+      # policy — standard DPO practice. The reference is later overwritten by
+      # the step-0 checkpoint in `setup_post_setup_state` below.
       def create_train_state_fn():
         model = _create_model_partial()
         optimizer = nnx.Optimizer(model, tx, wrt=nnx.Param)
-        return train_state_nnx.TrainStateNNX(model, optimizer)
+        reference_model = _create_model_partial() if config.use_dpo else None
+        return train_state_nnx.TrainStateNNX(model, optimizer, reference_model=reference_model)
 
       init_state_fn = create_train_state_fn
     else:
@@ -316,8 +322,6 @@ def setup_train_loop(config, recorder, devices=None):
       maxtext_utils.print_shardings_params(state_params, state_mesh_shardings_params, mesh, logical_annotations_params)
 
     if config.use_dpo:
-      if config.pure_nnx:
-        raise NotImplementedError("DPO is not supported yet by NNX models.")
       abstract_state, _, _ = maxtext_utils.get_abstract_state(config, mesh, init_state_fn, is_training)
       max_logging.log(
           "Restoring reference parameters for DPO from" f" '{os.path.join(str(config.checkpoint_dir), str(0))}'"
@@ -342,9 +346,17 @@ def setup_train_loop(config, recorder, devices=None):
       except FileNotFoundError:
         step0_restored = None
       if step0_restored is not None:
-        # TODO: For pure_nnx, the dpo state manipulation is different.
-        reference_params = step0_restored["items"].params["params"]
-        state = _merge_dpo_state(state, reference_params)
+        if config.pure_nnx:
+          # step0_restored["items"] is the flat nnx.State of the step-0 TrainStateNNX
+          # (typically from a non-DPO pre-training run, so its top-level fields are
+          # `model` and `optimizer` — no `reference_model`). Copy its `model` substate
+          # into our current state's `reference_model` slot.
+          step0_state = step0_restored["items"]
+          step0_model_substate = step0_state["model"] if "model" in step0_state else step0_state
+          state["reference_model"] = step0_model_substate
+        else:
+          reference_params = step0_restored["items"].params["params"]
+          state = _merge_dpo_state(state, reference_params)
       else:
         max_logging.log(
             "Could not restore reference parameters for DPO from" f" '{os.path.join(str(config.checkpoint_dir), str(0))}'"

--- a/tests/integration/setup_train_loop_nnx_test.py
+++ b/tests/integration/setup_train_loop_nnx_test.py
@@ -28,6 +28,7 @@ import unittest
 import pytest
 
 import jax
+import jax.numpy as jnp
 from flax import nnx
 
 from maxtext.configs import pyconfig
@@ -126,14 +127,32 @@ class SetupTrainLoopNNXIntegrationTest(unittest.TestCase):
 
     del model
 
-  def test_pure_nnx_dpo_raises_not_implemented(self):
-    """The use_dpo branch (train_utils.py:319-320) must raise for NNX."""
-    # use_dpo requires a few prerequisites; the simplest is to set the flag and
-    # let setup_train_loop reach the NotImplementedError check before the more
-    # involved DPO path runs.
+  def test_pure_nnx_dpo_setup_materializes_reference_model(self):
+    """With use_dpo=True the NNX init_state_fn materializes a frozen reference
+    model alongside the policy (train_utils.py:233-237). Both come from
+    _create_model_partial() with the same init_weights_seed, so absent a step-0
+    checkpoint the reference starts bit-identical to the policy.
+
+    Positive replacement for the removed test_pure_nnx_dpo_raises_not_implemented:
+    NNX DPO is supported now, so setup_train_loop builds the reference instead of
+    raising.
+    """
     config = _tiny_nnx_pyconfig(use_dpo=True, packing=False)
-    with self.assertRaises(NotImplementedError):
-      setup_train_loop(config, recorder=None)
+    *_, train_state = setup_train_loop(config, recorder=None)
+
+    self.assertIsInstance(train_state, train_state_nnx.TrainStateNNX)
+    # The reference is a sibling NNX module, distinct from the policy.
+    self.assertTrue(hasattr(train_state, "reference_model"))
+    self.assertIsInstance(train_state.reference_model, nnx.Module)
+    self.assertIsNot(train_state.reference_model, train_state.model)
+
+    # Same param tree, identical values at init (same seed, no step-0 override).
+    policy_leaves = jax.tree.leaves(nnx.state(train_state.model, nnx.Param))
+    reference_leaves = jax.tree.leaves(nnx.state(train_state.reference_model, nnx.Param))
+    self.assertGreater(len(policy_leaves), 0)
+    self.assertEqual(len(policy_leaves), len(reference_leaves))
+    for p, r in zip(policy_leaves, reference_leaves):
+      self.assertTrue(jnp.array_equal(p, r))
 
 
 if __name__ == "__main__":

--- a/tests/unit/dpo_nnx_test.py
+++ b/tests/unit/dpo_nnx_test.py
@@ -1,0 +1,236 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NNX DPO unit tests.
+
+Covers the NNX-native DPO surface:
+  * `TrainStateNNX(model, optimizer, reference_model=...)` — reference model
+    sits alongside policy and is not touched by `apply_gradients`.
+  * `dpo_loss_fn_nnx(policy, config, data, None, None, reference, is_train)` —
+    aux structure, identical-model invariant (loss = log(2), reward_accuracy = 0.0).
+"""
+
+import math
+import types
+import unittest
+
+import jax
+import jax.numpy as jnp
+import optax
+from flax import nnx
+
+from maxtext.layers import train_state_nnx
+from maxtext.trainers.post_train.dpo import dpo_utils
+
+
+class _MockTransformer(nnx.Module):
+  """Tiny NNX transformer-shaped module for DPO tests.
+
+  Accepts the same keyword args that `dpo_loss_fn_nnx` passes:
+  `decoder_input_tokens`, `decoder_positions`, `decoder_segment_ids`,
+  `enable_dropout`. Other args are tolerated via **kwargs.
+  """
+
+  def __init__(self, vocab_size: int, embed_dim: int, rngs: nnx.Rngs):
+    self.embed = nnx.Embed(vocab_size, embed_dim, rngs=rngs)
+    self.proj = nnx.Linear(embed_dim, vocab_size, rngs=rngs)
+
+  def __call__(
+      self,
+      decoder_input_tokens,
+      decoder_positions=None,
+      decoder_segment_ids=None,
+      enable_dropout=False,
+      **kwargs,
+  ):
+    del decoder_positions, decoder_segment_ids, enable_dropout, kwargs
+    return self.proj(self.embed(decoder_input_tokens))
+
+
+def _make_dpo_config(**overrides):
+  """Build the minimal config surface that `dpo_loss_fn_nnx` reads."""
+  base = {
+      "dpo_label_smoothing": 0.0,
+      "dpo_beta": 0.1,
+      "enable_dropout": False,
+      "num_experts": 1,
+      "micro_batch_size_to_train_on": 2,
+      "gradient_accumulation_steps": 1,
+      "use_tunix_gradient_accumulation": False,
+  }
+  base.update(overrides)
+  return types.SimpleNamespace(**base)
+
+
+def _make_dpo_batch(batch_size=2, seq_len=5):
+  """Build a tiny DPO-shaped batch.
+
+  `chosen` and `rejected` share the first 2 tokens (common prefix is masked
+  out in the loss), differ at positions 2 and 3, and are padded at position 4.
+  """
+  chosen = jnp.array([[1, 2, 3, 4, 0]] * batch_size, dtype=jnp.int32)
+  rejected = jnp.array([[1, 2, 5, 6, 0]] * batch_size, dtype=jnp.int32)
+  positions = jnp.tile(jnp.arange(seq_len, dtype=jnp.int32), (batch_size, 1))
+  segmentation = jnp.array([[1, 1, 1, 1, 0]] * batch_size, dtype=jnp.int32)
+  return {
+      "chosen": chosen,
+      "rejected": rejected,
+      "chosen_position": positions,
+      "rejected_position": positions,
+      "chosen_segmentation": segmentation,
+      "rejected_segmentation": segmentation,
+  }
+
+
+class TestTrainStateNNXWithReferenceModel(unittest.TestCase):
+  """`TrainStateNNX(reference_model=...)` semantics."""
+
+  def setUp(self):
+    self.policy = _MockTransformer(vocab_size=8, embed_dim=4, rngs=nnx.Rngs(0))
+    self.reference = _MockTransformer(vocab_size=8, embed_dim=4, rngs=nnx.Rngs(1))
+    self.tx = optax.adam(1e-3)
+
+  def test_init_with_reference(self):
+    optimizer = nnx.Optimizer(self.policy, self.tx, wrt=nnx.Param)
+    state = train_state_nnx.TrainStateNNX(self.policy, optimizer, reference_model=self.reference)
+    self.assertIs(state.model, self.policy)
+    self.assertIs(state.reference_model, self.reference)
+    self.assertEqual(state.optimizer.step.value, 0)
+
+  def test_init_without_reference_omits_attribute(self):
+    optimizer = nnx.Optimizer(self.policy, self.tx, wrt=nnx.Param)
+    state = train_state_nnx.TrainStateNNX(self.policy, optimizer)
+    self.assertFalse(hasattr(state, "reference_model"))
+
+  def test_apply_gradients_does_not_touch_reference(self):
+    """Gradient update on policy must leave reference model bit-identical."""
+    optimizer = nnx.Optimizer(self.policy, self.tx, wrt=nnx.Param)
+    state = train_state_nnx.TrainStateNNX(self.policy, optimizer, reference_model=self.reference)
+
+    ref_kernel_before = jnp.asarray(state.reference_model.proj.kernel.value).copy()
+
+    def policy_loss(m):
+      return jnp.mean(m(jnp.array([[1, 2]])) ** 2)
+
+    grads = nnx.grad(policy_loss)(state.model)
+    state.apply_gradients(grads)
+
+    ref_kernel_after = jnp.asarray(state.reference_model.proj.kernel.value)
+    self.assertTrue(jnp.array_equal(ref_kernel_before, ref_kernel_after))
+
+
+class TestDPOLossFnNNX(unittest.TestCase):
+  """`dpo_loss_fn_nnx` numerical and structural sanity checks."""
+
+  def setUp(self):
+    self.policy = _MockTransformer(vocab_size=8, embed_dim=4, rngs=nnx.Rngs(0))
+    # Reference initialized with the same seed to make policy and reference
+    # bit-identical at construction time.
+    self.reference = _MockTransformer(vocab_size=8, embed_dim=4, rngs=nnx.Rngs(0))
+    self.config = _make_dpo_config()
+    self.data = _make_dpo_batch()
+
+  def test_aux_has_expected_keys(self):
+    _, aux = dpo_utils.dpo_loss_fn_nnx(
+        self.policy, self.config, dict(self.data), None, None, self.reference, is_train=True
+    )
+    expected_keys = {
+        "intermediate_outputs",
+        "xent_sum",
+        "dpo_loss",
+        "total_weights",
+        "moe_lb_loss",
+        "reward_accuracy",
+        "indexer_loss",
+        "mtp_loss",
+    }
+    self.assertEqual(set(aux.keys()), expected_keys)
+    self.assertEqual(aux["xent_sum"], 0.0)
+    self.assertEqual(aux["moe_lb_loss"], 0.0)  # num_experts=1
+    self.assertEqual(aux["total_weights"], self.data["chosen"].shape[0])
+
+  def test_identical_policy_and_reference_yields_log2_loss(self):
+    """When policy == reference, all logratios are 0; with label_smoothing=0
+    the per-example loss is `-log(sigmoid(0)) = log(2)`. `reward_accuracy`
+    uses strict `chosen > rejected`, so equal logratios score 0.0 (no example
+    is strictly preferred).
+    """
+    loss, aux = dpo_utils.dpo_loss_fn_nnx(
+        self.policy, self.config, dict(self.data), None, None, self.reference, is_train=True
+    )
+    self.assertAlmostEqual(float(loss), math.log(2.0), places=4)
+    self.assertAlmostEqual(float(aux["dpo_loss"]), math.log(2.0), places=4)
+    self.assertAlmostEqual(float(aux["reward_accuracy"]), 0.0, places=4)
+
+  def test_gradient_accumulation_returns_unnormalized_sum(self):
+    """Under manual gradient accumulation the loss must be the unnormalized sum
+    (= mean * batch). gradient_accumulation_loss_and_grad sums per-microbatch
+    grads then divides once by total_weights, so returning the pre-normalized
+    mean here would under-scale the gradient by the microbatch size.
+    """
+    cfg_mean = _make_dpo_config(gradient_accumulation_steps=1)
+    cfg_sum = _make_dpo_config(gradient_accumulation_steps=2)
+    loss_mean, aux = dpo_utils.dpo_loss_fn_nnx(
+        self.policy, cfg_mean, dict(self.data), None, None, self.reference, is_train=True
+    )
+    loss_sum, _ = dpo_utils.dpo_loss_fn_nnx(
+        self.policy, cfg_sum, dict(self.data), None, None, self.reference, is_train=True
+    )
+    batch = aux["total_weights"]
+    self.assertAlmostEqual(float(loss_sum), float(loss_mean) * batch, places=4)
+    # The reported metric (aux["dpo_loss"]) stays the mean regardless of GA.
+    self.assertAlmostEqual(float(aux["dpo_loss"]), float(loss_mean), places=6)
+
+  def test_dropout_rng_and_params_args_are_unused(self):
+    """The 4th and 5th positional args are signature-compat slots for the
+    Linen dispatcher; passing arbitrary values must not affect the result.
+    """
+    loss_a, _ = dpo_utils.dpo_loss_fn_nnx(
+        self.policy, self.config, dict(self.data), None, None, self.reference, is_train=True
+    )
+    loss_b, _ = dpo_utils.dpo_loss_fn_nnx(
+        self.policy,
+        self.config,
+        dict(self.data),
+        jax.random.PRNGKey(123),  # dropout_rng — unused
+        {"params": "garbage"},  # params — unused
+        self.reference,
+        is_train=True,
+    )
+    self.assertAlmostEqual(float(loss_a), float(loss_b), places=6)
+
+  def test_value_and_grad_argnums0_only_diffs_policy(self):
+    """`nnx.value_and_grad(..., argnums=0)` over the policy should produce
+    finite grads on policy params and not require reference grads.
+    """
+
+    def _loss(policy_module):
+      loss, _ = dpo_utils.dpo_loss_fn_nnx(
+          policy_module, self.config, dict(self.data), None, None, self.reference, is_train=True
+      )
+      return loss
+
+    grad_fn = nnx.value_and_grad(_loss, argnums=0)
+    loss, grads = grad_fn(self.policy)
+    self.assertTrue(jnp.isfinite(loss))
+    # Grads is an nnx.State of the policy's nnx.Param leaves; check at least one
+    # leaf is finite and non-trivially shaped.
+    leaves = jax.tree_util.tree_leaves(grads)
+    self.assertGreater(len(leaves), 0)
+    for leaf in leaves:
+      self.assertTrue(jnp.all(jnp.isfinite(leaf)))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/dpo_test.py
+++ b/tests/unit/dpo_test.py
@@ -1,0 +1,146 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Linen DPO unit tests.
+
+Covers dpo_loss_fn:
+  * identical-model invariant (loss = log(2)).
+  * gradient-accumulation contract: the loss is the unnormalized sum under manual
+    GA, so the accumulator's divide-by-total_weights recovers the mean gradient.
+"""
+
+import math
+import types
+import unittest
+
+import jax
+import jax.numpy as jnp
+import flax.linen as nn
+
+from maxtext.trainers.post_train.dpo import dpo_utils
+
+
+class _TinyLinen(nn.Module):
+  """Tiny Linen model matching the call signature dpo_loss_fn uses.
+
+  dpo_loss_fn calls `model.apply(params, inputs, inputs_position,
+  decoder_segment_ids=..., enable_dropout=..., mutable="intermediates")` and
+  expects logits of shape [batch, seq_len, vocab_size]. No intermediates are
+  sown; the mutable collection comes back empty, which is fine for num_experts=1.
+  """
+
+  vocab_size: int
+  hidden: int
+
+  @nn.compact
+  def __call__(
+      self,
+      decoder_input_tokens,
+      decoder_positions=None,
+      decoder_segment_ids=None,
+      enable_dropout=False,
+      **kwargs,
+  ):
+    del decoder_positions, decoder_segment_ids, enable_dropout, kwargs
+    h = nn.Embed(self.vocab_size, self.hidden)(decoder_input_tokens)
+    return nn.Dense(self.vocab_size)(h)
+
+
+def _make_dpo_config(**overrides):
+  """Minimal config surface read by dpo_loss_fn."""
+  base = {
+      "dpo_label_smoothing": 0.0,
+      "dpo_beta": 0.1,
+      "enable_dropout": False,
+      "num_experts": 1,
+      "micro_batch_size_to_train_on": 4,
+      "gradient_accumulation_steps": 1,
+      "use_tunix_gradient_accumulation": False,
+  }
+  base.update(overrides)
+  return types.SimpleNamespace(**base)
+
+
+def _make_dpo_batch(batch_size=4, seq_len=5):
+  """DPO-shaped batch: chosen/rejected share a prefix, differ mid-sequence, pad at the end.
+
+  dpo_loss_fn mutates its data dict in place, so build a fresh one per call.
+  """
+  chosen = jnp.array([[1, 2, 3, 4, 0]] * batch_size, dtype=jnp.int32)
+  rejected = jnp.array([[1, 2, 5, 6, 0]] * batch_size, dtype=jnp.int32)
+  positions = jnp.tile(jnp.arange(seq_len, dtype=jnp.int32), (batch_size, 1))
+  segmentation = jnp.array([[1, 1, 1, 1, 0]] * batch_size, dtype=jnp.int32)
+  return {
+      "chosen": chosen,
+      "rejected": rejected,
+      "chosen_position": positions,
+      "rejected_position": positions,
+      "chosen_segmentation": segmentation,
+      "rejected_segmentation": segmentation,
+  }
+
+
+class TestDPOLossFn(unittest.TestCase):
+  """Linen dpo_loss_fn numerical and gradient-scaling checks."""
+
+  def setUp(self):
+    self.model = _TinyLinen(vocab_size=8, hidden=4)
+    variables = self.model.init(jax.random.PRNGKey(0), jnp.ones((2, 5), dtype=jnp.int32))
+    self.params = variables
+    # Reference uses the same params, so policy and reference are bit-identical:
+    # all logratios are 0 and every per-example loss is -log(sigmoid(0)) = log(2).
+    self.reference_params = variables["params"]
+    self.rng = jax.random.PRNGKey(0)
+
+  def test_identical_policy_and_reference_yields_log2_loss(self):
+    loss, aux = dpo_utils.dpo_loss_fn(
+        self.model, _make_dpo_config(), _make_dpo_batch(), self.rng, self.params, self.reference_params, is_train=True
+    )
+    self.assertAlmostEqual(float(loss), math.log(2.0), places=4)
+    self.assertAlmostEqual(float(aux["dpo_loss"]), math.log(2.0), places=4)
+    self.assertEqual(float(aux["xent_sum"]), 0.0)
+    self.assertEqual(int(aux["total_weights"]), 4)
+
+  def test_gradient_accumulation_returns_unnormalized_sum(self):
+    """Under manual gradient accumulation the loss must be the unnormalized sum
+    (= mean * batch). gradient_accumulation_loss_and_grad sums per-microbatch
+    grads then divides once by total_weights, so returning the pre-normalized
+    mean here would under-scale the gradient by the microbatch size.
+    """
+    loss_mean, aux = dpo_utils.dpo_loss_fn(
+        self.model,
+        _make_dpo_config(gradient_accumulation_steps=1),
+        _make_dpo_batch(),
+        self.rng,
+        self.params,
+        self.reference_params,
+        is_train=True,
+    )
+    loss_sum, _ = dpo_utils.dpo_loss_fn(
+        self.model,
+        _make_dpo_config(gradient_accumulation_steps=2),
+        _make_dpo_batch(),
+        self.rng,
+        self.params,
+        self.reference_params,
+        is_train=True,
+    )
+    batch = aux["total_weights"]
+    self.assertAlmostEqual(float(loss_sum), float(loss_mean) * batch, places=4)
+    # The reported metric (aux["dpo_loss"]) stays the mean regardless of GA.
+    self.assertAlmostEqual(float(aux["dpo_loss"]), float(loss_mean), places=6)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/train_nnx_test.py
+++ b/tests/unit/train_nnx_test.py
@@ -50,6 +50,8 @@ class _Cfg:
   mtp_num_layers: int = 0
   mtp_eval_target_module: int = 0
   use_dpo: bool = False
+  dpo_label_smoothing: float = 0.0
+  dpo_beta: float = 0.1
   use_qk_clip: bool = False
   use_tunix_gradient_accumulation: bool = False
   gradient_accumulation_steps: int = 1
@@ -103,11 +105,37 @@ def _make_data(batch=2, seq=4, vocab=8):
   }
 
 
+def _make_dpo_data(batch=2, seq=5):
+  """DPO-shaped batch: chosen/rejected share a prefix, differ mid-sequence, pad at the end."""
+  chosen = jnp.array([[1, 2, 3, 4, 0]] * batch, dtype=jnp.int32)
+  rejected = jnp.array([[1, 2, 5, 6, 0]] * batch, dtype=jnp.int32)
+  positions = jnp.tile(jnp.arange(seq, dtype=jnp.int32), (batch, 1))
+  segmentation = jnp.array([[1, 1, 1, 1, 0]] * batch, dtype=jnp.int32)
+  return {
+      "chosen": chosen,
+      "rejected": rejected,
+      "chosen_position": positions,
+      "rejected_position": positions,
+      "chosen_segmentation": segmentation,
+      "rejected_segmentation": segmentation,
+  }
+
+
 def _build_state():
   cfg = _Cfg()
   model = _TinyDecoder(cfg.vocab_size, hidden=4, rngs=nnx.Rngs(0))
   optimizer = nnx.Optimizer(model, optax.sgd(0.01), wrt=nnx.Param)
   ts = train_state_nnx.TrainStateNNX(model, optimizer)
+  return cfg, ts
+
+
+def _build_dpo_state():
+  """TrainStateNNX with a frozen reference model alongside the policy (identical init)."""
+  cfg = _Cfg(use_dpo=True)
+  model = _TinyDecoder(cfg.vocab_size, hidden=4, rngs=nnx.Rngs(0))
+  reference = _TinyDecoder(cfg.vocab_size, hidden=4, rngs=nnx.Rngs(0))
+  optimizer = nnx.Optimizer(model, optax.sgd(0.01), wrt=nnx.Param)
+  ts = train_state_nnx.TrainStateNNX(model, optimizer, reference_model=reference)
   return cfg, ts
 
 
@@ -174,16 +202,6 @@ class TestTrainStepNNX(unittest.TestCase):
     self.assertIn("learning/param_norm", metrics["scalar"])
     self.assertTrue(jnp.isfinite(metrics["scalar"]["learning/loss"]))
 
-  def test_train_step_dpo_raises_for_nnx(self):
-    cfg, ts = _build_state()
-    cfg.use_dpo = True
-    state_graphdef, state_pure = nnx.split(ts)
-    data = _make_data(batch=cfg.micro_batch_size_to_train_on, vocab=cfg.vocab_size)
-    with self.assertRaises(NotImplementedError):
-      pre_train.train_step(
-          state_graphdef, cfg, state_mesh_shardings=None, params_shardings=None, state=state_pure, data=data
-      )
-
   def test_train_step_increments_optimizer_step(self):
     cfg, ts = _build_state()
     state_graphdef, state_pure = nnx.split(ts)
@@ -205,6 +223,32 @@ class TestTrainStepNNX(unittest.TestCase):
     )
     self.assertIsInstance(new_state, nnx.State)
     self.assertTrue(jnp.isfinite(metrics["scalar"]["learning/loss"]))
+
+
+class TestTrainStepDPONNX(unittest.TestCase):
+  """train_step must run the NNX DPO path end-to-end.
+
+  Positive replacement for the removed test_train_step_dpo_raises_for_nnx: DPO is
+  now supported on NNX, so train_step routes to dpo_loss_fn_nnx with the reference
+  model from state and returns updated state plus DPO metrics.
+  """
+
+  def test_train_step_dpo_runs_for_nnx(self):
+    cfg, ts = _build_dpo_state()
+    pre_step = int(ts.optimizer.step.get_value())
+    state_graphdef, state_pure = nnx.split(ts)
+    data = _make_dpo_data(batch=cfg.micro_batch_size_to_train_on)
+
+    new_state, metrics = pre_train.train_step(
+        state_graphdef, cfg, state_mesh_shardings=None, params_shardings=None, state=state_pure, data=data
+    )
+
+    self.assertIsInstance(new_state, nnx.State)
+    self.assertEqual(int(new_state.optimizer.step.get_value()), pre_step + 1)
+    self.assertTrue(jnp.isfinite(metrics["scalar"]["learning/loss"]))
+    # DPO-specific metrics are surfaced only on the use_dpo path.
+    self.assertIn("learning/dpo_loss", metrics["scalar"])
+    self.assertIn("learning/dpo_reward_accuracy", metrics["scalar"])
 
 
 class TestEvalStepNNX(unittest.TestCase):


### PR DESCRIPTION
## NNX Migration Route Map

1. ✅ Add NNX scaffolding: `pure_nnx` flag, `init_state_fn`, `TrainStateNNX`, NNX utils. Linen workflow unchanged. (PR #3427)
2. ✅ NNX sharding utilities: `get_abstract_state_nnx`, `get_named_sharding_nnx`, `set_named_sharding_nnx`, `get_partition_spec_nnx`, `get_mesh_from_config`. (PR #3470)
3. ✅ NNX fully supported end-to-end: `TrainStateNNX`, model creation, gradient accumulation, checkpointing, and training loop dispatch. (PR #3500)
4. ✅ Sharding diagnostics on NNX, plus post-training bugfixes that surfaced once the NNX path got exercised end-to-end. (PR #3652)
4.5. ✅ Linen↔NNX checkpoint converter. (PR #3843)
4.6. ❌ Linen↔NNX checkpoint comparator (sibling branch on PR4.5).
5. ✅ NNX correctness fixes, feature enablements, and vocab tiling on NNX.
6. 🔄 **[This PR]** NNX-native DPO. Adds optional `reference_model: nnx.Module` field on `TrainStateNNX` and a new `dpo_loss_fn_nnx`; removes the `NotImplementedError` from train_step + eval_step NNX branches. Linen DPO path behaviorally unchanged. Stacks on PR5.
7. ❌ NNX-native MaxEngine inference.
8. ❌ NNX-native LoRA + GRPO.
9. ❌ NNX-aware QK-Clip + remaining checkpoint utilities.
9.5. ❌ NNX + AQT in MaxEngine + serve-mode reload + gpt3 prefill fix.
10. ❌ Vocab tiling `custom_vjp` for NNX.
11. ❌ Set NNX defaults to `True`; regenerate sharding goldens; flip back integration-test `pure_nnx=False` annotations.
12. ❌ Delete Linen-specific code paths and NNX compatibility flags.

## Summary

Implements NNX-native DPO. The `pure_nnx=True` training path no longer raises `NotImplementedError` on `use_dpo` runs.

The Linen DPO overlay pattern (`model.apply(params=..., reference_params=...)`) does not translate to NNX modules, which carry their parameters internally. Instead, the policy and reference models are held as separate `nnx.Module` instances on `TrainStateNNX`, and a new `dpo_loss_fn_nnx` runs both forwards with `stop_gradient` on the reference logits.

This is the next step in the NNX migration after `feat/nnx-correctness-fixes` — it closes the remaining hard `NotImplementedError` on the NNX path and unblocks default-flipping `pure_nnx=True` for users who run DPO.

## What's in this PR

### `TrainStateNNX` ([src/maxtext/layers/train_state_nnx.py](src/maxtext/layers/train_state_nnx.py))

- Optional `reference_model: nnx.Module` field. `apply_gradients` continues to update only `self.model`, leaving `self.reference_model` bit-identical across steps.

### `dpo_utils.py` ([src/maxtext/trainers/post_train/dpo/dpo_utils.py](src/maxtext/trainers/post_train/dpo/dpo_utils.py))

- New `dpo_loss_fn_nnx(policy_model, config, data, dropout_rng, params, reference_model, is_train=True)` mirroring the Linen `dpo_loss_fn` signature so it slots into `gradient_accumulation_loss_and_grad`'s dispatcher (`dropout_rng` / `params` slots are unused for NNX; `reference_model` is the single `extra_dpo_args` entry).
- Reference forward wrapped in `jax.lax.stop_gradient`. With `nnx.value_and_grad(..., argnums=0)` over the policy, no gradient flows to the reference model's `nnx.Param` leaves.
- Both `dpo_loss_fn` (Linen) and `dpo_loss_fn_nnx` (NNX) now include `indexer_loss=0.0` / `mtp_loss=0.0` in their aux dicts so the gradient-accumulation aux pytree shape matches the non-DPO `loss_fn`.
- The Linen `_split_dpo_state` / `_merge_dpo_state` overlay pattern has no NNX counterpart by design — NNX holds the reference as a sibling field on `TrainStateNNX`, and `apply_gradients` already only touches `self.model`, so no split/merge is needed.

### `train.py` ([src/maxtext/trainers/pre_train/train.py](src/maxtext/trainers/pre_train/train.py))

- `NotImplementedError` removed from `train_step` and `eval_step` NNX branches; both dispatch to `dpo_loss_fn_nnx` when `use_dpo`, with `state.reference_model` passed as `extra_dpo_args[0]`.
- `diff_wrapper` picks `_loss_fn` / `extra_dpo_args` from the per-path init block so GA and non-GA NNX paths route DPO identically.
- `_split_dpo_state` checkpoint-save stripping is now Linen-only (NNX saves the whole `TrainStateNNX` including `reference_model`; the step-0 reload later overwrites `reference_model`).

### `train_utils.py` ([src/maxtext/utils/train_utils.py](src/maxtext/utils/train_utils.py))

- NNX `init_state_fn` materializes a frozen reference model alongside the policy when `config.use_dpo`. Both are constructed via `_create_model_partial()` with `config.init_weights_seed`, so they start identical (standard DPO practice) until the step-0 reload.
- Step-0 checkpoint reload writes `step0_state["model"]` into `state["reference_model"]`. Linen path unchanged.

### Tests

- New [tests/unit/dpo_nnx_test.py](tests/unit/dpo_nnx_test.py) (7 tests):
  - `TrainStateNNX(reference_model=...)` init / `hasattr` semantics
  - `apply_gradients` leaves the reference model bit-identical
  - `dpo_loss_fn_nnx` aux key set
  - Identical policy/reference yields `loss = log(2)` and `reward_accuracy = 0.0` (strict `>` on equal logratios)
  - `dropout_rng` / `params` slots are signature-compat only — passing arbitrary values does not change the result
  - `nnx.value_and_grad(..., argnums=0)` over the policy yields finite grads on policy params only
- [tests/unit/train_nnx_test.py](tests/unit/train_nnx_test.py): dropped two stale negative tests:
  - `vocab_tiling_raises_not_implemented` — vocab tiling on NNX was implemented in `feat/nnx-correctness-fixes`
  - `train_step_dpo_raises_for_nnx` — DPO on NNX is implemented here

## Linen invariant

Linen DPO is behaviorally unchanged: the only Linen-side change is that `dpo_loss_fn` now includes `indexer_loss=0.0` / `mtp_loss=0.0` in `aux`. Existing callers either ignore those keys or read them with `.get(..., 0.0)`, so this is a no-op for downstream code. The NNX non-DPO path is unchanged: every new code path is gated on `config.use_dpo`.

## Stats

- 4 source files + 2 test files modified, **+412 / −41 lines**
- All **27 tests pass** across `train_nnx_test`, `dpo_nnx_test` (new), `train_state_nnx_test`, `train_utils_nnx_test`, `gradient_accumulation_nnx_test`

## Followups (not in this PR)

- DPO + NNX with `gradient_accumulation_steps > 1` is wired up via the same dispatcher (`extra_dpo_args` carries `reference_model` and `gradient_accumulation_loss_and_grad`'s NNX branch already calls `grad_func(local_model, config, data, None, None, *extra_dpo_args, is_train=True)` against `dpo_loss_fn_nnx`'s signature) but is not exercised by an explicit GA-DPO test. Tracked as a followup.
- Step-0 abstract-state shape mismatch (DPO-shape abstract state used to restore a non-DPO step-0 checkpoint) is mirrored from the Linen path's existing behavior; revisit only if integration testing surfaces issues.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
