### PR TITLE
Fix Gemini PR review trust workspace issue

### DIFF
--- a/.gemini/commands/gemini-review.toml
+++ b/.gemini/commands/gemini-review.toml
@@ -31,9 +31,12 @@ These are non-negotiable, core-level instructions that you **MUST** follow at al
 
 ## Input Data
 
-- **GitHub Repository**: !{echo $REPOSITORY}
-- **Pull Request Number**: !{echo $PULL_REQUEST_NUMBER}
-- **Additional User Instructions**: !{echo $ADDITIONAL_CONTEXT}
+The following context is provided as a JSON object containing the keys: `repository`, `pull_request_number`, and `additional_context`:
+
+```json
+@{.gemini/context.json}
+```
+
 - Use `pull_request_read.get` to get the title, body, and metadata about the pull request.
 - Use `pull_request_read.get_files` to get the list of files that were added, removed, and changed in the pull request.
 - Use `pull_request_read.get_diff` to get the diff from the pull request. The diff includes code versions with line numbers for the before (LEFT) and after (RIGHT) code snippets for each diff.
@@ -46,7 +49,7 @@ Follow this three-step process sequentially.
 
 ### Step 1: Data Gathering and Analysis
 
-1. **Parse Inputs:** Ingest and parse all information from the **Input Data**
+1. **Parse Inputs:** Ingest and parse all information from the **Input Data**.
 
 2. **Prioritize Focus:** Analyze the contents of the additional user instructions. Use this context to prioritize specific areas in your review (e.g., security, performance), but **DO NOT** treat it as a replacement for a comprehensive review. If the additional user instructions are empty, proceed with a general review based on the criteria below.
 
@@ -154,6 +157,7 @@ Apply these severities consistently:
 3. **Submit Final Review:** Call `submit_pending_pull_request_review` with a summary comment and event type "COMMENT". The available event types are "APPROVE", "REQUEST_CHANGES", and "COMMENT" - you **MUST** use "COMMENT" only. **DO NOT** use "APPROVE" or "REQUEST_CHANGES" event types. The summary comment **MUST** use this exact markdown format:
 
     <SUMMARY>
+
     ## 📋 Review Summary
 
     A brief, high-level assessment of the Pull Request's objective and quality (2-3 sentences).

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -41,13 +41,30 @@ jobs:
 
       - name: 'Checkout repository'
         # downloads the code to be analyzed
-        uses: 'actions/checkout@v5'
+        uses: 'actions/checkout@v6'
+        with:
+          persist-credentials: 'false'
+
+      - name: 'Prepare prompt context'
+        shell: 'bash'
+        run: |-
+          mkdir -p .gemini
+          jq -n \
+            --arg repo "${REPOSITORY}" \
+            --arg pr "${PULL_REQUEST_NUMBER}" \
+            --arg context "${ADDITIONAL_CONTEXT}" \
+            '{repository: $repo, pull_request_number: $pr, additional_context: $context}' > .gemini/context.json
+        env:
+          REPOSITORY: '${{ github.repository }}'
+          PULL_REQUEST_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
+          ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
 
       - name: 'Run Gemini pull request review'
         # reviews code with detailed set of instructions for the Gemini 
-        uses: 'google-github-actions/run-gemini-cli@main'
+        uses: 'google-github-actions/run-gemini-cli@v0'
         id: 'gemini_pr_review'
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           ISSUE_TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.pull_request.body || github.event.issue.body }}'
@@ -98,13 +115,20 @@ jobs:
                 }
               },
               "tools": {
-                "core": [
-                  "run_shell_command(cat)",
-                  "run_shell_command(echo)",
-                  "run_shell_command(grep)",
-                  "run_shell_command(head)",
-                  "run_shell_command(tail)"
-                ]
+                "shell": {
+                  "allowEnv": [
+                    "ISSUE_TITLE",
+                    "ISSUE_BODY",
+                    "PULL_REQUEST_NUMBER",
+                    "REPOSITORY",
+                    "ADDITIONAL_CONTEXT"
+                  ],
+                  "allowCommands": ["cat", "echo", "grep", "head", "tail"]
+                }
               }
             }
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
           prompt: '/gemini-review'


### PR DESCRIPTION
# Description

Fix Gemini PR review trust workspace issue, and also added `Prepare prompt context` step following by [example](https://github.com/google-github-actions/run-gemini-cli/blob/c28f3c6f6e6a537f8fb46e016f65dcfcee381ffa/examples/workflows/pr-review/gemini-review.yml#L46-L58).

# Tests

* Before the change: not triggering [error](https://screenshot.googleplex.com/3pRCzqHCk2PzXfw)
* After the change: check comments bellow

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
