### PR TITLE
Add tpu profiling options

### DIFF
--- a/src/maxtext/common/profiler.py
+++ b/src/maxtext/common/profiler.py
@@ -51,13 +51,29 @@ class Profiler:
       ManagedMLDiagnostics(config)  # Initialize the MLRun instance.
 
     self.profiling_options = jax.profiler.ProfileOptions()
+    advanced_config = {}
+
     if self.mode == "xplane" and not self.managed_mldiagnostics and config.profile_power_events:
-      self.profiling_options.advanced_configuration = {
-          "tpu_power_trace_level": config.xprof_tpu_power_trace_level,
-          "e2e_enable_fw_throttle_event": config.xprof_e2e_enable_fw_throttle_event,
-          "e2e_enable_fw_power_level_event": config.xprof_e2e_enable_fw_power_level_event,
-          "e2e_enable_fw_thermal_event": config.xprof_e2e_enable_fw_thermal_event,
-      }
+      advanced_config.update(
+          {
+              "tpu_power_trace_level": config.xprof_tpu_power_trace_level,
+              "e2e_enable_fw_throttle_event": config.xprof_e2e_enable_fw_throttle_event,
+              "e2e_enable_fw_power_level_event": config.xprof_e2e_enable_fw_power_level_event,
+              "e2e_enable_fw_thermal_event": config.xprof_e2e_enable_fw_thermal_event,
+          }
+      )
+
+    if self.mode == "xplane" and config.enable_tpu_profiling_options:
+      advanced_config.update(
+          {
+              "tpu_num_chips_to_profile_per_task": config.tpu_num_chips_to_profile_per_task,
+              "tpu_num_sparse_core_tiles_to_trace": config.tpu_num_sparse_core_tiles_to_trace,
+              "tpu_num_sparse_cores_to_trace": config.tpu_num_sparse_cores_to_trace,
+          }
+      )
+
+    if advanced_config:
+      self.profiling_options.advanced_configuration = advanced_config
 
   def maybe_activate_profiler(self, step, state):
     """Conditionally activates the profiler based on the current step.

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -802,6 +802,10 @@ hide_profiler_step_metric: False
 profile_cleanly: True # If set to true, adds a block_until_ready on train state which aligns the profile for each step.
 profile_periodically_period: -1 # If set to a positive integer, profile every profile_periodically_period steps.
 # This is useful to debug scenarios where performance is changing.
+enable_tpu_profiling_options: False
+tpu_num_chips_to_profile_per_task: 1
+tpu_num_sparse_core_tiles_to_trace: 1
+tpu_num_sparse_cores_to_trace: 2
 
 # Managed ML diagnostics settings. If the feature is enabled, it will
 # - create a managed ML diagnostics run with all the MaxText configs

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1598,6 +1598,12 @@ class Profiling(BaseModel):
   hide_profiler_step_metric: bool = Field(False, description="Whether to enable profiler step metric.")
   enable_jax_profiler: bool = Field(False, description="Enable the JAX live profiler.")
   jax_profiler_port: int = Field(9999, description="Port for the JAX profiler.")
+  enable_tpu_profiling_options: bool = Field(False, description="Enable TPU advanced profiling options.")
+  tpu_num_chips_to_profile_per_task: int = Field(1, description="Specifies the number of TPU chips to profile per task.")
+  tpu_num_sparse_cores_to_trace: int = Field(2, description="Specifies the number of TPU chips to profile per task.")
+  tpu_num_sparse_core_tiles_to_trace: int = Field(
+      1, description="Specifies the number of tiles within each sparse core to trace on the TPU."
+  )
   xprof_tpu_power_trace_level: XProfTPUPowerTraceMode = Field(
       XProfTPUPowerTraceMode.POWER_TRACE_NONE,
       description=(

--- a/src/maxtext/input_pipeline/olmo_data.py
+++ b/src/maxtext/input_pipeline/olmo_data.py
@@ -27,7 +27,6 @@ import ast
 import bisect
 import dataclasses
 import hashlib
-import io
 import json
 import os
 import struct


### PR DESCRIPTION
# Description

Add TPU advanced profiling options. Enable specifying the number of TPU and sparse core profiling. The default values for TPU is 1 and sparsecore is 2.

# Tests

Check for ragged kernel features, before this change we have [broken xprof](https://xprof.corp.google.com/trace_viewer/chengnuojin-7292591416925759291) and after this change it gets fixed see [fixed xprof](https://xprof.corp.google.com/trace_viewer/chengnuojin-7180065812936478086).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
