### PR TITLE
Remove "vision_output_length" from  convert_gemma4.sh script

### DIFF
--- a/tests/end_to_end/tpu/gemma4/26b/convert_gemma4.sh
+++ b/tests/end_to_end/tpu/gemma4/26b/convert_gemma4.sh
@@ -55,7 +55,6 @@ if [ ${USE_MULTIMODAL} == true ]; then
         dtype=float32 \
         matmul_precision=highest \
         per_device_batch_size=1 \
-        vision_output_length=280 \
         attention=dot_product \
         prompt="${TEST_PROMPT}" \
         image_path=${TEST_IMAGE} \

--- a/tests/end_to_end/tpu/gemma4/31b/convert_gemma4.sh
+++ b/tests/end_to_end/tpu/gemma4/31b/convert_gemma4.sh
@@ -55,7 +55,6 @@ if [ ${USE_MULTIMODAL} == true ]; then
         dtype=float32 \
         matmul_precision=highest \
         per_device_batch_size=1 \
-        vision_output_length=280 \
         attention=dot_product \
         prompt="${TEST_PROMPT}" \
         image_path=${TEST_IMAGE} \


### PR DESCRIPTION
# Description

Since the flag is already set in [gemma4-31b.yml](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/models/gemma4-31b.yml#L57) and [gemma4-26b.yml](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/configs/models/gemma4-26b.yml#L61). Setting in the script causes error 
```
ValueError: Keys ['vision_output_length'] are overridden by both model config and CLI/kwargs.This is not allowed, unless setting `override_model_config=True`.
```


# Tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
