### PR TITLE
Exclude RNG state when updating vllm with checkpoint for pre-rl evaluation

### DIFF
--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -596,8 +596,8 @@ def rl_train(argv: Sequence[str], kwargs: dict):
 
   # Run evaluation before training
   if trainer_config.num_test_batches > 0:
-    # Update vllm with model parameters from checkpoint
-    rl_cluster.rollout.update_params(nnx.state(actor_model))
+    # Update vllm with model parameters from checkpoint, excluding RNG state
+    rl_cluster.rollout.update_params(nnx.state(actor_model, nnx.Not(nnx.RngState)))
 
     (corr, total, accuracy, partial_accuracy, format_accuracy), _ = evaluate(
         trainer_config,


### PR DESCRIPTION
# Description

Running RL with Qwen3-0.6B on v5p-8 throws error when `num_test_batches>0`: https://paste.googleplex.com/6146006073868288

# Tests

Tested with Qwen3-0.6B on v5p-8

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
