### PR TITLE
[DeepSeek-V4] Implement core primitives (RoPE, GroupedLinear)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,6 +27,7 @@ addopts =
     --ignore=tests/unit/qwen3_5_layers_test.py
     --ignore=tests/unit/deepseek32_vs_reference_test.py
     --ignore=tests/unit/engram_vs_reference_test.py
+    --ignore=tests/unit/deepseek_v4_vs_reference_test.py
 markers =
     tpu_only: marks tests to be run on TPUs only
     tpu_backend: marks tests that require a TPU-enabled JAX install (TPU PJRT plugin), but not TPU hardware

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -16,6 +16,7 @@
 
 import dataclasses
 import math
+from typing import Any
 
 import jax
 from jax import lax
@@ -1800,3 +1801,135 @@ def qwen3_omni_mrope_embedding_as_linen(
       metadata_fn=variable_to_logically_partitioned,
       name=name,
   )
+
+
+class DeepSeekV4RotaryEmbedding(nnx.Module):
+  """DeepSeek-V4 partial rotary embedding with interleaved frequencies.
+
+  DeepSeek-V4 uses an interleaved positional encoding where consecutive channels
+  are paired together. Unlike standard rotary models that split dimensions globally
+  into first and second halves, this implementation pairs each even channel 2i
+  with the corresponding odd channel 2i + 1.
+
+  This results in two specific mathematical properties:
+  1. Inverse frequencies are computed for (dim // 2) unique theta angles.
+  2. Sinusoidal components are expanded consecutively (e.g., [f0, f0, f1, f1])
+     prior to application.
+  """
+
+  def __init__(
+      self,
+      head_dim: int,
+      partial_rotary_factor: float = 64.0 / 512.0,
+      rope_theta: float = 10000.0,
+      dtype: Any = jnp.float32,
+  ):
+    self.head_dim = head_dim
+    self.partial_rotary_factor = partial_rotary_factor
+    self.rope_theta = rope_theta
+    self.dtype = dtype
+
+    # Compute the partial rotary dimension (rope_head_dim)
+    self.dim = int(head_dim * partial_rotary_factor)
+
+  @property
+  def inv_freq(self):
+    # Compute base inverse frequencies for half of self.dim
+    half_dim = self.dim // 2
+    fraction = 2 * jnp.arange(0, half_dim, dtype=jnp.float32) / self.dim
+    return 1.0 / (self.rope_theta**fraction)
+
+  def get_freqs(self, position_ids: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
+    # position_ids: [B, S]
+    inv_freq_expanded = self.inv_freq[jnp.newaxis, jnp.newaxis, :]
+    position_ids_expanded = position_ids[:, :, jnp.newaxis].astype(jnp.float32)
+    freqs = position_ids_expanded * inv_freq_expanded
+
+    cos = jnp.cos(freqs).astype(jnp.float32)  # [B, S, dim/2]
+    sin = jnp.sin(freqs).astype(jnp.float32)  # [B, S, dim/2]
+
+    return cos, sin
+
+  def __call__(
+      self,
+      inputs: jnp.ndarray,
+      position: jnp.ndarray,
+      unsqueeze_dim: int | None = 1,
+      reverse: bool = False,
+  ) -> jnp.ndarray:
+    """Applies interleaved Rotary Position Embedding to the inputs.
+
+    Args:
+      inputs: The input sequence on which to apply the RoPE.
+      position: The positions of the tokens in the sequence.
+      unsqueeze_dim: The axis at which to insert an additional dimension into `cos`/`sin`
+        for broadcasting across attention heads. If None, no dimension is inserted.
+      reverse: If True, applies reverse rotation (-sin).
+
+    Returns:
+      The inputs with the trailing `rope_dim` rotated.
+    """
+    cos, sin = self.get_freqs(position)
+    if reverse:
+      sin = -sin
+    return _apply_rotary_pos_emb(inputs, cos, sin, unsqueeze_dim=unsqueeze_dim)
+
+
+def _rotate_half(x: jax.Array) -> jax.Array:
+  """Performs an interleaved half-rotation on the input tensor.
+
+  Pairs adjacent elements in the last dimension and negates the second element
+  of each pair. This transforms `[x0, x1, x2, x3]` into `[-x1, x0, -x3, x2]`.
+
+  Args:
+    x: Input tensor to be rotated.
+
+  Returns:
+    A rotated `jax.Array` of the exact same shape as the input.
+  """
+  x1 = x[..., 0::2]
+  x2 = x[..., 1::2]
+  return jnp.stack((-x2, x1), axis=-1).reshape(x.shape)
+
+
+def _apply_rotary_pos_emb(
+    x: jax.Array,
+    cos: jax.Array,
+    sin: jax.Array,
+    unsqueeze_dim: int | None = 1,
+) -> jax.Array:
+  """Applies DeepSeek-V4 interleaved Rotary Positional Embedding to the input.
+
+  The embedding is applied only to the trailing portion of the hidden dimension,
+  leaving the leading portion (the 'nope' dimension) untouched. The trigonometric
+  frequencies are provided in half-size and are duplicated consecutively to match
+  the interleaved rotation structure.
+
+  Args:
+    x: Input tensor of shape `[..., seq_len, head_dim]` or similar, where the last
+      dimension contains the combined nope and rope features.
+    cos: Cosine frequencies of shape `[..., seq_len, rope_dim // 2]`.
+    sin: Sine frequencies of shape `[..., seq_len, rope_dim // 2]`.
+    unsqueeze_dim: The axis at which to insert an additional dimension into `cos` and `sin`
+      for broadcasting across the attention heads. If None, no dimension is inserted. Default is 1.
+
+  Returns:
+    A `jax.Array` of the same shape and dtype as `x` with the trailing `rope_dim`
+    rotated and the leading `nope_dim` unmodified.
+  """
+  cos = jnp.repeat(cos, 2, axis=-1)
+  sin = jnp.repeat(sin, 2, axis=-1)
+
+  # Insert an expansion dimension to align the frequency tensors (e.g., [B, S, D])
+  # with the attention head axes of the input tensor (e.g., [B, S, H, D]).
+  if unsqueeze_dim is not None:
+    cos = jnp.expand_dims(cos, axis=unsqueeze_dim)
+    sin = jnp.expand_dims(sin, axis=unsqueeze_dim)
+
+  rope_dim = cos.shape[-1]
+  nope, rope = x[..., :-rope_dim], x[..., -rope_dim:]
+
+  rope_f32 = rope.astype(jnp.float32)
+  rotated = ((rope_f32 * cos) + (_rotate_half(rope_f32) * sin)).astype(x.dtype)
+
+  return jnp.concatenate([nope, rotated], axis=-1)

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -567,3 +567,143 @@ def mlp_block(
       abstract_init=False,
   )
   return module
+
+
+class DeepSeekV4GroupedLinear(nnx.Module):
+  """Block-diagonal grouped linear used by the grouped output projection in DeepSeek-V4.
+
+  The core attention's stacked output is `num_attention_heads * head_dim`-dim,
+  which is extremely large. A direct projection would dominate the per-token cost.
+  This module splits the heads into `g` groups, projecting each independently
+  to a smaller intermediate dimension, which are later mixed.
+  """
+
+  def __init__(
+      self,
+      in_features_per_group: int,
+      out_features: int,
+      n_groups: int,
+      weight_dtype: DType = jnp.float32,
+      dtype: DType = jnp.float32,
+      kernel_init: NdInitializer = nd_dense_init(1.0, "fan_in", "truncated_normal"),
+      kernel_axes: tuple[None | str, ...] = ("groups", "embed", "mlp"),
+      matmul_precision: str = "default",
+      parameter_memory_host_offload: bool = False,
+      *,
+      rngs: nnx.Rngs,
+  ):
+    """Initializes the DeepSeekV4GroupedLinear module.
+
+    Args:
+      in_features_per_group: The size of the input dimension for each group.
+      out_features: The total output dimension across all groups. Must be divisible by n_groups.
+      n_groups: The number of independent groups to split the projection into.
+      weight_dtype: the dtype of the weights (default: float32).
+      dtype: the dtype of the computation (default: float32).
+      kernel_init: initializer function for the weight matrix.
+      kernel_axes: logical axes for partitioning the kernel.
+      matmul_precision: Precision for matrix multiplication.
+      parameter_memory_host_offload: Determines whether to offload params to host
+      rngs: RNG state for initialization in nnx.
+    """
+    if out_features % n_groups != 0:
+      raise ValueError(f"out_features ({out_features}) must be divisible by n_groups ({n_groups})")
+
+    self.in_features_per_group = in_features_per_group
+    self.out_features = out_features
+    self.n_groups = n_groups
+    self.out_features_per_group = out_features // n_groups
+
+    self.weight_dtype = weight_dtype
+    self.dtype = dtype
+    self.kernel_init = kernel_init
+    self.kernel_axes = kernel_axes
+    self.matmul_precision = matmul_precision
+    self.parameter_memory_host_offload = parameter_memory_host_offload
+
+    # Kernel shape splits the projection up into a batched representation
+    kernel_shape = (self.n_groups, self.in_features_per_group, self.out_features_per_group)
+
+    # NdInitializer takes tuple positions to calculate fan_in / fan_out.
+    # Axis 1 represents the inner contracting dimension (fan_in).
+    # Axis 2 represents the output features dimension (fan_out).
+    kernel_in_axis = (1,)
+    kernel_out_axis = (2,)
+
+    self.kernel = nnx.Param(
+        self.kernel_init(
+            rngs.params(),
+            kernel_shape,
+            self.weight_dtype,
+            kernel_in_axis,
+            kernel_out_axis,
+        ),
+        sharding=self.kernel_axes,
+    )
+
+  def __call__(self, inputs: Array) -> Array:
+    """Applies a batched grouped linear transformation to the inputs.
+
+    Args:
+      inputs: The nd-array to be transformed. Expected shape is `[..., n_groups, in_features_per_group]`.
+
+    Returns:
+      The transformed input of shape `[..., n_groups, out_features_per_group]`.
+      When later flattened across the last two dims, this results in `out_features`.
+    """
+    inputs = jnp.asarray(inputs, self.dtype)
+
+    kernel = self.kernel[...]
+    if self.parameter_memory_host_offload:
+      max_logging.log("linear.py: Moving parameter grouped_linear kernel to device")
+      kernel = jax.device_put(kernel, max_utils.device_space())
+    kernel = jnp.asarray(kernel, self.dtype)
+
+    # Perform a batched matrix multiplication using einsum with explicit precision.
+    # We use jnp.einsum instead of explicitly flattening and using lax.dot_general
+    # to make the group-wise broadcast highly readable and natively batched.
+    #
+    # Notation breakdown:
+    #   ... : Any leading batch/sequence dimensions (e.g., [Batch, SeqLen]).
+    #   g   : The n_groups dimension.
+    #   i   : The in_features_per_group dimension (the contracting dimension).
+    #   o   : The out_features_per_group dimension.
+    #
+    # Input shape:  [..., g, i]
+    # Kernel shape: [g, i, o]
+    # Output shape: [..., g, o]
+    output = jnp.einsum("...gi,gio->...go", inputs, kernel, precision=lax.Precision(self.matmul_precision))
+
+    return output
+
+
+def deepseek_v4_grouped_linear(
+    *,
+    in_features_per_group: int,
+    out_features: int,
+    n_groups: int,
+    weight_dtype: DType = jnp.float32,
+    dtype: DType = jnp.float32,
+    kernel_init: NdInitializer = nd_dense_init(1.0, "fan_in", "truncated_normal"),
+    kernel_axes: tuple[None | str, ...] = ("groups", "embed", "mlp"),
+    matmul_precision: str = "default",
+    parameter_memory_host_offload: bool = False,
+    name: None | str = None,
+):
+  """Creates a DeepSeekV4GroupedLinear Linen module using nnx.bridge.to_linen."""
+  module = nnx_wrappers.to_linen(
+      DeepSeekV4GroupedLinear,
+      in_features_per_group=in_features_per_group,
+      out_features=out_features,
+      n_groups=n_groups,
+      weight_dtype=weight_dtype,
+      dtype=dtype,
+      kernel_init=kernel_init,
+      kernel_axes=kernel_axes,
+      matmul_precision=matmul_precision,
+      parameter_memory_host_offload=parameter_memory_host_offload,
+      name=name,
+      metadata_fn=variable_to_logically_partitioned,
+      abstract_init=False,
+  )
+  return module

--- a/tests/unit/deepseek_v4_vs_reference_test.py
+++ b/tests/unit/deepseek_v4_vs_reference_test.py
@@ -1,0 +1,265 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-8.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests validating DeepSeek-V4 MaxText components against PyTorch references."""
+
+import os
+import sys
+import unittest
+
+# pylint: disable=import-outside-toplevel, reimported
+import jax.numpy as jnp
+import numpy as np
+import torch
+
+# To ensure 1:1 parity and avoid outdated or error-prone copy-pasting of reference code,
+# this test directly imports the PyTorch reference implementation from a local clone of
+# the huggingface/transformers repository containing DeepSeek-V4 implementations.
+#
+# You can override the default location by setting the `TRANSFORMERS_REPO_PATH` environment variable:
+# e.g., `TRANSFORMERS_REPO_PATH=/path/to/transformers python tests/unit/deepseek_v4_vs_reference_test.py`
+transformers_repo_path = os.environ.get("TRANSFORMERS_REPO_PATH", "")
+sys.path.insert(0, os.path.join(transformers_repo_path, "src"))
+
+from transformers.models.deepseek_v4.configuration_deepseek_v4 import DeepseekV4Config
+
+from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
+    DeepseekV4RotaryEmbedding as DeepseekV4RotaryEmbedding_PT,
+    DeepseekV4GroupedLinear as DeepseekV4GroupedLinear_PT,
+    apply_rotary_pos_emb as ref_apply_rotary_pos_emb,
+)
+
+from maxtext.layers.embeddings import DeepSeekV4RotaryEmbedding
+from maxtext.layers.linears import DeepSeekV4GroupedLinear
+from flax import nnx
+
+# ==============================================================================
+# Tests
+# ==============================================================================
+
+
+class DeepSeekV4RotaryEmbeddingTest(unittest.TestCase):
+  """Tests to validate MaxText RoPE implementation against PyTorch reference."""
+
+  def setUp(self):
+    self.batch_size = 2
+    self.seq_len = 16
+    self.head_dim = 128
+    self.num_heads = 4
+    self.main_rope_theta = 10000.0
+    self.compress_rope_theta = 160000.0
+    self.partial_rotary_factor = 64.0 / 128.0
+
+    self.config = DeepseekV4Config(
+        hidden_size=self.num_heads * self.head_dim,
+        num_attention_heads=self.num_heads,
+        num_key_value_heads=1,
+        head_dim=self.head_dim,
+        rope_theta=self.main_rope_theta,
+        rope_parameters={
+            "main": {
+                "rope_type": "default",
+                "rope_theta": self.main_rope_theta,
+                "partial_rotary_factor": self.partial_rotary_factor,
+            },
+            "compress": {
+                "rope_type": "default",
+                "rope_theta": self.compress_rope_theta,
+                "partial_rotary_factor": self.partial_rotary_factor,
+            },
+        },
+    )
+
+  def test_rotary_embedding_main(self):
+    self._run_rotary_test(layer_type="main", expected_theta=self.main_rope_theta)
+
+  def test_rotary_embedding_compress(self):
+    self._run_rotary_test(layer_type="compress", expected_theta=self.compress_rope_theta)
+
+  def _run_rotary_test(self, layer_type, expected_theta):
+    """
+    Validates that the MaxText RoPE implementation is mathematically identical to
+    the PyTorch reference up to 1e-5 tolerance.
+
+    Test Flow:
+    1. Initializes PyTorch and MaxText Rotary modules with the exact same configuration.
+    2. Generates random floating-point noise for inputs to avoid trivial pass cases.
+    3. Computes `cos` and `sin` frequencies and compares them directly.
+    4. Applies interleaved RoPE rotation to the random inputs in both implementations.
+    5. Transposes shapes to match expected dimensions for each framework.
+    6. Verifies that the final rotated tensors match exactly.
+    """
+    # --------------------------------------------------------------------------
+    # 1. Initialization
+    # --------------------------------------------------------------------------
+    ref_rope = DeepseekV4RotaryEmbedding_PT(self.config)
+    mt_rope = DeepSeekV4RotaryEmbedding(
+        head_dim=self.head_dim,
+        partial_rotary_factor=self.partial_rotary_factor,
+        rope_theta=expected_theta,
+    )
+
+    # --------------------------------------------------------------------------
+    # 2. Input Generation
+    # --------------------------------------------------------------------------
+    # Generate non-trivial inputs using np.random.normal to guarantee we are not
+    # testing against zeros or ones.
+    # Initial shape: [Batch=2, SeqLen=16, NumHeads=4, HeadDim=128]
+    np.random.seed(42)
+    x_np = np.random.normal(size=(self.batch_size, self.seq_len, self.num_heads, self.head_dim)).astype(np.float32)
+
+    # Position IDs are strictly sequential per batch element: [0, 1, ..., 15]
+    position_ids_np = np.arange(self.seq_len)[None, :].repeat(self.batch_size, axis=0)
+
+    # Convert to framework-specific tensors
+    x_pt = torch.tensor(x_np)
+    position_ids_pt = torch.tensor(position_ids_np, dtype=torch.long)
+
+    x_mt = jnp.array(x_np)
+    position_ids_mt = jnp.array(position_ids_np)
+
+    # --------------------------------------------------------------------------
+    # 3. Frequency Generation (cos, sin)
+    # --------------------------------------------------------------------------
+    # PyTorch reference expects flattened hidden dim for computation: [B, S, H*D]
+    ref_cos, ref_sin = ref_rope(
+        x_pt.view(self.batch_size, self.seq_len, -1), position_ids=position_ids_pt, layer_type=layer_type
+    )
+
+    # MaxText natively operates without requiring flattening.
+    mt_cos, mt_sin = mt_rope.get_freqs(position_ids_mt)
+
+    # Verify that the calculated frequencies match.
+    # Shape of cos/sin: [Batch=2, SeqLen=16, RotaryDim // 2 = 32]
+    np.testing.assert_allclose(np.array(mt_cos), ref_cos.numpy(), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(np.array(mt_sin), ref_sin.numpy(), rtol=1e-5, atol=1e-5)
+
+    # --------------------------------------------------------------------------
+    # 4. Apply Interleaved RoPE Rotation
+    # --------------------------------------------------------------------------
+    # PyTorch reference `ref_apply_rotary_pos_emb` expects head dimension to be before sequence length:
+    # Expected PyTorch Shape: [Batch, NumHeads, SeqLen, HeadDim] = [2, 4, 16, 128]
+    x_pt_transpose = x_pt.transpose(1, 2)
+    ref_rotated = ref_apply_rotary_pos_emb(x_pt_transpose, ref_cos, ref_sin)
+
+    # Transpose PyTorch result back to MaxText native layout [B, S, H, D] for comparison
+    ref_rotated_np = ref_rotated.transpose(1, 2).numpy()
+
+    # MaxText `DeepSeekV4RotaryEmbedding` natively operates on [B, S, H, D].
+    # We pass unsqueeze_dim=2 to expand cos/sin from [B, S, D] to [B, S, 1, D]
+    # so they correctly broadcast over the NumHeads dimension.
+    mt_rotated = mt_rope(x_mt, position_ids_mt, unsqueeze_dim=2)
+    mt_rotated_np = np.array(mt_rotated)
+
+    # --------------------------------------------------------------------------
+    # 5. Final Validation
+    # --------------------------------------------------------------------------
+    # Validate the full mathematical rotation is perfectly equivalent.
+    np.testing.assert_allclose(mt_rotated_np, ref_rotated_np, rtol=1e-5, atol=1e-5)
+    print(f"Rotary Embedding test ({layer_type}) passed successfully.")
+
+
+class DeepSeekV4GroupedLinearTest(unittest.TestCase):
+  """Tests to validate MaxText GroupedLinear implementation against PyTorch reference."""
+
+  def setUp(self):
+    self.batch_size = 2
+    self.seq_len = 8
+    self.n_groups = 4
+    self.in_features_per_group = 128
+    self.out_features = 256  # 64 per group
+
+    self.rngs = nnx.Rngs(0)
+
+  def test_grouped_linear_forward(self):
+    """
+    Validates that the MaxText GroupedLinear projection is mathematically identical to
+    the PyTorch bmm logic up to 1e-5 tolerance.
+
+    Test Flow:
+    1. Initializes PyTorch and MaxText GroupedLinear modules with the same configuration.
+    2. Extracts the randomly initialized PyTorch weights and transposes them to match MaxText's kernel layout.
+    3. Injects the reshaped weights into the MaxText module to ensure exact mathematical parity.
+    4. Generates random floating-point noise for inputs.
+    5. Executes the forward pass in both implementations.
+    6. Verifies that the final projected tensors match exactly.
+    """
+    # --------------------------------------------------------------------------
+    # 1. Initialization
+    # --------------------------------------------------------------------------
+    ref_linear = DeepseekV4GroupedLinear_PT(
+        in_features_per_group=self.in_features_per_group,
+        out_features=self.out_features,
+        n_groups=self.n_groups,
+        bias=False,
+    )
+
+    # --------------------------------------------------------------------------
+    # 2. Extract and Reshape Weights
+    # --------------------------------------------------------------------------
+    # Shape of PyTorch weight is [out_features, in_features_per_group]
+    # In MaxText we expect [n_groups, in_features_per_group, out_features_per_group]
+    pt_weight = ref_linear.weight.data.numpy()  # e.g., [256, 128]
+
+    out_features_per_group = self.out_features // self.n_groups
+
+    # PyTorch's forward does: w = self.weight.view(self.n_groups, -1, hidden_dim).transpose(1, 2)
+    # This reshapes the weight matrix into group-specific chunks.
+    mt_weight_np = pt_weight.reshape(self.n_groups, out_features_per_group, self.in_features_per_group).transpose(0, 2, 1)
+
+    # --------------------------------------------------------------------------
+    # 3. Initialize MaxText Implementation
+    # --------------------------------------------------------------------------
+    mt_linear = DeepSeekV4GroupedLinear(
+        in_features_per_group=self.in_features_per_group,
+        out_features=self.out_features,
+        n_groups=self.n_groups,
+        rngs=self.rngs,
+    )
+    # Manually inject weights for mathematical comparison
+    mt_linear.kernel[...] = jnp.array(mt_weight_np)
+
+    # --------------------------------------------------------------------------
+    # 4. Input Generation
+    # --------------------------------------------------------------------------
+    # Generate non-trivial inputs using np.random.normal to guarantee we are not
+    # testing against zeros or ones.
+    # Shape: [Batch, SeqLen, N_Groups, InFeaturesPerGroup]
+    np.random.seed(42)
+    x_np = np.random.normal(size=(self.batch_size, self.seq_len, self.n_groups, self.in_features_per_group)).astype(
+        np.float32
+    )
+
+    x_pt = torch.tensor(x_np)
+    x_mt = jnp.array(x_np)
+
+    # --------------------------------------------------------------------------
+    # 5. Execute Forward Pass
+    # --------------------------------------------------------------------------
+    # PyTorch grouped linear takes [Batch, SeqLen, N_Groups, InFeaturesPerGroup]
+    ref_out = ref_linear(x_pt)
+
+    # MaxText grouped linear
+    mt_out = mt_linear(x_mt)
+
+    # --------------------------------------------------------------------------
+    # 6. Final Validation
+    # --------------------------------------------------------------------------
+    # Validate the full mathematical projection is perfectly equivalent.
+    np.testing.assert_allclose(np.array(mt_out), ref_out.detach().numpy(), rtol=1e-5, atol=1e-5)
+    print("Grouped Linear test passed successfully.")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
### Description

Implement foundational architectural core primitives required for DeepSeek-V4 integration into MaxText. These modules serve as the underlying foundation for the V4 architecture.

-   `DeepSeekGroupedLinear`: Block-diagonal grouped linear projection layer. This module enables parallel, memory-efficient group projections natively via `jax.lax.dot_general` / `einsum` broadcasting (`[B, S, hc_mult, D] -> [B, S, D]`).
-   `DeepSeekV4RotaryEmbedding`: Interleaved partial rotary positional embedding that pairs consecutive even/odd channels (as opposed to standard half-split pairs).
-   `Unit Tests`: Added unit tests (`tests/unit/deepseek_v4_vs_reference_test.py`) validating exact numerical parity against PyTorch reference implementations at `atol=1e-5, rtol=1e-5`.

### Tests

Tested on CPU

bash
```
pytest  tests/unit/deepseek_v4_vs_reference_test.py::DeepSeekV4RotaryEmbeddingTest  tests/unit/deepseek_v4_vs_reference_test.py::DeepSeekV4GroupedLinearTest

========================= 3 passed, 1 warning in 2.52s =========================

tests/unit/deepseek_v4_vs_reference_test.py ...                          [100%]
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
