### PR TITLE
[RL] enable multislice for validate_converter

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -228,3 +228,8 @@ train_split: 'train'
 eval_split: 'test'
 hf_name: 'main' # subset of Hugging Face dataset
 tokenizer_type: 'huggingface'
+
+##### MaxText to VLLM Converter validation parameters
+vllm_load_format: dummy # Format to load the model for conversion. Options are "auto", "dummy"
+debug_converter: False # If True, run key coverage check, weight stats, and GCS upload then exit without generation.
+gcs_debug_path: "" # If set and debug_converter=True, upload converted layer-0 and global tensors as .npy to this GCS prefix.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1830,6 +1830,18 @@ class VLLM(BaseModel):
   )
   vllm_hf_config_path: str = Field("", description="Path to HuggingFace model config for MaxText model.")
   use_standalone_converter: bool = Field(False, description="Use the standalone MaxText->torchax vLLM converter")
+  vllm_load_format: str = Field(
+      "dummy",
+      description="Weight load format for vLLM in converter validation. Options:'auto', 'dummy'.",
+  )
+  debug_converter: bool = Field(
+      False,
+      description="If True, run key coverage check, weight stats, and GCS upload.",
+  )
+  gcs_debug_path: str = Field(
+      "",
+      description="If set and debug_converter=True, upload converted layer-0 and global tensors as .npy files to GCS",
+  )
 
 
 class RL(BaseModel):

--- a/src/maxtext/integration/vllm/torchax_converter/validate_converter.py
+++ b/src/maxtext/integration/vllm/torchax_converter/validate_converter.py
@@ -21,34 +21,49 @@ This module provides a config-driven validation entrypoint that:
 4. assigns the converted weights before running a short generation check.
 
 	python -m maxtext.integration.vllm.torchax_converter.validate_converter \
-			src/maxtext/configs/base.yml model_name=qwen3-30b-a3b \
+			src/maxtext/configs/post_train/rl.yml model_name=qwen3-30b-a3b \
 			tokenizer_type=huggingface tokenizer_path=Qwen/Qwen3-30B-A3B \
 			load_parameters_path=<your_maxtext_checkpoint_path> run_name=qwen3_converter_validation \
 			per_device_batch_size=1 max_prefill_predict_length=8 max_target_length=16 steps=1 \
 			scan_layers=true skip_jax_distributed_system=true weight_dtype=bfloat16 \
-			attention=dot_product remat_policy=custom decoder_layer_input=offload \
-			query_proj=offload key_proj=offload value_proj=offload \
 			rollout_tensor_parallelism=4 hbm_utilization_vllm=0.6 async_scheduling=false \
-			prompt="Paris is" hf_access_token=<token>
+			prompt="Paris is" hf_access_token=<token> use_chat_template=true
+  For multislice (e.g. 2x128-device slices), additionally pass:
+        num_trainer_slices=1 num_samplers_slices=1
+
+Extra debugging flags (all optional, passed as key=value in argv):
+  debug_converter=true        Enable all debug checks (key coverage, weight stats, GCS
+                              upload) then exit without running generation. This flag gates
+                              all three debug features below.
+  vllm_load_format=auto       Load vLLM from an HF checkpoint instead of dummy weights.
+                              When set alongside debug_converter=true, weight stats are
+                              compared between the HF reference and the converted MaxText
+                              weights side-by-side.
+  gcs_debug_path=gs://…       Upload layer-0 and global tensors from the converted state
+                              as .npy files to this GCS prefix for offline inspection.
+                              Only active when debug_converter=true.
 
 Currently this validator supports: qwen3-30b-a3b, qwen3-30b-a3b-base, qwen3-235b-a22b, gemma4-26b.
 """
 
-import functools
 import gc
+import io
 import logging
 import os
 from typing import Sequence
 
 from absl import app
 import jax
+import jax.numpy as jnp
 from flax import nnx
+import numpy as np
 import transformers
+from tunix.rl.reshard import reshard_pytree
 from vllm import LLM
 from vllm import SamplingParams
+import pathwaysutils
 
 from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE
-from maxtext.configs import pyconfig
 from maxtext.integration.vllm.torchax_converter.base import GREEN
 from maxtext.integration.vllm.torchax_converter.base import RESET
 from maxtext.integration.vllm.torchax_converter.base import timer
@@ -90,32 +105,175 @@ def _clean_device_memory():
   logging.info("Device memory cleanup complete.")
 
 
-def _get_maxtext_model(config):
-  logging.info("Creating model with config: %s", config)
-  model, mesh = model_creation_utils.from_pretrained(
-      config,
-      model_mode=MODEL_MODE_AUTOREGRESSIVE,
+# ---------------------------------------------------------------------------
+# Debugging helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_layer0_key(key: str) -> bool:
+  return ".layers.0." in key
+
+
+def _is_non_layer_key(key: str) -> bool:
+  return "layers." not in key
+
+
+def _weight_stats_str(arr) -> str:
+  a = jnp.array(arr).astype(jnp.float32)
+  return (
+      f"shape={tuple(arr.shape)} dtype={arr.dtype} "
+      f"mean_abs={float(jnp.mean(jnp.abs(a))):.6f} "
+      f"std={float(jnp.std(a)):.6f} "
+      f"min={float(jnp.min(a)):.6f} "
+      f"max={float(jnp.max(a)):.6f}"
   )
-  return model, mesh
 
 
-def save_dict_to_file(state_dict, filename):
-  with open(filename, "w", encoding="utf-8") as f:
-    for key in sorted(state_dict.keys()):
-      f.write(f"{key}: {state_dict[key].shape}\n")
+def _log_weight_stats(converted_state: dict, vllm_state: dict, compare: bool) -> None:
+  """Log weight stats for non-layer and layer-0 keys.
+
+  When compare=True (vLLM loaded from a real checkpoint), prints stats from both
+  the converted MaxText weights and the vLLM reference side-by-side so mismatches
+  are easy to spot. When compare=False, prints only the converted side.
+  """
+  keys = sorted(k for k in converted_state if _is_non_layer_key(k) or _is_layer0_key(k))
+  logging.info("=" * 80)
+  logging.info("Weight stats (%d keys — non-layer + layer-0):", len(keys))
+  for key in keys:
+    if key in converted_state:
+      arr = converted_state[key]
+      weight_array = arr.value if hasattr(arr, "value") else arr
+      logging.info("  [CONVERTED] %s | %s", key, _weight_stats_str(weight_array))
+    if compare and key in vllm_state:
+      ref = np.array(vllm_state[key], dtype=np.float32)
+      conv = np.array(weight_array, dtype=np.float32)
+      # rel_frobenius = ||converted - ref||_F / ||ref||_F.
+      # ~0 means bit-for-bit correct; ~1 or above means the content is wrong.
+      # Unlike mean/std/min/max, this catches permutation and transposition bugs
+      # because it is order-sensitive.
+      rel_frob = float(np.linalg.norm(conv - ref)) / (float(np.linalg.norm(ref)) + 1e-8)
+      logging.info("  [VLLM-REF]  %s | %s", key, _weight_stats_str(vllm_state[key]))
+      logging.info("  [DIFF]      %s | rel_frobenius=%.6f", key, rel_frob)
+  logging.info("=" * 80)
 
 
-def validate_converter(config) -> None:
-  """Run end-to-end validation for MaxText to vLLM weight conversion."""
-  if config.model_name not in vllm_model_name_mapping:
+def _check_key_coverage(llm_state: dict, converted_state: dict) -> None:
+  """Check key coverage and shapes between vLLM state and converted state.
+
+  Collects all mismatches (missing keys, extra keys, shape mismatches) and
+  reports them together before raising, so a single run reveals all problems.
+  """
+  vllm_keys = set(llm_state.keys())
+  converted_keys = set(converted_state.keys())
+
+  missing = vllm_keys - converted_keys
+  extra = converted_keys - vllm_keys
+
+  if missing:
+    logging.warning("Keys in vLLM state NOT in converted state (%d):", len(missing))
+    for k in sorted(missing):
+      logging.warning("  MISSING: %s  vllm_shape=%s", k, llm_state[k].shape)
+
+  if extra:
+    logging.warning("Keys in converted state NOT in vLLM state (%d):", len(extra))
+    for k in sorted(extra):
+      arr = converted_state[k]
+      logging.warning("  EXTRA:   %s  converted_shape=%s", k, (arr.value if hasattr(arr, "value") else arr).shape)
+
+  shape_mismatches = []
+  for key in sorted(vllm_keys & converted_keys):
+    arr = converted_state[key]
+    weight_array = arr.value if hasattr(arr, "value") else arr
+    vshape = llm_state[key].shape
+    cshape = weight_array.shape
+    if vshape != cshape:
+      shape_mismatches.append((key, vshape, cshape))
+
+  if shape_mismatches:
+    logging.error("Shape mismatches (%d):", len(shape_mismatches))
+    for key, vshape, cshape in shape_mismatches:
+      logging.error("  MISMATCH: %s | vllm=%s  converted=%s", key, vshape, cshape)
+    raise ValueError(f"{len(shape_mismatches)} shape mismatch(es) found — see logs above")
+
+  logging.info(
+      "Key coverage OK: %d matched, %d missing, %d extra",
+      len(vllm_keys & converted_keys),
+      len(missing),
+      len(extra),
+  )
+
+
+def _upload_tensors_to_gcs(converted_state: dict, gcs_path: str) -> None:
+  """Upload layer-0 and non-layer tensors from converted_state as .npy to GCS.
+
+  Useful for offline inspection when running on a cluster where local file I/O
+  is inconvenient.  Set gcs_debug_path=gs://bucket/prefix in the config to enable.
+  """
+  try:
+    from google.cloud import storage as gcs  # pylint: disable=import-outside-toplevel
+  except ImportError:
+    logging.warning("GCS upload skipped: google-cloud-storage not installed")
+    return
+
+  path = gcs_path.removeprefix("gs://")
+  bucket_name, _, prefix = path.partition("/")
+  client = gcs.Client()
+  bucket = client.bucket(bucket_name)
+
+  to_upload = {k: v for k, v in converted_state.items() if _is_non_layer_key(k) or _is_layer0_key(k)}
+  logging.info("Uploading %d tensors to %s ...", len(to_upload), gcs_path)
+  for key, arr in sorted(to_upload.items()):
+    weight_array = arr.value if hasattr(arr, "value") else arr
+    safe_name = key.replace("/", "__").replace(".", "_")
+    blob_name = f"{prefix.rstrip('/')}/{safe_name}.npy" if prefix else f"{safe_name}.npy"
+    blob = bucket.blob(blob_name)
+    buf = io.BytesIO()
+    np.save(buf, np.array(weight_array))
+    buf.seek(0)
+    blob.upload_from_file(buf, content_type="application/octet-stream")
+    logging.info("  uploaded gs://%s/%s  shape=%s", bucket_name, blob_name, weight_array.shape)
+  logging.info("GCS upload complete: %d tensors -> gs://%s/%s", len(to_upload), bucket_name, prefix)
+
+
+# ---------------------------------------------------------------------------
+# Main validation logic
+# ---------------------------------------------------------------------------
+
+
+def validate_converter(argv) -> None:
+  """Run end-to-end validation for MaxText to vLLM weight conversion.
+
+  Device/config split mirrors train_rl.py:
+    - trainer_config uses ici_* parallelism for the MaxText mesh
+    - sampler_config uses rollout_* parallelism for the vLLM mesh
+  Single-slice (num_trainer_slices == -1): trainer and sampler share all devices.
+  Multislice: first num_trainer_slices slices go to MaxText, the next
+  num_samplers_slices slices go to vLLM.
+  """
+  trainer_config, sampler_config, trainer_devices, sampler_devices = model_creation_utils.setup_configs_and_devices(argv)
+
+  if trainer_config.model_name not in vllm_model_name_mapping:
     raise ValueError(
-        f"validate_converter.py does not support model '{config.model_name}'. "
+        f"validate_converter.py does not support model '{trainer_config.model_name}'. "
         f"Supported models: {sorted(vllm_model_name_mapping.keys())}"
     )
 
-  model, mesh = _get_maxtext_model(config)
+  # Optional debugging flags.
+  vllm_load_format = getattr(trainer_config, "vllm_load_format", "dummy")
+  debug_converter = getattr(trainer_config, "debug_converter", False)
+  gcs_debug_path = getattr(trainer_config, "gcs_debug_path", "")
+
+  # In single-slice mode setup_configs_and_devices returns the same object for both.
+  multislice = trainer_devices is not sampler_devices
+
+  logging.info("Creating MaxText model...")
+  model, mesh = model_creation_utils.from_pretrained(
+      trainer_config,
+      devices=trainer_devices,
+      model_mode=MODEL_MODE_AUTOREGRESSIVE,
+  )
   print(f"{GREEN}MaxText model loaded successfully{RESET}")
-  print(f"Model: {config.model_name}")
+  print(f"Model: {trainer_config.model_name}")
   print(f"Mesh: {mesh}")
 
   print("=" * 80)
@@ -128,66 +286,83 @@ def validate_converter(config) -> None:
       logging.info("Name: %s, shape: %s", path_str, leaf.shape)
       logging.info("\tSharding: %s", leaf.sharding)
 
-  if config.model_name.startswith("gemma4"):
-    converter = Gemma4MaxTextToVLLMConverter(config, mesh)
+  if trainer_config.model_name.startswith("gemma4"):
+    converter = Gemma4MaxTextToVLLMConverter(trainer_config, mesh)
   else:
-    converter = Qwen3MaxTextToVLLMConverter(config, mesh)
+    converter = Qwen3MaxTextToVLLMConverter(trainer_config, mesh)
   with timer("Overall Conversion"):
-    vllm_state = converter.convert(model_state)
-  del model_state
+    maxtext_vllm_state = converter.convert(model_state)
+  # Explicitly delete MaxText device buffers before resharding. Python del + gc
+  # is not enough — Pathways holds buffers in its object store independently of
+  # Python GC, so we must call .delete() on each array to free HBM.
+  for arr in jax.tree_util.tree_leaves(model_state):
+    if hasattr(arr, "delete"):
+      arr.delete()
+  del model_state, model, mesh, converter
   gc.collect()
 
   print("=" * 80)
-  print("Loading vLLM model for generation test...")
+  print(f"Loading vLLM model (load_format={vllm_load_format})...")
   print("=" * 80)
-  llm = LLM(
-      model=vllm_model_name_mapping[config.model_name],
-      max_model_len=config.max_target_length,
-      tensor_parallel_size=config.rollout_tensor_parallelism,
-      gpu_memory_utilization=getattr(config, "hbm_utilization_vllm", 0.5),
-      async_scheduling=getattr(config, "async_scheduling", False),
-      # load_format="dummy",
-  )
+  # load_format="dummy" skips loading real weights — converted MaxText weights
+  # are assigned afterwards.  Pass vllm_load_format=auto to load an HF checkpoint
+  # for reference stats comparison before assignment.
+  vllm_kwargs = {
+      "model": vllm_model_name_mapping[trainer_config.model_name],
+      "max_model_len": trainer_config.max_target_length,
+      "load_format": vllm_load_format,
+      "data_parallel_size": sampler_config.rollout_data_parallelism,
+      "tensor_parallel_size": sampler_config.rollout_tensor_parallelism,
+      "gpu_memory_utilization": getattr(sampler_config, "hbm_utilization_vllm", 0.5),
+      "async_scheduling": getattr(sampler_config, "async_scheduling", False),
+  }
+  if multislice:
+    # Pin vLLM to its assigned sampler devices so it doesn't overlap with trainer.
+    vllm_kwargs["additional_config"] = {
+        "sharding": {
+            "sharding_strategy": {
+                "device_indexes": [d.id for d in sampler_devices],
+            }
+        }
+    }
+  llm = LLM(**vllm_kwargs)
   print("\n" + "=" * 80)
-  llm_state = llm.llm_engine.model_executor.driver_worker.model_runner.state
-  # save_dict_to_file(llm_state, "vllm_model_state.txt")
-  # save_dict_to_file(vllm_state, "converted_vllm_state.txt")
+  golden_llm_state = llm.llm_engine.model_executor.driver_worker.model_runner.state
 
-  any_src = next(iter(vllm_state.values()))
-  any_src_arr = any_src.value if hasattr(any_src, "value") else any_src
-  any_dst = next(iter(llm_state.values()))
-  same_devices = frozenset(device.id for device in any_src_arr.sharding.mesh.devices.flat) == frozenset(
-      device.id for device in any_dst.sharding.mesh.devices.flat
-  )
-  logging.info(
-      "Weight sync: same_devices=%s (jit=%s, device_put=%s)",
-      same_devices,
-      same_devices,
-      not same_devices,
-  )
+  # --- Debug checks (key coverage, weight stats, GCS upload) ---------------
+  # These run only when debug_converter=true, since they are purely for
+  # debugging and add significant overhead + log volume in production runs.
+  if debug_converter:
+    print("=" * 80)
+    print("Checking key coverage and shapes...")
+    print("=" * 80)
+    _check_key_coverage(golden_llm_state, maxtext_vllm_state)
 
-  @functools.lru_cache(maxsize=None)
-  def _get_reshard_fn(dst_sharding):
-    if same_devices:
-      return jax.jit(lambda x: x, out_shardings=dst_sharding)
-    return functools.partial(jax.device_put, device=dst_sharding)
+    compare_stats = vllm_load_format != "dummy"
+    _log_weight_stats(maxtext_vllm_state, golden_llm_state, compare=compare_stats)
 
-  with timer(f"Assigning {len(vllm_state)} weights to vLLM model"):
-    for key, weight in vllm_state.items():
+    if gcs_debug_path:
+      with timer("GCS tensor upload"):
+        _upload_tensors_to_gcs(maxtext_vllm_state, gcs_debug_path)
+
+  # --- Weight assignment ----------------------------------------------------
+  with timer(f"Assigning {len(maxtext_vllm_state)} weights to vLLM model"):
+    for key, weight in maxtext_vllm_state.items():
       weight_array = weight.value if hasattr(weight, "value") else weight
-      dst_sharding = llm_state[key].sharding
-      assert (
-          llm_state[key].shape == weight_array.shape
-      ), f"Shape mismatch for {key}: expected {llm_state[key].shape}, got {weight_array.shape}"
-      llm_state[key] = _get_reshard_fn(dst_sharding)(weight_array)
+      dst_sharding = golden_llm_state[key].sharding
+      golden_llm_state[key] = reshard_pytree(weight_array, dst_sharding, donate_input=False, cache_plan=True)
 
-  sampling_params = SamplingParams(temperature=0.0, max_tokens=10)
-  prompt = getattr(config, "prompt", "Paris is")
-  if getattr(config, "use_chat_template", False):
-    tokenizer_path = getattr(config, "tokenizer_path", None) or vllm_model_name_mapping[config.model_name]
+  # --- Generation test ------------------------------------------------------
+  sampling_params = SamplingParams(
+      temperature=0.0,
+      max_tokens=trainer_config.max_target_length - trainer_config.max_prefill_predict_length,
+  )
+  prompt = getattr(trainer_config, "prompt", "Paris is")
+  if getattr(trainer_config, "use_chat_template", False):
+    tokenizer_path = getattr(trainer_config, "tokenizer_path", None) or vllm_model_name_mapping[trainer_config.model_name]
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         tokenizer_path,
-        token=getattr(config, "hf_access_token", None),
+        token=getattr(trainer_config, "hf_access_token", None),
     )
     messages = [{"role": "user", "content": prompt}]
     prompt = tokenizer.apply_chat_template(
@@ -196,22 +371,23 @@ def validate_converter(config) -> None:
         add_generation_prompt=True,
         add_special_tokens=False,
     )
-  elif config.model_name.startswith("gemma4") and not prompt.startswith("<bos>"):
+  elif trainer_config.model_name.startswith("gemma4") and not prompt.startswith("<bos>"):
     prompt = "<bos>" + prompt
+
   print("\n" + "=" * 80)
   print("Generation test after weight transfer:")
   with timer("Generation"):
-    print(llm.generate(prompt, sampling_params=sampling_params))
+    print(llm.generate(prompt, sampling_params=sampling_params, use_tqdm=False))
 
 
 def main(argv: Sequence[str]) -> None:
+  pathwaysutils.initialize()
   print(f"JAX devices: {jax.devices()}")
   _setup_jax_compilation_cache()
   _setup_vllm_environment()
   _clean_device_memory()
 
-  config = pyconfig.initialize(argv)
-  validate_converter(config)
+  validate_converter(argv)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR makes changes to validate_converter.py so it can run on multislice environment which is helpful in validating the conversion for larger models. It also adds helper functions to compare golden_vllm_state and maxtext_vllm_state for layer-0 keys which is hidden behind a flag `debug_converter` and an option to upload layer-0 weights to GCS for finding the mismatch. 
It also uses tunix's reshard function for transferring params instead of a device_put

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Single host v5p run with Qwen3-30B: https://paste.googleplex.com/5229816551964672
tpu7x-128 run with Qwen3-30B with 64 devices for maxtext model and the rest for vllm model initialization: https://cloudlogging.app.goo.gl/evFutCTxYt9zC99j6


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
