### PR TITLE
Use env credentials instead of passing them through

### DIFF
--- a/src/maxtext/configs/pyconfig.py
+++ b/src/maxtext/configs/pyconfig.py
@@ -324,6 +324,11 @@ def initialize_pydantic(argv: list[str] | None = None, **kwargs) -> MaxTextConfi
 
   # 2. Get overrides from CLI and kwargs
   cli_cfg = omegaconf.OmegaConf.from_cli(cli_args)
+  if "hf_access_token" in cli_cfg:
+    logger.warning(
+        "WARNING: Passing 'hf_access_token' via command-line arguments is deprecated and insecure because it makes "
+        "your token visible in 'ps' and shell history. Please set the 'HF_TOKEN' environment variable instead."
+    )
   kwargs_cfg = omegaconf.OmegaConf.create(kwargs)
   overrides_cfg = omegaconf.OmegaConf.merge(cli_cfg, kwargs_cfg)
 

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/README.md
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/README.md
@@ -4,8 +4,11 @@ The agent is used to automate the model-specific mappings of checkpoint conversi
 ## Quick starts
 To begin, you'll need:
 
-1. A Google atccount.
-2. An API key (create one in [Google AI Studio](https://aistudio.google.com/app/apikey)).
+1. A Google account.
+2. An API key (create one in [Google AI Studio](https://aistudio.google.com/app/apikey)), and set it as an environment variable:
+```bash
+export GEMINI_API_KEY="<Your-API-KEY>"
+```
 3. Install the Google Generative AI Python library:
 ```
 pip install -q -U "google-genai>=1.0.0"
@@ -30,7 +33,7 @@ After it, you can get two `*.json` files in `config.base_output_directory` folde
 
 ```bash
 python3 -m maxtext.experimental.agent.ckpt_conversion_agent.step1 --target_model=<model_name> \
-  --dir_path=src/maxtext/experimental/agent/ckpt_conversion_agent --api_key=<Your-API-KEY>
+  --dir_path=src/maxtext/experimental/agent/ckpt_conversion_agent
 ```
 
 Our engineer should check the `src/maxtext/experimental/agent/ckpt_conversion_agent/outputs/proposed_dsl.txt` for potential new DSL and assess if it's needed. Then we need to add this ops into `src/maxtext/experimental/agent/ckpt_conversion_agent/context/dsl.txt`.
@@ -39,7 +42,7 @@ Our engineer should check the `src/maxtext/experimental/agent/ckpt_conversion_ag
 
 ```bash
 python3 -m maxtext.experimental.agent.ckpt_conversion_agent.step2 --target_model=<model_name> \
-  --dir_path=src/maxtext/experimental/agent/ckpt_conversion_agent --api_key=<Your-API-KEY>
+  --dir_path=src/maxtext/experimental/agent/ckpt_conversion_agent
 ```
 
 ## Evaluation and Debugging
@@ -53,7 +56,7 @@ You can automatically verify the output by comparing the generated code against 
 
 ```bash
 python3 -m maxtext.experimental.agent.ckpt_conversion_agent.evaluation --files ground_truth/<model>.py \
-  outputs/hook_fn.py --api_key=<Your-API-KEY> --dir_path=src/maxtext/experimental/agent/ckpt_conversion_agent
+  outputs/hook_fn.py --dir_path=src/maxtext/experimental/agent/ckpt_conversion_agent
 ```
 
 ### Manual Debugging (No Ground-Truth Code)
@@ -121,5 +124,5 @@ Run the [One-shot agent Jyputer notebook](./baselines/one-shot-agent.ipynb)
 ### Prompt-chain Agent:
 ```bash
 python3 -m maxtext.experimental.agent.ckpt_conversion_agent.prompt_chain --target_model=<model_name> \
-  --dir_path=src/maxtext/experimental/agent/ckpt_conversion_agent --api_key=<Your-API-KEY>
+  --dir_path=src/maxtext/experimental/agent/ckpt_conversion_agent
 ```

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/analysis.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/analysis.py
@@ -27,7 +27,7 @@ class AnalysisAgent(BaseAgent):
   conversion script, with verification that every parameter is mapped.
   """
 
-  def __init__(self, api_key, dir_path, target_model="gemma3", max_retries=3):
+  def __init__(self, dir_path, target_model="gemma3", max_retries=3):
     """
     Initializes the PlanAgent.
 
@@ -35,7 +35,7 @@ class AnalysisAgent(BaseAgent):
         target_model (str): The target model for conversion.
         max_retries (int): The maximum number of retries for generation.
     """
-    super().__init__(api_key)
+    super().__init__()
 
     self.target_model = target_model
     self.max_retries = max_retries

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/base.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/base.py
@@ -16,6 +16,8 @@
 A base class for other agents
 """
 
+import os
+
 from google import genai
 from google.genai.types import GenerateContentConfig
 
@@ -25,16 +27,14 @@ MODEL_ID = "gemini-2.5-pro"
 class BaseAgent:
   """A base class for agents that provides text generation capabilities."""
 
-  def __init__(self, api_key, model_id=MODEL_ID):
+  def __init__(self, model_id=MODEL_ID):
     """
     Initializes the BaseAgent with a genai client.
-
-    Args:
-        client: An initialized genai.Client object.
     """
-    if not api_key:
-      raise ValueError("A valid api_key must be provided.")
-    client = genai.Client(api_key=api_key)
+    resolved_api_key = os.environ.get("GEMINI_API_KEY")
+    if not resolved_api_key:
+      raise ValueError("GEMINI_API_KEY environment variable is not set.")
+    client = genai.Client(api_key=resolved_api_key)
     self.client = client
     self.model_id = model_id
 

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/dsl.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/dsl.py
@@ -24,7 +24,7 @@ from maxtext.experimental.agent.ckpt_conversion_agent.base import BaseAgent
 class DSLAgent(BaseAgent):
   """DSL Agent"""
 
-  def __init__(self, api_key, dir_path, target_model="gemma3-4b", max_retries=3):
+  def __init__(self, dir_path, target_model="gemma3-4b", max_retries=3):
     """
     Initializes the DSLAgent.
 
@@ -33,7 +33,7 @@ class DSLAgent(BaseAgent):
         max_retries (int): The maximum number of retries for generation.
     """
     # Initialize the parent BaseAgent with the client
-    super().__init__(api_key)
+    super().__init__()
 
     self.target_model = target_model
     self.max_retries = max_retries
@@ -83,7 +83,6 @@ if __name__ == "__main__":
   parser.add_argument(
       "--dir_path", type=str, required=True, help='The file path to the context directory (e.g., "context/gemma3").'
   )
-  parser.add_argument("--api_key", type=str, help="Optional API key for external services.")
   args = parser.parse_args()
-  agent = DSLAgent(api_key=args.api_key, dir_path=args.dir_path, target_model=TARGET_MODEL)
+  agent = DSLAgent(dir_path=args.dir_path, target_model=TARGET_MODEL)
   global_verification_dsl = agent.verify_dsl()

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/evaluation.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/evaluation.py
@@ -66,12 +66,11 @@ def main():
       description="Gemini evaluate the agent code implementation against human-written ground truth code"
   )
   parser.add_argument("--files", nargs=2, help="Paths to code files to analyze.")
-  parser.add_argument("--api_key", type=str, help="API key.")
   parser.add_argument("--dir_path", type=str, help="Directory path.")
 
   args = parser.parse_args()
 
-  baseAgent = BaseAgent(api_key=args.api_key)
+  baseAgent = BaseAgent()
   dir_path = args.dir_path
 
   prompt_templates = {

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/mapping.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/mapping.py
@@ -28,7 +28,7 @@ class MappingAgent(BaseAgent):
   An agent that generates and verifies mapping functions for model conversion.
   """
 
-  def __init__(self, api_key, dir_path, target_model="gemma3-4b", max_retries=3):
+  def __init__(self, dir_path, target_model="gemma3-4b", max_retries=3):
     """
     Initializes the MappingAgent.
 
@@ -36,7 +36,7 @@ class MappingAgent(BaseAgent):
         target_model (str): The target model for conversion.
         max_retries (int): The maximum number of retries for generation.
     """
-    super().__init__(api_key)
+    super().__init__()
 
     self.target_model = target_model
     self.max_retries = max_retries
@@ -171,9 +171,8 @@ if __name__ == "__main__":
   parser.add_argument(
       "--dir_path", type=str, required=True, help='The file path to the context directory (e.g., "context/gemma3").'
   )
-  parser.add_argument("--api_key", type=str, help="Optional API key for external services.")
   args = parser.parse_args()
-  agent = MappingAgent(api_key=args.api_key, dir_path=args.dir_path, target_model=TARGET_MODEL)
+  agent = MappingAgent(dir_path=args.dir_path, target_model=TARGET_MODEL)
   try:
     param_mapping_code = agent.generate_param_mapping()
     shape_mapping_code = agent.generate_shape_mapping()

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/plan.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/plan.py
@@ -28,7 +28,7 @@ class PlanAgent(BaseAgent):
   conversion script, with verification that every parameter is mapped.
   """
 
-  def __init__(self, api_key, dir_path, target_model="gemma3", max_retries=3):
+  def __init__(self, dir_path, target_model="gemma3", max_retries=3):
     """
     Initializes the PlanAgent.
 
@@ -36,7 +36,7 @@ class PlanAgent(BaseAgent):
         target_model (str): The target model for conversion.
         max_retries (int): The maximum number of retries for generation.
     """
-    super().__init__(api_key)
+    super().__init__()
 
     self.target_model = target_model
     self.max_retries = max_retries
@@ -109,7 +109,6 @@ if __name__ == "__main__":
   parser.add_argument(
       "--dir_path", type=str, required=True, help='The file path to the context directory (e.g., "context/gemma3").'
   )
-  parser.add_argument("--api_key", type=str, help="Optional API key for external services.")
   args = parser.parse_args()
-  agent = PlanAgent(api_key=args.api_key, dir_path=args.dir_path, target_model=TARGET_MODEL)
+  agent = PlanAgent(dir_path=args.dir_path, target_model=TARGET_MODEL)
   agent.plan_conversion()

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/prompt_chain.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/prompt_chain.py
@@ -29,9 +29,9 @@ class prompt_chaining_agent(BaseAgent):
   with verification that every parameter is actually mapped.
   """
 
-  def __init__(self, api_key, target_model="gemma3", max_retries=3, dir_path="context"):
+  def __init__(self, target_model="gemma3", max_retries=3, dir_path="context"):
     # Initialize the parent BaseAgent with the client
-    super().__init__(api_key)
+    super().__init__()
     self.target_model = target_model
     self.max_retries = max_retries
     self.dir_path = dir_path
@@ -178,7 +178,6 @@ if __name__ == "__main__":
 
   parser.add_argument("--target_model", type=str, required=True, help='The name of the target model (e.g., "GEMMA3").')
   parser.add_argument("--dir_path", type=str, required=True, help="The file path to the ckpt conversion agent directory.")
-  parser.add_argument("--api_key", type=str, required=True, help="Gemini API key.")
   args = parser.parse_args()
-  agent = prompt_chaining_agent(api_key=args.api_key, target_model=args.target_model, dir_path=args.dir_path)
+  agent = prompt_chaining_agent(target_model=args.target_model, dir_path=args.dir_path)
   agent.run_chain()

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/step1.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/step1.py
@@ -28,17 +28,15 @@ if __name__ == "__main__":
   parser.add_argument(
       "--dir_path", type=str, required=True, help='The file path to the context directory (e.g., "context/gemma3").'
   )
-  parser.add_argument("--api_key", type=str, help="Optional API key for external services.")
   args = parser.parse_args()
 
   TARGET_MODEL = args.target_model
   dir_path = args.dir_path
-  api_key = args.api_key
 
-  analysisAgent = AnalysisAgent(api_key=api_key, dir_path=dir_path, target_model=TARGET_MODEL)
+  analysisAgent = AnalysisAgent(dir_path=dir_path, target_model=TARGET_MODEL)
   analysisAgent.analyze_model_structures()
 
-  dslAgent = DSLAgent(api_key=api_key, dir_path=dir_path, target_model=TARGET_MODEL)
+  dslAgent = DSLAgent(dir_path=dir_path, target_model=TARGET_MODEL)
   dslAgent.verify_dsl()
 
   # Human interaction needed,

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/step2.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/step2.py
@@ -29,21 +29,19 @@ if __name__ == "__main__":
   parser.add_argument(
       "--dir_path", type=str, required=True, help='The file path to the context directory (e.g., "context/gemma3").'
   )
-  parser.add_argument("--api_key", type=str, help="Optional API key for external services.")
   args = parser.parse_args()
 
   TARGET_MODEL = args.target_model
   dir_path = args.dir_path
-  api_key = args.api_key
 
   # Before proceed, check outputs/proposed_dsl.txt to consider if new ops are needed
 
-  planAgent = PlanAgent(api_key=api_key, dir_path=dir_path, target_model=TARGET_MODEL)
+  planAgent = PlanAgent(dir_path=dir_path, target_model=TARGET_MODEL)
   planAgent.plan_conversion()
 
-  mappingAgent = MappingAgent(api_key=api_key, dir_path=dir_path, target_model=TARGET_MODEL)
+  mappingAgent = MappingAgent(dir_path=dir_path, target_model=TARGET_MODEL)
   param_mapping_code = mappingAgent.generate_param_mapping()
   mappingAgent.generate_shape_mapping()
 
-  transformationAgent = TransformationAgent(api_key=api_key, dir_path=dir_path, target_model=TARGET_MODEL)
+  transformationAgent = TransformationAgent(dir_path=dir_path, target_model=TARGET_MODEL)
   transformationAgent.generate_hook_functions()

--- a/src/maxtext/experimental/agent/ckpt_conversion_agent/transformation.py
+++ b/src/maxtext/experimental/agent/ckpt_conversion_agent/transformation.py
@@ -27,14 +27,14 @@ class TransformationAgent(BaseAgent):
   An agent that generates transformation hook functions for model conversion.
   """
 
-  def __init__(self, api_key, dir_path, target_model="gemma3"):
+  def __init__(self, dir_path, target_model="gemma3"):
     """
     Initializes the TransformationAgent.
 
     Args:
         target_model (str): The target model for conversion.
     """
-    super().__init__(api_key)
+    super().__init__()
     self.target_model = target_model
     self.dir_path = dir_path
     self.dsl = load_text_file(f"{self.dir_path}/context/dsl.txt")
@@ -93,7 +93,6 @@ if __name__ == "__main__":
   parser.add_argument(
       "--dir_path", type=str, required=True, help='The file path to the context directory (e.g., "context/gemma3").'
   )
-  parser.add_argument("--api_key", type=str, help="Optional API key for external services.")
   args = parser.parse_args()
-  agent = TransformationAgent(api_key=args.api_key, dir_path=args.dir_path, target_model=TARGET_MODEL)
+  agent = TransformationAgent(dir_path=args.dir_path, target_model=TARGET_MODEL)
   global_hook_fn_code = agent.generate_hook_functions()

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -696,6 +696,8 @@ def from_pretrained(
         conversion_env = os.environ.copy()
         conversion_env["JAX_PLATFORMS"] = "cpu"
         # conversion_env["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={simulated_cpu_devices_count}"
+        if config.hf_access_token:
+          conversion_env["HF_TOKEN"] = config.hf_access_token
 
         to_maxtext_cmd = [
             sys.executable,
@@ -705,7 +707,6 @@ def from_pretrained(
             f"model_name={config.model_name}",
             f"base_output_directory={config.base_output_directory}",
             f"scan_layers={config.scan_layers}",
-            f"hf_access_token={config.hf_access_token}",
             "use_multimodal=false",
             "skip_jax_distributed_system=True",
             "--lazy_load_tensors=True",


### PR DESCRIPTION
# Description

This PR eliminates sensitive credential exposure (Gemini API keys and Hugging Face access tokens) via command-line arguments and traceback/subprocess logs. 

- **Why is this change being made**: Sensitive keys passed as CLI arguments are visible to other local users via `ps` / `/proc` and stored in bash history. Additionally, subprocess failures (like running `to_maxtext.py`) dump CLI arguments in plaintext in tracebacks/logs.
- **Implementation**:
  - Switch all `experimental/agent/ckpt_conversion_agent/` scripts to retrieve the Gemini API key strictly from the `GEMINI_API_KEY` environment variable.
  - Complete deletion of `api_key` parameters from all signatures and instantiations inside the experimental agent scripts.
  - Update `utils/model_creation_utils.py` to pass the Hugging Face token to the `to_maxtext` subprocess via the private `HF_TOKEN` environment variable instead of CLI parameters.
  - Add a security warning in `configs/pyconfig.py` if `hf_access_token` is passed via CLI to raise developer awareness while preserving E2E test backwards compatibility.

FIXES: b/510376457

# Tests

I successfully executed the remote parameter mapping tests on the dedicated TPU VM:
```bash
pytest tests/unit/param_mapping_test.py
```
All 20 tests passed successfully:
```
tests/unit/param_mapping_test.py ....................                    [100%]
======================== 20 passed, 1 warning in 0.17s =========================
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
