### PR TITLE
Parameterize bos_id in inference_microbenchmark.py

### DIFF
--- a/src/maxtext/inference/inference_microbenchmark.py
+++ b/src/maxtext/inference/inference_microbenchmark.py
@@ -332,8 +332,9 @@ def run_benchmarks(config):
     rng_shape = jax.ShapeDtypeStruct([4], jax.numpy.dtype("uint32"))
 
     for prefill_length in prefill_lengths:
+      is_bos = tokenizer_model.bos_id is not None
       prefill_tokens[prefill_length], prefill_true_lengths[prefill_length] = tokenizer_model.encode(
-          text, is_bos=True, prefill_lengths=[prefill_length]
+          text, is_bos=is_bos, prefill_lengths=[prefill_length]
       )
 
       key_shape = jax.ShapeDtypeStruct([prefill_length], jax.numpy.dtype("int32"))


### PR DESCRIPTION
# Description


**Problem:** 
`inference_microbenchmark.py` crashes when running models without a BOS token (like Qwen3) because it hardcodes `is_bos=True` during tokenization. This causes JetStream's `HuggingFaceTokenizer` to prepend `None` to the token list, resulting in a JAX `TypeError`.

**Solution:** 
Dynamically set `is_bos = tokenizer_model.bos_id is not None` to avoid prepending `None` for models that don't have a BOS token.


FIXES: b/508334388

# Tests

Ran the following command successfully on a v5p-8

```
python3 -m maxtext.inference.inference_microbenchmark   model_name=qwen3-4b   tokenizer_path=Qwen/Qwen3-4B   per_device_batch_size=1   max_prefill_predict_length=1024   max_target_length=2048   ici_autoregressive_parallelism=4   scan_layers=false   weight_dtype=bfloat16   attention=dot_product
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
