### PR TITLE
[DeepSeek-V4] Implement MoE routing primitives

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -264,6 +264,7 @@ routed_bias: false # a flag if a learnable bias is added for routing
 routed_bias_update_rate: 0.0 # a flag indicate the update rate applied to the router bias term
 mlp_bias: false # a flag if a learnable bias is added for MLP matmul, and originally implemented to support the GPT-OSS model architecture.
 n_routing_groups: -1 # number of groups for routing, disabled by default
+first_num_hash_layers: 0 # number of hash routing layers, used in DeepSeek V4 (0 means disabled)
 topk_routing_group: -1 # number of top groups to route inputs. For EP,
 # Splits the batch to allow for better scheduling when using expert parallelism by overlapping the
 # all-to-all communication with compute. Currently only implemented with DeepSeek sparse layers.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -227,6 +227,7 @@ ModelName = Literal[
     "deepseek3-test",
     "deepseek3-tiny",
     "deepseek3.2-671b",
+    "deepseek4",
     "deepseek-custom",
     "kimi-k2-1t",
     "gemma-7b",
@@ -499,6 +500,7 @@ class ModelArchitecture(BaseModel):
       -1.0,
       description="Upper bound to clip the MLP activation values. -1.0 means no clipping.",
   )
+
   normalization_layer_epsilon: float = Field(1.0e-05, description="Epsilon value for normalization layers.")
   fused_qkv: bool = Field(False, description="If supported, fuse the Q, K, and V projections.")
   attention_bias: bool = Field(
@@ -836,6 +838,9 @@ class DeepSeekMoE(BaseModel):
       "and originally implemented to support the GPT-OSS model architecture",
   )
   n_routing_groups: int = Field(-1, description="Number of groups for routing, disabled by default.")
+  first_num_hash_layers: int = Field(
+      0, description="Number of hash routing layers, used in DeepSeek V4 (0 means disabled)."
+  )
   topk_routing_group: int = Field(-1, description="Number of top groups to route inputs to.")
   use_batch_split_schedule: bool = Field(
       False,
@@ -2972,6 +2977,8 @@ class MaxTextConfig(
         raise ValueError("GPT-OSS MoE only supports dropless (capacity_factor=-1) with dense matmul.")
       if self.routed_bias and self.routed_bias_update_rate > 0.0 and self.decoder_block != DecoderBlockType.DEEPSEEK:
         raise ValueError("Loss-free load balancing is only supported for the DeepSeek decoder block.")
+      if self.model_name.startswith("deepseek4") and self.first_num_hash_layers > 0 and self.use_ring_of_experts:
+        raise ValueError("DeepSeek V4 hash routing is currently not supported with ring of experts.")
       self.validate_ragged_buffer_factor()
 
     # Gemma 4 small (E2B / E4B) uses per-layer KV sharing, which is incompatible with nn.scan.

--- a/src/maxtext/layers/linears.py
+++ b/src/maxtext/layers/linears.py
@@ -44,6 +44,9 @@ def _convert_to_activation_function(fn_or_string: str | Callable[..., Any]) -> C
   """Convert a string to an activation function."""
   if fn_or_string == "linear":
     return lambda x: x
+  elif fn_or_string == "sqrtsoftplus":
+    # Custom activation function used by DeepSeek V4 Top-K MoE router
+    return lambda x: jnp.sqrt(jax.nn.softplus(x))
   elif isinstance(fn_or_string, str):
     return getattr(nn, fn_or_string)
   elif callable(fn_or_string):

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -336,8 +336,10 @@ class GateLogit(nnx.Module):
 
     if self.score_func:
       output = linears._convert_to_activation_function(self.score_func)(output)
-      if self.model_name.startswith("deepseek3"):
-        pre_bias_logits = output
+
+    # NOTE: deepseek2 has a different pattern
+    if self.model_name.startswith(("deepseek3", "deepseek4")):
+      pre_bias_logits = output
 
     if self.use_bias:
       bias = jnp.asarray(self.bias[...], self.dtype)
@@ -361,6 +363,7 @@ class RoutedMoE(nnx.Module):
       weight_dtype: ctypes.DType = jnp.float32,
       dtype: ctypes.DType = jnp.float32,
       quant: Optional[quantizations.AqtQuantization] = None,
+      is_hash_routing: bool = False,
   ):
     """Initializes the RoutedMoE module.
 
@@ -376,6 +379,7 @@ class RoutedMoE(nnx.Module):
       weight_dtype: The data type of the kernel weights.
       dtype: The data type for the computation.
       quant: The quantization configuration. If None, no quantization is applied.
+      is_hash_routing: Whether this layer uses deterministic hash routing instead of top-K routing.
     """
     self.config = config
     self.num_experts = num_experts
@@ -388,6 +392,17 @@ class RoutedMoE(nnx.Module):
     self.dtype = dtype
     self.quant = quant
     self.rngs = rngs
+    self.is_hash_routing = is_hash_routing
+
+    # DeepSeek V4 Hash Routing
+    if self.is_hash_routing:
+      # Token-ID to Expert-ID lookup table for static routing
+      self.tid2eid = nnx.Variable(
+          jnp.zeros((self.config.vocab_size, self.num_experts_per_tok), dtype=jnp.int32),
+          out_sharding=None,  # Replicated across shards for local lookup
+      )
+    else:
+      self.tid2eid = None
 
     self.moe_expert_input_dim = (
         self.config.emb_dim if self.config.moe_expert_input_dim <= 0 else self.config.moe_expert_input_dim
@@ -427,7 +442,7 @@ class RoutedMoE(nnx.Module):
         quant=self.quant,
         kernel_init=self.kernel_init,
         kernel_axes=self.kernel_axes,
-        use_bias=self.config.routed_bias,
+        use_bias=self.config.routed_bias and not self.is_hash_routing,
         # tpu-inference applies the score function in the fused_moe_gmm kernel,
         # so we don't apply it here to avoid redundant computation.
         # See https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/layers/common/fused_moe_gmm.py#L58.
@@ -628,10 +643,14 @@ class RoutedMoE(nnx.Module):
     return self.mesh.shape.get("context_autoregressive", 1)
 
   def should_update_load_balance(self):
-    """Determines if loss-free load balancing updates should be applied."""
-    return self.config.routed_bias and self.config.routed_bias_update_rate > 0.0
+    """Determines if loss-free load balancing updates should be applied.
 
-  def get_topk(self, gate_logits, pre_bias_logits, rngs=None):
+    The bias update logic is only applicable to Top-K router.
+    Hash router does not use routed bias.
+    """
+    return self.config.routed_bias and self.config.routed_bias_update_rate > 0.0 and not self.is_hash_routing
+
+  def get_topk(self, gate_logits, pre_bias_logits, rngs=None, input_ids=None):
     """get topk."""
     # shape of top_k_weights & top_k_indices:
     # (batch, sequence, num_experts_per_tok).
@@ -643,7 +662,11 @@ class RoutedMoE(nnx.Module):
       top_k_weights, top_k_indices = random_routing(rng, gate_logits, self.num_experts_per_tok)
       return top_k_weights, top_k_indices
 
-    if self.config.model_name.startswith("deepseek3"):
+    if self.is_hash_routing:
+      top_k_indices = self.tid2eid[input_ids]
+      top_k_weights = jnp.take_along_axis(pre_bias_logits, top_k_indices, axis=-1)
+    # NOTE: deepseek2 has a different pattern
+    elif self.config.model_name.startswith(("deepseek3", "deepseek4")):
       top_k_weights, top_k_indices = self.deepseek_routing(gate_logits, pre_bias_logits)
     elif self.config.decoder_block == ctypes.DecoderBlockType.GEMMA4:
       router_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1)
@@ -666,8 +689,8 @@ class RoutedMoE(nnx.Module):
   def deepseek_scale_weights(self, weights):
     """Scales weights according to DeepSeek's v3 reference implementation."""
     # https://github.com/deepseek-ai/DeepSeek-V3/blob/2f7b80eecebf3d1c84da5a0d465f6639ea175012/inference/model.py#L592-L594.
-    if self.config.routed_score_func == "sigmoid":
-      weights /= weights.sum(-1, keepdims=True)
+    if self.config.routed_score_func in ("sigmoid", "sqrtsoftplus"):
+      weights /= weights.sum(-1, keepdims=True) + 1e-20
     weights *= self.config.routed_scaling_factor
     return weights
 
@@ -746,20 +769,35 @@ class RoutedMoE(nnx.Module):
         layer_act = self.activation_fn(layer_w0 * 1.702)
         glu = jnp.multiply(layer_w0, layer_act)
         intermediate_layer = jnp.multiply(glu, (layer_w1 + 1))
+      elif self.config.decoder_block == ctypes.DecoderBlockType.DEEPSEEK and self.config.mlp_activations_limit > 0.0:
+        # DeepSeek V4 uses bounds to clip the SwiGLU activations
+        layer_w0 = jnp.clip(layer_w0, min=None, max=self.config.mlp_activations_limit)
+        layer_w1 = jnp.clip(layer_w1, min=-self.config.mlp_activations_limit, max=self.config.mlp_activations_limit)
+        layer_act = self.activation_fn(layer_w0)
+        intermediate_layer = jnp.multiply(layer_act, layer_w1)
       else:
         layer_act = self.activation_fn(layer_w0)
         intermediate_layer = jnp.multiply(layer_act, layer_w1)
       return intermediate_layer.astype(self.dtype)
 
-  def permute(self, inputs, gate_logits, pre_bias_logits, use_custom_sort_vjp=True, rngs=None, roll_to_expert_id=None):
+  def permute(
+      self,
+      inputs,
+      gate_logits,
+      pre_bias_logits,
+      use_custom_sort_vjp=True,
+      rngs=None,
+      roll_to_expert_id=None,
+      input_ids=None,
+  ):
     """Permute tokens to group by expert to fit gmm call."""
     # reshape inputs (batch, sequence, emb) to (batch * sequence, emb)
     inputs_shape = inputs.shape
     bsz_times_seq_len = inputs_shape[0] * inputs_shape[1]
     inputs_2d = jnp.reshape(inputs, (bsz_times_seq_len, inputs_shape[2]))
-    weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs)
+    weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs, input_ids)
     lb_loss = None
-    if self.config.load_balance_loss_weight > 0.0:
+    if self.config.load_balance_loss_weight > 0.0 and not self.is_hash_routing:
       softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
       lb_loss = self.load_balance_loss(selected_experts, softmax_probs)
 
@@ -1122,6 +1160,7 @@ class RoutedMoE(nnx.Module):
       w0_bias,
       w1_bias,
       wo_bias,
+      input_ids=None,
   ):
     """Perform sparse matrix multiplication of inputs and Experts."""
 
@@ -1288,7 +1327,7 @@ class RoutedMoE(nnx.Module):
         wo_pspec = aqt.partition_spec(wo_pspec, (1,), wo_kernel.dtype, use_bias=False)
       return w0_pspec, w1_pspec, wo_pspec
 
-    def get_routed_moe_shardings(is_batch_sharded_by_expert):
+    def get_routed_moe_shardings(is_batch_sharded_by_expert, has_input_ids):
       if is_batch_sharded_by_expert:
         batch_logical_axis = "activation_batch"
       else:
@@ -1308,11 +1347,17 @@ class RoutedMoE(nnx.Module):
         wo_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_embed"))
 
       gate_logits_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
-      if self.config.model_name.startswith("deepseek3"):
+      # NOTE: deepseek2 has a different pattern
+      if self.config.model_name.startswith(("deepseek3", "deepseek4")):
         pre_bias_logits_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
       else:
-        # pre_bias_logits is None for non-DeepSeek v3 models
+        # pre_bias_logits is None for non-deepseek3/4 models, including deepseek2
         pre_bias_logits_pspec = None
+
+      if has_input_ids:
+        decoder_tokens_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length"))
+      else:
+        decoder_tokens_pspec = None
 
       # w0, w1, wo needs to be un sharded on fsdp / fsdp_transpose axis, so use
       # mlp_no_fsdp axis
@@ -1344,6 +1389,7 @@ class RoutedMoE(nnx.Module):
           w0_bias_pspec,
           w1_bias_pspec,
           wo_bias_pspec,
+          decoder_tokens_pspec,
       )
 
     is_batch_sharded_by_expert = is_batch_sharded_by_ep(inputs)
@@ -1359,10 +1405,11 @@ class RoutedMoE(nnx.Module):
         w0_bias_pspec,
         w1_bias_pspec,
         wo_bias_pspec,
-    ) = get_routed_moe_shardings(is_batch_sharded_by_expert)
+        decoder_tokens_pspec,
+    ) = get_routed_moe_shardings(is_batch_sharded_by_expert, input_ids is not None)
     w0_pspec, w1_pspec, wo_pspec = maybe_aqt_partition(w0_kernel, w0_pspec, w1_kernel, w1_pspec, wo_kernel, wo_pspec)
 
-    def route(x, logits, pre_bias_logits, rngs):
+    def route(x, logits, pre_bias_logits, rngs, input_ids=None):
       """Performs both across device and within device token routing/sorting"""
       num_ep = self.get_expert_parallelism_size()
       expert_shard_id = jax.lax.axis_index(self._expert_parallelism_name) if num_ep > 1 else 0
@@ -1390,11 +1437,12 @@ class RoutedMoE(nnx.Module):
             self.config.use_custom_sort_vjp,
             roll_to_expert_id=num_experts_per_shard * expert_shard_id,
             rngs=rngs,
+            input_ids=input_ids,
         )
 
       else:
         x, sorted_selected_experts, weights, group_sizes, selected_experts, lb_loss, bias_updates = self.permute(
-            x, logits, pre_bias_logits, self.config.use_custom_sort_vjp, rngs
+            x, logits, pre_bias_logits, self.config.use_custom_sort_vjp, rngs=rngs, input_ids=input_ids
         )
 
         if num_ep > 1:
@@ -1548,6 +1596,7 @@ class RoutedMoE(nnx.Module):
             w0_bias_pspec,
             w1_bias_pspec,
             wo_bias_pspec,
+            decoder_tokens_pspec,
             P(),  # Replicate the input key
         ),
         out_specs=(
@@ -1557,9 +1606,9 @@ class RoutedMoE(nnx.Module):
         ),
         check_vma=self.config.check_vma,
     )
-    def wrapper(x, logits, pre_bias_logits, w0, w1, wo, w0_bias, w1_bias, wo_bias, rngs):
+    def wrapper(x, logits, pre_bias_logits, w0, w1, wo, w0_bias, w1_bias, wo_bias, sharded_input_ids, rngs):
       batch_size, sequence_length, _ = x.shape
-      x, routing, route_metadata = route(x, logits, pre_bias_logits, rngs)
+      x, routing, route_metadata = route(x, logits, pre_bias_logits, rngs, input_ids=sharded_input_ids)
 
       if self.config.mlp_bias:
         w0_bias, w1_bias, wo_bias = self.transform_bias(routing.selected_experts, w0_bias, w1_bias, wo_bias)
@@ -1712,7 +1761,8 @@ class RoutedMoE(nnx.Module):
       input_axes = (batch_logical_axis, "activation_norm_length", None)
 
     gate_logits_axes = (batch_logical_axis, "activation_norm_length", None)
-    if self.config.model_name.startswith("deepseek3"):
+    # NOTE: deepseek2 has a different pattern
+    if self.config.model_name.startswith(("deepseek3", "deepseek4")):
       pre_bias_logits_axes = (batch_logical_axis, "activation_norm_length", None)
     else:
       pre_bias_logits_axes = None
@@ -1732,7 +1782,17 @@ class RoutedMoE(nnx.Module):
       wo_bias = self._maybe_shard_with_pspec(wo_bias, wo_bias_pspec)
 
     return wrapper(
-        inputs, gate_logits, pre_bias_logits, w0_kernel, w1_kernel, wo_kernel, w0_bias, w1_bias, wo_bias, self.rngs
+        inputs,
+        gate_logits,
+        pre_bias_logits,
+        w0_kernel,
+        w1_kernel,
+        wo_kernel,
+        w0_bias,
+        w1_bias,
+        wo_bias,
+        input_ids,
+        self.rngs,
     )
 
   def reshape_and_update_weights(self, weights, indices):
@@ -1992,16 +2052,18 @@ class RoutedMoE(nnx.Module):
       w0_bias,
       w1_bias,
       wo_bias,
+      input_ids=None,
   ) -> tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]]:
     """Dense matrix multiplication."""
     # gate_logits: batch, length, expert
     gate_logits = self._maybe_shard_with_logical(gate_logits, ("activation_batch_moe", "activation_length_moe", None))
-    if self.config.model_name.startswith("deepseek3"):
-      # pre_bias_logits is None for non-DeepSeek v3 models
+    # NOTE: deepseek2 has a different pattern
+    if self.config.model_name.startswith(("deepseek3", "deepseek4")):
+      # pre_bias_logits is None for non-deepseek3/4 models, including deepseek2
       pre_bias_logits = self._maybe_shard_with_logical(
           pre_bias_logits, ("activation_batch_moe", "activation_length_moe", None)
       )
-    top_k_weights, top_k_indices = self.get_topk(gate_logits, pre_bias_logits, self.rngs)
+    top_k_weights, top_k_indices = self.get_topk(gate_logits, pre_bias_logits, self.rngs, input_ids=input_ids)
     is_llama4_decoder_layer = self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4
     if is_llama4_decoder_layer:
       router_scores = jax.nn.sigmoid(top_k_weights.astype(jnp.float32)).astype(self.dtype)
@@ -2011,15 +2073,19 @@ class RoutedMoE(nnx.Module):
     matmul_precision = jax.lax.Precision(self.config.matmul_precision)
 
     # Calculate load balance loss
-    if self.config.model_call_mode != "inference":
+    # DeepSeek V4 uses Hash Routing for the first `first_num_hash_layers` layers.
+    # These layers route deterministically based on token IDs and do not generate auxiliary loss.
+    if self.config.model_call_mode != "inference" and not self.is_hash_routing:
       softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
       lb_loss = (
           self.load_balance_loss(top_k_indices, softmax_probs) if self.config.load_balance_loss_weight > 0.0 else None
       )
+      # TODO(dipakg-lang, b/521990776): Add sequence-wise balance loss * 0.0001
     else:
       lb_loss = None
 
     # Calculate routed bias updates (loss-free)
+    # The bias update logic is only applicable to Top-K routed layers.
     if self.should_update_load_balance():
       bias_updates = calculate_load_balance_updates(
           top_k_indices, self.config.num_experts, self.config.routed_bias_update_rate
@@ -2370,8 +2436,25 @@ class RoutedMoE(nnx.Module):
     return w0_kernel, w1_kernel, wo_kernel
 
   def __call__(
-      self, inputs: jax.Array, gate_inputs: jax.Array | None = None, out_sharding: NamedSharding | None = None
+      self,
+      inputs: jax.Array,
+      input_ids: jax.Array | None = None,
+      gate_inputs: jax.Array | None = None,
+      out_sharding: NamedSharding | None = None,
   ) -> tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]]:
+    """Executes the routed MoE block.
+
+    Args:
+      inputs: The input activations.
+      input_ids: Optional token IDs corresponding to the inputs, used strictly for Hash Routing
+        in DeepSeek V4's early MoE layers. If None, routing relies purely on `gate_inputs` or `inputs`.
+      gate_inputs: Optional alternate inputs to feed into the routing gate.
+      out_sharding: Optional sharding specification for the output.
+
+    Returns:
+      A tuple containing the MoE output, the load balance loss (if applicable),
+      and any routed bias updates.
+    """
     cfg = self.config
     inputs = inputs.astype(cfg.dtype)
     gate_dtype = jnp.float32 if cfg.float32_gate_logits else cfg.dtype
@@ -2383,7 +2466,7 @@ class RoutedMoE(nnx.Module):
     fused_kernel = None
     w0_kernel = None
     w1_kernel = None
-    if cfg.prefuse_moe_weights and cfg.attention == "vllm_rpa":
+    if cfg.prefuse_moe_weights and cfg.attention == "vllm_rpa" and not self.is_hash_routing:
       fused_kernel = jnp.asarray(self.wi[...], self.dtype)
     else:
       w0_kernel = jnp.asarray(self.wi_0[...], self.dtype)
@@ -2405,7 +2488,10 @@ class RoutedMoE(nnx.Module):
       w0_bias, w1_bias, wo_bias = None, None, None
 
     # vllm_rpa codepath uses fused_moe_func from tpu_inference for optimized inference.
-    if cfg.attention == "vllm_rpa":
+    # The fused MoE kernel currently only supports standard Top-K routing with associated
+    # weights. Hash routed layers bypass this kernel and fall back
+    # to the sparse matmul implementation.
+    if cfg.attention == "vllm_rpa" and not self.is_hash_routing:
       output, lb_loss, bias_updates = self.fused_moe_matmul(
           inputs, gate_logits, wo_kernel, w0_kernel=w0_kernel, w1_kernel=w1_kernel, fused_kernel=fused_kernel
       )
@@ -2423,11 +2509,11 @@ class RoutedMoE(nnx.Module):
             wo_bias,
         )
       output, lb_loss, bias_updates = self.sparse_matmul(
-          inputs, gate_logits, pre_bias_logits, w0_kernel, w1_kernel, wo_kernel, w0_bias, w1_bias, wo_bias
+          inputs, gate_logits, pre_bias_logits, w0_kernel, w1_kernel, wo_kernel, w0_bias, w1_bias, wo_bias, input_ids
       )
     else:
       output, lb_loss, bias_updates = self.dense_matmul(
-          inputs, gate_logits, pre_bias_logits, w0_kernel, w1_kernel, wo_kernel, w0_bias, w1_bias, wo_bias
+          inputs, gate_logits, pre_bias_logits, w0_kernel, w1_kernel, wo_kernel, w0_bias, w1_bias, wo_bias, input_ids
       )
     return output, lb_loss, bias_updates
 
@@ -2445,6 +2531,7 @@ class RoutedAndSharedMoE(nnx.Module):
       weight_dtype: ctypes.DType = jnp.float32,
       dtype: ctypes.DType = jnp.float32,
       quant: Optional[quantizations.AqtQuantization] = None,
+      is_hash_routing: bool = False,
   ):
     """Initializes the RoutedAndSharedMoE module.
 
@@ -2457,6 +2544,7 @@ class RoutedAndSharedMoE(nnx.Module):
       weight_dtype: The data type of the kernel weights.
       dtype: The data type for the computation.
       quant: The quantization configuration. If None, no quantization is applied.
+      is_hash_routing: Passed down to the internal `RoutedMoE` to determine routing behavior (e.g. hash vs top-K).
     """
     self.config = config
     self.mesh = mesh
@@ -2466,6 +2554,7 @@ class RoutedAndSharedMoE(nnx.Module):
     self.dtype = dtype
     self.quant = quant
     self.rngs = rngs
+    self.is_hash_routing = is_hash_routing
     self.moe_expert_input_dim = (
         self.config.emb_dim if self.config.moe_expert_input_dim <= 0 else self.config.moe_expert_input_dim
     )
@@ -2484,6 +2573,7 @@ class RoutedAndSharedMoE(nnx.Module):
         weight_dtype=self.config.weight_dtype,
         quant=self.quant,
         rngs=self.rngs,
+        is_hash_routing=self.is_hash_routing,
     )
 
     shared_expert_mlp_dim = maxtext_utils.get_shared_expert_mlp_dim(self.config)
@@ -2512,9 +2602,25 @@ class RoutedAndSharedMoE(nnx.Module):
       gate_inputs: jax.Array | None = None,
       intermediate_sharding: NamedSharding | None = None,
       out_sharding: NamedSharding | None = None,
+      input_ids: jax.Array | None = None,
   ) -> tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]]:
+    """Executes both the routed experts and the shared expert block.
+
+    Args:
+      inputs: The input activations.
+      original_inputs: The original pre-normalization inputs (unused by default).
+      gate_inputs: Optional alternate inputs to feed into the routing gate.
+      intermediate_sharding: Optional sharding spec for the shared experts intermediate output.
+      out_sharding: Optional sharding spec for the final combined output.
+      input_ids: Optional token IDs corresponding to the inputs, used strictly for Hash Routing
+        in DeepSeek V4's early MoE layers.
+
+    Returns:
+      A tuple containing the combined MoE output (routed + shared),
+      the load balance loss, and any routed bias updates.
+    """
     routed_experts, load_balance_loss, moe_bias_updates = self.routed_moe(
-        inputs, gate_inputs=gate_inputs, out_sharding=out_sharding
+        inputs, gate_inputs=gate_inputs, out_sharding=out_sharding, input_ids=input_ids
     )
     shared_experts = self.shared_experts(inputs, intermediate_sharding=intermediate_sharding, out_sharding=out_sharding)
     return routed_experts + shared_experts, load_balance_loss, moe_bias_updates
@@ -2604,6 +2710,7 @@ def get_routed_and_shared_moe(
     dtype: ctypes.DType = jnp.float32,
     quant: Optional[quantizations.AqtQuantization] = None,
     name: Optional[str] = None,
+    is_hash_routing: bool = False,
 ):
   """Creates a RoutedAndSharedMoE Linen module."""
 
@@ -2617,6 +2724,7 @@ def get_routed_and_shared_moe(
       dtype=dtype,
       quant=quant,
       name=name,
+      is_hash_routing=is_hash_routing,
       metadata_fn=variable_to_logically_partitioned,
       abstract_init=False,
   )

--- a/tests/unit/deepseek_v4_vs_reference_test.py
+++ b/tests/unit/deepseek_v4_vs_reference_test.py
@@ -38,6 +38,9 @@ from transformers.models.deepseek_v4.configuration_deepseek_v4 import DeepseekV4
 from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
     DeepseekV4RotaryEmbedding as DeepseekV4RotaryEmbedding_PT,
     DeepseekV4GroupedLinear as DeepseekV4GroupedLinear_PT,
+    DeepseekV4HashRouter as DeepseekV4HashRouter_PT,
+    DeepseekV4TopKRouter as DeepseekV4TopKRouter_PT,
+    DeepseekV4Experts as DeepseekV4Experts_PT,
     apply_rotary_pos_emb as ref_apply_rotary_pos_emb,
 )
 
@@ -47,6 +50,8 @@ from maxtext.layers.attention_op import AttentionOp
 from maxtext.common.common_types import AttentionType, DEFAULT_MASK_VALUE
 
 from flax import nnx
+from maxtext.layers.moe import RoutedMoE
+from maxtext.layers import initializers
 
 # ==============================================================================
 # Tests
@@ -280,7 +285,14 @@ class DeepSeekV4GroupedLinearTest(unittest.TestCase):
 # TODO(parambole): This test is duplicated here to maintain debugging continuity alongside the other reference tests.
 # It has also been duplicated into tests/unit/attention_test.py for CI/CD resilience, as this file is skipped in CI.
 class DeepSeekV4AttentionMaskingTest(unittest.TestCase):
-  """Tests to validate AttentionOp masking logic for DeepSeek-V4 attention patterns."""
+  """Tests to validate AttentionOp masking logic for DeepSeek-V4 attention patterns.
+
+  TODO: This test is intentionally duplicated here and in `tests/unit/attention_test.py`.
+  We keep it here because this file serves as the central source of truth for all DeepSeek-V4
+  specifics, keeping the masking logic validation closely coupled to the structural tests.
+  However, because `deepseek_v4_vs_reference_test.py` is currently skipped by our CI/CD pipeline,
+  it is mirrored in `attention_test.py` to ensure it runs resiliently on every PR.
+  """
 
   def setUp(self):
     self.config = pyconfig.initialize([sys.argv[0], "src/maxtext/configs/base.yml"], run_name="test")
@@ -724,6 +736,219 @@ class DeepSeekV4CompressedAttentionTest(unittest.TestCase):
 
   def test_document_packing_masking(self):
     self._run_e2e_test("heavily_compressed_attention", is_packed=True)
+
+
+class DeepSeekV4MoERouterTest(unittest.TestCase):
+
+  def setUp(self):
+    self.batch_size = 2
+    self.seq_len = 8
+    self.hidden_dim = 128
+    self.num_experts = 16
+    self.num_experts_per_tok = 4
+    self.vocab_size = 1000
+
+    self.pt_config = DeepseekV4Config(
+        hidden_size=self.hidden_dim,
+        num_local_experts=self.num_experts,
+        num_experts_per_tok=self.num_experts_per_tok,
+        routed_scaling_factor=2.0,
+        scoring_func="sqrtsoftplus",
+        vocab_size=self.vocab_size,
+    )
+
+    config_arguments = {
+        "per_device_batch_size": 1.0,
+        "run_name": "test",
+        "enable_checkpointing": False,
+        "base_emb_dim": self.hidden_dim,
+        "num_experts": self.num_experts,
+        "topk_routing_group": self.num_experts_per_tok,
+        "routed_scaling_factor": 2.0,
+        "routed_score_func": "sqrtsoftplus",
+        "routed_bias": True,
+        "n_routing_groups": -1,
+        "vocab_size": self.vocab_size,
+        "first_num_hash_layers": 3,
+        "decoder_block": "deepseek",
+        "model_name": "deepseek4",
+        "attention": "dot_product",
+        "base_mlp_dim": 256,
+        "base_moe_mlp_dim": 256,
+        "override_model_config": True,
+    }
+    argv = [sys.argv[0], "src/maxtext/configs/base.yml"]
+    self.mx_config = pyconfig.initialize(argv, **config_arguments)
+
+    devices = np.array(jax.devices()[:1])
+    self.mesh = jax.sharding.Mesh(devices, ("tensor",))
+    self.rngs = nnx.Rngs(0)
+
+  def test_hash_router(self):
+    pt_router = DeepseekV4HashRouter_PT(self.pt_config)
+    # Explicitly initialize PyTorch weights since torch.empty leaves garbage in memory,
+    # which causes NaN/Inf drift between PyTorch and MaxText/XLA execution.
+    torch.nn.init.normal_(pt_router.weight)
+
+    # Hash Router operates deterministically based on input_ids via a frozen tid2eid lookup table.
+    # In practice, this table is pre-computed (e.g. by K-Means on the dataset) and loaded statically.
+    # For this parity test, we randomly initialize the lookup table on the PyTorch side
+    # and explicitly sync it to the MaxText side to ensure both routers route the exact same way.
+    pt_tid2eid = torch.randint(0, self.num_experts, (self.vocab_size, self.num_experts_per_tok))
+    pt_router.tid2eid.copy_(pt_tid2eid)
+
+    mx_moe = RoutedMoE(
+        config=self.mx_config,
+        num_experts=self.num_experts,
+        num_experts_per_tok=self.num_experts_per_tok,
+        mesh=self.mesh,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed_moe", "mlp_moe", None),
+        rngs=self.rngs,
+        is_hash_routing=True,  # Hash layer
+    )
+
+    # Sync weights
+    mx_moe.tid2eid.value = jnp.array(pt_router.tid2eid.numpy())
+    mx_moe.gate.kernel.value = jnp.array(pt_router.weight.detach().numpy()).T
+
+    hidden_states = torch.randn(self.batch_size, self.seq_len, self.hidden_dim)
+    input_ids = torch.randint(0, self.vocab_size, (self.batch_size, self.seq_len))
+
+    # PT forward
+    _, pt_weights, pt_indices = pt_router(hidden_states, input_ids)
+
+    # MaxText forward
+    gate_logits, pre_bias_logits = mx_moe.gate(jnp.array(hidden_states.numpy()))
+    mx_weights, mx_indices = mx_moe.get_topk(
+        gate_logits, pre_bias_logits, rngs=self.rngs, input_ids=jnp.array(input_ids.numpy())
+    )
+
+    # --- Assertion Logic for Hash Router ---
+    # PyTorch returns flat tensors: (batch * seq_len, top_k)
+    # MaxText returns structured tensors: (batch, seq_len, top_k)
+    # We must explicitly reshape PyTorch outputs to match MaxText's nested sequence structure.
+    pt_indices_reshaped = pt_indices.numpy().reshape(self.batch_size, self.seq_len, -1)
+    pt_weights_reshaped = pt_weights.detach().numpy().reshape(self.batch_size, self.seq_len, -1)
+    np.testing.assert_allclose(mx_indices, pt_indices_reshaped, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(mx_weights, pt_weights_reshaped, rtol=1e-5, atol=1e-5)
+
+  def test_topk_router(self):
+    pt_router = DeepseekV4TopKRouter_PT(self.pt_config)
+
+    # Explicitly initialize PyTorch weights since torch.empty leaves garbage in memory,
+    # which causes NaN/Inf drift between PyTorch and MaxText/XLA execution.
+    torch.nn.init.normal_(pt_router.weight)
+    torch.nn.init.normal_(pt_router.e_score_correction_bias)
+
+    mx_moe = RoutedMoE(
+        config=self.mx_config,
+        num_experts=self.num_experts,
+        num_experts_per_tok=self.num_experts_per_tok,
+        mesh=self.mesh,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed_moe", "mlp_moe", None),
+        rngs=self.rngs,
+        is_hash_routing=False,  # TopK layer
+    )
+
+    # Sync weights
+    mx_moe.gate.kernel.value = jnp.array(pt_router.weight.detach().numpy()).T
+    mx_moe.gate.bias.value = jnp.array(pt_router.e_score_correction_bias.detach().numpy())
+
+    hidden_states = torch.randn(self.batch_size, self.seq_len, self.hidden_dim)
+
+    # PT forward
+    _, pt_weights, pt_indices = pt_router(hidden_states)
+
+    # MaxText forward
+    gate_logits, pre_bias_logits = mx_moe.gate(jnp.array(hidden_states.numpy()))
+    mx_weights, mx_indices = mx_moe.get_topk(gate_logits, pre_bias_logits, rngs=self.rngs)
+
+    # --- Assertion Logic for TopK Router ---
+    # PyTorch returns flat tensors: (batch * seq_len, top_k)
+    # MaxText returns structured tensors: (batch, seq_len, top_k)
+    # 1. Reshape PyTorch outputs to match MaxText's nested sequence structure.
+    pt_indices_reshaped = pt_indices.numpy().reshape(self.batch_size, self.seq_len, -1)
+    pt_weights_reshaped = pt_weights.detach().numpy().reshape(self.batch_size, self.seq_len, -1)
+
+    # 2. Sort both by indices so they can be compared directly.
+    # jax.lax.top_k and torch.topk resolve exact-value ties differently.
+    # Because TopK routing weights are summed commutatively during the MoE forward pass,
+    # only the mathematical *set* of selected experts matters, not their strict sorted order.
+    mx_sort_idx = np.argsort(mx_indices, axis=-1)
+    pt_sort_idx = np.argsort(pt_indices_reshaped, axis=-1)
+
+    mx_indices_sorted = np.take_along_axis(np.array(mx_indices), mx_sort_idx, axis=-1)
+    mx_weights_sorted = np.take_along_axis(np.array(mx_weights), mx_sort_idx, axis=-1)
+
+    pt_indices_sorted = np.take_along_axis(pt_indices_reshaped, pt_sort_idx, axis=-1)
+    pt_weights_sorted = np.take_along_axis(pt_weights_reshaped, pt_sort_idx, axis=-1)
+
+    np.testing.assert_allclose(mx_indices_sorted, pt_indices_sorted, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(mx_weights_sorted, pt_weights_sorted, rtol=1e-4, atol=1e-4)
+
+
+class DeepSeekV4SwiGLUClampTest(unittest.TestCase):
+
+  def test_swiglu_clamp(self):
+    limit = 10.0
+    pt_config = DeepseekV4Config(
+        hidden_size=128,
+        num_local_experts=2,
+        num_experts_per_tok=1,
+        intermediate_size=256,
+        swiglu_limit=limit,
+    )
+
+    config_arguments = {
+        "per_device_batch_size": 1.0,
+        "run_name": "test",
+        "enable_checkpointing": False,
+        "base_emb_dim": 128,
+        "num_experts": 2,
+        "topk_routing_group": 1,
+        "mlp_activations_limit": limit,
+        "decoder_block": "deepseek",
+        "model_name": "deepseek4",
+        "attention": "dot_product",
+        "base_mlp_dim": 256,
+        "base_moe_mlp_dim": 256,
+        "override_model_config": True,
+    }
+    argv = [sys.argv[0], "src/maxtext/configs/base.yml"]
+    mx_config = pyconfig.initialize(argv, **config_arguments)
+
+    pt_experts = DeepseekV4Experts_PT(pt_config)
+
+    devices = np.array(jax.devices()[:1])
+    mesh = jax.sharding.Mesh(devices, ("tensor",))
+    rngs = nnx.Rngs(0)
+
+    mx_moe = RoutedMoE(
+        config=mx_config,
+        num_experts=2,
+        num_experts_per_tok=1,
+        mesh=mesh,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed_moe", "mlp_moe", None),
+        rngs=rngs,
+    )
+
+    # Gate & Up merged matrix in PT
+    gate_up = torch.randn(1, 4, 256 * 2) * 20.0  # Force large values to trigger the clamping mechanism
+
+    # PyTorch reference executes the standard SwiGLU followed by clamping
+    # to self.config.swiglu_limit (which translates to mlp_activations_limit in MaxText)
+    pt_out = pt_experts._apply_gate(gate_up)  # pylint: disable=protected-access
+
+    # In MaxText, the gate and up projections are separated mathematically.
+    # apply_ffn_activation executes the swiglu limit internally during the activation phase.
+    gate, up = gate_up.chunk(2, dim=-1)
+    mx_out = mx_moe.apply_ffn_activation(jnp.array(gate.numpy()), jnp.array(up.numpy()))
+
+    # Validate that both clamped outputs match identically
+    np.testing.assert_allclose(mx_out, pt_out.numpy(), rtol=1e-5, atol=1e-5)
 
 
 if __name__ == "__main__":

--- a/tests/utils/reference_hlo_deepseek3.txt
+++ b/tests/utils/reference_hlo_deepseek3.txt
@@ -10,21 +10,21 @@ StackFrames
 
 
 %region_46.56 (top_k.25: bf16[], top_k.26: bf16[], top_k.27: s32[], top_k.28: s32[]) -> pred[] {
-  %constant.1424 = s32[]{:T(128)} constant(0)
-  %constant.1425 = s32[]{:T(128)} constant(2147483647)
+  %constant.1427 = s32[]{:T(128)} constant(0)
+  %constant.1428 = s32[]{:T(128)} constant(2147483647)
   %top_k.25 = bf16[]{:T(256)} parameter(0), metadata={op_name="top_k"}
   %top_k.26 = bf16[]{:T(256)} parameter(1), metadata={op_name="top_k"}
   %top_k.27 = s32[]{:T(128)} parameter(2), metadata={op_name="top_k"}
   %top_k.28 = s32[]{:T(128)} parameter(3), metadata={op_name="top_k"}
   %convert.393 = f32[]{:T(128)S(6)} convert(%top_k.25), metadata={op_name="convert.18"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %bitcast-convert.39 = s32[]{:T(128)S(6)} bitcast-convert(%convert.393), metadata={op_name="bitcast-convert.8"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %compare.144 = pred[]{:T(512)S(6)} compare(%bitcast-convert.39, %constant.1424), direction=LT, metadata={op_name="compare.38"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %xor.40 = s32[]{:T(128)S(6)} xor(%constant.1425, %bitcast-convert.39), metadata={op_name="xor.8"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %compare.144 = pred[]{:T(512)S(6)} compare(%bitcast-convert.39, %constant.1427), direction=LT, metadata={op_name="compare.38"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %xor.40 = s32[]{:T(128)S(6)} xor(%constant.1428, %bitcast-convert.39), metadata={op_name="xor.8"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %select.127 = s32[]{:T(128)S(6)} select(%compare.144, %xor.40, %bitcast-convert.39), metadata={op_name="select.16"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["1","3"]}]}}
   %convert.394 = f32[]{:T(128)S(6)} convert(%top_k.26), metadata={op_name="convert.19"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %bitcast-convert.40 = s32[]{:T(128)S(6)} bitcast-convert(%convert.394), metadata={op_name="bitcast-convert.9"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %compare.145 = pred[]{:T(512)S(6)} compare(%bitcast-convert.40, %constant.1424), direction=LT, metadata={op_name="compare.39"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %xor.41 = s32[]{:T(128)S(6)} xor(%constant.1425, %bitcast-convert.40), metadata={op_name="xor.9"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %compare.145 = pred[]{:T(512)S(6)} compare(%bitcast-convert.40, %constant.1427), direction=LT, metadata={op_name="compare.39"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %xor.41 = s32[]{:T(128)S(6)} xor(%constant.1428, %bitcast-convert.40), metadata={op_name="xor.9"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %select.128 = s32[]{:T(128)S(6)} select(%compare.145, %xor.41, %bitcast-convert.40), metadata={op_name="select.17"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["1","3"]}]}}
   %compare.146 = pred[]{:T(512)S(6)} compare(%select.127, %select.128), direction=GT, metadata={op_name="compare.0"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %compare.147 = pred[]{:T(512)S(6)} compare(%select.128, %select.127), direction=GT, metadata={op_name="compare.117"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
@@ -78,19 +78,19 @@ StackFrames
 %region_107.126 (psum.6: bf16[], psum.9: bf16[]) -> bf16[] {
   %psum.6 = bf16[]{:T(256)} parameter(0), metadata={op_name="psum"}
   %psum.9 = bf16[]{:T(256)} parameter(1), metadata={op_name="psum"}
-  ROOT %add.1417 = bf16[]{:T(256)} add(%psum.6, %psum.9), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.1445 = bf16[]{:T(256)} add(%psum.6, %psum.9), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
 %region_108.127 (psum.10: bf16[], psum.11: bf16[]) -> bf16[] {
   %psum.10 = bf16[]{:T(256)} parameter(0), metadata={op_name="psum"}
   %psum.11 = bf16[]{:T(256)} parameter(1), metadata={op_name="psum"}
-  ROOT %add.1418 = bf16[]{:T(256)} add(%psum.10, %psum.11), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.1446 = bf16[]{:T(256)} add(%psum.10, %psum.11), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
 %region_109.128 (psum.14: bf16[], psum.15: bf16[]) -> bf16[] {
   %psum.14 = bf16[]{:T(256)} parameter(0), metadata={op_name="psum"}
   %psum.15 = bf16[]{:T(256)} parameter(1), metadata={op_name="psum"}
-  ROOT %add.1419 = bf16[]{:T(256)} add(%psum.14, %psum.15), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.1447 = bf16[]{:T(256)} add(%psum.14, %psum.15), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
 %region_62.73 (reduce-window.111: s32[], reduce-window.112: s32[]) -> s32[] {
@@ -212,11 +212,11 @@ StackFrames
   %param_1.108 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.13 = s32[1024]{0:T(1024)} custom-call(%param_1.108), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/gather" stack_frame_id=0}
   %slice.892 = s32[512]{0:T(512)} slice(%custom-call.13), slice={[0:512]}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/gather" stack_frame_id=0}
-  %reshape.3298 = s32[4,128]{1,0:T(4,128)} reshape(%slice.892), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/broadcast_in_dim" stack_frame_id=0}
-  %transpose.847 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3298), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3306 = s32[4,128]{1,0:T(4,128)} reshape(%slice.892), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/broadcast_in_dim" stack_frame_id=0}
+  %transpose.847 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3306), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/broadcast_in_dim" stack_frame_id=0}
   %gather.183 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} gather(%param_0.17, %transpose.847), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/gather" stack_frame_id=0}
   %transpose.846 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} transpose(%gather.183), dimensions={0,1,2}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/gather" stack_frame_id=0}
-  ROOT %reshape.3297 = bf16[512,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.846), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/gather" stack_frame_id=0}
+  ROOT %reshape.3305 = bf16[512,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.846), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/gather" stack_frame_id=0}
 }
 
 %fused_computation.6 (param_0.20: f32[163840,32], param_1.110: s32[1024]) -> f32[512,32] {
@@ -224,11 +224,11 @@ StackFrames
   %param_1.110 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.15 = s32[1024]{0:T(1024)} custom-call(%param_1.110), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
   %slice.894 = s32[512]{0:T(512)} slice(%custom-call.15), slice={[0:512]}, metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
-  %reshape.3306 = s32[4,128]{1,0:T(4,128)} reshape(%slice.894), metadata={op_name="jit(train_step)/dense_layers/broadcast_in_dim" stack_frame_id=0}
-  %transpose.853 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3306), dimensions={0,1}, metadata={op_name="jit(train_step)/dense_layers/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3314 = s32[4,128]{1,0:T(4,128)} reshape(%slice.894), metadata={op_name="jit(train_step)/dense_layers/broadcast_in_dim" stack_frame_id=0}
+  %transpose.853 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3314), dimensions={0,1}, metadata={op_name="jit(train_step)/dense_layers/broadcast_in_dim" stack_frame_id=0}
   %gather.185 = f32[4,128,32]{2,1,0:T(8,128)} gather(%param_0.20, %transpose.853), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,32}, metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
   %transpose.852 = f32[4,128,32]{2,1,0:T(8,128)} transpose(%gather.185), dimensions={0,1,2}, metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
-  ROOT %reshape.3305 = f32[512,32]{1,0:T(8,128)} reshape(%transpose.852), metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
+  ROOT %reshape.3313 = f32[512,32]{1,0:T(8,128)} reshape(%transpose.852), metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
 }
 
 %fused_computation.7 (param_0.23: f32[163840,32], param_1.112: s32[1024]) -> f32[512,32] {
@@ -236,11 +236,11 @@ StackFrames
   %param_1.112 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.17 = s32[1024]{0:T(1024)} custom-call(%param_1.112), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
   %slice.896 = s32[512]{0:T(512)} slice(%custom-call.17), slice={[0:512]}, metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
-  %reshape.3314 = s32[4,128]{1,0:T(4,128)} reshape(%slice.896), metadata={op_name="jit(train_step)/dense_layers/broadcast_in_dim" stack_frame_id=0}
-  %transpose.859 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3314), dimensions={0,1}, metadata={op_name="jit(train_step)/dense_layers/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3322 = s32[4,128]{1,0:T(4,128)} reshape(%slice.896), metadata={op_name="jit(train_step)/dense_layers/broadcast_in_dim" stack_frame_id=0}
+  %transpose.859 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3322), dimensions={0,1}, metadata={op_name="jit(train_step)/dense_layers/broadcast_in_dim" stack_frame_id=0}
   %gather.187 = f32[4,128,32]{2,1,0:T(8,128)} gather(%param_0.23, %transpose.859), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,32}, metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
   %transpose.858 = f32[4,128,32]{2,1,0:T(8,128)} transpose(%gather.187), dimensions={0,1,2}, metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
-  ROOT %reshape.3313 = f32[512,32]{1,0:T(8,128)} reshape(%transpose.858), metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
+  ROOT %reshape.3321 = f32[512,32]{1,0:T(8,128)} reshape(%transpose.858), metadata={op_name="jit(train_step)/dense_layers/gather" stack_frame_id=0}
 }
 
 %fused_computation.8 (param_0.26: f32[163840,32], param_1.120: s32[1024]) -> f32[512,32] {
@@ -248,11 +248,11 @@ StackFrames
   %param_1.120 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.25 = s32[1024]{0:T(1024)} custom-call(%param_1.120), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
   %slice.904 = s32[512]{0:T(512)} slice(%custom-call.25), slice={[0:512]}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
-  %reshape.3322 = s32[4,128]{1,0:T(4,128)} reshape(%slice.904), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/select_n" stack_frame_id=0}
-  %transpose.865 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3322), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/select_n" stack_frame_id=0}
+  %reshape.3330 = s32[4,128]{1,0:T(4,128)} reshape(%slice.904), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/select_n" stack_frame_id=0}
+  %transpose.865 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3330), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/select_n" stack_frame_id=0}
   %gather.189 = f32[4,128,32]{2,1,0:T(8,128)} gather(%param_0.26, %transpose.865), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,32}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
   %transpose.864 = f32[4,128,32]{2,1,0:T(8,128)} transpose(%gather.189), dimensions={0,1,2}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
-  ROOT %reshape.3321 = f32[512,32]{1,0:T(8,128)S(1)} reshape(%transpose.864), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
+  ROOT %reshape.3329 = f32[512,32]{1,0:T(8,128)S(1)} reshape(%transpose.864), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
 }
 
 %fused_computation.9 (param_0.29: f32[163840,32], param_1.122: s32[1024]) -> f32[512,32] {
@@ -260,11 +260,11 @@ StackFrames
   %param_1.122 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.27 = s32[1024]{0:T(1024)} custom-call(%param_1.122), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
   %slice.906 = s32[512]{0:T(512)} slice(%custom-call.27), slice={[0:512]}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
-  %reshape.3330 = s32[4,128]{1,0:T(4,128)} reshape(%slice.906), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/select_n" stack_frame_id=0}
-  %transpose.871 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3330), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/select_n" stack_frame_id=0}
+  %reshape.3338 = s32[4,128]{1,0:T(4,128)} reshape(%slice.906), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/select_n" stack_frame_id=0}
+  %transpose.871 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3338), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/select_n" stack_frame_id=0}
   %gather.191 = f32[4,128,32]{2,1,0:T(8,128)} gather(%param_0.29, %transpose.871), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,32}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
   %transpose.870 = f32[4,128,32]{2,1,0:T(8,128)} transpose(%gather.191), dimensions={0,1,2}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
-  ROOT %reshape.3329 = f32[512,32]{1,0:T(8,128)S(1)} reshape(%transpose.870), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
+  ROOT %reshape.3337 = f32[512,32]{1,0:T(8,128)S(1)} reshape(%transpose.870), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/gather" stack_frame_id=0}
 }
 
 %fused_computation.10 (param_0.32: bf16[4096,512], param_1.126: s32[4096]) -> bf16[4096,512] {
@@ -272,11 +272,11 @@ StackFrames
   %param_1.126 = s32[4096]{0:T(1024)S(1)} parameter(1)
   %custom-call.31 = s32[4096]{0:T(1024)} custom-call(%param_1.126), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[4096]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %slice.910 = s32[4096]{0:T(1024)} slice(%custom-call.31), slice={[0:4096]}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  %reshape.3338 = s32[4096]{0:T(1024)} reshape(%slice.910), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
-  %transpose.877 = s32[4096]{0:T(1024)} transpose(%reshape.3338), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3346 = s32[4096]{0:T(1024)} reshape(%slice.910), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %transpose.877 = s32[4096]{0:T(1024)} transpose(%reshape.3346), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
   %gather.193 = bf16[4096,512]{1,0:T(8,128)(2,1)} gather(%param_0.32, %transpose.877), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,512}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %transpose.876 = bf16[4096,512]{1,0:T(8,128)(2,1)} transpose(%gather.193), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  ROOT %reshape.3337 = bf16[4096,512]{1,0:T(8,128)(2,1)} reshape(%transpose.876), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
+  ROOT %reshape.3345 = bf16[4096,512]{1,0:T(8,128)(2,1)} reshape(%transpose.876), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
 }
 
 %fused_computation.11 (param_0.35: bf16[4096,512], param_1.128: s32[4096]) -> bf16[4096,512] {
@@ -284,11 +284,11 @@ StackFrames
   %param_1.128 = s32[4096]{0:T(1024)S(1)} parameter(1)
   %custom-call.33 = s32[4096]{0:T(1024)} custom-call(%param_1.128), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[4096]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %slice.912 = s32[4096]{0:T(1024)} slice(%custom-call.33), slice={[0:4096]}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  %reshape.3346 = s32[4096]{0:T(1024)} reshape(%slice.912), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
-  %transpose.883 = s32[4096]{0:T(1024)} transpose(%reshape.3346), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3354 = s32[4096]{0:T(1024)} reshape(%slice.912), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %transpose.883 = s32[4096]{0:T(1024)} transpose(%reshape.3354), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
   %gather.195 = bf16[4096,512]{1,0:T(8,128)(2,1)} gather(%param_0.35, %transpose.883), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,512}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %transpose.882 = bf16[4096,512]{1,0:T(8,128)(2,1)} transpose(%gather.195), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  ROOT %reshape.3345 = bf16[4096,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.882), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
+  ROOT %reshape.3353 = bf16[4096,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.882), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
 }
 
 %fused_computation.12 (param_0.38: bf16[4096,512], param_1.130: s32[4096]) -> bf16[4096,512] {
@@ -296,11 +296,11 @@ StackFrames
   %param_1.130 = s32[4096]{0:T(1024)S(1)} parameter(1)
   %custom-call.35 = s32[4096]{0:T(1024)} custom-call(%param_1.130), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[4096]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %slice.914 = s32[4096]{0:T(1024)} slice(%custom-call.35), slice={[0:4096]}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  %reshape.3354 = s32[4096]{0:T(1024)} reshape(%slice.914), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
-  %transpose.889 = s32[4096]{0:T(1024)} transpose(%reshape.3354), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3362 = s32[4096]{0:T(1024)} reshape(%slice.914), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %transpose.889 = s32[4096]{0:T(1024)} transpose(%reshape.3362), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
   %gather.197 = bf16[4096,512]{1,0:T(8,128)(2,1)} gather(%param_0.38, %transpose.889), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,512}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %transpose.888 = bf16[4096,512]{1,0:T(8,128)(2,1)} transpose(%gather.197), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  ROOT %reshape.3353 = bf16[4096,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.888), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
+  ROOT %reshape.3361 = bf16[4096,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.888), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
 }
 
 %fused_computation.13 (param_0.41: bf16[4096,512], param_1.132: s32[4096]) -> bf16[4096,512] {
@@ -308,11 +308,11 @@ StackFrames
   %param_1.132 = s32[4096]{0:T(1024)S(1)} parameter(1)
   %custom-call.37 = s32[4096]{0:T(1024)} custom-call(%param_1.132), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[4096]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %slice.916 = s32[4096]{0:T(1024)} slice(%custom-call.37), slice={[0:4096]}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  %reshape.3362 = s32[4096]{0:T(1024)} reshape(%slice.916), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
-  %transpose.895 = s32[4096]{0:T(1024)} transpose(%reshape.3362), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3370 = s32[4096]{0:T(1024)} reshape(%slice.916), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %transpose.895 = s32[4096]{0:T(1024)} transpose(%reshape.3370), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
   %gather.199 = bf16[4096,512]{1,0:T(8,128)(2,1)} gather(%param_0.41, %transpose.895), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,512}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %transpose.894 = bf16[4096,512]{1,0:T(8,128)(2,1)} transpose(%gather.199), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  ROOT %reshape.3361 = bf16[4096,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.894), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
+  ROOT %reshape.3369 = bf16[4096,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.894), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
 }
 
 %fused_computation.15 (param_0.47: s32[256], param_1.124: s32[1024]) -> s32[263] {
@@ -320,11 +320,11 @@ StackFrames
   %param_1.124 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.29 = s32[1024]{0:T(1024)} custom-call(%param_1.124), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
   %slice.908 = s32[263]{0:T(512)} slice(%custom-call.29), slice={[0:263]}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
-  %reshape.3393 = s32[263]{0:T(512)} reshape(%slice.908), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.911 = s32[263]{0:T(512)} transpose(%reshape.3393), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3401 = s32[263]{0:T(512)} reshape(%slice.908), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.911 = s32[263]{0:T(512)} transpose(%reshape.3401), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
   %gather.204 = s32[263]{0:T(512)} gather(%param_0.47, %transpose.911), offset_dims={}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
   %transpose.910 = s32[263]{0:T(512)} transpose(%gather.204), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
-  ROOT %reshape.3392 = s32[263]{0:T(512)S(1)} reshape(%transpose.910), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
+  ROOT %reshape.3400 = s32[263]{0:T(512)S(1)} reshape(%transpose.910), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
 }
 
 %fused_computation.16 (param_0.50: s32[256], param_1.134: s32[1024]) -> s32[263] {
@@ -332,46 +332,46 @@ StackFrames
   %param_1.134 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.39 = s32[1024]{0:T(1024)} custom-call(%param_1.134), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/jit(_take)/gather" stack_frame_id=0}
   %slice.918 = s32[263]{0:T(512)} slice(%custom-call.39), slice={[0:263]}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/jit(_take)/gather" stack_frame_id=0}
-  %reshape.3416 = s32[263]{0:T(512)} reshape(%slice.918), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.921 = s32[263]{0:T(512)} transpose(%reshape.3416), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3424 = s32[263]{0:T(512)} reshape(%slice.918), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.921 = s32[263]{0:T(512)} transpose(%reshape.3424), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
   %gather.207 = s32[263]{0:T(512)} gather(%param_0.50, %transpose.921), offset_dims={}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/jit(_take)/gather" stack_frame_id=0}
   %transpose.920 = s32[263]{0:T(512)} transpose(%gather.207), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/jit(_take)/gather" stack_frame_id=0}
-  ROOT %reshape.3415 = s32[263]{0:T(512)S(1)} reshape(%transpose.920), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/jit(_take)/gather" stack_frame_id=0}
+  ROOT %reshape.3423 = s32[263]{0:T(512)S(1)} reshape(%transpose.920), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/jit(_take)/gather" stack_frame_id=0}
 }
 
 %region_173.198.clone (scatter-add.94: bf16[], scatter-add.96: bf16[]) -> bf16[] {
   %scatter-add.94 = bf16[]{:T(256)} parameter(0), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/scatter-add"}
   %scatter-add.96 = bf16[]{:T(256)} parameter(1), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/scatter-add"}
-  ROOT %add.1885 = bf16[]{:T(256)} add(%scatter-add.94, %scatter-add.96), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  ROOT %add.1918 = bf16[]{:T(256)} add(%scatter-add.94, %scatter-add.96), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/add" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
 %fused_computation.21 (param_0.55: bf16[129280,512], param_1.65: s32[512], param_2.24: bf16[512,512]) -> bf16[129280,512] {
   %param_0.55 = bf16[129280,512]{1,0:T(8,128)(2,1)} parameter(0)
   %param_1.65 = s32[512]{0:T(512)S(1)} parameter(1)
-  %reshape.3470 = s32[4,128]{1,0:T(4,128)} reshape(%param_1.65), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/broadcast_in_dim" stack_frame_id=0}
-  %transpose.954 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3470), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3478 = s32[4,128]{1,0:T(4,128)} reshape(%param_1.65), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/broadcast_in_dim" stack_frame_id=0}
+  %transpose.954 = s32[4,128]{1,0:T(4,128)} transpose(%reshape.3478), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/broadcast_in_dim" stack_frame_id=0}
   %param_2.24 = bf16[512,512]{1,0:T(8,128)(2,1)S(1)} parameter(2)
-  %reshape.3471 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} reshape(%param_2.24), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/dense_layers.wrapped_fn/while" stack_frame_id=0}
-  %transpose.955 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} transpose(%reshape.3471), dimensions={0,1,2}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/dense_layers.wrapped_fn/while" stack_frame_id=0}
+  %reshape.3479 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} reshape(%param_2.24), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/dense_layers.wrapped_fn/while" stack_frame_id=0}
+  %transpose.955 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} transpose(%reshape.3479), dimensions={0,1,2}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/dense_layers.wrapped_fn/while" stack_frame_id=0}
   ROOT %scatter.73 = bf16[129280,512]{1,0:T(8,128)(2,1)} scatter(%param_0.55, %transpose.954, %transpose.955), update_window_dims={2}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=2, to_apply=%region_173.198.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/scatter-add" stack_frame_id=0}
 }
 
 %region_12.18 (top_k.0: bf16[], top_k.6: bf16[], top_k.7: s32[], top_k.8: s32[]) -> pred[] {
-  %constant.1385 = s32[]{:T(128)} constant(0)
-  %constant.1386 = s32[]{:T(128)} constant(2147483647)
+  %constant.1387 = s32[]{:T(128)} constant(0)
+  %constant.1388 = s32[]{:T(128)} constant(2147483647)
   %top_k.0 = bf16[]{:T(256)} parameter(0), metadata={op_name="top_k"}
   %top_k.6 = bf16[]{:T(256)} parameter(1), metadata={op_name="top_k"}
   %top_k.7 = s32[]{:T(128)} parameter(2), metadata={op_name="top_k"}
   %top_k.8 = s32[]{:T(128)} parameter(3), metadata={op_name="top_k"}
   %convert.385 = f32[]{:T(128)S(6)} convert(%top_k.0), metadata={op_name="convert.16"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %bitcast-convert.35 = s32[]{:T(128)S(6)} bitcast-convert(%convert.385), metadata={op_name="bitcast-convert.6"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %compare.128 = pred[]{:T(512)S(6)} compare(%bitcast-convert.35, %constant.1385), direction=LT, metadata={op_name="compare.35"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %xor.36 = s32[]{:T(128)S(6)} xor(%constant.1386, %bitcast-convert.35), metadata={op_name="xor.6"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %compare.128 = pred[]{:T(512)S(6)} compare(%bitcast-convert.35, %constant.1387), direction=LT, metadata={op_name="compare.35"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %xor.36 = s32[]{:T(128)S(6)} xor(%constant.1388, %bitcast-convert.35), metadata={op_name="xor.6"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %select.118 = s32[]{:T(128)S(6)} select(%compare.128, %xor.36, %bitcast-convert.35), metadata={op_name="select.14"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["1","3"]}]}}
   %convert.386 = f32[]{:T(128)S(6)} convert(%top_k.6), metadata={op_name="convert.17"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %bitcast-convert.36 = s32[]{:T(128)S(6)} bitcast-convert(%convert.386), metadata={op_name="bitcast-convert.7"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %compare.129 = pred[]{:T(512)S(6)} compare(%bitcast-convert.36, %constant.1385), direction=LT, metadata={op_name="compare.36"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
-  %xor.37 = s32[]{:T(128)S(6)} xor(%constant.1386, %bitcast-convert.36), metadata={op_name="xor.7"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %compare.129 = pred[]{:T(512)S(6)} compare(%bitcast-convert.36, %constant.1387), direction=LT, metadata={op_name="compare.36"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
+  %xor.37 = s32[]{:T(128)S(6)} xor(%constant.1388, %bitcast-convert.36), metadata={op_name="xor.7"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %select.119 = s32[]{:T(128)S(6)} select(%compare.129, %xor.37, %bitcast-convert.36), metadata={op_name="select.15"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[{"indices":["1","3"]}]}}
   %compare.130 = pred[]{:T(512)S(6)} compare(%select.118, %select.119), direction=GT, metadata={op_name="compare.1"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
   %compare.131 = pred[]{:T(512)S(6)} compare(%select.119, %select.118), direction=GT, metadata={op_name="compare.108"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
@@ -421,11 +421,11 @@ StackFrames
   %param_1.114 = s32[1024]{0:T(1024)S(1)} parameter(1)
   %custom-call.19 = s32[1024]{0:T(1024)} custom-call(%param_1.114), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[1024]{0:T(1024)}}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
   %slice.898 = s32[263]{0:T(512)} slice(%custom-call.19), slice={[0:263]}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
-  %reshape.3614 = s32[263]{0:T(512)} reshape(%slice.898), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1037 = s32[263]{0:T(512)} transpose(%reshape.3614), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3622 = s32[263]{0:T(512)} reshape(%slice.898), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1037 = s32[263]{0:T(512)} transpose(%reshape.3622), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/jit(_take)/broadcast_in_dim" stack_frame_id=0}
   %gather.209 = s32[263]{0:T(512)} gather(%param_0.68, %transpose.1037), offset_dims={}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
   %transpose.1036 = s32[263]{0:T(512)} transpose(%gather.209), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
-  ROOT %reshape.3613 = s32[263]{0:T(512)S(1)} reshape(%transpose.1036), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
+  ROOT %reshape.3621 = s32[263]{0:T(512)S(1)} reshape(%transpose.1036), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/jit(_take)/gather" stack_frame_id=0}
 }
 
 %region_27.34.clone.1 (reduce-window.350: s32[], reduce-window.351: s32[]) -> s32[] {
@@ -465,11 +465,11 @@ StackFrames
   %param_1.116 = s32[4096]{0:T(1024)S(1)} parameter(1)
   %custom-call.21 = s32[4096]{0:T(1024)} custom-call(%param_1.116), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[4096]{0:T(1024)}}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %slice.900 = s32[4096]{0:T(1024)} slice(%custom-call.21), slice={[0:4096]}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  %reshape.3637 = s32[4096]{0:T(1024)} reshape(%slice.900), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1043 = s32[4096]{0:T(1024)} transpose(%reshape.3637), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3645 = s32[4096]{0:T(1024)} reshape(%slice.900), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1043 = s32[4096]{0:T(1024)} transpose(%reshape.3645), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
   %gather.210 = bf16[4096,512]{1,0:T(8,128)(2,1)} gather(%param_0.71, %transpose.1043), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %transpose.1042 = bf16[4096,512]{1,0:T(8,128)(2,1)} transpose(%gather.210), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  ROOT %reshape.3636 = bf16[4096,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.1042), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
+  ROOT %reshape.3644 = bf16[4096,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.1042), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
 }
 
 %region_31.39 (sort.50: s32[], sort.51: s32[], sort.52: s32[], sort.53: s32[], sort.54: s32[], sort.55: s32[]) -> pred[] {
@@ -491,11 +491,11 @@ StackFrames
   %param_1.118 = s32[4096]{0:T(1024)S(1)} parameter(1)
   %custom-call.23 = s32[4096]{0:T(1024)} custom-call(%param_1.118), custom_call_target="AssumeGatherIndicesInBound", operand_layout_constraints={s32[4096]{0:T(1024)}}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %slice.902 = s32[4096]{0:T(1024)} slice(%custom-call.23), slice={[0:4096]}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  %reshape.3639 = s32[4096]{0:T(1024)} reshape(%slice.902), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1045 = s32[4096]{0:T(1024)} transpose(%reshape.3639), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %reshape.3647 = s32[4096]{0:T(1024)} reshape(%slice.902), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1045 = s32[4096]{0:T(1024)} transpose(%reshape.3647), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/broadcast_in_dim" stack_frame_id=0}
   %gather.211 = bf16[4096,512]{1,0:T(8,128)(2,1)} gather(%param_0.72, %transpose.1045), offset_dims={1}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=1, slice_sizes={1,512}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
   %transpose.1044 = bf16[4096,512]{1,0:T(8,128)(2,1)} transpose(%gather.211), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
-  ROOT %reshape.3638 = bf16[4096,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.1044), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
+  ROOT %reshape.3646 = bf16[4096,512]{1,0:T(8,128)(2,1)S(1)} reshape(%transpose.1044), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/sort_activations/gather" stack_frame_id=0}
 }
 
 %compare (name: s32[], name.1: s32[], name.2: bf16[], name.3: bf16[]) -> pred[] {
@@ -538,45 +538,45 @@ StackFrames
   ROOT %compare.381 = pred[] compare(%name.16, %name.17), direction=LT, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%called_computation.13 (param_0.4523: s32[256]) -> s32[256] {
-  %param_0.4523 = s32[256]{0:T(256)} parameter(0)
-  ROOT %copy.2073 = s32[256]{0:T(256)} copy(%param_0.4523), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"1134","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.13 (param_0.4519: s32[256]) -> s32[256] {
+  %param_0.4519 = s32[256]{0:T(256)} parameter(0)
+  ROOT %copy.2073 = s32[256]{0:T(256)} copy(%param_0.4519), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"1134","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.13 (param_0.4524: s32[256]) -> s32[256] {
-  %param_0.4524 = s32[256]{0:T(256)} parameter(0)
-  ROOT %copy.2074.cloned.1 = s32[256]{0:T(256)} call(%param_0.4524), to_apply=%called_computation.13
+%async_computation.13 (param_0.4520: s32[256]) -> s32[256] {
+  %param_0.4520 = s32[256]{0:T(256)} parameter(0)
+  ROOT %copy.2074.cloned.1 = s32[256]{0:T(256)} call(%param_0.4520), to_apply=%called_computation.13
 }, execution_thread="sparsecore"
 
 %region_49.59 (scatter-add.14: s32[], scatter-add.15: s32[]) -> s32[] {
   %scatter-add.14 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.15 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.1362 = s32[]{:T(128)S(7)} add(%scatter-add.14, %scatter-add.15), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.1387 = s32[]{:T(128)S(7)} add(%scatter-add.14, %scatter-add.15), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.22.clone.clone (param_0.4525: s32[256], param_1.5325: s32[4096], param_2.4494: s32[4096]) -> s32[256] {
-  %param_0.4525 = s32[256]{0:T(256)} parameter(0)
-  %param_1.5325 = s32[4096]{0:T(1024)} parameter(1)
-  %reshape.3903 = s32[4096]{0:T(1024)} reshape(%param_1.5325), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(clip)/max" stack_frame_id=0}
-  %transpose.1100 = s32[4096]{0:T(1024)} transpose(%reshape.3903), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(clip)/max" stack_frame_id=0}
-  %param_2.4494 = s32[4096]{0:T(1024)} parameter(2)
-  %reshape.3904 = s32[4096]{0:T(1024)} reshape(%param_2.4494), metadata={op_name="jit(train_step)/moe_layers/shard_map/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1101 = s32[4096]{0:T(1024)} transpose(%reshape.3904), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/broadcast_in_dim" stack_frame_id=0}
-  ROOT %scatter-add.231 = s32[256]{0:T(256)} scatter(%param_0.4525, %transpose.1100, %transpose.1101), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_49.59, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.14 (param_0.4526: s32[256], param_1.5326: s32[4096], param_2.4495: s32[4096]) -> s32[256] {
-  %param_0.4526 = s32[256]{0:T(256)} parameter(0)
+%fused_computation.22.clone.clone (param_0.4521: s32[256], param_1.5326: s32[4096], param_2.4491: s32[4096]) -> s32[256] {
+  %param_0.4521 = s32[256]{0:T(256)} parameter(0)
   %param_1.5326 = s32[4096]{0:T(1024)} parameter(1)
-  %param_2.4495 = s32[4096]{0:T(1024)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.39 = s32[256]{0:T(256)} fusion(%param_0.4526, %param_1.5326, %param_2.4495), kind=kCustom, calls=%fused_computation.22.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["256"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"4160","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3911 = s32[4096]{0:T(1024)} reshape(%param_1.5326), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(clip)/max" stack_frame_id=0}
+  %transpose.1100 = s32[4096]{0:T(1024)} transpose(%reshape.3911), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(clip)/max" stack_frame_id=0}
+  %param_2.4491 = s32[4096]{0:T(1024)} parameter(2)
+  %reshape.3912 = s32[4096]{0:T(1024)} reshape(%param_2.4491), metadata={op_name="jit(train_step)/moe_layers/shard_map/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1101 = s32[4096]{0:T(1024)} transpose(%reshape.3912), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/broadcast_in_dim" stack_frame_id=0}
+  ROOT %scatter-add.231 = s32[256]{0:T(256)} scatter(%param_0.4521, %transpose.1100, %transpose.1101), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_49.59, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.14 (param_0.4527: s32[256], param_1.5327: s32[4096], param_2.4496: s32[4096]) -> s32[256] {
-  %param_0.4527 = s32[256]{0:T(256)} parameter(0)
+%called_computation.14 (param_0.4522: s32[256], param_1.5327: s32[4096], param_2.4492: s32[4096]) -> s32[256] {
+  %param_0.4522 = s32[256]{0:T(256)} parameter(0)
   %param_1.5327 = s32[4096]{0:T(1024)} parameter(1)
-  %param_2.4496 = s32[4096]{0:T(1024)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.40.cloned.1 = s32[256]{0:T(256)} call(%param_0.4527, %param_1.5327, %param_2.4496), to_apply=%called_computation.14, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/scatter-add" stack_frame_id=0}
+  %param_2.4492 = s32[4096]{0:T(1024)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.39 = s32[256]{0:T(256)} fusion(%param_0.4522, %param_1.5327, %param_2.4492), kind=kCustom, calls=%fused_computation.22.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["256"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"4160","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.14 (param_0.4523: s32[256], param_1.5328: s32[4096], param_2.4493: s32[4096]) -> s32[256] {
+  %param_0.4523 = s32[256]{0:T(256)} parameter(0)
+  %param_1.5328 = s32[4096]{0:T(1024)} parameter(1)
+  %param_2.4493 = s32[4096]{0:T(1024)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.40.cloned.1 = s32[256]{0:T(256)} call(%param_0.4523, %param_1.5328, %param_2.4493), to_apply=%called_computation.14, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation (param_0.84: s32[256], param_1.136: s32[4096], param_2.80: s32[4096], param_3.3085: token[]) -> s32[256] {
@@ -598,45 +598,45 @@ StackFrames
   ROOT %scatter_offload_custom_fusion.2.cloned.1 = s32[256]{0:T(256)} call(%param_0.85, %param_1.137, %param_2.81, %param_3.3084), to_apply=%called_computation, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%called_computation.15 (param_0.4528: f32[9]) -> f32[9] {
-  %param_0.4528 = f32[9]{0:T(128)} parameter(0)
-  ROOT %copy.2075 = f32[9]{0:T(128)} copy(%param_0.4528), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"1131","iteration_bounds":[],"scratchpad_allocation_size":"128","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.15 (param_0.4524: f32[9]) -> f32[9] {
+  %param_0.4524 = f32[9]{0:T(128)} parameter(0)
+  ROOT %copy.2075 = f32[9]{0:T(128)} copy(%param_0.4524), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"1131","iteration_bounds":[],"scratchpad_allocation_size":"128","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.15 (param_0.4529: f32[9]) -> f32[9] {
-  %param_0.4529 = f32[9]{0:T(128)} parameter(0)
-  ROOT %copy.2076.cloned.1 = f32[9]{0:T(128)} call(%param_0.4529), to_apply=%called_computation.15
+%async_computation.15 (param_0.4525: f32[9]) -> f32[9] {
+  %param_0.4525 = f32[9]{0:T(128)} parameter(0)
+  ROOT %copy.2076.cloned.1 = f32[9]{0:T(128)} call(%param_0.4525), to_apply=%called_computation.15
 }, execution_thread="sparsecore"
 
 %region_61.72 (scatter-add.24: f32[], scatter-add.25: f32[]) -> f32[] {
   %scatter-add.24 = f32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.25 = f32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.1368 = f32[]{:T(128)S(7)} add(%scatter-add.24, %scatter-add.25), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.1393 = f32[]{:T(128)S(7)} add(%scatter-add.24, %scatter-add.25), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.24.clone.clone (param_0.4530: f32[9], param_1.5328: s32[256], param_2.4497: f32[256]) -> f32[9] {
-  %param_0.4530 = f32[9]{0:T(128)} parameter(0)
-  %param_1.5328 = s32[256]{0:T(256)} parameter(1)
-  %reshape.3905 = s32[256]{0:T(256)} reshape(%param_1.5328), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1102 = s32[256]{0:T(256)} transpose(%reshape.3905), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %param_2.4497 = f32[256]{0:T(256)} parameter(2)
-  %reshape.3906 = f32[256]{0:T(256)} reshape(%param_2.4497), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1103 = f32[256]{0:T(256)} transpose(%reshape.3906), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  ROOT %scatter-add.232 = f32[9]{0:T(128)} scatter(%param_0.4530, %transpose.1102, %transpose.1103), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, indices_are_sorted=true, to_apply=%region_61.72, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.16 (param_0.4531: f32[9], param_1.5329: s32[256], param_2.4498: f32[256]) -> f32[9] {
-  %param_0.4531 = f32[9]{0:T(128)} parameter(0)
+%fused_computation.24.clone.clone (param_0.4526: f32[9], param_1.5329: s32[256], param_2.4494: f32[256]) -> f32[9] {
+  %param_0.4526 = f32[9]{0:T(128)} parameter(0)
   %param_1.5329 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4498 = f32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.41 = f32[9]{0:T(128)} fusion(%param_0.4531, %param_1.5329, %param_2.4498), kind=kCustom, calls=%fused_computation.24.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1312","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3913 = s32[256]{0:T(256)} reshape(%param_1.5329), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1102 = s32[256]{0:T(256)} transpose(%reshape.3913), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %param_2.4494 = f32[256]{0:T(256)} parameter(2)
+  %reshape.3914 = f32[256]{0:T(256)} reshape(%param_2.4494), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1103 = f32[256]{0:T(256)} transpose(%reshape.3914), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  ROOT %scatter-add.232 = f32[9]{0:T(128)} scatter(%param_0.4526, %transpose.1102, %transpose.1103), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, indices_are_sorted=true, to_apply=%region_61.72, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.16 (param_0.4532: f32[9], param_1.5330: s32[256], param_2.4499: f32[256]) -> f32[9] {
-  %param_0.4532 = f32[9]{0:T(128)} parameter(0)
+%called_computation.16 (param_0.4527: f32[9], param_1.5330: s32[256], param_2.4495: f32[256]) -> f32[9] {
+  %param_0.4527 = f32[9]{0:T(128)} parameter(0)
   %param_1.5330 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4499 = f32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.42.cloned.1 = f32[9]{0:T(128)} call(%param_0.4532, %param_1.5330, %param_2.4499), to_apply=%called_computation.16, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
+  %param_2.4495 = f32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.41 = f32[9]{0:T(128)} fusion(%param_0.4527, %param_1.5330, %param_2.4495), kind=kCustom, calls=%fused_computation.24.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1312","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.16 (param_0.4528: f32[9], param_1.5331: s32[256], param_2.4496: f32[256]) -> f32[9] {
+  %param_0.4528 = f32[9]{0:T(128)} parameter(0)
+  %param_1.5331 = s32[256]{0:T(256)} parameter(1)
+  %param_2.4496 = f32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.42.cloned.1 = f32[9]{0:T(128)} call(%param_0.4528, %param_1.5331, %param_2.4496), to_apply=%called_computation.16, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.1 (param_0.87: f32[9], param_1.139: s32[256], param_2.83: f32[256], param_3.3099: token[]) -> f32[9] {
@@ -658,45 +658,45 @@ StackFrames
   ROOT %scatter_offload_custom_fusion.5.cloned.1 = f32[9]{0:T(128)} call(%param_0.88, %param_1.140, %param_2.84, %param_3.3098), to_apply=%called_computation.1, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%called_computation.17 (param_0.4533: s32[263]) -> s32[263] {
-  %param_0.4533 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2077 = s32[263]{0:T(512)} copy(%param_0.4533), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.17 (param_0.4529: s32[263]) -> s32[263] {
+  %param_0.4529 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2077 = s32[263]{0:T(512)} copy(%param_0.4529), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.17 (param_0.4534: s32[263]) -> s32[263] {
-  %param_0.4534 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2078.cloned.1 = s32[263]{0:T(512)} call(%param_0.4534), to_apply=%called_computation.17
+%async_computation.17 (param_0.4530: s32[263]) -> s32[263] {
+  %param_0.4530 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2078.cloned.1 = s32[263]{0:T(512)} call(%param_0.4530), to_apply=%called_computation.17
 }, execution_thread="sparsecore"
 
 %region_63.74 (scatter-add.28: s32[], scatter-add.29: s32[]) -> s32[] {
   %scatter-add.28 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.29 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.1369 = s32[]{:T(128)S(7)} add(%scatter-add.28, %scatter-add.29), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.1394 = s32[]{:T(128)S(7)} add(%scatter-add.28, %scatter-add.29), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.25.clone.clone (param_0.4535: s32[263], param_1.5331: s32[8], param_2.4500: s32[8]) -> s32[263] {
-  %param_0.4535 = s32[263]{0:T(512)} parameter(0)
-  %param_1.5331 = s32[8]{0:T(128)} parameter(1)
-  %reshape.3907 = s32[8]{0:T(128)} reshape(%param_1.5331), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
-  %transpose.1104 = s32[8]{0:T(128)} transpose(%reshape.3907), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
-  %param_2.4500 = s32[8]{0:T(128)} parameter(2)
-  %reshape.3908 = s32[8]{0:T(128)} reshape(%param_2.4500), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
-  %transpose.1105 = s32[8]{0:T(128)} transpose(%reshape.3908), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
-  ROOT %scatter-add.233 = s32[263]{0:T(512)} scatter(%param_0.4535, %transpose.1104, %transpose.1105), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_63.74, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.18 (param_0.4536: s32[263], param_1.5332: s32[8], param_2.4501: s32[8]) -> s32[263] {
-  %param_0.4536 = s32[263]{0:T(512)} parameter(0)
+%fused_computation.25.clone.clone (param_0.4531: s32[263], param_1.5332: s32[8], param_2.4497: s32[8]) -> s32[263] {
+  %param_0.4531 = s32[263]{0:T(512)} parameter(0)
   %param_1.5332 = s32[8]{0:T(128)} parameter(1)
-  %param_2.4501 = s32[8]{0:T(128)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.43 = s32[263]{0:T(512)} fusion(%param_0.4536, %param_1.5332, %param_2.4501), kind=kCustom, calls=%fused_computation.25.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3915 = s32[8]{0:T(128)} reshape(%param_1.5332), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
+  %transpose.1104 = s32[8]{0:T(128)} transpose(%reshape.3915), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
+  %param_2.4497 = s32[8]{0:T(128)} parameter(2)
+  %reshape.3916 = s32[8]{0:T(128)} reshape(%param_2.4497), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
+  %transpose.1105 = s32[8]{0:T(128)} transpose(%reshape.3916), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
+  ROOT %scatter-add.233 = s32[263]{0:T(512)} scatter(%param_0.4531, %transpose.1104, %transpose.1105), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_63.74, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.18 (param_0.4537: s32[263], param_1.5333: s32[8], param_2.4502: s32[8]) -> s32[263] {
-  %param_0.4537 = s32[263]{0:T(512)} parameter(0)
+%called_computation.18 (param_0.4532: s32[263], param_1.5333: s32[8], param_2.4498: s32[8]) -> s32[263] {
+  %param_0.4532 = s32[263]{0:T(512)} parameter(0)
   %param_1.5333 = s32[8]{0:T(128)} parameter(1)
-  %param_2.4502 = s32[8]{0:T(128)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.44.cloned.1 = s32[263]{0:T(512)} call(%param_0.4537, %param_1.5333, %param_2.4502), to_apply=%called_computation.18, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
+  %param_2.4498 = s32[8]{0:T(128)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.43 = s32[263]{0:T(512)} fusion(%param_0.4532, %param_1.5333, %param_2.4498), kind=kCustom, calls=%fused_computation.25.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.18 (param_0.4533: s32[263], param_1.5334: s32[8], param_2.4499: s32[8]) -> s32[263] {
+  %param_0.4533 = s32[263]{0:T(512)} parameter(0)
+  %param_1.5334 = s32[8]{0:T(128)} parameter(1)
+  %param_2.4499 = s32[8]{0:T(128)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.44.cloned.1 = s32[263]{0:T(512)} call(%param_0.4533, %param_1.5334, %param_2.4499), to_apply=%called_computation.18, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.2 (param_0.90: s32[263], param_1.142: s32[8], param_2.86: s32[8], param_3.3105: token[]) -> s32[263] {
@@ -718,45 +718,45 @@ StackFrames
   ROOT %scatter_offload_custom_fusion.8.cloned.1 = s32[263]{0:T(512)} call(%param_0.91, %param_1.143, %param_2.87, %param_3.3104), to_apply=%called_computation.2, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/rematted_computation/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%called_computation.19 (param_0.4538: s32[263]) -> s32[263] {
-  %param_0.4538 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2079 = s32[263]{0:T(512)} copy(%param_0.4538), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.19 (param_0.4534: s32[263]) -> s32[263] {
+  %param_0.4534 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2079 = s32[263]{0:T(512)} copy(%param_0.4534), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.19 (param_0.4539: s32[263]) -> s32[263] {
-  %param_0.4539 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2080.cloned.1 = s32[263]{0:T(512)} call(%param_0.4539), to_apply=%called_computation.19
+%async_computation.19 (param_0.4535: s32[263]) -> s32[263] {
+  %param_0.4535 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2080.cloned.1 = s32[263]{0:T(512)} call(%param_0.4535), to_apply=%called_computation.19
 }, execution_thread="sparsecore"
 
 %region_73.86.clone (scatter-add.163: s32[], scatter-add.164: s32[]) -> s32[] {
   %scatter-add.163 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.164 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.2482 = s32[]{:T(128)S(7)} add(%scatter-add.163, %scatter-add.164), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.2527 = s32[]{:T(128)S(7)} add(%scatter-add.163, %scatter-add.164), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.26.clone.clone (param_0.4540: s32[263], param_1.5334: s32[256], param_2.4503: s32[256]) -> s32[263] {
-  %param_0.4540 = s32[263]{0:T(512)} parameter(0)
-  %param_1.5334 = s32[256]{0:T(256)} parameter(1)
-  %reshape.3909 = s32[256]{0:T(256)} reshape(%param_1.5334), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
-  %transpose.1106 = s32[256]{0:T(256)} transpose(%reshape.3909), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
-  %param_2.4503 = s32[256]{0:T(256)} parameter(2)
-  %reshape.3910 = s32[256]{0:T(256)} reshape(%param_2.4503), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1107 = s32[256]{0:T(256)} transpose(%reshape.3910), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  ROOT %scatter-add.234 = s32[263]{0:T(512)} scatter(%param_0.4540, %transpose.1106, %transpose.1107), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_73.86.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.20 (param_0.4541: s32[263], param_1.5335: s32[256], param_2.4504: s32[256]) -> s32[263] {
-  %param_0.4541 = s32[263]{0:T(512)} parameter(0)
+%fused_computation.26.clone.clone (param_0.4536: s32[263], param_1.5335: s32[256], param_2.4500: s32[256]) -> s32[263] {
+  %param_0.4536 = s32[263]{0:T(512)} parameter(0)
   %param_1.5335 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4504 = s32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.45 = s32[263]{0:T(512)} fusion(%param_0.4541, %param_1.5335, %param_2.4504), kind=kCustom, calls=%fused_computation.26.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"384","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3917 = s32[256]{0:T(256)} reshape(%param_1.5335), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
+  %transpose.1106 = s32[256]{0:T(256)} transpose(%reshape.3917), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
+  %param_2.4500 = s32[256]{0:T(256)} parameter(2)
+  %reshape.3918 = s32[256]{0:T(256)} reshape(%param_2.4500), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1107 = s32[256]{0:T(256)} transpose(%reshape.3918), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  ROOT %scatter-add.234 = s32[263]{0:T(512)} scatter(%param_0.4536, %transpose.1106, %transpose.1107), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_73.86.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.20 (param_0.4542: s32[263], param_1.5336: s32[256], param_2.4505: s32[256]) -> s32[263] {
-  %param_0.4542 = s32[263]{0:T(512)} parameter(0)
+%called_computation.20 (param_0.4537: s32[263], param_1.5336: s32[256], param_2.4501: s32[256]) -> s32[263] {
+  %param_0.4537 = s32[263]{0:T(512)} parameter(0)
   %param_1.5336 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4505 = s32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.46.cloned.1 = s32[263]{0:T(512)} call(%param_0.4542, %param_1.5336, %param_2.4505), to_apply=%called_computation.20, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
+  %param_2.4501 = s32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.45 = s32[263]{0:T(512)} fusion(%param_0.4537, %param_1.5336, %param_2.4501), kind=kCustom, calls=%fused_computation.26.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"384","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.20 (param_0.4538: s32[263], param_1.5337: s32[256], param_2.4502: s32[256]) -> s32[263] {
+  %param_0.4538 = s32[263]{0:T(512)} parameter(0)
+  %param_1.5337 = s32[256]{0:T(256)} parameter(1)
+  %param_2.4502 = s32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.46.cloned.1 = s32[263]{0:T(512)} call(%param_0.4538, %param_1.5337, %param_2.4502), to_apply=%called_computation.20, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.3 (param_0.93: s32[263], param_1.145: s32[256], param_2.89: s32[256], param_3.3091: token[]) -> s32[263] {
@@ -778,45 +778,45 @@ StackFrames
   ROOT %scatter_offload_custom_fusion.11.cloned.1 = s32[263]{0:T(512)} call(%param_0.94, %param_1.146, %param_2.90, %param_3.3090), to_apply=%called_computation.3, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%called_computation.21 (param_0.4543: f32[9]) -> f32[9] {
-  %param_0.4543 = f32[9]{0:T(128)} parameter(0)
-  ROOT %copy.2081 = f32[9]{0:T(128)} copy(%param_0.4543), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"1131","iteration_bounds":[],"scratchpad_allocation_size":"128","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.21 (param_0.4539: f32[9]) -> f32[9] {
+  %param_0.4539 = f32[9]{0:T(128)} parameter(0)
+  ROOT %copy.2081 = f32[9]{0:T(128)} copy(%param_0.4539), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"1131","iteration_bounds":[],"scratchpad_allocation_size":"128","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.21 (param_0.4544: f32[9]) -> f32[9] {
-  %param_0.4544 = f32[9]{0:T(128)} parameter(0)
-  ROOT %copy.2082.cloned.1 = f32[9]{0:T(128)} call(%param_0.4544), to_apply=%called_computation.21
+%async_computation.21 (param_0.4540: f32[9]) -> f32[9] {
+  %param_0.4540 = f32[9]{0:T(128)} parameter(0)
+  ROOT %copy.2082.cloned.1 = f32[9]{0:T(128)} call(%param_0.4540), to_apply=%called_computation.21
 }, execution_thread="sparsecore"
 
 %region_79.95.clone (scatter-add.167: f32[], scatter-add.168: f32[]) -> f32[] {
   %scatter-add.167 = f32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.168 = f32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.2484 = f32[]{:T(128)S(7)} add(%scatter-add.167, %scatter-add.168), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.2529 = f32[]{:T(128)S(7)} add(%scatter-add.167, %scatter-add.168), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.27.clone.clone (param_0.4545: f32[9], param_1.5337: s32[256], param_2.4506: f32[256]) -> f32[9] {
-  %param_0.4545 = f32[9]{0:T(128)} parameter(0)
-  %param_1.5337 = s32[256]{0:T(256)} parameter(1)
-  %reshape.3911 = s32[256]{0:T(256)} reshape(%param_1.5337), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1108 = s32[256]{0:T(256)} transpose(%reshape.3911), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %param_2.4506 = f32[256]{0:T(256)} parameter(2)
-  %reshape.3912 = f32[256]{0:T(256)} reshape(%param_2.4506), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1109 = f32[256]{0:T(256)} transpose(%reshape.3912), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  ROOT %scatter-add.235 = f32[9]{0:T(128)} scatter(%param_0.4545, %transpose.1108, %transpose.1109), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, indices_are_sorted=true, to_apply=%region_79.95.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.22 (param_0.4546: f32[9], param_1.5338: s32[256], param_2.4507: f32[256]) -> f32[9] {
-  %param_0.4546 = f32[9]{0:T(128)} parameter(0)
+%fused_computation.27.clone.clone (param_0.4541: f32[9], param_1.5338: s32[256], param_2.4503: f32[256]) -> f32[9] {
+  %param_0.4541 = f32[9]{0:T(128)} parameter(0)
   %param_1.5338 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4507 = f32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.47 = f32[9]{0:T(128)} fusion(%param_0.4546, %param_1.5338, %param_2.4507), kind=kCustom, calls=%fused_computation.27.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1312","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3919 = s32[256]{0:T(256)} reshape(%param_1.5338), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1108 = s32[256]{0:T(256)} transpose(%reshape.3919), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %param_2.4503 = f32[256]{0:T(256)} parameter(2)
+  %reshape.3920 = f32[256]{0:T(256)} reshape(%param_2.4503), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1109 = f32[256]{0:T(256)} transpose(%reshape.3920), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  ROOT %scatter-add.235 = f32[9]{0:T(128)} scatter(%param_0.4541, %transpose.1108, %transpose.1109), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, indices_are_sorted=true, to_apply=%region_79.95.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.22 (param_0.4547: f32[9], param_1.5339: s32[256], param_2.4508: f32[256]) -> f32[9] {
-  %param_0.4547 = f32[9]{0:T(128)} parameter(0)
+%called_computation.22 (param_0.4542: f32[9], param_1.5339: s32[256], param_2.4504: f32[256]) -> f32[9] {
+  %param_0.4542 = f32[9]{0:T(128)} parameter(0)
   %param_1.5339 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4508 = f32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.48.cloned.1 = f32[9]{0:T(128)} call(%param_0.4547, %param_1.5339, %param_2.4508), to_apply=%called_computation.22, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
+  %param_2.4504 = f32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.47 = f32[9]{0:T(128)} fusion(%param_0.4542, %param_1.5339, %param_2.4504), kind=kCustom, calls=%fused_computation.27.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1312","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.22 (param_0.4543: f32[9], param_1.5340: s32[256], param_2.4505: f32[256]) -> f32[9] {
+  %param_0.4543 = f32[9]{0:T(128)} parameter(0)
+  %param_1.5340 = s32[256]{0:T(256)} parameter(1)
+  %param_2.4505 = f32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.48.cloned.1 = f32[9]{0:T(128)} call(%param_0.4543, %param_1.5340, %param_2.4505), to_apply=%called_computation.22, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.4 (param_0.96: f32[9], param_1.148: s32[256], param_2.92: f32[256], param_3.3097: token[]) -> f32[9] {
@@ -838,45 +838,45 @@ StackFrames
   ROOT %scatter_offload_custom_fusion.14.cloned.1 = f32[9]{0:T(128)} call(%param_0.97, %param_1.149, %param_2.93, %param_3.3096), to_apply=%called_computation.4, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%called_computation.23 (param_0.4548: s32[263]) -> s32[263] {
-  %param_0.4548 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2083 = s32[263]{0:T(512)} copy(%param_0.4548), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.23 (param_0.4544: s32[263]) -> s32[263] {
+  %param_0.4544 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2083 = s32[263]{0:T(512)} copy(%param_0.4544), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.23 (param_0.4549: s32[263]) -> s32[263] {
-  %param_0.4549 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2084.cloned.1 = s32[263]{0:T(512)} call(%param_0.4549), to_apply=%called_computation.23
+%async_computation.23 (param_0.4545: s32[263]) -> s32[263] {
+  %param_0.4545 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2084.cloned.1 = s32[263]{0:T(512)} call(%param_0.4545), to_apply=%called_computation.23
 }, execution_thread="sparsecore"
 
 %region_81.97.clone (scatter-add.171: s32[], scatter-add.172: s32[]) -> s32[] {
   %scatter-add.171 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.172 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.2486 = s32[]{:T(128)S(7)} add(%scatter-add.171, %scatter-add.172), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.2531 = s32[]{:T(128)S(7)} add(%scatter-add.171, %scatter-add.172), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.28.clone.clone (param_0.4550: s32[263], param_1.5340: s32[8], param_2.4509: s32[8]) -> s32[263] {
-  %param_0.4550 = s32[263]{0:T(512)} parameter(0)
-  %param_1.5340 = s32[8]{0:T(128)} parameter(1)
-  %reshape.3913 = s32[8]{0:T(128)} reshape(%param_1.5340), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
-  %transpose.1110 = s32[8]{0:T(128)} transpose(%reshape.3913), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
-  %param_2.4509 = s32[8]{0:T(128)} parameter(2)
-  %reshape.3914 = s32[8]{0:T(128)} reshape(%param_2.4509), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
-  %transpose.1111 = s32[8]{0:T(128)} transpose(%reshape.3914), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
-  ROOT %scatter-add.236 = s32[263]{0:T(512)} scatter(%param_0.4550, %transpose.1110, %transpose.1111), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_81.97.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.24 (param_0.4551: s32[263], param_1.5341: s32[8], param_2.4510: s32[8]) -> s32[263] {
-  %param_0.4551 = s32[263]{0:T(512)} parameter(0)
+%fused_computation.28.clone.clone (param_0.4546: s32[263], param_1.5341: s32[8], param_2.4506: s32[8]) -> s32[263] {
+  %param_0.4546 = s32[263]{0:T(512)} parameter(0)
   %param_1.5341 = s32[8]{0:T(128)} parameter(1)
-  %param_2.4510 = s32[8]{0:T(128)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.49 = s32[263]{0:T(512)} fusion(%param_0.4551, %param_1.5341, %param_2.4510), kind=kCustom, calls=%fused_computation.28.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3921 = s32[8]{0:T(128)} reshape(%param_1.5341), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
+  %transpose.1110 = s32[8]{0:T(128)} transpose(%reshape.3921), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
+  %param_2.4506 = s32[8]{0:T(128)} parameter(2)
+  %reshape.3922 = s32[8]{0:T(128)} reshape(%param_2.4506), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
+  %transpose.1111 = s32[8]{0:T(128)} transpose(%reshape.3922), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
+  ROOT %scatter-add.236 = s32[263]{0:T(512)} scatter(%param_0.4546, %transpose.1110, %transpose.1111), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_81.97.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.24 (param_0.4552: s32[263], param_1.5342: s32[8], param_2.4511: s32[8]) -> s32[263] {
-  %param_0.4552 = s32[263]{0:T(512)} parameter(0)
+%called_computation.24 (param_0.4547: s32[263], param_1.5342: s32[8], param_2.4507: s32[8]) -> s32[263] {
+  %param_0.4547 = s32[263]{0:T(512)} parameter(0)
   %param_1.5342 = s32[8]{0:T(128)} parameter(1)
-  %param_2.4511 = s32[8]{0:T(128)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.50.cloned.1 = s32[263]{0:T(512)} call(%param_0.4552, %param_1.5342, %param_2.4511), to_apply=%called_computation.24, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
+  %param_2.4507 = s32[8]{0:T(128)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.49 = s32[263]{0:T(512)} fusion(%param_0.4547, %param_1.5342, %param_2.4507), kind=kCustom, calls=%fused_computation.28.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.24 (param_0.4548: s32[263], param_1.5343: s32[8], param_2.4508: s32[8]) -> s32[263] {
+  %param_0.4548 = s32[263]{0:T(512)} parameter(0)
+  %param_1.5343 = s32[8]{0:T(128)} parameter(1)
+  %param_2.4508 = s32[8]{0:T(128)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.50.cloned.1 = s32[263]{0:T(512)} call(%param_0.4548, %param_1.5343, %param_2.4508), to_apply=%called_computation.24, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.5 (param_0.99: s32[263], param_1.151: s32[8], param_2.95: s32[8], param_3.3107: token[]) -> s32[263] {
@@ -898,45 +898,45 @@ StackFrames
   ROOT %scatter_offload_custom_fusion.17.cloned.1 = s32[263]{0:T(512)} call(%param_0.100, %param_1.152, %param_2.96, %param_3.3106), to_apply=%called_computation.5, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%called_computation.25 (param_0.4553: s32[263]) -> s32[263] {
-  %param_0.4553 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2085 = s32[263]{0:T(512)} copy(%param_0.4553), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.25 (param_0.4549: s32[263]) -> s32[263] {
+  %param_0.4549 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2085 = s32[263]{0:T(512)} copy(%param_0.4549), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.25 (param_0.4554: s32[263]) -> s32[263] {
-  %param_0.4554 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2086.cloned.1 = s32[263]{0:T(512)} call(%param_0.4554), to_apply=%called_computation.25
+%async_computation.25 (param_0.4550: s32[263]) -> s32[263] {
+  %param_0.4550 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2086.cloned.1 = s32[263]{0:T(512)} call(%param_0.4550), to_apply=%called_computation.25
 }, execution_thread="sparsecore"
 
 %region_96.114 (scatter-add.48: s32[], scatter-add.49: s32[]) -> s32[] {
   %scatter-add.48 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.49 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.1406 = s32[]{:T(128)S(7)} add(%scatter-add.48, %scatter-add.49), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.1434 = s32[]{:T(128)S(7)} add(%scatter-add.48, %scatter-add.49), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.29.clone.clone (param_0.4555: s32[263], param_1.5343: s32[256], param_2.4512: s32[256]) -> s32[263] {
-  %param_0.4555 = s32[263]{0:T(512)} parameter(0)
-  %param_1.5343 = s32[256]{0:T(256)} parameter(1)
-  %reshape.3915 = s32[256]{0:T(256)} reshape(%param_1.5343), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/select_n" stack_frame_id=0}
-  %transpose.1112 = s32[256]{0:T(256)} transpose(%reshape.3915), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/select_n" stack_frame_id=0}
-  %param_2.4512 = s32[256]{0:T(256)} parameter(2)
-  %reshape.3916 = s32[256]{0:T(256)} reshape(%param_2.4512), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1113 = s32[256]{0:T(256)} transpose(%reshape.3916), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  ROOT %scatter-add.237 = s32[263]{0:T(512)} scatter(%param_0.4555, %transpose.1112, %transpose.1113), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_96.114, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.26 (param_0.4556: s32[263], param_1.5344: s32[256], param_2.4513: s32[256]) -> s32[263] {
-  %param_0.4556 = s32[263]{0:T(512)} parameter(0)
+%fused_computation.29.clone.clone (param_0.4551: s32[263], param_1.5344: s32[256], param_2.4509: s32[256]) -> s32[263] {
+  %param_0.4551 = s32[263]{0:T(512)} parameter(0)
   %param_1.5344 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4513 = s32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.51 = s32[263]{0:T(512)} fusion(%param_0.4556, %param_1.5344, %param_2.4513), kind=kCustom, calls=%fused_computation.29.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"384","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3923 = s32[256]{0:T(256)} reshape(%param_1.5344), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/select_n" stack_frame_id=0}
+  %transpose.1112 = s32[256]{0:T(256)} transpose(%reshape.3923), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/select_n" stack_frame_id=0}
+  %param_2.4509 = s32[256]{0:T(256)} parameter(2)
+  %reshape.3924 = s32[256]{0:T(256)} reshape(%param_2.4509), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1113 = s32[256]{0:T(256)} transpose(%reshape.3924), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  ROOT %scatter-add.237 = s32[263]{0:T(512)} scatter(%param_0.4551, %transpose.1112, %transpose.1113), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_96.114, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.26 (param_0.4557: s32[263], param_1.5345: s32[256], param_2.4514: s32[256]) -> s32[263] {
-  %param_0.4557 = s32[263]{0:T(512)} parameter(0)
+%called_computation.26 (param_0.4552: s32[263], param_1.5345: s32[256], param_2.4510: s32[256]) -> s32[263] {
+  %param_0.4552 = s32[263]{0:T(512)} parameter(0)
   %param_1.5345 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4514 = s32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.52.cloned.1 = s32[263]{0:T(512)} call(%param_0.4557, %param_1.5345, %param_2.4514), to_apply=%called_computation.26, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
+  %param_2.4510 = s32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.51 = s32[263]{0:T(512)} fusion(%param_0.4552, %param_1.5345, %param_2.4510), kind=kCustom, calls=%fused_computation.29.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"384","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.26 (param_0.4553: s32[263], param_1.5346: s32[256], param_2.4511: s32[256]) -> s32[263] {
+  %param_0.4553 = s32[263]{0:T(512)} parameter(0)
+  %param_1.5346 = s32[256]{0:T(256)} parameter(1)
+  %param_2.4511 = s32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.52.cloned.1 = s32[263]{0:T(512)} call(%param_0.4553, %param_1.5346, %param_2.4511), to_apply=%called_computation.26, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.6 (param_0.102: s32[263], param_1.154: s32[256], param_2.98: s32[256], param_3.3093: token[]) -> s32[263] {
@@ -961,32 +961,32 @@ StackFrames
 %region_102.120 (scatter-add.52: f32[], scatter-add.53: f32[]) -> f32[] {
   %scatter-add.52 = f32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.53 = f32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.1409 = f32[]{:T(128)S(7)} add(%scatter-add.52, %scatter-add.53), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.1437 = f32[]{:T(128)S(7)} add(%scatter-add.52, %scatter-add.53), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.30.clone.clone (param_0.4560: f32[9], param_1.5346: s32[256], param_2.4515: f32[256]) -> f32[9] {
-  %param_0.4560 = f32[9]{0:T(128)} parameter(0)
-  %param_1.5346 = s32[256]{0:T(256)} parameter(1)
-  %reshape.3917 = s32[256]{0:T(256)} reshape(%param_1.5346), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1114 = s32[256]{0:T(256)} transpose(%reshape.3917), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/broadcast_in_dim" stack_frame_id=0}
-  %param_2.4515 = f32[256]{0:T(256)} parameter(2)
-  %reshape.3918 = f32[256]{0:T(256)} reshape(%param_2.4515), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1115 = f32[256]{0:T(256)} transpose(%reshape.3918), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  ROOT %scatter-add.238 = f32[9]{0:T(128)} scatter(%param_0.4560, %transpose.1114, %transpose.1115), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, indices_are_sorted=true, to_apply=%region_102.120, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.28 (param_0.4561: f32[9], param_1.5347: s32[256], param_2.4516: f32[256]) -> f32[9] {
-  %param_0.4561 = f32[9]{0:T(128)} parameter(0)
+%fused_computation.30.clone.clone (param_0.4556: f32[9], param_1.5347: s32[256], param_2.4512: f32[256]) -> f32[9] {
+  %param_0.4556 = f32[9]{0:T(128)} parameter(0)
   %param_1.5347 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4516 = f32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.53 = f32[9]{0:T(128)} fusion(%param_0.4561, %param_1.5347, %param_2.4516), kind=kCustom, calls=%fused_computation.30.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1312","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3925 = s32[256]{0:T(256)} reshape(%param_1.5347), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1114 = s32[256]{0:T(256)} transpose(%reshape.3925), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/broadcast_in_dim" stack_frame_id=0}
+  %param_2.4512 = f32[256]{0:T(256)} parameter(2)
+  %reshape.3926 = f32[256]{0:T(256)} reshape(%param_2.4512), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1115 = f32[256]{0:T(256)} transpose(%reshape.3926), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  ROOT %scatter-add.238 = f32[9]{0:T(128)} scatter(%param_0.4556, %transpose.1114, %transpose.1115), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, indices_are_sorted=true, to_apply=%region_102.120, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.28 (param_0.4562: f32[9], param_1.5348: s32[256], param_2.4517: f32[256]) -> f32[9] {
-  %param_0.4562 = f32[9]{0:T(128)} parameter(0)
+%called_computation.28 (param_0.4557: f32[9], param_1.5348: s32[256], param_2.4513: f32[256]) -> f32[9] {
+  %param_0.4557 = f32[9]{0:T(128)} parameter(0)
   %param_1.5348 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4517 = f32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.54.cloned.1 = f32[9]{0:T(128)} call(%param_0.4562, %param_1.5348, %param_2.4517), to_apply=%called_computation.28, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
+  %param_2.4513 = f32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.53 = f32[9]{0:T(128)} fusion(%param_0.4557, %param_1.5348, %param_2.4513), kind=kCustom, calls=%fused_computation.30.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1312","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.28 (param_0.4558: f32[9], param_1.5349: s32[256], param_2.4514: f32[256]) -> f32[9] {
+  %param_0.4558 = f32[9]{0:T(128)} parameter(0)
+  %param_1.5349 = s32[256]{0:T(256)} parameter(1)
+  %param_2.4514 = f32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.54.cloned.1 = f32[9]{0:T(128)} call(%param_0.4558, %param_1.5349, %param_2.4514), to_apply=%called_computation.28, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.7 (param_0.105: f32[9], param_1.157: s32[256], param_2.101: f32[256], param_3.3101: token[]) -> f32[9] {
@@ -1009,32 +1009,32 @@ StackFrames
 %region_104.122 (scatter-add.83: s32[], scatter-add.84: s32[]) -> s32[] {
   %scatter-add.83 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.84 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.1410 = s32[]{:T(128)S(7)} add(%scatter-add.83, %scatter-add.84), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.1438 = s32[]{:T(128)S(7)} add(%scatter-add.83, %scatter-add.84), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.31.clone.clone (param_0.4565: s32[263], param_1.5349: s32[8], param_2.4518: s32[8]) -> s32[263] {
-  %param_0.4565 = s32[263]{0:T(512)} parameter(0)
-  %param_1.5349 = s32[8]{0:T(128)} parameter(1)
-  %reshape.3919 = s32[8]{0:T(128)} reshape(%param_1.5349), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/select_n" stack_frame_id=0}
-  %transpose.1116 = s32[8]{0:T(128)} transpose(%reshape.3919), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/select_n" stack_frame_id=0}
-  %param_2.4518 = s32[8]{0:T(128)} parameter(2)
-  %reshape.3920 = s32[8]{0:T(128)} reshape(%param_2.4518), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
-  %transpose.1117 = s32[8]{0:T(128)} transpose(%reshape.3920), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
-  ROOT %scatter-add.239 = s32[263]{0:T(512)} scatter(%param_0.4565, %transpose.1116, %transpose.1117), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_104.122, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.30 (param_0.4566: s32[263], param_1.5350: s32[8], param_2.4519: s32[8]) -> s32[263] {
-  %param_0.4566 = s32[263]{0:T(512)} parameter(0)
+%fused_computation.31.clone.clone (param_0.4561: s32[263], param_1.5350: s32[8], param_2.4515: s32[8]) -> s32[263] {
+  %param_0.4561 = s32[263]{0:T(512)} parameter(0)
   %param_1.5350 = s32[8]{0:T(128)} parameter(1)
-  %param_2.4519 = s32[8]{0:T(128)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.55 = s32[263]{0:T(512)} fusion(%param_0.4566, %param_1.5350, %param_2.4519), kind=kCustom, calls=%fused_computation.31.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3927 = s32[8]{0:T(128)} reshape(%param_1.5350), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/select_n" stack_frame_id=0}
+  %transpose.1116 = s32[8]{0:T(128)} transpose(%reshape.3927), dimensions={0}, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/select_n" stack_frame_id=0}
+  %param_2.4515 = s32[8]{0:T(128)} parameter(2)
+  %reshape.3928 = s32[8]{0:T(128)} reshape(%param_2.4515), metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
+  %transpose.1117 = s32[8]{0:T(128)} transpose(%reshape.3928), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/jit(gmm)/broadcast.80" stack_frame_id=0}
+  ROOT %scatter-add.239 = s32[263]{0:T(512)} scatter(%param_0.4561, %transpose.1116, %transpose.1117), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_104.122, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.30 (param_0.4567: s32[263], param_1.5351: s32[8], param_2.4520: s32[8]) -> s32[263] {
-  %param_0.4567 = s32[263]{0:T(512)} parameter(0)
+%called_computation.30 (param_0.4562: s32[263], param_1.5351: s32[8], param_2.4516: s32[8]) -> s32[263] {
+  %param_0.4562 = s32[263]{0:T(512)} parameter(0)
   %param_1.5351 = s32[8]{0:T(128)} parameter(1)
-  %param_2.4520 = s32[8]{0:T(128)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.56.cloned.1 = s32[263]{0:T(512)} call(%param_0.4567, %param_1.5351, %param_2.4520), to_apply=%called_computation.30, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
+  %param_2.4516 = s32[8]{0:T(128)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.55 = s32[263]{0:T(512)} fusion(%param_0.4562, %param_1.5351, %param_2.4516), kind=kCustom, calls=%fused_computation.31.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.30 (param_0.4563: s32[263], param_1.5352: s32[8], param_2.4517: s32[8]) -> s32[263] {
+  %param_0.4563 = s32[263]{0:T(512)} parameter(0)
+  %param_1.5352 = s32[8]{0:T(128)} parameter(1)
+  %param_2.4517 = s32[8]{0:T(128)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.56.cloned.1 = s32[263]{0:T(512)} call(%param_0.4563, %param_1.5352, %param_2.4517), to_apply=%called_computation.30, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/shard_map/jit(tgmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.8 (param_0.108: s32[263], param_1.160: s32[8], param_2.104: s32[8], param_3.3109: token[]) -> s32[263] {
@@ -1057,32 +1057,32 @@ StackFrames
 %region_14.20 (scatter-add.0: s32[], scatter-add.1: s32[]) -> s32[] {
   %scatter-add.0 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.1 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.1322 = s32[]{:T(128)S(7)} add(%scatter-add.0, %scatter-add.1), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.1345 = s32[]{:T(128)S(7)} add(%scatter-add.0, %scatter-add.1), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.17.clone.clone.clone (param_0.4570: s32[256], param_1.5352: s32[4096], param_2.4521: s32[4096]) -> s32[256] {
-  %param_0.4570 = s32[256]{0:T(256)} parameter(0)
-  %param_1.5352 = s32[4096]{0:T(1024)} parameter(1)
-  %reshape.3921 = s32[4096]{0:T(1024)} reshape(%param_1.5352), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/select_n" stack_frame_id=0}
-  %transpose.1118 = s32[4096]{0:T(1024)} transpose(%reshape.3921), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/select_n" stack_frame_id=0}
-  %param_2.4521 = s32[4096]{0:T(1024)} parameter(2)
-  %reshape.3922 = s32[4096]{0:T(1024)} reshape(%param_2.4521), metadata={op_name="jit(train_step)/moe_layers/shard_map/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1119 = s32[4096]{0:T(1024)} transpose(%reshape.3922), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/broadcast_in_dim" stack_frame_id=0}
-  ROOT %scatter-add.240 = s32[256]{0:T(256)} scatter(%param_0.4570, %transpose.1118, %transpose.1119), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_14.20, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.32 (param_0.4571: s32[256], param_1.5353: s32[4096], param_2.4522: s32[4096]) -> s32[256] {
-  %param_0.4571 = s32[256]{0:T(256)} parameter(0)
+%fused_computation.17.clone.clone.clone (param_0.4566: s32[256], param_1.5353: s32[4096], param_2.4518: s32[4096]) -> s32[256] {
+  %param_0.4566 = s32[256]{0:T(256)} parameter(0)
   %param_1.5353 = s32[4096]{0:T(1024)} parameter(1)
-  %param_2.4522 = s32[4096]{0:T(1024)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.57 = s32[256]{0:T(256)} fusion(%param_0.4571, %param_1.5353, %param_2.4522), kind=kCustom, calls=%fused_computation.17.clone.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["256"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"4160","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3929 = s32[4096]{0:T(1024)} reshape(%param_1.5353), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/select_n" stack_frame_id=0}
+  %transpose.1118 = s32[4096]{0:T(1024)} transpose(%reshape.3929), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/select_n" stack_frame_id=0}
+  %param_2.4518 = s32[4096]{0:T(1024)} parameter(2)
+  %reshape.3930 = s32[4096]{0:T(1024)} reshape(%param_2.4518), metadata={op_name="jit(train_step)/moe_layers/shard_map/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1119 = s32[4096]{0:T(1024)} transpose(%reshape.3930), dimensions={0}, metadata={op_name="jit(train_step)/moe_layers/shard_map/broadcast_in_dim" stack_frame_id=0}
+  ROOT %scatter-add.240 = s32[256]{0:T(256)} scatter(%param_0.4566, %transpose.1118, %transpose.1119), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_14.20, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.32 (param_0.4572: s32[256], param_1.5354: s32[4096], param_2.4523: s32[4096]) -> s32[256] {
-  %param_0.4572 = s32[256]{0:T(256)} parameter(0)
+%called_computation.32 (param_0.4567: s32[256], param_1.5354: s32[4096], param_2.4519: s32[4096]) -> s32[256] {
+  %param_0.4567 = s32[256]{0:T(256)} parameter(0)
   %param_1.5354 = s32[4096]{0:T(1024)} parameter(1)
-  %param_2.4523 = s32[4096]{0:T(1024)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.58.cloned.1 = s32[256]{0:T(256)} call(%param_0.4572, %param_1.5354, %param_2.4523), to_apply=%called_computation.32, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/scatter-add" stack_frame_id=0}
+  %param_2.4519 = s32[4096]{0:T(1024)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.57 = s32[256]{0:T(256)} fusion(%param_0.4567, %param_1.5354, %param_2.4519), kind=kCustom, calls=%fused_computation.17.clone.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["256"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"4160","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.32 (param_0.4568: s32[256], param_1.5355: s32[4096], param_2.4520: s32[4096]) -> s32[256] {
+  %param_0.4568 = s32[256]{0:T(256)} parameter(0)
+  %param_1.5355 = s32[4096]{0:T(1024)} parameter(1)
+  %param_2.4520 = s32[4096]{0:T(1024)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.58.cloned.1 = s32[256]{0:T(256)} call(%param_0.4568, %param_1.5355, %param_2.4520), to_apply=%called_computation.32, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.9 (param_0.111: s32[256], param_1.163: s32[4096], param_2.107: s32[4096], param_3.3087: token[]) -> s32[256] {
@@ -1102,45 +1102,45 @@ StackFrames
   ROOT %scatter_offload_custom_fusion.29.cloned.1 = s32[256]{0:T(256)} call(%param_0.112, %param_1.164, %param_2.108, %param_3.3086), to_apply=%called_computation.9, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%called_computation.33 (param_0.4573: s32[263]) -> s32[263] {
-  %param_0.4573 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2093 = s32[263]{0:T(512)} copy(%param_0.4573), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.33 (param_0.4569: s32[263]) -> s32[263] {
+  %param_0.4569 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2093 = s32[263]{0:T(512)} copy(%param_0.4569), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.33 (param_0.4574: s32[263]) -> s32[263] {
-  %param_0.4574 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2094.cloned.1 = s32[263]{0:T(512)} call(%param_0.4574), to_apply=%called_computation.33
+%async_computation.33 (param_0.4570: s32[263]) -> s32[263] {
+  %param_0.4570 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2094.cloned.1 = s32[263]{0:T(512)} call(%param_0.4570), to_apply=%called_computation.33
 }, execution_thread="sparsecore"
 
 %region_20.26.clone.1 (scatter-add.141: s32[], scatter-add.142: s32[]) -> s32[] {
   %scatter-add.141 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.142 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.2471 = s32[]{:T(128)S(7)} add(%scatter-add.141, %scatter-add.142), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.2516 = s32[]{:T(128)S(7)} add(%scatter-add.141, %scatter-add.142), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.18.clone.clone.clone (param_0.4575: s32[263], param_1.5355: s32[256], param_2.4524: s32[256]) -> s32[263] {
-  %param_0.4575 = s32[263]{0:T(512)} parameter(0)
-  %param_1.5355 = s32[256]{0:T(256)} parameter(1)
-  %reshape.3923 = s32[256]{0:T(256)} reshape(%param_1.5355), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
-  %transpose.1120 = s32[256]{0:T(256)} transpose(%reshape.3923), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
-  %param_2.4524 = s32[256]{0:T(256)} parameter(2)
-  %reshape.3924 = s32[256]{0:T(256)} reshape(%param_2.4524)
-  %transpose.1121 = s32[256]{0:T(256)} transpose(%reshape.3924), dimensions={0}
-  ROOT %scatter-add.241 = s32[263]{0:T(512)} scatter(%param_0.4575, %transpose.1120, %transpose.1121), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_20.26.clone.1, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.34 (param_0.4576: s32[263], param_1.5356: s32[256], param_2.4525: s32[256]) -> s32[263] {
-  %param_0.4576 = s32[263]{0:T(512)} parameter(0)
+%fused_computation.18.clone.clone.clone (param_0.4571: s32[263], param_1.5356: s32[256], param_2.4521: s32[256]) -> s32[263] {
+  %param_0.4571 = s32[263]{0:T(512)} parameter(0)
   %param_1.5356 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4525 = s32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.59 = s32[263]{0:T(512)} fusion(%param_0.4576, %param_1.5356, %param_2.4525), kind=kCustom, calls=%fused_computation.18.clone.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"384","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3931 = s32[256]{0:T(256)} reshape(%param_1.5356), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
+  %transpose.1120 = s32[256]{0:T(256)} transpose(%reshape.3931), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
+  %param_2.4521 = s32[256]{0:T(256)} parameter(2)
+  %reshape.3932 = s32[256]{0:T(256)} reshape(%param_2.4521)
+  %transpose.1121 = s32[256]{0:T(256)} transpose(%reshape.3932), dimensions={0}
+  ROOT %scatter-add.241 = s32[263]{0:T(512)} scatter(%param_0.4571, %transpose.1120, %transpose.1121), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_20.26.clone.1, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.34 (param_0.4577: s32[263], param_1.5357: s32[256], param_2.4526: s32[256]) -> s32[263] {
-  %param_0.4577 = s32[263]{0:T(512)} parameter(0)
+%called_computation.34 (param_0.4572: s32[263], param_1.5357: s32[256], param_2.4522: s32[256]) -> s32[263] {
+  %param_0.4572 = s32[263]{0:T(512)} parameter(0)
   %param_1.5357 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4526 = s32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.60.cloned.1 = s32[263]{0:T(512)} call(%param_0.4577, %param_1.5357, %param_2.4526), to_apply=%called_computation.34, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
+  %param_2.4522 = s32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.59 = s32[263]{0:T(512)} fusion(%param_0.4572, %param_1.5357, %param_2.4522), kind=kCustom, calls=%fused_computation.18.clone.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"384","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.34 (param_0.4573: s32[263], param_1.5358: s32[256], param_2.4523: s32[256]) -> s32[263] {
+  %param_0.4573 = s32[263]{0:T(512)} parameter(0)
+  %param_1.5358 = s32[256]{0:T(256)} parameter(1)
+  %param_2.4523 = s32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.60.cloned.1 = s32[263]{0:T(512)} call(%param_0.4573, %param_1.5358, %param_2.4523), to_apply=%called_computation.34, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.10 (param_0.114: s32[263], param_1.166: s32[256], param_2.110: s32[256], param_3.3089: token[]) -> s32[263] {
@@ -1162,45 +1162,45 @@ StackFrames
   ROOT %scatter_offload_custom_fusion.32.cloned.1 = s32[263]{0:T(512)} call(%param_0.115, %param_1.167, %param_2.111, %param_3.3088), to_apply=%called_computation.10, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%called_computation.35 (param_0.4578: f32[9]) -> f32[9] {
-  %param_0.4578 = f32[9]{0:T(128)} parameter(0)
-  ROOT %copy.2095 = f32[9]{0:T(128)} copy(%param_0.4578), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"1131","iteration_bounds":[],"scratchpad_allocation_size":"128","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.35 (param_0.4574: f32[9]) -> f32[9] {
+  %param_0.4574 = f32[9]{0:T(128)} parameter(0)
+  ROOT %copy.2095 = f32[9]{0:T(128)} copy(%param_0.4574), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"1131","iteration_bounds":[],"scratchpad_allocation_size":"128","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.35 (param_0.4579: f32[9]) -> f32[9] {
-  %param_0.4579 = f32[9]{0:T(128)} parameter(0)
-  ROOT %copy.2096.cloned.1 = f32[9]{0:T(128)} call(%param_0.4579), to_apply=%called_computation.35
+%async_computation.35 (param_0.4575: f32[9]) -> f32[9] {
+  %param_0.4575 = f32[9]{0:T(128)} parameter(0)
+  ROOT %copy.2096.cloned.1 = f32[9]{0:T(128)} call(%param_0.4575), to_apply=%called_computation.35
 }, execution_thread="sparsecore"
 
 %region_26.33.clone.1 (scatter-add.145: f32[], scatter-add.146: f32[]) -> f32[] {
   %scatter-add.145 = f32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.146 = f32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.2473 = f32[]{:T(128)S(7)} add(%scatter-add.145, %scatter-add.146), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.2518 = f32[]{:T(128)S(7)} add(%scatter-add.145, %scatter-add.146), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.19.clone.clone.clone (param_0.4580: f32[9], param_1.5358: s32[256], param_2.4527: f32[256]) -> f32[9] {
-  %param_0.4580 = f32[9]{0:T(128)} parameter(0)
-  %param_1.5358 = s32[256]{0:T(256)} parameter(1)
-  %reshape.3925 = s32[256]{0:T(256)} reshape(%param_1.5358), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %transpose.1122 = s32[256]{0:T(256)} transpose(%reshape.3925), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
-  %param_2.4527 = f32[256]{0:T(256)} parameter(2)
-  %reshape.3926 = f32[256]{0:T(256)} reshape(%param_2.4527)
-  %transpose.1123 = f32[256]{0:T(256)} transpose(%reshape.3926), dimensions={0}
-  ROOT %scatter-add.242 = f32[9]{0:T(128)} scatter(%param_0.4580, %transpose.1122, %transpose.1123), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, indices_are_sorted=true, to_apply=%region_26.33.clone.1, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.36 (param_0.4581: f32[9], param_1.5359: s32[256], param_2.4528: f32[256]) -> f32[9] {
-  %param_0.4581 = f32[9]{0:T(128)} parameter(0)
+%fused_computation.19.clone.clone.clone (param_0.4576: f32[9], param_1.5359: s32[256], param_2.4524: f32[256]) -> f32[9] {
+  %param_0.4576 = f32[9]{0:T(128)} parameter(0)
   %param_1.5359 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4528 = f32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.61 = f32[9]{0:T(128)} fusion(%param_0.4581, %param_1.5359, %param_2.4528), kind=kCustom, calls=%fused_computation.19.clone.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1312","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3933 = s32[256]{0:T(256)} reshape(%param_1.5359), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %transpose.1122 = s32[256]{0:T(256)} transpose(%reshape.3933), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/broadcast_in_dim" stack_frame_id=0}
+  %param_2.4524 = f32[256]{0:T(256)} parameter(2)
+  %reshape.3934 = f32[256]{0:T(256)} reshape(%param_2.4524)
+  %transpose.1123 = f32[256]{0:T(256)} transpose(%reshape.3934), dimensions={0}
+  ROOT %scatter-add.242 = f32[9]{0:T(128)} scatter(%param_0.4576, %transpose.1122, %transpose.1123), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, indices_are_sorted=true, to_apply=%region_26.33.clone.1, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.36 (param_0.4582: f32[9], param_1.5360: s32[256], param_2.4529: f32[256]) -> f32[9] {
-  %param_0.4582 = f32[9]{0:T(128)} parameter(0)
+%called_computation.36 (param_0.4577: f32[9], param_1.5360: s32[256], param_2.4525: f32[256]) -> f32[9] {
+  %param_0.4577 = f32[9]{0:T(128)} parameter(0)
   %param_1.5360 = s32[256]{0:T(256)} parameter(1)
-  %param_2.4529 = f32[256]{0:T(256)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.62.cloned.1 = f32[9]{0:T(128)} call(%param_0.4582, %param_1.5360, %param_2.4529), to_apply=%called_computation.36, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
+  %param_2.4525 = f32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.61 = f32[9]{0:T(128)} fusion(%param_0.4577, %param_1.5360, %param_2.4525), kind=kCustom, calls=%fused_computation.19.clone.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["16"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"1312","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.36 (param_0.4578: f32[9], param_1.5361: s32[256], param_2.4526: f32[256]) -> f32[9] {
+  %param_0.4578 = f32[9]{0:T(128)} parameter(0)
+  %param_1.5361 = s32[256]{0:T(256)} parameter(1)
+  %param_2.4526 = f32[256]{0:T(256)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.62.cloned.1 = f32[9]{0:T(128)} call(%param_0.4578, %param_1.5361, %param_2.4526), to_apply=%called_computation.36, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.11 (param_0.117: f32[9], param_1.169: s32[256], param_2.113: f32[256], param_3.3095: token[]) -> f32[9] {
@@ -1222,45 +1222,45 @@ StackFrames
   ROOT %scatter_offload_custom_fusion.35.cloned.1 = f32[9]{0:T(128)} call(%param_0.118, %param_1.170, %param_2.114, %param_3.3094), to_apply=%called_computation.11, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%called_computation.37 (param_0.4583: s32[263]) -> s32[263] {
-  %param_0.4583 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2097 = s32[263]{0:T(512)} copy(%param_0.4583), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+%called_computation.37 (param_0.4579: s32[263]) -> s32[263] {
+  %param_0.4579 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2097 = s32[263]{0:T(512)} copy(%param_0.4579), backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["32"],"input_window_bounds":[],"estimated_cycles":"1141","iteration_bounds":[],"scratchpad_allocation_size":"512","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"16","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%async_computation.37 (param_0.4584: s32[263]) -> s32[263] {
-  %param_0.4584 = s32[263]{0:T(512)} parameter(0)
-  ROOT %copy.2098.cloned.1 = s32[263]{0:T(512)} call(%param_0.4584), to_apply=%called_computation.37
+%async_computation.37 (param_0.4580: s32[263]) -> s32[263] {
+  %param_0.4580 = s32[263]{0:T(512)} parameter(0)
+  ROOT %copy.2098.cloned.1 = s32[263]{0:T(512)} call(%param_0.4580), to_apply=%called_computation.37
 }, execution_thread="sparsecore"
 
 %region_28.35.clone.1 (scatter-add.149: s32[], scatter-add.150: s32[]) -> s32[] {
   %scatter-add.149 = s32[]{:T(128)S(7)} parameter(0), metadata={op_name="scatter-add"}
   %scatter-add.150 = s32[]{:T(128)S(7)} parameter(1), metadata={op_name="scatter-add"}
-  ROOT %add.2475 = s32[]{:T(128)S(7)} add(%scatter-add.149, %scatter-add.150), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
+  ROOT %add.2520 = s32[]{:T(128)S(7)} add(%scatter-add.149, %scatter-add.150), metadata={op_name="add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["128"],"input_window_bounds":[],"estimated_cycles":"1165","iteration_bounds":[],"scratchpad_allocation_size":"520","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[{"unroll_dimension":"0","unroll_factor":"4","pipeline_remainder":false,"fully_unroll_if_trip_count_is_at_most":"0"}],"vectorizing_shape":[]},"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
-%fused_computation.20.clone.clone.clone (param_0.4585: s32[263], param_1.5361: s32[8], param_2.4530: s32[8]) -> s32[263] {
-  %param_0.4585 = s32[263]{0:T(512)} parameter(0)
-  %param_1.5361 = s32[8]{0:T(128)} parameter(1)
-  %reshape.3927 = s32[8]{0:T(128)} reshape(%param_1.5361), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
-  %transpose.1124 = s32[8]{0:T(128)} transpose(%reshape.3927), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
-  %param_2.4530 = s32[8]{0:T(128)} parameter(2)
-  %reshape.3928 = s32[8]{0:T(128)} reshape(%param_2.4530)
-  %transpose.1125 = s32[8]{0:T(128)} transpose(%reshape.3928), dimensions={0}
-  ROOT %scatter-add.243 = s32[263]{0:T(512)} scatter(%param_0.4585, %transpose.1124, %transpose.1125), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_28.35.clone.1, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
-}, execution_thread="sparsecore"
-
-%called_computation.38 (param_0.4586: s32[263], param_1.5362: s32[8], param_2.4531: s32[8]) -> s32[263] {
-  %param_0.4586 = s32[263]{0:T(512)} parameter(0)
+%fused_computation.20.clone.clone.clone (param_0.4581: s32[263], param_1.5362: s32[8], param_2.4527: s32[8]) -> s32[263] {
+  %param_0.4581 = s32[263]{0:T(512)} parameter(0)
   %param_1.5362 = s32[8]{0:T(128)} parameter(1)
-  %param_2.4531 = s32[8]{0:T(128)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.63 = s32[263]{0:T(512)} fusion(%param_0.4586, %param_1.5362, %param_2.4531), kind=kCustom, calls=%fused_computation.20.clone.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %reshape.3935 = s32[8]{0:T(128)} reshape(%param_1.5362), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
+  %transpose.1124 = s32[8]{0:T(128)} transpose(%reshape.3935), dimensions={0}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/select_n" stack_frame_id=0}
+  %param_2.4527 = s32[8]{0:T(128)} parameter(2)
+  %reshape.3936 = s32[8]{0:T(128)} reshape(%param_2.4527)
+  %transpose.1125 = s32[8]{0:T(128)} transpose(%reshape.3936), dimensions={0}
+  ROOT %scatter-add.243 = s32[263]{0:T(512)} scatter(%param_0.4581, %transpose.1124, %transpose.1125), update_window_dims={}, inserted_window_dims={0}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%region_28.35.clone.1, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
-%async_computation.38 (param_0.4587: s32[263], param_1.5363: s32[8], param_2.4532: s32[8]) -> s32[263] {
-  %param_0.4587 = s32[263]{0:T(512)} parameter(0)
+%called_computation.38 (param_0.4582: s32[263], param_1.5363: s32[8], param_2.4528: s32[8]) -> s32[263] {
+  %param_0.4582 = s32[263]{0:T(512)} parameter(0)
   %param_1.5363 = s32[8]{0:T(128)} parameter(1)
-  %param_2.4532 = s32[8]{0:T(128)} parameter(2)
-  ROOT %scatter_offload_custom_fusion.64.cloned.1 = s32[263]{0:T(512)} call(%param_0.4587, %param_1.5363, %param_2.4532), to_apply=%called_computation.38, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
+  %param_2.4528 = s32[8]{0:T(128)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.63 = s32[263]{0:T(512)} fusion(%param_0.4582, %param_1.5363, %param_2.4528), kind=kCustom, calls=%fused_computation.20.clone.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}, backend_config={"flag_configs":[],"window_config":{"kernel_window_bounds":[],"output_window_bounds":["8"],"input_window_bounds":[],"estimated_cycles":"9223372036854775807","iteration_bounds":[],"scratchpad_allocation_size":"256","cost_model_type":"COST_MODEL_TYPE_INVALID","ml_estimated_microseconds":0,"is_mask":false,"pad_output_on_minor_dim":"0","pad_input_on_minor_dim":"0","estimated_vmem_bytes":"0","estimated_bundle_count":"0","estimated_scoped_vmem_bytes":"0"},"loop_config":{"loop_order":[],"unrolled_loops":[],"vectorizing_shape":[]},"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+}, execution_thread="sparsecore"
+
+%async_computation.38 (param_0.4583: s32[263], param_1.5364: s32[8], param_2.4529: s32[8]) -> s32[263] {
+  %param_0.4583 = s32[263]{0:T(512)} parameter(0)
+  %param_1.5364 = s32[8]{0:T(128)} parameter(1)
+  %param_2.4529 = s32[8]{0:T(128)} parameter(2)
+  ROOT %scatter_offload_custom_fusion.64.cloned.1 = s32[263]{0:T(512)} call(%param_0.4583, %param_1.5364, %param_2.4529), to_apply=%called_computation.38, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/shard_map/jit(gmm)/scatter-add" stack_frame_id=0}
 }, execution_thread="sparsecore"
 
 %called_computation.12 (param_0.120: s32[263], param_1.172: s32[8], param_2.116: s32[8], param_3.3103: token[]) -> s32[263] {
@@ -1288,17 +1288,17 @@ StackFrames
   ROOT %reduce_sum.258 = f32[]{:T(128)} add(%reduce_sum.431, %reduce_sum.254), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.467 (param_0.4170: f32[3,1536,128,192]) -> f32[] {
-  %param_0.4170 = f32[3,1536,128,192]{2,3,0,1:T(8,128)} parameter(0)
-  %bitcast.672 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} bitcast(%param_0.4170), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/dense_layers.wrapped_fn/transpose" stack_frame_id=0}
+%fused_computation.466 (param_0.4166: f32[3,1536,128,192]) -> f32[] {
+  %param_0.4166 = f32[3,1536,128,192]{2,3,0,1:T(8,128)} parameter(0)
+  %bitcast.672 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} bitcast(%param_0.4166), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/dense_layers.wrapped_fn/transpose" stack_frame_id=0}
   %square.564 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%bitcast.672, %bitcast.672), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5086 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.669 = f32[]{:T(128)} reduce(%square.564, %constant.5086), dimensions={0,1,2,3}, to_apply=%region_154.179, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %constant.5101 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.669 = f32[]{:T(128)} reduce(%square.564, %constant.5101), dimensions={0,1,2,3}, to_apply=%region_154.179, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.468 (param_0.1421: f32[1536,3,128,192]) -> bf16[3,1536,128,192] {
-  %param_0.1421 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} parameter(0)
-  %copy.1550 = bf16[1536,3,128,192]{2,0,3,1:T(8,128)(2,1)} copy(%param_0.1421), sharding={replicated}, metadata={op_name="state.params[\'params\'][\'decoder\'][\'dense_layers\'][\'self_attention\'][\'wq_b\'][\'kernel\']"}
+%fused_computation.467 (param_0.1420: f32[1536,3,128,192]) -> bf16[3,1536,128,192] {
+  %param_0.1420 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} parameter(0)
+  %copy.1550 = bf16[1536,3,128,192]{2,0,3,1:T(8,128)(2,1)} copy(%param_0.1420), sharding={replicated}, metadata={op_name="state.params[\'params\'][\'decoder\'][\'dense_layers\'][\'self_attention\'][\'wq_b\'][\'kernel\']"}
   ROOT %bitcast.673 = bf16[3,1536,128,192]{2,1,3,0:T(8,128)(2,1)} bitcast(%copy.1550), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/dense_layers.wrapped_fn/transpose" stack_frame_id=0}
 }
 
@@ -1314,55 +1314,55 @@ StackFrames
   ROOT %reduce_sum.450 = f32[]{:T(128)} add(%reduce_sum.655, %reduce_sum.449), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.469 (param_0.4140: f32[1536,3,128,192], param_1.5025: f32[], param_2.4298: f32[], param_3.2951: f32[], param_4.2203: f32[1536,3,128,192], param_5.2006: f32[], param_6.1443: f32[3,1536,128,192], param_7.1124: pred[], param_8.889: f32[1536,3,128,192]) -> (f32[], f32[1536,3,128,192], f32[1536,3,128,192], f32[1536,3,128,192], f32[]) {
-  %param_0.4140 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} parameter(0)
+%fused_computation.468 (param_0.4136: f32[1536,3,128,192], param_1.5026: f32[], param_2.4295: f32[], param_3.2951: f32[], param_4.2203: f32[1536,3,128,192], param_5.2006: f32[], param_6.1443: f32[3,1536,128,192], param_7.1124: pred[], param_8.889: f32[1536,3,128,192]) -> (f32[], f32[1536,3,128,192], f32[1536,3,128,192], f32[1536,3,128,192], f32[]) {
+  %param_0.4136 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} parameter(0)
   %param_3.2951 = f32[]{:T(128)S(6)} parameter(3)
-  %mul.4715.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%param_3.2951), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4713.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%param_3.2951), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_7.1124 = pred[]{:T(512)S(6)} parameter(7)
   %select_n.2121.clone.1 = pred[1536,3,128,192]{2,3,1,0:T(8,128)(4,1)} broadcast(%param_7.1124), dimensions={}, metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
   %param_6.1443 = f32[3,1536,128,192]{2,3,0,1:T(8,128)} parameter(6)
   %bitcast.1374.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} bitcast(%param_6.1443), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/dense_layers.wrapped_fn/transpose" stack_frame_id=0}
   %param_5.2006 = f32[]{:T(128)} parameter(5)
-  %div.2565.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%param_5.2006), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2564.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} divide(%bitcast.1374.clone.1, %div.2565.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %select_n.2120.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} select(%select_n.2121.clone.1, %bitcast.1374.clone.1, %div.2564.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
-  %constant.4845.clone.1 = f32[]{:T(128)} constant(0.1)
-  %broadcast.4252.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%constant.4845.clone.1), dimensions={}, metadata={op_name="broadcast.334"}
-  %mul.4721.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%select_n.2120.clone.1, %broadcast.4252.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %div.2562.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%param_5.2006), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2561.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} divide(%bitcast.1374.clone.1, %div.2562.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %select_n.2120.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} select(%select_n.2121.clone.1, %bitcast.1374.clone.1, %div.2561.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
+  %constant.4860.clone.1 = f32[]{:T(128)} constant(0.1)
+  %broadcast.4272.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%constant.4860.clone.1), dimensions={}, metadata={op_name="broadcast.334"}
+  %mul.4719.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%select_n.2120.clone.1, %broadcast.4272.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_8.889 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} parameter(8)
-  %constant.4849.clone.1 = f32[]{:T(128)} constant(0.9)
-  %mul.4722.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%constant.4849.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4720.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%param_8.889, %mul.4722.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3429.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} add(%mul.4721.clone.1, %mul.4720.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_2.4298 = f32[]{:T(128)S(6)} parameter(2)
-  %div.2561.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%param_2.4298), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %constant.4864.clone.1 = f32[]{:T(128)} constant(0.9)
+  %mul.4720.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%constant.4864.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4718.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%param_8.889, %mul.4720.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3488.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} add(%mul.4719.clone.1, %mul.4718.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_2.4295 = f32[]{:T(128)S(6)} parameter(2)
+  %div.2558.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%param_2.4295), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %integer_pow.399.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%select_n.2120.clone.1, %select_n.2120.clone.1), metadata={op_name="jit(train_step)/integer_pow" stack_frame_id=0}
-  %constant.4848.clone.1 = f32[]{:T(128)} constant(0.05)
-  %mul.4719.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%constant.4848.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4717.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%integer_pow.399.clone.1, %mul.4719.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %constant.4863.clone.1 = f32[]{:T(128)} constant(0.05)
+  %mul.4717.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%constant.4863.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4715.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%integer_pow.399.clone.1, %mul.4717.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_4.2203 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} parameter(4)
-  %constant.4847.clone.1 = f32[]{:T(128)} constant(0.95)
-  %mul.4718.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%constant.4847.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4716.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%param_4.2203, %mul.4718.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3428.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} add(%mul.4717.clone.1, %mul.4716.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_1.5025 = f32[]{:T(128)S(6)} parameter(1)
-  %div.2560.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%param_1.5025), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2559.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} divide(%add.3428.clone.1, %div.2560.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %sqrt.157.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} sqrt(%div.2559.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
-  %constant.4846.clone.1 = f32[]{:T(128)} constant(1e-08)
-  %add.3427.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%constant.4846.clone.1), dimensions={}, metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %add.3426.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} add(%sqrt.157.clone.1, %add.3427.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %multiply.1293.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%div.2561.clone.1, %add.3426.clone.1), metadata={op_name="multiply.290"}
-  %div.2558.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} divide(%add.3429.clone.1, %multiply.1293.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %mul.4714.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%param_0.4140, %broadcast.4252.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3425.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} add(%div.2558.clone.1, %mul.4714.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %mul.4713.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%mul.4715.clone.1, %add.3425.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3424.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} add(%param_0.4140, %mul.4713.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %square.565 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%add.3424.clone.1, %add.3424.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5056 = f32[]{:T(128)} constant(0)
-  %reduce.670 = f32[]{:T(128)} reduce(%square.565, %constant.5056), dimensions={0,1,2,3}, to_apply=%region_221.246, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  %reduce.671.clone.1 = f32[]{:T(128)} reduce(%integer_pow.399.clone.1, %constant.5056), dimensions={0,1,2,3}, to_apply=%region_187.212, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.656 = (f32[]{:T(128)}, f32[1536,3,128,192]{2,3,1,0:T(8,128)}, f32[1536,3,128,192]{2,3,1,0:T(8,128)}, f32[1536,3,128,192]{2,3,1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.670, %add.3424.clone.1, %add.3428.clone.1, %add.3429.clone.1, %reduce.671.clone.1)
+  %constant.4862.clone.1 = f32[]{:T(128)} constant(0.95)
+  %mul.4716.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%constant.4862.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4714.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%param_4.2203, %mul.4716.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3487.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} add(%mul.4715.clone.1, %mul.4714.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_1.5026 = f32[]{:T(128)S(6)} parameter(1)
+  %div.2557.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%param_1.5026), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2556.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} divide(%add.3487.clone.1, %div.2557.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %sqrt.157.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} sqrt(%div.2556.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
+  %constant.4861.clone.1 = f32[]{:T(128)} constant(1e-08)
+  %add.3486.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} broadcast(%constant.4861.clone.1), dimensions={}, metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %add.3485.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} add(%sqrt.157.clone.1, %add.3486.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %multiply.1293.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%div.2558.clone.1, %add.3485.clone.1), metadata={op_name="multiply.290"}
+  %div.2555.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} divide(%add.3488.clone.1, %multiply.1293.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %mul.4712.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%param_0.4136, %broadcast.4272.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3484.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} add(%div.2555.clone.1, %mul.4712.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %mul.4711.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%mul.4713.clone.1, %add.3484.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3483.clone.1 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} add(%param_0.4136, %mul.4711.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %square.565 = f32[1536,3,128,192]{2,3,1,0:T(8,128)} multiply(%add.3483.clone.1, %add.3483.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
+  %constant.5071 = f32[]{:T(128)} constant(0)
+  %reduce.670 = f32[]{:T(128)} reduce(%square.565, %constant.5071), dimensions={0,1,2,3}, to_apply=%region_221.246, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %reduce.671.clone.1 = f32[]{:T(128)} reduce(%integer_pow.399.clone.1, %constant.5071), dimensions={0,1,2,3}, to_apply=%region_187.212, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.656 = (f32[]{:T(128)}, f32[1536,3,128,192]{2,3,1,0:T(8,128)}, f32[1536,3,128,192]{2,3,1,0:T(8,128)}, f32[1536,3,128,192]{2,3,1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.670, %add.3483.clone.1, %add.3487.clone.1, %add.3488.clone.1, %reduce.671.clone.1)
 }
 
 %region_160.185 (reduce_sum.473: f32[], reduce_sum.293: f32[]) -> f32[] {
@@ -1377,19 +1377,19 @@ StackFrames
   ROOT %reduce_sum.461 = f32[]{:T(128)} add(%reduce_sum.459, %reduce_sum.460), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.495 (param_0.4166: bf16[256,512,512], param_1.5047: bf16[256,512,512]) -> (f32[], f32[]) {
-  %param_0.4166 = bf16[256,512,512]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %broadcast_in_dim.1245 = f32[256,512,512]{2,1,0:T(8,128)} convert(%param_0.4166), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/broadcast_in_dim" stack_frame_id=0}
+%fused_computation.494 (param_0.4162: bf16[256,512,512], param_1.5048: bf16[256,512,512]) -> (f32[], f32[]) {
+  %param_0.4162 = bf16[256,512,512]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %broadcast_in_dim.1245 = f32[256,512,512]{2,1,0:T(8,128)} convert(%param_0.4162), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/broadcast_in_dim" stack_frame_id=0}
   %bitcast.695 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%broadcast_in_dim.1245), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/transpose" stack_frame_id=0}
   %square.570 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.695, %bitcast.695), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5082 = f32[]{:T(128)} constant(0)
-  %reduce.672 = f32[]{:T(128)} reduce(%square.570, %constant.5082), dimensions={0,1,2,3}, to_apply=%region_160.185, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  %param_1.5047 = bf16[256,512,512]{2,1,0:T(8,128)(2,1)} parameter(1)
-  %broadcast_in_dim.1253.clone.1 = f32[256,512,512]{2,1,0:T(8,128)} convert(%param_1.5047), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/broadcast_in_dim" stack_frame_id=0}
+  %constant.5097 = f32[]{:T(128)} constant(0)
+  %reduce.672 = f32[]{:T(128)} reduce(%square.570, %constant.5097), dimensions={0,1,2,3}, to_apply=%region_160.185, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %param_1.5048 = bf16[256,512,512]{2,1,0:T(8,128)(2,1)} parameter(1)
+  %broadcast_in_dim.1253.clone.1 = f32[256,512,512]{2,1,0:T(8,128)} convert(%param_1.5048), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/broadcast_in_dim" stack_frame_id=0}
   %bitcast.703.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%broadcast_in_dim.1253.clone.1), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/transpose" stack_frame_id=0}
   %square.576.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.703.clone.1, %bitcast.703.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %reduce.674.clone.1 = f32[]{:T(128)} reduce(%square.576.clone.1, %constant.5082), dimensions={0,1,2,3}, to_apply=%region_158.183, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.763 = (f32[]{:T(128)}, f32[]{:T(128)}) tuple(%reduce.672, %reduce.674.clone.1)
+  %reduce.674.clone.1 = f32[]{:T(128)} reduce(%square.576.clone.1, %constant.5097), dimensions={0,1,2,3}, to_apply=%region_158.183, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.764 = (f32[]{:T(128)}, f32[]{:T(128)}) tuple(%reduce.672, %reduce.674.clone.1)
 }
 
 %region_159.184 (reduce_sum.466: f32[], reduce_sum.279: f32[]) -> f32[] {
@@ -1398,13 +1398,13 @@ StackFrames
   ROOT %reduce_sum.286 = f32[]{:T(128)} add(%reduce_sum.466, %reduce_sum.279), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.497 (param_0.4165: bf16[256,512,512]) -> f32[] {
-  %param_0.4165 = bf16[256,512,512]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %broadcast_in_dim.1249 = f32[256,512,512]{2,1,0:T(8,128)} convert(%param_0.4165), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/broadcast_in_dim" stack_frame_id=0}
+%fused_computation.496 (param_0.4161: bf16[256,512,512]) -> f32[] {
+  %param_0.4161 = bf16[256,512,512]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %broadcast_in_dim.1249 = f32[256,512,512]{2,1,0:T(8,128)} convert(%param_0.4161), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/broadcast_in_dim" stack_frame_id=0}
   %bitcast.699 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%broadcast_in_dim.1249), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/transpose" stack_frame_id=0}
   %square.573 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.699, %bitcast.699), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5081 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.673 = f32[]{:T(128)} reduce(%square.573, %constant.5081), dimensions={0,1,2,3}, to_apply=%region_159.184, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %constant.5096 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.673 = f32[]{:T(128)} reduce(%square.573, %constant.5096), dimensions={0,1,2,3}, to_apply=%region_159.184, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
 }
 
 %region_227.252 (reduce_sum.935: f32[], reduce_sum.631: f32[]) -> f32[] {
@@ -1419,61 +1419,61 @@ StackFrames
   ROOT %reduce_sum.472 = f32[]{:T(128)} add(%reduce_sum.697, %reduce_sum.471), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.515 (param_0.4134: f32[], param_1.5019: f32[256,1,512,512], param_2.4292: f32[], param_3.2945: f32[256,1,512,512], param_4.2197: f32[], param_5.2000: bf16[256,512,512], param_6.1437: pred[], param_7.1118: f32[], param_8.883: f32[256,1,512,512]) -> (f32[], f32[256,1,512,512], f32[256,1,512,512], f32[256,1,512,512], f32[]) {
+%fused_computation.514 (param_0.4130: f32[], param_1.5020: f32[256,1,512,512], param_2.4289: f32[], param_3.2945: f32[256,1,512,512], param_4.2197: f32[], param_5.2000: bf16[256,512,512], param_6.1437: pred[], param_7.1118: f32[], param_8.883: f32[256,1,512,512]) -> (f32[], f32[256,1,512,512], f32[256,1,512,512], f32[256,1,512,512], f32[]) {
   %param_8.883 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(8)
   %bitcast.1359.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_8.883), sharding={replicated}, metadata={op_name="state.params[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wo\']"}
   %param_7.1118 = f32[]{:T(128)S(6)} parameter(7)
-  %mul.4664.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_7.1118), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4662.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_7.1118), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_6.1437 = pred[]{:T(512)S(6)} parameter(6)
   %select_n.2103.clone.1 = pred[256,1,512,512]{3,2,0,1:T(8,128)(4,1)} broadcast(%param_6.1437), dimensions={}, metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
   %param_5.2000 = bf16[256,512,512]{2,1,0:T(8,128)(2,1)} parameter(5)
   %broadcast_in_dim.1459.clone.1 = f32[256,512,512]{2,1,0:T(8,128)} convert(%param_5.2000), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/broadcast_in_dim" stack_frame_id=0}
   %bitcast.1361.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%broadcast_in_dim.1459.clone.1), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/transpose" stack_frame_id=0}
   %param_4.2197 = f32[]{:T(128)} parameter(4)
-  %div.2523.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_4.2197), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2522.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%bitcast.1361.clone.1, %div.2523.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %select_n.2102.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} select(%select_n.2103.clone.1, %bitcast.1361.clone.1, %div.2522.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
-  %constant.4815.clone.1 = f32[]{:T(128)} constant(0.1)
-  %broadcast.4232.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4815.clone.1), dimensions={}, metadata={op_name="broadcast.2344"}
-  %mul.4666.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%select_n.2102.clone.1, %broadcast.4232.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %div.2520.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_4.2197), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2519.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%bitcast.1361.clone.1, %div.2520.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %select_n.2102.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} select(%select_n.2103.clone.1, %bitcast.1361.clone.1, %div.2519.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
+  %constant.4830.clone.1 = f32[]{:T(128)} constant(0.1)
+  %broadcast.4252.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4830.clone.1), dimensions={}, metadata={op_name="broadcast.2362"}
+  %mul.4664.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%select_n.2102.clone.1, %broadcast.4252.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_3.2945 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(3)
   %bitcast.1360.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_3.2945), sharding={replicated}, metadata={op_name="state.opt_state[0].mu[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wo\']"}
-  %constant.4814.clone.1 = f32[]{:T(128)} constant(0.9)
-  %broadcast.4231.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4814.clone.1), dimensions={}, metadata={op_name="broadcast.329"}
-  %mul.4665.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1360.clone.1, %broadcast.4231.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3394.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4666.clone.1, %mul.4665.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_2.4292 = f32[]{:T(128)S(6)} parameter(2)
-  %div.2521.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_2.4292), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %constant.4829.clone.1 = f32[]{:T(128)} constant(0.9)
+  %broadcast.4251.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4829.clone.1), dimensions={}, metadata={op_name="broadcast.329"}
+  %mul.4663.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1360.clone.1, %broadcast.4251.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3453.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4664.clone.1, %mul.4663.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_2.4289 = f32[]{:T(128)S(6)} parameter(2)
+  %div.2518.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_2.4289), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %integer_pow.393.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%select_n.2102.clone.1, %select_n.2102.clone.1), metadata={op_name="jit(train_step)/integer_pow" stack_frame_id=0}
-  %constant.4813.clone.1 = f32[]{:T(128)} constant(0.05)
-  %broadcast.4234.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4813.clone.1), dimensions={}, metadata={op_name="broadcast.2347"}
-  %mul.4668.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%integer_pow.393.clone.1, %broadcast.4234.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %param_1.5019 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(1)
-  %bitcast.1362.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_1.5019), sharding={replicated}, metadata={op_name="state.opt_state[0].nu[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wo\']"}
-  %constant.4812.clone.1 = f32[]{:T(128)} constant(0.95)
-  %broadcast.4233.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4812.clone.1), dimensions={}, metadata={op_name="broadcast.312"}
-  %mul.4667.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1362.clone.1, %broadcast.4233.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3395.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4668.clone.1, %mul.4667.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_0.4134 = f32[]{:T(128)S(6)} parameter(0)
-  %div.2520.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_0.4134), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2519.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3395.clone.1, %div.2520.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %sqrt.151.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} sqrt(%div.2519.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
-  %constant.4816.clone.1 = f32[]{:T(128)} constant(1e-08)
-  %broadcast.4230.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4816.clone.1), dimensions={}, metadata={op_name="broadcast.305"}
-  %add.3393.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%sqrt.151.clone.1, %broadcast.4230.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %multiply.1287.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%div.2521.clone.1, %add.3393.clone.1), metadata={op_name="multiply.296"}
-  %div.2518.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3394.clone.1, %multiply.1287.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %mul.4663.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1359.clone.1, %broadcast.4232.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3392.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%div.2518.clone.1, %mul.4663.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %mul.4662.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%mul.4664.clone.1, %add.3392.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3391.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%bitcast.1359.clone.1, %mul.4662.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %square.577 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%add.3391.clone.1, %add.3391.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5050 = f32[]{:T(128)} constant(0)
-  %reduce.675 = f32[]{:T(128)} reduce(%square.577, %constant.5050), dimensions={0,1,2,3}, to_apply=%region_227.252, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  %bitcast.849.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3395.clone.1)
-  %bitcast.822.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3394.clone.1)
-  %reduce.684.clone.1 = f32[]{:T(128)} reduce(%integer_pow.393.clone.1, %constant.5050), dimensions={0,1,2,3}, to_apply=%region_193.218, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.666 = (f32[]{:T(128)}, f32[256,1,512,512]{3,2,0,1:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.675, %add.3391.clone.1, %bitcast.849.clone.1, %bitcast.822.clone.1, %reduce.684.clone.1)
+  %constant.4828.clone.1 = f32[]{:T(128)} constant(0.05)
+  %broadcast.4254.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4828.clone.1), dimensions={}, metadata={op_name="broadcast.2365"}
+  %mul.4666.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%integer_pow.393.clone.1, %broadcast.4254.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %param_1.5020 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(1)
+  %bitcast.1362.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_1.5020), sharding={replicated}, metadata={op_name="state.opt_state[0].nu[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wo\']"}
+  %constant.4827.clone.1 = f32[]{:T(128)} constant(0.95)
+  %broadcast.4253.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4827.clone.1), dimensions={}, metadata={op_name="broadcast.312"}
+  %mul.4665.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1362.clone.1, %broadcast.4253.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3454.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4666.clone.1, %mul.4665.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_0.4130 = f32[]{:T(128)S(6)} parameter(0)
+  %div.2517.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_0.4130), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2516.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3454.clone.1, %div.2517.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %sqrt.151.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} sqrt(%div.2516.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
+  %constant.4831.clone.1 = f32[]{:T(128)} constant(1e-08)
+  %broadcast.4250.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4831.clone.1), dimensions={}, metadata={op_name="broadcast.305"}
+  %add.3452.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%sqrt.151.clone.1, %broadcast.4250.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %multiply.1287.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%div.2518.clone.1, %add.3452.clone.1), metadata={op_name="multiply.296"}
+  %div.2515.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3453.clone.1, %multiply.1287.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %mul.4661.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1359.clone.1, %broadcast.4252.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3451.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%div.2515.clone.1, %mul.4661.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %mul.4660.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%mul.4662.clone.1, %add.3451.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3450.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%bitcast.1359.clone.1, %mul.4660.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %square.577 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%add.3450.clone.1, %add.3450.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
+  %constant.5065 = f32[]{:T(128)} constant(0)
+  %reduce.675 = f32[]{:T(128)} reduce(%square.577, %constant.5065), dimensions={0,1,2,3}, to_apply=%region_227.252, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %bitcast.849.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3454.clone.1)
+  %bitcast.822.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3453.clone.1)
+  %reduce.684.clone.1 = f32[]{:T(128)} reduce(%integer_pow.393.clone.1, %constant.5065), dimensions={0,1,2,3}, to_apply=%region_193.218, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.666 = (f32[]{:T(128)}, f32[256,1,512,512]{3,2,0,1:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.675, %add.3450.clone.1, %bitcast.849.clone.1, %bitcast.822.clone.1, %reduce.684.clone.1)
 }
 
 %region_226.251 (reduce_sum.928: f32[], reduce_sum.625: f32[]) -> f32[] {
@@ -1488,61 +1488,61 @@ StackFrames
   ROOT %reduce_sum.470 = f32[]{:T(128)} add(%reduce_sum.690, %reduce_sum.465), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.516 (param_0.4135: f32[], param_1.5020: f32[256,1,512,512], param_2.4293: f32[], param_3.2946: f32[256,1,512,512], param_4.2198: f32[], param_5.2001: bf16[256,512,512], param_6.1438: pred[], param_7.1119: f32[], param_8.884: f32[256,1,512,512]) -> (f32[], f32[256,1,512,512], f32[256,1,512,512], f32[256,1,512,512], f32[]) {
+%fused_computation.515 (param_0.4131: f32[], param_1.5021: f32[256,1,512,512], param_2.4290: f32[], param_3.2946: f32[256,1,512,512], param_4.2198: f32[], param_5.2001: bf16[256,512,512], param_6.1438: pred[], param_7.1119: f32[], param_8.884: f32[256,1,512,512]) -> (f32[], f32[256,1,512,512], f32[256,1,512,512], f32[256,1,512,512], f32[]) {
   %param_8.884 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(8)
   %bitcast.1363.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_8.884), sharding={replicated}, metadata={op_name="state.params[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wi_1\']"}
   %param_7.1119 = f32[]{:T(128)S(6)} parameter(7)
-  %mul.4671.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_7.1119), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4669.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_7.1119), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_6.1438 = pred[]{:T(512)S(6)} parameter(6)
   %select_n.2105.clone.1 = pred[256,1,512,512]{3,2,0,1:T(8,128)(4,1)} broadcast(%param_6.1438), dimensions={}, metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
   %param_5.2001 = bf16[256,512,512]{2,1,0:T(8,128)(2,1)} parameter(5)
   %broadcast_in_dim.1460.clone.1 = f32[256,512,512]{2,1,0:T(8,128)} convert(%param_5.2001), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/broadcast_in_dim" stack_frame_id=0}
   %bitcast.1365.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%broadcast_in_dim.1460.clone.1), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/transpose" stack_frame_id=0}
   %param_4.2198 = f32[]{:T(128)} parameter(4)
-  %div.2529.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_4.2198), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2528.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%bitcast.1365.clone.1, %div.2529.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %select_n.2104.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} select(%select_n.2105.clone.1, %bitcast.1365.clone.1, %div.2528.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
-  %constant.4820.clone.1 = f32[]{:T(128)} constant(0.1)
-  %broadcast.4237.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4820.clone.1), dimensions={}, metadata={op_name="broadcast.2344"}
-  %mul.4673.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%select_n.2104.clone.1, %broadcast.4237.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %div.2526.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_4.2198), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2525.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%bitcast.1365.clone.1, %div.2526.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %select_n.2104.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} select(%select_n.2105.clone.1, %bitcast.1365.clone.1, %div.2525.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
+  %constant.4835.clone.1 = f32[]{:T(128)} constant(0.1)
+  %broadcast.4257.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4835.clone.1), dimensions={}, metadata={op_name="broadcast.2362"}
+  %mul.4671.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%select_n.2104.clone.1, %broadcast.4257.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_3.2946 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(3)
   %bitcast.1364.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_3.2946), sharding={replicated}, metadata={op_name="state.opt_state[0].mu[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wi_1\']"}
-  %constant.4819.clone.1 = f32[]{:T(128)} constant(0.9)
-  %broadcast.4236.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4819.clone.1), dimensions={}, metadata={op_name="broadcast.329"}
-  %mul.4672.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1364.clone.1, %broadcast.4236.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3399.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4673.clone.1, %mul.4672.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_2.4293 = f32[]{:T(128)S(6)} parameter(2)
-  %div.2527.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_2.4293), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %constant.4834.clone.1 = f32[]{:T(128)} constant(0.9)
+  %broadcast.4256.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4834.clone.1), dimensions={}, metadata={op_name="broadcast.329"}
+  %mul.4670.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1364.clone.1, %broadcast.4256.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3458.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4671.clone.1, %mul.4670.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_2.4290 = f32[]{:T(128)S(6)} parameter(2)
+  %div.2524.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_2.4290), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %integer_pow.394.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%select_n.2104.clone.1, %select_n.2104.clone.1), metadata={op_name="jit(train_step)/integer_pow" stack_frame_id=0}
-  %constant.4818.clone.1 = f32[]{:T(128)} constant(0.05)
-  %broadcast.4239.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4818.clone.1), dimensions={}, metadata={op_name="broadcast.2347"}
-  %mul.4675.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%integer_pow.394.clone.1, %broadcast.4239.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %param_1.5020 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(1)
-  %bitcast.1366.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_1.5020), sharding={replicated}, metadata={op_name="state.opt_state[0].nu[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wi_1\']"}
-  %constant.4817.clone.1 = f32[]{:T(128)} constant(0.95)
-  %broadcast.4238.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4817.clone.1), dimensions={}, metadata={op_name="broadcast.312"}
-  %mul.4674.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1366.clone.1, %broadcast.4238.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3400.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4675.clone.1, %mul.4674.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_0.4135 = f32[]{:T(128)S(6)} parameter(0)
-  %div.2526.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_0.4135), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2525.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3400.clone.1, %div.2526.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %sqrt.152.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} sqrt(%div.2525.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
-  %constant.4821.clone.1 = f32[]{:T(128)} constant(1e-08)
-  %broadcast.4235.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4821.clone.1), dimensions={}, metadata={op_name="broadcast.305"}
-  %add.3398.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%sqrt.152.clone.1, %broadcast.4235.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %multiply.1288.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%div.2527.clone.1, %add.3398.clone.1), metadata={op_name="multiply.295"}
-  %div.2524.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3399.clone.1, %multiply.1288.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %mul.4670.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1363.clone.1, %broadcast.4237.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3397.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%div.2524.clone.1, %mul.4670.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %mul.4669.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%mul.4671.clone.1, %add.3397.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3396.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%bitcast.1363.clone.1, %mul.4669.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %square.578 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%add.3396.clone.1, %add.3396.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5051 = f32[]{:T(128)} constant(0)
-  %reduce.676 = f32[]{:T(128)} reduce(%square.578, %constant.5051), dimensions={0,1,2,3}, to_apply=%region_226.251, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  %bitcast.840.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3400.clone.1)
-  %bitcast.813.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3399.clone.1)
-  %reduce.685.clone.1 = f32[]{:T(128)} reduce(%integer_pow.394.clone.1, %constant.5051), dimensions={0,1,2,3}, to_apply=%region_192.217, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.665 = (f32[]{:T(128)}, f32[256,1,512,512]{3,2,0,1:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.676, %add.3396.clone.1, %bitcast.840.clone.1, %bitcast.813.clone.1, %reduce.685.clone.1)
+  %constant.4833.clone.1 = f32[]{:T(128)} constant(0.05)
+  %broadcast.4259.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4833.clone.1), dimensions={}, metadata={op_name="broadcast.2365"}
+  %mul.4673.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%integer_pow.394.clone.1, %broadcast.4259.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %param_1.5021 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(1)
+  %bitcast.1366.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_1.5021), sharding={replicated}, metadata={op_name="state.opt_state[0].nu[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wi_1\']"}
+  %constant.4832.clone.1 = f32[]{:T(128)} constant(0.95)
+  %broadcast.4258.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4832.clone.1), dimensions={}, metadata={op_name="broadcast.312"}
+  %mul.4672.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1366.clone.1, %broadcast.4258.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3459.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4673.clone.1, %mul.4672.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_0.4131 = f32[]{:T(128)S(6)} parameter(0)
+  %div.2523.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_0.4131), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2522.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3459.clone.1, %div.2523.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %sqrt.152.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} sqrt(%div.2522.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
+  %constant.4836.clone.1 = f32[]{:T(128)} constant(1e-08)
+  %broadcast.4255.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4836.clone.1), dimensions={}, metadata={op_name="broadcast.305"}
+  %add.3457.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%sqrt.152.clone.1, %broadcast.4255.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %multiply.1288.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%div.2524.clone.1, %add.3457.clone.1), metadata={op_name="multiply.295"}
+  %div.2521.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3458.clone.1, %multiply.1288.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %mul.4668.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1363.clone.1, %broadcast.4257.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3456.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%div.2521.clone.1, %mul.4668.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %mul.4667.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%mul.4669.clone.1, %add.3456.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3455.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%bitcast.1363.clone.1, %mul.4667.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %square.578 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%add.3455.clone.1, %add.3455.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
+  %constant.5066 = f32[]{:T(128)} constant(0)
+  %reduce.676 = f32[]{:T(128)} reduce(%square.578, %constant.5066), dimensions={0,1,2,3}, to_apply=%region_226.251, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %bitcast.840.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3459.clone.1)
+  %bitcast.813.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3458.clone.1)
+  %reduce.685.clone.1 = f32[]{:T(128)} reduce(%integer_pow.394.clone.1, %constant.5066), dimensions={0,1,2,3}, to_apply=%region_192.217, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.665 = (f32[]{:T(128)}, f32[256,1,512,512]{3,2,0,1:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.676, %add.3455.clone.1, %bitcast.840.clone.1, %bitcast.813.clone.1, %reduce.685.clone.1)
 }
 
 %region_225.250 (reduce_sum.921: f32[], reduce_sum.619: f32[]) -> f32[] {
@@ -1557,61 +1557,61 @@ StackFrames
   ROOT %reduce_sum.464 = f32[]{:T(128)} add(%reduce_sum.683, %reduce_sum.463), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.517 (param_0.4136: f32[], param_1.5021: f32[256,1,512,512], param_2.4294: f32[], param_3.2947: f32[256,1,512,512], param_4.2199: f32[], param_5.2002: bf16[256,512,512], param_6.1439: pred[], param_7.1120: f32[], param_8.885: f32[256,1,512,512]) -> (f32[], f32[256,1,512,512], f32[256,1,512,512], f32[256,1,512,512], f32[]) {
+%fused_computation.516 (param_0.4132: f32[], param_1.5022: f32[256,1,512,512], param_2.4291: f32[], param_3.2947: f32[256,1,512,512], param_4.2199: f32[], param_5.2002: bf16[256,512,512], param_6.1439: pred[], param_7.1120: f32[], param_8.885: f32[256,1,512,512]) -> (f32[], f32[256,1,512,512], f32[256,1,512,512], f32[256,1,512,512], f32[]) {
   %param_8.885 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(8)
   %bitcast.1367.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_8.885), sharding={replicated}, metadata={op_name="state.params[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wi_0\']"}
   %param_7.1120 = f32[]{:T(128)S(6)} parameter(7)
-  %mul.4678.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_7.1120), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4676.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_7.1120), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_6.1439 = pred[]{:T(512)S(6)} parameter(6)
   %select_n.2107.clone.1 = pred[256,1,512,512]{3,2,0,1:T(8,128)(4,1)} broadcast(%param_6.1439), dimensions={}, metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
   %param_5.2002 = bf16[256,512,512]{2,1,0:T(8,128)(2,1)} parameter(5)
   %broadcast_in_dim.1461.clone.1 = f32[256,512,512]{2,1,0:T(8,128)} convert(%param_5.2002), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/broadcast_in_dim" stack_frame_id=0}
   %bitcast.1369.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%broadcast_in_dim.1461.clone.1), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/transpose" stack_frame_id=0}
   %param_4.2199 = f32[]{:T(128)} parameter(4)
-  %div.2535.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_4.2199), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2534.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%bitcast.1369.clone.1, %div.2535.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %select_n.2106.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} select(%select_n.2107.clone.1, %bitcast.1369.clone.1, %div.2534.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
-  %constant.4825.clone.1 = f32[]{:T(128)} constant(0.1)
-  %broadcast.4242.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4825.clone.1), dimensions={}, metadata={op_name="broadcast.2344"}
-  %mul.4680.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%select_n.2106.clone.1, %broadcast.4242.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %div.2532.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_4.2199), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2531.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%bitcast.1369.clone.1, %div.2532.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %select_n.2106.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} select(%select_n.2107.clone.1, %bitcast.1369.clone.1, %div.2531.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
+  %constant.4840.clone.1 = f32[]{:T(128)} constant(0.1)
+  %broadcast.4262.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4840.clone.1), dimensions={}, metadata={op_name="broadcast.2362"}
+  %mul.4678.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%select_n.2106.clone.1, %broadcast.4262.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_3.2947 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(3)
   %bitcast.1368.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_3.2947), sharding={replicated}, metadata={op_name="state.opt_state[0].mu[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wi_0\']"}
-  %constant.4824.clone.1 = f32[]{:T(128)} constant(0.9)
-  %broadcast.4241.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4824.clone.1), dimensions={}, metadata={op_name="broadcast.329"}
-  %mul.4679.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1368.clone.1, %broadcast.4241.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3404.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4680.clone.1, %mul.4679.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_2.4294 = f32[]{:T(128)S(6)} parameter(2)
-  %div.2533.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_2.4294), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %constant.4839.clone.1 = f32[]{:T(128)} constant(0.9)
+  %broadcast.4261.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4839.clone.1), dimensions={}, metadata={op_name="broadcast.329"}
+  %mul.4677.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1368.clone.1, %broadcast.4261.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3463.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4678.clone.1, %mul.4677.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_2.4291 = f32[]{:T(128)S(6)} parameter(2)
+  %div.2530.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_2.4291), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %integer_pow.395.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%select_n.2106.clone.1, %select_n.2106.clone.1), metadata={op_name="jit(train_step)/integer_pow" stack_frame_id=0}
-  %constant.4823.clone.1 = f32[]{:T(128)} constant(0.05)
-  %broadcast.4244.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4823.clone.1), dimensions={}, metadata={op_name="broadcast.2347"}
-  %mul.4682.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%integer_pow.395.clone.1, %broadcast.4244.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %param_1.5021 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(1)
-  %bitcast.1370.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_1.5021), sharding={replicated}, metadata={op_name="state.opt_state[0].nu[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wi_0\']"}
-  %constant.4822.clone.1 = f32[]{:T(128)} constant(0.95)
-  %broadcast.4243.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4822.clone.1), dimensions={}, metadata={op_name="broadcast.312"}
-  %mul.4681.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1370.clone.1, %broadcast.4243.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3405.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4682.clone.1, %mul.4681.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_0.4136 = f32[]{:T(128)S(6)} parameter(0)
-  %div.2532.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_0.4136), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2531.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3405.clone.1, %div.2532.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %sqrt.153.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} sqrt(%div.2531.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
-  %constant.4826.clone.1 = f32[]{:T(128)} constant(1e-08)
-  %broadcast.4240.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4826.clone.1), dimensions={}, metadata={op_name="broadcast.305"}
-  %add.3403.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%sqrt.153.clone.1, %broadcast.4240.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %multiply.1289.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%div.2533.clone.1, %add.3403.clone.1), metadata={op_name="multiply.294"}
-  %div.2530.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3404.clone.1, %multiply.1289.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %mul.4677.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1367.clone.1, %broadcast.4242.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3402.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%div.2530.clone.1, %mul.4677.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %mul.4676.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%mul.4678.clone.1, %add.3402.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3401.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%bitcast.1367.clone.1, %mul.4676.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %square.579 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%add.3401.clone.1, %add.3401.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5052 = f32[]{:T(128)} constant(0)
-  %reduce.677 = f32[]{:T(128)} reduce(%square.579, %constant.5052), dimensions={0,1,2,3}, to_apply=%region_225.250, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  %bitcast.831.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3405.clone.1)
-  %bitcast.804.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3404.clone.1)
-  %reduce.686.clone.1 = f32[]{:T(128)} reduce(%integer_pow.395.clone.1, %constant.5052), dimensions={0,1,2,3}, to_apply=%region_191.216, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.664 = (f32[]{:T(128)}, f32[256,1,512,512]{3,2,0,1:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.677, %add.3401.clone.1, %bitcast.831.clone.1, %bitcast.804.clone.1, %reduce.686.clone.1)
+  %constant.4838.clone.1 = f32[]{:T(128)} constant(0.05)
+  %broadcast.4264.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4838.clone.1), dimensions={}, metadata={op_name="broadcast.2365"}
+  %mul.4680.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%integer_pow.395.clone.1, %broadcast.4264.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %param_1.5022 = f32[256,1,512,512]{3,2,1,0:T(8,128)} parameter(1)
+  %bitcast.1370.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} bitcast(%param_1.5022), sharding={replicated}, metadata={op_name="state.opt_state[0].nu[\'params\'][\'decoder\'][\'moe_layers\'][\'DeepSeekMoeBlock_0\'][\'MoeBlock_0\'][\'wi_0\']"}
+  %constant.4837.clone.1 = f32[]{:T(128)} constant(0.95)
+  %broadcast.4263.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4837.clone.1), dimensions={}, metadata={op_name="broadcast.312"}
+  %mul.4679.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1370.clone.1, %broadcast.4263.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3464.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%mul.4680.clone.1, %mul.4679.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_0.4132 = f32[]{:T(128)S(6)} parameter(0)
+  %div.2529.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%param_0.4132), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2528.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3464.clone.1, %div.2529.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %sqrt.153.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} sqrt(%div.2528.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
+  %constant.4841.clone.1 = f32[]{:T(128)} constant(1e-08)
+  %broadcast.4260.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} broadcast(%constant.4841.clone.1), dimensions={}, metadata={op_name="broadcast.305"}
+  %add.3462.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%sqrt.153.clone.1, %broadcast.4260.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %multiply.1289.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%div.2530.clone.1, %add.3462.clone.1), metadata={op_name="multiply.294"}
+  %div.2527.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} divide(%add.3463.clone.1, %multiply.1289.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %mul.4675.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%bitcast.1367.clone.1, %broadcast.4262.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3461.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%div.2527.clone.1, %mul.4675.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %mul.4674.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%mul.4676.clone.1, %add.3461.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3460.clone.1 = f32[256,1,512,512]{3,2,0,1:T(8,128)} add(%bitcast.1367.clone.1, %mul.4674.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %square.579 = f32[256,1,512,512]{3,2,0,1:T(8,128)} multiply(%add.3460.clone.1, %add.3460.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
+  %constant.5067 = f32[]{:T(128)} constant(0)
+  %reduce.677 = f32[]{:T(128)} reduce(%square.579, %constant.5067), dimensions={0,1,2,3}, to_apply=%region_225.250, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %bitcast.831.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3464.clone.1)
+  %bitcast.804.clone.1 = f32[256,1,512,512]{3,2,1,0:T(8,128)} bitcast(%add.3463.clone.1)
+  %reduce.686.clone.1 = f32[]{:T(128)} reduce(%integer_pow.395.clone.1, %constant.5067), dimensions={0,1,2,3}, to_apply=%region_191.216, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.664 = (f32[]{:T(128)}, f32[256,1,512,512]{3,2,0,1:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[256,1,512,512]{3,2,1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.677, %add.3460.clone.1, %bitcast.831.clone.1, %bitcast.804.clone.1, %reduce.686.clone.1)
 }
 
 %region_155.180 (reduce_sum.438: f32[], reduce_sum.259: f32[]) -> f32[] {
@@ -1620,62 +1620,62 @@ StackFrames
   ROOT %reduce_sum.260 = f32[]{:T(128)} add(%reduce_sum.438, %reduce_sum.259), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.529.clone.clone.clone (param_0.4079: bf16[4,128,129280], param_1.4953: s32[4,128], param_2.4225: f32[4,128], param_3.2913: f32[4,128], param_4.2170: bf16[4,128], param_5.1978: f32[4,128]) -> bf16[4,128,129280] {
+%fused_computation.528.clone.clone.clone (param_0.4075: bf16[4,128,129280], param_1.4954: s32[4,128], param_2.4222: f32[4,128], param_3.2913: f32[4,128], param_4.2170: bf16[4,128], param_5.1978: f32[4,128]) -> bf16[4,128,129280] {
   %param_5.1978 = f32[4,128]{1,0:T(4,128)S(1)} parameter(5)
-  %mul.4891 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_5.1978), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %mul.4889 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_5.1978), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
   %param_3.2913 = f32[4,128]{1,0:T(4,128)S(1)} parameter(3)
-  %mul.4890 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_3.2913), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %param_0.4079 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %convert_element_type.3155 = f32[4,128,129280]{2,1,0:T(8,128)} convert(%param_0.4079), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/convert_element_type" stack_frame_id=0}
+  %mul.4888 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_3.2913), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %param_0.4075 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %convert_element_type.3151 = f32[4,128,129280]{2,1,0:T(8,128)} convert(%param_0.4075), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/convert_element_type" stack_frame_id=0}
   %param_4.2170 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(4)
   %sub.791 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_4.2170), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.790 = f32[4,128,129280]{2,1,0:T(8,128)} subtract(%convert_element_type.3155, %sub.791), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.790 = f32[4,128,129280]{2,1,0:T(8,128)} subtract(%convert_element_type.3151, %sub.791), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %exp.534 = f32[4,128,129280]{2,1,0:T(8,128)} exponential(%sub.790), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
-  %mul.4889 = f32[4,128,129280]{2,1,0:T(8,128)} multiply(%mul.4890, %exp.534), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  %param_2.4225 = f32[4,128]{1,0:T(4,128)S(1)} parameter(2)
-  %div.2688 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_2.4225), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
-  %div.2687 = f32[4,128,129280]{2,1,0:T(8,128)} divide(%mul.4889, %div.2688), metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
-  %param_1.4953 = s32[4,128]{1,0:T(4,128)S(1)} parameter(1)
-  %eq.363 = s32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_1.4953), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
+  %mul.4887 = f32[4,128,129280]{2,1,0:T(8,128)} multiply(%mul.4888, %exp.534), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  %param_2.4222 = f32[4,128]{1,0:T(4,128)S(1)} parameter(2)
+  %div.2685 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_2.4222), dimensions={0,1}, metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
+  %div.2684 = f32[4,128,129280]{2,1,0:T(8,128)} divide(%mul.4887, %div.2685), metadata={op_name="jit(train_step)/transpose(jvp())/div" stack_frame_id=0}
+  %param_1.4954 = s32[4,128]{1,0:T(4,128)S(1)} parameter(1)
+  %eq.363 = s32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_1.4954), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %eq.362 = s32[4,128,129280]{2,1,0:T(8,128)} iota(), iota_dimension=2, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %eq.361 = pred[4,128,129280]{2,1,0:T(8,128)(4,1)} compare(%eq.363, %eq.362), direction=EQ, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
-  %convert_element_type.3154 = f32[4,128,129280]{2,1,0:T(8,128)} convert(%eq.361), metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/convert_element_type" stack_frame_id=0}
-  %sub.789 = f32[4,128,129280]{2,1,0:T(8,128)} subtract(%div.2687, %convert_element_type.3154), metadata={op_name="jit(train_step)/transpose(jvp())/sub" stack_frame_id=0}
-  %mul.4888 = f32[4,128,129280]{2,1,0:T(8,128)} multiply(%mul.4891, %sub.789), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
-  ROOT %convert_element_type.3153 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} convert(%mul.4888), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/convert_element_type" stack_frame_id=0}
+  %convert_element_type.3150 = f32[4,128,129280]{2,1,0:T(8,128)} convert(%eq.361), metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/convert_element_type" stack_frame_id=0}
+  %sub.789 = f32[4,128,129280]{2,1,0:T(8,128)} subtract(%div.2684, %convert_element_type.3150), metadata={op_name="jit(train_step)/transpose(jvp())/sub" stack_frame_id=0}
+  %mul.4886 = f32[4,128,129280]{2,1,0:T(8,128)} multiply(%mul.4889, %sub.789), metadata={op_name="jit(train_step)/transpose(jvp())/mul" stack_frame_id=0}
+  ROOT %convert_element_type.3149 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} convert(%mul.4886), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/convert_element_type" stack_frame_id=0}
 }
 
-%fused_computation.939.clone.clone (param_0.4080: f32[4,128], param_1.4954: bf16[4,128,512], param_2.4227: bf16[512]) -> bf16[4,128,512] {
-  %param_2.4227 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
-  %dot_general.831 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4227), dimensions={2}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/...k,k->...k/dot_general" stack_frame_id=0}
-  %param_1.4954 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert_element_type.3157 = f32[4,128,512]{2,1,0:T(8,128)} convert(%param_1.4954), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/convert_element_type" stack_frame_id=0}
-  %param_0.4080 = f32[4,128]{1,0:T(4,128)S(1)} parameter(0)
-  %mul.4893 = f32[4,128,512]{2,1,0:T(8,128)} broadcast(%param_0.4080), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/mul" stack_frame_id=0}
-  %mul.4892 = f32[4,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.3157, %mul.4893), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/mul" stack_frame_id=0}
-  %convert_element_type.3156 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4892), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/convert_element_type" stack_frame_id=0}
-  ROOT %dot_general.830 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} multiply(%dot_general.831, %convert_element_type.3156), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.935.clone.clone (param_0.4076: f32[4,128], param_1.4955: bf16[4,128,512], param_2.4224: bf16[512]) -> bf16[4,128,512] {
+  %param_2.4224 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(2)
+  %dot_general.831 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4224), dimensions={2}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/...k,k->...k/dot_general" stack_frame_id=0}
+  %param_1.4955 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert_element_type.3153 = f32[4,128,512]{2,1,0:T(8,128)} convert(%param_1.4955), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/convert_element_type" stack_frame_id=0}
+  %param_0.4076 = f32[4,128]{1,0:T(4,128)S(1)} parameter(0)
+  %mul.4891 = f32[4,128,512]{2,1,0:T(8,128)} broadcast(%param_0.4076), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/mul" stack_frame_id=0}
+  %mul.4890 = f32[4,128,512]{2,1,0:T(8,128)} multiply(%convert_element_type.3153, %mul.4891), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/mul" stack_frame_id=0}
+  %convert_element_type.3152 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} convert(%mul.4890), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/convert_element_type" stack_frame_id=0}
+  ROOT %dot_general.830 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} multiply(%dot_general.831, %convert_element_type.3152), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/...k,k->...k/dot_general" stack_frame_id=0}
 }
 
-%fused_computation.518 (param_0.4169: bf16[4,128,129280], param_1.5049: s32[4,128], param_2.4319: f32[4,128], param_3.2969: f32[4,128], param_4.2219: bf16[4,128], param_5.2020: f32[4,128], param_6.1457: f32[4,128], param_7.1138: bf16[4,128,512], param_8.902: bf16[512]) -> (f32[], bf16[512,129280,1]) {
+%fused_computation.517 (param_0.4165: bf16[4,128,129280], param_1.5050: s32[4,128], param_2.4316: f32[4,128], param_3.2969: f32[4,128], param_4.2219: bf16[4,128], param_5.2020: f32[4,128], param_6.1457: f32[4,128], param_7.1138: bf16[4,128,512], param_8.902: bf16[512]) -> (f32[], bf16[512,129280,1]) {
   %param_6.1457 = f32[4,128]{1,0:T(4,128)S(1)} parameter(6)
   %param_7.1138 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)S(1)} parameter(7)
   %param_8.902 = bf16[512]{0:T(512)(128)(2,1)S(1)} parameter(8)
-  %fusion.577.clone.1 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} fusion(%param_6.1457, %param_7.1138, %param_8.902), kind=kLoop, calls=%fused_computation.939.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/...k,k->...k/dot_general" stack_frame_id=0}
-  %param_0.4169 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %param_1.5049 = s32[4,128]{1,0:T(4,128)S(1)} parameter(1)
-  %param_2.4319 = f32[4,128]{1,0:T(4,128)S(1)} parameter(2)
+  %fusion.573.clone.1 = bf16[4,128,512]{2,1,0:T(8,128)(2,1)} fusion(%param_6.1457, %param_7.1138, %param_8.902), kind=kLoop, calls=%fused_computation.935.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/decoder_norm/...k,k->...k/dot_general" stack_frame_id=0}
+  %param_0.4165 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %param_1.5050 = s32[4,128]{1,0:T(4,128)S(1)} parameter(1)
+  %param_2.4316 = f32[4,128]{1,0:T(4,128)S(1)} parameter(2)
   %param_3.2969 = f32[4,128]{1,0:T(4,128)S(1)} parameter(3)
   %param_4.2219 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(4)
   %param_5.2020 = f32[4,128]{1,0:T(4,128)S(1)} parameter(5)
-  %multiply_convert_fusion.1.clone.1 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} fusion(%param_0.4169, %param_1.5049, %param_2.4319, %param_3.2969, %param_4.2219, /*index=5*/%param_5.2020), kind=kLoop, calls=%fused_computation.529.clone.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/convert_element_type" stack_frame_id=0}
-  %convolution.141.clone.1 = bf16[512,129280,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.577.clone.1, %multiply_convert_fusion.1.clone.1), window={size=4}, dim_labels=0fb_0io->bf0, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/logits_dense/dot_general" stack_frame_id=0}
+  %multiply_convert_fusion.1.clone.1 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} fusion(%param_0.4165, %param_1.5050, %param_2.4316, %param_3.2969, %param_4.2219, /*index=5*/%param_5.2020), kind=kLoop, calls=%fused_computation.528.clone.clone.clone, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/convert_element_type" stack_frame_id=0}
+  %convolution.141.clone.1 = bf16[512,129280,1]{1,0,2:T(8,128)(2,1)} convolution(%fusion.573.clone.1, %multiply_convert_fusion.1.clone.1), window={size=4}, dim_labels=0fb_0io->bf0, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/logits_dense/dot_general" stack_frame_id=0}
   %bitcast.776 = bf16[512,129280]{1,0:T(8,128)(2,1)} bitcast(%convolution.141.clone.1), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/logits_dense/dot_general" stack_frame_id=0}
-  %convert_element_type.2657 = f32[512,129280]{1,0:T(8,128)} convert(%bitcast.776), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/logits_dense/convert_element_type" stack_frame_id=0}
-  %square.581 = f32[512,129280]{1,0:T(8,128)} multiply(%convert_element_type.2657, %convert_element_type.2657), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5085 = f32[]{:T(128)} constant(0)
-  %reduce.678 = f32[]{:T(128)} reduce(%square.581, %constant.5085), dimensions={0,1}, to_apply=%region_155.180, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.753 = (f32[]{:T(128)}, bf16[512,129280,1]{1,0,2:T(8,128)(2,1)}) tuple(%reduce.678, %convolution.141.clone.1)
+  %convert_element_type.2653 = f32[512,129280]{1,0:T(8,128)} convert(%bitcast.776), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/logits_dense/convert_element_type" stack_frame_id=0}
+  %square.581 = f32[512,129280]{1,0:T(8,128)} multiply(%convert_element_type.2653, %convert_element_type.2653), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
+  %constant.5100 = f32[]{:T(128)} constant(0)
+  %reduce.678 = f32[]{:T(128)} reduce(%square.581, %constant.5100), dimensions={0,1}, to_apply=%region_155.180, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.754 = (f32[]{:T(128)}, bf16[512,129280,1]{1,0,2:T(8,128)(2,1)}) tuple(%reduce.678, %convolution.141.clone.1)
 }
 
 %region_174.199 (reduce_sum.564: f32[], reduce_sum.387: f32[]) -> f32[] {
@@ -1684,12 +1684,12 @@ StackFrames
   ROOT %reduce_sum.388 = f32[]{:T(128)} add(%reduce_sum.564, %reduce_sum.387), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.519 (param_0.4153: bf16[129280,512]) -> f32[] {
-  %param_0.4153 = bf16[129280,512]{1,0:T(8,128)(2,1)} parameter(0)
-  %convert_element_type.2659 = f32[129280,512]{1,0:T(8,128)} convert(%param_0.4153), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/convert_element_type" stack_frame_id=0}
-  %square.583 = f32[129280,512]{1,0:T(8,128)} multiply(%convert_element_type.2659, %convert_element_type.2659), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5069 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.679 = f32[]{:T(128)} reduce(%square.583, %constant.5069), dimensions={0,1}, to_apply=%region_174.199, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+%fused_computation.518 (param_0.4149: bf16[129280,512]) -> f32[] {
+  %param_0.4149 = bf16[129280,512]{1,0:T(8,128)(2,1)} parameter(0)
+  %convert_element_type.2655 = f32[129280,512]{1,0:T(8,128)} convert(%param_0.4149), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/convert_element_type" stack_frame_id=0}
+  %square.583 = f32[129280,512]{1,0:T(8,128)} multiply(%convert_element_type.2655, %convert_element_type.2655), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
+  %constant.5084 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.679 = f32[]{:T(128)} reduce(%square.583, %constant.5084), dimensions={0,1}, to_apply=%region_174.199, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
 }
 
 %region_240.265 (reduce_sum.1026: f32[], reduce_sum.689: f32[]) -> f32[] {
@@ -1704,55 +1704,55 @@ StackFrames
   ROOT %reduce_sum.534 = f32[]{:T(128)} add(%reduce_sum.788, %reduce_sum.533), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.520 (param_0.4121: f32[129280,512], param_1.5006: f32[], param_2.4279: f32[], param_3.2932: f32[], param_4.2184: f32[129280,512], param_5.1987: f32[], param_6.1424: bf16[129280,512], param_7.1105: pred[], param_8.870: f32[129280,512]) -> (f32[], f32[129280,512], f32[129280,512], f32[129280,512], f32[]) {
-  %param_0.4121 = f32[129280,512]{1,0:T(8,128)} parameter(0)
+%fused_computation.519 (param_0.4117: f32[129280,512], param_1.5007: f32[], param_2.4276: f32[], param_3.2932: f32[], param_4.2184: f32[129280,512], param_5.1987: f32[], param_6.1424: bf16[129280,512], param_7.1105: pred[], param_8.870: f32[129280,512]) -> (f32[], f32[129280,512], f32[129280,512], f32[129280,512], f32[]) {
+  %param_0.4117 = f32[129280,512]{1,0:T(8,128)} parameter(0)
   %param_3.2932 = f32[]{:T(128)S(6)} parameter(3)
-  %mul.4552.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%param_3.2932), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4550.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%param_3.2932), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_7.1105 = pred[]{:T(512)S(6)} parameter(7)
   %select_n.2061.clone.1 = pred[129280,512]{1,0:T(8,128)(4,1)} broadcast(%param_7.1105), dimensions={}, metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
   %param_6.1424 = bf16[129280,512]{1,0:T(8,128)(2,1)} parameter(6)
-  %convert_element_type.3098.clone.1 = f32[129280,512]{1,0:T(8,128)} convert(%param_6.1424), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/convert_element_type" stack_frame_id=0}
+  %convert_element_type.3094.clone.1 = f32[129280,512]{1,0:T(8,128)} convert(%param_6.1424), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder._apply_embedding/token_embedder/convert_element_type" stack_frame_id=0}
   %param_5.1987 = f32[]{:T(128)} parameter(5)
-  %div.2429.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%param_5.1987), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2428.clone.1 = f32[129280,512]{1,0:T(8,128)} divide(%convert_element_type.3098.clone.1, %div.2429.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %select_n.2060.clone.1 = f32[129280,512]{1,0:T(8,128)} select(%select_n.2061.clone.1, %convert_element_type.3098.clone.1, %div.2428.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
-  %constant.4735.clone.1 = f32[]{:T(128)} constant(0.1)
-  %broadcast.4182.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%constant.4735.clone.1), dimensions={}, metadata={op_name="broadcast.318"}
-  %mul.4558.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%select_n.2060.clone.1, %broadcast.4182.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %div.2426.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%param_5.1987), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2425.clone.1 = f32[129280,512]{1,0:T(8,128)} divide(%convert_element_type.3094.clone.1, %div.2426.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %select_n.2060.clone.1 = f32[129280,512]{1,0:T(8,128)} select(%select_n.2061.clone.1, %convert_element_type.3094.clone.1, %div.2425.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
+  %constant.4750.clone.1 = f32[]{:T(128)} constant(0.1)
+  %broadcast.4202.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%constant.4750.clone.1), dimensions={}, metadata={op_name="broadcast.318"}
+  %mul.4556.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%select_n.2060.clone.1, %broadcast.4202.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_8.870 = f32[129280,512]{1,0:T(8,128)} parameter(8)
-  %constant.4739.clone.1 = f32[]{:T(128)} constant(0.9)
-  %mul.4559.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%constant.4739.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4557.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%param_8.870, %mul.4559.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3324.clone.1 = f32[129280,512]{1,0:T(8,128)} add(%mul.4558.clone.1, %mul.4557.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_2.4279 = f32[]{:T(128)S(6)} parameter(2)
-  %div.2425.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%param_2.4279), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %constant.4754.clone.1 = f32[]{:T(128)} constant(0.9)
+  %mul.4557.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%constant.4754.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4555.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%param_8.870, %mul.4557.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3383.clone.1 = f32[129280,512]{1,0:T(8,128)} add(%mul.4556.clone.1, %mul.4555.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_2.4276 = f32[]{:T(128)S(6)} parameter(2)
+  %div.2422.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%param_2.4276), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %integer_pow.380.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%select_n.2060.clone.1, %select_n.2060.clone.1), metadata={op_name="jit(train_step)/integer_pow" stack_frame_id=0}
-  %constant.4738.clone.1 = f32[]{:T(128)} constant(0.05)
-  %mul.4556.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%constant.4738.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4554.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%integer_pow.380.clone.1, %mul.4556.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %constant.4753.clone.1 = f32[]{:T(128)} constant(0.05)
+  %mul.4554.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%constant.4753.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4552.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%integer_pow.380.clone.1, %mul.4554.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_4.2184 = f32[129280,512]{1,0:T(8,128)} parameter(4)
-  %constant.4737.clone.1 = f32[]{:T(128)} constant(0.95)
-  %mul.4555.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%constant.4737.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4553.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%param_4.2184, %mul.4555.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3323.clone.1 = f32[129280,512]{1,0:T(8,128)} add(%mul.4554.clone.1, %mul.4553.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_1.5006 = f32[]{:T(128)S(6)} parameter(1)
-  %div.2424.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%param_1.5006), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2423.clone.1 = f32[129280,512]{1,0:T(8,128)} divide(%add.3323.clone.1, %div.2424.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %sqrt.138.clone.1 = f32[129280,512]{1,0:T(8,128)} sqrt(%div.2423.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
-  %constant.4736.clone.1 = f32[]{:T(128)} constant(1e-08)
-  %add.3322.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%constant.4736.clone.1), dimensions={}, metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %add.3321.clone.1 = f32[129280,512]{1,0:T(8,128)} add(%sqrt.138.clone.1, %add.3322.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %multiply.1274.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%div.2425.clone.1, %add.3321.clone.1), metadata={op_name="multiply.309"}
-  %div.2422.clone.1 = f32[129280,512]{1,0:T(8,128)} divide(%add.3324.clone.1, %multiply.1274.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %mul.4551.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%param_0.4121, %broadcast.4182.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3320.clone.1 = f32[129280,512]{1,0:T(8,128)} add(%div.2422.clone.1, %mul.4551.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %mul.4550.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%mul.4552.clone.1, %add.3320.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3319.clone.1 = f32[129280,512]{1,0:T(8,128)} add(%param_0.4121, %mul.4550.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %square.584 = f32[129280,512]{1,0:T(8,128)} multiply(%add.3319.clone.1, %add.3319.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5037 = f32[]{:T(128)} constant(0)
-  %reduce.680 = f32[]{:T(128)} reduce(%square.584, %constant.5037), dimensions={0,1}, to_apply=%region_240.265, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  %reduce.687.clone.1 = f32[]{:T(128)} reduce(%integer_pow.380.clone.1, %constant.5037), dimensions={0,1}, to_apply=%region_206.231, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.667 = (f32[]{:T(128)}, f32[129280,512]{1,0:T(8,128)}, f32[129280,512]{1,0:T(8,128)}, f32[129280,512]{1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.680, %add.3319.clone.1, %add.3323.clone.1, %add.3324.clone.1, %reduce.687.clone.1)
+  %constant.4752.clone.1 = f32[]{:T(128)} constant(0.95)
+  %mul.4553.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%constant.4752.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4551.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%param_4.2184, %mul.4553.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3382.clone.1 = f32[129280,512]{1,0:T(8,128)} add(%mul.4552.clone.1, %mul.4551.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_1.5007 = f32[]{:T(128)S(6)} parameter(1)
+  %div.2421.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%param_1.5007), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2420.clone.1 = f32[129280,512]{1,0:T(8,128)} divide(%add.3382.clone.1, %div.2421.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %sqrt.138.clone.1 = f32[129280,512]{1,0:T(8,128)} sqrt(%div.2420.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
+  %constant.4751.clone.1 = f32[]{:T(128)} constant(1e-08)
+  %add.3381.clone.1 = f32[129280,512]{1,0:T(8,128)} broadcast(%constant.4751.clone.1), dimensions={}, metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %add.3380.clone.1 = f32[129280,512]{1,0:T(8,128)} add(%sqrt.138.clone.1, %add.3381.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %multiply.1274.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%div.2422.clone.1, %add.3380.clone.1), metadata={op_name="multiply.309"}
+  %div.2419.clone.1 = f32[129280,512]{1,0:T(8,128)} divide(%add.3383.clone.1, %multiply.1274.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %mul.4549.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%param_0.4117, %broadcast.4202.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3379.clone.1 = f32[129280,512]{1,0:T(8,128)} add(%div.2419.clone.1, %mul.4549.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %mul.4548.clone.1 = f32[129280,512]{1,0:T(8,128)} multiply(%mul.4550.clone.1, %add.3379.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3378.clone.1 = f32[129280,512]{1,0:T(8,128)} add(%param_0.4117, %mul.4548.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %square.584 = f32[129280,512]{1,0:T(8,128)} multiply(%add.3378.clone.1, %add.3378.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
+  %constant.5052 = f32[]{:T(128)} constant(0)
+  %reduce.680 = f32[]{:T(128)} reduce(%square.584, %constant.5052), dimensions={0,1}, to_apply=%region_240.265, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %reduce.687.clone.1 = f32[]{:T(128)} reduce(%integer_pow.380.clone.1, %constant.5052), dimensions={0,1}, to_apply=%region_206.231, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.667 = (f32[]{:T(128)}, f32[129280,512]{1,0:T(8,128)}, f32[129280,512]{1,0:T(8,128)}, f32[129280,512]{1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.680, %add.3378.clone.1, %add.3382.clone.1, %add.3383.clone.1, %reduce.687.clone.1)
 }
 
 %region_222.247 (reduce_sum.900: f32[], reduce_sum.605: f32[]) -> f32[] {
@@ -1767,56 +1767,56 @@ StackFrames
   ROOT %reduce_sum.455 = f32[]{:T(128)} add(%reduce_sum.662, %reduce_sum.451), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.521 (param_0.4139: f32[512,129280], param_1.5024: f32[], param_2.4297: f32[], param_3.2950: f32[], param_4.2202: f32[512,129280], param_5.2005: f32[], param_6.1442: bf16[512,129280,1], param_7.1123: pred[], param_8.888: f32[512,129280]) -> (f32[], f32[512,129280], f32[512,129280], f32[512,129280], f32[]) {
-  %param_0.4139 = f32[512,129280]{1,0:T(8,128)} parameter(0)
+%fused_computation.520 (param_0.4135: f32[512,129280], param_1.5025: f32[], param_2.4294: f32[], param_3.2950: f32[], param_4.2202: f32[512,129280], param_5.2005: f32[], param_6.1442: bf16[512,129280,1], param_7.1123: pred[], param_8.888: f32[512,129280]) -> (f32[], f32[512,129280], f32[512,129280], f32[512,129280], f32[]) {
+  %param_0.4135 = f32[512,129280]{1,0:T(8,128)} parameter(0)
   %param_3.2950 = f32[]{:T(128)S(6)} parameter(3)
-  %mul.4705.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%param_3.2950), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4703.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%param_3.2950), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_7.1123 = pred[]{:T(512)S(6)} parameter(7)
   %select_n.2117.clone.1 = pred[512,129280]{1,0:T(8,128)(4,1)} broadcast(%param_7.1123), dimensions={}, metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
   %param_6.1442 = bf16[512,129280,1]{1,0,2:T(8,128)(2,1)} parameter(6)
   %bitcast.1372.clone.1 = bf16[512,129280]{1,0:T(8,128)(2,1)} bitcast(%param_6.1442), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/logits_dense/dot_general" stack_frame_id=0}
-  %convert_element_type.3100.clone.1 = f32[512,129280]{1,0:T(8,128)} convert(%bitcast.1372.clone.1), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/logits_dense/convert_element_type" stack_frame_id=0}
+  %convert_element_type.3096.clone.1 = f32[512,129280]{1,0:T(8,128)} convert(%bitcast.1372.clone.1), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/decoder.apply_output_head/logits_dense/convert_element_type" stack_frame_id=0}
   %param_5.2005 = f32[]{:T(128)} parameter(5)
-  %div.2557.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%param_5.2005), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2556.clone.1 = f32[512,129280]{1,0:T(8,128)} divide(%convert_element_type.3100.clone.1, %div.2557.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %select_n.2116.clone.1 = f32[512,129280]{1,0:T(8,128)} select(%select_n.2117.clone.1, %convert_element_type.3100.clone.1, %div.2556.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
-  %constant.4839.clone.1 = f32[]{:T(128)} constant(0.1)
-  %broadcast.4250.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%constant.4839.clone.1), dimensions={}, metadata={op_name="broadcast.333"}
-  %mul.4711.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%select_n.2116.clone.1, %broadcast.4250.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %div.2554.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%param_5.2005), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2553.clone.1 = f32[512,129280]{1,0:T(8,128)} divide(%convert_element_type.3096.clone.1, %div.2554.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %select_n.2116.clone.1 = f32[512,129280]{1,0:T(8,128)} select(%select_n.2117.clone.1, %convert_element_type.3096.clone.1, %div.2553.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
+  %constant.4854.clone.1 = f32[]{:T(128)} constant(0.1)
+  %broadcast.4270.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%constant.4854.clone.1), dimensions={}, metadata={op_name="broadcast.333"}
+  %mul.4709.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%select_n.2116.clone.1, %broadcast.4270.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_8.888 = f32[512,129280]{1,0:T(8,128)} parameter(8)
-  %constant.4843.clone.1 = f32[]{:T(128)} constant(0.9)
-  %mul.4712.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%constant.4843.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4710.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%param_8.888, %mul.4712.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3423.clone.1 = f32[512,129280]{1,0:T(8,128)} add(%mul.4711.clone.1, %mul.4710.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_2.4297 = f32[]{:T(128)S(6)} parameter(2)
-  %div.2553.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%param_2.4297), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %constant.4858.clone.1 = f32[]{:T(128)} constant(0.9)
+  %mul.4710.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%constant.4858.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4708.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%param_8.888, %mul.4710.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3482.clone.1 = f32[512,129280]{1,0:T(8,128)} add(%mul.4709.clone.1, %mul.4708.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_2.4294 = f32[]{:T(128)S(6)} parameter(2)
+  %div.2550.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%param_2.4294), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %integer_pow.398.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%select_n.2116.clone.1, %select_n.2116.clone.1), metadata={op_name="jit(train_step)/integer_pow" stack_frame_id=0}
-  %constant.4842.clone.1 = f32[]{:T(128)} constant(0.05)
-  %mul.4709.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%constant.4842.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4707.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%integer_pow.398.clone.1, %mul.4709.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %constant.4857.clone.1 = f32[]{:T(128)} constant(0.05)
+  %mul.4707.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%constant.4857.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4705.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%integer_pow.398.clone.1, %mul.4707.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_4.2202 = f32[512,129280]{1,0:T(8,128)} parameter(4)
-  %constant.4841.clone.1 = f32[]{:T(128)} constant(0.95)
-  %mul.4708.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%constant.4841.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4706.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%param_4.2202, %mul.4708.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3422.clone.1 = f32[512,129280]{1,0:T(8,128)} add(%mul.4707.clone.1, %mul.4706.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_1.5024 = f32[]{:T(128)S(6)} parameter(1)
-  %div.2552.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%param_1.5024), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2551.clone.1 = f32[512,129280]{1,0:T(8,128)} divide(%add.3422.clone.1, %div.2552.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %sqrt.156.clone.1 = f32[512,129280]{1,0:T(8,128)} sqrt(%div.2551.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
-  %constant.4840.clone.1 = f32[]{:T(128)} constant(1e-08)
-  %add.3421.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%constant.4840.clone.1), dimensions={}, metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %add.3420.clone.1 = f32[512,129280]{1,0:T(8,128)} add(%sqrt.156.clone.1, %add.3421.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %multiply.1292.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%div.2553.clone.1, %add.3420.clone.1), metadata={op_name="multiply.291"}
-  %div.2550.clone.1 = f32[512,129280]{1,0:T(8,128)} divide(%add.3423.clone.1, %multiply.1292.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %mul.4704.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%param_0.4139, %broadcast.4250.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3419.clone.1 = f32[512,129280]{1,0:T(8,128)} add(%div.2550.clone.1, %mul.4704.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %mul.4703.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%mul.4705.clone.1, %add.3419.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3418.clone.1 = f32[512,129280]{1,0:T(8,128)} add(%param_0.4139, %mul.4703.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %square.585 = f32[512,129280]{1,0:T(8,128)} multiply(%add.3418.clone.1, %add.3418.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5055 = f32[]{:T(128)} constant(0)
-  %reduce.681 = f32[]{:T(128)} reduce(%square.585, %constant.5055), dimensions={0,1}, to_apply=%region_222.247, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  %reduce.688.clone.1 = f32[]{:T(128)} reduce(%integer_pow.398.clone.1, %constant.5055), dimensions={0,1}, to_apply=%region_188.213, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.668 = (f32[]{:T(128)}, f32[512,129280]{1,0:T(8,128)}, f32[512,129280]{1,0:T(8,128)}, f32[512,129280]{1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.681, %add.3418.clone.1, %add.3422.clone.1, %add.3423.clone.1, %reduce.688.clone.1)
+  %constant.4856.clone.1 = f32[]{:T(128)} constant(0.95)
+  %mul.4706.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%constant.4856.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4704.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%param_4.2202, %mul.4706.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3481.clone.1 = f32[512,129280]{1,0:T(8,128)} add(%mul.4705.clone.1, %mul.4704.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_1.5025 = f32[]{:T(128)S(6)} parameter(1)
+  %div.2549.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%param_1.5025), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2548.clone.1 = f32[512,129280]{1,0:T(8,128)} divide(%add.3481.clone.1, %div.2549.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %sqrt.156.clone.1 = f32[512,129280]{1,0:T(8,128)} sqrt(%div.2548.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
+  %constant.4855.clone.1 = f32[]{:T(128)} constant(1e-08)
+  %add.3480.clone.1 = f32[512,129280]{1,0:T(8,128)} broadcast(%constant.4855.clone.1), dimensions={}, metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %add.3479.clone.1 = f32[512,129280]{1,0:T(8,128)} add(%sqrt.156.clone.1, %add.3480.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %multiply.1292.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%div.2550.clone.1, %add.3479.clone.1), metadata={op_name="multiply.291"}
+  %div.2547.clone.1 = f32[512,129280]{1,0:T(8,128)} divide(%add.3482.clone.1, %multiply.1292.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %mul.4702.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%param_0.4135, %broadcast.4270.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3478.clone.1 = f32[512,129280]{1,0:T(8,128)} add(%div.2547.clone.1, %mul.4702.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %mul.4701.clone.1 = f32[512,129280]{1,0:T(8,128)} multiply(%mul.4703.clone.1, %add.3478.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3477.clone.1 = f32[512,129280]{1,0:T(8,128)} add(%param_0.4135, %mul.4701.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %square.585 = f32[512,129280]{1,0:T(8,128)} multiply(%add.3477.clone.1, %add.3477.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
+  %constant.5070 = f32[]{:T(128)} constant(0)
+  %reduce.681 = f32[]{:T(128)} reduce(%square.585, %constant.5070), dimensions={0,1}, to_apply=%region_222.247, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %reduce.688.clone.1 = f32[]{:T(128)} reduce(%integer_pow.398.clone.1, %constant.5070), dimensions={0,1}, to_apply=%region_188.213, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.668 = (f32[]{:T(128)}, f32[512,129280]{1,0:T(8,128)}, f32[512,129280]{1,0:T(8,128)}, f32[512,129280]{1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.681, %add.3477.clone.1, %add.3481.clone.1, %add.3482.clone.1, %reduce.688.clone.1)
 }
 
 %region_207.232 (reduce_sum.795: f32[], reduce_sum.535: f32[]) -> f32[] {
@@ -1825,23 +1825,23 @@ StackFrames
   ROOT %reduce_sum.540 = f32[]{:T(128)} add(%reduce_sum.795, %reduce_sum.535), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.522 (param_0.4190: bf16[4,128,129280], param_1.5063: f32[4,128], param_2.4329: s32[4,128], param_3.2977: bf16[4,128]) -> f32[4,128] {
-  %param_2.4329 = s32[4,128]{1,0:T(4,128)S(1)} parameter(2)
-  %eq.299 = s32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_2.4329), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
+%fused_computation.521 (param_0.4186: bf16[4,128,129280], param_1.5064: f32[4,128], param_2.4326: s32[4,128], param_3.2977: bf16[4,128]) -> f32[4,128] {
+  %param_2.4326 = s32[4,128]{1,0:T(4,128)S(1)} parameter(2)
+  %eq.299 = s32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_2.4326), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %eq.294 = s32[4,128,129280]{2,1,0:T(8,128)} iota(), iota_dimension=2, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
   %eq.293 = pred[4,128,129280]{2,1,0:T(8,128)(4,1)} compare(%eq.299, %eq.294), direction=EQ, metadata={op_name="jit(train_step)/jvp(jit(_one_hot))/eq" stack_frame_id=0}
-  %param_0.4190 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %convert_element_type.2664 = f32[4,128,129280]{2,1,0:T(8,128)} convert(%param_0.4190), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/convert_element_type" stack_frame_id=0}
+  %param_0.4186 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %convert_element_type.2660 = f32[4,128,129280]{2,1,0:T(8,128)} convert(%param_0.4186), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/convert_element_type" stack_frame_id=0}
   %param_3.2977 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(3)
   %sub.652 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_3.2977), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.643 = f32[4,128,129280]{2,1,0:T(8,128)} subtract(%convert_element_type.2664, %sub.652), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %param_1.5063 = f32[4,128]{1,0:T(4,128)S(1)} parameter(1)
-  %sub.650 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_1.5063), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.643 = f32[4,128,129280]{2,1,0:T(8,128)} subtract(%convert_element_type.2660, %sub.652), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %param_1.5064 = f32[4,128]{1,0:T(4,128)S(1)} parameter(1)
+  %sub.650 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_1.5064), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %sub.639 = f32[4,128,129280]{2,1,0:T(8,128)} subtract(%sub.643, %sub.650), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %constant.5109 = f32[]{:T(128)} constant(0)
-  %broadcast.3757 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%constant.5109), dimensions={}, metadata={op_name="broadcast.514"}
-  %mul.3612 = f32[4,128,129280]{2,1,0:T(8,128)} select(%eq.293, %sub.639, %broadcast.3757), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
-  ROOT %reduce.682 = f32[4,128]{1,0:T(4,128)S(1)} reduce(%mul.3612, %constant.5109), dimensions={2}, to_apply=%region_207.232, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %constant.5124 = f32[]{:T(128)} constant(0)
+  %broadcast.3777 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%constant.5124), dimensions={}, metadata={op_name="broadcast.514"}
+  %mul.3612 = f32[4,128,129280]{2,1,0:T(8,128)} select(%eq.293, %sub.639, %broadcast.3777), metadata={op_name="jit(train_step)/jvp()/mul" stack_frame_id=0}
+  ROOT %reduce.682 = f32[4,128]{1,0:T(4,128)S(1)} reduce(%mul.3612, %constant.5124), dimensions={2}, to_apply=%region_207.232, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %region_37.47 (reduce_sum.76: f32[], reduce_sum.80: f32[]) -> f32[] {
@@ -1850,15 +1850,15 @@ StackFrames
   ROOT %reduce_sum.83 = f32[]{:T(128)} add(%reduce_sum.76, %reduce_sum.80), metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.533 (param_0.4191: bf16[4,128,129280], param_1.5064: bf16[4,128]) -> f32[4,128] {
-  %param_0.4191 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} parameter(0)
-  %convert_element_type.2670 = f32[4,128,129280]{2,1,0:T(8,128)} convert(%param_0.4191), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/convert_element_type" stack_frame_id=0}
-  %param_1.5064 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(1)
-  %sub.653 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_1.5064), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
-  %sub.649 = f32[4,128,129280]{2,1,0:T(8,128)} subtract(%convert_element_type.2670, %sub.653), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+%fused_computation.532 (param_0.4187: bf16[4,128,129280], param_1.5065: bf16[4,128]) -> f32[4,128] {
+  %param_0.4187 = bf16[4,128,129280]{2,1,0:T(8,128)(2,1)} parameter(0)
+  %convert_element_type.2666 = f32[4,128,129280]{2,1,0:T(8,128)} convert(%param_0.4187), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/decoder.apply_output_head/convert_element_type" stack_frame_id=0}
+  %param_1.5065 = bf16[4,128]{1,0:T(4,128)(2,1)S(1)} parameter(1)
+  %sub.653 = f32[4,128,129280]{2,1,0:T(8,128)} broadcast(%param_1.5065), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
+  %sub.649 = f32[4,128,129280]{2,1,0:T(8,128)} subtract(%convert_element_type.2666, %sub.653), metadata={op_name="jit(train_step)/jvp()/sub" stack_frame_id=0}
   %exp.448 = f32[4,128,129280]{2,1,0:T(8,128)} exponential(%sub.649), metadata={op_name="jit(train_step)/jvp()/exp" stack_frame_id=0}
-  %constant.5110 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.683 = f32[4,128]{1,0:T(4,128)S(1)} reduce(%exp.448, %constant.5110), dimensions={2}, to_apply=%region_37.47, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
+  %constant.5125 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.683 = f32[4,128]{1,0:T(4,128)S(1)} reduce(%exp.448, %constant.5125), dimensions={2}, to_apply=%region_37.47, metadata={op_name="jit(train_step)/jvp()/reduce_sum" stack_frame_id=0}
 }
 
 %region_152.177 (reduce_sum.417: f32[], reduce_sum.244: f32[]) -> f32[] {
@@ -1867,17 +1867,17 @@ StackFrames
   ROOT %reduce_sum.251 = f32[]{:T(128)} add(%reduce_sum.417, %reduce_sum.244), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.541 (param_0.4172: f32[3,512,128,256]) -> f32[] {
-  %param_0.4172 = f32[3,512,128,256]{3,2,0,1:T(8,128)} parameter(0)
-  %bitcast.752 = f32[512,3,128,256]{3,2,1,0:T(8,128)} bitcast(%param_0.4172), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/dense_layers.wrapped_fn/transpose" stack_frame_id=0}
+%fused_computation.540 (param_0.4168: f32[3,512,128,256]) -> f32[] {
+  %param_0.4168 = f32[3,512,128,256]{3,2,0,1:T(8,128)} parameter(0)
+  %bitcast.752 = f32[512,3,128,256]{3,2,1,0:T(8,128)} bitcast(%param_0.4168), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/dense_layers.wrapped_fn/transpose" stack_frame_id=0}
   %square.588 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%bitcast.752, %bitcast.752), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5088 = f32[]{:T(128)} constant(0)
-  ROOT %reduce.689 = f32[]{:T(128)} reduce(%square.588, %constant.5088), dimensions={0,1,2,3}, to_apply=%region_152.177, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %constant.5103 = f32[]{:T(128)} constant(0)
+  ROOT %reduce.689 = f32[]{:T(128)} reduce(%square.588, %constant.5103), dimensions={0,1,2,3}, to_apply=%region_152.177, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
 }
 
-%fused_computation.542 (param_0.1602: f32[512,3,128,256]) -> bf16[3,512,128,256] {
-  %param_0.1602 = f32[512,3,128,256]{3,2,1,0:T(8,128)} parameter(0)
-  %copy.1551 = bf16[512,3,128,256]{3,0,2,1:T(8,128)(2,1)} copy(%param_0.1602), sharding={replicated}, metadata={op_name="state.params[\'params\'][\'decoder\'][\'dense_layers\'][\'self_attention\'][\'wkv_b\'][\'kernel\']"}
+%fused_computation.541 (param_0.1601: f32[512,3,128,256]) -> bf16[3,512,128,256] {
+  %param_0.1601 = f32[512,3,128,256]{3,2,1,0:T(8,128)} parameter(0)
+  %copy.1551 = bf16[512,3,128,256]{3,0,2,1:T(8,128)(2,1)} copy(%param_0.1601), sharding={replicated}, metadata={op_name="state.params[\'params\'][\'decoder\'][\'dense_layers\'][\'self_attention\'][\'wkv_b\'][\'kernel\']"}
   ROOT %bitcast.753 = bf16[3,512,128,256]{3,1,2,0:T(8,128)(2,1)} bitcast(%copy.1551), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/dense_layers.wrapped_fn/transpose" stack_frame_id=0}
 }
 
@@ -1893,55 +1893,55 @@ StackFrames
   ROOT %reduce_sum.442 = f32[]{:T(128)} add(%reduce_sum.641, %reduce_sum.437), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.543 (param_0.4142: f32[512,3,128,256], param_1.5027: f32[], param_2.4300: f32[], param_3.2953: f32[], param_4.2205: f32[512,3,128,256], param_5.2008: f32[], param_6.1445: f32[3,512,128,256], param_7.1126: pred[], param_8.891: f32[512,3,128,256]) -> (f32[], f32[512,3,128,256], f32[512,3,128,256], f32[512,3,128,256], f32[]) {
-  %param_0.4142 = f32[512,3,128,256]{3,2,1,0:T(8,128)} parameter(0)
+%fused_computation.542 (param_0.4138: f32[512,3,128,256], param_1.5028: f32[], param_2.4297: f32[], param_3.2953: f32[], param_4.2205: f32[512,3,128,256], param_5.2008: f32[], param_6.1445: f32[3,512,128,256], param_7.1126: pred[], param_8.891: f32[512,3,128,256]) -> (f32[], f32[512,3,128,256], f32[512,3,128,256], f32[512,3,128,256], f32[]) {
+  %param_0.4138 = f32[512,3,128,256]{3,2,1,0:T(8,128)} parameter(0)
   %param_3.2953 = f32[]{:T(128)S(6)} parameter(3)
-  %mul.4735.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%param_3.2953), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4733.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%param_3.2953), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_7.1126 = pred[]{:T(512)S(6)} parameter(7)
   %select_n.2129.clone.1 = pred[512,3,128,256]{3,2,1,0:T(8,128)(4,1)} broadcast(%param_7.1126), dimensions={}, metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
   %param_6.1445 = f32[3,512,128,256]{3,2,0,1:T(8,128)} parameter(6)
   %bitcast.1378.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} bitcast(%param_6.1445), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/dense_layers.wrapped_fn/transpose" stack_frame_id=0}
   %param_5.2008 = f32[]{:T(128)} parameter(5)
-  %div.2581.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%param_5.2008), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2580.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} divide(%bitcast.1378.clone.1, %div.2581.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %select_n.2128.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} select(%select_n.2129.clone.1, %bitcast.1378.clone.1, %div.2580.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
-  %constant.4857.clone.1 = f32[]{:T(128)} constant(0.1)
-  %broadcast.4256.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%constant.4857.clone.1), dimensions={}, metadata={op_name="broadcast.336"}
-  %mul.4741.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%select_n.2128.clone.1, %broadcast.4256.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %div.2578.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%param_5.2008), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2577.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} divide(%bitcast.1378.clone.1, %div.2578.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %select_n.2128.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} select(%select_n.2129.clone.1, %bitcast.1378.clone.1, %div.2577.clone.1), metadata={op_name="jit(train_step)/select_n" stack_frame_id=0}
+  %constant.4872.clone.1 = f32[]{:T(128)} constant(0.1)
+  %broadcast.4276.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%constant.4872.clone.1), dimensions={}, metadata={op_name="broadcast.336"}
+  %mul.4739.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%select_n.2128.clone.1, %broadcast.4276.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_8.891 = f32[512,3,128,256]{3,2,1,0:T(8,128)} parameter(8)
-  %constant.4861.clone.1 = f32[]{:T(128)} constant(0.9)
-  %mul.4742.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%constant.4861.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4740.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%param_8.891, %mul.4742.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3441.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} add(%mul.4741.clone.1, %mul.4740.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_2.4300 = f32[]{:T(128)S(6)} parameter(2)
-  %div.2577.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%param_2.4300), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %constant.4876.clone.1 = f32[]{:T(128)} constant(0.9)
+  %mul.4740.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%constant.4876.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4738.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%param_8.891, %mul.4740.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3500.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} add(%mul.4739.clone.1, %mul.4738.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_2.4297 = f32[]{:T(128)S(6)} parameter(2)
+  %div.2574.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%param_2.4297), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
   %integer_pow.401.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%select_n.2128.clone.1, %select_n.2128.clone.1), metadata={op_name="jit(train_step)/integer_pow" stack_frame_id=0}
-  %constant.4860.clone.1 = f32[]{:T(128)} constant(0.05)
-  %mul.4739.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%constant.4860.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4737.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%integer_pow.401.clone.1, %mul.4739.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %constant.4875.clone.1 = f32[]{:T(128)} constant(0.05)
+  %mul.4737.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%constant.4875.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4735.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%integer_pow.401.clone.1, %mul.4737.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
   %param_4.2205 = f32[512,3,128,256]{3,2,1,0:T(8,128)} parameter(4)
-  %constant.4859.clone.1 = f32[]{:T(128)} constant(0.95)
-  %mul.4738.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%constant.4859.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %mul.4736.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%param_4.2205, %mul.4738.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3440.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} add(%mul.4737.clone.1, %mul.4736.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %param_1.5027 = f32[]{:T(128)S(6)} parameter(1)
-  %div.2576.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%param_1.5027), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %div.2575.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} divide(%add.3440.clone.1, %div.2576.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %sqrt.159.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} sqrt(%div.2575.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
-  %constant.4858.clone.1 = f32[]{:T(128)} constant(1e-08)
-  %add.3439.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%constant.4858.clone.1), dimensions={}, metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %add.3438.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} add(%sqrt.159.clone.1, %add.3439.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %multiply.1295.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%div.2577.clone.1, %add.3438.clone.1), metadata={op_name="multiply.288"}
-  %div.2574.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} divide(%add.3441.clone.1, %multiply.1295.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
-  %mul.4734.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%param_0.4142, %broadcast.4256.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3437.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} add(%div.2574.clone.1, %mul.4734.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %mul.4733.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%mul.4735.clone.1, %add.3437.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
-  %add.3436.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} add(%param_0.4142, %mul.4733.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
-  %square.589 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%add.3436.clone.1, %add.3436.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5058 = f32[]{:T(128)} constant(0)
-  %reduce.690 = f32[]{:T(128)} reduce(%square.589, %constant.5058), dimensions={0,1,2,3}, to_apply=%region_219.244, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  %reduce.691.clone.1 = f32[]{:T(128)} reduce(%integer_pow.401.clone.1, %constant.5058), dimensions={0,1,2,3}, to_apply=%region_185.210, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.663 = (f32[]{:T(128)}, f32[512,3,128,256]{3,2,1,0:T(8,128)}, f32[512,3,128,256]{3,2,1,0:T(8,128)}, f32[512,3,128,256]{3,2,1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.690, %add.3436.clone.1, %add.3440.clone.1, %add.3441.clone.1, %reduce.691.clone.1)
+  %constant.4874.clone.1 = f32[]{:T(128)} constant(0.95)
+  %mul.4736.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%constant.4874.clone.1), dimensions={}, metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %mul.4734.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%param_4.2205, %mul.4736.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3499.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} add(%mul.4735.clone.1, %mul.4734.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %param_1.5028 = f32[]{:T(128)S(6)} parameter(1)
+  %div.2573.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%param_1.5028), dimensions={}, metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %div.2572.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} divide(%add.3499.clone.1, %div.2573.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %sqrt.159.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} sqrt(%div.2572.clone.1), metadata={op_name="jit(train_step)/sqrt" stack_frame_id=0}
+  %constant.4873.clone.1 = f32[]{:T(128)} constant(1e-08)
+  %add.3498.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} broadcast(%constant.4873.clone.1), dimensions={}, metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %add.3497.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} add(%sqrt.159.clone.1, %add.3498.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %multiply.1295.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%div.2574.clone.1, %add.3497.clone.1), metadata={op_name="multiply.288"}
+  %div.2571.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} divide(%add.3500.clone.1, %multiply.1295.clone.1), metadata={op_name="jit(train_step)/div" stack_frame_id=0}
+  %mul.4732.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%param_0.4138, %broadcast.4276.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3496.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} add(%div.2571.clone.1, %mul.4732.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %mul.4731.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%mul.4733.clone.1, %add.3496.clone.1), metadata={op_name="jit(train_step)/mul" stack_frame_id=0}
+  %add.3495.clone.1 = f32[512,3,128,256]{3,2,1,0:T(8,128)} add(%param_0.4138, %mul.4731.clone.1), metadata={op_name="jit(train_step)/add" stack_frame_id=0}
+  %square.589 = f32[512,3,128,256]{3,2,1,0:T(8,128)} multiply(%add.3495.clone.1, %add.3495.clone.1), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
+  %constant.5073 = f32[]{:T(128)} constant(0)
+  %reduce.690 = f32[]{:T(128)} reduce(%square.589, %constant.5073), dimensions={0,1,2,3}, to_apply=%region_219.244, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  %reduce.691.clone.1 = f32[]{:T(128)} reduce(%integer_pow.401.clone.1, %constant.5073), dimensions={0,1,2,3}, to_apply=%region_185.210, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.663 = (f32[]{:T(128)}, f32[512,3,128,256]{3,2,1,0:T(8,128)}, f32[512,3,128,256]{3,2,1,0:T(8,128)}, f32[512,3,128,256]{3,2,1,0:T(8,128)}, f32[]{:T(128)}) tuple(%reduce.690, %add.3495.clone.1, %add.3499.clone.1, %add.3500.clone.1, %reduce.691.clone.1)
 }
 
 %region_172.197 (reduce_sum.557: f32[], reduce_sum.381: f32[]) -> f32[] {
@@ -1950,16 +1950,16 @@ StackFrames
   ROOT %reduce_sum.386 = f32[]{:T(128)} add(%reduce_sum.557, %reduce_sum.381), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.783.clone.clone (param_0.4106: f32[4,128], param_1.4998: bf16[4,128,1536], param_2.4261: bf16[1536]) -> bf16[4,128,1536,1] {
-  %param_2.4261 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(2)
-  %dot_general.851 = bf16[4,128,1536]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4261), dimensions={2}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/...k,k->...k/dot_general" stack_frame_id=0}
-  %param_1.4998 = bf16[4,128,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
-  %convert_element_type.3179 = f32[4,128,1536]{2,1,0:T(8,128)} convert(%param_1.4998), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/convert_element_type" stack_frame_id=0}
-  %param_0.4106 = f32[4,128]{1,0:T(4,128)S(1)} parameter(0)
-  %mul.4939 = f32[4,128,1536]{2,1,0:T(8,128)} broadcast(%param_0.4106), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/mul" stack_frame_id=0}
-  %mul.4938 = f32[4,128,1536]{2,1,0:T(8,128)} multiply(%convert_element_type.3179, %mul.4939), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/mul" stack_frame_id=0}
-  %convert_element_type.3178 = bf16[4,128,1536]{2,1,0:T(8,128)(2,1)} convert(%mul.4938), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/convert_element_type" stack_frame_id=0}
-  %dot_general.850 = bf16[4,128,1536]{2,1,0:T(8,128)(2,1)} multiply(%dot_general.851, %convert_element_type.3178), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/...k,k->...k/dot_general" stack_frame_id=0}
+%fused_computation.782.clone.clone (param_0.4102: f32[4,128], param_1.4999: bf16[4,128,1536], param_2.4258: bf16[1536]) -> bf16[4,128,1536,1] {
+  %param_2.4258 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(2)
+  %dot_general.851 = bf16[4,128,1536]{2,1,0:T(8,128)(2,1)} broadcast(%param_2.4258), dimensions={2}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/...k,k->...k/dot_general" stack_frame_id=0}
+  %param_1.4999 = bf16[4,128,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(1)
+  %convert_element_type.3175 = f32[4,128,1536]{2,1,0:T(8,128)} convert(%param_1.4999), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/convert_element_type" stack_frame_id=0}
+  %param_0.4102 = f32[4,128]{1,0:T(4,128)S(1)} parameter(0)
+  %mul.4937 = f32[4,128,1536]{2,1,0:T(8,128)} broadcast(%param_0.4102), dimensions={0,1}, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/mul" stack_frame_id=0}
+  %mul.4936 = f32[4,128,1536]{2,1,0:T(8,128)} multiply(%convert_element_type.3175, %mul.4937), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/mul" stack_frame_id=0}
+  %convert_element_type.3174 = bf16[4,128,1536]{2,1,0:T(8,128)(2,1)} convert(%mul.4936), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/convert_element_type" stack_frame_id=0}
+  %dot_general.850 = bf16[4,128,1536]{2,1,0:T(8,128)(2,1)} multiply(%dot_general.851, %convert_element_type.3174), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/...k,k->...k/dot_general" stack_frame_id=0}
   ROOT %bitcast.1466 = bf16[4,128,1536,1]{2,1,0,3:T(8,128)(2,1)} bitcast(%dot_general.850), metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/...k,k->...k/dot_general" stack_frame_id=0}
 }
 
@@ -1968,21 +1968,21 @@ StackFrames
   ROOT %bitcast.1488 = bf16[4,128,128,192]{2,1,0,3:T(8,128)(2,1)} bitcast(%bitcast_input.12)
 }
 
-%fused_computation.552 (param_0.4154: bf16[4,128,128,192], param_1.5038: f32[4,128], param_2.4311: bf16[4,128,1536], param_3.2964: bf16[1536]) -> (f32[], bf16[1536,128,192,1]) {
-  %param_1.5038 = f32[4,128]{1,0:T(4,128)S(1)} parameter(1)
-  %param_2.4311 = bf16[4,128,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
+%fused_computation.551 (param_0.4150: bf16[4,128,128,192], param_1.5039: f32[4,128], param_2.4308: bf16[4,128,1536], param_3.2964: bf16[1536]) -> (f32[], bf16[1536,128,192,1]) {
+  %param_1.5039 = f32[4,128]{1,0:T(4,128)S(1)} parameter(1)
+  %param_2.4308 = bf16[4,128,1536]{2,1,0:T(8,128)(2,1)S(1)} parameter(2)
   %param_3.2964 = bf16[1536]{0:T(1024)(128)(2,1)S(1)} parameter(3)
-  %fusion.460.clone.1 = bf16[4,128,1536,1]{2,1,0,3:T(8,128)(2,1)} fusion(%param_1.5038, %param_2.4311, %param_3.2964), kind=kLoop, calls=%fused_computation.783.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/...k,k->...k/dot_general" stack_frame_id=0}
-  %param_0.4154 = bf16[4,128,128,192]{2,1,0,3:T(8,128)(2,1)S(1)} parameter(0)
-  %fusion.751 = bf16[4,128,128,192]{2,1,0,3:T(8,128)(2,1)} fusion(%param_0.4154), kind=kLoop, calls=%bitcast_fusion.12
-  %convolution.146.clone.1 = bf16[1536,128,192,1]{1,0,3,2:T(8,128)(2,1)} convolution(%fusion.460.clone.1, %fusion.751), window={size=192x4 pad=191_191x0_0 rhs_reversal=1x0}, dim_labels=1fb0_1io0->bf01, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/dot_general" stack_frame_id=0}
+  %fusion.459.clone.1 = bf16[4,128,1536,1]{2,1,0,3:T(8,128)(2,1)} fusion(%param_1.5039, %param_2.4308, %param_3.2964), kind=kLoop, calls=%fused_computation.782.clone.clone, metadata={op_name="jit(train_step)/jvp(TransformerLinenPure.apply)/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/moe_layers/...k,k->...k/dot_general" stack_frame_id=0}
+  %param_0.4150 = bf16[4,128,128,192]{2,1,0,3:T(8,128)(2,1)S(1)} parameter(0)
+  %fusion.746 = bf16[4,128,128,192]{2,1,0,3:T(8,128)(2,1)} fusion(%param_0.4150), kind=kLoop, calls=%bitcast_fusion.12
+  %convolution.146.clone.1 = bf16[1536,128,192,1]{1,0,3,2:T(8,128)(2,1)} convolution(%fusion.459.clone.1, %fusion.746), window={size=192x4 pad=191_191x0_0 rhs_reversal=1x0}, dim_labels=1fb0_1io0->bf01, metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/dot_general" stack_frame_id=0}
   %bitcast.861 = bf16[1536,128,192]{1,0,2:T(8,128)(2,1)} bitcast(%convolution.146.clone.1), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/closed_call/checkpoint/moe_layers/dot_general" stack_frame_id=0}
   %broadcast_in_dim.1275 = f32[1536,128,192]{1,0,2:T(8,128)} convert(%bitcast.861), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/while/body/broadcast_in_dim" stack_frame_id=0}
   %bitcast.763 = f32[1536,1,128,192]{2,0,3,1:T(8,128)} bitcast(%broadcast_in_dim.1275), metadata={op_name="jit(train_step)/transpose(jvp(TransformerLinenPure.apply))/TransformerLinenPure/decoder/moe_layers.wrapped_fn/transpose" stack_frame_id=0}
   %square.592 = f32[1536,1,128,192]{2,0,3,1:T(8,128)} multiply(%bitcast.763, %bitcast.763), metadata={op_name="jit(train_step)/square" stack_frame_id=0}
-  %constant.5070 = f32[]{:T(128)} constant(0)
-  %reduce.692 = f32[]{:T(128)} reduce(%square.592, %constant.5070), dimensions={0,1,2,3}, to_apply=%region_172.197, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
-  ROOT %tuple.762 = (f32[]{:T(128)}, bf16[1536,128,192,1]{1,0,3,2:T(8,128)(2,1)}) tuple(%reduce.692, %convolution.146.clone.1)
+  %constant.5085 = f32[]{:T(128)} constant(0)
+  %reduce.692 = f32[]{:T(128)} reduce(%square.592, %constant.5085), dimensions={0,1,2,3}, to_apply=%region_172.197, metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}
+  ROOT %tuple.763 = (f32[]{:T(128)}, bf16[1536,128,192,1]{1,0,3,2:T(8,128)(2,1)}) tuple(%reduce.692, %convolution.146.clone.1)
 }
 
 %region_239.264 (reduce_sum.1019: f32[], reduce_sum.687: f32[]) -> f32[] {
@@ -1997,4 +1997,4 @@ StackFrames
   ROOT %reduce_sum.528 = f32[]{:T(128)} add(%reduce_sum.781, %reduce_sum.527), metadata={op_name="jit(train_step)/reduce_sum" stack_frame_id=0}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[],"aliasing_operands":{"lists":[]}}
 }
 
-%fused_computation.557 (param_0.4122: f32[], param_1.5007: f32[], param_2.4280: f32[], param_3.2933: f32[1536,1,128,192], param_4.2185: f32[1536,1,128,192], param_5.1988: f32[], param_6.1425: bf16[1536,128,192,1], param_7.1106: pred[], param_8.871: f32[1536,1,128,192]) -> (f32[], f32[1536,1,128,192], f32[1536,1,128,192], f32[1536,1,128,192], f32[]) {
+%fused_computation.556 (param_0.4118: f32[], param_1.5008: f32[], param_2.4277: f32[], param_3.2933: f32[1536,1,128,192], param_4.2185: f32[1536,1,128,192], param_5.1988: f32[], param_6.1425: bf16[1536,128,192,1], param_7.1106: pred[], param_8.871: f32[1536,1,128,192]) -> (f32[], f32[1536,1,128,192], f32[1536,1,128,192], f32[1536,1,128,192], f32[]) {


### PR DESCRIPTION
Description
===========
Implement Mixture of Experts (MoE) routing primitives and infrastructural updates required for DeepSeek-V4 integration into MaxText. 

-   **DeepSeek Routing Primitives:** Integrated token-based hash routing logic and DeepSeek-specific Top-K routing directly into `moe.py`'s `get_topk` function.
-   **Safe Layer Parameters:** Updated `RoutedMoE` and `RoutedAndSharedMoE` to accept `layer_idx` and `input_ids` via optional keyword arguments. This allows DeepSeek to pipe these variables down into the hashing logic, while safely defaulting to `0` and `None` so existing callers are entirely unimpacted.
-   **Hardware Optimization Bypasses:** Added boundary checks to bypass the TPU `fused_moe_matmul` (via the `vllm_rpa` block) specifically for hash-routed layers where it is unsupported.
-   **Activation Functions:** Registered the `sqrtsoftplus` custom activation function in `linears.py` required by the DeepSeek V4 MoE router.
-   **Unit test suite** (`tests/unit/deepseek_v4_vs_reference_test.py`): Validates MoE routing parity against PyTorch reference implementations.


Tests
=====
Tested on CPU. All DeepSeek V4 and core MoE unit tests pass successfully. 
```bash
pytest tests/unit/deepseek_v4_vs_reference_test.py tests/unit/moe_test.py
============================= test session starts ==============================
collecting ... 
collected 43 items
tests/unit/deepseek_v4_vs_reference_test.py ............                 [ 27%]
tests/unit/moe_test.py ...............................                   [100%]
================ 25 passed, 18 skipped, 123 warnings in 47.50s =================
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
