### PR TITLE
Add explicit service cleanup and timeout to fix flaky pathways tests

### DIFF
--- a/.github/workflows/build_and_test_maxtext.yml
+++ b/.github/workflows/build_and_test_maxtext.yml
@@ -172,21 +172,6 @@ jobs:
       is_scheduled_run: ${{ github.event_name == 'schedule' }}
       maxtext_sha: ${{ needs.build_and_upload_maxtext_package.outputs.maxtext_sha }}
 
-  cpu-tests:
-    name: ${{ matrix.flavor }} tests
-    needs: [build_and_upload_maxtext_package]
-    if: needs.analyze_code_changes.outputs.run_tests == 'true'
-    uses: ./.github/workflows/run_tests_coordinator.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [cpu-unit, cpu-post-training-unit]
-    with:
-      flavor: ${{ matrix.flavor }}
-      base_image: maxtext-unit-test-tpu:py312
-      is_scheduled_run: ${{ github.event_name == 'schedule' }}
-      maxtext_sha: ${{ needs.build_and_upload_maxtext_package.outputs.maxtext_sha }}
-
   maxtext_tpu_pathways_unit_tests:
     needs: build_and_upload_maxtext_package
     if: needs.analyze_code_changes.outputs.run_tests == 'true'
@@ -222,6 +207,21 @@ jobs:
       xla_python_client_mem_fraction: 0.75
       tf_force_gpu_allow_growth: false
       container_resource_option: "--privileged"
+      is_scheduled_run: ${{ github.event_name == 'schedule' }}
+      maxtext_sha: ${{ needs.build_and_upload_maxtext_package.outputs.maxtext_sha }}
+
+  cpu-tests:
+    name: ${{ matrix.flavor }} tests
+    needs: [build_and_upload_maxtext_package]
+    if: needs.analyze_code_changes.outputs.run_tests == 'true'
+    uses: ./.github/workflows/run_tests_coordinator.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [cpu-unit, cpu-post-training-unit]
+    with:
+      flavor: ${{ matrix.flavor }}
+      base_image: maxtext-unit-test-tpu:py312
       is_scheduled_run: ${{ github.event_name == 'schedule' }}
       maxtext_sha: ${{ needs.build_and_upload_maxtext_package.outputs.maxtext_sha }}
 

--- a/.github/workflows/build_and_test_maxtext.yml
+++ b/.github/workflows/build_and_test_maxtext.yml
@@ -218,7 +218,7 @@ jobs:
       base_image: maxtext-unit-test-tpu:py312
       cloud_runner: linux-x86-ct6e-180-4tpu
       pytest_marker: 'not cpu_only and not gpu_only and integration_test and not post_training'
-      pytest_addopts: '--ignore=tests/post_training --ignore=tests/integration/hlo_diff_test.py'
+      pytest_addopts: '-n 0 --ignore=tests/post_training --ignore=tests/integration/hlo_diff_test.py'
       xla_python_client_mem_fraction: 0.75
       tf_force_gpu_allow_growth: false
       container_resource_option: "--privileged"

--- a/.github/workflows/run_pathways_tests.yml
+++ b/.github/workflows/run_pathways_tests.yml
@@ -115,6 +115,15 @@ jobs:
           else
             echo "Docker not available or cannot connect to daemon. Skipping explicit cleanup."
           fi
+      - name: Debug Resource Usage
+        if: always()
+        run: |
+          echo "=== Memory Usage ==="
+          free -m || true
+          echo "=== Network Connections ==="
+          netstat -tuln || true
+          echo "=== File Descriptors ==="
+          cat /proc/sys/fs/file-nr || true
     services:
       resource_manager:
         image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260413-jax_0.9.2

--- a/.github/workflows/run_pathways_tests.yml
+++ b/.github/workflows/run_pathways_tests.yml
@@ -59,6 +59,7 @@ permissions:
 
 jobs:
   run:
+    timeout-minutes: 60
     runs-on: ${{ inputs.cloud_runner != '' && inputs.cloud_runner || fromJson(format('["self-hosted", "{0}", "{1}"]', inputs.device_type, inputs.device_name)) }}
     container:
       image: gcr.io/tpu-prod-env-multipod/${{ inputs.base_image }}
@@ -105,6 +106,15 @@ jobs:
           .venv/bin/python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" -k "not AotHloIdenticalTest and not CompileThenLoad" --durations=0
         env:
           PYTHONPATH: "${{ github.workspace }}/src"
+      - name: Explicitly Stop Pathways Services
+        if: always()
+        run: |
+          if command -v docker &> /dev/null && docker ps &> /dev/null; then
+            echo "Docker found, stopping Pathways services..."
+            docker ps -q --filter label=maxtext-ci-pathways=true | xargs -r docker stop
+          else
+            echo "Docker not available or cannot connect to daemon. Skipping explicit cleanup."
+          fi
     services:
       resource_manager:
         image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260413-jax_0.9.2
@@ -112,6 +122,7 @@ jobs:
           - "29001:29001"
           - "29002:29002"
         options:
+          --label maxtext-ci-pathways=true
           --entrypoint=[/usr/pathways/run/cloud_pathways_server_sanitized, --server_port=29001, --node_type=resource_manager, --enforce_kernel_ipv6_support=false, --instance_count=1, --instance_type=tpuv6e:2x2, --gcs_scratch_location=gs://cloud-pathways-staging/tmp]
         env:
           TPU_SKIP_MDS_QUERY: true
@@ -124,6 +135,7 @@ jobs:
           - "8471:8471"
           - "8080:8080"
         options:
+          --label maxtext-ci-pathways=true
           --entrypoint=[/usr/pathways/run/cloud_pathways_server_sanitized, --server_port=29005, --resource_manager_address=localhost:29001, --enforce_kernel_ipv6_support=false, --gcs_scratch_location=gs://cloud-pathways-staging/tmp]
           --tpu=4
 
@@ -135,4 +147,5 @@ jobs:
           IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS: true
           XLA_FLAGS: "--xla_dump_to=/tmp/aot_test_dump --xla_dump_hlo_as_text --xla_dump_hlo_module_re=jit_train_step"
         options:
+          --label maxtext-ci-pathways=true
           --entrypoint=[/usr/pathways/run/cloud_proxy_server_sanitized, --server_port=29000, --resource_manager_address=localhost:29001, --enforce_kernel_ipv6_support=false, --gcs_scratch_location=gs://cloud-pathways-staging/tmp, --xla_tpu_scoped_vmem_limit_kib=65536, --xla_tpu_spmd_rng_bit_generator_unsafe=true]


### PR DESCRIPTION
# Description

Pathways TPU integration tests have been very flaky. This PR introduces explicit Pathways resource cleanup.

# Tests

Existing

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
