### PR TITLE
Improve error message when column_name mismatches the dataset

### DIFF
--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -556,14 +556,20 @@ class ParseFeatures(grain.MapTransform):
     example.ParseFromString(element)
     features = example.features.feature
 
+    missing = [c for c in self.data_columns if c not in features]
+    if missing:
+      raise ValueError(
+          f"Column {missing} not found in dataset. Available columns: {sorted(features.keys())}. "
+          "Please set train_data_columns or eval_data_columns accordingly."
+      )
+
     parsed = {}
     for col in self.data_columns:
-      if col in features:
-        f = features[col]
-        if self.tokenize:
-          parsed[col] = np.array(f.bytes_list.value, dtype=object)
-        else:
-          parsed[col] = np.array(f.int64_list.value, dtype=np.int32)
+      f = features[col]
+      if self.tokenize:
+        parsed[col] = np.array(f.bytes_list.value, dtype=object)
+      else:
+        parsed[col] = np.array(f.int64_list.value, dtype=np.int32)
     return parsed
 
 
@@ -601,6 +607,12 @@ class KeepFeatures(grain.MapTransform):
 
   def map(self, element: dict[str, Any]) -> dict[str, Any]:
     """Applies the feature filtering to the input element."""
+    missing = [n for n in self.feature_names if n not in element]
+    if missing:
+      raise ValueError(
+          f"Column {missing} not found in dataset. Available columns: {sorted(element.keys())}. "
+          "Please set train_data_columns or eval_data_columns accordingly."
+      )
     return {k: v for k, v in element.items() if k in self.feature_names}
 
 

--- a/src/maxtext/input_pipeline/tfds_data_processing.py
+++ b/src/maxtext/input_pipeline/tfds_data_processing.py
@@ -95,6 +95,13 @@ def preprocessing_pipeline(
     hf_access_token: str = "",
 ):
   """pipeline for preprocessing TFDS dataset."""
+  missing = [c for c in data_column_names if c not in dataset.element_spec]
+  if missing:
+    raise ValueError(
+        f"Column {missing} not found in dataset. Available columns: {sorted(dataset.element_spec.keys())}. "
+        "Please set train_data_columns or eval_data_columns accordingly."
+    )
+
   if not use_dpo:
     assert len(data_column_names) == 1
     dataset = dataset.map(


### PR DESCRIPTION
# Description
Currently when there is mismatch between the train_data_columns or eval_data_columns set by user and the columns in dataset, the error message is unclear, with no pointer to the available columns and the related flags. This PR improves it.

# Tests
Manually tested.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
