### PR TITLE
Add OLMo 3 7B/32B HF configs for checkpoint conversion

### DIFF
--- a/src/maxtext/checkpoint_conversion/utils/hf_model_configs.py
+++ b/src/maxtext/checkpoint_conversion/utils/hf_model_configs.py
@@ -705,9 +705,9 @@ deepseek2_16b_dict = {
     "qk_rope_head_dim": 64,
     "rms_norm_eps": 1e-06,
     "rope_scaling": {
-        "beta_fast": 32,
-        "beta_slow": 1,
-        "factor": 40,
+        "beta_fast": 32.0,
+        "beta_slow": 1.0,
+        "factor": 40.0,
         "mscale": 0.707,
         "mscale_all_dim": 0.707,
         "original_max_position_embeddings": 4096,
@@ -767,9 +767,9 @@ deepseek3_671b_dict = {
     "qk_rope_head_dim": 64,
     "rms_norm_eps": 1e-06,
     "rope_scaling": {
-        "beta_fast": 32,
-        "beta_slow": 1,
-        "factor": 40,
+        "beta_fast": 32.0,
+        "beta_slow": 1.0,
+        "factor": 40.0,
         "mscale": 1.0,
         "mscale_all_dim": 1.0,
         "original_max_position_embeddings": 4096,
@@ -1139,6 +1139,42 @@ mixtral_8x22b_dict = {
 mixtral_8x22b_config = transformers.MixtralConfig(**mixtral_8x22b_dict)
 
 
+# shared by olmo3-7b and olmo3-7b-pt (only rope_scaling/max_position_embeddings differ)
+olmo3_7b_dict = {
+    "architectures": ["Olmo3ForCausalLM"],
+    "model_type": "olmo3",
+    "hidden_size": 4096,
+    "num_hidden_layers": 32,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 32,
+    "intermediate_size": 11008,
+    "vocab_size": 100278,
+    "max_position_embeddings": 8192,
+    "rope_theta": 500000,
+    "sliding_window": 4096,
+    "rms_norm_eps": 1.0e-6,
+    "torch_dtype": "bfloat16",
+    "tie_word_embeddings": False,
+    "pad_token_id": 100277,
+    "hidden_act": "silu",
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "use_cache": True,
+}
+olmo3_7b_config = transformers.Olmo3Config(**olmo3_7b_dict)
+
+# from https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/main/config.json
+olmo3_32b_dict = {
+    **olmo3_7b_dict,
+    "hidden_size": 5120,
+    "num_hidden_layers": 64,
+    "num_attention_heads": 40,
+    "num_key_value_heads": 8,
+    "intermediate_size": 27648,
+}
+olmo3_32b_config = transformers.Olmo3Config(**olmo3_32b_dict)
+
+
 # {maxtext model name: hf model config}
 HF_MODEL_CONFIGS = {
     "gemma2-2b": gemma2_2b_config,
@@ -1180,4 +1216,7 @@ HF_MODEL_CONFIGS = {
     "qwen3-next-80b-a3b": qwen3_next_80b_a3b_config,
     "mixtral-8x7b": mixtral_8x7b_config,
     "mixtral-8x22b": mixtral_8x22b_config,
+    "olmo3-7b": olmo3_7b_config,
+    "olmo3-7b-pt": olmo3_7b_config,
+    "olmo3-32b": olmo3_32b_config,
 }

--- a/src/maxtext/configs/models/olmo3-32b.yml
+++ b/src/maxtext/configs/models/olmo3-32b.yml
@@ -15,7 +15,6 @@
 # AllenAI OLMo 3 32B Configuration
 # https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/main/config.json
 
-model_name: "olmo3_32b"
 decoder_block: "olmo3"
 
 # Model Dimensions
@@ -47,7 +46,7 @@ beta_fast: 32.0
 beta_slow: 1.0
 max_position_embeddings: 65536
 rope_attention_scaling: True
-rope_truncate: False
+rope_truncate: True  # HF transformers defaults truncate=True for YaRN; matches HF correction-range floor/ceil
 
 # Embeddings
 vocab_size: 100278

--- a/src/maxtext/configs/models/olmo3-7b-pt.yml
+++ b/src/maxtext/configs/models/olmo3-7b-pt.yml
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# AllenAI OLMo 3 7B Configuration for pretraining.
-# It uses default RoPE for both global and sliding window attention.
+# AllenAI OLMo 3 7B configuration for stage 1 / stage 2 pretraining revisions
+# of allenai/Olmo-3-1025-7B (e.g. `stage1-step1413814`, `stage2-step*`). At
+# these revisions the HF config has rope_scaling=null and
+# max_position_embeddings=8192, so default RoPE is used for both global and
+# sliding-window attention. YaRN scaling at 65k is introduced at stage 3 of
+# pretraining; for stage-3 / post-trained checkpoints use olmo3-7b.yml instead.
 # https://huggingface.co/allenai/Olmo-3-1025-7B/tree/stage1-step1413814
 
 decoder_block: "olmo3"

--- a/src/maxtext/configs/models/olmo3-7b.yml
+++ b/src/maxtext/configs/models/olmo3-7b.yml
@@ -46,7 +46,7 @@ beta_fast: 32.0
 beta_slow: 1.0
 max_position_embeddings: 65536
 rope_attention_scaling: True
-rope_truncate: False
+rope_truncate: True  # HF transformers defaults truncate=True for YaRN; matches HF correction-range floor/ceil
 
 # Embeddings
 vocab_size: 100278

--- a/src/maxtext/input_pipeline/olmo_data.py
+++ b/src/maxtext/input_pipeline/olmo_data.py
@@ -27,7 +27,6 @@ import ast
 import bisect
 import dataclasses
 import hashlib
-import io
 import json
 import os
 import struct

--- a/src/maxtext/models/olmo3.py
+++ b/src/maxtext/models/olmo3.py
@@ -96,9 +96,11 @@ class Olmo3DecoderLayer(nnx.Module):
         rngs=rngs,
     )
 
+    # Match HF runtime: a single rotary (with rope_scaling/YaRN) is applied to every layer,
+    # including sliding-window. The "RoPE scaling is not applied to sliding window attention
+    # layers" comment in HF's modular_olmo3.py is unimplemented design intent — its code
+    # passes the same (cos, sin) to all layers.
     current_rope_type = config.rope_type.lower()
-    if self.attention_type == attentions.AttentionType.LOCAL_SLIDING:
-      current_rope_type = "default"
 
     # Self-attention block
     self.attention = Attention(


### PR DESCRIPTION
# Description

Adds OLMo 3 7B (Instruct & PT) and OLMo 3 32B HF configs for HF→MaxText checkpoint conversion, plus runtime fixes that bring the OLMo 3 forward pass into agreement with HF transformers.                                                                   
                             
# Changes                                                                                              
 - `hf_model_configs.py`: add `olmo3_7b_config` (shared by `olmo3-7b` and  `olmo3-7b-pt`) and `olmo3_32b_config`; register all three in `HF_MODEL_CONFIGS`.
 
- `models/olmo3.py`: drop the per-layer `rope_type` override. HF's `Olmo3Model` applies a single rotary (with `rope_scaling`) to every layer including  sliding-window — the comment "RoPE scaling is not applied to sliding window attention layers" in HF's `modular_olmo3.py` is unimplemented design intent.                         

- `olmo3-7b.yml`, `olmo3-32b.yml`: `rope_truncate: True` to match HF's  `truncate=True` default for YaRN.                                                                                                                       

- cast `rope_scaling.{beta_fast,beta_slow,factor}` to floats in  pre-existing deepseek2/3 dicts to silence transformers warnings. 


# Tests

End-to-end conversion + `forward_pass_logit_checker` against the HF reference,  on CPU, fp32, scan_layers=True, max_prefill/target=16:                                                 

  **`olmo3-7b-pt` (stage 1)**                                                                            
  - HF reference: `allenai/Olmo-3-1025-7B@stage1-step1413814`                                                                         
  - Max KL: **6.4e-05**
 
  **`olmo3-7b` (Instruct)**
  - HF reference: `allenai/Olmo-3-7B-Instruct` 
  - Max KL: **8.83e-05**
  
  **`olmo3-32b` (Think)**                                                                              
  - HF reference: `allenai/Olmo-3-32B-Think`                                                                             
  - Max KL: **2.37e-05**

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
