### PR TITLE
[NNX] NNX migration prep (4.6/N): Linen<->NNX checkpoint comparator

### DIFF
--- a/src/maxtext/checkpoint_conversion/compare_linen_nnx_checkpoint.py
+++ b/src/maxtext/checkpoint_conversion/compare_linen_nnx_checkpoint.py
@@ -1,0 +1,609 @@
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compare checkpoint tree structures, shapes, and values.
+
+Supports comparing any combination of Linen and NNX checkpoints:
+- Linen vs NNX (cross-format comparison)
+- Linen vs Linen (same-format comparison)
+- NNX vs NNX (same-format comparison)
+
+The script auto-detects the format of each checkpoint and applies the
+appropriate normalization. Cross-format transformations (like layer axis
+transposition) are only applied when comparing Linen vs NNX.
+
+Key differences between Linen and NNX checkpoints:
+- Linen: params/params/decoder/layers/0/... (per-layer, double nested)
+- NNX: model/decoder/layers/... (stacked layers, single nested, {value: array} wrappers)
+
+The script handles:
+- Double 'params' nesting in Linen checkpoints
+- 'model' key in NNX checkpoints (vs 'params' in Linen)
+- {value: array} wrappers in NNX checkpoints
+- Layer axis transposition (NNX stacks layers along axis 0, only for cross-format)
+- RNG filtering (NNX has rngs, Linen doesn't)
+
+Usage:
+  # Compare Linen vs NNX (structure and shapes only)
+  python compare_linen_nnx_checkpoint.py \
+    --ckpt_path_1="gs://bucket/linen_checkpoint/0/items" \
+    --ckpt_path_2="gs://bucket/nnx_checkpoint/0/items"
+
+  # Compare NNX vs NNX
+  python compare_linen_nnx_checkpoint.py \
+    --ckpt_path_1="gs://bucket/nnx_checkpoint_a/0/items" \
+    --ckpt_path_2="gs://bucket/nnx_checkpoint_b/0/items"
+
+  # Compare Linen vs Linen
+  python compare_linen_nnx_checkpoint.py \
+    --ckpt_path_1="gs://bucket/linen_checkpoint_a/0/items" \
+    --ckpt_path_2="gs://bucket/linen_checkpoint_b/0/items"
+
+  # Compare with value checking
+  python compare_linen_nnx_checkpoint.py \
+    --ckpt_path_1="gs://bucket/checkpoint_a/0/items" \
+    --ckpt_path_2="gs://bucket/checkpoint_b/0/items" \
+    --compare_values --atol=1e-5 --rtol=1e-5
+"""
+
+import os
+from typing import Any, Dict, Sequence
+
+# MUST set before importing JAX to force CPU-only mode
+os.environ["JAX_PLATFORMS"] = "cpu"
+
+import jax
+import jax.numpy as jnp
+from jax.tree_util import tree_flatten_with_path, keystr, tree_structure, tree_map_with_path
+import numpy as np
+from etils import epath
+import orbax.checkpoint as ocp
+from absl import app
+from absl import flags
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    "ckpt_path_1",
+    None,
+    "Path to the first checkpoint items directory. Format is auto-detected.",
+)
+flags.DEFINE_string(
+    "ckpt_path_2",
+    None,
+    "Path to the second checkpoint items directory. Format is auto-detected.",
+)
+flags.DEFINE_boolean(
+    "verbose",
+    False,
+    "Print detailed per-parameter information.",
+)
+flags.DEFINE_boolean(
+    "transpose_nnx_layers",
+    False,
+    "Transpose NNX layer params from (layers, ...) to (...) for comparison. "
+    "NNX stacks layers along axis 0, while Linen stores per-layer params. "
+    "Only applied for cross-format (Linen vs NNX) comparisons.",
+)
+flags.DEFINE_string(
+    "compare_only",
+    "params",
+    "Which parts to compare: 'params' for params only, 'all' for full state.",
+)
+flags.DEFINE_boolean(
+    "ignore_rngs",
+    True,
+    "Ignore RNG-related paths in comparison (NNX has rngs, Linen doesn't).",
+)
+flags.DEFINE_boolean(
+    "compare_values",
+    False,
+    "Also compare parameter values (not just structure and shapes).",
+)
+flags.DEFINE_float(
+    "atol",
+    1e-5,
+    "Absolute tolerance for value comparison.",
+)
+flags.DEFINE_float(
+    "rtol",
+    1e-5,
+    "Relative tolerance for value comparison.",
+)
+
+
+def log(message: str) -> None:
+  """Log a message with prefix."""
+  print(f"[compare_ckpt] {message}")
+
+
+def is_rng_path(path: str) -> bool:
+  """Check if a path is RNG-related."""
+  path_lower = path.lower()
+  return "rngs" in path_lower or "rng" in path_lower
+
+
+def filter_rngs(tree: Dict[str, Any]) -> Dict[str, Any]:
+  """Filter out RNG-related keys from a tree."""
+  if not isinstance(tree, dict):
+    return tree
+
+  result = {}
+  for key, value in tree.items():
+    # Skip RNG-related keys
+    if is_rng_path(key):
+      continue
+    # Recursively filter nested dicts
+    if isinstance(value, dict):
+      filtered = filter_rngs(value)
+      if filtered:  # Only add if not empty after filtering
+        result[key] = filtered
+    else:
+      result[key] = value
+  return result
+
+
+def detect_format(state: dict) -> str:
+  """Detects checkpoint format from state structure ('linen' or 'nnx').
+
+  Linen format:
+    - Top-level keys: ['params', 'opt_state', 'step']
+    - params/params/decoder/... (double nested)
+
+  NNX format:
+    - Top-level keys: ['model', 'optimizer'] (nnx.State style)
+    - model/decoder/... with {value: array} wrappers
+  """
+  # Check for NNX nnx.State format (has 'model' key instead of 'params')
+  if "model" in state:
+    return "nnx"
+
+  if "params" not in state:
+    raise ValueError(f"Checkpoint does not contain 'params' or 'model' key. Found keys: {list(state.keys())}")
+
+  params = state["params"]
+
+  # Check for Linen's double 'params' nesting
+  if isinstance(params, dict) and "params" in params:
+    inner = params["params"]
+    if isinstance(inner, dict) and ("decoder" in inner or "encoder" in inner):
+      return "linen"
+
+  # Check for NNX's flat structure (params/decoder/...)
+  if isinstance(params, dict) and ("decoder" in params or "encoder" in params):
+    return "nnx"
+
+  # Try to detect by looking for {value: array} wrappers (NNX style)
+  if _has_value_wrappers(params):
+    return "nnx"
+
+  raise ValueError(
+      f"Could not detect checkpoint format. params keys: {list(params.keys()) if isinstance(params, dict) else type(params)}"
+  )
+
+
+def _has_value_wrappers(tree: Any) -> bool:
+  """Check if tree contains {value: array} wrappers (NNX style)."""
+  if isinstance(tree, dict):
+    if set(tree.keys()) == {"value"}:
+      inner = tree["value"]
+      if hasattr(inner, "shape") or isinstance(inner, (np.ndarray, jnp.ndarray)):
+        return True
+    for v in tree.values():
+      if _has_value_wrappers(v):
+        return True
+  return False
+
+
+def _strip_value_wrappers(tree: Any) -> Any:
+  """Recursively strips {'value': array} wrappers from a tree."""
+  if isinstance(tree, dict):
+    if set(tree.keys()) == {"value"}:
+      inner = tree["value"]
+      if hasattr(inner, "shape") or isinstance(inner, (np.ndarray, jnp.ndarray)):
+        return inner
+    return {k: _strip_value_wrappers(v) for k, v in tree.items()}
+  elif isinstance(tree, (list, tuple)):
+    return type(tree)(_strip_value_wrappers(item) for item in tree)
+  else:
+    return tree
+
+
+def _normalize_linen_params(params: dict) -> dict:
+  """Normalize Linen params by removing double 'params' nesting."""
+  if isinstance(params, dict) and "params" in params:
+    inner = params["params"]
+    if isinstance(inner, dict) and ("decoder" in inner or "encoder" in inner):
+      return inner
+  return params
+
+
+def _normalize_nnx_params(params: dict) -> dict:
+  """Normalize NNX params by stripping {value: array} wrappers."""
+  return _strip_value_wrappers(params)
+
+
+def load_checkpoint(checkpoint_path: str, metadata_only: bool = False) -> dict:
+  """Loads checkpoint from local or GCS path.
+
+  If metadata_only=True, returns a pytree of ArrayMetadata (shape/dtype only)
+  without downloading any tensor data. This is fast and sufficient for
+  structure/shape comparison.
+  """
+  log(f"Loading checkpoint from: {checkpoint_path}")
+  if metadata_only:
+    log("  Mode: metadata only (no tensor data downloaded)")
+
+  checkpoint_dir = epath.Path(checkpoint_path)
+
+  # Create checkpointer and get metadata
+  ckptr = ocp.Checkpointer(ocp.PyTreeCheckpointHandler())
+
+  try:
+    metadata = ckptr.metadata(checkpoint_dir)
+
+    if metadata_only:
+      tree = metadata.item_metadata.tree
+      log(f"  Loaded metadata keys: {list(tree.keys())}")
+      return tree
+
+    # Create a mesh with all available devices for unsharded restoration
+    devices = np.array(jax.devices()).reshape((-1,))
+    single_device_mesh = jax.sharding.Mesh(devices, ("x",))
+    unsharded = jax.sharding.NamedSharding(single_device_mesh, jax.sharding.PartitionSpec())
+
+    # Build restore args that restore arrays without original sharding
+    restore_args = jax.tree_util.tree_map(
+        lambda x: ocp.ArrayRestoreArgs(sharding=unsharded) if hasattr(x, "shape") else None,
+        metadata.item_metadata.tree,
+        is_leaf=lambda x: hasattr(x, "shape"),
+    )
+    state = ckptr.restore(checkpoint_dir, restore_args=restore_args)
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    if metadata_only:
+      log(f"  Metadata loading failed: {e}")
+      raise
+    # Fallback to simple restore without sharding args
+    log(f"  Falling back to simple restore: {e}")
+    checkpointer = ocp.PyTreeCheckpointer()
+    state = checkpointer.restore(checkpoint_path)
+
+  if state is None:
+    raise ValueError(f"Failed to restore checkpoint from {checkpoint_path}")
+
+  log(f"  Loaded keys: {list(state.keys())}")
+  return state
+
+
+def transform_nnx_params_for_comparison(nnx_params: Dict[str, Any]) -> Dict[str, Any]:
+  """Transform NNX params to match Linen structure for comparison.
+
+  NNX stacks layer parameters along axis 0 (shape: [num_layers, ...]),
+  while Linen stores per-layer parameters (shape: [...]).
+
+  This function transposes layer params from (layers, d1, d2, ...) to (d1, layers, d2, ...)
+  to align with how Linen params would look if stacked.
+  """
+
+  def _transform(path, leaf: jax.Array) -> jax.Array:
+    key_str = keystr(path)
+
+    # Only transform arrays in 'layers' with ndim >= 2
+    if "layers" in key_str and hasattr(leaf, "ndim") and leaf.ndim >= 2:
+      # Transpose from (layers, d1, d2, ...) to (d1, layers, d2, ...)
+      axes = (1, 0) + tuple(range(2, leaf.ndim))
+      result = jnp.transpose(leaf, axes=axes)
+      if FLAGS.verbose:
+        log(f"  TRANSPOSING: {key_str} shape {leaf.shape} -> {result.shape}")
+      return result
+    else:
+      return leaf
+
+  log("Transforming NNX params (transposing layer dimensions)...")
+  return tree_map_with_path(_transform, nnx_params)
+
+
+def get_tree_structure_info(tree: Dict[str, Any]) -> Dict[str, tuple]:
+  """Get structure info as dict of path -> (shape, dtype)."""
+  flat_with_path, _ = tree_flatten_with_path(tree)
+  return {
+      keystr(p): (
+          getattr(leaf, "shape", "N/A"),
+          str(getattr(leaf, "dtype", type(leaf).__name__)),
+      )
+      for p, leaf in flat_with_path
+  }
+
+
+def print_structure_diff(params1: Dict, params2: Dict, name1: str = "Linen", name2: str = "NNX"):
+  """Print structural differences between two param trees."""
+  info1 = get_tree_structure_info(params1)
+  info2 = get_tree_structure_info(params2)
+  keys1, keys2 = set(info1.keys()), set(info2.keys())
+
+  only_in_1 = sorted(keys1 - keys2)
+  only_in_2 = sorted(keys2 - keys1)
+  common = keys1 & keys2
+
+  if only_in_1:
+    print(f"\n--- Paths only in {name1} ({len(only_in_1)}) ---")
+    for k in only_in_1:
+      shape, dtype = info1[k]
+      print(f"  - {k}: shape={shape}, dtype={dtype}")
+
+  if only_in_2:
+    print(f"\n--- Paths only in {name2} ({len(only_in_2)}) ---")
+    for k in only_in_2:
+      shape, dtype = info2[k]
+      print(f"  + {k}: shape={shape}, dtype={dtype}")
+
+  # Check for shape/dtype mismatches in common paths
+  shape_mismatches = []
+  dtype_mismatches = []
+  for k in common:
+    shape1, dtype1 = info1[k]
+    shape2, dtype2 = info2[k]
+    if shape1 != shape2:
+      shape_mismatches.append((k, shape1, shape2))
+    if dtype1 != dtype2:
+      dtype_mismatches.append((k, dtype1, dtype2))
+
+  if shape_mismatches:
+    print(f"\n--- Shape mismatches ({len(shape_mismatches)}) ---")
+    for k, s1, s2 in shape_mismatches:
+      print(f"  {k}: {name1}={s1}, {name2}={s2}")
+
+  if dtype_mismatches:
+    print(f"\n--- Dtype mismatches ({len(dtype_mismatches)}) ---")
+    for k, d1, d2 in dtype_mismatches:
+      print(f"  {k}: {name1}={d1}, {name2}={d2}")
+
+  return only_in_1, only_in_2, shape_mismatches, dtype_mismatches
+
+
+def compare_params(
+    params1: Dict[str, Any],
+    params2: Dict[str, Any],
+    verbose: bool = False,
+    compare_values: bool = False,
+    atol: float = 1e-5,
+    rtol: float = 1e-5,
+    name1: str = "Ckpt1",
+    name2: str = "Ckpt2",
+) -> bool:
+  """Compare two parameter trees for structure, shape, and optionally values.
+
+  Returns True if tree structures, shapes, and (optionally) values match.
+  """
+  # First check tree structure
+  if tree_structure(params1) != tree_structure(params2):
+    print("\n[✗] Tree structures differ.")
+    print_structure_diff(params1, params2, name1=name1, name2=name2)
+    return False
+
+  print("\n[✓] Tree structures are the same.")
+
+  all_match = True
+  num_params = 0
+  shape_mismatches = []
+  dtype_mismatches = []
+  value_mismatches = []
+  value_matches = 0
+
+  def _compare_leaf(path, x, y):
+    nonlocal all_match, num_params, shape_mismatches, dtype_mismatches, value_mismatches, value_matches
+    key_str = keystr(path)
+    num_params += 1
+
+    shape1 = getattr(x, "shape", "N/A")
+    shape2 = getattr(y, "shape", "N/A")
+    dtype1 = getattr(x, "dtype", type(x).__name__)
+    dtype2 = getattr(y, "dtype", type(y).__name__)
+
+    # Check shape
+    shape_match = shape1 == shape2
+    if not shape_match:
+      shape_mismatches.append((key_str, shape1, shape2))
+      all_match = False
+
+    # Check dtype
+    dtype_match = str(dtype1) == str(dtype2)
+    if not dtype_match:
+      dtype_mismatches.append((key_str, dtype1, dtype2))
+      all_match = False
+
+    # Check values if requested and shapes match
+    if compare_values and shape_match and hasattr(x, "shape") and hasattr(y, "shape"):
+      try:
+        x_arr = np.asarray(x)
+        y_arr = np.asarray(y)
+        is_close = bool(np.allclose(x_arr, y_arr, atol=atol, rtol=rtol))
+
+        if is_close:
+          value_matches += 1
+          if verbose:
+            print(f"  [✓] {key_str} | Shape: {shape1} | Values match")
+        else:
+          diff = np.abs(x_arr - y_arr)
+          mean_diff = float(np.mean(diff))
+          max_diff = float(np.max(diff))
+          value_mismatches.append((key_str, mean_diff, max_diff))
+          all_match = False
+          if verbose:
+            print(f"  [✗] {key_str} | Shape: {shape1} | Mean diff: {mean_diff:.2e}, Max diff: {max_diff:.2e}")
+      except Exception as e:  # pylint: disable=broad-exception-caught
+        value_mismatches.append((key_str, f"Error: {e}", ""))
+        all_match = False
+    elif verbose and not compare_values:
+      print(f"  {key_str} | Shape: {shape1} | Dtype: {dtype1}")
+
+  tree_map_with_path(_compare_leaf, params1, params2)
+
+  # Print summary
+  print("\n--- Summary ---")
+  print(f"Total parameters: {num_params}")
+
+  if shape_mismatches:
+    print(f"\n[✗] Shape mismatches ({len(shape_mismatches)}):")
+    for key_str, s1, s2 in shape_mismatches:
+      print(f"  {key_str}: {name1}={s1}, {name2}={s2}")
+  else:
+    print("[✓] All shapes match.")
+
+  if dtype_mismatches:
+    print(f"\n[✗] Dtype mismatches ({len(dtype_mismatches)}):")
+    for key_str, d1, d2 in dtype_mismatches:
+      print(f"  {key_str}: {name1}={d1}, {name2}={d2}")
+  else:
+    print("[✓] All dtypes match.")
+
+  if compare_values:
+    if value_mismatches:
+      print(f"\n[✗] Value mismatches ({len(value_mismatches)}):")
+      for item in value_mismatches[:20]:  # Show first 20
+        if len(item) == 3:
+          key_str, mean_diff, max_diff = item
+          if isinstance(mean_diff, float):
+            print(f"  {key_str}: mean_diff={mean_diff:.2e}, max_diff={max_diff:.2e}")
+          else:
+            print(f"  {key_str}: {mean_diff}")
+      if len(value_mismatches) > 20:
+        print(f"  ... and {len(value_mismatches) - 20} more (use --verbose to see all)")
+    else:
+      print(f"[✓] All values match (atol={atol}, rtol={rtol}).")
+    print(f"    Values matching: {value_matches}/{num_params}")
+
+  return all_match
+
+
+def _extract_params(state: dict, fmt: str) -> dict:
+  """Extract params from a checkpoint state based on its detected format."""
+  if fmt == "linen":
+    return state.get("params", {})
+  else:
+    # NNX format: params are in 'model' key
+    return state.get("model", state.get("params", {}))
+
+
+def _normalize_params(params: dict, fmt: str) -> dict:
+  """Normalize params based on detected format."""
+  if fmt == "linen":
+    return _normalize_linen_params(params)
+  else:
+    return _normalize_nnx_params(params)
+
+
+def main(argv: Sequence[str]):
+  if len(argv) > 1:
+    raise app.UsageError("Too many command-line arguments.")
+
+  ckpt_path_1 = FLAGS.ckpt_path_1
+  ckpt_path_2 = FLAGS.ckpt_path_2
+  if not ckpt_path_1 or not ckpt_path_2:
+    raise app.UsageError("--ckpt_path_1 and --ckpt_path_2 are required.")
+
+  print("=" * 80)
+  print("Checkpoint Comparator")
+  print("=" * 80)
+
+  print(f"\nCheckpoint 1: {ckpt_path_1}")
+  print(f"Checkpoint 2: {ckpt_path_2}")
+  print(f"Transpose NNX layers: {FLAGS.transpose_nnx_layers}")
+  print(f"Ignore RNGs: {FLAGS.ignore_rngs}")
+  print(f"Compare values: {FLAGS.compare_values}")
+  if FLAGS.compare_values:
+    print(f"  Tolerance: atol={FLAGS.atol}, rtol={FLAGS.rtol}")
+
+  # Load checkpoints — use metadata-only when not comparing values to avoid
+  # downloading tensor data (which can be 100+ GiB and cause XPK timeouts).
+  metadata_only = not FLAGS.compare_values
+  print("\n" + "-" * 40)
+  state_1 = load_checkpoint(ckpt_path_1, metadata_only=metadata_only)
+  state_2 = load_checkpoint(ckpt_path_2, metadata_only=metadata_only)
+
+  # Detect formats
+  format_1 = detect_format(state_1)
+  format_2 = detect_format(state_2)
+  log(f"Detected checkpoint 1 format: {format_1}")
+  log(f"Detected checkpoint 2 format: {format_2}")
+
+  is_cross_format = format_1 != format_2
+  name_1 = f"Ckpt1({format_1})"
+  name_2 = f"Ckpt2({format_2})"
+
+  # Extract and normalize params
+  print("\n" + "-" * 40)
+  log("Normalizing parameters...")
+
+  if FLAGS.compare_only == "params":
+    params_1 = _extract_params(state_1, format_1)
+    params_2 = _extract_params(state_2, format_2)
+  else:
+    params_1 = state_1
+    params_2 = state_2
+
+  params_1 = _normalize_params(params_1, format_1)
+  log(f"  Checkpoint 1 ({format_1}): normalized")
+  params_2 = _normalize_params(params_2, format_2)
+  log(f"  Checkpoint 2 ({format_2}): normalized")
+
+  # Filter out RNG paths if requested
+  if FLAGS.ignore_rngs:
+    print("\n" + "-" * 40)
+    log("Filtering out RNG-related paths...")
+    params_1 = filter_rngs(params_1)
+    params_2 = filter_rngs(params_2)
+
+  # Transform NNX params for cross-format comparison (transpose layer dimensions)
+  # Only apply when comparing Linen vs NNX, not for same-format comparisons
+  if FLAGS.transpose_nnx_layers and is_cross_format:
+    print("\n" + "-" * 40)
+    if format_1 == "nnx":
+      params_1 = transform_nnx_params_for_comparison(params_1)
+    if format_2 == "nnx":
+      params_2 = transform_nnx_params_for_comparison(params_2)
+
+  # Compare
+  print("\n" + "-" * 40)
+  log("Comparing parameters...")
+
+  success = compare_params(
+      params_1,
+      params_2,
+      verbose=FLAGS.verbose,
+      compare_values=FLAGS.compare_values,
+      atol=FLAGS.atol,
+      rtol=FLAGS.rtol,
+      name1=name_1,
+      name2=name_2,
+  )
+
+  # Final verdict
+  print("\n" + "=" * 80)
+  if success:
+    print("CHECKPOINTS MATCH")
+    if FLAGS.compare_values:
+      print("  Tree structure, shapes, and values are identical!")
+    else:
+      print("  Tree structure and all shapes are identical!")
+  else:
+    print("CHECKPOINTS DIFFER")
+    print("  See details above for mismatches.")
+  print("=" * 80)
+
+  return 0 if success else 1
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/src/maxtext/checkpoint_conversion/linen_nnx_converter.py
+++ b/src/maxtext/checkpoint_conversion/linen_nnx_converter.py
@@ -1,0 +1,581 @@
+# Copyright 2023-2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bidirectional conversion between Linen and NNX checkpoint formats.
+
+Top-level key mapping:
+  Linen → NNX:
+    params/params/<model>  →  model/<model>       (remove double-nesting, rename, add {value:} wrappers)
+    opt_state              →  optimizer/opt_state  (remove 'params' level from mu/nu)
+    step                   →  optimizer/step       (move inside optimizer)
+
+  NNX → Linen:
+    model/<model>          →  params/params/<model>  (strip {value:} wrappers, add double-nesting)
+    optimizer/opt_state    →  opt_state               (add 'params' level to mu/nu)
+    optimizer/step         →  step                    (move to top level)
+
+Layer structure (--scan_layers):
+  linen_to_nnx:
+    scan_layers=True  (default): stack layers_N arrays → 'layers' tensor with layer dim at axis 1
+    scan_layers=False:           rename layers_N → integer-keyed 'layers/{N}'
+
+  nnx_to_linen (auto-detected):
+    Stacked 'layers' tensor  → unstack along axis 1 → layers_N per-layer arrays
+    Integer-keyed layers/{N} → rename to layers_N
+
+Usage:
+  python linen_nnx_converter.py \\
+    --source_path="gs://bucket/checkpoint/0/items" \\
+    --target_path="gs://bucket/converted/" \\
+    --direction=auto
+"""
+
+import argparse
+import os
+import re
+import time
+from typing import Any
+
+# MUST set before importing JAX to force CPU-only mode
+os.environ["JAX_PLATFORMS"] = "cpu"
+
+import jax
+import numpy as np
+from etils import epath
+import orbax.checkpoint as ocp
+
+
+def log(message: str) -> None:
+  print(f"[linen_nnx_converter] {message}")
+
+
+# ── Format detection ───────────────────────────────────────────────────────────
+
+
+def detect_format(state: dict) -> str:
+  """Detects checkpoint format ('linen' or 'nnx') from top-level keys."""
+  # NNX: uses 'model' as the top-level params key
+  if "model" in state:
+    return "nnx"
+
+  if "params" not in state:
+    raise ValueError(f"Cannot detect checkpoint format: no 'model' or 'params' key. " f"Found: {list(state.keys())}")
+
+  params = state["params"]
+
+  # Linen: double-nested params/params/decoder
+  if isinstance(params, dict) and "params" in params:
+    inner = params["params"]
+    if isinstance(inner, dict) and ("decoder" in inner or "encoder" in inner):
+      return "linen"
+
+  # Old NNX format: params/decoder (single-nested with value wrappers)
+  if isinstance(params, dict) and ("decoder" in params or "encoder" in params):
+    if _has_value_wrappers(params):
+      return "nnx"
+
+  if "optimizer" in state:
+    return "nnx"
+  if "opt_state" in state:
+    return "linen"
+
+  raise ValueError(
+      f"Could not detect checkpoint format. Keys: {list(state.keys())}, "
+      f"params keys: {list(params.keys()) if isinstance(params, dict) else type(params)}"
+  )
+
+
+# ── Value wrapper helpers ──────────────────────────────────────────────────────
+
+
+def _has_value_wrappers(tree: Any) -> bool:
+  """Returns True if tree contains {value: array} wrappers (NNX style)."""
+  if isinstance(tree, dict):
+    if set(tree.keys()) == {"value"}:
+      inner = tree["value"]
+      if hasattr(inner, "shape") or isinstance(inner, np.ndarray):
+        return True
+    for v in tree.values():
+      if _has_value_wrappers(v):
+        return True
+  return False
+
+
+def _strip_value_wrappers(tree: Any) -> Any:
+  """Recursively strips {value: array} wrappers from a tree."""
+  if isinstance(tree, dict):
+    if set(tree.keys()) == {"value"}:
+      inner = tree["value"]
+      if hasattr(inner, "shape") or isinstance(inner, np.ndarray):
+        return inner
+    return {k: _strip_value_wrappers(v) for k, v in tree.items()}
+  elif isinstance(tree, (list, tuple)):
+    return type(tree)(_strip_value_wrappers(item) for item in tree)
+  else:
+    return tree
+
+
+def _add_value_wrappers(tree: Any) -> Any:
+  """Recursively wraps leaf arrays in {value: array} (NNX nnx.Param format)."""
+  if isinstance(tree, dict):
+    if set(tree.keys()) == {"value"}:
+      inner = tree["value"]
+      if hasattr(inner, "shape") or isinstance(inner, np.ndarray):
+        return tree  # Already wrapped
+    return {k: _add_value_wrappers(v) for k, v in tree.items()}
+  elif isinstance(tree, (list, tuple)):
+    return type(tree)(_add_value_wrappers(item) for item in tree)
+  elif hasattr(tree, "shape") or isinstance(tree, np.ndarray):
+    return {"value": tree}
+  else:
+    return tree
+
+
+# ── Layer structure helpers ────────────────────────────────────────────────────
+
+
+def _stack_layers(decoder: dict) -> tuple[dict, bool]:
+  """Stacks per-layer parameters (layers_N) into a single 'layers' dict at axis 0.
+
+  Returns (result_dict, was_stacked).
+  """
+  layer_pattern = re.compile(r"^layers_(\d+)$")
+  layer_indices = {}
+  other_keys = {}
+
+  for key, value in decoder.items():
+    match = layer_pattern.match(key)
+    if match:
+      layer_indices[int(match.group(1))] = value
+    else:
+      other_keys[key] = value
+
+  if not layer_indices:
+    return decoder, False
+
+  sorted_indices = sorted(layer_indices.keys())
+  num_layers = len(sorted_indices)
+  log(f"  Found {num_layers} individual layers, stacking into 'layers'")
+
+  def stack_arrays(layers_data: list) -> Any:
+    first = layers_data[0]
+    if hasattr(first, "shape") or isinstance(first, np.ndarray):
+      return np.stack([np.asarray(layers_data[i]) for i in range(len(layers_data))], axis=0)
+    elif isinstance(first, dict):
+      result = {}
+      for key in first.keys():
+        child_data = [layers_data[i].get(key) for i in range(len(layers_data))]
+        if all(c is not None for c in child_data):
+          result[key] = stack_arrays(child_data)
+      return result
+    else:
+      return first
+
+  layers_data = [layer_indices[i] for i in sorted_indices]
+  stacked = stack_arrays(layers_data)
+
+  result = dict(other_keys)
+  result["layers"] = stacked
+  return result, True
+
+
+def _rename_layers_to_integer_keys(decoder: dict) -> dict:
+  """Converts layers_N keys to integer-keyed dict under 'layers' (no stacking).
+
+  Converts {layers_0: {...}, layers_1: {...}} → {layers: {'0': {...}, '1': {...}}}.
+  Used for scan_layers=False linen→nnx conversion (Pattern C).
+  """
+  layer_pattern = re.compile(r"^layers_(\d+)$")
+  layer_indices = {}
+  other_keys = {}
+
+  for key, value in decoder.items():
+    match = layer_pattern.match(key)
+    if match:
+      layer_indices[int(match.group(1))] = value
+    else:
+      other_keys[key] = value
+
+  if not layer_indices:
+    return decoder
+
+  sorted_indices = sorted(layer_indices.keys())
+  log(f"  Found {len(sorted_indices)} individual layers, renaming to integer-keyed 'layers/N'")
+  result = dict(other_keys)
+  result["layers"] = {str(i): layer_indices[i] for i in sorted_indices}
+  return result
+
+
+def _transpose_layers_axes(tree: Any, src_axis: int, dst_axis: int) -> Any:
+  """Transposes the layers dimension in arrays within a tree (src_axis ↔ dst_axis)."""
+  if src_axis == dst_axis:
+    return tree
+  if isinstance(tree, dict):
+    return {k: _transpose_layers_axes(v, src_axis, dst_axis) for k, v in tree.items()}
+  elif isinstance(tree, (list, tuple)):
+    return type(tree)(_transpose_layers_axes(item, src_axis, dst_axis) for item in tree)
+  elif hasattr(tree, "shape") and len(tree.shape) >= 2:
+    axes = list(range(len(tree.shape)))
+    axes[src_axis], axes[dst_axis] = axes[dst_axis], axes[src_axis]
+    result = np.transpose(np.asarray(tree), axes=axes)
+    log(f"    Transposed: {tree.shape} → {result.shape}")
+    return result
+  else:
+    return tree
+
+
+def _detect_num_layers(tree: Any, scan_axis: int) -> int | None:
+  """Detects num_layers from the first array with ndim > scan_axis."""
+  if hasattr(tree, "shape") or isinstance(tree, np.ndarray):
+    shape = getattr(tree, "shape", None) or np.asarray(tree).shape
+    if len(shape) > scan_axis:
+      return shape[scan_axis]
+    return None
+  if isinstance(tree, dict):
+    for v in tree.values():
+      result = _detect_num_layers(v, scan_axis)
+      if result is not None:
+        return result
+  return None
+
+
+def _unstack_single_layer(tree: Any, idx: int, scan_axis: int) -> Any:
+  """Extracts a single layer by indexing at scan_axis."""
+  if hasattr(tree, "shape") or isinstance(tree, np.ndarray):
+    arr = np.asarray(tree)
+    if arr.ndim > scan_axis:
+      return np.take(arr, idx, axis=scan_axis)
+    return arr
+  if isinstance(tree, dict):
+    return {k: _unstack_single_layer(v, idx, scan_axis) for k, v in tree.items()}
+  if isinstance(tree, (list, tuple)):
+    return type(tree)(_unstack_single_layer(v, idx, scan_axis) for v in tree)
+  return tree
+
+
+def _convert_layers_to_linen_format(decoder: dict) -> dict:
+  """Converts NNX 'layers' back to Linen's layers_N format (auto-detects NNX style).
+
+  Handles:
+    - Stacked tensor (Pattern B):  layers/<arrays with layer dim at axis 1>
+                                   → layers_0, layers_1, ...  (unstack along axis 1)
+    - Integer-keyed (Pattern C):   layers/0, layers/1, ...
+                                   → layers_0, layers_1, ...  (rename)
+  """
+  if "layers" not in decoder:
+    return decoder
+
+  layers_val = decoder["layers"]
+  other_keys = {k: v for k, v in decoder.items() if k != "layers"}
+
+  if not isinstance(layers_val, dict):
+    # Already a non-dict (shouldn't happen normally), keep as-is
+    return decoder
+
+  # Pattern C: integer-keyed per-layer dict → rename
+  if all(k.isdigit() for k in layers_val.keys()):
+    result = dict(other_keys)
+    for idx_str, layer_data in sorted(layers_val.items(), key=lambda x: int(x[0])):
+      result[f"layers_{idx_str}"] = layer_data
+    log(f"  Renamed integer-keyed layers/N → layers_N ({len(layers_val)} layers)")
+    return result
+
+  # Pattern B: stacked tensor (layer dim at axis 1) → unstack
+  num_layers = _detect_num_layers(layers_val, scan_axis=1)
+  if num_layers is None:
+    log("  WARNING: Could not detect num_layers for unstacking, keeping 'layers' as-is")
+    result = dict(other_keys)
+    result["layers"] = layers_val
+    return result
+
+  result = dict(other_keys)
+  for i in range(num_layers):
+    result[f"layers_{i}"] = _unstack_single_layer(layers_val, idx=i, scan_axis=1)
+  log(f"  Unstacked scanned 'layers' → layers_N ({num_layers} layers at axis 1)")
+  return result
+
+
+# ── Optimizer state helpers ────────────────────────────────────────────────────
+
+
+def _convert_opt_state_linen_to_nnx(opt_state: Any) -> Any:
+  """Removes 'params' nesting from mu/nu in linen opt_state.
+
+  NNX optimizer state has plain arrays (no {value:} wrappers).
+  Linen opt_state mirrors the params structure (params/decoder/...),
+  so we remove the 'params' level to get decoder/... directly.
+  """
+  if isinstance(opt_state, dict):
+    result = {}
+    for k, v in opt_state.items():
+      if k == "params":
+        # Remove this level by merging its contents up
+        converted = _convert_opt_state_linen_to_nnx(v)
+        if isinstance(converted, dict):
+          result.update(converted)
+        else:
+          result[k] = converted
+      else:
+        result[k] = _convert_opt_state_linen_to_nnx(v)
+    return result
+  elif isinstance(opt_state, (list, tuple)):
+    return type(opt_state)(_convert_opt_state_linen_to_nnx(item) for item in opt_state)
+  else:
+    return opt_state  # Plain array or scalar — no value wrapper for opt_state
+
+
+def _convert_opt_state_nnx_to_linen(opt_state: Any, depth: int = 0) -> Any:
+  """Adds 'params' nesting to mu/nu, removes any stray {value:} wrappers.
+
+  NNX optimizer mu/nu contains decoder/... directly.
+  Linen expects mu/params/decoder/... (one 'params' level mirroring the params structure).
+  """
+  if isinstance(opt_state, dict):
+    # Strip any {value:} wrappers in opt_state (shouldn't be there but handle gracefully)
+    if set(opt_state.keys()) == {"value"}:
+      inner = opt_state["value"]
+      if hasattr(inner, "shape") or isinstance(inner, np.ndarray):
+        return inner
+
+    result = {}
+    for k, v in opt_state.items():
+      converted = _convert_opt_state_nnx_to_linen(v, depth + 1)
+      # Add one 'params' level after mu/nu (mirrors linen's params structure)
+      if k in ("mu", "nu") and isinstance(converted, dict):
+        result[k] = {"params": converted}
+      else:
+        result[k] = converted
+    return result
+  elif isinstance(opt_state, (list, tuple)):
+    return type(opt_state)(_convert_opt_state_nnx_to_linen(item, depth + 1) for item in opt_state)
+  else:
+    return opt_state
+
+
+# ── Main conversion functions ──────────────────────────────────────────────────
+
+
+def convert_linen_to_nnx(state: dict, scan_layers: bool = True) -> dict:
+  """Converts Linen checkpoint to NNX format.
+
+  Args:
+    state: Linen checkpoint dict with keys ['params', 'opt_state', 'step'].
+    scan_layers: If True (default), stack per-layer arrays and insert layer
+                 dim at axis 1 (for NNX with scan_layers=True).
+                 If False, rename layers_N → integer-keyed layers/N
+                 (for NNX with scan_layers=False).
+  """
+  result = {}
+
+  if "params" in state:
+    linen_params = state["params"]
+    # Remove double 'params' nesting: params/params/decoder → decoder
+    if isinstance(linen_params, dict) and "params" in linen_params:
+      nnx_params = linen_params["params"]
+      log("  params: Removed double 'params' nesting (params/params → model)")
+    else:
+      nnx_params = linen_params
+      log("  params: No double nesting found")
+
+    stripped = _strip_value_wrappers(nnx_params)
+
+    for component in ("decoder", "encoder"):
+      if component in stripped and isinstance(stripped[component], dict):
+        if scan_layers:
+          stripped[component], was_stacked = _stack_layers(stripped[component])
+          if was_stacked and "layers" in stripped[component]:
+            log(f"  {component}/layers: Transposing stacked (layers, ...) → (..., layers, ...) at axis 1")
+            stripped[component]["layers"] = _transpose_layers_axes(stripped[component]["layers"], src_axis=0, dst_axis=1)
+        else:
+          stripped[component] = _rename_layers_to_integer_keys(stripped[component])
+
+    result["model"] = _add_value_wrappers(stripped)
+    log("  model: Saved with {value:} wrappers under 'model' key")
+
+  # optimizer: move step inside, keep opt_state
+  optimizer_dict = {}
+  if "step" in state:
+    optimizer_dict["step"] = state["step"]
+    log(f"  optimizer/step: Moved from top-level (step={state['step']})")
+  if "opt_state" in state:
+    optimizer_dict["opt_state"] = _convert_opt_state_linen_to_nnx(state["opt_state"])
+    log("  optimizer/opt_state: Removed 'params' nesting from mu/nu")
+  if optimizer_dict:
+    result["optimizer"] = optimizer_dict
+
+  return result
+
+
+def convert_nnx_to_linen(state: dict) -> dict:
+  """Converts NNX checkpoint to Linen format.
+
+  Reads from 'model'/'optimizer' keys (or falls back to old 'params'/'opt_state' format).
+  Layer structure is auto-detected (stacked vs integer-keyed).
+  """
+  result = {}
+
+  model_key = "model" if "model" in state else "params"
+  if model_key in state:
+    nnx_params = state[model_key]
+    stripped = _strip_value_wrappers(nnx_params)
+    log(f"  {model_key}: Removed {{value:}} wrappers")
+
+    for component in ("decoder", "encoder"):
+      if component in stripped and isinstance(stripped[component], dict):
+        stripped[component] = _convert_layers_to_linen_format(stripped[component])
+
+    # Add double 'params' nesting: decoder → params/params/decoder
+    result["params"] = {"params": stripped}
+    log("  params: Added double 'params' nesting (model → params/params)")
+
+  # optimizer: extract step and opt_state back to top level
+  if "optimizer" in state:
+    optimizer = state["optimizer"]
+    if "step" in optimizer:
+      result["step"] = optimizer["step"]
+      log("  step: Extracted from optimizer/step to top level")
+    if "opt_state" in optimizer:
+      result["opt_state"] = _convert_opt_state_nnx_to_linen(optimizer["opt_state"])
+      log("  opt_state: Added 'params' nesting to mu/nu")
+  elif "opt_state" in state:
+    # Backward compat: old format with opt_state at top level
+    result["opt_state"] = _convert_opt_state_nnx_to_linen(state["opt_state"])
+    log("  opt_state: Converted from top-level opt_state (old format)")
+
+  if "step" in state and "step" not in result:
+    result["step"] = state["step"]
+
+  return result
+
+
+# ── Checkpoint I/O ─────────────────────────────────────────────────────────────
+
+
+def load_checkpoint(checkpoint_path: str) -> dict:
+  """Loads checkpoint from local or GCS path."""
+  log(f"Loading checkpoint from: {checkpoint_path}")
+
+  checkpoint_dir = epath.Path(checkpoint_path)
+  ckptr = ocp.Checkpointer(ocp.PyTreeCheckpointHandler())
+  metadata = ckptr.metadata(checkpoint_dir)
+
+  devices = np.array(jax.devices()).reshape((-1,))
+  single_device_mesh = jax.sharding.Mesh(devices, ("x",))
+  unsharded = jax.sharding.NamedSharding(single_device_mesh, jax.sharding.PartitionSpec())
+
+  restore_args = jax.tree_util.tree_map(
+      lambda x: ocp.ArrayRestoreArgs(sharding=unsharded) if hasattr(x, "shape") else None,
+      metadata.item_metadata.tree,
+      is_leaf=lambda x: hasattr(x, "shape"),
+  )
+
+  state = ckptr.restore(checkpoint_dir, restore_args=restore_args)
+  log(f"  Loaded keys: {list(state.keys())}")
+  return state
+
+
+def save_checkpoint(state: dict, output_path: str) -> None:
+  """Saves checkpoint to local or GCS path."""
+  log(f"Saving checkpoint to: {output_path}")
+
+  output_dir = epath.Path(output_path)
+  output_dir.mkdir(exist_ok=True, parents=True)
+
+  ckptr = ocp.PyTreeCheckpointer()
+  ckptr.save(output_dir, state, force=True)
+  log("  Checkpoint saved successfully")
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description="Convert between Linen and NNX checkpoint formats.",
+      formatter_class=argparse.RawDescriptionHelpFormatter,
+  )
+  parser.add_argument(
+      "--source_path",
+      type=str,
+      required=True,
+      help="Path to source checkpoint items directory (e.g. gs://bucket/ckpt/0/items).",
+  )
+  parser.add_argument(
+      "--target_path",
+      type=str,
+      required=True,
+      help="Path to save converted checkpoint.",
+  )
+  parser.add_argument(
+      "--direction",
+      type=str,
+      choices=["auto", "linen_to_nnx", "nnx_to_linen"],
+      default="auto",
+      help="Conversion direction. 'auto' detects from source format.",
+  )
+  parser.add_argument(
+      "--scan_layers",
+      action=argparse.BooleanOptionalAction,
+      default=True,
+      help=(
+          "For linen_to_nnx only: if True (default), stack per-layer arrays into a "
+          "scanned 'layers' tensor with layer dim at axis 1 (for NNX with scan_layers=True). "
+          "If False, rename layers_N to integer-keyed layers/N without stacking "
+          "(for NNX with scan_layers=False)."
+      ),
+  )
+
+  args = parser.parse_args()
+
+  print("=" * 80)
+  print("Linen <-> NNX Checkpoint Converter")
+  print("=" * 80)
+
+  start_time = time.time()
+
+  state = load_checkpoint(args.source_path)
+
+  if args.direction == "auto":
+    source_format = detect_format(state)
+    target_format = "nnx" if source_format == "linen" else "linen"
+    log(f"Auto-detected: {source_format} → {target_format}")
+  else:
+    source_format = args.direction.split("_to_")[0]
+    target_format = args.direction.split("_to_")[1]
+    log(f"Using specified direction: {source_format} → {target_format}")
+
+  log(f"Converting: {source_format} → {target_format}")
+  if source_format == "linen":
+    log(f"scan_layers={args.scan_layers}")
+
+  if source_format == "linen" and target_format == "nnx":
+    converted_state = convert_linen_to_nnx(state, scan_layers=args.scan_layers)
+  elif source_format == "nnx" and target_format == "linen":
+    converted_state = convert_nnx_to_linen(state)
+  else:
+    raise ValueError(f"Invalid conversion: {source_format} → {target_format}")
+
+  save_checkpoint(converted_state, args.target_path)
+
+  elapsed = time.time() - start_time
+  print("\n" + "=" * 80)
+  print(f"Conversion complete in {elapsed:.2f} seconds")
+  print(f"  Source: {args.source_path}")
+  print(f"  Target: {args.target_path}")
+  print(f"  Direction: {source_format} → {target_format}")
+  print("=" * 80)
+
+
+if __name__ == "__main__":
+  main()

--- a/tests/unit/compare_linen_nnx_checkpoint_test.py
+++ b/tests/unit/compare_linen_nnx_checkpoint_test.py
@@ -1,0 +1,501 @@
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for compare_linen_nnx_checkpoint utilities."""
+
+import io
+import unittest
+from unittest.mock import patch
+import numpy as np
+
+from absl import flags as absl_flags
+from maxtext.checkpoint_conversion.compare_linen_nnx_checkpoint import (
+    is_rng_path,
+    filter_rngs,
+    detect_format,
+    _has_value_wrappers,
+    _strip_value_wrappers,
+    _normalize_linen_params,
+    _normalize_nnx_params,
+    _extract_params,
+    _normalize_params,
+    get_tree_structure_info,
+    print_structure_diff,
+    compare_params,
+    transform_nnx_params_for_comparison,
+)
+
+
+def _arr(*shape):
+  """Helper: float32 array of given shape, values 0..prod(shape)-1."""
+  return np.arange(int(np.prod(shape)), dtype=np.float32).reshape(shape)
+
+
+def setUpModule():
+  # Mark FLAGS as parsed so FLAGS.verbose etc. are accessible without a full
+  # app.run(). Required flags (ckpt_path_1/2) are not needed in unit tests.
+  absl_flags.FLAGS.mark_as_parsed()
+
+
+# ---------------------------------------------------------------------------
+# is_rng_path
+# ---------------------------------------------------------------------------
+
+
+class TestIsRngPath(unittest.TestCase):
+  """Tests for is_rng_path."""
+
+  def test_returns_true_for_rngs(self):
+    self.assertTrue(is_rng_path("model/decoder/rngs/dropout"))
+
+  def test_returns_true_for_rng(self):
+    self.assertTrue(is_rng_path("model/rngs/params/key"))
+
+  def test_returns_true_case_insensitive(self):
+    self.assertTrue(is_rng_path("model/RNGs/state"))
+    self.assertTrue(is_rng_path("model/RNG/state"))
+
+  def test_returns_false_for_normal_path(self):
+    self.assertFalse(is_rng_path("model/decoder/layers/kernel"))
+
+  def test_returns_false_for_empty_string(self):
+    self.assertFalse(is_rng_path(""))
+
+
+# ---------------------------------------------------------------------------
+# filter_rngs
+# ---------------------------------------------------------------------------
+
+
+class TestFilterRngs(unittest.TestCase):
+  """Tests for filter_rngs."""
+
+  def test_removes_top_level_rngs_key(self):
+    tree = {"model": {"kernel": _arr(4)}, "rngs": {"dropout": _arr(2)}}
+    result = filter_rngs(tree)
+    self.assertNotIn("rngs", result)
+    self.assertIn("model", result)
+
+  def test_removes_nested_rngs_key(self):
+    tree = {"model": {"kernel": _arr(4), "rngs": {"key": _arr(2)}}}
+    result = filter_rngs(tree)
+    self.assertNotIn("rngs", result["model"])
+    self.assertIn("kernel", result["model"])
+
+  def test_keeps_empty_parent_when_only_child_is_rng(self):
+    # After filtering, the parent dict becomes empty and is dropped.
+    tree = {"model": {"rngs": {"key": _arr(2)}}}
+    result = filter_rngs(tree)
+    self.assertNotIn("model", result)
+
+  def test_passthrough_for_non_rng_tree(self):
+    tree = {"params": {"kernel": _arr(4), "bias": _arr(2)}}
+    result = filter_rngs(tree)
+    self.assertEqual(set(result.keys()), {"params"})
+
+  def test_passthrough_for_non_dict_input(self):
+    arr = _arr(4)
+    self.assertIs(filter_rngs(arr), arr)
+
+
+# ---------------------------------------------------------------------------
+# _has_value_wrappers
+# ---------------------------------------------------------------------------
+
+
+class TestHasValueWrappers(unittest.TestCase):
+  """Tests for _has_value_wrappers."""
+
+  def test_returns_true_for_direct_value_wrapper(self):
+    tree = {"value": _arr(3, 4)}
+    self.assertTrue(_has_value_wrappers(tree))
+
+  def test_returns_true_for_nested_wrapper(self):
+    tree = {"decoder": {"kernel": {"value": _arr(2, 2)}}}
+    self.assertTrue(_has_value_wrappers(tree))
+
+  def test_returns_false_for_plain_array(self):
+    self.assertFalse(_has_value_wrappers(_arr(3)))
+
+  def test_returns_false_for_multi_key_dict(self):
+    tree = {"value": _arr(2), "extra": _arr(2)}
+    self.assertFalse(_has_value_wrappers(tree))
+
+  def test_returns_false_for_value_key_with_non_array(self):
+    tree = {"value": 42}
+    self.assertFalse(_has_value_wrappers(tree))
+
+
+# ---------------------------------------------------------------------------
+# _strip_value_wrappers
+# ---------------------------------------------------------------------------
+
+
+class TestStripValueWrappers(unittest.TestCase):
+  """Tests for _strip_value_wrappers."""
+
+  def test_strips_direct_wrapper(self):
+    arr = _arr(3, 4)
+    result = _strip_value_wrappers({"value": arr})
+    np.testing.assert_array_equal(result, arr)
+
+  def test_strips_nested_wrappers(self):
+    arr = _arr(2, 2)
+    tree = {"decoder": {"kernel": {"value": arr}}}
+    result = _strip_value_wrappers(tree)
+    np.testing.assert_array_equal(result["decoder"]["kernel"], arr)
+
+  def test_passthrough_plain_array(self):
+    arr = _arr(4)
+    self.assertIs(_strip_value_wrappers(arr), arr)
+
+  def test_handles_list(self):
+    arr = _arr(2)
+    result = _strip_value_wrappers([{"value": arr}])
+    np.testing.assert_array_equal(result[0], arr)
+
+  def test_handles_tuple(self):
+    arr = _arr(2)
+    result = _strip_value_wrappers(({"value": arr},))
+    np.testing.assert_array_equal(result[0], arr)
+
+  def test_passthrough_non_array_scalar(self):
+    self.assertEqual(_strip_value_wrappers(42), 42)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_linen_params
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeLinenParams(unittest.TestCase):
+  """Tests for _normalize_linen_params."""
+
+  def test_removes_double_nesting(self):
+    inner = {"decoder": {"layers": {}}}
+    params = {"params": inner}
+    result = _normalize_linen_params(params)
+    self.assertIs(result, inner)
+
+  def test_removes_double_nesting_encoder(self):
+    inner = {"encoder": {"layers": {}}}
+    params = {"params": inner}
+    result = _normalize_linen_params(params)
+    self.assertIs(result, inner)
+
+  def test_passthrough_when_no_double_nesting(self):
+    params = {"decoder": {"layers": {}}}
+    result = _normalize_linen_params(params)
+    self.assertIs(result, params)
+
+  def test_passthrough_when_inner_has_no_decoder_encoder(self):
+    params = {"params": {"other_key": {}}}
+    result = _normalize_linen_params(params)
+    self.assertIs(result, params)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_nnx_params
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeNnxParams(unittest.TestCase):
+  """Tests for _normalize_nnx_params."""
+
+  def test_strips_value_wrappers(self):
+    arr = _arr(2, 3)
+    params = {"decoder": {"kernel": {"value": arr}}}
+    result = _normalize_nnx_params(params)
+    np.testing.assert_array_equal(result["decoder"]["kernel"], arr)
+
+  def test_passthrough_plain_tree(self):
+    arr = _arr(4)
+    params = {"decoder": {"kernel": arr}}
+    result = _normalize_nnx_params(params)
+    np.testing.assert_array_equal(result["decoder"]["kernel"], arr)
+
+
+# ---------------------------------------------------------------------------
+# detect_format
+# ---------------------------------------------------------------------------
+
+
+class TestDetectFormat(unittest.TestCase):
+  """Tests for detect_format."""
+
+  def test_detects_nnx_via_model_key(self):
+    state = {"model": {"decoder": {}}, "optimizer": {}}
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_detects_linen_via_double_nested_decoder(self):
+    state = {"params": {"params": {"decoder": {}}}}
+    self.assertEqual(detect_format(state), "linen")
+
+  def test_detects_linen_via_double_nested_encoder(self):
+    state = {"params": {"params": {"encoder": {}}}}
+    self.assertEqual(detect_format(state), "linen")
+
+  def test_detects_nnx_via_value_wrappers(self):
+    arr = _arr(2, 2)
+    state = {"params": {"decoder": {"kernel": {"value": arr}}}}
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_raises_when_no_params_or_model_key(self):
+    with self.assertRaises(ValueError):
+      detect_format({"step": 0})
+
+  def test_raises_on_undetectable_format(self):
+    with self.assertRaises(ValueError):
+      detect_format({"params": {"unknown_key": {}}})
+
+
+# ---------------------------------------------------------------------------
+# _extract_params
+# ---------------------------------------------------------------------------
+
+
+class TestExtractParams(unittest.TestCase):
+  """Tests for _extract_params."""
+
+  def test_extracts_linen_params(self):
+    params = {"params": {"decoder": {}}}
+    state = {"params": params, "opt_state": {}}
+    self.assertIs(_extract_params(state, "linen"), params)
+
+  def test_extracts_nnx_params_from_model_key(self):
+    model = {"decoder": {}}
+    state = {"model": model, "optimizer": {}}
+    self.assertIs(_extract_params(state, "nnx"), model)
+
+  def test_extracts_nnx_params_falls_back_to_params_key(self):
+    params = {"decoder": {}}
+    state = {"params": params}
+    self.assertIs(_extract_params(state, "nnx"), params)
+
+  def test_returns_empty_dict_when_key_missing(self):
+    state = {"optimizer": {}}
+    result = _extract_params(state, "linen")
+    self.assertEqual(result, {})
+
+
+# ---------------------------------------------------------------------------
+# _normalize_params
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeParams(unittest.TestCase):
+  """Tests for _normalize_params."""
+
+  def test_dispatches_to_linen(self):
+    inner = {"decoder": {}}
+    params = {"params": inner}
+    result = _normalize_params(params, "linen")
+    self.assertIs(result, inner)
+
+  def test_dispatches_to_nnx(self):
+    arr = _arr(2, 2)
+    params = {"decoder": {"kernel": {"value": arr}}}
+    result = _normalize_params(params, "nnx")
+    np.testing.assert_array_equal(result["decoder"]["kernel"], arr)
+
+
+# ---------------------------------------------------------------------------
+# get_tree_structure_info
+# ---------------------------------------------------------------------------
+
+
+class TestGetTreeStructureInfo(unittest.TestCase):
+  """Tests for get_tree_structure_info."""
+
+  def test_returns_shape_and_dtype(self):
+    tree = {"kernel": _arr(3, 4), "bias": _arr(4)}
+    info = get_tree_structure_info(tree)
+    self.assertEqual(info["['kernel']"], ((3, 4), "float32"))
+    self.assertEqual(info["['bias']"], ((4,), "float32"))
+
+  def test_handles_nested_tree(self):
+    tree = {"decoder": {"kernel": _arr(2, 2)}}
+    info = get_tree_structure_info(tree)
+    self.assertEqual(len(info), 1)
+    shapes = [v[0] for v in info.values()]
+    self.assertIn((2, 2), shapes)
+
+  def test_handles_non_array_leaves(self):
+    tree = {"step": 5}
+    info = get_tree_structure_info(tree)
+    self.assertEqual(len(info), 1)
+    shape, _ = list(info.values())[0]
+    self.assertEqual(shape, "N/A")
+
+
+# ---------------------------------------------------------------------------
+# print_structure_diff
+# ---------------------------------------------------------------------------
+
+
+class TestPrintStructureDiff(unittest.TestCase):
+  """Tests for print_structure_diff."""
+
+  def _make_params(self, keys_and_shapes):
+    return {k: _arr(*s) for k, s in keys_and_shapes.items()}
+
+  def test_returns_empty_tuples_when_identical(self):
+    params = self._make_params({"kernel": (4, 4), "bias": (4,)})
+    with patch("sys.stdout", new_callable=io.StringIO):
+      only1, only2, shape_mm, dtype_mm = print_structure_diff(params, params)
+    self.assertEqual(only1, [])
+    self.assertEqual(only2, [])
+    self.assertEqual(shape_mm, [])
+    self.assertEqual(dtype_mm, [])
+
+  def test_detects_key_only_in_first(self):
+    p1 = self._make_params({"kernel": (4, 4), "bias": (4,)})
+    p2 = self._make_params({"kernel": (4, 4)})
+    with patch("sys.stdout", new_callable=io.StringIO):
+      only1, only2, _, _ = print_structure_diff(p1, p2)
+    self.assertEqual(len(only1), 1)
+    self.assertEqual(only2, [])
+
+  def test_detects_key_only_in_second(self):
+    p1 = self._make_params({"kernel": (4, 4)})
+    p2 = self._make_params({"kernel": (4, 4), "bias": (4,)})
+    with patch("sys.stdout", new_callable=io.StringIO):
+      only1, only2, _, _ = print_structure_diff(p1, p2)
+    self.assertEqual(only1, [])
+    self.assertEqual(len(only2), 1)
+
+  def test_detects_shape_mismatch(self):
+    p1 = {"kernel": _arr(4, 4)}
+    p2 = {"kernel": _arr(4, 8)}
+    with patch("sys.stdout", new_callable=io.StringIO):
+      _, _, shape_mm, _ = print_structure_diff(p1, p2)
+    self.assertEqual(len(shape_mm), 1)
+
+  def test_detects_dtype_mismatch(self):
+    p1 = {"kernel": np.zeros((4,), dtype=np.float32)}
+    p2 = {"kernel": np.zeros((4,), dtype=np.float16)}
+    with patch("sys.stdout", new_callable=io.StringIO):
+      _, _, _, dtype_mm = print_structure_diff(p1, p2)
+    self.assertEqual(len(dtype_mm), 1)
+
+
+# ---------------------------------------------------------------------------
+# compare_params
+# ---------------------------------------------------------------------------
+
+
+class TestCompareParams(unittest.TestCase):
+  """Tests for compare_params."""
+
+  def test_returns_true_for_identical_params(self):
+    params = {"kernel": _arr(4, 4), "bias": _arr(4)}
+    with patch("builtins.print"):
+      result = compare_params(params, params)
+    self.assertTrue(result)
+
+  def test_returns_false_for_different_structures(self):
+    p1 = {"kernel": _arr(4, 4)}
+    p2 = {"kernel": _arr(4, 4), "bias": _arr(4)}
+    with patch("builtins.print"):
+      result = compare_params(p1, p2)
+    self.assertFalse(result)
+
+  def test_returns_false_for_shape_mismatch(self):
+    p1 = {"kernel": _arr(4, 4)}
+    p2 = {"kernel": _arr(4, 8)}
+    with patch("builtins.print"):
+      result = compare_params(p1, p2)
+    self.assertFalse(result)
+
+  def test_returns_false_for_dtype_mismatch(self):
+    p1 = {"kernel": np.zeros((4,), dtype=np.float32)}
+    p2 = {"kernel": np.zeros((4,), dtype=np.float16)}
+    with patch("builtins.print"):
+      result = compare_params(p1, p2)
+    self.assertFalse(result)
+
+  def test_value_comparison_passes_when_equal(self):
+    arr = _arr(4)
+    with patch("builtins.print"):
+      result = compare_params({"w": arr}, {"w": arr.copy()}, compare_values=True)
+    self.assertTrue(result)
+
+  def test_value_comparison_fails_when_different(self):
+    p1 = {"w": np.array([1.0, 2.0], dtype=np.float32)}
+    p2 = {"w": np.array([1.0, 9.0], dtype=np.float32)}
+    with patch("builtins.print"):
+      result = compare_params(p1, p2, compare_values=True, atol=1e-5, rtol=1e-5)
+    self.assertFalse(result)
+
+  def test_value_comparison_passes_within_tolerance(self):
+    p1 = {"w": np.array([1.0], dtype=np.float32)}
+    p2 = {"w": np.array([1.0 + 1e-7], dtype=np.float32)}
+    with patch("builtins.print"):
+      result = compare_params(p1, p2, compare_values=True, atol=1e-5, rtol=1e-5)
+    self.assertTrue(result)
+
+  def test_verbose_mode_does_not_raise(self):
+    params = {"kernel": _arr(2, 2)}
+    with patch("builtins.print"):
+      result = compare_params(params, params, verbose=True, compare_values=True)
+    self.assertTrue(result)
+
+  def test_nested_params(self):
+    params = {"decoder": {"kernel": _arr(4, 4), "bias": _arr(4)}}
+    with patch("builtins.print"):
+      result = compare_params(params, params)
+    self.assertTrue(result)
+
+
+# ---------------------------------------------------------------------------
+# transform_nnx_params_for_comparison
+# ---------------------------------------------------------------------------
+
+
+class TestTransformNnxParamsForComparison(unittest.TestCase):
+  """Tests for transform_nnx_params_for_comparison."""
+
+  def test_transposes_layer_array(self):
+    # Shape (num_layers=3, d=4) -> (d=4, num_layers=3)
+    arr = _arr(3, 4)
+    tree = {"layers": {"kernel": arr}}
+    with patch("builtins.print"):
+      result = transform_nnx_params_for_comparison(tree)
+    self.assertEqual(result["layers"]["kernel"].shape, (4, 3))
+
+  def test_does_not_transpose_non_layer_array(self):
+    arr = _arr(3, 4)
+    tree = {"embedding": arr}
+    with patch("builtins.print"):
+      result = transform_nnx_params_for_comparison(tree)
+    self.assertEqual(result["embedding"].shape, (3, 4))
+
+  def test_does_not_transpose_1d_layer_array(self):
+    arr = _arr(4)
+    tree = {"layers": {"bias": arr}}
+    with patch("builtins.print"):
+      result = transform_nnx_params_for_comparison(tree)
+    self.assertEqual(result["layers"]["bias"].shape, (4,))
+
+  def test_transposes_higher_rank_layer_array(self):
+    # Shape (num_layers=2, d1=3, d2=5) -> (d1=3, num_layers=2, d2=5)
+    arr = _arr(2, 3, 5)
+    tree = {"layers": {"kernel": arr}}
+    with patch("builtins.print"):
+      result = transform_nnx_params_for_comparison(tree)
+    self.assertEqual(result["layers"]["kernel"].shape, (3, 2, 5))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/linen_nnx_converter_test.py
+++ b/tests/unit/linen_nnx_converter_test.py
@@ -1,0 +1,869 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for linen_nnx_converter utilities."""
+
+import unittest
+import numpy as np
+from unittest.mock import MagicMock, patch
+
+from maxtext.checkpoint_conversion.linen_nnx_converter import (
+    detect_format,
+    _has_value_wrappers,
+    _strip_value_wrappers,
+    _add_value_wrappers,
+    _transpose_layers_axes,
+    _stack_layers,
+    convert_linen_to_nnx,
+    convert_nnx_to_linen,
+    _convert_opt_state_linen_to_nnx,
+    _convert_opt_state_nnx_to_linen,
+    load_checkpoint,
+    save_checkpoint,
+    main,
+)
+
+
+def _make_array(*shape):
+  """Helper to create a numpy array with given shape."""
+  return np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+
+
+class TestDetectFormat(unittest.TestCase):
+  """Tests for the detect_format function."""
+
+  def test_raises_when_no_params_key(self):
+    with self.assertRaises(ValueError):
+      detect_format({"step": 0})
+
+  def test_detects_nnx_format_via_model_key(self):
+    # NNX: top-level "model" key
+    state = {"model": {"decoder": {"layers": {}}}, "optimizer": {}}
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_detects_linen_format_double_nested(self):
+    state = {"params": {"params": {"decoder": {"layers": {}}}}}
+    self.assertEqual(detect_format(state), "linen")
+
+  def test_detects_nnx_format_single_nested_with_value_wrappers(self):
+    # Old NNX format: params/decoder with {value:} wrappers
+    arr = _make_array(2, 2)
+    state = {"params": {"decoder": {"kernel": {"value": arr}}}}
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_detects_linen_via_encoder(self):
+    state = {"params": {"params": {"encoder": {"layers": {}}}}}
+    self.assertEqual(detect_format(state), "linen")
+
+  def test_detects_nnx_via_encoder_with_value_wrappers(self):
+    arr = _make_array(2, 2)
+    state = {"params": {"encoder": {"kernel": {"value": arr}}}}
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_detects_nnx_via_optimizer_key(self):
+    arr = _make_array(2, 2)
+    state = {"params": {"something": arr}, "optimizer": {"step": 0}}
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_detects_linen_via_opt_state(self):
+    arr = _make_array(2, 2)
+    state = {
+        "params": {"something": arr},
+        "opt_state": {"params": {"mu": {"decoder": {"kernel": arr}}}},
+    }
+    self.assertEqual(detect_format(state), "linen")
+
+  def test_detects_nnx_via_optimizer_over_opt_state(self):
+    # "optimizer" key takes precedence for NNX detection
+    arr = _make_array(2, 2)
+    state = {
+        "params": {"something": arr},
+        "optimizer": {"step": 0, "opt_state": {}},
+    }
+    self.assertEqual(detect_format(state), "nnx")
+
+  def test_raises_on_undetectable_format(self):
+    state = {"params": {"some_unknown_key": 42}}
+    with self.assertRaises(ValueError):
+      detect_format(state)
+
+
+class TestHasValueWrappers(unittest.TestCase):
+  """Tests for the _has_value_wrappers helper."""
+
+  def test_returns_true_for_value_wrapper(self):
+    arr = _make_array(2, 2)
+    self.assertTrue(_has_value_wrappers({"value": arr}))
+
+  def test_returns_true_for_nested_value_wrapper(self):
+    arr = _make_array(2, 2)
+    self.assertTrue(_has_value_wrappers({"mu": {"value": arr}}))
+
+  def test_returns_false_for_plain_array(self):
+    # A plain array is not a {"value": ...} wrapper dict
+    self.assertFalse(_has_value_wrappers(_make_array(2, 2)))
+
+  def test_returns_false_for_multi_key_dict(self):
+    arr = _make_array(2, 2)
+    self.assertFalse(_has_value_wrappers({"value": arr, "extra": arr}))
+
+  def test_returns_false_for_non_array_value(self):
+    self.assertFalse(_has_value_wrappers({"value": "string"}))
+
+
+class TestStripValueWrappers(unittest.TestCase):
+  """Tests for the _strip_value_wrappers helper."""
+
+  def test_strips_single_wrapper(self):
+    arr = _make_array(3, 4)
+    result = _strip_value_wrappers({"value": arr})
+    np.testing.assert_array_equal(result, arr)
+
+  def test_strips_nested_wrappers(self):
+    arr = _make_array(2, 2)
+    wrapped = {"decoder": {"layers": {"kernel": {"value": arr}}}}
+    stripped = _strip_value_wrappers(wrapped)
+    np.testing.assert_array_equal(stripped["decoder"]["layers"]["kernel"], arr)
+
+  def test_passes_through_plain_array(self):
+    arr = _make_array(2, 3)
+    result = _strip_value_wrappers(arr)
+    np.testing.assert_array_equal(result, arr)
+
+  def test_handles_list_and_tuple(self):
+    arr = _make_array(2)
+    result_list = _strip_value_wrappers([{"value": arr}])
+    result_tuple = _strip_value_wrappers(({"value": arr},))
+    np.testing.assert_array_equal(result_list[0], arr)
+    np.testing.assert_array_equal(result_tuple[0], arr)
+
+  def test_passes_through_non_array_value(self):
+    # A dict with key "value" but scalar content should not be unwrapped
+    d = {"value": 42}
+    result = _strip_value_wrappers(d)
+    self.assertEqual(result, d)
+
+
+class TestAddValueWrappers(unittest.TestCase):
+  """Tests for the _add_value_wrappers helper."""
+
+  def test_wraps_array(self):
+    arr = _make_array(3, 4)
+    result = _add_value_wrappers(arr)
+    self.assertIsInstance(result, dict)
+    self.assertIn("value", result)
+    np.testing.assert_array_equal(result["value"], arr)
+
+  def test_wraps_nested_arrays(self):
+    arr = _make_array(2, 2)
+    nested = {"decoder": {"layers": {"kernel": arr}}}
+    wrapped = _add_value_wrappers(nested)
+    self.assertEqual(set(wrapped["decoder"]["layers"]["kernel"].keys()), {"value"})
+    np.testing.assert_array_equal(wrapped["decoder"]["layers"]["kernel"]["value"], arr)
+
+  def test_idempotent_on_already_wrapped(self):
+    arr = _make_array(2)
+    already_wrapped = {"value": arr}
+    result = _add_value_wrappers(already_wrapped)
+    # Should not double-wrap
+    self.assertEqual(set(result.keys()), {"value"})
+    np.testing.assert_array_equal(result["value"], arr)
+
+  def test_handles_list_and_tuple(self):
+    arr = _make_array(2)
+    result_list = _add_value_wrappers([arr])
+    result_tuple = _add_value_wrappers((arr,))
+    self.assertEqual(set(result_list[0].keys()), {"value"})
+    self.assertEqual(set(result_tuple[0].keys()), {"value"})
+
+  def test_passes_through_non_array_scalars(self):
+    result = _add_value_wrappers(42)
+    self.assertEqual(result, 42)
+    result_str = _add_value_wrappers("text")
+    self.assertEqual(result_str, "text")
+
+
+class TestTransposeLayersAxes(unittest.TestCase):
+  """Tests for the _transpose_layers_axes helper."""
+
+  def test_noop_when_same_axis(self):
+    arr = _make_array(4, 2, 3)
+    result = _transpose_layers_axes(arr, src_axis=0, dst_axis=0)
+    np.testing.assert_array_equal(result, arr)
+
+  def test_transposes_axis_0_to_1(self):
+    arr = _make_array(4, 2, 3)
+    result = _transpose_layers_axes(arr, src_axis=0, dst_axis=1)
+    self.assertEqual(result.shape, (2, 4, 3))
+
+  def test_transposes_axis_1_to_0(self):
+    arr = _make_array(2, 4, 3)
+    result = _transpose_layers_axes(arr, src_axis=1, dst_axis=0)
+    self.assertEqual(result.shape, (4, 2, 3))
+
+  def test_transposes_nested_dict(self):
+    arr = _make_array(4, 2, 3)
+    tree = {"decoder": {"layers": {"kernel": arr}}}
+    result = _transpose_layers_axes(tree, src_axis=0, dst_axis=1)
+    self.assertEqual(result["decoder"]["layers"]["kernel"].shape, (2, 4, 3))
+
+  def test_passes_through_1d_array(self):
+    arr = _make_array(5)
+    result = _transpose_layers_axes(arr, src_axis=0, dst_axis=1)
+    # 1D array has no axis 1, should be returned unchanged
+    np.testing.assert_array_equal(result, arr)
+
+  def test_handles_list(self):
+    arr = _make_array(4, 2, 3)
+    result = _transpose_layers_axes([arr], src_axis=0, dst_axis=1)
+    self.assertIsInstance(result, list)
+    self.assertEqual(result[0].shape, (2, 4, 3))
+
+  def test_handles_tuple(self):
+    arr = _make_array(4, 2, 3)
+    result = _transpose_layers_axes((arr,), src_axis=0, dst_axis=1)
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(result[0].shape, (2, 4, 3))
+
+
+class TestStackLayers(unittest.TestCase):
+  """Tests for the _stack_layers helper."""
+
+  def test_stacks_individual_layers(self):
+    arr0 = _make_array(3, 4)
+    arr1 = _make_array(3, 4)
+    decoder = {
+        "layers_0": {"mlp": {"kernel": arr0}},
+        "layers_1": {"mlp": {"kernel": arr1}},
+    }
+    result, was_stacked = _stack_layers(decoder)
+    self.assertTrue(was_stacked)
+    self.assertIn("layers", result)
+    stacked = result["layers"]["mlp"]["kernel"]
+    self.assertEqual(stacked.shape, (2, 3, 4))
+    np.testing.assert_array_equal(stacked[0], arr0)
+    np.testing.assert_array_equal(stacked[1], arr1)
+
+  def test_noop_when_no_layer_pattern(self):
+    arr = _make_array(3, 4)
+    decoder = {"layers": {"mlp": {"kernel": arr}}}
+    result, was_stacked = _stack_layers(decoder)
+    self.assertFalse(was_stacked)
+    self.assertIs(result, decoder)
+
+  def test_preserves_non_layer_keys(self):
+    norm_weight = _make_array(4)
+    arr0 = _make_array(3, 4)
+    decoder = {
+        "layers_0": {"mlp": {"kernel": arr0}},
+        "final_norm": {"scale": norm_weight},
+    }
+    result, was_stacked = _stack_layers(decoder)
+    self.assertTrue(was_stacked)
+    self.assertIn("final_norm", result)
+    np.testing.assert_array_equal(result["final_norm"]["scale"], norm_weight)
+
+  def test_stacks_three_layers(self):
+    arrays = [_make_array(2, 2) for _ in range(3)]
+    decoder = {f"layers_{i}": {"w": arrays[i]} for i in range(3)}
+    result, was_stacked = _stack_layers(decoder)
+    self.assertTrue(was_stacked)
+    stacked = result["layers"]["w"]
+    self.assertEqual(stacked.shape, (3, 2, 2))
+
+  def test_non_array_non_dict_leaf(self):
+    # Scalar leaf — stack_arrays returns first element
+    decoder = {"layers_0": {"count": 1}, "layers_1": {"count": 2}}
+    result, was_stacked = _stack_layers(decoder)
+    self.assertTrue(was_stacked)
+    self.assertIn("layers", result)
+
+  def test_with_missing_key_in_some_layers(self):
+    arr = _make_array(3, 4)
+    decoder = {
+        "layers_0": {"mlp": {"kernel": arr, "bias": arr}},
+        "layers_1": {"mlp": {"kernel": arr}},  # no "bias"
+    }
+    result, was_stacked = _stack_layers(decoder)
+    self.assertTrue(was_stacked)
+    self.assertIn("kernel", result["layers"]["mlp"])
+
+
+class TestConvertLinenToNNX(unittest.TestCase):
+  """Tests for the convert_linen_to_nnx function."""
+
+  def _make_linen_state(self, add_opt_state=False):
+    """Creates a minimal Linen checkpoint structure."""
+    arr = _make_array(2, 4, 3)
+    state = {
+        "step": 10,
+        "params": {
+            "params": {
+                "decoder": {
+                    "layers": {"mlp": {"wi": {"kernel": arr}}},
+                    "decoder_norm": {"scale": _make_array(4)},
+                }
+            }
+        },
+    }
+    if add_opt_state:
+      state["opt_state"] = {"params": {"mu": {"decoder": {"layers": {"kernel": arr}}}}}
+    return state
+
+  def test_converts_step_under_optimizer(self):
+    state = self._make_linen_state()
+    result = convert_linen_to_nnx(state)
+    self.assertEqual(result["optimizer"]["step"], 10)
+
+  def test_step_not_at_top_level(self):
+    state = self._make_linen_state()
+    result = convert_linen_to_nnx(state)
+    self.assertNotIn("step", result)
+
+  def test_params_stored_under_model_key(self):
+    state = self._make_linen_state()
+    result = convert_linen_to_nnx(state)
+    self.assertIn("model", result)
+    self.assertNotIn("params", result)
+
+  def test_removes_double_nesting(self):
+    state = self._make_linen_state()
+    result = convert_linen_to_nnx(state)
+    # model should have 'decoder' directly, not 'params.decoder'
+    self.assertIn("decoder", result["model"])
+    self.assertNotIn("params", result["model"])
+
+  def test_adds_value_wrappers(self):
+    state = self._make_linen_state()
+    result = convert_linen_to_nnx(state)
+    # Arrays should be wrapped in {"value": array}
+    kernel = result["model"]["decoder"]["layers"]["mlp"]["wi"]["kernel"]
+    self.assertIsInstance(kernel, dict)
+    self.assertIn("value", kernel)
+
+  def test_converts_opt_state_under_optimizer(self):
+    state = self._make_linen_state(add_opt_state=True)
+    result = convert_linen_to_nnx(state)
+    self.assertIn("opt_state", result["optimizer"])
+    # Linen opt_state had nested 'params' level; it should be removed
+    self.assertNotIn("params", result["optimizer"]["opt_state"])
+
+  def test_no_step_produces_no_optimizer_step(self):
+    arr = _make_array(2, 4, 3)
+    state = {"params": {"params": {"decoder": {"layers": {"kernel": arr}}}}}
+    result = convert_linen_to_nnx(state)
+    self.assertNotIn("step", result)
+    self.assertIn("model", result)
+
+  def test_no_double_nesting_still_converts(self):
+    # Linen state without double-nesting (unusual but handled)
+    arr = _make_array(2, 4)
+    state = {"params": {"decoder": {"layers": {"kernel": arr}}}}
+    result = convert_linen_to_nnx(state)
+    self.assertIn("decoder", result["model"])
+
+  def test_no_params_key_only_step(self):
+    state = {"step": 3}
+    result = convert_linen_to_nnx(state)
+    self.assertEqual(result["optimizer"]["step"], 3)
+    self.assertNotIn("model", result)
+
+  def test_with_per_layer_params_stacked_and_transposed(self):
+    # Linen checkpoint with layers_0, layers_1 → stacked + transposed to axis 1
+    arr = _make_array(3, 4)
+    state = {
+        "params": {
+            "params": {
+                "decoder": {
+                    "layers_0": {"mlp": {"kernel": arr}},
+                    "layers_1": {"mlp": {"kernel": arr}},
+                }
+            }
+        }
+    }
+    result = convert_linen_to_nnx(state)
+    stacked = result["model"]["decoder"]["layers"]["mlp"]["kernel"]["value"]
+    # Original (3, 4) stacked → (2, 3, 4), transposed to (3, 2, 4)
+    self.assertEqual(stacked.shape, (3, 2, 4))
+
+
+class TestConvertNNXToLinen(unittest.TestCase):
+  """Tests for the convert_nnx_to_linen function."""
+
+  def _make_nnx_state(self, add_opt_state=False):
+    """Creates an NNX checkpoint with 'model' and 'optimizer' keys.
+
+    Uses 'attention' (not 'layers') as the sub-key so _convert_layers_to_linen_format
+    does not try to unstack the data.
+    """
+    arr = _make_array(2, 4, 3)
+    state = {
+        "model": {
+            "decoder": {
+                "attention": {"wi": {"kernel": {"value": arr}}},
+                "decoder_norm": {"scale": {"value": _make_array(4)}},
+            }
+        },
+        "optimizer": {"step": 5},
+    }
+    if add_opt_state:
+      state["optimizer"]["opt_state"] = {
+          "mu": {"decoder": {"layers": {"kernel": {"value": arr}}}},
+          "nu": {"decoder": {"layers": {"kernel": {"value": arr}}}},
+      }
+    return state
+
+  def test_converts_step(self):
+    state = self._make_nnx_state()
+    result = convert_nnx_to_linen(state)
+    self.assertEqual(result["step"], 5)
+
+  def test_adds_double_nesting(self):
+    state = self._make_nnx_state()
+    result = convert_nnx_to_linen(state)
+    self.assertIn("params", result["params"])
+    self.assertIn("decoder", result["params"]["params"])
+
+  def test_strips_value_wrappers(self):
+    state = self._make_nnx_state()
+    result = convert_nnx_to_linen(state)
+    kernel = result["params"]["params"]["decoder"]["attention"]["wi"]["kernel"]
+    self.assertIsInstance(kernel, np.ndarray)
+
+  def test_converts_opt_state(self):
+    state = self._make_nnx_state(add_opt_state=True)
+    result = convert_nnx_to_linen(state)
+    self.assertIn("opt_state", result)
+    # mu/nu should get a 'params' level added
+    self.assertIn("params", result["opt_state"]["mu"])
+    self.assertIn("params", result["opt_state"]["nu"])
+
+  def test_backward_compat_params_key(self):
+    # Old NNX format: "params" instead of "model", top-level "step"
+    arr = _make_array(2, 4, 3)
+    state = {
+        "step": 5,
+        "params": {
+            "decoder": {
+                "layers": {"mlp": {"wi": {"kernel": {"value": arr}}}},
+                "decoder_norm": {"scale": {"value": _make_array(4)}},
+            }
+        },
+    }
+    result = convert_nnx_to_linen(state)
+    self.assertEqual(result["step"], 5)
+    self.assertIn("decoder", result["params"]["params"])
+
+  def test_no_step(self):
+    arr = _make_array(2, 4)
+    state = {"model": {"decoder": {"layers": {"kernel": {"value": arr}}}}}
+    result = convert_nnx_to_linen(state)
+    self.assertNotIn("step", result)
+    self.assertIn("params", result)
+
+
+class TestRoundTrip(unittest.TestCase):
+  """Verifies that linen->nnx->linen round-trip preserves data."""
+
+  def test_linen_to_nnx_to_linen(self):
+    # Use "attention" (not "layers") so _convert_layers_to_linen_format
+    # does not try to unstack the dict as a stacked-layers tensor.
+    arr = _make_array(2, 4, 3)
+    linen_state = {
+        "step": 42,
+        "params": {
+            "params": {
+                "decoder": {
+                    "attention": {"mlp": {"wi": {"kernel": arr}}},
+                    "norm": {"scale": _make_array(4)},
+                }
+            }
+        },
+    }
+    nnx_state = convert_linen_to_nnx(linen_state)
+    recovered_state = convert_nnx_to_linen(nnx_state)
+
+    self.assertEqual(recovered_state["step"], 42)
+    recovered_kernel = recovered_state["params"]["params"]["decoder"]["attention"]["mlp"]["wi"]["kernel"]
+    np.testing.assert_array_equal(recovered_kernel, arr)
+
+  def test_nnx_to_linen_to_nnx(self):
+    arr = _make_array(2, 4, 3)
+    nnx_state = {
+        "model": {
+            "decoder": {
+                "layers": {"mlp": {"wi": {"kernel": {"value": arr}}}},
+            }
+        },
+        "optimizer": {"step": 7},
+    }
+    linen_state = convert_nnx_to_linen(nnx_state)
+    recovered_state = convert_linen_to_nnx(linen_state)
+
+    self.assertEqual(recovered_state["optimizer"]["step"], 7)
+    recovered_kernel = recovered_state["model"]["decoder"]["layers"]["mlp"]["wi"]["kernel"]
+    self.assertIn("value", recovered_kernel)
+    np.testing.assert_array_equal(recovered_kernel["value"], arr)
+
+
+class TestConvertOptState(unittest.TestCase):
+  """Tests for the _convert_opt_state_linen_to_nnx and _convert_opt_state_nnx_to_linen helpers."""
+
+  def test_linen_to_nnx_removes_params_level(self):
+    arr = _make_array(3, 4)
+    opt_state = {"mu": {"params": {"decoder": {"kernel": arr}}}}
+    result = _convert_opt_state_linen_to_nnx(opt_state)
+    # 'params' key removed; decoder promoted
+    self.assertNotIn("params", result["mu"])
+    self.assertIn("decoder", result["mu"])
+    # Arrays are plain (no value wrappers in NNX opt_state)
+    np.testing.assert_array_equal(result["mu"]["decoder"]["kernel"], arr)
+
+  def test_linen_to_nnx_handles_list_input(self):
+    arr = _make_array(2, 2)
+    opt_state = [{"decoder": {"kernel": arr}}, {"decoder": {"kernel": arr}}]
+    result = _convert_opt_state_linen_to_nnx(opt_state)
+    self.assertIsInstance(result, list)
+    np.testing.assert_array_equal(result[0]["decoder"]["kernel"], arr)
+
+  def test_linen_to_nnx_handles_tuple_input(self):
+    arr = _make_array(2, 2)
+    opt_state = ({"decoder": {"kernel": arr}},)
+    result = _convert_opt_state_linen_to_nnx(opt_state)
+    self.assertIsInstance(result, tuple)
+    np.testing.assert_array_equal(result[0]["decoder"]["kernel"], arr)
+
+  def test_linen_to_nnx_handles_non_array_non_dict(self):
+    # Scalars should be passed through unchanged
+    result = _convert_opt_state_linen_to_nnx(42)
+    self.assertEqual(result, 42)
+
+  def test_linen_to_nnx_params_key_with_non_dict_value(self):
+    # When k == "params" but converted value is not a dict, store it as-is
+    opt_state = {"params": 99}
+    result = _convert_opt_state_linen_to_nnx(opt_state)
+    self.assertIn("params", result)
+    self.assertEqual(result["params"], 99)
+
+  def test_nnx_to_linen_adds_params_level_and_strips(self):
+    arr = _make_array(3, 4)
+    opt_state = {
+        "mu": {"decoder": {"kernel": {"value": arr}}},
+        "nu": {"decoder": {"kernel": {"value": arr}}},
+    }
+    result = _convert_opt_state_nnx_to_linen(opt_state)
+    # mu/nu should have 'params' nested inside
+    self.assertIn("params", result["mu"])
+    self.assertIn("params", result["nu"])
+    # Arrays unwrapped
+    kernel = result["mu"]["params"]["decoder"]["kernel"]
+    np.testing.assert_array_equal(kernel, arr)
+
+  def test_nnx_to_linen_handles_list_input(self):
+    arr = _make_array(2, 2)
+    opt_state = [{"decoder": {"kernel": {"value": arr}}}]
+    result = _convert_opt_state_nnx_to_linen(opt_state)
+    self.assertIsInstance(result, list)
+    np.testing.assert_array_equal(result[0]["decoder"]["kernel"], arr)
+
+  def test_nnx_to_linen_handles_tuple_input(self):
+    arr = _make_array(2, 2)
+    opt_state = ({"decoder": {"kernel": {"value": arr}}},)
+    result = _convert_opt_state_nnx_to_linen(opt_state)
+    self.assertIsInstance(result, tuple)
+    np.testing.assert_array_equal(result[0]["decoder"]["kernel"], arr)
+
+  def test_nnx_to_linen_passes_through_scalars(self):
+    result = _convert_opt_state_nnx_to_linen("scalar_string")
+    self.assertEqual(result, "scalar_string")
+
+  def test_nnx_to_linen_value_wrapper_with_non_array_inner(self):
+    # {"value": scalar} should NOT be unwrapped (only arrays get unwrapped)
+    d = {"value": 42}
+    result = _convert_opt_state_nnx_to_linen(d)
+    self.assertIn("value", result)
+    self.assertEqual(result["value"], 42)
+
+
+class TestConvertLinenToNNXEncoder(unittest.TestCase):
+  """Tests encoder path in convert_linen_to_nnx."""
+
+  def test_converts_encoder_params(self):
+    arr = _make_array(2, 4, 3)
+    state = {
+        "params": {
+            "params": {
+                "encoder": {
+                    "layers": {"mlp": {"wi": {"kernel": arr}}},
+                }
+            }
+        }
+    }
+    result = convert_linen_to_nnx(state)
+    self.assertIn("encoder", result["model"])
+    kernel = result["model"]["encoder"]["layers"]["mlp"]["wi"]["kernel"]
+    self.assertIsInstance(kernel, dict)
+    self.assertIn("value", kernel)
+
+  def test_converts_encoder_with_per_layer_stacking(self):
+    arr = _make_array(3, 4)
+    state = {
+        "params": {
+            "params": {
+                "encoder": {
+                    "layers_0": {"mlp": {"kernel": arr}},
+                    "layers_1": {"mlp": {"kernel": arr}},
+                }
+            }
+        }
+    }
+    result = convert_linen_to_nnx(state)
+    stacked = result["model"]["encoder"]["layers"]["mlp"]["kernel"]["value"]
+    # Stacked at axis 0 → (2, 3, 4), then transposed to (3, 2, 4)
+    self.assertEqual(stacked.shape, (3, 2, 4))
+
+
+class TestAdditionalEdgeCases(unittest.TestCase):
+  """Covers remaining edge cases."""
+
+  def test_detect_format_params_has_params_but_no_decoder_encoder(self):
+    # params["params"] exists but inner has no decoder/encoder -> falls through
+    # no optimizer/opt_state -> should raise
+    state = {"params": {"params": {"some_other_key": {}}}}
+    with self.assertRaises(ValueError):
+      detect_format(state)
+
+  def test_detect_format_opt_state_returns_linen(self):
+    # Any state with "opt_state" (but no "model"/"optimizer") detects as linen
+    arr = _make_array(2)
+    state = {
+        "params": {"something": arr},
+        "opt_state": {"mu": {"decoder": {"kernel": arr}}},
+    }
+    self.assertEqual(detect_format(state), "linen")
+
+  def test_add_value_wrappers_value_key_with_non_array(self):
+    # {"value": "text"} is not a wrapper (inner is not an array), recurse normally
+    d = {"value": "not_an_array"}
+    result = _add_value_wrappers(d)
+    self.assertEqual(result, {"value": "not_an_array"})
+
+  def test_convert_nnx_to_linen_no_step(self):
+    arr = _make_array(2, 4)
+    state = {"model": {"decoder": {"layers": {"kernel": {"value": arr}}}}}
+    result = convert_nnx_to_linen(state)
+    self.assertNotIn("step", result)
+    self.assertIn("params", result)
+
+  def test_convert_nnx_to_linen_already_has_params_nesting(self):
+    arr = _make_array(2, 4)
+    state = {"params": {"params": {"decoder": {"layers": {"kernel": {"value": arr}}}}}}
+    result = convert_nnx_to_linen(state)
+    self.assertIn("params", result)
+
+  def test_convert_nnx_to_linen_no_params_key(self):
+    state = {"optimizer": {"step": 8}}
+    result = convert_nnx_to_linen(state)
+    self.assertEqual(result["step"], 8)
+    self.assertNotIn("params", result)
+
+
+class TestLoadCheckpoint(unittest.TestCase):
+  """Tests for load_checkpoint with mocked orbax/epath."""
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.ocp")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.epath")
+  def test_load_checkpoint_calls_checkpointer_and_returns_state(self, mock_epath, mock_ocp):
+    arr = _make_array(2, 2)
+    expected_state = {"params": arr, "step": 0}
+
+    mock_path = MagicMock()
+    mock_epath.Path.return_value = mock_path
+
+    mock_metadata = MagicMock()
+    mock_metadata.item_metadata.tree = {"params": arr}
+
+    mock_ckptr = MagicMock()
+    mock_ckptr.metadata.return_value = mock_metadata
+    mock_ckptr.restore.return_value = expected_state
+    mock_ocp.Checkpointer.return_value = mock_ckptr
+    mock_ocp.ArrayRestoreArgs.return_value = MagicMock()
+
+    result = load_checkpoint("/tmp/test_ckpt")
+
+    mock_epath.Path.assert_called_once_with("/tmp/test_ckpt")
+    mock_ocp.Checkpointer.assert_called_once()
+    mock_ckptr.metadata.assert_called_once_with(mock_path)
+    mock_ckptr.restore.assert_called_once()
+    self.assertEqual(result, expected_state)
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.ocp")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.epath")
+  def test_load_checkpoint_with_empty_tree_metadata(self, mock_epath, mock_ocp):
+    expected_state = {"step": 5}
+
+    mock_path = MagicMock()
+    mock_epath.Path.return_value = mock_path
+
+    mock_metadata = MagicMock()
+    mock_metadata.item_metadata.tree = {}
+
+    mock_ckptr = MagicMock()
+    mock_ckptr.metadata.return_value = mock_metadata
+    mock_ckptr.restore.return_value = expected_state
+    mock_ocp.Checkpointer.return_value = mock_ckptr
+
+    result = load_checkpoint("/tmp/empty_ckpt")
+
+    self.assertEqual(result["step"], 5)
+
+
+class TestSaveCheckpoint(unittest.TestCase):
+  """Tests for save_checkpoint with mocked orbax/epath."""
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.ocp")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.epath")
+  def test_save_checkpoint_creates_dir_and_saves(self, mock_epath, mock_ocp):
+    state = {"params": _make_array(2, 2), "step": 1}
+
+    mock_path = MagicMock()
+    mock_epath.Path.return_value = mock_path
+
+    mock_ckptr = MagicMock()
+    mock_ocp.PyTreeCheckpointer.return_value = mock_ckptr
+
+    save_checkpoint(state, "/tmp/output")
+
+    mock_epath.Path.assert_called_once_with("/tmp/output")
+    mock_path.mkdir.assert_called_once_with(exist_ok=True, parents=True)
+    mock_ocp.PyTreeCheckpointer.assert_called_once()
+    mock_ckptr.save.assert_called_once_with(mock_path, state, force=True)
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.ocp")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.epath")
+  def test_save_checkpoint_passes_state_unchanged(self, mock_epath, mock_ocp):
+    state = {"step": 99, "params": {"decoder": {}}}
+
+    mock_path = MagicMock()
+    mock_epath.Path.return_value = mock_path
+    mock_ckptr = MagicMock()
+    mock_ocp.PyTreeCheckpointer.return_value = mock_ckptr
+
+    save_checkpoint(state, "/tmp/out2")
+
+    call_args = mock_ckptr.save.call_args
+    self.assertIs(call_args[0][1], state)
+
+
+class TestMain(unittest.TestCase):
+  """Tests for the main() CLI entry point."""
+
+  def _run_main(self, argv):
+    with patch("sys.argv", ["prog"] + argv):
+      main()
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_explicit_linen_to_nnx(self, mock_load, mock_save):
+    arr = _make_array(2, 4, 3)
+    mock_load.return_value = {
+        "step": 1,
+        "params": {"params": {"decoder": {"layers": {"kernel": arr}}}},
+    }
+    self._run_main(["--source_path=/src", "--target_path=/dst", "--direction=linen_to_nnx"])
+    mock_load.assert_called_once_with("/src")
+    mock_save.assert_called_once()
+    saved_state = mock_save.call_args[0][0]
+    # NNX format: decoder at top level of model
+    self.assertIn("decoder", saved_state["model"])
+    self.assertEqual(mock_save.call_args[0][1], "/dst")
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_explicit_nnx_to_linen(self, mock_load, mock_save):
+    arr = _make_array(2, 4, 3)
+    mock_load.return_value = {
+        "model": {"decoder": {"layers": {"kernel": {"value": arr}}}},
+        "optimizer": {"step": 2},
+    }
+    self._run_main(["--source_path=/src", "--target_path=/dst", "--direction=nnx_to_linen"])
+    mock_load.assert_called_once_with("/src")
+    mock_save.assert_called_once()
+    saved_state = mock_save.call_args[0][0]
+    # Linen format: double nesting
+    self.assertIn("params", saved_state["params"])
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_auto_detects_linen_converts_to_nnx(self, mock_load, mock_save):
+    arr = _make_array(2, 4, 3)
+    mock_load.return_value = {
+        "step": 3,
+        "params": {"params": {"decoder": {"layers": {"kernel": arr}}}},
+    }
+    self._run_main(["--source_path=/src", "--target_path=/dst", "--direction=auto"])
+    mock_save.assert_called_once()
+    saved_state = mock_save.call_args[0][0]
+    # Auto-detected linen → NNX format: model key
+    self.assertIn("decoder", saved_state["model"])
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_auto_detects_nnx_converts_to_linen(self, mock_load, mock_save):
+    arr = _make_array(2, 4, 3)
+    mock_load.return_value = {
+        "model": {"decoder": {"layers": {"kernel": {"value": arr}}}},
+        "optimizer": {"step": 4},
+    }
+    self._run_main(["--source_path=/src", "--target_path=/dst", "--direction=auto"])
+    mock_save.assert_called_once()
+    saved_state = mock_save.call_args[0][0]
+    # Auto-detected nnx → Linen format
+    self.assertIn("params", saved_state["params"])
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_default_direction_is_auto(self, mock_load, mock_save):
+    arr = _make_array(2, 4, 3)
+    mock_load.return_value = {
+        "params": {"params": {"decoder": {"layers": {"kernel": arr}}}},
+    }
+    # No --direction arg -> defaults to "auto"
+    self._run_main(["--source_path=/src", "--target_path=/dst"])
+    mock_save.assert_called_once()
+
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.save_checkpoint")
+  @patch("maxtext.checkpoint_conversion.linen_nnx_converter.load_checkpoint")
+  def test_main_scan_layers_false(self, mock_load, mock_save):
+    arr = _make_array(3, 4)
+    mock_load.return_value = {
+        "params": {
+            "params": {
+                "decoder": {
+                    "layers_0": {"mlp": {"kernel": arr}},
+                    "layers_1": {"mlp": {"kernel": arr}},
+                }
+            }
+        }
+    }
+    self._run_main(["--source_path=/src", "--target_path=/dst", "--direction=linen_to_nnx", "--no-scan_layers"])
+    saved_state = mock_save.call_args[0][0]
+    # With scan_layers=False: integer-keyed layers/N
+    layers = saved_state["model"]["decoder"]["layers"]
+    self.assertIsInstance(layers, dict)
+    self.assertTrue(all(k.isdigit() for k in layers.keys()))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## NNX Migration Route Map

1. ✅ Add NNX scaffolding: `pure_nnx` flag, `init_state_fn`, `TrainStateNNX`, NNX utils. Linen workflow unchanged. (PR #3427)
2. ✅ NNX sharding utilities: `get_abstract_state_nnx`, `get_named_sharding_nnx`, `set_named_sharding_nnx`, `get_partition_spec_nnx`, `get_mesh_from_config`. (PR #3470)
3. ✅ NNX fully supported end-to-end: `TrainStateNNX`, model creation, gradient accumulation, checkpointing, and training loop dispatch. (PR #3500)
4. ✅ Sharding diagnostics on NNX, plus post-training bugfixes that surfaced once the NNX path got exercised end-to-end. (PR #3652)
4.5. ✅ Linen↔NNX checkpoint converter. (PR #3843)
4.6. 🔄 **[This PR]** Linen↔NNX checkpoint comparator (stacked on PR4.5; the two are file-disjoint).
5. ❌ NNX correctness fixes, feature enablements, and vocab tiling on NNX.
6. ❌ NNX-native DPO.
7. ❌ NNX-native MaxEngine inference.
8. ❌ NNX-native LoRA + GRPO.
9. ❌ NNX-aware QK-Clip + remaining checkpoint utilities.
9.5. ❌ NNX + AQT in MaxEngine + serve-mode reload + gpt3 prefill fix.
10. ❌ Vocab tiling `custom_vjp` for NNX.
11. ❌ Set NNX defaults to `True`; regenerate sharding goldens; flip back integration-test `pure_nnx=False` annotations.
12. ❌ Delete Linen-specific code paths and NNX compatibility flags.

## Description

Companion to PR4.5 (the converter). This PR adds `compare_linen_nnx_checkpoint.py` — a structural and numerical comparison utility used during the NNX migration to validate parity between Linen and NNX checkpoints. Split out of the original PR4.5 bundle on 2026-05-07 so each PR stays narrowly reviewable. PR4.5 and PR4.6 are file-disjoint, and the comparator does not import the converter — PR4.6 only stacks on PR4.5 so reviewers see the delta cleanly.

This is a pure addition — no existing files are modified, no production-code paths reference the utility, and no Linen or NNX runtime behavior changes. PR5+ do not depend on this branch.

**Diff:** +1110 / −0 across 2 new files.

## What it does

`src/maxtext/checkpoint_conversion/compare_linen_nnx_checkpoint.py`:

- **Three comparison modes** — Linen vs NNX (cross-format), Linen vs Linen, NNX vs NNX.
- **Format auto-detection** — picks Linen vs NNX per checkpoint and applies matching normalization:
  - Strip `{value: ...}` wrappers on NNX
  - Collapse double `params` nesting on Linen
  - Filter NNX-only RNG entries
- **Cross-format-only transforms** — layer-axis transposition between Linen per-layer arrays and NNX stacked tensors only runs for Linen↔NNX comparisons.
- **What it reports** — tree-structure mismatches, shape mismatches, and (with `--compare_values`) numerical diffs at configurable `--atol` / `--rtol`.

## Tests

`tests/unit/compare_linen_nnx_checkpoint_test.py` — pure-CPU, 60 cases. Covers structural diffing, shape mismatches, numerical comparison at configurable tolerances, and each of the cross- / same-format combinations.

Existing tests untouched.

## Stats

- **Diff:** +1110 / −0 across 2 files (2 new, 0 modified).
- **Production-code impact:** none. No existing source file imports the utility.
- **Linen preservation:** trivially preserved — no Linen file is touched.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
