### PR TITLE
Add different github label for docker image build workflow failure

### DIFF
--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -106,3 +106,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           title-template: "MaxText Docker Image Build Failure"
+          label-name: "docker-image-build-failure"


### PR DESCRIPTION
# Description

This PR updates the Build Images workflow (UploadDockerImages.yml) to assign a specific GitHub label to issues that are automatically created when a Docker image build fails.

By utilizing the `label-name` parameter in the `failed-build-issue-action`, we can now distinguish Docker-related build failures from other CI failures (such as unit or integration tests). This improvement facilitates better issue tracking and allows for more efficient triaging of build-specific problems.

Specifically, the `notify_failure` job in `.github/workflows/UploadDockerImages.yml` has been modified to include the intended label during issue creation.
# Tests

https://github.com/AI-Hypercomputer/maxtext/actions/runs/25391288681/job/74472066553 created a new issue: https://github.com/AI-Hypercomputer/maxtext/issues/3818

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
