### PR TITLE
Adding adapter changes needed for gemma4 inference.

### DIFF
--- a/src/dependencies/extra_deps/post_train_base_deps.txt
+++ b/src/dependencies/extra_deps/post_train_base_deps.txt
@@ -1,1 +1,1 @@
-google-tunix @ https://github.com/google/tunix/archive/9d25e2647520b205ef43e5182ded030d20f3f52b.zip
+google-tunix @ https://github.com/google/tunix/archive/387072374f99a100cb11f99dec951940b1475a04.zip

--- a/src/dependencies/extra_deps/post_train_github_deps.txt
+++ b/src/dependencies/extra_deps/post_train_github_deps.txt
@@ -1,3 +1,3 @@
 -r post_train_base_deps.txt
-tpu-inference @ https://github.com/vllm-project/tpu-inference/archive/40876e81f04226f9b7b1e4bbdc9051d6b1364b9d.zip
-vllm @ git+https://github.com/vllm-project/vllm@595562651a5a4539ffa910d8570c08fb5169bdc9
+tpu-inference @ https://github.com/vllm-project/tpu-inference/archive/39d9a9d38d3c96a7e1e57f9e693cf1c96a44e87d.zip
+vllm @ git+https://github.com/vllm-project/vllm@529c671e8075d265a48b72e0eaaeb5e30d2f1630

--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -103,36 +103,50 @@ def generate_maxtext_config(vllm_config: VllmConfig, mesh: Mesh) -> pyconfig.Hyp
 
   # Gather information on the hidden size of MoE models to determine if padding is needed
   # to meet MLP MoE requirements for tpu-inference GMM_v2 kernel.
-  hidden_size = getattr(vllm_config.model_config.hf_config, "moe_intermediate_size", None)
-  padded_hidden_size = hidden_size
+  hf_config = (
+      vllm_config.model_config.hf_config.text_config
+      if hasattr(vllm_config.model_config.hf_config, "text_config")
+      else vllm_config.model_config.hf_config
+  )
+  hidden_size = getattr(hf_config, "moe_intermediate_size", None)
   num_lanes = pltpu.get_tpu_info().num_lanes
+  use_global_kv_heads = hasattr(hf_config, "num_global_key_value_heads")
+  num_kv_heads = hf_config.num_key_value_heads
+
+  # Get the number KV heads used in global attention layers if specified.
+  num_global_kv_heads = hf_config.num_global_key_value_heads if use_global_kv_heads else None
 
   max_logging.log(
-      f"vLLM sharding config: hidden_size={hidden_size}, tp={tp}, "
-      f"attn_dp={attn_dp}, ep={ep}, moe_mlp_tp_size={moe_mlp_tp_size}"
+      f"vLLM sharding config: hidden_size={hidden_size}, kv_heads={num_kv_heads}, global_kv_heads={num_global_kv_heads}, "
+      f"num_lanes={num_lanes}, tp={tp}, attn_dp={attn_dp}, ep={ep}, moe_mlp_tp_size={moe_mlp_tp_size}"
   )
 
   # Replicate the number of KV heads if its less than the total degree of model parallelism
-  if (
-      kv_tp_size % vllm_config.model_config.get_total_num_kv_heads() == 0
-      and vllm_config.model_config.get_total_num_kv_heads() < kv_tp_size
-  ):
+  if kv_tp_size % num_kv_heads == 0 and num_kv_heads < kv_tp_size:
     max_logging.log(
-        f"Padding num_kv_heads from {vllm_config.model_config.get_total_num_kv_heads()} "
-        f"to {kv_tp_size} to match the degree of tensor parallelism."
+        f"Padding num_kv_heads from {num_kv_heads} to {kv_tp_size} to match the degree of tensor parallelism."
     )
     overrides["base_num_kv_heads"] = kv_tp_size
+
+  # Replicate the number of global KV heads if its less than the total degree of model parallelism
+  if use_global_kv_heads and kv_tp_size % num_global_kv_heads == 0 and num_global_kv_heads < kv_tp_size:
+    max_logging.log(
+        f"Padding num_global_kv_heads from {num_global_kv_heads} "
+        f"to {kv_tp_size} to match the degree of tensor parallelism."
+    )
+    overrides["global_num_kv_heads"] = kv_tp_size
 
   # Pad the hidden size of MoE models if the MLP dimension is less than expected by the GMM_v2 kernel in tpu-inference.
   # The GMM_v2 kernel requires the MLP dimension per expert to be at least 2x the number of TPU lanes
   # to ensure efficient execution. See the validate_inputs() method in the following file for more details:
   # https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/kernels/megablox/gmm_v2.py
-  if hidden_size is not None and tp > 1 and (hidden_size // moe_mlp_tp_size) % (2 * num_lanes) != 0:
+  if hidden_size is not None and (hidden_size // moe_mlp_tp_size) % (2 * num_lanes) != 0:
+    padded_hidden_size = next_power_of_two(hidden_size)
     while (padded_hidden_size // moe_mlp_tp_size) < (2 * num_lanes):
-      padded_hidden_size = next_power_of_two(padded_hidden_size)
+      padded_hidden_size = next_power_of_two(padded_hidden_size + 1)
 
     max_logging.log(
-        f"Padding moe_intermediate_size from {hidden_size} " f"to {padded_hidden_size} to match MLP MoE requirements."
+        f"Padding moe_intermediate_size from {hidden_size} to {padded_hidden_size} to match MLP MoE requirements."
     )
     overrides["padded_base_moe_mlp_dim"] = padded_hidden_size
 
@@ -191,7 +205,7 @@ class MaxTextForCausalLM(nnx.Module):
       attention_metadata: AttentionMetadata,
       *args,
       **kwargs,
-  ) -> tuple[list[jax.Array], jax.Array, list[jax.Array]]:
+  ) -> tuple[list[jax.Array], jax.Array, list[jax.Array], list[jax.Array] | None]:
     """Performs a forward pass through the causal language model.
 
     Args:
@@ -206,6 +220,7 @@ class MaxTextForCausalLM(nnx.Module):
         - updated_kv_caches: A list of updated KV caches.
         - hidden: The hidden states.
         - aux_hidden_states: A list of auxiliary hidden states.
+        - expert_indices: A list of expert indices or None.
 
     Raises:
       ValueError: If the model is not an instance of `nnx.Module`.
@@ -219,6 +234,7 @@ class MaxTextForCausalLM(nnx.Module):
 
     with self.mesh, nn.logical_axis_rules(self.maxtext_config.logical_axis_rules):
       aux_hidden_states = []
+      expert_indices = None
       hidden, kv_caches = self.model(
           decoder_input_tokens=input_ids,
           decoder_positions=input_positions,
@@ -231,7 +247,7 @@ class MaxTextForCausalLM(nnx.Module):
       # To be compatible with vLLM, we reshape to (batch * seq, dim).
       hidden = hidden.reshape((-1, hidden.shape[-1]))
 
-    return kv_caches, hidden, aux_hidden_states
+    return kv_caches, hidden, aux_hidden_states, expert_indices
 
   def forward(self, *args, **kwargs):
     """Alias for __call__ for compatibility.


### PR DESCRIPTION
# Description

Adds necessary changes to enable MaxText on vLLM decoding of `gemma4-26b-a4b`. This includes replicating the number of global attention layer KV heads if necessary, and enable padding of MoE hidden dimension for GMM_v2 kernel execution. 

This PR also updates LKG `tpu-inference`, `vllm` and `tunix` commits. Note that `tpu-inference` is currently longer pre-compilation times, this is currently being debugged and we will upgrade the `tpu-inference` version one more time once its fixed. 

# Tests

`vllm_decode.py` with both EP=4 and TP=4

```
I0504 22:23:13.593252 126702982401152 vllm_decode.py:165] Prompt: <bos><|turn>user
Tell me three fun facts about Buenos Aires.<turn|>
<|turn>model
<|channel>thought
<channel|>, Generated text: Here are three fun facts about Buenos Aires:

### 1. It is the "Paris of the South"
Buenos Aires is world-renowned for its stunning European-style architecture. During the late 19th and early 20th centuries, the city underwent massive urban development inspired by Paris. This resulted in wide boulevards, grand palaces, and ornate cafes, giving the city a sophisticated, Old World atmosphere that is rare in the Americas.

### 2. It is the birthplace of Tango
While many people associate Tango with Argentina as a whole, the dance and music were born in the working-class neighborhoods and port districts of Buenos Aires (like La Boca). It evolved from a mix of African, European, and local rhythms, eventually transforming from a scandalous street dance into one of the most elegant and passionate art forms in the world.

### 3. It has a massive "Bookstore Culture"
Buenos Aires is often called the "City of Books." It has more bookstores per capita than almost any other city in the world. One of its most famous landmarks is **El Ateneo Grand Splendid**, a massive bookstore housed inside a beautifully restored 1919 theater. Instead of aisles, you browse books on stages, and you can even sit in the old theater boxes to read.
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
