### PR TITLE
Add weekly linkchecker and report failures on issue

### DIFF
--- a/.github/workflows/check_docs_build.yml
+++ b/.github/workflows/check_docs_build.yml
@@ -3,6 +3,7 @@ name: Check the Documentation Build
 on:
   pull_request:
     types: [opened, synchronize]
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -13,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -54,8 +55,6 @@ jobs:
           . $GITHUB_WORKSPACE/venv/bin/activate
           uv pip install -e . --no-deps
           uv pip install torch
-          # verify links; the build fails if errors are found
-          sphinx-build -b linkcheck docs docs/_build/linkcheck -q --keep-going
           # generates the actual website
           sphinx-build -b html docs docs/_build/html
         env:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,81 @@
+
+name: Documentation Link Checker
+
+on:
+  schedule:
+    # Run every Monday at 9:00 AM UTC
+    - cron: '0 9 * * 1'
+  workflow_call:
+  workflow_dispatch: # Allow manual triggering
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install uv and set the Python version
+        uses: astral-sh/setup-uv@eb1897b8dc4b5d5bfe39a428a8f2304605e0983c  # v7.0.0
+        with:
+          python-version: '3.12'
+          enable-cache: true
+
+      - name: Set venv
+        run: uv venv --python 3.12 $GITHUB_WORKSPACE/venv
+
+      - name: Install dependencies
+        run: . $GITHUB_WORKSPACE/venv/bin/activate && uv pip install -r src/dependencies/requirements/requirements_docs.txt
+
+      - name: Run Sphinx linkcheck
+        id: linkcheck
+        continue-on-error: true
+        run: |
+          . $GITHUB_WORKSPACE/venv/bin/activate
+          sphinx-build -b linkcheck docs docs/_build/linkcheck -q --keep-going
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
+
+      - name: Prepare issue body
+        if: steps.linkcheck.outcome == 'failure'
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          echo "ISSUE_DATE=$DATE" >> $GITHUB_ENV
+
+          cat > issue-body.md << 'EOF'
+          ## Documentation Link Check Failed
+
+          The weekly documentation link checker has detected broken links.
+
+          **Workflow Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ### Broken Links Report
+
+          EOF
+
+          if [ -f docs/_build/linkcheck/output.txt ]; then
+            echo '```' >> issue-body.md
+            cat docs/_build/linkcheck/output.txt >> issue-body.md
+            echo '```' >> issue-body.md
+          else
+            echo 'No output file generated.' >> issue-body.md
+          fi
+
+          echo '' >> issue-body.md
+          echo 'Please review and fix the broken links in the documentation.' >> issue-body.md
+
+      - name: Create issue for broken links
+        if: steps.linkcheck.outcome == 'failure'
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # v6.0.0
+        with:
+          title: Documentation Link Check Failed - ${{ env.ISSUE_DATE }}
+          content-filepath: ./issue-body.md
+          labels: |
+            documentation

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -43,6 +43,17 @@ jobs:
     uses: ./.github/workflows/build_and_test_maxtext.yml
     secrets: inherit
 
+  build_docs:
+    name: Build Documentation
+    needs: [build_and_test_maxtext_package]
+    uses: ./.github/workflows/check_docs_build.yml
+    secrets: inherit
+
+  check_links:
+    name: Check Links in Documentation
+    uses: ./.github/workflows/linkcheck.yml
+    secrets: inherit
+
   publish_maxtext_package_to_pypi:
     name: Publish MaxText package to PyPI
     needs: [build_and_test_maxtext_package]


### PR DESCRIPTION
# Description

Currently, we perform a full link check (for external URLs) on every CI run, which:
- slows the documentation check,
- fails if we are trying to reference new pages in a PR, and
- can result in rate limiting issues (notably seen for some HuggingFace links).

This PR changes the link checker to only run once a week (on mondays) and to report any failures as an issue to the MaxText repo.

As a note, the _internal_ links (those referencing documents within the MaxText docs folder) are automatically checked during the docs build. The [current docs build](https://github.com/AI-Hypercomputer/maxtext/blob/ee3fb762f67b978cd927c1d99a71935b78ec7adc/.github/workflows/check_docs_build.yml#L60) does NOT fail on warnings (including broken internal links), but it should, and this will be fixed in a subsequent PR.

The link checker can also be run manually from the repo Actions tab. 

# Tests

To see what this would look like, I have implemented this fully on my fork of MaxText. You can see the action run here: https://github.com/melissawm/maxtext/actions/runs/25226702400 

Note it has failed (as expected) and the generated issue with the failure report is here: https://github.com/melissawm/maxtext/issues/2

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [N/A] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
