### PR TITLE
Add checkpoint resharding script for faster loading

### DIFF
--- a/src/maxtext/checkpoint_conversion/reshard_checkpoint.py
+++ b/src/maxtext/checkpoint_conversion/reshard_checkpoint.py
@@ -1,0 +1,151 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This script re-shards a MaxText checkpoint on CPU, assuming linen format.
+- The Orbax checkpoint is streamed from storage directly into the target sharded layout on a simulated CPU mesh,
+  and then saved to a new checkpoint.
+- The goal is to pre-shard checkpoints (source) to accelerate loading on TPUs (target) by reducing re-sharding overhead.
+  E.g., when target sharding is fsdp=64, checkpoint loading time varies across source sharding (fsdp=16 < ep=16)
+
+Key Parameters:
+- `--simulated_cpu_devices_count` (defaults to 16). Examples:
+  - **Suitable for most cases**: `--simulated_cpu_devices_count=16 ici_fsdp_parallelism=16`
+  - More customization: `--simulated_cpu_devices_count=32 ici_fsdp_parallelism=16 ici_expert_parallelism=2`
+- `weight_dtype`: The dtype used to load and save the checkpoint. **Highly recommend** using `weight_dtype=bfloat16`.
+- `load_parameters_path`: The input checkpoint path (GCS or local).
+- `base_output_directory`: The output directory (GCS or local).
+  - The output checkpoint path will be `<base_output_directory>/0/items`
+
+Memory Requirements:
+- For X billion parameters, needs slightly over 2X GB RAM (each param takes 2 bytes with `weight_dtype=bfloat16`).
+- Note: We only hold one model copy in memory, as the re-sharding happens dynamically during the read operation.
+  Additional buffer memory is needed mainly for the I/O streaming overhead, usually small compared to model weight.
+- Example: DeepSeek-V3 with MTP layers has 685B parameters, uses 1.37 TB for weights, and hits a peak RAM of ~1.45 TB.
+
+Example Commands:
+
+python3 -m maxtext.checkpoint_conversion.reshard_checkpoint \
+  model_name=deepseek2-16b attention=dot_product mla_naive_kvcache=false \
+  scan_layers=True load_parameters_path=<input_ckpt_path> \
+  base_output_directory=<output_ckpt_dir> \
+  weight_dtype=bfloat16 \
+  checkpoint_storage_concurrent_gb=1024 checkpoint_storage_use_ocdbt=True checkpoint_storage_use_zarr3=True \
+  skip_jax_distributed_system=True ici_fsdp_parallelism=16 \
+  --simulated_cpu_devices_count=16
+
+python3 -m maxtext.checkpoint_conversion.reshard_checkpoint \
+  model_name=deepseek3-671b mtp_num_layers=1 mtp_loss_scaling_factor=0.1 attention=dot_product mla_naive_kvcache=false \
+  scan_layers=True load_parameters_path=<input_ckpt_path> \
+  base_output_directory=<output_ckpt_dir> \
+  weight_dtype=bfloat16 \
+  checkpoint_storage_concurrent_gb=1024 checkpoint_storage_use_ocdbt=True checkpoint_storage_use_zarr3=True \
+  skip_jax_distributed_system=True ici_fsdp_parallelism=16 ici_expert_parallelism=2 \
+  --simulated_cpu_devices_count=32
+"""
+
+
+import argparse
+import os
+import sys
+import time
+from typing import Sequence
+from absl import app
+
+import jax
+from flax.training import train_state
+
+from maxtext.configs import pyconfig
+from maxtext.inference.maxengine import maxengine
+from maxtext.utils import max_utils, max_logging
+from maxtext.common import checkpointing
+from maxtext.checkpoint_conversion.utils.utils import print_peak_memory
+
+
+def main(argv: Sequence[str]) -> None:
+  config = pyconfig.initialize(argv)
+  max_utils.print_system_information()
+  max_logging.log(f"Load and save checkpoint with weight dtype: {config.weight_dtype}")
+
+  # 1. Engine sets up the mesh based on config
+  engine = maxengine.MaxEngine(config)
+  rng = jax.random.PRNGKey(1234)
+  rng, rng_load_params = jax.random.split(rng)
+
+  # 2. Load parameters and reshard with the mesh
+  start = time.time()
+  params = engine.load_params(rng_load_params)
+  max_logging.log(f"Elapse for checkpoint load (with reshard): {(time.time() - start) / 60:.2f} min")
+
+  # 3. Save checkpoint
+  start = time.time()
+  save_ckpt_directory = config.base_output_directory
+
+  # Dummy configs for the checkpoint_manager
+  step_number = 0
+  enable_checkpointing = True
+  async_checkpointing = False
+  save_interval_steps = 1
+
+  checkpoint_manager = checkpointing.create_orbax_checkpoint_manager(
+      save_ckpt_directory,
+      enable_checkpointing,
+      async_checkpointing,
+      save_interval_steps,
+      use_ocdbt=config.checkpoint_storage_use_ocdbt,
+      use_zarr3=config.checkpoint_storage_use_zarr3,
+  )
+  if checkpoint_manager is None:
+    raise RuntimeError("Failed to create Orbax checkpoint manager.")
+
+  state_new = train_state.TrainState(
+      step=step_number, apply_fn=None, params=params, tx=None, opt_state={}  # type: ignore
+  )
+
+  if checkpointing.save_checkpoint(checkpoint_manager, step_number, state_new):
+    save_ckpt_path = os.path.join(save_ckpt_directory, str(step_number), "items")
+    max_logging.log(f"Saved checkpoint: {save_ckpt_path}")
+    # Upon preemption, exit when and only when all ongoing saves are complete.
+    checkpoint_manager.wait_until_finished()
+
+  max_logging.log(f"Elapse for checkpoint save: {(time.time() - start) / 60:.2f} min")
+  print_peak_memory()
+
+
+if __name__ == "__main__":
+  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
+  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"  # Suppress TensorFlow logging
+
+  # Define local parser
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      "--simulated_cpu_devices_count",
+      type=int,
+      required=False,
+      default=16,
+      help="Number of simulated CPU devices for sharding the checkpoint",
+  )
+
+  # Parse known args returns the namespace AND the list of remaining arguments
+  local_args, remaining_args = parser.parse_known_args()
+
+  # Reconstruct model_args (script name + the args MaxText needs)
+  model_args = [sys.argv[0]] + remaining_args
+
+  # Set JAX environment
+  jax.config.update("jax_platforms", "cpu")
+  # Simulate CPU devices as virtual mesh
+  os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={local_args.simulated_cpu_devices_count}"
+
+  app.run(main, argv=model_args)

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/llama_or_mistral_ckpt.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/llama_or_mistral_ckpt.py
@@ -1760,17 +1760,18 @@ def save_weights_to_checkpoint(
       use_ocdbt=use_ocdbt,
       use_zarr3=use_zarr3,
   )
+  if checkpoint_manager is None:
+    raise RuntimeError("Failed to create Orbax checkpoint manager.")
 
   state_new = train_state.TrainState(
-      step=0, apply_fn=None, params={"params": jax_weights}, tx=None, opt_state={}  # type: ignore
+      step=step_number_to_save_new_ckpt, apply_fn=None, params={"params": jax_weights}, tx=None, opt_state={}  # type: ignore
   )
 
   logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
-  if checkpoint_manager is not None:
-    if checkpointing.save_checkpoint(checkpoint_manager, step_number_to_save_new_ckpt, state_new):
-      max_logging.log(f"saved a checkpoint at step {step_number_to_save_new_ckpt}")
-    # Upon preemption, exit when and only when all ongoing saves are complete.
-    checkpoint_manager.wait_until_finished()
+  if checkpointing.save_checkpoint(checkpoint_manager, step_number_to_save_new_ckpt, state_new):
+    max_logging.log(f"saved a checkpoint at step {step_number_to_save_new_ckpt}")
+  # Upon preemption, exit when and only when all ongoing saves are complete.
+  checkpoint_manager.wait_until_finished()
 
   max_logging.log(f"Elapse for checkpoint save: {(time.time() - start) / 60:.2f} min")
 


### PR DESCRIPTION
# Description

This script re-shards a MaxText checkpoint on CPU. The goal is to pre-shard checkpoints (source) to accelerate loading on TPUs (target) by reducing re-sharding overhead. 

FIXES: b/504714612

### Introduction

**Problem**: In checkpoint conversion, we typically shard along the 0th dimension (usually the expert dimension for MoE). Consequently, loading is fast when the target sharding is EP (e.g., a few minutes), but noticeably slow for FSDP (e.g., an hour). This is a major bottleneck because FSDP is our most common use case.

**Effectiveness**: Our experiments show that pre-sharding a checkpoint to fsdp=16 **reduces the loading time of DeepSeek-V3 from 60 minutes to 6 minutes** on a v5p-128 cluster targeting fsdp=64. Furthermore, the solution scales efficiently to v7x 1k chips, maintaining a brief 10-minute load time.

Generalizability: While this was built to solve the FSDP loading bottleneck, the solution generalizes to pre-shard checkpoints into other target sharding layout.

### Method

The Orbax checkpoint is streamed from storage directly into the target sharded layout on a simulated CPU mesh, and then saved to a new checkpoint.

Key operation trace: [maxengine.load_params](https://github.com/AI-Hypercomputer/maxtext/blob/1adb45ce021c39103c0266854189f47f79c88386/src/maxtext/inference/maxengine/maxengine.py#L253) -> [maxtext_utils.setup_decode_state](https://github.com/AI-Hypercomputer/maxtext/blob/1adb45ce021c39103c0266854189f47f79c88386/src/maxtext/utils/maxtext_utils.py#L1326) -> [checkpointing.load_params_from_path](https://github.com/AI-Hypercomputer/maxtext/blob/1adb45ce021c39103c0266854189f47f79c88386/src/maxtext/common/checkpointing.py#L750) -> orbax.checkpoint.Checkpointer.restore


### User Guide

Full details are in docstring.

Key Parameters:
- `--simulated_cpu_devices_count` (defaults to 16). Examples:
  - **Suitable for most cases**: `--simulated_cpu_devices_count=16 ici_fsdp_parallelism=16`
  - More customization: `--simulated_cpu_devices_count=32 ici_fsdp_parallelism=16 ici_expert_parallelism=2`
- `weight_dtype`: The dtype used to load and save the checkpoint. **Highly recommend** using `weight_dtype=bfloat16`.

Memory Requirements:
- For X billion parameters, needs slightly over 2X GB RAM (each param takes 2 bytes with `weight_dtype=bfloat16`).
- Note: We only hold one model copy in memory, as the re-sharding happens dynamically during the read operation. Additional buffer memory is needed mainly for the I/O streaming overhead, usually small compared to model weight.
- Example: deepseek3 with MTP layers has 685B parameters, uses 1.37 TB for weights, and hits a peak RAM of ~1.45 TB (overhead is trivial relative to weight).
- Example: deepseek2-16b, uses 32GB for weights, and hits a peak RAM of ~63 GB (overhead seems non-trivial, as the model size is small).


# Tests

### deepseek3-671b with mtp

Full test details in b/504714612 (comment3, comment8)
- pre-sharded with fsdp=16
  - conversion on CPU: time 134min, peak RAM 1486 GB, [log](https://paste.googleplex.com/6007249236525056)
  - The loading time is reduced to 6min (from 1hr), target sharding is fsdp=64 on v5p-128. 
- loading time on v7x with 1k chips is 10min

### deepseek2-16b

Reshard:
```
# reshard CKPT1 to CKPT2 on CPU
python3 -m maxtext.checkpoint_conversion.reshard_checkpoint \
model_name=deepseek2-16b attention=dot_product mla_naive_kvcache=false \
scan_layers=True load_parameters_path=$CKPT1 \
base_output_directory=$CKPT2_DIR \
weight_dtype=bfloat16 \
checkpoint_storage_concurrent_gb=1024 checkpoint_storage_use_ocdbt=True checkpoint_storage_use_zarr3=True \
skip_jax_distributed_system=True ici_fsdp_parallelism=16 \
--simulated_cpu_devices_count=16
```
- log: https://paste.googleplex.com/4918283263410176
- Elapsed: 2 minutes, Peak Memory: 63.11 GB (32GB for weight, overhead is non-trivial as the model is small)

Inspect structure: 
- [CKPT1 (old)](https://paste.googleplex.com/5239524838998016): shard 0th dim into 16 shards when possible
- [CKPT2 (new)](https://paste.googleplex.com/5363034844430336): shard with fsdp=16
```
# CKPT1 (old)
ArrayMetadata :  name=params.params.decoder.moe_layers.DeepSeekMoeBlock_0.MoeBlock_0.wi_0,  directory=gs://ml-auto-solutions/output/unowned/maxtext_nightly_deepseek2-16b-v5p-8-2026-04-20-06-52-15/scanned/0/items,  shape=(64, 26, 2048, 1408),  sharding=NamedShardingMetadata(shape=[16], axis_names=['checkpoint_sharding_axis'], axis_types=(Auto,), partition_spec=('checkpoint_sharding_axis',)) device_mesh=DeviceMetadataMesh(mesh=[DeviceMetadata(id=0), DeviceMetadata(id=1), DeviceMetadata(id=2), DeviceMetadata(id=3), DeviceMetadata(id=4), DeviceMetadata(id=5), DeviceMetadata(id=6), DeviceMetadata(id=7), DeviceMetadata(id=8), DeviceMetadata(id=9), DeviceMetadata(id=10), DeviceMetadata(id=11), DeviceMetadata(id=12), DeviceMetadata(id=13), DeviceMetadata(id=14), DeviceMetadata(id=15)]),  dtype=float16,  storage=StorageMetadata(chunk_shape=(4, 26, 2048, 1408), write_shape=(4, 26, 2048, 1408)),

# CKPT2 (new)
ArrayMetadata :  name=params.params.decoder.moe_layers.DeepSeekMoeBlock_0.MoeBlock_0.wi_0,  directory=gs://shuningjin-multipod-dev/conversion/ds2-fsdp-2026-05-03-10-58/0/items,  shape=(64, 26, 2048, 1408),  sharding=NamedShardingMetadata(shape=[ 1  1  1 16  1  1  1  1  1  1  1  1], axis_names=['diloco', 'data', 'stage', 'fsdp', 'fsdp_transpose', 'context', 'context_autoregressive', 'tensor', 'tensor_transpose', 'tensor_sequence', 'expert', 'autoregressive'], axis_types=(Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto), partition_spec=('expert', None, ['fsdp', 'tensor_transpose', 'context'], ['fsdp_transpose', 'tensor', 'tensor_sequence', 'autoregressive'])) device_mesh=DeviceMetadataMesh(mesh=[[[[[[[[[[[[DeviceMetadata(id=0)]]]]]]]], [[[[[[[[DeviceMetadata(id=1)]]]]]]]], [[[[[[[[DeviceMetadata(id=2)]]]]]]]], [[[[[[[[DeviceMetadata(id=3)]]]]]]]], [[[[[[[[DeviceMetadata(id=4)]]]]]]]], [[[[[[[[DeviceMetadata(id=5)]]]]]]]], [[[[[[[[DeviceMetadata(id=6)]]]]]]]], [[[[[[[[DeviceMetadata(id=7)]]]]]]]], [[[[[[[[DeviceMetadata(id=8)]]]]]]]], [[[[[[[[DeviceMetadata(id=9)]]]]]]]], [[[[[[[[DeviceMetadata(id=10)]]]]]]]], [[[[[[[[DeviceMetadata(id=11)]]]]]]]], [[[[[[[[DeviceMetadata(id=12)]]]]]]]], [[[[[[[[DeviceMetadata(id=13)]]]]]]]], [[[[[[[[DeviceMetadata(id=14)]]]]]]]], [[[[[[[[DeviceMetadata(id=15)]]]]]]]]]]]]),  dtype=bfloat16,  storage=StorageMetadata(chunk_shape=(64, 26, 128, 1408), write_shape=(64, 26, 128, 1408)),
```

forward_pass_logit_checker, load with target sharding fsdp=16: 
- [CKPT1 (old)](https://paste.googleplex.com/5893882467450880): Finished load in 85.74 seconds
- [CKPT2 (new)](https://paste.googleplex.com/6392070957826048): Finished load in 44.90 seconds


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
