### PR TITLE
Refactor: extract shared post-training hooks and update SFT implementation

### DIFF
--- a/src/maxtext/trainers/post_train/hooks.py
+++ b/src/maxtext/trainers/post_train/hooks.py
@@ -1,0 +1,238 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared training and data loading hooks for post-training."""
+
+from collections import defaultdict
+import abc
+from typing import override
+
+import jax
+import jax.numpy as jnp
+import time
+
+from flax import nnx
+
+from tunix.sft import peft_trainer
+from tunix.sft.hooks import DataHooks, TrainingHooks
+
+from maxtext.input_pipeline.input_pipeline_interface import create_data_iterator
+from maxtext.common.data_loader import DataLoader
+from maxtext.common.goodput import GoodputEvent, record_goodput
+from maxtext.common.metric_logger import MetricLogger, MetadataKey
+from maxtext.utils import exceptions
+from maxtext.utils import gcs_utils
+from maxtext.utils import max_logging
+from maxtext.utils import max_utils
+from maxtext.utils import sharding
+
+
+class BaseTrainingHooks(TrainingHooks, abc.ABC):
+  """Shared training hooks for post-training."""
+
+  def __init__(self, config, mesh, learning_rate_schedule, goodput_recorder):
+    self.config = config
+    self.mesh = mesh
+    self.metric_logger = MetricLogger(self.config, learning_rate_schedule)
+    self.goodput_recorder = goodput_recorder
+    self.metadata = {}
+    self.train_metadata = defaultdict(float)
+    self.eval_metadata = defaultdict(float)
+    self.step_start_time = 0.0
+
+  @override
+  def on_train_start(self, train_ctx: peft_trainer.PeftTrainer):
+    """Called at the beginning of training."""
+    state = nnx.state(train_ctx.model)
+    params = state.filter(nnx.Param)
+
+    if not self.config.using_pipeline_parallelism:
+      sharding.assert_params_sufficiently_sharded(params, self.mesh, self.config.sharding_tolerance)
+
+    self.metric_logger.write_setup_info_to_tensorboard(params)
+    if MetadataKey.PER_DEVICE_TFLOPS in self.metric_logger.metadata:
+      train_ctx._flops_measured = True  # pylint: disable=protected-access
+
+    if self.config.dump_hlo:
+      jax.block_until_ready(state)  # Ensure compilation has finished
+      gcs_utils.upload_dump(
+          self.config.dump_hlo_local_dir,
+          self.config.dump_hlo_gcs_dir,
+          module_name=self.config.dump_hlo_module_name,
+          delete_local_after=self.config.dump_hlo_delete_local_after,
+          all_host_upload=self.config.dump_hlo_upload_all,
+      )
+
+    self.metadata["first_train_step"] = train_ctx.train_steps
+    self.step_start_time = time.perf_counter()
+
+  @override
+  def on_train_end(self, train_ctx: peft_trainer.PeftTrainer):  # pylint: disable=unused-argument
+    """Called at the end of training."""
+    assert (
+        "first_train_step" in self.metadata
+    ), "BaseTrainingHooks.on_train_start() must be called before BaseTrainingHooks.on_train_end()"
+
+    if self.metric_logger:
+      self.metric_logger.flush_metrics_and_cleanup()
+
+  @override
+  def on_train_step_start(self, train_ctx: peft_trainer.PeftTrainer):
+    """Called at the beginning of a training step."""
+    if self.config.enable_goodput_recording:
+      record_goodput(self.goodput_recorder, f"record_{GoodputEvent.STEP.value}_start_time", train_ctx.train_steps)
+
+    # Calculate the number of non-padded tokens in the batch
+    self.train_metadata[train_ctx.train_steps] = {
+        "total_weights": self.get_total_weights(train_ctx.data_hooks.train_batch),
+    }
+
+  @override
+  def on_train_step_end(
+      self,
+      train_ctx: peft_trainer.PeftTrainer,
+      train_step: int,
+      train_loss: float,
+      step_time: float = 0.0,  # No longer provided. See https://github.com/google/tunix/pull/1289.
+  ):
+    """Called at the end of training step."""
+    # This hook is called by Tunix after the step counter has been incremented for logging purposes.
+    # Therefore, using `train_step - 1` to refer to the state of the previous step counter.
+    # However, we will use the current `train_step` value to record metrics in this hook to be
+    # consistent with Tunix's metric logging convention.
+    assert train_step - 1 in self.train_metadata, (
+        "BaseTrainingHooks.on_train_step_start() must be called before" " BaseTrainingHooks.on_train_step_end()"
+    )
+
+    if self.metadata["first_train_step"] == train_step - 1:
+      max_utils.print_mem_stats("After params initialized")
+
+    # Use our own timing since Tunix passes 0.0
+    current_time = time.perf_counter()
+    step_time = current_time - self.step_start_time
+    self.step_start_time = current_time
+
+    metrics = {
+        "scalar": {
+            "learning/loss": train_loss,
+            "learning/total_weights": self.train_metadata[train_step - 1]["total_weights"],
+        }
+    }
+
+    # Attempt to pull additional metrics from Tunix metrics_logger
+    for mt_key, tunix_key in [
+        ("learning/perplexity", "perplexity"),
+        ("learning/lm_loss", "sft_loss"),
+        ("learning/dpo_loss", "or_loss"),
+        ("learning/grad_norm", "grad_norm"),
+        ("learning/reward_accuracy", "rewards/accuracy"),
+        ("learning/reward_margin", "rewards/margin"),
+    ]:
+      try:
+        val = train_ctx.metrics_logger.get_metric(train_ctx.metrics_prefix, tunix_key, "train")
+        metrics["scalar"][mt_key] = float(val)
+      except:  # pylint: disable=bare-except
+        pass
+
+    self.metric_logger.record_train_metrics(metrics, train_step, step_time)
+    self.metric_logger.write_metrics(metrics, train_step)
+    del self.train_metadata[train_step - 1]
+
+  @override
+  def on_eval_step_start(self, train_ctx: peft_trainer.PeftTrainer):
+    """Called at the beginning of an evaluation step."""
+    self.eval_metadata["eval_step_count"] += 1.0
+    self.eval_metadata["total_weights"] += self.get_total_weights(train_ctx.data_hooks.eval_batch)
+
+  @override
+  def on_eval_step_end(self, train_ctx: peft_trainer.PeftTrainer, eval_loss: float):
+    """Called at the end of evaluation step."""
+    assert (
+        self.eval_metadata["eval_step_count"] != 0
+    ), "BaseTrainingHooks.on_eval_step_start() must be called before BaseTrainingHooks.on_eval_step_end()"
+
+    avg_loss = eval_loss / self.eval_metadata["eval_step_count"]
+    metrics = {
+        "scalar": {
+            "eval/total_loss": eval_loss,
+            "eval/avg_loss": avg_loss,
+            "eval/total_weights": self.eval_metadata["total_weights"],
+        }
+    }
+
+    # Attempt to pull additional eval metrics from Tunix metrics_logger
+    for mt_key, tunix_key in [
+        ("eval/avg_perplexity", "perplexity"),
+        ("eval/avg_sft_loss", "sft_loss"),
+        ("eval/avg_or_loss", "or_loss"),
+        ("evaluation/dpo_reward_accuracy", "rewards/accuracy"),
+        ("evaluation/dpo_reward_margin", "rewards/margin"),
+    ]:
+      try:
+        val = train_ctx.metrics_logger.get_metric(train_ctx.metrics_prefix, tunix_key, "eval")
+        metrics["scalar"][mt_key] = float(val)
+      except:  # pylint: disable=bare-except
+        pass
+
+    # If perplexity wasn't found (e.g. SFT mode where loss is CE), fallback to exp(loss)
+    if "eval/avg_perplexity" not in metrics["scalar"]:
+      metrics["scalar"]["eval/avg_perplexity"] = float(jnp.exp(avg_loss))
+
+    self.metric_logger.write_metrics(metrics, train_ctx.train_steps, is_training=False)
+    self.eval_metadata.clear()
+
+    if avg_loss <= self.config.target_eval_loss:
+      raise exceptions.StopTraining(f"Target loss {self.config.target_eval_loss=} is achieved.")
+
+  @abc.abstractmethod
+  def get_total_weights(self, batch) -> jax.Array:
+    """Calculate the number of non-padded tokens in the batch."""
+
+
+class BaseDataHooks(DataHooks):
+  """Shared data hooks for post-training."""
+
+  def __init__(self, config, mesh, goodput_recorder):
+    self.config = config
+    self.train_data_iterator, self.eval_data_iterator = create_data_iterator(config, mesh)
+    self.train_data_loader = DataLoader(config, mesh, self.train_data_iterator, goodput_recorder=goodput_recorder)
+    self.train_batch = None
+    self.eval_batch = None
+
+  @override
+  def load_next_train_batch(self, train_ctx: peft_trainer.PeftTrainer):  # pylint: disable=unused-argument
+    """Loads the next batch of data for training."""
+    try:
+      self.train_batch = self.train_data_loader.load_next_batch()
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      max_logging.log(f"Exception in load_next_train_batch: {str(e)}")
+      self.train_batch = None
+    return self.train_batch
+
+  @override
+  def load_next_eval_batch(self, train_ctx: peft_trainer.PeftTrainer):
+    """Loads the next batch of data for evaluation."""
+    try:
+      # Run evaluation only for `config.eval_steps` steps.
+      if (
+          self.config.eval_steps > 0
+          and train_ctx.training_hooks.eval_metadata["eval_step_count"] >= self.config.eval_steps
+      ):
+        self.eval_batch = None
+      else:
+        self.eval_batch = next(self.eval_data_iterator)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      max_logging.log(f"Exception in load_next_eval_batch: {str(e)}")
+      self.eval_batch = None
+    return self.eval_batch

--- a/src/maxtext/trainers/post_train/sft/hooks.py
+++ b/src/maxtext/trainers/post_train/sft/hooks.py
@@ -1,4 +1,4 @@
-# Copyright 2023–2025 Google LLC
+# Copyright 2023–2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,196 +15,22 @@
 
 """Training and data loading hooks for SFT"""
 
-from collections import defaultdict
-from sys import version_info
-
-if version_info >= (3, 12):
-  # pylint: disable=no-name-in-module
-  from typing import override
-else:
-  from typing_extensions import override
+from typing import override
 
 import jax
-import time
 import jax.numpy as jnp
 
-from flax import nnx
-
-from tunix.sft import peft_trainer
-from tunix.sft.hooks import DataHooks, TrainingHooks
-
-from maxtext.input_pipeline.input_pipeline_interface import create_data_iterator
-from maxtext.common.data_loader import DataLoader
-from maxtext.common.goodput import GoodputEvent, record_goodput
-from maxtext.common.metric_logger import MetricLogger, MetadataKey
-from maxtext.utils import exceptions
-from maxtext.utils import gcs_utils
-from maxtext.utils import max_logging
-from maxtext.utils import max_utils
-from maxtext.utils import sharding
+from maxtext.trainers.post_train.hooks import BaseTrainingHooks, BaseDataHooks
 
 
-class SFTTrainingHooks(TrainingHooks):
+class SFTTrainingHooks(BaseTrainingHooks):
   """Training hooks for SFT."""
 
-  def __init__(self, config, mesh, learning_rate_schedule, goodput_recorder):
-    self.config = config
-    self.mesh = mesh
-    self.metric_logger = MetricLogger(self.config, learning_rate_schedule)
-    self.goodput_recorder = goodput_recorder
-    self.metadata = {}
-    self.train_metadata = defaultdict(float)
-    self.eval_metadata = defaultdict(float)
-    self.step_start_time = 0.0
-
   @override
-  def on_train_start(self, train_ctx: peft_trainer.PeftTrainer):
-    """Called at the beginning of training."""
-    state = nnx.state(train_ctx.model)
-    params = state.filter(nnx.Param)
-
-    if not self.config.using_pipeline_parallelism:
-      sharding.assert_params_sufficiently_sharded(params, self.mesh, self.config.sharding_tolerance)
-
-    self.metric_logger.write_setup_info_to_tensorboard(params)
-    if MetadataKey.PER_DEVICE_TFLOPS in self.metric_logger.metadata:
-      train_ctx._flops_measured = True  # pylint: disable=protected-access
-
-    if self.config.dump_hlo:
-      jax.block_until_ready(state)  # Ensure compilation has finished
-      gcs_utils.upload_dump(
-          self.config.dump_hlo_local_dir,
-          self.config.dump_hlo_gcs_dir,
-          module_name=self.config.dump_hlo_module_name,
-          delete_local_after=self.config.dump_hlo_delete_local_after,
-          all_host_upload=self.config.dump_hlo_upload_all,
-      )
-
-    self.metadata["first_train_step"] = train_ctx.train_steps
-    self.step_start_time = time.perf_counter()
-
-  @override
-  def on_train_end(self, train_ctx: peft_trainer.PeftTrainer):  # pylint: disable=unused-argument
-    """Called at the end of training."""
-    assert (
-        "first_train_step" in self.metadata
-    ), "SFTTrainingHooks.on_train_start() must be called before SFTTrainingHooks.on_train_end()"
-
-    if self.metric_logger:
-      self.metric_logger.flush_metrics_and_cleanup()
-
-  @override
-  def on_train_step_start(self, train_ctx: peft_trainer.PeftTrainer):
-    """Called at the beginning of a training step."""
-    if self.config.enable_goodput_recording:
-      record_goodput(self.goodput_recorder, f"record_{GoodputEvent.STEP.value}_start_time", train_ctx.train_steps)
-
-    # Calculate the number of non-padded tokens in the batch
-    total_weights = jnp.sum(train_ctx.data_hooks.train_batch["targets_segmentation"] != 0)
-
-    self.train_metadata[train_ctx.train_steps] = {
-        "total_weights": total_weights,
-    }
-
-  @override
-  def on_train_step_end(
-      self,
-      train_ctx: peft_trainer.PeftTrainer,
-      train_step: int,
-      train_loss: float,
-      step_time: float = 0.0,  # No longer provided. See https://github.com/google/tunix/pull/1289.
-  ):
-    """Called at the end of training step.
-    This hook is called by Tunix after the step counter has been incremented for logging purposes.
-    Therefore, using `train_step - 1` to refer to the state of the previous step counter.
-    However, we will use the current `train_step` value to record metrics in this hook to be
-    consistent with Tunix's metric logging convention.
-    """
-    assert train_step - 1 in self.train_metadata, (
-        "SFTTrainingHooks.on_train_step_start() must be called before" " SFTTrainingHooks.on_train_step_end()"
-    )
-
-    if self.metadata["first_train_step"] == train_step - 1:
-      max_utils.print_mem_stats("After params initialized")
-
-    # Use our own timing since Tunix passes 0.0
-    current_time = time.perf_counter()
-    step_time = current_time - self.step_start_time
-    self.step_start_time = current_time
-
-    metrics = {
-        "scalar": {
-            "learning/loss": train_loss,
-            "learning/total_weights": self.train_metadata[train_step - 1]["total_weights"],
-        }
-    }
-    self.metric_logger.record_train_metrics(metrics, train_step, step_time)
-    self.metric_logger.write_metrics(metrics, train_step)
-    del self.train_metadata[train_step - 1]
-
-  @override
-  def on_eval_step_start(self, train_ctx: peft_trainer.PeftTrainer):
-    """Called at the beginning of an evaluation step."""
-    self.eval_metadata["eval_step_count"] += 1.0
-    # Calculate the number of non-padded tokens in the batch
-    self.eval_metadata["total_weights"] += jnp.sum(train_ctx.data_hooks.eval_batch["targets_segmentation"] != 0)
-
-  @override
-  def on_eval_step_end(self, train_ctx: peft_trainer.PeftTrainer, eval_loss: float):
-    """Called at the end of evaluation step."""
-    assert (
-        self.eval_metadata["eval_step_count"] != 0
-    ), "SFTTrainingHooks.on_eval_step_start() must be called before SFTTrainingHooks.on_eval_step_end()"
-
-    avg_loss = eval_loss / self.eval_metadata["eval_step_count"]
-    metrics = {
-        "scalar": {
-            "eval/total_loss": eval_loss,
-            "eval/avg_loss": avg_loss,
-            "eval/avg_perplexity": jnp.exp(avg_loss),
-            "eval/total_weights": self.eval_metadata["total_weights"],
-        }
-    }
-    self.metric_logger.write_metrics(metrics, train_ctx.train_steps, is_training=False)
-    self.eval_metadata.clear()
-
-    if avg_loss <= self.config.target_eval_loss:
-      raise exceptions.StopTraining(f"Target loss {self.config.target_eval_loss=} is achieved.")
+  def get_total_weights(self, batch) -> jax.Array:
+    """Calculate the number of non-padded tokens in the batch."""
+    return jnp.sum(batch["targets_segmentation"] != 0)
 
 
-class SFTDataHooks(DataHooks):
+class SFTDataHooks(BaseDataHooks):
   """Data hooks for SFT."""
-
-  def __init__(self, config, mesh, goodput_recorder):
-    self.config = config
-    self.train_data_iterator, self.eval_data_iterator = create_data_iterator(config, mesh)
-    self.train_data_loader = DataLoader(config, mesh, self.train_data_iterator, goodput_recorder=goodput_recorder)
-    self.train_batch = None
-    self.eval_batch = None
-
-  @override
-  def load_next_train_batch(self, train_ctx: peft_trainer.PeftTrainer):  # pylint: disable=unused-argument
-    """Loads the next batch of data for training."""
-    try:
-      self.train_batch = self.train_data_loader.load_next_batch()
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      max_logging.log(f"Exception in load_next_train_batch: {str(e)}")
-      self.train_batch = None
-    return self.train_batch
-
-  @override
-  def load_next_eval_batch(self, train_ctx: peft_trainer.PeftTrainer):
-    """Loads the next batch of data for evaluation."""
-    try:
-      # Run evaluation only for `config.eval_steps` steps.
-      if (
-          self.config.eval_steps > 0
-          and train_ctx.training_hooks.eval_metadata["eval_step_count"] >= self.config.eval_steps
-      ):
-        self.eval_batch = None
-      else:
-        self.eval_batch = next(self.eval_data_iterator)
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      max_logging.log(f"Exception in load_next_eval_batch: {str(e)}")
-      self.eval_batch = None
-    return self.eval_batch

--- a/tests/post_training/unit/hooks_test.py
+++ b/tests/post_training/unit/hooks_test.py
@@ -1,0 +1,127 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for shared base training and data loading hooks for post-training"""
+
+from collections import defaultdict
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("tunix")
+pytestmark = [pytest.mark.cpu_only, pytest.mark.external_training, pytest.mark.post_training]
+
+import jax
+from jax.sharding import Mesh
+import numpy as np
+
+from maxtext.configs import pyconfig
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
+from maxtext.trainers.post_train.hooks import BaseTrainingHooks
+from maxtext.common.metric_logger import MetricLogger
+from maxtext.utils import maxtext_utils
+
+
+class DummyTrainingHooks(BaseTrainingHooks):
+  """Dummy training hooks for testing base functionality."""
+
+  def get_total_weights(self, batch) -> jax.Array:
+    return np.sum(batch["targets_segmentation"] != 0)
+
+
+class BaseHooksTest(unittest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.test_dir = tempfile.mkdtemp()
+    self.metrics_file = os.path.join(self.test_dir, "metrics.txt")
+    self.config = pyconfig.initialize(
+        ["", os.path.join(MAXTEXT_CONFIGS_DIR, "post_train", "sft.yml")],
+        per_device_batch_size=1,
+        run_name="test",
+        base_output_directory=self.test_dir,
+        tensorboard_dir=self.test_dir,
+        metrics_dir=self.test_dir,
+        metrics_file=self.metrics_file,
+        skip_jax_distributed_system=True,
+    )
+    self.mesh = Mesh(maxtext_utils.create_device_mesh(self.config), self.config.mesh_axes)
+    self.learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(self.config)
+
+    self.training_hooks = DummyTrainingHooks(self.config, self.mesh, self.learning_rate_schedule, goodput_recorder=None)
+    self.training_hooks.metric_logger = MetricLogger(self.config, self.learning_rate_schedule)
+    self.training_hooks.metric_logger.metadata = defaultdict(float)
+
+    expected_shape = [jax.device_count(), self.config.max_target_length]
+    self.expected_batch = {
+        "targets_segmentation": np.ones(expected_shape, dtype=int),
+    }
+    self.mock_train_ctx = MagicMock()
+    self.mock_train_ctx.metrics_logger.get_metric.side_effect = KeyError("Metric not found")
+
+  def tearDown(self):
+    shutil.rmtree(self.test_dir)
+    super().tearDown()
+
+  def _read_logged_metrics(self, num_expected=1):
+    """Read and parse metrics logged by the MetricLogger."""
+    metrics = []
+    if os.path.exists(self.metrics_file):
+      with open(self.metrics_file, "r", encoding="utf8") as f:
+        for line in f:
+          metrics.append(json.loads(line))
+    self.assertEqual(len(metrics), num_expected)
+    return metrics
+
+  def test_training_hooks_for_train_step(self):
+    self.training_hooks.metadata = {"first_train_step": 0}
+    self.mock_train_ctx.data_hooks.train_batch = self.expected_batch
+    self.mock_train_ctx.train_steps = 0
+    self.training_hooks.on_train_step_start(self.mock_train_ctx)
+    self.mock_train_ctx.train_steps = 1
+    self.training_hooks.on_train_step_start(self.mock_train_ctx)
+    self.training_hooks.on_train_step_end(self.mock_train_ctx, train_step=1, train_loss=5.0, step_time=0.004)
+
+    metrics = self._read_logged_metrics(num_expected=1)[0]
+    self.assertEqual(metrics["step"], 1)
+    self.assertAlmostEqual(metrics["learning/loss"], 5.0)
+    self.assertEqual(metrics["learning/total_weights"], (jax.device_count() * self.config.max_target_length))
+
+  def test_training_hooks_for_eval_step(self):
+    self.mock_train_ctx.data_hooks.eval_batch = self.expected_batch
+    self.mock_train_ctx.train_steps = 0
+    total_eval_steps = 2
+    for _ in range(total_eval_steps):
+      self.training_hooks.on_eval_step_start(self.mock_train_ctx)
+    self.training_hooks.on_eval_step_end(self.mock_train_ctx, eval_loss=10.0)
+
+    metrics = self._read_logged_metrics(num_expected=1)[0]
+    self.assertEqual(metrics["step"], 0)
+    self.assertAlmostEqual(metrics["eval/total_loss"], 10.0)
+    self.assertAlmostEqual(metrics["eval/avg_loss"], 5.0)
+    self.assertAlmostEqual(metrics["eval/avg_perplexity"], np.exp(5.0), places=2)
+    self.assertEqual(metrics["eval/total_weights"], jax.device_count() * self.config.max_target_length * total_eval_steps)
+
+  def test_on_train_end_asserts_if_on_train_start_not_called(self):
+    with self.assertRaises(AssertionError):
+      self.training_hooks.on_train_end(self.mock_train_ctx)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/post_training/unit/sft_hooks_test.py
+++ b/tests/post_training/unit/sft_hooks_test.py
@@ -1,4 +1,4 @@
-# Copyright 2023–2025 Google LLC
+# Copyright 2023–2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,27 +14,24 @@
 
 """Tests for training and data loading hooks for SFT"""
 
-from collections import defaultdict
+import unittest
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 pytest.importorskip("tunix")
-pytestmark = [pytest.mark.tpu_only, pytest.mark.external_training, pytest.mark.post_training]
+pytestmark = [pytest.mark.cpu_only, pytest.mark.external_training, pytest.mark.post_training]
 
 import jax
-
+from jax.sharding import Mesh
 import numpy as np
-import json
 import os
 import shutil
 import tempfile
-import unittest
-from unittest.mock import MagicMock, patch
-from jax.sharding import Mesh
 
 from maxtext.configs import pyconfig
 from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
-from maxtext.trainers.post_train.sft import hooks
-from maxtext.common.metric_logger import MetricLogger
+from maxtext.trainers.post_train.sft import hooks as sft_hooks
 from maxtext.utils import maxtext_utils
 
 
@@ -43,113 +40,39 @@ class SFTHooksTest(unittest.TestCase):
   def setUp(self):
     super().setUp()
     self.test_dir = tempfile.mkdtemp()
-    self.metrics_file = os.path.join(self.test_dir, "metrics.txt")
     self.config = pyconfig.initialize(
         ["", os.path.join(MAXTEXT_CONFIGS_DIR, "post_train", "sft.yml")],
         per_device_batch_size=1,
         run_name="test",
         base_output_directory=self.test_dir,
         tensorboard_dir=self.test_dir,
-        metrics_dir=self.test_dir,
-        metrics_file=self.metrics_file,
         skip_jax_distributed_system=True,
     )
     self.mesh = Mesh(maxtext_utils.create_device_mesh(self.config), self.config.mesh_axes)
-    learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(self.config)
-
-    self.training_hooks = hooks.SFTTrainingHooks(self.config, self.mesh, learning_rate_schedule, goodput_recorder=None)
-    # We will use the written metrics to validate the correctness.
-    # The reason to use a real MetricLogger is to avoid a problem like what was observed in
-    # https://github.com/AI-Hypercomputer/maxtext/pull/3691, where the MetricLogger was changed
-    # to expect a new metric that the SFT code did not provide.
-    self.training_hooks.metric_logger = MetricLogger(self.config, learning_rate_schedule)
-    # Initialize metadata to avoid KeyErrors in real MetricLogger
-    self.training_hooks.metric_logger.metadata = defaultdict(float)
-
-    expected_shape = [jax.device_count(), self.config.max_target_length]
-    self.expected_batch = {
-        "inputs": np.zeros(expected_shape, dtype=int),
-        "targets_segmentation": np.ones(expected_shape, dtype=int),
-    }
-    self.mock_data_iterator = MagicMock()
-    self.mock_data_iterator.__next__.return_value = self.expected_batch
-
-    self.mock_train_ctx = MagicMock()
 
   def tearDown(self):
     shutil.rmtree(self.test_dir)
     super().tearDown()
 
-  def _read_logged_metrics(self, num_expected=1):
-    """Read and parse metrics logged by the MetricLogger."""
-    metrics = []
-    if os.path.exists(self.metrics_file):
-      with open(self.metrics_file, "r", encoding="utf8") as f:
-        for line in f:
-          metrics.append(json.loads(line))
-    self.assertEqual(len(metrics), num_expected)
-    return metrics
+  @patch("maxtext.trainers.post_train.hooks.create_data_iterator")
+  def test_sft_data_hooks_load_next_train_batch(self, mock_create_data_iterator):
+    expected_batch = {"inputs": np.zeros([jax.device_count(), self.config.max_target_length], dtype=int)}
+    mock_data_iterator = MagicMock()
+    mock_data_iterator.__next__.return_value = expected_batch
+    mock_create_data_iterator.return_value = mock_data_iterator, None
 
-  @patch("maxtext.trainers.post_train.sft.hooks.create_data_iterator")
-  def test_data_hooks_load_next_train_batch(self, mock_create_data_iterator):
-    mock_create_data_iterator.return_value = self.mock_data_iterator, None
-    data_hooks = hooks.SFTDataHooks(self.config, self.mesh, goodput_recorder=None)
+    data_hooks = sft_hooks.SFTDataHooks(self.config, self.mesh, goodput_recorder=None)
     data_hooks.load_next_train_batch(train_ctx=None)
 
     self.assertIsNotNone(data_hooks.train_batch)
-    self.assertEqual(data_hooks.train_batch["inputs"].shape, self.expected_batch["inputs"].shape)
-    self.assertTrue((data_hooks.train_batch["inputs"] == self.expected_batch["inputs"]).all())
+    self.assertEqual(data_hooks.train_batch["inputs"].shape, expected_batch["inputs"].shape)
 
-  @patch("maxtext.trainers.post_train.sft.hooks.create_data_iterator")
-  def test_data_hooks_load_next_eval_batch(self, mock_create_data_iterator):
-    mock_create_data_iterator.return_value = None, self.mock_data_iterator
-    data_hooks = hooks.SFTDataHooks(self.config, self.mesh, goodput_recorder=None)
-    data_hooks.load_next_eval_batch(train_ctx=None)
-
-    self.assertIsNotNone(data_hooks.eval_batch)
-    self.assertEqual(data_hooks.eval_batch["inputs"].shape, self.expected_batch["inputs"].shape)
-    self.assertTrue((data_hooks.eval_batch["inputs"] == self.expected_batch["inputs"]).all())
-
-  def test_training_hooks_for_train_step(self):
-    self.training_hooks.metadata = {"first_train_step": 0}
-    self.mock_train_ctx.data_hooks.train_batch = self.expected_batch
-    self.mock_train_ctx.train_steps = 0
-    self.training_hooks.on_train_step_start(self.mock_train_ctx)
-    self.mock_train_ctx.train_steps = 1
-    self.training_hooks.on_train_step_start(self.mock_train_ctx)
-    self.training_hooks.on_train_step_end(self.mock_train_ctx, train_step=1, train_loss=5.0, step_time=0.004)
-
-    metrics = self._read_logged_metrics(num_expected=1)[0]
-    self.assertEqual(metrics["step"], 1)
-    self.assertAlmostEqual(metrics["learning/loss"], 5.0)
-    self.assertEqual(metrics["learning/total_weights"], (jax.device_count() * self.config.max_target_length))
-
-  def test_training_hooks_for_eval_step(self):
-    self.mock_train_ctx.data_hooks.eval_batch = self.expected_batch
-    self.mock_train_ctx.train_steps = 0
-    total_eval_steps = 2
-    for _ in range(total_eval_steps):
-      self.training_hooks.on_eval_step_start(self.mock_train_ctx)
-    self.training_hooks.on_eval_step_end(self.mock_train_ctx, eval_loss=10.0)
-
-    metrics = self._read_logged_metrics(num_expected=1)[0]
-    self.assertEqual(metrics["step"], 0)
-    self.assertAlmostEqual(metrics["eval/total_loss"], 10.0)
-    self.assertAlmostEqual(metrics["eval/avg_loss"], 5.0)
-    self.assertAlmostEqual(metrics["eval/avg_perplexity"], np.exp(5.0), places=2)
-    self.assertEqual(metrics["eval/total_weights"], jax.device_count() * self.config.max_target_length * total_eval_steps)
-
-  def test_on_train_end_asserts_if_on_train_start_not_called(self):
-    with self.assertRaises(AssertionError):
-      self.training_hooks.on_train_end(self.mock_train_ctx)
-
-  def test_on_train_step_end_asserts_if_on_train_step_start_not_called(self):
-    with self.assertRaises(AssertionError):
-      self.training_hooks.on_train_step_end(self.mock_train_ctx, train_step=1, train_loss=5.0, step_time=0.004)
-
-  def test_on_eval_step_end_asserts_if_on_eval_step_start_not_called(self):
-    with self.assertRaises(AssertionError):
-      self.training_hooks.on_eval_step_end(self.mock_train_ctx, eval_loss=10.0)
+  def test_sft_training_hooks_get_total_weights(self):
+    learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(self.config)
+    training_hooks = sft_hooks.SFTTrainingHooks(self.config, self.mesh, learning_rate_schedule, goodput_recorder=None)
+    batch = {"targets_segmentation": np.array([[1, 1, 0], [1, 0, 0]])}
+    total_weights = training_hooks.get_total_weights(batch)
+    self.assertEqual(total_weights, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Generalize the SFT hooks such that they can be used in DPO as well.

We move the shared code into `src/maxtext/trainers/post_train/hooks.py` while the SFT-specific overrides reside in the SFT sub-directory.

This PR is a pre-requisite for #3668 (DPO implementation)

# Tests

Test run of a local SFT training.
Ran the unit tests, including logits comparison test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
