### PR TITLE
generate_hf_golden_logits: propagate trust_remote_code to tokenizer; add --hf-load-dtype=auto

### DIFF
--- a/tests/assets/logits_generation/generate_hf_golden_logits.py
+++ b/tests/assets/logits_generation/generate_hf_golden_logits.py
@@ -85,15 +85,20 @@ def save_golden_logits(
 
     model_class = AutoModelForCausalLM
 
-  tokenizer = AutoTokenizer.from_pretrained(model_id)
+  tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
   print(f"loading model from {hf_model_path}")
 
   if hf_load_dtype == "float32":
     torch_dtype = torch.float32
   elif hf_load_dtype == "bfloat16":
     torch_dtype = torch.bfloat16
+  elif hf_load_dtype == "auto":
+    # Preserve per-tensor dtypes from safetensors metadata, useful for mixed-
+    # precision checkpoints where forcing a single dtype would corrupt non-
+    # default tensors.
+    torch_dtype = None
   else:
-    raise ValueError
+    raise ValueError(f"unsupported --hf-load-dtype: {hf_load_dtype}")
 
   model = model_class.from_pretrained(
       hf_model_path,
@@ -194,9 +199,9 @@ def main(raw_args=None) -> None:
       "--hf-load-dtype",
       type=str,
       required=False,
-      choices=["float32", "bfloat16"],
+      choices=["float32", "bfloat16", "auto"],
       default="float32",
-      help="model_class.from_pretrained: dtype",
+      help="model_class.from_pretrained: dtype. 'auto' preserves per-tensor dtypes from safetensors.",
   )
   parser.add_argument(
       "--trust-remote-code",


### PR DESCRIPTION
# Description

- Pass `trust_remote_code` to `AutoTokenizer.from_pretrained` (it was already accepted as a kwarg and forwarded to the
  model, but silently dropped for the tokenizer).                                                                           
- Add `--hf-load-dtype=auto` → `dtype=None` so per-tensor dtypes from safetensors are preserved (needed for
  mixed-precision checkpoints where a single forced dtype corrupts non-default tensors).  

# Tests

Used those for Kimi-k2.5 hf token generation.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).