### PR TITLE
 Distillation: Log per-step TFLOPs (student fwd+bwd, teacher fwd-only)

### DIFF
--- a/src/maxtext/configs/post_train/distillation.yml
+++ b/src/maxtext/configs/post_train/distillation.yml
@@ -49,7 +49,7 @@ save_checkpoint_on_completion: True
 # --- Batch Size Strategy ---
 # Global Batch Size = per_device_batch_size * num_devices * gradient_accumulation_steps
 per_device_batch_size: 2
-gradient_accumulation_steps: 8
+gradient_accumulation_steps: 1
 
 # --- Learning Rate Schedule ---
 learning_rate: 2.0e-4

--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -33,6 +33,7 @@ from array_record.python import array_record_module
 from orbax import checkpoint
 
 from maxtext.utils import max_logging
+from maxtext.utils import maxtext_utils
 # Reuse MaxText's native checkpointing logic
 from maxtext.common.checkpointing import GrainCheckpointHandler, GrainCheckpointSave, GrainCheckpointRestore
 from tunix.sft import checkpoint_manager as tunix_checkpoint_manager
@@ -191,6 +192,21 @@ class MaxTextToTunixIterator:
 # and far below fp32 exp overflow (~88).
 _PPL_CE_CAP = 20.0
 
+METRIC_TOTAL_LOSS = "distill/total_loss"
+METRIC_HARD_LOSS = "distill/hard_loss"
+METRIC_SOFT_LOSS = "distill/soft_loss"
+METRIC_TEACHER_LOSS = "distill/teacher_loss"
+METRIC_KL_DIV_T1 = "distill/kl_div_T1"
+METRIC_KL_DIV_AT_T = "distill/kl_div_at_T"
+METRIC_STUDENT_PERPLEXITY = "distill/student_perplexity"
+METRIC_TEACHER_PERPLEXITY = "distill/teacher_perplexity"
+METRIC_OUT_PROJ_FEATURE_LOSS = "distill/out_proj_feature_loss"
+METRIC_MOE_LB_LOSS = "distill/moe_lb_loss"
+METRIC_TEACHER_MOE_LB_LOSS = "distill/teacher_moe_lb_loss"
+METRIC_TEMPERATURE = "distill/temperature"
+METRIC_ALPHA = "distill/alpha"
+METRIC_BETA_FEATURE = "distill/beta_feature"
+
 
 def compute_schedule(
     step: jax.Array,
@@ -249,6 +265,35 @@ def weighted_mean(sum_count_pairs: Sequence[tuple[Any, Any]] | np.ndarray) -> fl
   if total <= 0.0:
     return 0.0
   return float(arr[:, 0].sum() / total)
+
+
+def calculate_distillation_tflops_per_device(
+    student_config,
+    teacher_config,
+    is_offline: bool = False,
+) -> tuple[float, float, float]:
+  """Per-step per-device TFLOPs for online distillation.
+
+  Student counts full forward + backward (matches the standard `* 3` accounting
+  in `calculate_tflops_training_per_device`). Teacher counts forward only, so we
+  divide its standard total by 3. In offline mode the teacher is not run, so its
+  contribution is zero.
+
+  Caller contract: `teacher_config`'s `per_device_batch_size`, `max_target_length`,
+  and `gradient_accumulation_steps` must already match `student_config`'s, since
+  the teacher runs on batches produced by the shared input pipeline. The
+  distillation entry point (`train_distill.main`) sets this up.
+
+  Returns:
+    (combined, student, teacher) per-step per-device TFLOPs.
+  """
+  student_tflops, _, _ = maxtext_utils.calculate_tflops_training_per_device(student_config, log=False)
+  if is_offline or teacher_config is None:
+    teacher_tflops = 0.0
+  else:
+    teacher_full, _, _ = maxtext_utils.calculate_tflops_training_per_device(teacher_config, log=False)
+    teacher_tflops = teacher_full / 3.0
+  return student_tflops + teacher_tflops, student_tflops, teacher_tflops
 
 
 class DistillationStrategy(abc.ABC):
@@ -558,27 +603,27 @@ class CombinedDistillationStrategy(DistillationStrategy):
     one = jnp.array(1.0, dtype=jnp.float32)
     metrics: dict[str, tuple[jax.Array, jax.Array]] = {
         # Token-weighted: emit (sum, valid_count) so multi-host averaging is unbiased.
-        "distill/soft_loss": (soft_loss_sum_scaled, valid_count),
-        "distill/hard_loss": (ce_student_sum, valid_count),
-        "distill/teacher_loss": (ce_teacher_sum, valid_count),
+        METRIC_SOFT_LOSS: (soft_loss_sum_scaled, valid_count),
+        METRIC_HARD_LOSS: (ce_student_sum, valid_count),
+        METRIC_TEACHER_LOSS: (ce_teacher_sum, valid_count),
         # Next-token prediction perplexity (per-step approximation of exp(hard_loss)).
         # The headline `_train_perplexity` Tunix prints is exp(total_loss) which for
         # distillation is exp(α·soft + (1-α)·hard + β·feature) and NOT next-token PPL.
-        "distill/student_perplexity": (student_perplexity_step, one),
-        "distill/teacher_perplexity": (teacher_perplexity_step, one),
+        METRIC_STUDENT_PERPLEXITY: (student_perplexity_step, one),
+        METRIC_TEACHER_PERPLEXITY: (teacher_perplexity_step, one),
         # KL at the current (scheduled) temperature T, without the T^2 scaling
         # that soft_loss applies. Pair with kl_div_T1 to compare T vs T=1.
-        "distill/kl_div_at_T": (kl_softened_sum, valid_count),
+        METRIC_KL_DIV_AT_T: (kl_softened_sum, valid_count),
         # KL at T=1: comparable across runs / annealing schedules.
-        "distill/kl_div_T1": (kl_t1_sum, valid_count),
+        METRIC_KL_DIV_T1: (kl_t1_sum, valid_count),
         # Per-step quantities: (value, 1.0) so the aggregator yields a simple mean over steps.
-        "distill/out_proj_feature_loss": (feature_loss, one),
-        "distill/moe_lb_loss": (moe_lb_loss, one),
-        "distill/teacher_moe_lb_loss": (teacher_moe_lb_loss, one),
-        "distill/total_loss": (total_loss, one),
-        "distill/temperature": (temperature, one),
-        "distill/alpha": (alpha, one),
-        "distill/beta_feature": (beta_feature, one),
+        METRIC_OUT_PROJ_FEATURE_LOSS: (feature_loss, one),
+        METRIC_MOE_LB_LOSS: (moe_lb_loss, one),
+        METRIC_TEACHER_MOE_LB_LOSS: (teacher_moe_lb_loss, one),
+        METRIC_TOTAL_LOSS: (total_loss, one),
+        METRIC_TEMPERATURE: (temperature, one),
+        METRIC_ALPHA: (alpha, one),
+        METRIC_BETA_FEATURE: (beta_feature, one),
     }
     return total_loss, metrics
 

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -216,6 +216,9 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
       strategy: distillation_utils.DistillationStrategy,
       optimizer,
       training_config,
+      student_config: pyconfig.HyperParameters,
+      teacher_config: pyconfig.HyperParameters | None,
+      is_offline: bool = False,
       student_freeze_param_filter: Callable[[Any], bool] | None = None,
       **kwargs,
   ):
@@ -226,6 +229,15 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
     super().__init__(model=model, optimizer=dummy_optimizer, training_config=training_config, **kwargs)
 
     self.strategy = strategy
+
+    # Per-step per-device TFLOPs (constants for the run): student fwd+bwd + teacher fwd-only.
+    self._tflops_combined, self._tflops_student, self._tflops_teacher = (
+        distillation_utils.calculate_distillation_tflops_per_device(student_config, teacher_config, is_offline=is_offline)
+    )
+    max_logging.log(
+        f"Per-step per-device TFLOPs — combined: {self._tflops_combined:.2f}, "
+        f"student (fwd+bwd): {self._tflops_student:.2f}, teacher (fwd-only): {self._tflops_teacher:.2f}"
+    )
 
     # override optimizer to only use student_model.
     if training_config.gradient_accumulation_steps is not None and training_config.gradient_accumulation_steps > 1:
@@ -331,6 +343,37 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
     labels = self.strategy.create_labels(inputs["targets"], targets_segmentation=inputs.get("targets_segmentation", None))
     return self.strategy.compute_eval_loss(student_output, labels)
 
+  def _log_metrics(self, loss, step=None, step_time_delta=None, additional_metrics=None):
+    """Adds per-device TFLOPs (and per-sec variants) to the standard Tunix metrics."""
+    super()._log_metrics(loss=loss, step=step, step_time_delta=step_time_delta, additional_metrics=additional_metrics)
+
+    tflops_metrics = {
+        "perf/per_device_tflops": self._tflops_combined,
+        "perf/per_device_tflops_student": self._tflops_student,
+        "perf/per_device_tflops_teacher": self._tflops_teacher,
+    }
+    tflops_per_sec = None
+    if step_time_delta is not None and step_time_delta > 0:
+      tflops_per_sec = self._tflops_combined / step_time_delta
+      tflops_metrics.update(
+          {
+              "perf/per_device_tflops_per_sec": tflops_per_sec,
+              "perf/per_device_tflops_per_sec_student": self._tflops_student / step_time_delta,
+              "perf/per_device_tflops_per_sec_teacher": self._tflops_teacher / step_time_delta,
+          }
+      )
+    for name, value in tflops_metrics.items():
+      self.metrics_logger.log(self.metrics_prefix, name, value, self._mode, step)
+
+    # Console summary — keep it tight; everything else is in TensorBoard.
+    if tflops_per_sec is not None and self._mode == metrics_logger.Mode.TRAIN:
+      max_logging.log(
+          f"step {step} | step_time={step_time_delta:.2f}s | "
+          f"TFLOPs/s/device: {tflops_per_sec:.2f} "
+          f"(student={self._tflops_student / step_time_delta:.2f}, "
+          f"teacher={self._tflops_teacher / step_time_delta:.2f})"
+      )
+
   def _prepare_inputs(
       self, input_data: distillation_utils.MaxTextTrainingInput
   ) -> distillation_utils.MaxTextTrainingInput:
@@ -376,7 +419,39 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
         self._buffered_train_metrics.additional_metrics[name] = ([], distillation_utils.weighted_mean)
 
       self._buffered_train_metrics.additional_metrics[name][0].append(value)
-    max_logging.log(f"Distillation metrics: {aux}")
+
+    # Compact per-step summary: only the metrics that change run-to-run, and
+    # only those that are nonzero (so MoE / feature-distill terms hide when off).
+    # `aux` values are (sum, count) tuples; reduce to scalar via sum/count.
+    def _scalar(v):
+      s, c = v
+      c = float(c)
+      return float(s) / c if c > 0 else 0.0
+
+    headline_keys = (
+        distillation_utils.METRIC_TOTAL_LOSS,
+        distillation_utils.METRIC_HARD_LOSS,
+        distillation_utils.METRIC_SOFT_LOSS,
+        distillation_utils.METRIC_KL_DIV_T1,
+        distillation_utils.METRIC_STUDENT_PERPLEXITY,
+        distillation_utils.METRIC_TEACHER_PERPLEXITY,
+    )
+    optional_keys = (
+        distillation_utils.METRIC_OUT_PROJ_FEATURE_LOSS,
+        distillation_utils.METRIC_MOE_LB_LOSS,
+        distillation_utils.METRIC_TEACHER_MOE_LB_LOSS,
+    )
+    parts = []
+    for k in headline_keys:
+      if k in aux:
+        parts.append(f"{k.split('/', 1)[1]}={_scalar(aux[k]):.4g}")
+    for k in optional_keys:
+      if k in aux:
+        v = _scalar(aux[k])
+        if v != 0:
+          parts.append(f"{k.split('/', 1)[1]}={v:.4g}")
+    if parts:
+      max_logging.log("Distillation metrics | " + " ".join(parts))
 
   def setup_checkpoint_manager_and_restore(self, raw_train_iter, config):
     """Configures the trainer's CheckpointManager and restores states.
@@ -632,6 +707,9 @@ def train_distill(
         strategy=strategy,
         optimizer=optimizer,
         training_config=train_config,
+        student_config=student_config,
+        teacher_config=teacher_config,
+        is_offline=is_offline,
         student_freeze_param_filter=student_freeze_param_fn if student_params_to_update else None,
     )
     trainer.is_managed_externally = True
@@ -802,6 +880,20 @@ def main(argv: Sequence[str]) -> None:
   # This ensures flags like `num_query_heads=16` passed in CLI don't affect the Teacher.
   teacher_argv = [argv[0], argv[1]]
   teacher_config = pyconfig.initialize(teacher_argv, **teacher_overrides)
+
+  # Batch shape (per_device_batch_size / max_target_length / gradient_accumulation_steps)
+  # must be set at the YAML top level — not inside *_overrides — since student and
+  # teacher share the input pipeline.
+  for batch_field in ("per_device_batch_size", "max_target_length", "gradient_accumulation_steps"):
+    s_val = getattr(student_config, batch_field)
+    t_val = getattr(teacher_config, batch_field)
+    if s_val != t_val:
+      raise ValueError(
+          f"Distillation batch shape mismatch on '{batch_field}': "
+          f"student={s_val} vs teacher={t_val}. The teacher consumes batches from the "
+          f"student-driven input pipeline, so these must agree. Set '{batch_field}' at "
+          f"the YAML top level (not inside *_overrides) so both configs inherit it."
+      )
 
   # 4. Run Training
   train_distill(student_config, teacher_config, is_offline, global_config.offline_data_dir)

--- a/tests/post_training/unit/distillation_tflops_test.py
+++ b/tests/post_training/unit/distillation_tflops_test.py
@@ -1,0 +1,126 @@
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Unit tests for `calculate_distillation_tflops_per_device`.
+
+Verifies the canonical training-FLOPs heuristic for online distillation:
+  - student does fwd + bwd ≈ 6 * P_student * tokens
+  - teacher does fwd only  ≈ 2 * P_teacher * tokens
+  - combined per-step TFLOPs is the sum
+  - offline mode zeroes the teacher contribution
+"""
+
+import pytest
+
+pytest.importorskip("tunix")
+
+pytestmark = [pytest.mark.cpu_only, pytest.mark.post_training]
+
+import unittest
+from unittest import mock
+
+from absl.testing import absltest
+
+from maxtext.trainers.post_train.distillation import distillation_utils
+
+
+def _make_fake_calculate_tflops(tflops_by_id):
+  """Returns a fake `calculate_tflops_training_per_device` keyed by `id(config)`.
+
+  The real function returns `(total_tflops, learnable_weight_tflops, attention_tflops)`
+  where `total = 6 * P * tokens / 1e12` for fwd+bwd. The fake mirrors that signature.
+  """
+
+  def _fake(config, log=False):
+    del log
+    total = tflops_by_id[id(config)]
+    return total, 0.0, 0.0
+
+  return _fake
+
+
+class DistillationTflopsTest(unittest.TestCase):
+  """Tests for the per-step distillation TFLOPs accounting."""
+
+  def test_online_uses_6P_student_and_2P_teacher(self):
+    # P in #params, D in #tokens. Use values where the answer is exact in float.
+    p_student, p_teacher, tokens = 1_000_000_000, 4_000_000_000, 8192
+
+    student_tflops_fwd_bwd = 6 * p_student * tokens / 1e12  # 6PD
+    teacher_tflops_fwd_bwd = 6 * p_teacher * tokens / 1e12  # underlying util always returns 6PD
+
+    student_config = mock.Mock(name="student_config")
+    teacher_config = mock.Mock(name="teacher_config")
+    fake = _make_fake_calculate_tflops(
+        {
+            id(student_config): student_tflops_fwd_bwd,
+            id(teacher_config): teacher_tflops_fwd_bwd,
+        }
+    )
+
+    with mock.patch.object(distillation_utils.maxtext_utils, "calculate_tflops_training_per_device", side_effect=fake):
+      combined, student, teacher = distillation_utils.calculate_distillation_tflops_per_device(
+          student_config, teacher_config, is_offline=False
+      )
+
+    # Student: full fwd + bwd = 6 * P * D.
+    self.assertAlmostEqual(student, 6 * p_student * tokens / 1e12, places=9)
+    # Teacher: forward only = 2 * P * D (= 6PD / 3).
+    self.assertAlmostEqual(teacher, 2 * p_teacher * tokens / 1e12, places=9)
+    # Combined: 6 P_s D + 2 P_t D.
+    self.assertAlmostEqual(combined, (6 * p_student + 2 * p_teacher) * tokens / 1e12, places=9)
+
+  def test_offline_zeroes_teacher_contribution(self):
+    p_student, tokens = 1_000_000_000, 8192
+    student_tflops_fwd_bwd = 6 * p_student * tokens / 1e12
+
+    student_config = mock.Mock(name="student_config")
+    teacher_config = mock.Mock(name="teacher_config")
+    fake = _make_fake_calculate_tflops(
+        {
+            id(student_config): student_tflops_fwd_bwd,
+            # Teacher entry exists but should never be consulted in offline mode;
+            # making it large would explode the assertion if it were used.
+            id(teacher_config): 1e9,
+        }
+    )
+
+    with mock.patch.object(distillation_utils.maxtext_utils, "calculate_tflops_training_per_device", side_effect=fake):
+      combined, student, teacher = distillation_utils.calculate_distillation_tflops_per_device(
+          student_config, teacher_config, is_offline=True
+      )
+
+    self.assertEqual(teacher, 0.0)
+    self.assertAlmostEqual(student, 6 * p_student * tokens / 1e12, places=9)
+    self.assertAlmostEqual(combined, student, places=9)
+
+  def test_none_teacher_config_zeroes_teacher_contribution(self):
+    p_student, tokens = 5e8, 4096
+    student_tflops_fwd_bwd = 6 * p_student * tokens / 1e12
+
+    student_config = mock.Mock(name="student_config")
+    fake = _make_fake_calculate_tflops({id(student_config): student_tflops_fwd_bwd})
+
+    with mock.patch.object(distillation_utils.maxtext_utils, "calculate_tflops_training_per_device", side_effect=fake):
+      combined, student, teacher = distillation_utils.calculate_distillation_tflops_per_device(
+          student_config, teacher_config=None, is_offline=False
+      )
+
+    self.assertEqual(teacher, 0.0)
+    self.assertAlmostEqual(combined, student, places=9)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
# Description

- Add `calculate_distillation_tflops_per_device` and wire it into `MaxTextDistillationTrainer` to log
  per-step per-device TFLOPs to TensorBoard (`perf/per_device_tflops{,_student,_teacher}` and `_per_sec` 
  variants).
- Console summary per step: `step N | step_time=Xs | TFLOPs/s/device: Y (student=A, teacher=B)`.       

- Replace the raw `Distillation metrics: {dict}` dump in `_post_process_train_step` with a compact,    
  selective line; optional metrics (feature loss, MoE LB) hide when zero.                                


# Tests

Unit test and end to end test checking the logs.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
