### PR TITLE
Do not block Add Label due to skipped checkRun

### DIFF
--- a/.github/workflows/AddLabel.yml
+++ b/.github/workflows/AddLabel.yml
@@ -112,7 +112,7 @@ jobs:
               // Ignore the current running workflow
               if (checkRun.name.endsWith(context.job)) continue
 
-              if (checkRun.status !== 'completed' || checkRun.conclusion !== 'success') {
+              if (checkRun.status !== 'completed' || !['success', 'skipped'].includes(checkRun.conclusion)) {
                 core.info(`Waiting for check: ${checkRun.name} (Status: ${checkRun.status}, Conclusion: ${checkRun.conclusion})`);
                 return; // Exit without failing
               }


### PR DESCRIPTION
# Description

AddPullReady was designed to wait for all checks on a commit to reach a status of `success` before it will add the "pull ready" label. But it missed `skipped` case. In that case, the script stops and reports that it is "waiting" for the dispatch check, even though that check has already finished. 

The PR fixed above scenario, treating `skipped` in conclusion of checkRun same as `success`. So that it won't block adding pull_ready label.

# Tests
CI/CD work flow.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
