### PR TITLE
Conditionally branch tokamax.ragged_dot calls based on use_manual_quantization

### DIFF
--- a/src/maxtext/kernels/megablox/ops.py
+++ b/src/maxtext/kernels/megablox/ops.py
@@ -172,18 +172,27 @@ def _gmm_fwd(
     if transpose_rhs:
       rhs = rhs.swapaxes(1, 2)
 
-    out = tokamax.ragged_dot(
-        lhs=lhs,
-        rhs=rhs,
-        group_sizes=group_sizes,
-        precision=jax.lax.Precision.DEFAULT,
-        preferred_element_type=preferred_element_type,
-        group_offset=group_offset,
-        implementation="mosaic",
-        manual_axis_type=jax.sharding.ManualAxisType(
-            varying=frozenset(["data", "fsdp", "expert"])
-        ) if use_manual_quantization else None,
-    )
+    if use_manual_quantization:
+      out = tokamax.ragged_dot(
+          lhs=lhs,
+          rhs=rhs,
+          group_sizes=group_sizes,
+          precision=jax.lax.Precision.DEFAULT,
+          preferred_element_type=preferred_element_type,
+          group_offset=group_offset,
+          implementation="mosaic",
+          manual_axis_type=jax.sharding.ManualAxisType(varying=frozenset(["data", "fsdp", "expert"])),
+      )
+    else:
+      out = tokamax.ragged_dot(
+          lhs=lhs,
+          rhs=rhs,
+          group_sizes=group_sizes,
+          precision=jax.lax.Precision.DEFAULT,
+          preferred_element_type=preferred_element_type,
+          group_offset=group_offset,
+          implementation="mosaic",
+      )
   else:
     out = backend.gmm(
         lhs,
@@ -264,32 +273,53 @@ def _gmm_bwd(
     if not transpose_rhs:
       dlhs_rhs = dlhs_rhs.swapaxes(1, 2)
 
-    dlhs = tokamax.ragged_dot(
-        lhs=dlhs_dout,
-        rhs=dlhs_rhs,
-        group_sizes=group_sizes,
-        precision=jax.lax.Precision.DEFAULT,
-        preferred_element_type=lhs_dtype,
-        group_offset=group_offset,
-        implementation="mosaic",
-        manual_axis_type=jax.sharding.ManualAxisType(
-            varying=frozenset(["data", "fsdp", "expert"])
-        ) if use_manual_quantization else None,
-    )
-    drhs = tokamax.ragged_dot_general(
-        lhs=lhs,
-        rhs=drhs_dout,
-        group_sizes=group_sizes,
-        ragged_dot_dimension_numbers=DRHS_RAGGED_DOT_DIM_NUMS,
-        precision=jax.lax.Precision.DEFAULT,
-        preferred_element_type=rhs_dtype,
-        group_offset=group_offset,
-        implementation="mosaic",
-        manual_axis_type=jax.sharding.ManualAxisType(
-            varying=frozenset(["expert"]),
-            unreduced=frozenset(["data", "fsdp"])
-        ) if use_manual_quantization else None,
-    )
+    if use_manual_quantization:
+      dlhs = tokamax.ragged_dot(
+          lhs=dlhs_dout,
+          rhs=dlhs_rhs,
+          group_sizes=group_sizes,
+          precision=jax.lax.Precision.DEFAULT,
+          preferred_element_type=lhs_dtype,
+          group_offset=group_offset,
+          implementation="mosaic",
+          manual_axis_type=jax.sharding.ManualAxisType(varying=frozenset(["data", "fsdp", "expert"])),
+      )
+    else:
+      dlhs = tokamax.ragged_dot(
+          lhs=dlhs_dout,
+          rhs=dlhs_rhs,
+          group_sizes=group_sizes,
+          precision=jax.lax.Precision.DEFAULT,
+          preferred_element_type=lhs_dtype,
+          group_offset=group_offset,
+          implementation="mosaic",
+      )
+    if use_manual_quantization:
+      drhs = tokamax.ragged_dot_general(
+          lhs=lhs,
+          rhs=drhs_dout,
+          group_sizes=group_sizes,
+          ragged_dot_dimension_numbers=DRHS_RAGGED_DOT_DIM_NUMS,
+          precision=jax.lax.Precision.DEFAULT,
+          preferred_element_type=rhs_dtype,
+          group_offset=group_offset,
+          implementation="mosaic",
+          manual_axis_type=jax.sharding.ManualAxisType(
+              varying=frozenset(["expert"]),
+              unreduced=frozenset(["data", "fsdp"]),
+          ),
+      )
+    else:
+      drhs = tokamax.ragged_dot_general(
+          lhs=lhs,
+          rhs=drhs_dout,
+          group_sizes=group_sizes,
+          ragged_dot_dimension_numbers=DRHS_RAGGED_DOT_DIM_NUMS,
+          precision=jax.lax.Precision.DEFAULT,
+          preferred_element_type=rhs_dtype,
+          group_offset=group_offset,
+          implementation="mosaic",
+      )
     if quantization_rule and quantization_rule.bwd_qtype and weight_gather_axes:
       # Scatter back in reverse order of gather
       for axis_name, axis_idx in reversed(weight_gather_axes):


### PR DESCRIPTION
# Description

Conditionally branch tokamax.ragged_dot calls based on use_manual_quantization to avoid passing None to manual_axis_type

The ubench nightly tests broke due to `TypeError: ragged_dot() got an unexpected keyword argument 'manual_axis_type'`

FIXES: b/511266446

# Tests

Tested locally with AOT compiling and successfully compiled.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
