### PR TITLE
Qwen3-Omni SFT+Eval on ChartQA

### DIFF
--- a/benchmarks/multimodal/multimodal_eval.py
+++ b/benchmarks/multimodal/multimodal_eval.py
@@ -150,6 +150,13 @@ def construct_prompt(
         question=parsed_dataset_example.question,
         choices=choices_text if choices_text else "N/A",
     )
+    if config.use_multimodal and "qwen3-omni" in config.model_name:
+      prompt = mm_processor.reformat_prompt(
+          prompt,
+          image_placeholder,
+          config.model_name,
+          num_images=1,
+      )
   elif local_args.ckpt_type == "sft":
     prompt = mm_processor.reformat_prompt(
         parsed_dataset_example.question,
@@ -200,11 +207,31 @@ def main(config, local_args):
     print("\n" + "*" * 50)
 
     # Tokenize the input
-    tokens, true_length = tokenizer.encode(prompt, is_bos=True, prefill_lengths=[prefill_length])
+    is_bos = config.add_bos and getattr(tokenizer, "bos_id", None) is not None
+    tokens, true_length = tokenizer.encode(prompt, is_bos=is_bos, prefill_lengths=[prefill_length])
+    position_ids = None
+    mrope_position_deltas = None
+
     if config.use_multimodal:
       tokens = mm_processor.prepare_text_for_image_fusion(tokens=tokens, config=config, processor_output=processor_output)
       image_offsets = mm_processor.get_image_offsets(config=config, processor_output=processor_output)
       true_length += image_offsets
+
+      if config.use_mrope:
+        from maxtext.multimodal import processor_qwen3_omni  # pylint: disable=import-outside-toplevel
+
+        position_ids, mrope_position_deltas = processor_qwen3_omni.get_rope_index(
+            input_ids=tokens[np.newaxis, :],  # Add batch dimension for processing
+            image_grid_thw=processor_output.pixel_grid_thw,  # pytype: disable=attribute-error
+            video_grid_thw=processor_output.video_grid_thw,  # pytype: disable=attribute-error
+            attention_mask=np.ones_like(tokens)[np.newaxis, :],
+            use_audio_in_video=config.use_audio and getattr(processor_output, "num_videos", 0) > 0,
+            audio_lengths=processor_output.audio_lengths,  # pytype: disable=attribute-error
+            second_per_grids=processor_output.video_second_per_grid,  # pytype: disable=attribute-error
+            spatial_merge_size=config.spatial_merge_size_for_vit,  # pytype: disable=attribute-error
+            position_id_per_seconds=config.position_id_per_seconds,
+        )
+
     if true_length > max_prefill_predict_length:
       max_logging.log(
           f"Warning: Prompt length {true_length} exceeds max prefill length" f" {max_prefill_predict_length}. Truncating."
@@ -216,7 +243,18 @@ def main(config, local_args):
 
     # Perform prefill
     prefill_result, first_token = engine.prefill(
-        params=params, padded_tokens=tokens, images=processor_output.pixel_values, true_length=true_length
+        params=params,
+        padded_tokens=tokens,
+        positions=position_ids,
+        mrope_deltas=mrope_position_deltas,
+        images=processor_output.pixel_values if config.use_multimodal else None,
+        image_masks=getattr(processor_output, "pixel_mask", None)
+        if config.use_multimodal and "llama4" in config.model_name
+        else None,
+        audio_values=getattr(processor_output, "audio_values", None) if config.use_audio else None,
+        audio_masks=getattr(processor_output, "audio_mask", None) if config.use_audio else None,
+        true_length=true_length,
+        slot=0,
     )
     slot = 0
 
@@ -243,8 +281,9 @@ def main(config, local_args):
         break
 
     correct_answer = parsed_dataset_example.answer
+    # If fails to parse answer, use the raw output as the predicted answer for correctness checking
     if predicted_answer == utils_rl.FALLBACK_ANSWER:
-      predicted_answer = utils_rl.extract_answer(output, tmvp_config)
+      predicted_answer = output
 
     exact_correct, _ = utils_rl.check_correctness(predicted_answer, [correct_answer], tmvp_config)
     is_correct = exact_correct

--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -118,6 +118,7 @@ def vision_sft_preprocessing_pipeline(
       add_eos_token=False,
       legacy=False,
       token=config.hf_access_token,
+      extra_special_tokens={},
   )
   pad_id = _get_pad_id(tokenizer)
 
@@ -256,6 +257,7 @@ def preprocessing_pipeline(
       add_eos_token=add_eos if not use_sft else False,
       legacy=False,
       token=hf_access_token,
+      extra_special_tokens={},
   )
 
   dataset = dataset.select_columns(data_column_names)

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -745,6 +745,9 @@ class PadOrTrimToMaxLength(grain.MapTransform):
     if preprocessed_image.pixel_values is None:
       raise ValueError("Input preprocessed_image must have pixel_values to pad images.")
 
+    if self.config.model_name and self.config.model_name.startswith("qwen3-omni"):
+      return preprocessed_image
+
     # Determine the maximum number of images/masks allowed.
     image_offsets = mm_processor.get_image_offsets(self.config, preprocessed_image)
     single_image_offset = image_offsets // preprocessed_image.pixel_values.shape[0]

--- a/src/maxtext/multimodal/processor.py
+++ b/src/maxtext/multimodal/processor.py
@@ -68,6 +68,10 @@ def preprocess_image_for_training(image, model_name):
     from maxtext.multimodal.processor_llama4 import preprocess_mm_data_llama4  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_llama4(image)
+  elif model_name in ["qwen3-omni-30b-a3b"]:
+    from maxtext.multimodal.processor_qwen3_omni import preprocess_mm_data_qwen3_omni_for_training  # pylint: disable=import-outside-toplevel
+
+    return preprocess_mm_data_qwen3_omni_for_training(image)
   else:
     raise ValueError(f"Model {model_name} not supported for image preprocessing.")
 

--- a/src/maxtext/multimodal/processor_qwen3_omni.py
+++ b/src/maxtext/multimodal/processor_qwen3_omni.py
@@ -122,7 +122,7 @@ def smart_resize(
   return h_bar, w_bar
 
 
-def pre_process_qwen3_image(image: np.ndarray | list[np.ndarray], config):
+def pre_process_qwen3_image(image: np.ndarray | list[np.ndarray], config, force_resize=None):
   """Performs a bi-linear resize (with anti-aliasing) and normalizes the image."""
   patch_size = config.patch_size_for_vit
   merge_size = config.spatial_merge_size_for_vit
@@ -135,23 +135,27 @@ def pre_process_qwen3_image(image: np.ndarray | list[np.ndarray], config):
 
   for img in images_in:
     pil_img = Image.fromarray(img)
-    # Qwen3-Omni performs one resize during fetch_image and another resize before patchify.
-    resized_height_1, resized_width_1 = smart_resize(
-        height=img.shape[0],
-        width=img.shape[1],
-        factor=IMAGE_FACTOR,
-        min_pixels=MIN_PIXELS,
-        max_pixels=MAX_PIXELS,
-    )
-    pil_img = pil_img.resize((resized_width_1, resized_height_1))
-    resized_height_2, resized_width_2 = smart_resize(
-        height=resized_height_1,
-        width=resized_width_1,
-        factor=patch_size * merge_size,
-        min_pixels=MIN_PIXELS,
-        max_pixels=MAX_PIXELS,
-    )
-    resized_img_pil = pil_img.resize((resized_width_2, resized_height_2), resample=resample_method)
+    if force_resize is not None:
+      resized_height_2, resized_width_2 = force_resize
+      resized_img_pil = pil_img.resize((resized_width_2, resized_height_2), resample=resample_method)
+    else:
+      # Qwen3-Omni performs one resize during fetch_image and another resize before patchify.
+      resized_height_1, resized_width_1 = smart_resize(
+          height=img.shape[0],
+          width=img.shape[1],
+          factor=IMAGE_FACTOR,
+          min_pixels=MIN_PIXELS,
+          max_pixels=MAX_PIXELS,
+      )
+      pil_img = pil_img.resize((resized_width_1, resized_height_1))
+      resized_height_2, resized_width_2 = smart_resize(
+          height=resized_height_1,
+          width=resized_width_1,
+          factor=patch_size * merge_size,
+          min_pixels=MIN_PIXELS,
+          max_pixels=MAX_PIXELS,
+      )
+      resized_img_pil = pil_img.resize((resized_width_2, resized_height_2), resample=resample_method)
     resized_img_np = np.array(resized_img_pil).astype(np.float32)
 
     img_np = mm_utils.normalize_images(resized_img_np, mean=IMAGE_MEAN, std=IMAGE_STD)
@@ -472,6 +476,35 @@ def pre_process_audio_qwen3_omni(audio_array):
   audio_features = _np_extract_fbank_features(audio_features)
   audio_features_mask = np.ones((audio_features.shape[0], audio_features.shape[2]), dtype=np.int32)
   return audio_features, audio_features_mask
+
+
+def preprocess_mm_data_qwen3_omni_for_training(images):
+  """Preprocesses image(s) for Qwen3-Omni SFT training using default model constants."""
+
+  class _DefaultConfig:
+    patch_size_for_vit = 16
+    spatial_merge_size_for_vit = 2
+    temporal_patch_size_for_vit = QWEN3_TEMPORAL_PATCH_SIZE
+
+  images_in = [images] if isinstance(images, np.ndarray) else images
+  pixel_values, pixel_grid_thw = pre_process_qwen3_image(
+      images_in, _DefaultConfig(), force_resize=(QWEN3_OMNI_IMAGE_SIZE, QWEN3_OMNI_IMAGE_SIZE)
+  )
+  pixel_values = np.reshape(
+      pixel_values,
+      (
+          len(images_in),
+          3,  # num_channels_for_vit
+          _DefaultConfig.temporal_patch_size_for_vit * pixel_grid_thw[0, 0],
+          _DefaultConfig.patch_size_for_vit * pixel_grid_thw[0, 1],
+          _DefaultConfig.patch_size_for_vit * pixel_grid_thw[0, 2],
+      ),
+  )
+  return Qwen3OmniPreprocessorOutput(
+      num_images=len(images_in),
+      pixel_values=pixel_values,
+      pixel_grid_thw=pixel_grid_thw,
+  )
 
 
 def preprocess_mm_data_qwen3_omni(config):


### PR DESCRIPTION
# Description

* **Qwen3-Omni SFT Support**: Adding `preprocess_mm_data_qwen3_omni_for_training` for batched data preparation with correct shape. Isolated Qwen3-Omni data pipelines by adding an early return in `PadOrTrimToMaxLength` to skip Gemma-specific fixed visual padding, enabling verified SFT runs on TPU VMs.
* **Qwen3-Omni mmeval Support**: Added 3D mROPE position embedding support, enabled robust base-model prompt reformatting, and resolved tokenizer crashes by gracefully bypassing BOS token prepending for tokenizers with no `bos_id` (like Qwen3-Omni). Also reusing `preprocess_mm_data_qwen3_omni_for_training` above for formatting multimodal data for evaluation
* **Gemma-4 Tokenizer Bug Fix**: Patched SFT data loading to pass `extra_special_tokens={}` during tokenizer creation, successfully bypassing a Hugging Face loading crash caused by Gemma-4's list-formatted special tokens config ([b/502053535](https://b.corp.google.com/issues/502053535), which is also broken at maxtext head).

# Tests

10-step E2E SFT test run with a decreasing loss pattern:
```
python -m maxtext.trainers.post_train.sft.train_sft_deprecated src/maxtext/configs/post_train/sft-vision-chartqa.yml model_name=qwen3-omni-30b-a3b tokenizer_path=Qwen/Qwen3-Omni-30B-A3B-Instruct base_output_directory=gs://hengtaoguo-maxtext-logs/sft/qwen3-omni-30b-a3b per_device_batch_size=2 dataset_type=hf steps=10 max_target_length=1024 checkpoint_period=100 attention=dot_product enable_checkpointing=false hf_access_token=<your_token>
```

```
I0510 21:11:20.578492 140261636574336 metric_logger.py:196] completed step: 0, seconds: 35.570, TFLOP/s/device: 0.129, Tokens/s/device: 57.577, total_weights: 36, loss: 12.508, lm_loss: 12.508, perplexity: 270415.000, moe_lb_loss: 0.000
I0510 21:11:20.581142 140261636574336 metric_logger.py:281] To see full metrics 'tensorboard --logdir=gs://hengtaoguo-maxtext-logs/sft/qwen3-omni-30b-a3b/qwen3-omni-30b-a3b_2026-05-10-21-09/tensorboard/'
I0510 21:11:21.169645 140261636574336 metric_logger.py:196] completed step: 1, seconds: 0.373, TFLOP/s/device: 12.277, Tokens/s/device: 5492.840, total_weights: 43, loss: 12.423, lm_loss: 12.423, perplexity: 248505.000, moe_lb_loss: 0.000
I0510 21:11:21.254970 140261636574336 metric_logger.py:196] completed step: 2, seconds: 0.591, TFLOP/s/device: 7.741, Tokens/s/device: 3463.584, total_weights: 39, loss: 10.753, lm_loss: 10.753, perplexity: 46787.500, moe_lb_loss: 0.000
I0510 21:11:21.364491 140261636574336 metric_logger.py:196] completed step: 3, seconds: 0.042, TFLOP/s/device: 108.389, Tokens/s/device: 48495.181, total_weights: 37, loss: 9.743, lm_loss: 9.743, perplexity: 17027.156, moe_lb_loss: 0.000
I0510 21:11:21.473644 140261636574336 metric_logger.py:196] completed step: 4, seconds: 0.082, TFLOP/s/device: 55.869, Tokens/s/device: 24996.949, total_weights: 40, loss: 8.718, lm_loss: 8.718, perplexity: 6109.984, moe_lb_loss: 0.000
I0510 21:11:21.582713 140261636574336 metric_logger.py:196] completed step: 5, seconds: 0.110, TFLOP/s/device: 41.799, Tokens/s/device: 18701.659, total_weights: 40, loss: 8.500, lm_loss: 8.500, perplexity: 4913.453, moe_lb_loss: 0.000
I0510 21:11:21.691225 140261636574336 metric_logger.py:196] completed step: 6, seconds: 0.108, TFLOP/s/device: 42.365, Tokens/s/device: 18955.065, total_weights: 44, loss: 7.646, lm_loss: 7.646, perplexity: 2091.277, moe_lb_loss: 0.000
I0510 21:11:21.799779 140261636574336 metric_logger.py:196] completed step: 7, seconds: 0.109, TFLOP/s/device: 41.890, Tokens/s/device: 18742.221, total_weights: 41, loss: 7.797, lm_loss: 7.797, perplexity: 2434.350, moe_lb_loss: 0.000
I0510 21:11:21.908020 140261636574336 metric_logger.py:196] completed step: 8, seconds: 0.102, TFLOP/s/device: 45.077, Tokens/s/device: 20168.200, total_weights: 42, loss: 7.082, lm_loss: 7.082, perplexity: 1190.472, moe_lb_loss: 0.000
I0510 21:11:22.016094 140261636574336 metric_logger.py:196] completed step: 9, seconds: 0.109, TFLOP/s/device: 42.172, Tokens/s/device: 18868.620, total_weights: 40, loss: 7.796, lm_loss: 7.796, perplexity: 2430.939, moe_lb_loss: 0.000
```

5-sample mmeval:
```
python -m benchmarks.multimodal.multimodal_eval maxtext/configs/base.yml model_name=qwen3-omni-30b-a3b tokenizer_path=Qwen/Qwen3-Omni-30B-A3B-Instruct tokenizer_type=huggingface load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-omni-30b-a3b/unscanned/001/0/items base_output_directory=gs://hengtaoguo-maxtext-logs/eval per_device_batch_size=1 run_name=mmeval_test steps=1 async_checkpointing=false scan_layers=false use_multimodal=true attention=\'dot_product\' max_prefill_predict_length=1024 max_target_length=1044 hf_path=HuggingFaceM4/ChartQA hf_eval_split=test hf_access_token=<your_token> base_num_decoder_layers=48 add_bos=False override_model_config=True --num_examples=5 --image_resize=336
```

```
**************************************************
INFO:absl:1 | How many food item is shown in the bar graph?
[Model output] <answer>10</answer>
[Label answer] 14
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 1/2500
INFO:absl:Uploaded the results file to GCS bucket: gs://hengtaoguo-maxtext-logs/eval/2026-05-19-19-42-08.csv
Evaluating HuggingFaceM4/ChartQA dataset:   0%| | 1/2500 [01:22<57:23:39,
**************************************************
INFO:absl:2 | What is the difference in value between Lamb and Corn?
[Model output] <answer>0.6</answer>
[Label answer] 0.57
Matching: False
INFO:absl:Running accuracy: 0.0000 | Processed: 2/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%| | 2/2500 [02:20<47:10:14,
**************************************************
INFO:absl:3 | How many bars are shown in the chart?
[Model output] <answer>3</answer>
[Label answer] 3
Matching: True
INFO:absl:Running accuracy: 0.3333 | Processed: 3/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%| | 3/2500 [03:20<44:34:14,
**************************************************
INFO:absl:4 | Is the sum value of Madagascar more then Fiji?
[Model output] No
[Label answer] No
Matching: True
INFO:absl:Running accuracy: 0.5000 | Processed: 4/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%| | 4/2500 [04:19<43:15:46,
**************************************************
INFO:absl:5 | What's the value of the lowest bar?
[Model output] 23
[Label answer] 23
Matching: True
INFO:absl:Running accuracy: 0.6000 | Processed: 5/2500
Evaluating HuggingFaceM4/ChartQA dataset:   0%| | 4/2500 [05:18<55:14:28,
INFO:absl:
Final accuracy on HuggingFaceM4/ChartQA dataset: 0.6000
INFO:absl:Saved predictions to mm_eval_results.csv
INFO:absl:Uploaded the results file to GCS bucket: gs://hengtaoguo-maxtext-logs/eval/2026-05-19-19-42-08.csv
INFO:absl:Removed temporary results file: mm_eval_results.csv
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
