### PR TITLE
Skip HLO diff tests for maxtext_jax_nightly docker image

### DIFF
--- a/.github/workflows/promote_docker_image.yml
+++ b/.github/workflows/promote_docker_image.yml
@@ -73,6 +73,7 @@ jobs:
       base_image: ${{ inputs.image_name }}:${{ inputs.image_tag }}
       is_scheduled_run: true
       maxtext_installed: true
+      additional_pytest_args: ${{ contains(inputs.image_name, 'maxtext_jax_nightly') && '--ignore=tests/integration/hlo_diff_test.py' || '' }}
 
   tagging:
     needs: [test]

--- a/.github/workflows/run_tests_coordinator.yml
+++ b/.github/workflows/run_tests_coordinator.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: boolean
         default: false
+      additional_pytest_args:
+        description: 'Additional pytest arguments to pass during test execution'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -137,6 +142,7 @@ jobs:
             "cpu-unit": "--ignore=tests/post_training",
             "cpu-post-training-unit": ""
           }')[inputs.flavor] }}
+        ${{ inputs.additional_pytest_args }}
 
       # Resource Scaling
       xla_python_client_mem_fraction: "${{ contains(inputs.flavor, 'gpu') && '0.65' || '0.75' }}"


### PR DESCRIPTION
# Description

This PR modifies the "Build Images" workflow to allow skipping specific tests during the promotion of Docker images. Specifically, it introduces an `additional_pytest_args` input to the test coordinator workflow and uses it to ignore `tests/integration/hlo_diff_test.py` when the image being processed is `maxtext_jax_nightly`.

# Tests
- Verified that the `additional_pytest_args` are correctly passed through the workflow chain.
- Confirmed that the logic correctly identifies `maxtext_jax_nightly` to trigger the test exclusion.
- https://github.com/AI-Hypercomputer/maxtext/actions/runs/25229397649/job/73981953466

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
