### PR TITLE
[NNX] NNX migration prep (9.5/N): NNX + AQT in MaxEngine + serve-mode reload + gpt3 prefill fix

### DIFF
--- a/src/maxtext/inference/maxengine/maxengine.py
+++ b/src/maxtext/inference/maxengine/maxengine.py
@@ -117,14 +117,25 @@ class MaxEngine(_BaseEngine):
     # Model and Optimizer definition.
     quant = quantizations.configure_quantization(config)
     if config.pure_nnx:
+      # `serve` only when the on-disk checkpoint already carries `qrhs.frozen`
+      # (no full-precision kernel). For `checkpoint_is_quantized=False` with
+      # quant enabled we stay in `train` mode and let AQT quantize per-forward
+      # against the full-precision kernel — same numerical result as `serve`
+      # for absmax calibration, just slower.
+      nnx_quant_mode_str = "serve" if (quant is not None and config.checkpoint_is_quantized) else "train"
       # We need both PREFILL and AR abstract models because the cache vars inherit
       # CACHE_BATCH_PREFILL vs CACHE_BATCH from the construction model_mode, and
       # bulk_insert searches for the substring "cache_batch" in the AR-mode names.
-      _create_model = model_creation_utils.get_nnx_create_model_fn(config, mesh=self._mesh, model_mode=MODEL_MODE_PREFILL)
-      _create_model_ar = model_creation_utils.get_nnx_create_model_fn(
-          config, mesh=self._mesh, model_mode=MODEL_MODE_AUTOREGRESSIVE
+      # Calling nnx.eval_shape directly (instead of create_nnx_abstract_model) avoids
+      # the jax.set_mesh wrap that trips Flax 0.12.6 on logical-only axes like "norm".
+      _create_model = model_creation_utils.get_nnx_create_model_fn(
+          config, mesh=self._mesh, model_mode=MODEL_MODE_PREFILL, quant_mode_str=nnx_quant_mode_str
       )
-      with jax.set_mesh(self._mesh), nn_partitioning.axis_rules(config.logical_axis_rules):
+      _create_model_ar = model_creation_utils.get_nnx_create_model_fn(
+          config, mesh=self._mesh, model_mode=MODEL_MODE_AUTOREGRESSIVE, quant_mode_str=nnx_quant_mode_str
+      )
+      self._nnx_quant_mode_str = nnx_quant_mode_str
+      with nn_partitioning.axis_rules(config.logical_axis_rules):
         abstract_model = nnx.eval_shape(_create_model)
         abstract_model_ar = nnx.eval_shape(_create_model_ar)
       self.model = abstract_model
@@ -370,9 +381,15 @@ class MaxEngine(_BaseEngine):
     return params
 
   def _load_params_nnx(self, params, rng):
-    """NNX equivalent of load_params: returns an nnx.Param state and populates KV cache shardings."""
-    if self.model.quant is not None:
-      raise NotImplementedError("pure_nnx + quantization not yet supported. Use pure_nnx=False.")
+    """NNX equivalent of load_params: returns an nnx.Param state and populates KV cache shardings.
+
+    Quantization handling:
+      * `checkpoint_is_quantized=True`: model built in `serve` mode (no full
+        kernel), `from_pretrained` reads `qrhs.frozen` from disk.
+      * `checkpoint_is_quantized=False` + `quantization=...`: model built in
+        `train` mode, full-precision kernel loaded; AQT layers quantize per
+        forward. Same output as serve mode (absmax calibration), slower.
+    """
 
     if params:
       print("Resharding given NNX params")
@@ -401,13 +418,46 @@ class MaxEngine(_BaseEngine):
       max_logging.log("Loading NNX params via from_pretrained")
       with self._mesh:
         nnx_model = model_creation_utils.from_pretrained(
-            self.config, mesh=self._mesh, model_mode=MODEL_MODE_AUTOREGRESSIVE
+            self.config,
+            mesh=self._mesh,
+            model_mode=MODEL_MODE_AUTOREGRESSIVE,
+            quant_mode_str=self._nnx_quant_mode_str,
         )
-      # Refresh graphdef from the concrete loaded model so subsequent merges line up.
-      graphdef, params_state, _, rest_state = nnx.split(nnx_model, nnx.Param, nnx.Cache, ...)
+      # 4-way split keeps the loaded AQT `qrhs.frozen` leaves (and any other
+      # non-Param/non-Cache vars) in `loaded_rest_state` so they survive into
+      # `_nnx_rest_state`. Param-only filtering would silently drop them and
+      # the model would run with random qrhs values.
+      _, params_state, _, loaded_rest_state = nnx.split(nnx_model, nnx.Param, nnx.Cache, ...)
+      # `_prefill_jit` re-merges with `self.graphdef`, which must be the PREFILL
+      # graphdef built in `__init__` (matching `_create_model_fn`). Don't
+      # overwrite with the AR-mode graphdef from `from_pretrained` — the
+      # PREFILL/AR attention ops have different cache variable shapes, and a
+      # mismatch trips the `assert prefill_kv_cache` check inside attention_op.
+      with nn_partitioning.axis_rules(self.config.logical_axis_rules):
+        concrete_model = self._create_model_fn()
+      graphdef, _, _, rest_state = nnx.split(concrete_model, nnx.Param, nnx.Cache, ...)
+      # Overlay loaded non-Param/non-Cache leaves (e.g. AQT qrhs.frozen) onto
+      # the PREFILL-mode rest_state. The PREFILL concrete_model already has
+      # placeholder qrhs vars at the right paths; we just swap in the loaded
+      # values. Anything only in `loaded_rest_state` (e.g. AR-only RNG slots)
+      # is ignored. We keep PREFILL rest_state as the base so RNG variables
+      # match the PREFILL graphdef's expectations.
+      loaded_rest_dict = loaded_rest_state.to_pure_dict()
+      rest_dict = rest_state.to_pure_dict()
+
+      def _overlay(dst, src):
+        if isinstance(dst, dict):
+          for k, v in dst.items():
+            if k in src:
+              dst[k] = _overlay(v, src[k])
+          return dst
+        return src if not isinstance(src, dict) else dst
+
+      rest_dict = _overlay(rest_dict, loaded_rest_dict)
+      nnx.replace_by_pure_dict(rest_state, rest_dict)
       self.graphdef = graphdef
       self._nnx_rest_state = rest_state
-      del nnx_model
+      del nnx_model, concrete_model
 
     self.abstract_params = jax.tree.map(
         lambda x: jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype, sharding=x.sharding)
@@ -495,7 +545,16 @@ class MaxEngine(_BaseEngine):
     if rng is None:
       rng = jax.random.PRNGKey(0)
     if self.config.pure_nnx:
-      raise NotImplementedError("pure_nnx + quantize_params not yet supported.")
+      # NNX takes a different code path: convert-on-load lives in `_load_params_nnx`
+      # via `_convert_and_quantize_nnx`, which runs the dummy forward against a
+      # CONVERT-mode model and transfers `qrhs.frozen` into the SERVE model.
+      # The standalone `quantize_params(state, rng)` API expects a Linen-shape
+      # `state.params` dict and isn't reachable on the NNX pathway in maxengine
+      # (load_params already dispatched to _load_params_nnx).
+      raise NotImplementedError(
+          "Use load_params() on NNX — the convert step runs inside _load_params_nnx via "
+          "_convert_and_quantize_nnx. quantize_params(state, rng) is the Linen API."
+      )
 
     self.model.quant.quant_mode = quantizations.get_quant_mode("convert")
 

--- a/src/maxtext/models/gpt3.py
+++ b/src/maxtext/models/gpt3.py
@@ -28,6 +28,7 @@ from flax import linen as nn
 from flax import nnx
 
 from maxtext.common.common_types import Config, DType, AxisNames, BATCH, LENGTH, EMBED, HEAD, D_KV, Array, MODEL_MODE_TRAIN
+from maxtext.inference import kvcache
 from maxtext.layers import initializers, nnx_wrappers
 from maxtext.layers.linears import DenseGeneral, MlpBlock, canonicalize_tuple, normalize_axes
 from maxtext.layers import quantizations
@@ -35,7 +36,6 @@ from maxtext.layers import linears
 from maxtext.layers.attentions import AttentionOp, KVQuant
 from maxtext.layers.initializers import Initializer, NdInitializer, nd_dense_init
 from maxtext.layers.quantizations import AqtQuantization as Quant
-from maxtext.inference import kvcache
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 
@@ -258,6 +258,7 @@ class Gpt3MultiHeadAttention(nnx.Module):
         mesh=self.mesh,
         attention_kernel=self.attention_kernel,
         max_target_length=self.max_target_length,
+        max_prefill_predict_length=self.max_prefill_predict_length,
         float32_qk_product=self.float32_qk_product,
         float32_logits=self.float32_logits,
         quant=self.quant,

--- a/src/maxtext/utils/layerwise_quantization.py
+++ b/src/maxtext/utils/layerwise_quantization.py
@@ -47,6 +47,8 @@ from maxtext.models import deepseek, models
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
+from maxtext.utils import maxtext_utils_nnx
+from maxtext.utils import model_creation_utils
 import orbax.checkpoint as ocp
 from tqdm import tqdm
 from maxtext.configs import pyconfig
@@ -164,18 +166,25 @@ class LayerwiseQuantization:
     self.config = config
     self.rng = rng
 
-    # TODO(ranlihao): Remove this assertion once the Layerwise quantization is supported for other decoder blocks.
-    assert (
-        config.decoder_block == common_types.DecoderBlockType.DEEPSEEK
-    ), f"Layerwise quantization is only supported for {common_types.DecoderBlockType.DEEPSEEK}\
-      , but got {config.decoder_block}."
+    # The Linen path runs layer-by-layer (memory-efficient for big DeepSeek
+    # models) and is DeepSeek-specific because it relies on the per-layer
+    # `DeepSeek*ToLinen` wrappers. The NNX path runs whole-model convert
+    # forward and is model-agnostic — see `_load_and_quantize_nnx`.
+    if not config.pure_nnx:
+      assert config.decoder_block == common_types.DecoderBlockType.DEEPSEEK, (
+          f"Linen layerwise quantization only supports {common_types.DecoderBlockType.DEEPSEEK}, "
+          f"got {config.decoder_block}."
+      )
     # Mesh definition
     devices_array = maxtext_utils.create_device_mesh(config=config)
     self._mesh = jax.sharding.Mesh(devices_array, config.mesh_axes)
 
-    # Input and output are both Linen-format (uses DeepSeek*ToLinen layers below).
-    # Route to Linen regardless of pure_nnx.
     self.quant = quantizations.configure_quantization(config)
+    if config.pure_nnx:
+      # NNX takes a separate code path that builds the model via from_pretrained;
+      # no Linen abstract-state bookkeeping is needed here.
+      self.unboxed_abstract_state = None
+      return
     model = models.transformer_as_linen(
         config, mesh=self._mesh, quant=self.quant, model_mode=common_types.MODEL_MODE_TRAIN
     )
@@ -187,6 +196,9 @@ class LayerwiseQuantization:
     """
     Load parameters layer by layer and quantize them.
     """
+    if self.config.pure_nnx:
+      self._load_and_quantize_nnx()
+      return
     quantized_params = {}
     quantized_params["params"] = {"decoder": {}}
     quantized_params["aqt"] = {"decoder": {}}
@@ -271,6 +283,132 @@ class LayerwiseQuantization:
     quantized_params["params"]["token_embedder"] = self._load_layer("token_embedder")["params"]["token_embedder"]
 
     maxtext_utils.save_quantized_checkpoint_if_configured(self.config, quantized_params)
+
+  def _load_and_quantize_nnx(self) -> None:
+    """Whole-model NNX convert: load full-precision via TRAIN-mode `from_pretrained`,
+    transfer kernels into a fresh CONVERT-mode model, run a forward (the
+    `ToNNX(AqtDotGeneral)` bridge auto-captures `qrhs.frozen`), strip kernels at
+    quantized paths, and save the serve-mode-shaped state.
+
+    Two-step load: input checkpoints are typically full-precision (no AQT state
+    on disk), so we can't `from_pretrained(quant_mode_str="convert")` directly —
+    orbax would fail to find the missing `qrhs.frozen` leaves. Instead we load
+    in TRAIN mode (which has only kernels), then copy them into a randomly
+    initialized CONVERT model that already has the AQT variables provisioned.
+    """
+    config = self.config
+    # MODEL_MODE_TRAIN avoids the PREFILL/AUTOREGRESSIVE cache plumbing — AQT
+    # layers populate `qrhs.frozen` regardless of model_mode, so train mode is
+    # simpler and faster.
+    max_logging.log("Loading full-precision NNX checkpoint in TRAIN mode...")
+    with self._mesh:
+      train_model = model_creation_utils.from_pretrained(
+          config,
+          mesh=self._mesh,
+          model_mode=common_types.MODEL_MODE_TRAIN,
+          quant_mode_str="train",
+      )
+
+    max_logging.log("Building CONVERT-mode model (random init) and copying kernels in...")
+    rngs = maxtext_utils_nnx.create_nnx_rngs(config, rng_key=self.rng)
+    with nn_partitioning.axis_rules(config.logical_axis_rules):
+      convert_model = model_creation_utils.from_config(
+          config,
+          mesh=self._mesh,
+          rngs=rngs,
+          model_mode=common_types.MODEL_MODE_TRAIN,
+          quant_mode_str="convert",
+      )
+    self._copy_kernel_leaves_(convert_model, train_model)
+    del train_model
+
+    # Forward populates AqtDotGeneral_0.qrhs.frozen on every quantized layer.
+    L = config.max_target_length
+    decoder_input_tokens = jnp.zeros((1, L), dtype=jnp.int32)
+    decoder_positions = jnp.arange(L, dtype=jnp.int32)[None, :]
+    decoder_segment_ids = jnp.ones((1, L), dtype=jnp.int32)
+    max_logging.log("Running CONVERT-mode forward to populate AQT scale factors...")
+    with nn_partitioning.axis_rules(config.logical_axis_rules):
+      _ = convert_model(
+          decoder_input_tokens,
+          decoder_positions,
+          decoder_segment_ids=decoder_segment_ids,
+          enable_dropout=False,
+          model_mode=common_types.MODEL_MODE_TRAIN,
+      )
+
+    # Convert-mode state has both `kernel` (full precision) and `AqtDotGeneral_0.qrhs.frozen`
+    # at every quantized DenseGeneral; the serve-mode reader expects only the latter.
+    convert_state = nnx.state(convert_model).to_pure_dict()
+    serve_state = self._strip_kernels_at_quantized_paths(convert_state)
+
+    if config.save_quantized_params_path:
+      max_logging.log(f"Saving NNX-format quantized checkpoint to {config.save_quantized_params_path}")
+
+      # Wrap each leaf in `{"value": <array>}` so the on-disk shape matches what
+      # `from_pretrained`'s NNX-detection branch reads back (it later does
+      # `tree.map(lambda v: v["value"], ...)` on each leaf). Save directly via
+      # orbax — `save_params_to_path` would add an outer `{"params": ...}` wrap
+      # that the NNX path doesn't expect.
+      def _wrap_value(node):
+        if isinstance(node, dict):
+          return {k: _wrap_value(v) for k, v in node.items()}
+        return {"value": node}
+
+      wrapped = _wrap_value(serve_state)
+      orbax_checkpointer = ocp.PyTreeCheckpointer(
+          use_ocdbt=config.checkpoint_storage_use_ocdbt,
+          use_zarr3=config.checkpoint_storage_use_zarr3,
+      )
+      orbax_checkpointer.save(config.save_quantized_params_path, wrapped, force=True)
+      max_logging.log(f"Saved NNX-format quantized checkpoint at: {config.save_quantized_params_path}")
+    else:
+      max_logging.log("Skipping save: save_quantized_params_path is null.")
+
+  @staticmethod
+  def _copy_kernel_leaves_(dst_model, src_model):
+    """Copy the full-precision parameter leaves (kernel/embedding/scale/bias)
+    from src into dst, leaving dst's AQT and RNG variables untouched.
+    """
+    src_dict = nnx.state(src_model).to_pure_dict()
+    dst_state = nnx.state(dst_model)
+    dst_dict = dst_state.to_pure_dict()
+
+    def walk(d_node, s_node):
+      if not (isinstance(d_node, dict) and isinstance(s_node, dict)):
+        return
+      for key, d_child in d_node.items():
+        if key not in s_node:
+          continue
+        s_child = s_node[key]
+        if key in ("kernel", "embedding", "scale", "bias") and not isinstance(d_child, dict):
+          d_node[key] = s_child
+        elif isinstance(d_child, dict):
+          walk(d_child, s_child)
+
+    walk(dst_dict, src_dict)
+    nnx.replace_by_pure_dict(dst_state, dst_dict)
+    nnx.update(dst_model, dst_state)
+
+  @staticmethod
+  def _strip_kernels_at_quantized_paths(state_dict):
+    """Drop `kernel` keys at any node that has a sibling `AqtDotGeneral_0`.
+
+    In convert mode each quantized DenseGeneral keeps both the full-precision
+    `kernel` (an nnx.Param) and the AQT-quantized `AqtDotGeneral_0.qrhs.frozen`
+    side-by-side. Serve mode (the on-disk shape `from_pretrained` reads back)
+    only carries the latter; the kernel is recreated as a dummy zero in
+    `linears.DenseGeneral.__call__`.
+    """
+    if not isinstance(state_dict, dict):
+      return state_dict
+    has_aqt = "AqtDotGeneral_0" in state_dict
+    out = {}
+    for k, v in state_dict.items():
+      if k == "kernel" and has_aqt:
+        continue
+      out[k] = LayerwiseQuantization._strip_kernels_at_quantized_paths(v) if isinstance(v, dict) else v
+    return out
 
   def _load_layer(self, layer_name):
     """Loads a specific layer's parameters from the checkpoint."""

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -1631,8 +1631,17 @@ def get_nnx_named_sharding_with_scan_axis(abs_var_state: nnx.State, mesh) -> nnx
   def _make_named_sharding(v):
     val = v.get_value()
     if not hasattr(val, "shape"):
-      # Non-tensor value (e.g., optax MaskedNode for non-trainable params). Preserve
-      # as-is so the treedef matches abs_var_state in the downstream jax.tree.map.
+      # `val` is either truly leafless (e.g. optax MaskedNode) or a composite
+      # pytree of tensors (e.g. AQT QTensor on serve-mode quantized variables —
+      # a `qvalue` int8 array + a list of `scale` bf16 arrays). For the latter
+      # we must emit a parallel tree of NamedSharding leaves so the downstream
+      # `jax.tree.map(lambda a, s: ShapeDtypeStruct(..., sharding=s), abs, names)`
+      # finds a real Sharding at every position. Replicated sharding is a safe
+      # default — AQT serve-mode QTensors are normally small (per-channel scale
+      # factors and packed int8 weights) and don't need axis-aware sharding.
+      if jax.tree_util.tree_leaves(val):
+        replicated = NamedSharding(mesh, PartitionSpec())
+        return v.replace(jax.tree.map(lambda _: replicated, val))
       return v
     metadata = v.get_metadata()
     out_sharding = metadata.get("out_sharding") or metadata.get("sharding_names") or metadata.get("sharding")

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -39,9 +39,11 @@ import subprocess
 import sys
 from etils import epath
 from flax import nnx
+from flax.core.meta import Partitioned
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax.sharding import Mesh
 from maxtext.configs import pyconfig
 from maxtext.common.common_types import MODEL_MODE_AUTOREGRESSIVE, MODEL_MODE_TRAIN
@@ -228,6 +230,8 @@ def _fuse_moe_weights(ckpt_tree, model_arrays_tree):
       return key.key
     if hasattr(key, "attr"):
       return key.attr
+    if hasattr(key, "name"):
+      return key.name
     return key
 
   def _lookup_model(path):
@@ -364,17 +368,33 @@ def _fix_restore_args_for_shape_mismatch(restore_args, stored_metadata_tree, mes
       return str(key.key)
     if hasattr(key, "attr"):
       return str(key.attr)
+    if hasattr(key, "name"):
+      return str(key.name)
     return str(key)
 
   def _lookup_stored_meta(path):
     """Navigate stored_metadata_tree using path keys from the restore_args tree."""
+    # Try the clean name (e.g. `qvalue`) first, then fall back to `str(key)`
+    # (e.g. `.qvalue`) — orbax may use either form for GetAttrKey. SequenceKey
+    # indexes into lists/tuples (e.g. QTensor.scale is `list[ArrayMetadata]`).
     node = stored_metadata_tree
     for key in path:
-      name = _key_str(key)
-      if isinstance(node, dict) and name in node:
-        node = node[name]
-      else:
+      if isinstance(key, jax.tree_util.SequenceKey):
+        if isinstance(node, (list, tuple)) and 0 <= key.idx < len(node):
+          node = node[key.idx]
+          continue
         return None
+      if not isinstance(node, dict):
+        return None
+      name = _key_str(key)
+      if name in node:
+        node = node[name]
+        continue
+      raw = str(key)
+      if raw in node:
+        node = node[raw]
+        continue
+      return None
     return node
 
   mismatched_paths_sharded = []
@@ -466,6 +486,7 @@ def from_config(
     *,
     model_mode: str = MODEL_MODE_TRAIN,
     rngs: None = None,
+    quant_mode_str: str = "train",
 ) -> nn.Module:
   ...
 
@@ -478,6 +499,7 @@ def from_config(
     *,
     model_mode: str = MODEL_MODE_TRAIN,
     rngs: nnx.Rngs,
+    quant_mode_str: str = "train",
 ) -> models.Transformer:
   ...
 
@@ -489,25 +511,18 @@ def from_config(
     *,
     model_mode: str = MODEL_MODE_TRAIN,
     rngs: nnx.Rngs | None = None,
+    quant_mode_str: str = "train",
 ) -> nn.Module | models.Transformer:
   """Load a pretrained MaxText model from checkpoint.
 
-  This function loads a model from a checkpoint.
-
-  Args:
-      config: Config object.
-      devices: Sequence of devices to use for the model. If None, use all
-        available devices.
-
-  Returns:
-      Transformer: The loaded model instance (only the model)
-
-  Example:
-      model = from_config(config)
+  `quant_mode_str` is one of "train", "convert", "serve" — controls the AQT
+  quantization mode at model construction time. NNX layers freeze their
+  param shape on `quant_mode_str` (e.g. SERVE skips the full-precision kernel),
+  so callers loading a pre-quantized checkpoint must pass `"serve"`.
   """
   if mesh is None:
     mesh = maxtext_utils.get_mesh_from_config(config, devices)
-  model = create_model(config, mesh, model_mode=model_mode, rngs=rngs)
+  model = create_model(config, mesh, model_mode=model_mode, rngs=rngs, quant_mode_str=quant_mode_str)
 
   # Return only the model
   return model
@@ -521,28 +536,35 @@ def get_transformer_model(config, mesh, quant, model_mode: str = MODEL_MODE_TRAI
     return models.transformer_as_linen(config, mesh, quant=quant, model_mode=model_mode)
 
 
-def create_model(config, mesh, model_mode: str = MODEL_MODE_TRAIN, rngs: nnx.Rngs | None = None):
+def create_model(
+    config, mesh, model_mode: str = MODEL_MODE_TRAIN, rngs: nnx.Rngs | None = None, *, quant_mode_str: str = "train"
+):
   """Instantiates and returns the model object, sharded across the mesh."""
   # Model definition
-  quant = quantizations.configure_quantization(config)
+  quant = quantizations.configure_quantization(config, quant_mode_str=quant_mode_str)
   model = get_transformer_model(config, mesh, quant, model_mode=model_mode, rngs=rngs)
   model = quantizations.maybe_quantize_model(model, config)
   return model
 
 
-def get_nnx_create_model_fn(config, mesh=None, devices=None, model_mode=MODEL_MODE_TRAIN, rng_key=None) -> Callable:
+def get_nnx_create_model_fn(
+    config, mesh=None, devices=None, model_mode=MODEL_MODE_TRAIN, rng_key=None, *, quant_mode_str: str = "train"
+) -> Callable:
 
   def _create_model():
     rngs = maxtext_utils_nnx.create_nnx_rngs(config, model_mode=model_mode, rng_key=rng_key)
-    return from_config(config, devices, mesh, rngs=rngs, model_mode=model_mode)
+    return from_config(config, devices, mesh, rngs=rngs, model_mode=model_mode, quant_mode_str=quant_mode_str)
 
   return _create_model
 
 
 def create_nnx_abstract_model(
-    config, mesh=None, devices=None, model_mode=MODEL_MODE_TRAIN, rng_key=None
+    config, mesh=None, devices=None, model_mode=MODEL_MODE_TRAIN, rng_key=None, *, quant_mode_str: str = "train"
 ) -> tuple[Callable, nnx.Module]:
   """Creates an abstract NNX model.
+
+  `quant_mode_str` is forwarded to model construction so AQT layers freeze
+  the right param shape (e.g. SERVE skips the full-precision kernel).
 
   Returns:
     A tuple containing (create_model_fn, abstract_model):
@@ -551,7 +573,7 @@ def create_nnx_abstract_model(
   """
 
   with nn.logical_axis_rules(config.logical_axis_rules):
-    _create_model = get_nnx_create_model_fn(config, mesh, devices, model_mode, rng_key)
+    _create_model = get_nnx_create_model_fn(config, mesh, devices, model_mode, rng_key, quant_mode_str=quant_mode_str)
     if mesh is None:
       _tmp = nnx.eval_shape(_create_model)
       mesh = _tmp.mesh
@@ -559,8 +581,11 @@ def create_nnx_abstract_model(
     # nnx.get_abstract_model, which uses get_var_pspec internally and ignores
     # param_scan_axis / nnx.PARTITION_NAME metadata set by _create_scanned_layers,
     # causing the stacked layers axis to be missing from the PartitionSpec.
-    with jax.set_mesh(mesh):
-      abs_model = nnx.eval_shape(_create_model)
+    # Wrapping in `jax.set_mesh(mesh)` trips Flax 0.12.6's `_to_variable` for
+    # serve-mode AQT variables (NamedSharding with `spec=None` rejected under
+    # AbstractMesh). Sharding is resolved afterwards via the helper, so the
+    # wrap is unnecessary here.
+    abs_model = nnx.eval_shape(_create_model)
     graphdef, abs_var_state = nnx.split(abs_model)
     named_sharding_state = maxtext_utils.get_nnx_named_sharding_with_scan_axis(abs_var_state, mesh)
     abstract_state = jax.tree.map(
@@ -774,8 +799,15 @@ def from_pretrained(
     rng_key=None,
     wrap_with_tunix_adapter=False,
     tokenizer_pad_id=None,
+    *,
+    quant_mode_str: str = "train",
 ):
-  """Creates a NNX model with sharded parameters, possibly loading from a checkpoint."""
+  """Creates a NNX model with sharded parameters, possibly loading from a checkpoint.
+
+  `quant_mode_str` is forwarded to model construction. Pass `"serve"` when
+  loading a pre-quantized checkpoint so AQT layers materialize the on-disk
+  scale factors instead of full-precision kernels.
+  """
   original_mesh = mesh
   if config.convert_checkpoint_if_possible and not config.load_parameters_path:
     if not (epath.Path(config.base_output_directory) / "0" / "items").exists():
@@ -835,7 +867,9 @@ def from_pretrained(
     config = pyconfig.HyperParameters(new_config)
 
   if config.pure_nnx:
-    _create_model, abstract_model = create_nnx_abstract_model(config, mesh, devices, model_mode, rng_key)
+    _create_model, abstract_model = create_nnx_abstract_model(
+        config, mesh, devices, model_mode, rng_key, quant_mode_str=quant_mode_str
+    )
     model = maxtext_utils_nnx.create_nnx_sharded_model(abstract_model, _create_model, mesh=mesh)
     # TODO: print debug_sharding info
   else:
@@ -846,7 +880,9 @@ def from_pretrained(
   # the checkpoint-loading branch below needs the logical PartitionSpec tree
   # (axis names like "kv_heads", "mlp_moe") for repeat/zero-pad dispatch in
   # _align_checkpoint_to_model_shapes. nnx.eval_shape is cheap (abstract trace).
-  _create_model_for_specs = get_nnx_create_model_fn(config, mesh, devices, model_mode, rng_key)
+  _create_model_for_specs = get_nnx_create_model_fn(
+      config, mesh, devices, model_mode, rng_key, quant_mode_str=quant_mode_str
+  )
   with nn.logical_axis_rules(config.logical_axis_rules):
     _abs_model_for_specs = nnx.eval_shape(_create_model_for_specs)
   _, _abs_state_for_specs = nnx.split(_abs_model_for_specs)
@@ -950,10 +986,48 @@ def from_pretrained(
           }
         else:
           # NNX checkpoint: {'decoder': {'value': ...}}, or NNX-RL with extra 'base' nesting.
-          # Restore only nnx.Param — RNG variable shapes may differ between checkpoint and model.
+          # Restore only nnx.Param — RNG variable shapes may differ between checkpoint and model,
+          # and pure-dict checkpoints written by `layerwise_quantization._load_and_quantize_nnx`
+          # don't carry RNG/dropout state at all (they only persist nnx.Param leaves, including
+          # AQT serve-mode `qrhs.frozen` which is a Param subclass).
+          def _build_value_target(v):
+            # `v[...]` (a.k.a. `v.get_value(index=...)`) descends into the inner
+            # value with `value[Ellipsis]`. AQT serve-mode `qrhs.frozen` variables
+            # wrap a QTensor whose `__getitem__` calls `qvalue[idx]` on a
+            # `LogicallyPartitioned` wrapper — that fails. For QTensor (and any
+            # composite pytree value), use the unwrapped value directly so the
+            # restore target preserves the QTensor's qvalue/scale sub-structure.
+            inner = v.get_value() if hasattr(v, "get_value") else v[...]
+            if hasattr(inner, "shape"):
+              return {"value": v[...]}
+            # AQT QTensor: qvalue/scale leaves come back wrapped in flax
+            # `Partitioned` (a logical-axis sharding box). The on-disk save in
+            # `_load_and_quantize_nnx` flushes the QTensor as plain arrays —
+            # paths look like `qrhs.frozen.value.qvalue` / `...scale.0`. If we
+            # leave Partitioned in place, jax.tree adds an extra `.value` key
+            # under each leaf (`qrhs.frozen.value.qvalue.value`) and orbax
+            # silently fills with zeros because that path doesn't exist on
+            # disk. Strip Partitioned wrappers so the target tree matches.
+            inner = jax.tree.map(
+                lambda x: x.value if isinstance(x, Partitioned) else x,
+                inner,
+                is_leaf=lambda x: isinstance(x, Partitioned),
+            )
+            return {"value": inner}
+
+          # Keep persisted weight-like leaves: `nnx.Param` plus AQT serve-mode
+          # `qrhs.frozen` (a separate `aqt` Variable type, NOT a Param subclass).
+          # Excluded: `nnx.RngState` (regenerated per load, shapes can drift) and
+          # `nnx.Cache` (PREFILL/AR scratch, not persisted). Pure-dict checkpoints
+          # written by `layerwise_quantization._load_and_quantize_nnx` carry both
+          # Param kernels and `aqt`-typed `qrhs.frozen` quantized payloads.
+          if hasattr(sharded_state, "filter"):
+            param_state = sharded_state.filter(lambda path, var: not isinstance(var, (nnx.RngState, nnx.Cache)))
+          else:
+            param_state = sharded_state
           target_for_restore = jax.tree.map(
-              lambda v: {"value": v[...]},
-              sharded_state,
+              _build_value_target,
+              param_state,
               is_leaf=lambda n: isinstance(n, nnx.Variable),
           )
           has_base_key = "base" in metadata.item_metadata.tree
@@ -967,10 +1041,14 @@ def from_pretrained(
 
         # Free memory used by initial sharded_state before restore, to make room for the incoming checkpoint arrays.
         def _free_device_memory(node):
+          val = node
           if isinstance(node, nnx.Variable) and not isinstance(node, nnx.RngState):
-            val = node[...]
-          else:
-            val = node
+            inner = node.get_value() if hasattr(node, "get_value") else node[...]
+            # Same QTensor caveat as `_build_value_target`: AQT serve-mode `qrhs.frozen`
+            # wraps a QTensor whose `__getitem__` fails on `LogicallyPartitioned`.
+            # We only need to free a single jax.Array leaf — for composite values
+            # there's nothing to free at this level, so skip.
+            val = inner if hasattr(inner, "shape") else None
 
           if isinstance(val, jax.Array) and not val.is_deleted():
             val.delete()
@@ -997,8 +1075,14 @@ def from_pretrained(
           checkpoint = restored["params"]["params"]
 
         if checkpoint:
+          # Same QTensor caveat as `_build_value_target` / `_free_device_memory`:
+          # `v[...]` fails on Variables wrapping QTensors. Use `get_value()` to
+          # access the inner value directly without index-style descent.
+          def _unwrap_for_align(v):
+            return v.get_value() if hasattr(v, "get_value") else v[...]
+
           model_arrays = jax.tree.map(
-              lambda v: v[...],
+              _unwrap_for_align,
               sharded_state,
               is_leaf=lambda n: isinstance(n, nnx.Variable),
           )
@@ -1047,6 +1131,12 @@ def from_pretrained(
                   )
                   for k, v in ckpt.items()
               }
+            # AQT serve-mode `qrhs.frozen` wraps a QTensor (composite pytree of
+            # qvalue+scale arrays), not a single jax.Array. Shape alignment
+            # only makes sense for full-precision kernels — quantized payloads
+            # are saved in the exact shape the model expects, so pass through.
+            if not isinstance(ckpt, (jax.Array, jax.ShapeDtypeStruct, np.ndarray)):
+              return ckpt
             return _align_checkpoint_to_model_shapes(ckpt, model_arr, axes)
 
           checkpoint = _walk_align(checkpoint, model_arrays, logical_axes_tree)

--- a/tests/integration/maxengine_test.py
+++ b/tests/integration/maxengine_test.py
@@ -255,12 +255,51 @@ class MaxEngineTest(unittest.TestCase):
           msg=f"next_pos didn't advance at step {step}",
       )
 
-  def test_quantize_raises_for_nnx(self):
-    """NNX path raises NotImplementedError when quantization is set."""
+  def test_quantize_passes_gate_for_nnx(self):
+    """pure_nnx + quantization (convert-on-load) reaches the actual machinery in train mode."""
+    # checkpoint_is_quantized defaults to False — full-precision on disk, AQT
+    # quantizes per-forward against the loaded kernel (train mode).
     cfg = self._init_nnx_pyconfig(quantization="int8")
     engine = maxengine.MaxEngine(cfg, jax.devices())
-    with self.assertRaises(NotImplementedError):
+    self.assertEqual(engine._nnx_quant_mode_str, "train")  # pylint: disable=protected-access
+    try:
       engine.load_params(rng=self.rng)
+    except NotImplementedError as e:
+      self.fail(f"convert-on-load path should not raise NotImplementedError; got: {e}")
+    except Exception:  # pylint: disable=broad-except
+      pass  # any other failure (e.g. checkpoint not found) is fine for this test
+
+  def test_load_pre_quantized_nnx_passes_quant_gate(self):
+    """pure_nnx + quantization + checkpoint_is_quantized=True clears the load gate."""
+    cfg = self._init_nnx_pyconfig(quantization="int8", checkpoint_is_quantized=True)
+    engine = maxengine.MaxEngine(cfg, jax.devices())
+    self.assertEqual(engine._nnx_quant_mode_str, "serve")  # pylint: disable=protected-access
+    try:
+      engine.load_params(rng=self.rng)
+    except NotImplementedError as e:
+      self.fail(f"checkpoint_is_quantized=True path should not raise NotImplementedError; got: {e}")
+    except Exception:  # pylint: disable=broad-except
+      pass  # any other failure (e.g. checkpoint not found) is fine for this test
+
+  def test_quantized_prefill_nnx_train_mode(self):
+    """End-to-end: NNX prefill with quantization=int8 + checkpoint_is_quantized=False.
+
+    TRAIN-mode AQT layers quantize per-forward against the loaded full-precision
+    kernel; output must be finite and shape-valid. This is the real numerical
+    verification that the convert-on-load path produces a usable model.
+    """
+    cfg = self._init_nnx_pyconfig(quantization="int8")
+    self.assertFalse(cfg.checkpoint_is_quantized)
+    devices_array = maxtext_utils.create_device_mesh(cfg)
+    mesh = Mesh(devices_array, cfg.mesh_axes)
+    params_state = self._build_nnx_params(cfg, mesh)
+
+    engine = maxengine.MaxEngine(cfg, jax.devices())
+    self.assertEqual(engine._nnx_quant_mode_str, "train")  # pylint: disable=protected-access
+    params = engine.load_params(params=params_state)
+    input_tokens = jnp.array([1, 306, 5360, 304, 0, 0, 0, 0])
+    prefill_result, _ = engine.prefill(params=params, padded_tokens=input_tokens, true_length=4)
+    self.assertTrue(jnp.all(jnp.isfinite(prefill_result["logits"])))
 
   def test_lora_load_single_adapter_reaches_loader_on_nnx(self):
     """pure_nnx + LoRA: load_single_adapter dispatches to the NNX loader.

--- a/tests/unit/aqt_serve_roundtrip_nnx_test.py
+++ b/tests/unit/aqt_serve_roundtrip_nnx_test.py
@@ -1,0 +1,170 @@
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Round-trip test for the NNX serve-mode AQT checkpoint path.
+
+Builds a small NNX model in CONVERT mode with int8 quantization, runs a forward
+to populate `qrhs.frozen`, saves the serve-mode-shape state to a local orbax
+checkpoint, then reloads via `from_pretrained(quant_mode_str="serve")` and
+checks that the loaded QTensor leaves match what was saved.
+
+This guards the chain of issues exercised by serve-mode reload (sharding helper
+for QTensor, v[...] vs get_value() for composite values, Param-only filter
+dropping aqt-typed leaves, Partitioned-unwrap for matching on-disk paths).
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+import jax
+import jax.numpy as jnp
+import orbax.checkpoint as ocp
+from flax import nnx
+from flax.core.meta import Partitioned
+from flax.linen import partitioning as nn_partitioning
+
+from maxtext.configs import pyconfig
+from maxtext.utils import maxtext_utils, model_creation_utils, maxtext_utils_nnx
+from maxtext.utils.globals import MAXTEXT_PKG_DIR
+from maxtext.utils.layerwise_quantization import LayerwiseQuantization
+
+
+def _wrap_value(node):
+  """Add `{"value": ...}` per-leaf wrap matching `_load_and_quantize_nnx` save format."""
+  if isinstance(node, dict):
+    return {k: _wrap_value(v) for k, v in node.items()}
+  return {"value": node}
+
+
+def _unbox(x):
+  return x.value if isinstance(x, Partitioned) else x
+
+
+def _walk_qrhs(state):
+  """Yield (path_str, variable) pairs for every qrhs.frozen entry in an nnx.State."""
+  for path, var in state.flat_state():
+    keys = [str(getattr(k, "key", k)) for k in path]
+    if "qrhs" in keys and "frozen" in keys:
+      yield ".".join(keys), var
+
+
+class ServeModeRoundTripTest(unittest.TestCase):
+  """End-to-end save+reload of a serve-mode NNX AQT checkpoint."""
+
+  def _init_cfg(self, ckpt_path, *, checkpoint_is_quantized):
+    """Build a pyconfig for save or reload."""
+    # Use base.yml + gpt3-52k. The decoupled test config strips
+    # logical_axis_rules (e.g. "norm"), which the AQT serve-mode model
+    # construction needs.
+    base_yml = os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")
+    args = [
+        sys.argv[0],
+        base_yml,
+        "model_name=gpt3-52k",
+        "pure_nnx=true",
+        "enable_nnx=true",
+        "pure_nnx_decoder=true",
+        "max_target_length=64",
+        "max_prefill_predict_length=16",
+        "per_device_batch_size=1",
+        "scan_layers=true",
+        "quantization=int8",
+        "checkpoint_storage_use_ocdbt=false",
+        "checkpoint_storage_use_zarr3=false",
+        "skip_jax_distributed_system=true",
+    ]
+    if checkpoint_is_quantized:
+      args += [
+          f"load_parameters_path={ckpt_path}",
+          "checkpoint_is_quantized=true",
+          "enable_checkpointing=true",  # required by config validator when load_parameters_path is set
+      ]
+    else:
+      args += ["enable_checkpointing=false"]
+    return pyconfig.initialize(args)
+
+  def test_save_then_reload_preserves_qrhs_frozen(self):
+    """Save a serve-mode-shape NNX checkpoint, then reload it and compare qvalue arrays."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+      ckpt_path = os.path.join(tmpdir, "quantized_ckpt")
+
+      # Step 1: build CONVERT-mode model + run forward to populate qrhs.frozen.
+      cfg_save = self._init_cfg(ckpt_path, checkpoint_is_quantized=False)
+      mesh = maxtext_utils.get_mesh_from_config(cfg_save)
+      rngs = maxtext_utils_nnx.create_nnx_rngs(cfg_save)
+      with nn_partitioning.axis_rules(cfg_save.logical_axis_rules):
+        convert_model = model_creation_utils.from_config(
+            cfg_save,
+            mesh=mesh,
+            rngs=rngs,
+            model_mode="train",
+            quant_mode_str="convert",
+        )
+      L = cfg_save.max_prefill_predict_length
+      tokens = jnp.zeros((1, L), dtype=jnp.int32)
+      pos = jnp.arange(L, dtype=jnp.int32)[None, :]
+      seg = jnp.ones((1, L), dtype=jnp.int32)
+      with nn_partitioning.axis_rules(cfg_save.logical_axis_rules):
+        _ = convert_model(tokens, pos, decoder_segment_ids=seg, enable_dropout=False, model_mode="train")
+
+      # Step 2: capture the qrhs.frozen leaves we expect to round-trip, then save.
+      convert_state = nnx.state(convert_model).to_pure_dict()
+      serve_state = LayerwiseQuantization._strip_kernels_at_quantized_paths(convert_state)  # pylint: disable=protected-access
+      saved_qrhs = {}
+      for path, var in _walk_qrhs(nnx.state(convert_model)):
+        qt = var.value if hasattr(var, "value") else var
+        saved_qrhs[path] = _unbox(qt.qvalue)
+
+      # Replicate arrays across the mesh; orbax rejects SingleDeviceSharding
+      # once another test has initialized JAX-distributed state.
+      replicated = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+      serve_state = jax.tree.map(
+          lambda x: jax.device_put(x, replicated) if isinstance(x, jax.Array) else x,
+          serve_state,
+      )
+
+      orbax_checkpointer = ocp.PyTreeCheckpointer(use_ocdbt=False, use_zarr3=False)
+      orbax_checkpointer.save(ckpt_path, _wrap_value(serve_state), force=True)
+      self.assertGreater(len(saved_qrhs), 0, "Test config must produce at least one qrhs.frozen leaf")
+
+      # Step 3: reload via from_pretrained in serve mode.
+      cfg_load = self._init_cfg(ckpt_path, checkpoint_is_quantized=True)
+      with nn_partitioning.axis_rules(cfg_load.logical_axis_rules):
+        loaded_model = model_creation_utils.from_pretrained(
+            cfg_load,
+            mesh=mesh,
+            model_mode="autoregressive",
+            quant_mode_str="serve",
+        )
+
+      # Step 4: assert every saved qrhs.frozen leaf matches what was persisted.
+      loaded_state = nnx.state(loaded_model)
+      loaded_qrhs = dict(_walk_qrhs(loaded_state))
+      self.assertEqual(set(saved_qrhs.keys()), set(loaded_qrhs.keys()))
+      for path, saved_qv in saved_qrhs.items():
+        var = loaded_qrhs[path]
+        qt = var.value if hasattr(var, "value") else var
+        loaded_qv = _unbox(qt.qvalue)
+        self.assertEqual(loaded_qv.shape, saved_qv.shape, f"shape mismatch at {path}")
+        self.assertEqual(loaded_qv.dtype, saved_qv.dtype, f"dtype mismatch at {path}")
+        self.assertTrue(
+            jnp.array_equal(loaded_qv.astype(jnp.int32), saved_qv.astype(jnp.int32)),
+            f"qvalue not preserved at {path}",
+        )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/layerwise_quantization_nnx_test.py
+++ b/tests/unit/layerwise_quantization_nnx_test.py
@@ -1,0 +1,77 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the NNX path of layerwise_quantization.
+
+Covers `_strip_kernels_at_quantized_paths` — the convert→serve shape converter
+that drops the redundant full-precision kernel from quantized DenseGeneral
+nodes while leaving non-quantized kernels (norms, embeddings) intact.
+"""
+
+import unittest
+
+from maxtext.utils.layerwise_quantization import LayerwiseQuantization
+
+
+class StripKernelsTest(unittest.TestCase):
+
+  def test_drops_kernel_at_quantized_dense(self):
+    """A node with both `kernel` and `AqtDotGeneral_0` loses the kernel."""
+    state = {
+        "decoder": {
+            "layers": {
+                "mlp": {
+                    "wi": {
+                        "kernel": "FULL_PRECISION_W",
+                        "AqtDotGeneral_0": {"qrhs": {"frozen": "AQT_STATE"}},
+                    }
+                }
+            }
+        }
+    }
+    out = LayerwiseQuantization._strip_kernels_at_quantized_paths(state)  # pylint: disable=protected-access
+    wi = out["decoder"]["layers"]["mlp"]["wi"]
+    self.assertNotIn("kernel", wi)
+    self.assertIn("AqtDotGeneral_0", wi)
+    self.assertEqual(wi["AqtDotGeneral_0"]["qrhs"]["frozen"], "AQT_STATE")
+
+  def test_preserves_non_quantized_kernel(self):
+    """A non-quantized kernel (e.g. embedding, norm) survives."""
+    state = {
+        "decoder": {
+            "decoder_norm": {"scale": "NORM_SCALE"},
+            "logits_dense": {"kernel": "LOGITS_KERNEL"},  # no AqtDotGeneral_0 sibling
+        },
+        "token_embedder": {"embedding": "EMB"},
+    }
+    out = LayerwiseQuantization._strip_kernels_at_quantized_paths(state)  # pylint: disable=protected-access
+    self.assertEqual(out["decoder"]["logits_dense"]["kernel"], "LOGITS_KERNEL")
+    self.assertEqual(out["decoder"]["decoder_norm"]["scale"], "NORM_SCALE")
+    self.assertEqual(out["token_embedder"]["embedding"], "EMB")
+
+  def test_mixed_tree(self):
+    """Quantized + non-quantized at the same depth: only the quantized one strips."""
+    state = {
+        "self_attention": {
+            "qkv_proj": {"kernel": "QKV", "AqtDotGeneral_0": "AQT"},
+            "out": {"kernel": "OUT_FULL"},  # non-quantized output projection
+        }
+    }
+    out = LayerwiseQuantization._strip_kernels_at_quantized_paths(state)  # pylint: disable=protected-access
+    self.assertNotIn("kernel", out["self_attention"]["qkv_proj"])
+    self.assertEqual(out["self_attention"]["out"]["kernel"], "OUT_FULL")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## NNX Migration Route Map

1. ✅ Add NNX scaffolding: `pure_nnx` flag, `init_state_fn`, `TrainStateNNX`, NNX utils. Linen workflow unchanged. (PR #3427)
2. ✅ NNX sharding utilities. (PR #3470)
3. ✅ NNX fully supported end-to-end: model creation, gradient accumulation, checkpointing, dispatch. (PR #3500)
4. ✅ Sharding diagnostics on NNX + post-training bugfixes. (PR #3652)
4.5. ✅ Linen↔NNX checkpoint converter. (PR #3843)
5. ✅ NNX correctness fixes, feature enablements, and vocab tiling MVP on NNX.
6. ✅ NNX-native DPO.
7. ✅ NNX-native MaxEngine inference (core prefill/generate/insert path). (PR #3821)
7.5. ✅ Finish NNX MaxEngine inference carve-outs.
8. ✅ NNX-native LoRA + GRPO. (PR #3824)
9. ✅ NNX-aware QK-Clip + NNX-format checkpoint utilities. (PR #3836)
9.5. 🔄 **[This PR]** NNX + AQT in MaxEngine + serve-mode reload + gpt3 prefill fix.
10. ❌ Vocab tiling `custom_vjp` for NNX.
11. ❌ Set NNX defaults to `True`; regenerate sharding goldens; flip back integration-test `pure_nnx=False` annotations.
12. ❌ Delete Linen-specific code paths and NNX compatibility flags.

## Description

Migrates the NNX + AQT integration in MaxEngine so `pure_nnx=True` can both load pre-quantized checkpoints directly (`checkpoint_is_quantized=True`) and convert full-precision checkpoints to int8 on load (`checkpoint_is_quantized=False` + `quantization=int8`). Also bundles a pre-existing gpt3 prefill / autoregressive bug surfaced by the AQT end-to-end validation.

Originally part of PR9; split into its own follow-up to keep each PR reviewable. Linen paths byte-for-byte preserved (every NNX edit is gated on `config.pure_nnx`). Stacks on PR9 (`feat/nnx-qk-clip-and-checkpoint-utils`); the two halves are file-disjoint.

**Diff:** +641 / −58 across 8 files (5 src, 3 test, 2 new).

## What it does

- **`quant_mode_str` plumbing** — thread `"train"` / `"convert"` / `"serve"` through `from_config` → `create_model` → `get_nnx_create_model_fn` → `create_nnx_abstract_model` → `from_pretrained`. Default `"train"` preserves existing callers; `"serve"` propagates to `configure_quantization` so AQT layers don't materialize the full-precision kernel when the on-disk checkpoint already carries qrhs scale factors.
- **`maxengine.__init__`** — selects the quant mode from `config.checkpoint_is_quantized`; `_load_params_nnx` drops its `NotImplementedError`. Two paths now work: pre-quantized loads via `quant_mode_str="serve"`; full-precision + `quantization=int8` loads in TRAIN mode and AQT quantizes per-forward against the loaded kernel (same numerical result as serve mode for absmax calibration).
- **`layerwise_quantization._load_and_quantize_nnx`** (new) — whole-model NNX convert path. Load full-precision in TRAIN mode → copy kernels into a separate CONVERT-mode model → run a forward (the `ToNNX(AqtDotGeneral)` bridge auto-captures `qrhs.frozen`) → strip kernels at quantized paths via `_strip_kernels_at_quantized_paths` → save serve-mode-shape state. The DeepSeek-only assertion is lifted for NNX.
- **Sharding helpers + `from_pretrained` QTensor handling** — 5 chained fixes that kept serve-mode reload from working:
  1. `get_nnx_named_sharding_with_scan_axis` emits a parallel-tree of replicated `NamedSharding` leaves when a Variable's value is a composite pytree (QTensor int8 `qvalue` + bf16 `scale` list). Previously returned the Variable as-is when `val` had no `.shape`.
  2. `_build_value_target` / `_free_device_memory` / `_unwrap_for_align` use `Variable.get_value()` instead of `v[...]` — `QTensor.__getitem__` trips on the `LogicallyPartitioned` wrapper around `qvalue`.
  3. Restore filter widened from `nnx.Param` only to "everything except `nnx.RngState` / `nnx.Cache`", and `_load_params_nnx` adds a 4-way `nnx.split` + overlay so `aqt`-typed `qrhs.frozen` leaves survive into the rest-state.
  4. `_build_value_target` strips `Partitioned` wrappers around composite-leaf values so the restore tree path matches the on-disk layout. Without this, `jax.tree.flatten_with_path` added an extra `.value` key under every QTensor leaf and orbax silently filled the missing paths with zero-init values (`qvalue=0`, `scale=1` — exactly the symptom).
  5. `_walk_align` skips composite leaves in per-axis shape alignment — quantized payloads are saved at the model shape; previously crashed on `QTensor.shape` (which delegates to `qvalue.shape` on a `LogicallyPartitioned`).

  Also dropped a redundant `jax.set_mesh(mesh)` wrap in `create_nnx_abstract_model` — under `jax.set_mesh`, Flax 0.12.6's `_to_variable` rejects serve-mode AQT variables (`NamedSharding(mesh=AbstractMesh, spec=None)`).

- **gpt3 prefill fix (`models/gpt3.py`)** — pre-existing bug surfaced by the AQT e2e validation. `Gpt3MultiHeadAttention.__call__` invoked `attention_op(...)` without ever calling `update_kv_caches` to build `cached_values`, so any non-TRAIN forward (prefill or autoregressive) tripped `assert prefill_kv_cache`. Mirrors the standard `Attention` plumbing in `attentions.py`: `__init__` constructs `KVCache_0` when `model_mode != MODEL_MODE_TRAIN` (and threads `max_prefill_predict_length` into `AttentionOp`, was `-1` default); `__call__` calls `self.KVCache_0(...)` and passes `[prefill_kv_cache, ar_kv_cache]` as `cached_values`. TRAIN-mode shape unchanged. Bundled here because the AQT e2e exercises this path.

## Tests

- **`aqt_serve_roundtrip_nnx_test`** (new, 1 test) — end-to-end regression. Builds a small CONVERT-mode NNX model with `quantization=int8`, runs a forward to populate `qrhs.frozen`, saves serve-mode state to orbax, reloads via `from_pretrained(quant_mode_str="serve")`, asserts every saved `qvalue` byte-matches what came back. Guards the full chain of QTensor / Partitioned / filter fixes.
- **`layerwise_quantization_nnx_test`** (new, 3 tests) — `_strip_kernels_at_quantized_paths` covering quantized-kernel removal, non-quantized preservation (norms, embeddings), mixed-shape trees.
- **`maxengine_test`** — replaced `test_quantize_raises_for_nnx` with `test_quantize_passes_gate_for_nnx`; added `test_load_pre_quantized_nnx_passes_quant_gate` (serve-mode gate) and `test_quantized_prefill_nnx_train_mode` (real numerical prefill with `quantization=int8` + random params + TRAIN mode produces finite logits).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
