### PR TITLE
Pass student_config to tests in train_distill_test.py

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -217,7 +217,7 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
       optimizer,
       training_config,
       student_config: pyconfig.HyperParameters,
-      teacher_config: pyconfig.HyperParameters | None,
+      teacher_config: pyconfig.HyperParameters | None = None,
       is_offline: bool = False,
       student_freeze_param_filter: Callable[[Any], bool] | None = None,
       **kwargs,
@@ -345,7 +345,7 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
 
   def _log_metrics(self, loss, step=None, step_time_delta=None, additional_metrics=None):
     """Adds per-device TFLOPs (and per-sec variants) to the standard Tunix metrics."""
-    super()._log_metrics(loss=loss, step=step, step_time_delta=step_time_delta, additional_metrics=additional_metrics)
+    super()._log_metrics(loss=loss, step=step, additional_metrics=additional_metrics)
 
     tflops_metrics = {
         "perf/per_device_tflops": self._tflops_combined,

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -891,7 +891,11 @@ class TrainDistillTest(unittest.TestCase):
     self.assertTrue(any(c == "1" or c.endswith("1") for c in checkpoints), f"Checkpoint 1 not found in {checkpoints}")
     self.assertTrue(any(c == "2" or c.endswith("2") for c in checkpoints), f"Checkpoint 2 not found in {checkpoints}")
 
-  def test_checkpointing_and_resume(self):
+  @mock.patch(
+      "maxtext.trainers.post_train.distillation.distillation_utils.calculate_distillation_tflops_per_device",
+      return_value=(0.0, 0.0, 0.0),
+  )
+  def test_checkpointing_and_resume(self, _mock_tflops):
     """Trains a few steps, saves a checkpoint, and resumes from it."""
 
     # 1. Setup minimal dummy model and models bundle
@@ -941,6 +945,7 @@ class TrainDistillTest(unittest.TestCase):
         strategy=strategy,
         optimizer=optimizer1,
         training_config=train_config,
+        student_config=config,
     )
     trainer1._lora_enabled = False
     trainer1.is_managed_externally = True
@@ -989,6 +994,7 @@ class TrainDistillTest(unittest.TestCase):
         strategy=strategy,
         optimizer=optimizer2,
         training_config=train_config,
+        student_config=config,
     )
     trainer2._lora_enabled = False
 
@@ -1085,6 +1091,10 @@ class TrainDistillTest(unittest.TestCase):
 
     mock_teacher_cfg = mock.Mock()
     mock_teacher_cfg.vocab_size = 32000
+    mock_teacher_cfg.per_device_batch_size = mock_student_cfg.per_device_batch_size
+    mock_teacher_cfg.max_target_length = mock_student_cfg.max_target_length
+    mock_teacher_cfg.gradient_accumulation_steps = mock_student_cfg.gradient_accumulation_steps
+
     mock_pyconfig_init.side_effect = [mock_global, mock_student_cfg, mock_teacher_cfg]
 
     # 2. Model Loading
@@ -1183,6 +1193,10 @@ class TrainDistillTest(unittest.TestCase):
 
     mock_teacher_cfg = mock.Mock()
     mock_teacher_cfg.vocab_size = 32000
+    mock_teacher_cfg.per_device_batch_size = mock_student_cfg.per_device_batch_size
+    mock_teacher_cfg.max_target_length = mock_student_cfg.max_target_length
+    mock_teacher_cfg.gradient_accumulation_steps = mock_student_cfg.gradient_accumulation_steps
+
     mock_pyconfig_init.side_effect = [mock_global, mock_student_cfg, mock_teacher_cfg]
 
     mock_student_model = mock.Mock()
@@ -1206,8 +1220,11 @@ class TrainDistillTest(unittest.TestCase):
     self.assertIs(model_bundle.student_model, mock_student_model)
     self.assertIs(model_bundle.teacher_model, mock_teacher_model)
 
-  def test_student_freeze_param_filter(self):
-    """Verifies that student_freeze_param_filter correctly freezes specified parameters."""
+  @mock.patch(
+      "maxtext.trainers.post_train.distillation.distillation_utils.calculate_distillation_tflops_per_device",
+      return_value=(0.0, 0.0, 0.0),
+  )
+  def test_student_freeze_param_filter(self, _mock_tflops):
 
     # 1. Setup a dummy model with multiple layers
     class DummyModel(nnx.Module):
@@ -1260,6 +1277,7 @@ class TrainDistillTest(unittest.TestCase):
         strategy=strategy,
         optimizer=optax.sgd(0.1),
         training_config=train_config,
+        student_config=mock.Mock(),
         student_freeze_param_filter=freeze_filter,
     )
     trainer._lora_enabled = False


### PR DESCRIPTION
# Description

This PR fixes post-training unit tests that were borken by https://github.com/AI-Hypercomputer/maxtext/pull/3791.

Key changes:
- Pass `student_config` to MaxTextDistillationTrainer in train_distill_test.py
- `step_time_delta` removed from `_log_metrics()` in Tunix: cl/889401107

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
