### PR TITLE
Fix test by updating the module names

### DIFF
--- a/tests/unit/metric_logger_abort_test.py
+++ b/tests/unit/metric_logger_abort_test.py
@@ -25,6 +25,7 @@ from maxtext.common.metric_logger import MetricLogger, MetadataKey
 class MetricLoggerAbortTest(unittest.TestCase):
 
   def _make_logger(self, abort_on_nan_loss, abort_on_inf_loss):
+    """Helper to create a MetricLogger with mocked config."""
     logger = MetricLogger.__new__(MetricLogger)  # skip __init__
     logger.config = SimpleNamespace(
         abort_on_nan_loss=abort_on_nan_loss,
@@ -105,12 +106,10 @@ class MetricLoggerMetadataTest(unittest.TestCase):
     logger.metadata = {}
 
     with (
-        mock.patch("maxtext.src.maxtext.utils.max_utils.calculate_num_params_from_pytree", return_value=1e9),
-        mock.patch(
-            "maxtext.src.maxtext.utils.maxtext_utils.calculate_tflops_training_per_device", return_value=(100.0, 0, 0)
-        ),
-        mock.patch("maxtext.src.maxtext.utils.maxtext_utils.calculate_tokens_training_per_device", return_value=1000.0),
-        mock.patch("maxtext.src.maxtext.utils.max_logging.log"),
+        mock.patch("maxtext.utils.max_utils.calculate_num_params_from_pytree", return_value=1e9),
+        mock.patch("maxtext.utils.maxtext_utils.calculate_tflops_training_per_device", return_value=(100.0, 0, 0)),
+        mock.patch("maxtext.utils.maxtext_utils.calculate_tokens_training_per_device", return_value=1000.0),
+        mock.patch("maxtext.utils.max_logging.log"),
     ):
       logger.write_setup_info_to_tensorboard({})
 


### PR DESCRIPTION
# Description

Fix test error:
```
FAILED tests/unit/metric_logger_abort_test.py::MetricLoggerMetadataTest::test_metadata_init_without_tensorboard - AttributeError: module 'maxtext' has no attribute 'src'
```

The error was introduced in a recent PR.

# Tests

CI Tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
