### PR TITLE
Elasticity events goodput logs

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -561,6 +561,13 @@ def train_loop(config, recorder, state=None):
     # Write train config params, num model params, and XLA flags to tensorboard
     metric_logger.write_setup_info_to_tensorboard(state.params)
 
+  _reinit_recorder = max_utils._pending_reinit_recorder
+  if _reinit_recorder is not None:
+    _reinit_recorder.record_custom_badput_event_end_time(
+        custom_badput_event_type='elastic_reinitialization'
+    )
+    max_utils._pending_reinit_recorder = None
+
   _job_completed_gracefully = False
   try:
     last_step_completion = datetime.datetime.now()
@@ -711,9 +718,40 @@ def main(argv: Sequence[str]) -> None:
   config, recorder, diagnostic_config = initialize(argv)
   record_goodput(recorder, RECORD_JOB_START_TIME)
 
+  outer_recorder = recorder
   clean_up_checkpoints = functools.partial(max_utils.clean_up_checkpoints, checkpoint_dir=config.checkpoint_dir)
 
+  _elastic_event_state = {}
+
+  def on_elastic_event():
+    em = max_utils.elastic_manager
+    if em is not None and em.new_slice_event.is_set():
+      event_type = 'elastic_scale_up'
+    else:
+      event_type = 'elastic_slice_down'
+    _elastic_event_state['event_type'] = event_type
+    if outer_recorder:
+      outer_recorder.record_custom_badput_event_start_time(
+          custom_badput_event_type=event_type
+      )
+
+  def on_slices_ready():
+    event_type = _elastic_event_state.pop('event_type', 'elastic_slice_down')
+    if outer_recorder:
+      outer_recorder.record_custom_badput_event_end_time(
+          custom_badput_event_type=event_type
+      )
+
+  def on_elastic_event_with_cleanup():
+    clean_up_checkpoints()
+    on_elastic_event()
+
   def train():
+    if outer_recorder:
+      outer_recorder.record_custom_badput_event_start_time(
+          custom_badput_event_type='elastic_reinitialization'
+      )
+    max_utils._pending_reinit_recorder = outer_recorder
     config, recorder, diagnostic_config = initialize(argv)
     run(config, recorder, diagnostic_config)
 
@@ -727,7 +765,8 @@ def main(argv: Sequence[str]) -> None:
         train = max_utils.elastic_manager.replica_resize(
             max_resizes=10,  # Handle up to 10 slice up or slice down transitions
             poll_interval=10,  # Monitor thread checks inactive slice health every 10 seconds
-            on_elastic_event_callback=clean_up_checkpoints,
+            pre_callback=on_slices_ready,
+            on_elastic_event_callback=on_elastic_event_with_cleanup,
         )(train)
 
       elif elastic_mode == "pause-resume":
@@ -735,7 +774,8 @@ def main(argv: Sequence[str]) -> None:
             max_retries=10,  # Handle up to 10 disruptions before restarting
             poll_interval=10,  # While paused, checks every 10 seconds for health
             timeout=300,  # Waits for slices to rejoin for 5 minutes
-            on_elastic_event_callback=clean_up_checkpoints,
+            pre_callback=on_slices_ready,
+            on_elastic_event_callback=on_elastic_event_with_cleanup,
         )(train)
 
       else:

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -736,22 +736,23 @@ def main(argv: Sequence[str]) -> None:
       )
 
   def on_slices_ready():
-    event_type = _elastic_event_state.pop('event_type', 'elastic_slice_down')
+    if not _elastic_event_state:
+      return
+    event_type = _elastic_event_state.pop('event_type')
     if outer_recorder:
       outer_recorder.record_custom_badput_event_end_time(
           custom_badput_event_type=event_type
       )
+      outer_recorder.record_custom_badput_event_start_time(
+          custom_badput_event_type='elastic_reinitialization'
+      )
+    max_utils._pending_reinit_recorder = outer_recorder
 
   def on_elastic_event_with_cleanup():
     clean_up_checkpoints()
     on_elastic_event()
 
   def train():
-    if outer_recorder:
-      outer_recorder.record_custom_badput_event_start_time(
-          custom_badput_event_type='elastic_reinitialization'
-      )
-    max_utils._pending_reinit_recorder = outer_recorder
     config, recorder, diagnostic_config = initialize(argv)
     run(config, recorder, diagnostic_config)
 

--- a/src/maxtext/utils/max_utils.py
+++ b/src/maxtext/utils/max_utils.py
@@ -53,6 +53,7 @@ HYBRID_RING_32X8 = "hybrid_ring_32x8"
 
 
 elastic_manager: manager.Manager | None = None
+_pending_reinit_recorder = None
 
 
 # pylint: disable=too-many-positional-arguments


### PR DESCRIPTION
# Description

Adding three types of elastic event goodput logs using the Custom Badput APIs:

- elastic_scale_up
- elastic_slice_down
- elastic_reinitialization

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
