### PR TITLE
Downgrade setuptools in post-training to 80.10.2

### DIFF
--- a/src/dependencies/requirements/base_requirements/tpu-post-train-requirements.txt
+++ b/src/dependencies/requirements/base_requirements/tpu-post-train-requirements.txt
@@ -30,6 +30,7 @@ python-json-logger
 pyzmq
 ray
 runai-model-streamer[s3,gcs]
+setuptools<81.0.0
 sortedcontainers
 torchax
 torchvision

--- a/src/dependencies/requirements/generated_requirements/tpu-post-train-requirements.txt
+++ b/src/dependencies/requirements/generated_requirements/tpu-post-train-requirements.txt
@@ -8,9 +8,10 @@ aiohttp>=3.13.5
 aiosignal>=1.4.0
 annotated-doc>=0.0.4
 annotated-types>=0.7.0
-anthropic>=0.97.0
+anthropic>=0.98.0
 antlr4-python3-runtime>=4.9.3
 anyio>=4.13.0
+apache-tvm-ffi>=0.1.10
 appnope>=0.1.4 ; sys_platform == 'darwin'
 aqtp>=0.9.0
 array-record>=0.8.3
@@ -21,11 +22,11 @@ astunparse>=1.6.3
 attrs>=25.4.0
 auditwheel>=6.6.0
 black>=25.12.0
-boto3>=1.42.97
-botocore>=1.42.97
+boto3>=1.43.2
+botocore>=1.43.2
 build>=1.4.0
-cachetools>=7.0.6
-cbor2>=5.9.0
+cachetools>=7.1.1
+cbor2>=6.0.1
 certifi>=2026.2.25
 cffi>=2.0.0 ; implementation_name == 'pypy' or platform_python_implementation != 'PyPy'
 cfgv>=3.5.0
@@ -42,8 +43,9 @@ comm>=0.2.3
 compressed-tensors>=0.15.0.1
 contourpy>=1.3.3
 cryptography>=47.0.0
-cuda-bindings>=12.9.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-cuda-pathfinder>=1.5.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+cuda-bindings>=13.2.0 ; sys_platform == 'linux'
+cuda-pathfinder>=1.5.4 ; sys_platform == 'linux'
+cuda-toolkit>=13.0.2 ; sys_platform == 'linux'
 cycler>=0.12.1
 dataclasses-json>=0.6.7
 datasets>=4.8.5
@@ -75,11 +77,11 @@ gcsfs>=2026.2.0
 gepa>=0.1.1
 gguf>=0.18.0
 google-api-core>=2.30.3
-google-api-python-client>=2.194.0
-google-auth>=2.49.2
+google-api-python-client>=2.195.0
+google-auth>=2.50.0
 google-auth-httplib2>=0.3.1
 google-auth-oauthlib>=1.3.1
-google-cloud-aiplatform>=1.148.1
+google-cloud-aiplatform>=1.149.0
 google-cloud-appengine-logging>=1.9.0
 google-cloud-audit-log>=0.5.0
 google-cloud-bigquery>=3.41.0
@@ -91,7 +93,7 @@ google-cloud-resource-manager>=1.17.0
 google-cloud-storage>=3.10.1
 google-cloud-storage-control>=1.11.0
 google-crc32c>=1.8.0
-google-genai>=1.73.1
+google-genai>=1.74.0
 google-metrax>=0.2.3
 google-pasta>=0.2.0
 google-resumable-media>=2.8.2
@@ -101,6 +103,7 @@ grain>=0.2.16
 grpc-google-iam-v1>=0.14.4
 grpcio>=1.78.0
 grpcio-status>=1.78.0
+grpcio-tools>=1.78.0
 gspread>=6.2.1
 gviz-api>=1.10.0
 h11>=0.16.0
@@ -110,7 +113,7 @@ hf-xet>=1.4.3 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or 
 httpcore>=1.0.9
 httplib2>=0.31.2
 httpx>=0.28.1
-huggingface-hub>=1.12.0
+huggingface-hub>=1.13.0
 humanize>=4.15.0
 hypothesis>=6.142.1
 identify>=2.6.19
@@ -129,7 +132,7 @@ jaraco-functools>=4.4.0
 jax>=0.9.2
 jaxlib>=0.9.2
 jaxtyping>=0.3.9
-jedi>=0.19.2
+jedi>=0.20.0
 jinja2>=3.1.6
 jiter>=0.14.0
 jmespath>=1.1.0
@@ -139,15 +142,15 @@ jsonschema-specifications>=2025.9.1
 jupyter-client>=8.8.0
 jupyter-core>=5.9.1
 jupyterlab-widgets>=3.0.16
-kagglehub>=1.0.0
-kagglesdk>=0.1.21
+kagglehub>=1.0.1
+kagglesdk>=0.1.23
 keras>=3.13.2
 kiwisolver>=1.5.0
 latex2sympy2-extended>=1.11.0
 libclang>=18.1.1
 libcst>=1.8.6
 libtpu>=0.0.39
-llguidance>=1.7.3
+llguidance>=1.7.5
 llvmlite>=0.47.0
 loguru>=0.7.3
 lxml>=6.1.0
@@ -160,7 +163,7 @@ matplotlib>=3.10.8
 matplotlib-inline>=0.2.1
 mccabe>=0.7.0
 mdurl>=0.1.2
-mistral-common>=1.11.0
+mistral-common>=1.11.1
 ml-collections>=1.1.0
 ml-dtypes>=0.5.4
 ml-goodput-measurement>=0.0.16
@@ -181,38 +184,38 @@ nodeenv>=1.10.0
 numba>=0.65.1
 numpy>=2.1.3
 numpy-typing-compat>=20251206.2.1
-nvidia-cublas-cu12>=12.8.4.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cublas>=13.1.0.3 ; sys_platform == 'linux'
 nvidia-cuda-cccl>=13.2.27
-nvidia-cuda-cupti-cu12>=12.8.90 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cuda-nvrtc-cu12>=12.8.93 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cuda-runtime-cu12>=12.8.90 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cudnn-cu12>=9.10.2.21 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cufft-cu12>=11.3.3.83 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cufile-cu12>=1.13.1.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-curand-cu12>=10.3.9.90 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cusolver-cu12>=11.7.3.90 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cusparse-cu12>=12.5.8.93 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cusparselt-cu12>=0.7.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-nccl-cu12>=2.27.5 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-nvjitlink-cu12>=12.8.93 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-nvshmem-cu12>=3.4.5 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-nvtx-cu12>=12.8.90 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cuda-cupti>=13.0.85 ; sys_platform == 'linux'
+nvidia-cuda-nvrtc>=13.0.88 ; sys_platform == 'linux'
+nvidia-cuda-runtime>=13.0.96 ; sys_platform == 'linux'
+nvidia-cudnn-cu13>=9.19.0.56 ; sys_platform == 'linux'
+nvidia-cufft>=12.0.0.61 ; sys_platform == 'linux'
+nvidia-cufile>=1.15.1.6 ; sys_platform == 'linux'
+nvidia-curand>=10.4.0.35 ; sys_platform == 'linux'
+nvidia-cusolver>=12.0.4.66 ; sys_platform == 'linux'
+nvidia-cusparse>=12.6.3.3 ; sys_platform == 'linux'
+nvidia-cusparselt-cu13>=0.8.0 ; sys_platform == 'linux'
+nvidia-nccl-cu13>=2.28.9 ; sys_platform == 'linux'
+nvidia-nvjitlink>=13.0.88 ; sys_platform == 'linux'
+nvidia-nvshmem-cu13>=3.4.5 ; sys_platform == 'linux'
+nvidia-nvtx>=13.0.85 ; sys_platform == 'linux'
 oauthlib>=3.3.1
 omegaconf>=2.3.0
-openai>=2.32.0
+openai>=2.33.0
 openai-harmony>=0.0.8
 opentelemetry-api>=1.41.1
 opt-einsum>=3.4.0
 optax>=0.2.6
 optree>=0.19.0
 optype>=0.17.0
-orbax-checkpoint>=0.11.36
+orbax-checkpoint>=0.11.37
 orbax-export>=0.0.8
 packaging>=26.0
 pandas>=3.0.2
 papermill>=2.7.0
 parameterized>=0.9.0
-parso>=0.8.6
+parso>=0.8.7
 partial-json-parser>=0.2.1.1.post7
 pathspec>=1.1.1
 pathwaysutils>=0.1.8
@@ -270,16 +273,16 @@ requests>=2.32.5
 requests-oauthlib>=2.0.0
 rich>=14.3.3
 rpds-py>=0.30.0
-runai-model-streamer>=0.15.8
-runai-model-streamer-gcs>=0.15.8
-runai-model-streamer-s3>=0.15.8
-s3transfer>=0.16.1
+runai-model-streamer>=0.15.9
+runai-model-streamer-gcs>=0.15.9
+runai-model-streamer-s3>=0.15.9
+s3transfer>=0.17.0
 safetensors>=0.7.0
 scipy>=1.17.1
 scipy-stubs>=1.17.1.2
 sentencepiece>=0.2.1
 seqio>=0.0.20
-setuptools>=82.0.1
+setuptools>=80.10.2
 shellingham>=1.5.4
 simple-parsing>=0.1.8
 simplejson>=4.1.1
@@ -307,18 +310,18 @@ tokenizers>=0.22.2
 toml>=0.10.2
 tomlkit>=0.14.0
 toolz>=1.1.0
-torch>=2.10.0
-torchax>=0.0.11
-torchvision>=0.25.0
+torch>=2.11.0
+torchax>=0.0.12
+torchvision>=0.26.0
 tornado>=6.5.5
 tpu-info>=0.11.0
 tqdm>=4.67.3
 traitlets>=5.14.3
-transformers>=5.6.2
+transformers>=5.7.0
 treescope>=0.1.10
-triton>=3.6.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+triton>=3.6.0 ; sys_platform == 'linux'
 typeguard>=2.13.3
-typer>=0.25.0
+typer>=0.25.1
 typing-extensions>=4.15.0
 typing-inspect>=0.9.0
 typing-inspection>=0.4.2
@@ -329,14 +332,14 @@ uvicorn>=0.46.0
 uvloop>=0.22.1
 virtualenv>=20.36.1
 wadler-lindig>=0.1.7
-wcwidth>=0.6.0
+wcwidth>=0.7.0
 websockets>=16.0
 werkzeug>=3.1.8
 wheel>=0.46.3
 widgetsnbextension>=4.0.15
 win32-setctime>=1.2.0 ; sys_platform == 'win32'
 wrapt>=2.1.2
-xgrammar>=0.1.33
+xgrammar>=0.2.0
 xprof>=2.22.2
 xxhash>=3.7.0
 yapf>=0.43.0


### PR DESCRIPTION
# Description

```
uv pip install -e .[tpu-post-train] --resolution=lowest
install_tpu_post_train_extra_deps
tensorboard
```
fails with the error: `ModuleNotFoundError: No module named 'pkg_resources'`

This PR downgrades `setuptools` for `tensorboard` to run.

# Tests

```
uv pip install -e .[tpu-post-train] --resolution=lowest
install_tpu_post_train_extra_deps
tensorboard
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
