### PR TITLE
Improve error message when tokenize_data config doesn't match dataset

### DIFF
--- a/src/maxtext/input_pipeline/data_processing_utils.py
+++ b/src/maxtext/input_pipeline/data_processing_utils.py
@@ -31,7 +31,7 @@ def parse_and_keep_features(dataset, config, data_columns, tokenize):
     dataset = dataset.map(input_pipeline_utils.ParseFeatures(data_columns, tokenize))
     dataset = dataset.map(input_pipeline_utils.NormalizeFeatures(data_columns, tokenize))
   else:
-    dataset = dataset.map(input_pipeline_utils.KeepFeatures(feature_names=data_columns))
+    dataset = dataset.map(input_pipeline_utils.KeepFeatures(feature_names=data_columns, tokenize=tokenize))
   return dataset
 
 

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -544,7 +544,12 @@ def make_tfrecord_iter_dataset(path: str):
 
 @dataclasses.dataclass
 class ParseFeatures(grain.MapTransform):
-  """Parse serialized example"""
+  """Parse serialized tf.train.Example protos for arrayrecord/tfrecord datasets.
+
+  Also validates that the stored field type matches `tokenize`: raises
+  ValueError if `tokenize=True` but the column contains integers (pre-tokenized)
+  or if `tokenize=False` but the column contains bytes (raw text).
+  """
 
   def __init__(self, data_columns, tokenize):
     self.data_columns = data_columns
@@ -567,8 +572,18 @@ class ParseFeatures(grain.MapTransform):
     for col in self.data_columns:
       f = features[col]
       if self.tokenize:
+        if not f.bytes_list.value:
+          raise ValueError(
+              f"tokenize_data=True but column '{col}' has no text (bytes) data. "
+              "Set tokenize_train_data or tokenize_eval_data to False if your dataset is already tokenized."
+          )
         parsed[col] = np.array(f.bytes_list.value, dtype=object)
       else:
+        if not f.int64_list.value:
+          raise ValueError(
+              f"tokenize_data=False but column '{col}' has no integer token data. "
+              "Set tokenize_train_data or tokenize_eval_data to True if your dataset needs tokenization."
+          )
         parsed[col] = np.array(f.int64_list.value, dtype=np.int32)
     return parsed
 
@@ -590,20 +605,17 @@ class NormalizeFeatures(grain.MapTransform):
 
 @dataclasses.dataclass
 class KeepFeatures(grain.MapTransform):
-  """Keep only specified features in the dataset element.
+  """Filter dataset elements to specified features for parquet and other non-proto formats.
 
-  This transform filters the input dictionary, retaining only the keys
-  that are present in `feature_names`.
+  Retains only the keys present in `feature_names`. Validates the stored value
+  type against `tokenize`: raises ValueError if `tokenize=True` but a column
+  contains integer data (pre-tokenized), or if `tokenize=False` but a column
+  contains string/bytes data (raw text).
   """
 
-  def __init__(self, feature_names: list[str]):
-    """Initializes the KeepFeatures transform.
-
-    Args:
-      feature_names: A list of strings, where each string is the name of a
-        feature to be kept in the dataset element.
-    """
+  def __init__(self, feature_names: list[str], tokenize: bool = True):
     self.feature_names = feature_names
+    self.tokenize = tokenize
 
   def map(self, element: dict[str, Any]) -> dict[str, Any]:
     """Applies the feature filtering to the input element."""
@@ -613,7 +625,26 @@ class KeepFeatures(grain.MapTransform):
           f"Column {missing} not found in dataset. Available columns: {sorted(element.keys())}. "
           "Please set train_data_columns or eval_data_columns accordingly."
       )
-    return {k: v for k, v in element.items() if k in self.feature_names}
+    filtered = {k: v for k, v in element.items() if k in self.feature_names}
+    for col, val in filtered.items():
+      if self.tokenize:
+        if isinstance(val, np.ndarray) and np.issubdtype(val.dtype, np.integer):
+          raise ValueError(
+              f"tokenize_data=True but column '{col}' contains integer (pre-tokenized) data. "
+              "Set tokenize_train_data or tokenize_eval_data to False if your dataset is already tokenized."
+          )
+        if isinstance(val, (list, tuple)) and val and isinstance(val[0], (int, np.integer)):
+          raise ValueError(
+              f"tokenize_data=True but column '{col}' contains integer (pre-tokenized) data. "
+              "Set tokenize_train_data or tokenize_eval_data to False if your dataset is already tokenized."
+          )
+      else:
+        if isinstance(val, (str, bytes)):
+          raise ValueError(
+              f"tokenize_data=False but column '{col}' contains text data. "
+              "Set tokenize_train_data or tokenize_eval_data to True if your dataset needs tokenization."
+          )
+    return filtered
 
 
 @dataclasses.dataclass

--- a/src/maxtext/input_pipeline/tfds_data_processing.py
+++ b/src/maxtext/input_pipeline/tfds_data_processing.py
@@ -102,6 +102,19 @@ def preprocessing_pipeline(
         "Please set train_data_columns or eval_data_columns accordingly."
     )
 
+  for col in data_column_names:
+    col_dtype = dataset.element_spec[col].dtype
+    if tokenize and col_dtype != tf.string:
+      raise ValueError(
+          f"tokenize_data=True but column '{col}' has dtype {col_dtype} (expected tf.string). "
+          "Set tokenize_train_data or tokenize_eval_data to False if your dataset is already tokenized."
+      )
+    if not tokenize and col_dtype == tf.string:
+      raise ValueError(
+          f"tokenize_data=False but column '{col}' has dtype tf.string (expected integer). "
+          "Set tokenize_train_data or tokenize_eval_data to True if your dataset needs tokenization."
+      )
+
   if not use_dpo:
     assert len(data_column_names) == 1
     dataset = dataset.map(

--- a/tests/unit/grain_data_processing_test.py
+++ b/tests/unit/grain_data_processing_test.py
@@ -426,6 +426,38 @@ class GrainTFRecordProcessingTest(GrainBaseProcessingTest, unittest.TestCase):
     self.train_iter = grain_data_processing.make_grain_train_iterator(self.config, self.mesh, self.process_indices)
 
 
+class GrainTFRecordPreTokenizedProcessingTest(GrainTFRecordProcessingTest):
+  """Test grain data processing with a pre-tokenized TFRecord dataset (tokenize_train_data=False).
+
+  Uses c4/en/3.0.5 validation_tokenized_5662seqs split, which stores token IDs
+  in an 'ids' int64 column rather than raw text.
+  """
+
+  def setUp(self):
+    super().setUp()
+    base = get_test_dataset_path() if is_decoupled() else os.path.join(tempfile.gettempdir(), "gcsfuse")
+    grain_train_file = os.path.join(base, "c4", "en", "3.0.5", "c4-validation_tokenized_5662seqs.tfrecord-00000-of-00001")
+    self.config = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path()],
+        per_device_batch_size=1,
+        run_name="test",
+        mesh_axes=["data"],
+        logical_axis_rules=[["batch", "data"]],
+        data_sharding=["data"],
+        base_output_directory=self.config.base_output_directory,
+        dataset_type="grain",
+        grain_file_type="tfrecord",
+        grain_train_files=grain_train_file,
+        grain_worker_count=1,
+        grain_per_worker_buffer_size=1,
+        tokenize_train_data=False,
+        train_data_columns=["ids"],
+        tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "tokenizer.default"),
+        enable_checkpointing=False,
+    )
+    self.train_iter = grain_data_processing.make_grain_train_iterator(self.config, self.mesh, self.process_indices)
+
+
 @pytest.mark.external_training
 class GrainSFTParquetProcessingTest(unittest.TestCase):
   """Tests the SFT pipeline end-to-end using the real ultrachat_200k parquet dataset."""


### PR DESCRIPTION
# Description

Currently when the flag `tokenize_{train/eval}_data` doesn't match with the dataset (pre-tokenized or not), the data pipeline often crash without clear error message, for example: https://buganizer.corp.google.com/issues/509946269#comment10 

# Tests

* Add unit test for pre-tokenized dataset
* Manually tested error cases

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
