### PR TITLE
[NNX] NNX migration prep (4.5/N): Linen<->NNX checkpoint converter

### DIFF
--- a/src/maxtext/checkpoint_conversion/linen_nnx_converter.py
+++ b/src/maxtext/checkpoint_conversion/linen_nnx_converter.py
@@ -1,0 +1,581 @@
+# Copyright 2023-2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bidirectional conversion between Linen and NNX checkpoint formats.
+
+Top-level key mapping:
+  Linen → NNX:
+    params/params/<model>  →  model/<model>       (remove double-nesting, rename, add {value:} wrappers)
+    opt_state              →  optimizer/opt_state  (remove 'params' level from mu/nu)
+    step                   →  optimizer/step       (move inside optimizer)
+
+  NNX → Linen:
+    model/<model>          →  params/params/<model>  (strip {value:} wrappers, add double-nesting)
+    optimizer/opt_state    →  opt_state               (add 'params' level to mu/nu)
+    optimizer/step         →  step                    (move to top level)
+
+Layer structure (--scan_layers):
+  linen_to_nnx:
+    scan_layers=True  (default): stack layers_N arrays → 'layers' tensor with layer dim at axis 1
+    scan_layers=False:           rename layers_N → integer-keyed 'layers/{N}'
+
+  nnx_to_linen (auto-detected):
+    Stacked 'layers' tensor  → unstack along axis 1 → layers_N per-layer arrays
+    Integer-keyed layers/{N} → rename to layers_N
+
+Usage:
+  python linen_nnx_converter.py \\
+    --source_path="gs://bucket/checkpoint/0/items" \\
+    --target_path="gs://bucket/converted/" \\
+    --direction=auto
+"""
+
+import argparse
+import os
+import re
+import time
+from typing import Any
+
+# MUST set before importing JAX to force CPU-only mode
+os.environ["JAX_PLATFORMS"] = "cpu"
+
+import jax
+import numpy as np
+from etils import epath
+import orbax.checkpoint as ocp
+
+
+def log(message: str) -> None:
+  print(f"[linen_nnx_converter] {message}")
+
+
+# ── Format detection ───────────────────────────────────────────────────────────
+
+
+def detect_format(state: dict) -> str:
+  """Detects checkpoint format ('linen' or 'nnx') from top-level keys."""
+  # NNX: uses 'model' as the top-level params key
+  if "model" in state:
+    return "nnx"
+
+  if "params" not in state:
+    raise ValueError(f"Cannot detect checkpoint format: no 'model' or 'params' key. " f"Found: {list(state.keys())}")
+
+  params = state["params"]
+
+  # Linen: double-nested params/params/decoder
+  if isinstance(params, dict) and "params" in params:
+    inner = params["params"]
+    if isinstance(inner, dict) and ("decoder" in inner or "encoder" in inner):
+      return "linen"
+
+  # Old NNX format: params/decoder (single-nested with value wrappers)
+  if isinstance(params, dict) and ("decoder" in params or "encoder" in params):
+    if _has_value_wrappers(params):
+      return "nnx"
+
+  if "optimizer" in state:
+    return "nnx"
+  if "opt_state" in state:
+    return "linen"
+
+  raise ValueError(
+      f"Could not detect checkpoint format. Keys: {list(state.keys())}, "
+      f"params keys: {list(params.keys()) if isinstance(params, dict) else type(params)}"
+  )
+
+
+# ── Value wrapper helpers ──────────────────────────────────────────────────────
+
+
+def _has_value_wrappers(tree: Any) -> bool:
+  """Returns True if tree contains {value: array} wrappers (NNX style)."""
+  if isinstance(tree, dict):
+    if set(tree.keys()) == {"value"}:
+      inner = tree["value"]
+      if hasattr(inner, "shape") or isinstance(inner, np.ndarray):
+        return True
+    for v in tree.values():
+      if _has_value_wrappers(v):
+        return True
+  return False
+
+
+def _strip_value_wrappers(tree: Any) -> Any:
+  """Recursively strips {value: array} wrappers from a tree."""
+  if isinstance(tree, dict):
+    if set(tree.keys()) == {"value"}:
+      inner = tree["value"]
+      if hasattr(inner, "shape") or isinstance(inner, np.ndarray):
+        return inner
+    return {k: _strip_value_wrappers(v) for k, v in tree.items()}
+  elif isinstance(tree, (list, tuple)):
+    return type(tree)(_strip_value_wrappers(item) for item in tree)
+  else:
+    return tree
+
+
+def _add_value_wrappers(tree: Any) -> Any:
+  """Recursively wraps leaf arrays in {value: array} (NNX nnx.Param format)."""
+  if isinstance(tree, dict):
+    if set(tree.keys()) == {"value"}:
+      inner = tree["value"]
+      if hasattr(inner, "shape") or isinstance(inner, np.ndarray):
+        return tree  # Already wrapped
+    return {k: _add_value_wrappers(v) for k, v in tree.items()}
+  elif isinstance(tree, (list, tuple)):
+    return type(tree)(_add_value_wrappers(item) for item in tree)
+  elif hasattr(tree, "shape") or isinstance(tree, np.ndarray):
+    return {"value": tree}
+  else:
+    return tree
+
+
+# ── Layer structure helpers ────────────────────────────────────────────────────
+
+
+def _stack_layers(decoder: dict) -> tuple[dict, bool]:
+  """Stacks per-layer parameters (layers_N) into a single 'layers' dict at axis 0.
+
+  Returns (result_dict, was_stacked).
+  """
+  layer_pattern = re.compile(r"^layers_(\d+)$")
+  layer_indices = {}
+  other_keys = {}
+
+  for key, value in decoder.items():
+    match = layer_pattern.match(key)
+    if match:
+      layer_indices[int(match.group(1))] = value
+    else:
+      other_keys[key] = value
+
+  if not layer_indices:
+    return decoder, False
+
+  sorted_indices = sorted(layer_indices.keys())
+  num_layers = len(sorted_indices)
+  log(f"  Found {num_layers} individual layers, stacking into 'layers'")
+
+  def stack_arrays(layers_data: list) -> Any:
+    first = layers_data[0]
+    if hasattr(first, "shape") or isinstance(first, np.ndarray):
+      return np.stack([np.asarray(layers_data[i]) for i in range(len(layers_data))], axis=0)
+    elif isinstance(first, dict):
+      result = {}
+      for key in first.keys():
+        child_data = [layers_data[i].get(key) for i in range(len(layers_data))]
+        if all(c is not None for c in child_data):
+          result[key] = stack_arrays(child_data)
+      return result
+    else:
+      return first
+
+  layers_data = [layer_indices[i] for i in sorted_indices]
+  stacked = stack_arrays(layers_data)
+
+  result = dict(other_keys)
+  result["layers"] = stacked
+  return result, True
+
+
+def _rename_layers_to_integer_keys(decoder: dict) -> dict:
+  """Converts layers_N keys to integer-keyed dict under 'layers' (no stacking).
+
+  Converts {layers_0: {...}, layers_1: {...}} → {layers: {'0': {...}, '1': {...}}}.
+  Used for scan_layers=False linen→nnx conversion (Pattern C).
+  """
+  layer_pattern = re.compile(r"^layers_(\d+)$")
+  layer_indices = {}
+  other_keys = {}
+
+  for key, value in decoder.items():
+    match = layer_pattern.match(key)
+    if match:
+      layer_indices[int(match.group(1))] = value
+    else:
+      other_keys[key] = value
+
+  if not layer_indices:
+    return decoder
+
+  sorted_indices = sorted(layer_indices.keys())
+  log(f"  Found {len(sorted_indices)} individual layers, renaming to integer-keyed 'layers/N'")
+  result = dict(other_keys)
+  result["layers"] = {str(i): layer_indices[i] for i in sorted_indices}
+  return result
+
+
+def _transpose_layers_axes(tree: Any, src_axis: int, dst_axis: int) -> Any:
+  """Transposes the layers dimension in arrays within a tree (src_axis ↔ dst_axis)."""
+  if src_axis == dst_axis:
+    return tree
+  if isinstance(tree, dict):
+    return {k: _transpose_layers_axes(v, src_axis, dst_axis) for k, v in tree.items()}
+  elif isinstance(tree, (list, tuple)):
+    return type(tree)(_transpose_layers_axes(item, src_axis, dst_axis) for item in tree)
+  elif hasattr(tree, "shape") and len(tree.shape) >= 2:
+    axes = list(range(len(tree.shape)))
+    axes[src_axis], axes[dst_axis] = axes[dst_axis], axes[src_axis]
+    result = np.transpose(np.asarray(tree), axes=axes)
+    log(f"    Transposed: {tree.shape} → {result.shape}")
+    return result
+  else:
+    return tree
+
+
+def _detect_num_layers(tree: Any, scan_axis: int) -> int | None:
+  """Detects num_layers from the first array with ndim > scan_axis."""
+  if hasattr(tree, "shape") or isinstance(tree, np.ndarray):
+    shape = getattr(tree, "shape", None) or np.asarray(tree).shape
+    if len(shape) > scan_axis:
+      return shape[scan_axis]
+    return None
+  if isinstance(tree, dict):
+    for v in tree.values():
+      result = _detect_num_layers(v, scan_axis)
+      if result is not None:
+        return result
+  return None
+
+
+def _unstack_single_layer(tree: Any, idx: int, scan_axis: int) -> Any:
+  """Extracts a single layer by indexing at scan_axis."""
+  if hasattr(tree, "shape") or isinstance(tree, np.ndarray):
+    arr = np.asarray(tree)
+    if arr.ndim > scan_axis:
+      return np.take(arr, idx, axis=scan_axis)
+    return arr
+  if isinstance(tree, dict):
+    return {k: _unstack_single_layer(v, idx, scan_axis) for k, v in tree.items()}
+  if isinstance(tree, (list, tuple)):
+    return type(tree)(_unstack_single_layer(v, idx, scan_axis) for v in tree)
+  return tree
+
+
+def _convert_layers_to_linen_format(decoder: dict) -> dict:
+  """Converts NNX 'layers' back to Linen's layers_N format (auto-detects NNX style).
+
+  Handles:
+    - Stacked tensor (Pattern B):  layers/<arrays with layer dim at axis 1>
+                                   → layers_0, layers_1, ...  (unstack along axis 1)
+    - Integer-keyed (Pattern C):   layers/0, layers/1, ...
+                                   → layers_0, layers_1, ...  (rename)
+  """
+  if "layers" not in decoder:
+    return decoder
+
+  layers_val = decoder["layers"]
+  other_keys = {k: v for k, v in decoder.items() if k != "layers"}
+
+  if not isinstance(layers_val, dict):
+    # Already a non-dict (shouldn't happen normally), keep as-is
+    return decoder
+
+  # Pattern C: integer-keyed per-layer dict → rename
+  if all(k.isdigit() for k in layers_val.keys()):
+    result = dict(other_keys)
+    for idx_str, layer_data in sorted(layers_val.items(), key=lambda x: int(x[0])):
+      result[f"layers_{idx_str}"] = layer_data
+    log(f"  Renamed integer-keyed layers/N → layers_N ({len(layers_val)} layers)")
+    return result
+
+  # Pattern B: stacked tensor (layer dim at axis 1) → unstack
+  num_layers = _detect_num_layers(layers_val, scan_axis=1)
+  if num_layers is None:
+    log("  WARNING: Could not detect num_layers for unstacking, keeping 'layers' as-is")
+    result = dict(other_keys)
+    result["layers"] = layers_val
+    return result
+
+  result = dict(other_keys)
+  for i in range(num_layers):
+    result[f"layers_{i}"] = _unstack_single_layer(layers_val, idx=i, scan_axis=1)
+  log(f"  Unstacked scanned 'layers' → layers_N ({num_layers} layers at axis 1)")
+  return result
+
+
+# ── Optimizer state helpers ────────────────────────────────────────────────────
+
+
+def _convert_opt_state_linen_to_nnx(opt_state: Any) -> Any:
+  """Removes 'params' nesting from mu/nu in linen opt_state.
+
+  NNX optimizer state has plain arrays (no {value:} wrappers).
+  Linen opt_state mirrors the params structure (params/decoder/...),
+  so we remove the 'params' level to get decoder/... directly.
+  """
+  if isinstance(opt_state, dict):
+    result = {}
+    for k, v in opt_state.items():
+      if k == "params":
+        # Remove this level by merging its contents up
+        converted = _convert_opt_state_linen_to_nnx(v)
+        if isinstance(converted, dict):
+          result.update(converted)
+        else:
+          result[k] = converted
+      else:
+        result[k] = _convert_opt_state_linen_to_nnx(v)
+    return result
+  elif isinstance(opt_state, (list, tuple)):
+    return type(opt_state)(_convert_opt_state_linen_to_nnx(item) for item in opt_state)
+  else:
+    return opt_state  # Plain array or scalar — no value wrapper for opt_state
+
+
+def _convert_opt_state_nnx_to_linen(opt_state: Any, depth: int = 0) -> Any:
+  """Adds 'params' nesting to mu/nu, removes any stray {value:} wrappers.
+
+  NNX optimizer mu/nu contains decoder/... directly.
+  Linen expects mu/params/decoder/... (one 'params' level mirroring the params structure).
+  """
+  if isinstance(opt_state, dict):
+    # Strip any {value:} wrappers in opt_state (shouldn't be there but handle gracefully)
+    if set(opt_state.keys()) == {"value"}:
+      inner = opt_state["value"]
+      if hasattr(inner, "shape") or isinstance(inner, np.ndarray):
+        return inner
+
+    result = {}
+    for k, v in opt_state.items():
+      converted = _convert_opt_state_nnx_to_linen(v, depth + 1)
+      # Add one 'params' level after mu/nu (mirrors linen's params structure)
+      if k in ("mu", "nu") and isinstance(converted, dict):
+        result[k] = {"params": converted}
+      else:
+        result[k] = converted
+    return result
+  elif isinstance(opt_state, (list, tuple)):
+    return type(opt_state)(_convert_opt_state_nnx_to_linen(item, depth + 1) for item in opt_state)
+  else:
+    return opt_state
+
+
+# ── Main conversion functions ──────────────────────────────────────────────────
+
+
+def convert_linen_to_nnx(state: dict, scan_layers: bool = True) -> dict:
+  """Converts Linen checkpoint to NNX format.
+
+  Args:
+    state: Linen checkpoint dict with keys ['params', 'opt_state', 'step'].
+    scan_layers: If True (default), stack per-layer arrays and insert layer
+                 dim at axis 1 (for NNX with scan_layers=True).
+                 If False, rename layers_N → integer-keyed layers/N
+                 (for NNX with scan_layers=False).
+  """
+  result = {}
+
+  if "params" in state:
+    linen_params = state["params"]
+    # Remove double 'params' nesting: params/params/decoder → decoder
+    if isinstance(linen_params, dict) and "params" in linen_params:
+      nnx_params = linen_params["params"]
+      log("  params: Removed double 'params' nesting (params/params → model)")
+    else:
+      nnx_params = linen_params
+      log("  params: No double nesting found")
+
+    stripped = _strip_value_wrappers(nnx_params)
+
+    for component in ("decoder", "encoder"):
+      if component in stripped and isinstance(stripped[component], dict):
+        if scan_layers:
+          stripped[component], was_stacked = _stack_layers(stripped[component])
+          if was_stacked and "layers" in stripped[component]:
+            log(f"  {component}/layers: Transposing stacked (layers, ...) → (..., layers, ...) at axis 1")
+            stripped[component]["layers"] = _transpose_layers_axes(stripped[component]["layers"], src_axis=0, dst_axis=1)
+        else:
+          stripped[component] = _rename_layers_to_integer_keys(stripped[component])
+
+    result["model"] = _add_value_wrappers(stripped)
+    log("  model: Saved with {value:} wrappers under 'model' key")
+
+  # optimizer: move step inside, keep opt_state
+  optimizer_dict = {}
+  if "step" in state:
+    optimizer_dict["step"] = state["step"]
+    log(f"  optimizer/step: Moved from top-level (step={state['step']})")
+  if "opt_state" in state:
+    optimizer_dict["opt_state"] = _convert_opt_state_linen_to_nnx(state["opt_state"])
+    log("  optimizer/opt_state: Removed 'params' nesting from mu/nu")
+  if optimizer_dict:
+    result["optimizer"] = optimizer_dict
+
+  return result
+
+
+def convert_nnx_to_linen(state: dict) -> dict:
+  """Converts NNX checkpoint to Linen format.
+
+  Reads from 'model'/'optimizer' keys (or falls back to old 'params'/'opt_state' format).
+  Layer structure is auto-detected (stacked vs integer-keyed).
+  """
+  result = {}
+
+  model_key = "model" if "model" in state else "params"
+  if model_key in state:
+    nnx_params = state[model_key]
+    stripped = _strip_value_wrappers(nnx_params)
+    log(f"  {model_key}: Removed {{value:}} wrappers")
+
+    for component in ("decoder", "encoder"):
+      if component in stripped and isinstance(stripped[component], dict):
+        stripped[component] = _convert_layers_to_linen_format(stripped[component])
+
+    # Add double 'params' nesting: decoder → params/params/decoder
+    result["params"] = {"params": stripped}
+    log("  params: Added double 'params' nesting (model → params/params)")
+
+  # optimizer: extract step and opt_state back to top level
+  if "optimizer" in state:
+    optimizer = state["optimizer"]
+    if "step" in optimizer:
+      result["step"] = optimizer["step"]
+      log("  step: Extracted from optimizer/step to top level")
+    if "opt_state" in optimizer:
+      result["opt_state"] = _convert_opt_state_nnx_to_linen(optimizer["opt_state"])
+      log("  opt_state: Added 'params' nesting to mu/nu")
+  elif "opt_state" in state:
+    # Backward compat: old format with opt_state at top level
+    result["opt_state"] = _convert_opt_state_nnx_to_linen(state["opt_state"])
+    log("  opt_state: Converted from top-level opt_state (old format)")
+
+  if "step" in state and "step" not in result:
+    result["step"] = state["step"]
+
+  return result
+
+
+# ── Checkpoint I/O ─────────────────────────────────────────────────────────────
+
+
+def load_checkpoint(checkpoint_path: str) -> dict:
+  """Loads checkpoint from local or GCS path."""
+  log(f"Loading checkpoint from: {checkpoint_path}")
+
+  checkpoint_dir = epath.Path(checkpoint_path)
+  ckptr = ocp.Checkpointer(ocp.PyTreeCheckpointHandler())
+  metadata = ckptr.metadata(checkpoint_dir)
+
+  devices = np.array(jax.devices()).reshape((-1,))
+  single_device_mesh = jax.sharding.Mesh(devices, ("x",))
+  unsharded = jax.sharding.NamedSharding(single_device_mesh, jax.sharding.PartitionSpec())
+
+  restore_args = jax.tree_util.tree_map(
+      lambda x: ocp.ArrayRestoreArgs(sharding=unsharded) if hasattr(x, "shape") else None,
+      metadata.item_metadata.tree,
+      is_leaf=lambda x: hasattr(x, "shape"),
+  )
+
+  state = ckptr.restore(checkpoint_dir, restore_args=restore_args)
+  log(f"  Loaded keys: {list(state.keys())}")
+  return state
+
+
+def save_checkpoint(state: dict, output_path: str) -> None:
+  """Saves checkpoint to local or GCS path."""
+  log(f"Saving checkpoint to: {output_path}")
+
+  output_dir = epath.Path(output_path)
+  output_dir.mkdir(exist_ok=True, parents=True)
+
+  ckptr = ocp.PyTreeCheckpointer()
+  ckptr.save(output_dir, state, force=True)
+  log("  Checkpoint saved successfully")
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description="Convert between Linen and NNX checkpoint formats.",
+      formatter_class=argparse.RawDescriptionHelpFormatter,
+  )
+  parser.add_argument(
+      "--source_path",
+      type=str,
+      required=True,
+      help="Path to source checkpoint items directory (e.g. gs://bucket/ckpt/0/items).",
+  )
+  parser.add_argument(
+      "--target_path",
+      type=str,
+      required=True,
+      help="Path to save converted checkpoint.",
+  )
+  parser.add_argument(
+      "--direction",
+      type=str,
+      choices=["auto", "linen_to_nnx", "nnx_to_linen"],
+      default="auto",
+      help="Conversion direction. 'auto' detects from source format.",
+  )
+  parser.add_argument(
+      "--scan_layers",
+      action=argparse.BooleanOptionalAction,
+      default=True,
+      help=(
+          "For linen_to_nnx only: if True (default), stack per-layer arrays into a "
+          "scanned 'layers' tensor with layer dim at axis 1 (for NNX with scan_layers=True). "
+          "If False, rename layers_N to integer-keyed layers/N without stacking "
+          "(for NNX with scan_layers=False)."
+      ),
+  )
+
+  args = parser.parse_args()
+
+  print("=" * 80)
+  print("Linen <-> NNX Checkpoint Converter")
+  print("=" * 80)
+
+  start_time = time.time()
+
+  state = load_checkpoint(args.source_path)
+
+  if args.direction == "auto":
+    source_format = detect_format(state)
+    target_format = "nnx" if source_format == "linen" else "linen"
+    log(f"Auto-detected: {source_format} → {target_format}")
+  else:
+    source_format = args.direction.split("_to_")[0]
+    target_format = args.direction.split("_to_")[1]
+    log(f"Using specified direction: {source_format} → {target_format}")
+
+  log(f"Converting: {source_format} → {target_format}")
+  if source_format == "linen":
+    log(f"scan_layers={args.scan_layers}")
+
+  if source_format == "linen" and target_format == "nnx":
+    converted_state = convert_linen_to_nnx(state, scan_layers=args.scan_layers)
+  elif source_format == "nnx" and target_format == "linen":
+    converted_state = convert_nnx_to_linen(state)
+  else:
+    raise ValueError(f"Invalid conversion: {source_format} → {target_format}")
+
+  save_checkpoint(converted_state, args.target_path)
+
+  elapsed = time.time() - start_time
+  print("\n" + "=" * 80)
+  print(f"Conversion complete in {elapsed:.2f} seconds")
+  print(f"  Source: {args.source_path}")
+  print(f"  Target: {args.target_path}")
+  print(f"  Direction: {source_format} → {target_format}")
+  print("=" * 80)
+
+
+if __name__ == "__main__":
+  main()

--- a/tests/unit/linen_nnx_converter_test.py
+++ b/tests/unit/linen_nnx_converter_test.py
@@ -1,0 +1,869 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for linen_nnx_converter utilities."""
+
+import unittest
+import numpy as np
+from unittest.mock import MagicMock, patch
+
+from maxtext.checkpoint_conversion.linen_nnx_converter import (
+    detect_format,
+    _has_value_wrappers,
+    _strip_value_wrappers,
+    _add_value_wrappers,
+    _transpose_layers_axes,
+    _stack_layers,
+    convert_linen_to_nnx,
+    convert_nnx_to_linen,
+    _convert_opt_state_linen_to_nnx,
+    _convert_opt_state_nnx_to_linen,
+    load_checkpoint,
+    save_checkpoint,
+    main,
+)
+
+
+def _make_array(*shape):
+  """Helper to create a numpy array with given shape."""
+  return np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+
+
+class TestDetectFormat(unittest.TestCase):
+  """Tests for the detect_format function."""
+
+  def test_raises_when_no_params_key(self):
+    with self.assertRaises(ValueError):
+      detect_format({"step": 0})
+
+  def test_detects_nnx_format_via_model_key(self):
+    # NNX: top-level "model" key
+    state = {"model": {"decoder": {"layers": {}}}, "optimizer": {}}
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_detects_linen_format_double_nested(self):
+    state = {"params": {"params": {"decoder": {"layers": {}}}}}
+    self.assertEqual(detect_format(state), "linen")
+
+  def test_detects_nnx_format_single_nested_with_value_wrappers(self):
+    # Old NNX format: params/decoder with {value:} wrappers
+    arr = _make_array(2, 2)
+    state = {"params": {"decoder": {"kernel": {"value": arr}}}}
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_detects_linen_via_encoder(self):
+    state = {"params": {"params": {"encoder": {"layers": {}}}}}
+    self.assertEqual(detect_format(state), "linen")
+
+  def test_detects_nnx_via_encoder_with_value_wrappers(self):
+    arr = _make_array(2, 2)
+    state = {"params": {"encoder": {"kernel": {"value": arr}}}}
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_detects_nnx_via_optimizer_key(self):
+    arr = _make_array(2, 2)
+    state = {"params": {"something": arr}, "optimizer": {"step": 0}}
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_detects_linen_via_opt_state(self):
+    arr = _make_array(2, 2)
+    state = {
+        "params": {"something": arr},
+        "opt_state": {"params": {"mu": {"decoder": {"kernel": arr}}}},
+    }
+    self.assertEqual(detect_format(state), "linen")
+
+  def test_detects_nnx_via_optimizer_over_opt_state(self):
+    # "optimizer" key takes precedence for NNX detection
+    arr = _make_array(2, 2)
+    state = {
+        "params": {"something": arr},
+        "optimizer": {"step": 0, "opt_state": {}},
+    }
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_raises_on_undetectable_format(self):
+    state = {"params": {"some_unknown_key": 42}}
+    with self.assertRaises(ValueError):
+      detect_format(state)
+
+
+class TestHasValueWrappers(unittest.TestCase):
+  """Tests for the _has_value_wrappers helper."""
+
+  def test_returns_true_for_value_wrapper(self):
+    arr = _make_array(2, 2)
+    self.assertTrue(_has_value_wrappers({"value": arr}))
+
+  def test_returns_true_for_nested_value_wrapper(self):
+    arr = _make_array(2, 2)
+    self.assertTrue(_has_value_wrappers({"mu": {"value": arr}}))
+
+  def test_returns_false_for_plain_array(self):
+    # A plain array is not a {"value": ...} wrapper dict
+    self.assertFalse(_has_value_wrappers(_make_array(2, 2)))
+
+  def test_returns_false_for_multi_key_dict(self):
+    arr = _make_array(2, 2)
+    self.assertFalse(_has_value_wrappers({"value": arr, "extra": arr}))
+
+  def test_returns_false_for_non_array_value(self):
+    self.assertFalse(_has_value_wrappers({"value": "string"}))
+
+
+class TestStripValueWrappers(unittest.TestCase):
+  """Tests for the _strip_value_wrappers helper."""
+
+  def test_strips_single_wrapper(self):
+    arr = _make_array(3, 4)
+    result = _strip_value_wrappers({"value": arr})
+    np.testing.assert_array_equal(result, arr)
+
+  def test_strips_nested_wrappers(self):
+    arr = _make_array(2, 2)
+    wrapped = {"decoder": {"layers": {"kernel": {"value": arr}}}}
+    stripped = _strip_value_wrappers(wrapped)
+    np.testing.assert_array_equal(stripped["decoder"]["layers"]["kernel"], arr)
+
+  def test_passes_through_plain_array(self):
+    arr = _make_array(2, 3)
+    result = _strip_value_wrappers(arr)
+    np.testing.assert_array_equal(result, arr)
+
+  def test_handles_list_and_tuple(self):
+    arr = _make_array(2)
+    result_list = _strip_value_wrappers([{"value": arr}])
+    result_tuple = _strip_value_wrappers(({"value": arr},))
+    np.testing.assert_array_equal(result_list[0], arr)
+    np.testing.assert_array_equal(result_tuple[0], arr)
+
+  def test_passes_through_non_array_value(self):
+    # A dict with key "value" but scalar content should not be unwrapped
+    d = {"value": 42}
+    result = _strip_value_wrappers(d)
+    self.assertEqual(result, d)
+
+
+class TestAddValueWrappers(unittest.TestCase):
+  """Tests for the _add_value_wrappers helper."""
+
+  def test_wraps_array(self):
+    arr = _make_array(3, 4)
+    result = _add_value_wrappers(arr)
+    self.assertIsInstance(result, dict)
+    self.assertIn("value", result)
+    np.testing.assert_array_equal(result["value"], arr)
+
+  def test_wraps_nested_arrays(self):
+    arr = _make_array(2, 2)
+    nested = {"decoder": {"layers": {"kernel": arr}}}
+    wrapped = _add_value_wrappers(nested)
+    self.assertEqual(set(wrapped["decoder"]["layers"]["kernel"].keys()), {"value"})
+    np.testing.assert_array_equal(wrapped["decoder"]["layers"]["kernel"]["value"], arr)
+
+  def test_idempotent_on_already_wrapped(self):
+    arr = _make_array(2)
+    already_wrapped = {"value": arr}
+    result = _add_value_wrappers(already_wrapped)
+    # Should not double-wrap
+    self.assertEqual(set(result.keys()), {"value"})
+    np.testing.assert_array_equal(result["value"], arr)
+
+  def test_handles_list_and_tuple(self):
+    arr = _make_array(2)
+    result_list = _add_value_wrappers([arr])
+    result_tuple = _add_value_wrappers((arr,))
+    self.assertEqual(set(result_list[0].keys()), {"value"})
+    self.assertEqual(set(result_tuple[0].keys()), {"value"})
+
+  def test_passes_through_non_array_scalars(self):
+    result = _add_value_wrappers(42)
+    self.assertEqual(result, 42)
+    result_str = _add_value_wrappers("text")
+    self.assertEqual(result_str, "text")
+
+
+class TestTransposeLayersAxes(unittest.TestCase):
+  """Tests for the _transpose_layers_axes helper."""
+
+  def test_noop_when_same_axis(self):
+    arr = _make_array(4, 2, 3)
+    result = _transpose_layers_axes(arr, src_axis=0, dst_axis=0)
+    np.testing.assert_array_equal(result, arr)
+
+  def test_transposes_axis_0_to_1(self):
+    arr = _make_array(4, 2, 3)
+    result = _transpose_layers_axes(arr, src_axis=0, dst_axis=1)
+    self.assertEqual(result.shape, (2, 4, 3))
+
+  def test_transposes_axis_1_to_0(self):
+    arr = _make_array(2, 4, 3)
+    result = _transpose_layers_axes(arr, src_axis=1, dst_axis=0)
+    self.assertEqual(result.shape, (4, 2, 3))
+
+  def test_transposes_nested_dict(self):
+    arr = _make_array(4, 2, 3)
+    tree = {"decoder": {"layers": {"kernel": arr}}}
+    result = _transpose_layers_axes(tree, src_axis=0, dst_axis=1)
+    self.assertEqual(result["decoder"]["layers"]["kernel"].shape, (2, 4, 3))
+
+  def test_passes_through_1d_array(self):
+    arr = _make_array(5)
+    result = _transpose_layers_axes(arr, src_axis=0, dst_axis=1)
+    # 1D array has no axis 1, should be returned unchanged
+    np.testing.assert_array_equal(result, arr)
+
+  def test_handles_list(self):
+    arr = _make_array(4, 2, 3)
+    result = _transpose_layers_axes([arr], src_axis=0, dst_axis=1)
+    self.assertIsInstance(result, list)
+    self.assertEqual(result[0].shape, (2, 4, 3))
+
+  def test_handles_tuple(self):
+    arr = _make_array(4, 2, 3)
+    result = _transpose_layers_axes((arr,), src_axis=0, dst_axis=1)
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(result[0].shape, (2, 4, 3))
+
+
+class TestStackLayers(unittest.TestCase):
+  """Tests for the _stack_layers helper."""
+
+  def test_stacks_individual_layers(self):
+    arr0 = _make_array(3, 4)
+    arr1 = _make_array(3, 4)
+    decoder = {
+        "layers_0": {"mlp": {"kernel": arr0}},
+        "layers_1": {"mlp": {"kernel": arr1}},
+    }
+    result, was_stacked = _stack_layers(decoder)
+    self.assertTrue(was_stacked)
+    self.assertIn("layers", result)
+    stacked = result["layers"]["mlp"]["kernel"]
+    self.assertEqual(stacked.shape, (2, 3, 4))
+    np.testing.assert_array_equal(stacked[0], arr0)
+    np.testing.assert_array_equal(stacked[1], arr1)
+
+  def test_noop_when_no_layer_pattern(self):
+    arr = _make_array(3, 4)
+    decoder = {"layers": {"mlp": {"kernel": arr}}}
+    result, was_stacked = _stack_layers(decoder)
+    self.assertFalse(was_stacked)
+    self.assertIs(result, decoder)
+
+  def test_preserves_non_layer_keys(self):
+    norm_weight = _make_array(4)
+    arr0 = _make_array(3, 4)
+    decoder = {
+        "layers_0": {"mlp": {"kernel": arr0}},
+        "final_norm": {"scale": norm_weight},
+    }
+    result, was_stacked = _stack_layers(decoder)
+    self.assertTrue(was_stacked)
+    self.assertIn("final_norm", result)
+    np.testing.assert_array_equal(result["final_norm"]["scale"], norm_weight)
+
+  def test_stacks_three_layers(self):
+    arrays = [_make_array(2, 2) for _ in range(3)]
+    decoder = {f"layers_{i}": {"w": arrays[i]} for i in range(3)}
+    result, was_stacked = _stack_layers(decoder)
+    self.assertTrue(was_stacked)
+    stacked = result["layers"]["w"]
+    self.assertEqual(stacked.shape, (3, 2, 2))
+
+  def test_non_array_non_dict_leaf(self):
+    # Scalar leaf — stack_arrays returns first element
+    decoder = {"layers_0": {"count": 1}, "layers_1": {"count": 2}}
+    result, was_stacked = _stack_layers(decoder)
+    self.assertTrue(was_stacked)
+    self.assertIn("layers", result)
+
+  def test_with_missing_key_in_some_layers(self):
+    arr = _make_array(3, 4)
+    decoder = {
+        "layers_0": {"mlp": {"kernel": arr, "bias": arr}},
+        "layers_1": {"mlp": {"kernel": arr}},  # no "bias"
+    }
+    result, was_stacked = _stack_layers(decoder)
+    self.assertTrue(was_stacked)
+    self.assertIn("kernel", result["layers"]["mlp"])
+
+
+class TestConvertLinenToNNX(unittest.TestCase):
+  """Tests for the convert_linen_to_nnx function."""
+
+  def _make_linen_state(self, add_opt_state=False):
+    """Creates a minimal Linen checkpoint structure."""
+    arr = _make_array(2, 4, 3)
+    state = {
+        "step": 10,
+        "params": {
+            "params": {
+                "decoder": {
+                    "layers": {"mlp": {"wi": {"kernel": arr}}},
+                    "decoder_norm": {"scale": _make_array(4)},
+                }
+            }
+        },
+    }
+    if add_opt_state:
+      state["opt_state"] = {"params": {"mu": {"decoder": {"layers": {"kernel": arr}}}}}
+    return state
+
+  def test_converts_step_under_optimizer(self):
+    state = self._make_linen_state()
+    result = convert_linen_to_nnx(state)
+    self.assertEqual(result["optimizer"]["step"], 10)
+
+  def test_step_not_at_top_level(self):
+    state = self._make_linen_state()
+    result = convert_linen_to_nnx(state)
+    self.assertNotIn("step", result)
+
+  def test_params_stored_under_model_key(self):
+    state = self._make_linen_state()
+    result = convert_linen_to_nnx(state)
+    self.assertIn("model", result)
+    self.assertNotIn("params", result)
+
+  def test_removes_double_nesting(self):
+    state = self._make_linen_state()
+    result = convert_linen_to_nnx(state)
+    # model should have 'decoder' directly, not 'params.decoder'
+    self.assertIn("decoder", result["model"])
+    self.assertNotIn("params", result["model"])
+
+  def test_adds_value_wrappers(self):
+    state = self._make_linen_state()
+    result = convert_linen_to_nnx(state)
+    # Arrays should be wrapped in {"value": array}
+    kernel = result["model"]["decoder"]["layers"]["mlp"]["wi"]["kernel"]
+    self.assertIsInstance(kernel, dict)
+    self.assertIn("value", kernel)
+
+  def test_converts_opt_state_under_optimizer(self):
+    state = self._make_linen_state(add_opt_state=True)
+    result = convert_linen_to_nnx(state)
+    self.assertIn("opt_state", result["optimizer"])
+    # Linen opt_state had nested 'params' level; it should be removed
+    self.assertNotIn("params", result["optimizer"]["opt_state"])
+
+  def test_no_step_produces_no_optimizer_step(self):
+    arr = _make_array(2, 4, 3)
+    state = {"params": {"params": {"decoder": {"layers": {"kernel": arr}}}}}
+    result = convert_linen_to_nnx(state)
+    self.assertNotIn("step", result)
+    self.assertIn("model", result)
+
+  def test_no_double_nesting_still_converts(self):
+    # Linen state without double-nesting (unusual but handled)
+    arr = _make_array(2, 4)
+    state = {"params": {"decoder": {"layers": {"kernel": arr}}}}
+    result = convert_linen_to_nnx(state)
+    self.assertIn("decoder", result["model"])
+
+  def test_no_params_key_only_step(self):
+    state = {"step": 3}
+    result = convert_linen_to_nnx(state)
+    self.assertEqual(result["optimizer"]["step"], 3)
+    self.assertNotIn("model", result)
+
+  def test_with_per_layer_params_stacked_and_transposed(self):
+    # Linen checkpoint with layers_0, layers_1 → stacked + transposed to axis 1
+    arr = _make_array(3, 4)
+    state = {
+        "params": {
+            "params": {
+                "decoder": {
+                    "layers_0": {"mlp": {"kernel": arr}},
+                    "layers_1": {"mlp": {"kernel": arr}},
+                }
+            }
+        }
+    }
+    result = convert_linen_to_nnx(state)
+    stacked = result["model"]["decoder"]["layers"]["mlp"]["kernel"]["value"]
+    # Original (3, 4) stacked → (2, 3, 4), transposed to (3, 2, 4)
+    self.assertEqual(stacked.shape, (3, 2, 4))
+
+
+class TestConvertNNXToLinen(unittest.TestCase):
+  """Tests for the convert_nnx_to_linen function."""
+
+  def _make_nnx_state(self, add_opt_state=False):
+    """Creates an NNX checkpoint with 'model' and 'optimizer' keys.
+
+    Uses 'attention' (not 'layers') as the sub-key so _convert_layers_to_linen_format
+    does not try to unstack the data.
+    """
+    arr = _make_array(2, 4, 3)
+    state = {
+        "model": {
+            "decoder": {
+                "attention": {"wi": {"kernel": {"value": arr}}},
+                "decoder_norm": {"scale": {"value": _make_array(4)}},
+            }
+        },
+        "optimizer": {"step": 5},
+    }
+    if add_opt_state:
+      state["optimizer"]["opt_state"] = {
+          "mu": {"decoder": {"layers": {"kernel": {"value": arr}}}},
+          "nu": {"decoder": {"layers": {"kernel": {"value": arr}}}},
+      }
+    return state
+
+  def test_converts_step(self):
+    state = self._make_nnx_state()
+    result = convert_nnx_to_linen(state)
+    self.assertEqual(result["step"], 5)
+
+  def test_adds_double_nesting(self):
+    state = self._make_nnx_state()
+    result = convert_nnx_to_linen(state)
+    self.assertIn("params", result["params"])
+    self.assertIn("decoder", result["params"]["params"])
+
+  def test_strips_value_wrappers(self):
+    state = self._make_nnx_state()
+    result = convert_nnx_to_linen(state)
+    kernel = result["params"]["params"]["decoder"]["attention"]["wi"]["kernel"]
+    self.assertIsInstance(kernel, np.ndarray)
+
+  def test_converts_opt_state(self):
+    state = self._make_nnx_state(add_opt_state=True)
+    result = convert_nnx_to_linen(state)
+    self.assertIn("opt_state", result)
+    # mu/nu should get a 'params' level added
+    self.assertIn("params", result["opt_state"]["mu"])
+    self.assertIn("params", result["opt_state"]["nu"])
+
+  def test_backward_compat_params_key(self):
+    # Old NNX format: "params" instead of "model", top-level "step"
+    arr = _make_array(2, 4, 3)
+    state = {
+        "step": 5,
+        "params": {
+            "decoder": {
+                "layers": {"mlp": {"wi": {"kernel": {"value": arr}}}},
+                "decoder_norm": {"scale": {"value": _make_array(4)}},
+            }
+        },
+    }
+    result = convert_nnx_to_linen(state)
+    self.assertEqual(result["step"], 5)
+    self.assertIn("decoder", result["params"]["params"])
+
+  def test_no_step(self):
+    arr = _make_array(2, 4)
+    state = {"model": {"decoder": {"layers": {"kernel": {"value": arr}}}}}
+    result = convert_nnx_to_linen(state)
+    self.assertNotIn("step", result)
+    self.assertIn("params", result)
+
+
+class TestRoundTrip(unittest.TestCase):
+  """Verifies that linen->nnx->linen round-trip preserves data."""
+
+  def test_linen_to_nnx_to_linen(self):
+    # Use "attention" (not "layers") so _convert_layers_to_linen_format
+    # does not try to unstack the dict as a stacked-layers tensor.
+    arr = _make_array(2, 4, 3)
+    linen_state = {
+        "step": 42,
+        "params": {
+            "params": {
+                "decoder": {
+                    "attention": {"mlp": {"wi": {"kernel": arr}}},
+                    "norm": {"scale": _make_array(4)},
+                }
+            }
+        },
+    }
+    nnx_state = convert_linen_to_nnx(linen_state)
+    recovered_state = convert_nnx_to_linen(nnx_state)
+
+    self.assertEqual(recovered_state["step"], 42)
+    recovered_kernel = recovered_state["params"]["params"]["decoder"]["attention"]["mlp"]["wi"]["kernel"]
+    np.testing.assert_array_equal(recovered_kernel, arr)
+
+  def test_nnx_to_linen_to_nnx(self):
+    arr = _make_array(2, 4, 3)
+    nnx_state = {
+        "model": {
+            "decoder": {
+                "layers": {"mlp": {"wi": {"kernel": {"value": arr}}}},
+            }
+        },
+        "optimizer": {"step": 7},
+    }
+    linen_state = convert_nnx_to_linen(nnx_state)
+    recovered_state = convert_linen_to_nnx(linen_state)
+
+    self.assertEqual(recovered_state["optimizer"]["step"], 7)
+    recovered_kernel = recovered_state["model"]["decoder"]["layers"]["mlp"]["wi"]["kernel"]
+    self.assertIn("value", recovered_kernel)
+    np.testing.assert_array_equal(recovered_kernel["value"], arr)
+
+
+class TestConvertOptState(unittest.TestCase):
+  """Tests for the _convert_opt_state_linen_to_nnx and _convert_opt_state_nnx_to_linen helpers."""
+
+  def test_linen_to_nnx_removes_params_level(self):
+    arr = _make_array(3, 4)
+    opt_state = {"mu": {"params": {"decoder": {"kernel": arr}}}}
+    result = _convert_opt_state_linen_to_nnx(opt_state)
+    # 'params' key removed; decoder promoted
+    self.assertNotIn("params", result["mu"])
+    self.assertIn("decoder", result["mu"])
+    # Arrays are plain (no value wrappers in NNX opt_state)
+    np.testing.assert_array_equal(result["mu"]["decoder"]["kernel"], arr)
+
+  def test_linen_to_nnx_handles_list_input(self):
+    arr = _make_array(2, 2)
+    opt_state = [{"decoder": {"kernel": arr}}, {"decoder": {"kernel": arr}}]
+    result = _convert_opt_state_linen_to_nnx(opt_state)
+    self.assertIsInstance(result, list)
+    np.testing.assert_array_equal(result[0]["decoder"]["kernel"], arr)
+
+  def test_linen_to_nnx_handles_tuple_input(self):
+    arr = _make_array(2, 2)
+    opt_state = ({"decoder": {"kernel": arr}},)
+    result = _convert_opt_state_linen_to_nnx(opt_state)
+    self.assertIsInstance(result, tuple)
+    np.testing.assert_array_equal(result[0]["decoder"]["kernel"], arr)
+
+  def test_linen_to_nnx_handles_non_array_non_dict(self):
+    # Scalars should be passed through unchanged
+    result = _convert_opt_state_linen_to_nnx(42)
+    self.assertEqual(result, 42)
+
+  def test_linen_to_nnx_params_key_with_non_dict_value(self):
+    # When k == "params" but converted value is not a dict, store it as-is
+    opt_state = {"params": 99}
+    result = _convert_opt_state_linen_to_nnx(opt_state)
+    self.assertIn("params", result)
+    self.assertEqual(result["params"], 99)
+
+  def test_nnx_to_linen_adds_params_level_and_strips(self):
+    arr = _make_array(3, 4)
+    opt_state = {
+        "mu": {"decoder": {"kernel": {"value": arr}}},
+        "nu": {"decoder": {"kernel": {"value": arr}}},
+    }
+    result = _convert_opt_state_nnx_to_linen(opt_state)
+    # mu/nu should have 'params' nested inside
+    self.assertIn("params", result["mu"])
+    self.assertIn("params", result["nu"])
+    # Arrays unwrapped
+    kernel = result["mu"]["params"]["decoder"]["kernel"]
+    np.testing.assert_array_equal(kernel, arr)
+
+  def test_nnx_to_linen_handles_list_input(self):
+    arr = _make_array(2, 2)
+    opt_state = [{"decoder": {"kernel": {"value": arr}}}]
+    result = _convert_opt_state_nnx_to_linen(opt_state)
+    self.assertIsInstance(result, list)
+    np.testing.assert_array_equal(result[0]["decoder"]["kernel"], arr)
+
+  def test_nnx_to_linen_handles_tuple_input(self):
+    arr = _make_array(2, 2)
+    opt_state = ({"decoder": {"kernel": {"value": arr}}},)
+    result = _convert_opt_state_nnx_to_linen(opt_state)
+    self.assertIsInstance(result, tuple)
+    np.testing.assert_array_equal(result[0]["decoder"]["kernel"], arr)
+
+  def test_nnx_to_linen_passes_through_scalars(self):
+    result = _convert_opt_state_nnx_to_linen("scalar_string")
+    self.assertEqual(result, "scalar_string")
+
+  def test_nnx_to_linen_value_wrapper_with_non_array_inner(self):
+    # {"value": scalar} should NOT be unwrapped (only arrays get unwrapped)
+    d = {"value": 42}
+    result = _convert_opt_state_nnx_to_linen(d)
+    self.assertIn("value", result)
+    self.assertEqual(result["value"], 42)
+
+
+class TestConvertLinenToNNXEncoder(unittest.TestCase):
+  """Tests encoder path in convert_linen_to_nnx."""
+
+  def test_converts_encoder_params(self):
+    arr = _make_array(2, 4, 3)
+    state = {
+        "params": {
+            "params": {
+                "encoder": {
+                    "layers": {"mlp": {"wi": {"kernel": arr}}},
+                }
+            }
+        }
+    }
+    result = convert_linen_to_nnx(state)
+    self.assertIn("encoder", result["model"])
+    kernel = result["model"]["encoder"]["layers"]["mlp"]["wi"]["kernel"]
+    self.assertIsInstance(kernel, dict)
+    self.assertIn("value", kernel)
+
+  def test_converts_encoder_with_per_layer_stacking(self):
+    arr = _make_array(3, 4)
+    state = {
+        "params": {
+            "params": {
+                "encoder": {
+                    "layers_0": {"mlp": {"kernel": arr}},
+                    "layers_1": {"mlp": {"kernel": arr}},
+                }
+            }
+        }
+    }
+    result = convert_linen_to_nnx(state)
+    stacked = result["model"]["encoder"]["layers"]["mlp"]["kernel"]["value"]
+    # Stacked at axis 0 → (2, 3, 4), then transposed to (3, 2, 4)
+    self.assertEqual(stacked.shape, (3, 2, 4))
+
+
+class TestAdditionalEdgeCases(unittest.TestCase):
+  """Covers remaining edge cases."""
+
+  def test_detect_format_params_has_params_but_no_decoder_encoder(self):
+    # params["params"] exists but inner has no decoder/encoder -> falls through
+    # no optimizer/opt_state -> should raise
+    state = {"params": {"params": {"some_other_key": {}}}}
+    with self.assertRaises(ValueError):
+      detect_format(state)
+
+  def test_detect_format_opt_state_returns_linen(self):
+    # Any state with "opt_state" (but no "model"/"optimizer") detects as linen
+    arr = _make_array(2)
+    state = {
+        "params": {"something": arr},
+        "opt_state": {"mu": {"decoder": {"kernel": arr}}},
+    }
+    self.assertEqual(detect_format(state), "linen")
+
+  def test_add_value_wrappers_value_key_with_non_array(self):
+    # {"value": "text"} is not a wrapper (inner is not an array), recurse normally
+    d = {"value": "not_an_array"}
+    result = _add_value_wrappers(d)
+    self.assertEqual(result, {"value": "not_an_array"})
+
+  def test_convert_nnx_to_linen_no_step(self):
+    arr = _make_array(2, 4)
+    state = {"model": {"decoder": {"layers": {"kernel": {"value": arr}}}}}
+    result = convert_nnx_to_linen(state)
+    self.assertNotIn("step", result)
+    self.assertIn("params", result)
+
+  def test_convert_nnx_to_linen_already_has_params_nesting(self):
+    arr = _make_array(2, 4)
+    state = {"params": {"params": {"decoder": {"layers": {"kernel": {"value": arr}}}}}}
+    result = convert_nnx_to_linen(state)
+    self.assertIn("params", result)
+
+  def test_convert_nnx_to_linen_no_params_key(self):
+    state = {"optimizer": {"step": 8}}
+    result = convert_nnx_to_linen(state)
+    self.assertEqual(result["step"], 8)
+    self.assertNotIn("params", result)
+
+
+class TestLoadCheckpoint(unittest.TestCase):
+  """Tests for load_checkpoint with mocked orbax/epath."""
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.ocp")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.epath")
+  def test_load_checkpoint_calls_checkpointer_and_returns_state(self, mock_epath, mock_ocp):
+    arr = _make_array(2, 2)
+    expected_state = {"params": arr, "step": 0}
+
+    mock_path = MagicMock()
+    mock_epath.Path.return_value = mock_path
+
+    mock_metadata = MagicMock()
+    mock_metadata.item_metadata.tree = {"params": arr}
+
+    mock_ckptr = MagicMock()
+    mock_ckptr.metadata.return_value = mock_metadata
+    mock_ckptr.restore.return_value = expected_state
+    mock_ocp.Checkpointer.return_value = mock_ckptr
+    mock_ocp.ArrayRestoreArgs.return_value = MagicMock()
+
+    result = load_checkpoint("/tmp/test_ckpt")
+
+    mock_epath.Path.assert_called_once_with("/tmp/test_ckpt")
+    mock_ocp.Checkpointer.assert_called_once()
+    mock_ckptr.metadata.assert_called_once_with(mock_path)
+    mock_ckptr.restore.assert_called_once()
+    self.assertEqual(result, expected_state)
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.ocp")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.epath")
+  def test_load_checkpoint_with_empty_tree_metadata(self, mock_epath, mock_ocp):
+    expected_state = {"step": 5}
+
+    mock_path = MagicMock()
+    mock_epath.Path.return_value = mock_path
+
+    mock_metadata = MagicMock()
+    mock_metadata.item_metadata.tree = {}
+
+    mock_ckptr = MagicMock()
+    mock_ckptr.metadata.return_value = mock_metadata
+    mock_ckptr.restore.return_value = expected_state
+    mock_ocp.Checkpointer.return_value = mock_ckptr
+
+    result = load_checkpoint("/tmp/empty_ckpt")
+
+    self.assertEqual(result["step"], 5)
+
+
+class TestSaveCheckpoint(unittest.TestCase):
+  """Tests for save_checkpoint with mocked orbax/epath."""
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.ocp")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.epath")
+  def test_save_checkpoint_creates_dir_and_saves(self, mock_epath, mock_ocp):
+    state = {"params": _make_array(2, 2), "step": 1}
+
+    mock_path = MagicMock()
+    mock_epath.Path.return_value = mock_path
+
+    mock_ckptr = MagicMock()
+    mock_ocp.PyTreeCheckpointer.return_value = mock_ckptr
+
+    save_checkpoint(state, "/tmp/output")
+
+    mock_epath.Path.assert_called_once_with("/tmp/output")
+    mock_path.mkdir.assert_called_once_with(exist_ok=True, parents=True)
+    mock_ocp.PyTreeCheckpointer.assert_called_once()
+    mock_ckptr.save.assert_called_once_with(mock_path, state, force=True)
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.ocp")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.epath")
+  def test_save_checkpoint_passes_state_unchanged(self, mock_epath, mock_ocp):
+    state = {"step": 99, "params": {"decoder": {}}}
+
+    mock_path = MagicMock()
+    mock_epath.Path.return_value = mock_path
+    mock_ckptr = MagicMock()
+    mock_ocp.PyTreeCheckpointer.return_value = mock_ckptr
+
+    save_checkpoint(state, "/tmp/out2")
+
+    call_args = mock_ckptr.save.call_args
+    self.assertIs(call_args[0][1], state)
+
+
+class TestMain(unittest.TestCase):
+  """Tests for the main() CLI entry point."""
+
+  def _run_main(self, argv):
+    with patch("sys.argv", ["prog"] + argv):
+      main()
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_explicit_linen_to_nnx(self, mock_load, mock_save):
+    arr = _make_array(2, 4, 3)
+    mock_load.return_value = {
+        "step": 1,
+        "params": {"params": {"decoder": {"layers": {"kernel": arr}}}},
+    }
+    self._run_main(["--source_path=/src", "--target_path=/dst", "--direction=linen_to_nnx"])
+    mock_load.assert_called_once_with("/src")
+    mock_save.assert_called_once()
+    saved_state = mock_save.call_args[0][0]
+    # NNX format: decoder at top level of model
+    self.assertIn("decoder", saved_state["model"])
+    self.assertEqual(mock_save.call_args[0][1], "/dst")
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_explicit_nnx_to_linen(self, mock_load, mock_save):
+    arr = _make_array(2, 4, 3)
+    mock_load.return_value = {
+        "model": {"decoder": {"layers": {"kernel": {"value": arr}}}},
+        "optimizer": {"step": 2},
+    }
+    self._run_main(["--source_path=/src", "--target_path=/dst", "--direction=nnx_to_linen"])
+    mock_load.assert_called_once_with("/src")
+    mock_save.assert_called_once()
+    saved_state = mock_save.call_args[0][0]
+    # Linen format: double nesting
+    self.assertIn("params", saved_state["params"])
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_auto_detects_linen_converts_to_nnx(self, mock_load, mock_save):
+    arr = _make_array(2, 4, 3)
+    mock_load.return_value = {
+        "step": 3,
+        "params": {"params": {"decoder": {"layers": {"kernel": arr}}}},
+    }
+    self._run_main(["--source_path=/src", "--target_path=/dst", "--direction=auto"])
+    mock_save.assert_called_once()
+    saved_state = mock_save.call_args[0][0]
+    # Auto-detected linen → NNX format: model key
+    self.assertIn("decoder", saved_state["model"])
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_auto_detects_nnx_converts_to_linen(self, mock_load, mock_save):
+    arr = _make_array(2, 4, 3)
+    mock_load.return_value = {
+        "model": {"decoder": {"layers": {"kernel": {"value": arr}}}},
+        "optimizer": {"step": 4},
+    }
+    self._run_main(["--source_path=/src", "--target_path=/dst", "--direction=auto"])
+    mock_save.assert_called_once()
+    saved_state = mock_save.call_args[0][0]
+    # Auto-detected nnx → Linen format
+    self.assertIn("params", saved_state["params"])
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_default_direction_is_auto(self, mock_load, mock_save):
+    arr = _make_array(2, 4, 3)
+    mock_load.return_value = {
+        "params": {"params": {"decoder": {"layers": {"kernel": arr}}}},
+    }
+    # No --direction arg -> defaults to "auto"
+    self._run_main(["--source_path=/src", "--target_path=/dst"])
+    mock_save.assert_called_once()
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_scan_layers_false(self, mock_load, mock_save):
+    arr = _make_array(3, 4)
+    mock_load.return_value = {
+        "params": {
+            "params": {
+                "decoder": {
+                    "layers_0": {"mlp": {"kernel": arr}},
+                    "layers_1": {"mlp": {"kernel": arr}},
+                }
+            }
+        }
+    }
+    self._run_main(["--source_path=/src", "--target_path=/dst", "--direction=linen_to_nnx", "--no-scan_layers"])
+    saved_state = mock_save.call_args[0][0]
+    # With scan_layers=False: integer-keyed layers/N
+    layers = saved_state["model"]["decoder"]["layers"]
+    self.assertIsInstance(layers, dict)
+    self.assertTrue(all(k.isdigit() for k in layers.keys()))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## NNX Migration Route Map

1. ✅ Add NNX scaffolding: `pure_nnx` flag, `init_state_fn`, `TrainStateNNX`, NNX utils. Linen workflow unchanged. (PR #3427)
2. ✅ NNX sharding utilities: `get_abstract_state_nnx`, `get_named_sharding_nnx`, `set_named_sharding_nnx`, `get_partition_spec_nnx`, `get_mesh_from_config`. (PR #3470)
3. ✅ NNX fully supported end-to-end: `TrainStateNNX`, model creation, gradient accumulation, checkpointing, and training loop dispatch. (PR #3500)
4. ✅ Sharding diagnostics on NNX, plus post-training bugfixes that surfaced once the NNX path got exercised end-to-end. (PR #3652)
4.5. 🔄 **[This PR]** Linen↔NNX checkpoint converter. Originally bundled with the comparator under PR4.5; further split into PR4.5 (converter) + PR4.6 (comparator) on 2026-05-07 to keep each reviewable.
4.6. ❌ Linen↔NNX checkpoint comparator (stacked follow-up on this branch).
5. ❌ NNX correctness fixes, feature enablements, and vocab tiling on NNX.
6. ❌ NNX-native DPO.
7. ❌ NNX-native MaxEngine inference.
8. ❌ NNX-native LoRA + GRPO.
9. ❌ NNX-aware QK-Clip + remaining checkpoint utilities.
9.5. ❌ NNX + AQT in MaxEngine + serve-mode reload + gpt3 prefill fix.
10. ❌ Vocab tiling `custom_vjp` for NNX.
11. ❌ Set NNX defaults to `True`; regenerate sharding goldens; flip back integration-test `pure_nnx=False` annotations.
12. ❌ Delete Linen-specific code paths and NNX compatibility flags.

## Description

This PR adds `linen_nnx_converter.py` — a bidirectional Linen↔NNX checkpoint converter used during the NNX migration to translate checkpoints between the two formats. Originally bundled with a comparison utility; the comparator was split into a stacked follow-up (PR4.6) on 2026-05-07 so each PR stays narrowly reviewable. PR4.5 and PR4.6 are file-disjoint.

This is a pure addition — no existing files are modified, no production-code paths reference the utility, and no Linen or NNX runtime behavior changes. PR5+ do not depend on this branch.

**Diff:** +1450 / −0 across 2 new files.

## What it does

`src/maxtext/checkpoint_conversion/linen_nnx_converter.py`:

- **Bidirectional conversion** — Linen → NNX and NNX → Linen. Round-trips are designed to preserve byte values; the unit tests assert this on synthetic checkpoints.
- **Top-level key mapping** (handled symmetrically in both directions):
  - Linen `params/params/<model>` ↔ NNX `model/<model>` (remove/add double-nesting; add/strip `{value: ...}` wrappers).
  - Linen `opt_state` ↔ NNX `optimizer/opt_state` (remove/add `params` level on `mu` / `nu`).
  - Linen `step` ↔ NNX `optimizer/step` (move in/out of `optimizer`).
- **Layer structure** — `--scan_layers=True` (default) stacks per-layer arrays into a single `layers` tensor (layer axis at position 1); `--scan_layers=False` keeps integer-keyed `layers/{N}`. NNX→Linen direction auto-detects the source layout.
- **Format detection** — `--direction=auto` picks Linen vs NNX from top-level keys (`model` → NNX, `params` → Linen).
- **CPU-only** — sets `JAX_PLATFORMS=cpu` before importing JAX so it runs on a workstation without TPU/GPU access.

## Tests

`tests/unit/linen_nnx_converter_test.py` — pure-CPU, 84 cases. Covers:
- Format detection
- Value-wrapper add/strip
- Layer-axis transpose
- Layer stacking / unstacking
- Full Linen→NNX and NNX→Linen `convert_*` paths
- Opt-state conversion in both directions
- Checkpoint load/save (orbax mocked)
- The CLI `main` entry point

Existing tests untouched.

## Stats

- **Diff:** +1450 / −0 across 2 files (2 new, 0 modified).
- **Production-code impact:** none. No existing source file imports the utility.
- **Linen preservation:** trivially preserved — no Linen file is touched.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
