### PR TITLE
Fix ckpt conversion for qwen3-moe models (transformers==5.8.0)

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_huggingface.py
+++ b/src/maxtext/checkpoint_conversion/to_huggingface.py
@@ -210,6 +210,10 @@ def _validate_or_update_architecture(hf_config, max_config, override: bool):
       if isinstance(mt_value, int):
         mt_value = mt_value * 2
 
+    # Special handling for Qwen3-MoE: hf.intermediate_size is the aggregated dense MLP dim, but mt.mlp_dim is dim per expert
+    if "qwen3" in max_config.model_name and getattr(max_config, "num_experts", 0) > 1 and hf_attr == "intermediate_size":
+      mt_value = mt_value * getattr(max_config, "num_experts_per_tok", 1)
+
     # Handle vocab size padding
     if hf_attr == "vocab_size" and isinstance(mt_value, int) and isinstance(hf_value, int):
       # MaxText often pads vocab size to a multiple of 128 or 256 for TPU efficiency

--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -813,7 +813,7 @@ if __name__ == "__main__":
       "--eager_load_method",
       type=str,
       required=False,
-      default="transformers",
+      default="safetensors",
       choices=["transformers", "safetensors"],
       help="Backend to use for eager loading: `transformers_class.from_pretrained` or `safetensors.safe_open` with pt",
   )

--- a/src/maxtext/checkpoint_conversion/utils/hf_shape.py
+++ b/src/maxtext/checkpoint_conversion/utils/hf_shape.py
@@ -716,7 +716,7 @@ def QWEN_HF_WEIGHTS_TO_SHAPE(config):
   }
 
   # Determine if the model is MoE based on config keys
-  num_experts = config.get("num_experts", 0)
+  num_experts = config.get("num_experts", config.get("num_local_experts", 0))
 
   for layer_idx in range(num_hidden_layers):
     layer_prefix = f"model.layers.{layer_idx}"

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -607,7 +607,7 @@ def QWEN_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
       or scanned with expert stacking (nested list of strings).
   """
   n_layers = config["num_hidden_layers"]
-  num_experts = config.get("num_experts", 0)
+  num_experts = config.get("num_experts", config.get("num_local_experts", 0))
 
   mapping = {
       "params-token_embedder-embedding": "model.embed_tokens.weight",
@@ -753,7 +753,7 @@ def QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, 
       transformation functions.
   """
   n_layers = config["num_hidden_layers"]
-  num_experts = config.get("num_experts", 0)
+  num_experts = config.get("num_experts", config.get("num_local_experts", 0))
 
   def pad_embedding_layer(input_tensor, target_shape):
     """Pads or truncates embedding layer to match target vocab size."""


### PR DESCRIPTION
# Description

This PR updates the Qwen MoE parameter mapping and hook functions to support breaking configuration changes introduced in `transformers==5.8.0` (breaking [b/511249077](https://b.corp.google.com/issues/511249077)):

- Check both `num_experts` and `num_local_experts` in case of transformers version differences.
- Use `--eager_load_method=safetensors` as default in to_maxtext.
- Updated `_validate_or_update_architecture` to handle Qwen3-MoE family.

### 1. Configuration Renaming (`num_experts` → `num_local_experts`)
In `Qwen3MoeConfig`, the configuration attribute tracking the number of MoE experts was renamed ([commands to reproduce](https://paste.googleplex.com/5166972875702272)).
- **`4.57.0`**: `config.num_experts`
- **`5.8.0`**: `config.num_local_experts`
- **Impact**: Caused MaxText's mapping functions to default to `0` experts, mistaking the MoE architecture for a dense model.
- **Solution**: This PR checks for both names: `num_experts` first then `num_local_experts`. Such fallback pattern supports both old and new transformers versions.

### 2. Fused Expert Layers (Individual → Stacked/Fused)
In `Qwen3MoeForCausalLM`, the PyTorch model structure was refactored from individual expert modules to single stacked tensors ([commands to reproduce](https://paste.googleplex.com/5166972875702272)).
- **`4.57.0`**: Separate expert sub-modules with individual projections (`experts.0.gate_proj.weight`, `experts.0.up_proj.weight`, etc.).
- **`5.8.0`**: All experts are stacked together into a single layer, and the gate/up projections are fused into single tensors (`experts.gate_up_proj` and `experts.down_proj`).
- **Impact**: Caused missing key errors when MaxText attempted to extract weights via `state_dict()`. 
- **Solution**: Bypassed successfully by setting to `--eager_load_method=safetensors`.

Qwen3-MoE `to_huggingface` runs may be flawed previously, since the `_validate_or_update_architecture` were checking mis-aligned hyperparameters. This PR updated the logics by comparing `intermediate_size` with `base_mlp_dim*num_experts_per_tok` for Qwen3-MoE.

# Tests

```
# to maxtext
python -m maxtext.checkpoint_conversion.to_maxtext src/maxtext/configs/base.yml model_name=qwen3-30b-a3b base_output_directory=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-30b-a3b/scanned/2026-05-11-new2 scan_layers=true hf_access_token=<your_token> weight_dtype=bfloat16 hardware=cpu skip_jax_distributed_system=True checkpoint_storage_use_ocdbt=False checkpoint_storage_use_zarr3=False --eager_load_method=safetensors

# to huggingface
python -m maxtext.checkpoint_conversion.to_huggingface model_name=qwen3-30b-a3b load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-30b-a3b/scanned/2026-05-11-new/0/items base_output_directory=/dev/shm/hengtaoguo/hf_safetensor/qwen3-30b-a3b/2026-05-11-new scan_layers=true weight_dtype=bfloat16 hardware=cpu skip_jax_distributed_system=True hf_access_token=<your_token>

# logits check
python -m tests.utils.forward_pass_logit_checker maxtext/configs/base.yml run_name=ht_test model_name=qwen3-30b-a3b tokenizer_path=Qwen/Qwen3-30B-A3B-Thinking-2507 load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-30b-a3b/scanned/2026-05-11-new/0/items scan_layers=True max_prefill_predict_length=4 ici_tensor_parallelism=4 hf_access_token=<your_token> --run_hf_model=True --hf_model_path=Qwen/Qwen3-30B-A3B-Thinking-2507 --max_kl_div=0.15
```

[Logs](https://paste.googleplex.com/6000495249457152)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
