### PR TITLE
Add zero1 aot support in train compile

### DIFF
--- a/src/maxtext/trainers/pre_train/train_compile.py
+++ b/src/maxtext/trainers/pre_train/train_compile.py
@@ -205,6 +205,16 @@ def is_oom(argv: Sequence[str]) -> bool:
       model,
   ) = get_shaped_inputs(topology_mesh, config)
 
+  # Update params_shardings when shard_optimizer_over_data is enabled (Zero-1)
+  params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
+
+  # When ZeRO-1 is enabled, we need to use the original params_shardings for input shardings
+  # but keep the updated state_mesh_shardings for the optimizer state
+  if config.shard_optimizer_over_data:
+    input_state_mesh_shardings = state_mesh_shardings.replace(params=params_shardings)
+  else:
+    input_state_mesh_shardings = state_mesh_shardings
+
   # Get data sharding
   data_sharding = sharding.get_input_data_sharding(config, topology_mesh)
 
@@ -216,7 +226,7 @@ def is_oom(argv: Sequence[str]) -> bool:
       static_argnums,
       donate_argnums,
   ) = maxtext_utils.get_functional_train_with_signature(
-      train.train_step, data_sharding, state_mesh_shardings, model, config
+      train.train_step, data_sharding, input_state_mesh_shardings, model, config, params_shardings
   )
 
   try:
@@ -271,6 +281,16 @@ def main(argv: Sequence[str]) -> None:
       model,
   ) = get_shaped_inputs(topology_mesh, config)
 
+  # Update params_shardings when shard_optimizer_over_data is enabled (Zero-1)
+  params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
+
+  # When ZeRO-1 is enabled, we need to use the original params_shardings for input shardings
+  # but keep the updated state_mesh_shardings for the optimizer state
+  if config.shard_optimizer_over_data:
+    input_state_mesh_shardings = state_mesh_shardings.replace(params=params_shardings)
+  else:
+    input_state_mesh_shardings = state_mesh_shardings
+
   # Get data sharding
   data_sharding = sharding.get_input_data_sharding(config, topology_mesh)
   if config.enable_diloco:
@@ -282,7 +302,7 @@ def main(argv: Sequence[str]) -> None:
     shaped_train_args = (diloco_state, shaped_train_args[1], shaped_train_args[2])
 
     # Wrap train_step with diloco
-    train_step_partial = functools.partial(train.train_step, model, config, inner_state_shardings, None)
+    train_step_partial = functools.partial(train.train_step, model, config, inner_state_shardings, params_shardings)
     train_step_fn = diloco.build_diloco_train_step(config, train_step_partial)
 
     # For DiLoCo, the train_step_fn is already fully wrapped and takes (state, batch, prng)
@@ -301,7 +321,7 @@ def main(argv: Sequence[str]) -> None:
         static_argnums,
         donate_argnums,
     ) = maxtext_utils.get_functional_train_with_signature(
-        train.train_step, data_sharding, state_mesh_shardings, model, config
+        train.train_step, data_sharding, input_state_mesh_shardings, model, config, params_shardings
     )
 
   # print weights sharding info under debug sharding mode

--- a/tests/integration/diloco_test.py
+++ b/tests/integration/diloco_test.py
@@ -295,7 +295,8 @@ class DiLoCoTest(unittest.TestCase):
         )
     )
 
-  @pytest.mark.tpu_only
+  @pytest.mark.cpu_only
+  @pytest.mark.tpu_backend
   def test_diloco_two_slices(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_compiled_diloco.pickle")

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -1102,3 +1102,24 @@ class TrainCompile(parameterized.TestCase):
       # and did NOT unpickle them into JAX serialization bytes.
       assert loaded_legacy.startswith(b"\x80")
       assert loaded_legacy != serialized
+
+  @pytest.mark.cpu_only
+  def test_zero1_optimizer_sharding(self):
+    """AOT test for Zero-1 optimizer sharding (shard_optimizer_over_data)"""
+    temp_dir = gettempdir()
+    compiled_trainstep_file = os.path.join(temp_dir, "test_zero1_optimizer_sharding.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "base_emb_dim=256",
+            "base_mlp_dim=256",
+            "base_num_decoder_layers=2",
+            "ici_data_parallelism=4",
+            "shard_optimizer_over_data=true",
+            "shard_mode=explicit",
+        )
+    )


### PR DESCRIPTION
# Description

Previously AOT using ZeRO-1 sharding was not supported for train_compile. This PR debugs this issue and enable this funciton. It also adds a test protecting Zero-1 sharding for AOT.

This PR also corrects one of diloco tests as CPU test instead of TPU test.

# Tests

CI and added test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
