### PR TITLE
Add OLMo-3 7B stage-1 pretraining scripts

### DIFF
--- a/docs/guides/data_input_pipeline/olmo_grain.md
+++ b/docs/guides/data_input_pipeline/olmo_grain.md
@@ -46,7 +46,9 @@ instances, and yields the shapes the MaxText pretrain trainer expects.
    tokenizer_path: allenai/Olmo-3-7B-Instruct
    ```
 
-   See `scripts/run_olmo3_7b_grain_smoke.sh` for a runnable smoke launcher.
+   See `scripts/run_olmo3_7b_grain_smoke.sh` for a runnable smoke launcher,
+   or `src/maxtext/trainers/pre_train/scripts/olmo/` for end-to-end stage-1
+   pretraining launchers (single-host + XPK).
 
 ## Resume
 

--- a/src/maxtext/trainers/pre_train/scripts/olmo/README.md
+++ b/src/maxtext/trainers/pre_train/scripts/olmo/README.md
@@ -1,0 +1,181 @@
+# OLMo-3 7B stage-1 pretraining launchers
+
+End-to-end launchers for reproducing AI2's [OLMo-3-1025-7B](https://huggingface.co/allenai/Olmo-3-1025-7B)
+stage-1 pretraining in MaxText. Hyperparameters mirror OLMo-core's
+[`OLMo-3-1025-7B-pretrain-1.py`](https://github.com/allenai/OLMo-core/blob/main/src/scripts/official/OLMo3/OLMo-3-1025-7B-pretrain-1.py):
+global batch ≈4M tokens, peak LR 3e-4 cosine to 0.1×, 2k warmup, β=(0.9, 0.95),
+ε=1e-8, WD 0.1, grad-clip 1.0, z-loss 1e-5, logits in fp32, skip-step-on-spike.
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `run_olmo3_7b_stage1.sh` | Direct host launcher. Used by the XPK wrapper inside the runner image; also usable standalone for single-host smoke tests. |
+| `xpk_olmo3_7b_stage1.sh` | XPK wrapper for multi-host TPU clusters. Modes: `submit` / `monitor` / `resume_until_done` (deletes + resubmits on Kueue preemption until a target step is reached). |
+
+Both scripts are env-var driven. Header comments in each enumerate required vs. optional env.
+
+## Quick start (multi-host TPU via XPK)
+
+```bash
+source ~/.hf_token.sh
+
+export XPK_CLUSTER=<your-cluster>
+export XPK_PROJECT=<your-project>
+export XPK_ZONE=<your-zone>
+export XPK_DEVICE_TYPE=tpu7x-4x8x8       # or tpu7x-4x4x4 for a smoke run
+export XPK_TOTAL_DEVICES=512             # set to match device-type * 2 (Ironwood has 2 JAX devices/chip)
+export XPK_BASE_OUTPUT_DIR=gs://<your-bucket>/olmo/runs
+export XPK_RUN_NAME=olmo3_7b_stage1
+
+export OLMO_INDEX_PATH=/tmp/olmo-data/olmo/indices/olmo_index_seq8192.json
+export OLMO_GCS_BASE=gs://<your-bucket>/
+export LOAD_PARAMETERS_PATH=gs://<your-bucket>/olmo/checkpoints/stage1-step0/0/items
+
+bash src/maxtext/trainers/pre_train/scripts/olmo/xpk_olmo3_7b_stage1.sh submit
+bash src/maxtext/trainers/pre_train/scripts/olmo/xpk_olmo3_7b_stage1.sh monitor
+# Drive the full pretrain (auto-resubmits on preemption):
+STEPS_OVERRIDE=1414078 \
+  bash src/maxtext/trainers/pre_train/scripts/olmo/xpk_olmo3_7b_stage1.sh resume_until_done
+```
+
+`STEPS=1414078` (= 5.928T tokens at 512 × 8192/step) matches AI2's stage-1
+horizon. The wrapper passes `LIBTPU_INIT_ARGS` (Ironwood XLA flags) and the
+full MaxText perf flag set automatically — no manual override needed.
+
+## Quick start (single-host / smoke test)
+
+```bash
+source $MAXTEXT_ROOT/maxtext_venv/bin/activate
+
+INDEX_PATH=/tmp/olmo-data/olmo/indices/olmo_index_seq8192.json \
+GCS_BASE=gs://<your-bucket>/ \
+LOCAL_MOUNT=/tmp/olmo-data \
+OUTPUT_DIR=gs://<your-bucket>/olmo/runs \
+LOAD_PARAMETERS_PATH=gs://<your-bucket>/olmo/checkpoints/stage1-step0/0/items \
+HF_SECRETS=~/.hf_token.sh \
+RUN_NAME=olmo3_7b_stage1 \
+STEPS=50 WARMUP_STEPS=10 CHECKPOINT_PERIOD=50 \
+bash src/maxtext/trainers/pre_train/scripts/olmo/run_olmo3_7b_stage1.sh
+```
+
+## Prerequisites
+
+**Tokenized data corpus.** AI2 maintains the OLMo-mix manifests in
+[`allenai/OLMo-core/src/olmo_core/data/mixes/`](https://github.com/allenai/OLMo-core/tree/main/src/olmo_core/data/mixes)
+(stage-1 uses
+[`OLMo-mix-0625-official.txt`](https://github.com/allenai/OLMo-core/blob/main/src/olmo_core/data/mixes/OLMo-mix-0625-official.txt)
+or
+[`OLMo-mix-0925-official.txt`](https://github.com/allenai/OLMo-core/blob/main/src/olmo_core/data/mixes/OLMo-mix-0925-official.txt);
+the matching `DataMix` enum values are in
+[`mixes/__init__.py`](https://github.com/allenai/OLMo-core/blob/main/src/olmo_core/data/mixes/__init__.py)).
+This MaxText repo also vendors copies of these at root for offline use. The
+underlying preprocessed `.npy` tokens live under AI2's `s3://ai2-llm/` bucket
+(see the `base_dir` arg on `DataMix.build` in
+[`OLMo-core`](https://github.com/allenai/OLMo-core/blob/main/src/olmo_core/data/mixes/__init__.py));
+mirror them into your own GCS bucket with
+[`tools/data_generation/download_olmo_data_to_gcs.py`](../../../../../tools/data_generation/download_olmo_data_to_gcs.py)
+(reads a manifest, pulls from AI2's source, uploads to `--gcs-dest`).
+
+**Data index.** Once the corpus is mirrored, build the index with
+[`tools/data_generation/build_olmo_npy_index.py`](../../../../../tools/data_generation/build_olmo_npy_index.py)
+against the same manifest + sequence length, then upload the resulting JSON
+to GCS. Mount your bucket read-only via gcsfuse inside the pod — the XPK
+wrapper does this automatically (`MOUNT_GCSFUSE=1`).
+
+See [`docs/guides/data_input_pipeline/olmo_grain.md`](../../../../../../docs/guides/data_input_pipeline/olmo_grain.md)
+for the full data-pipeline reference.
+
+**Init weights.** Two supported starting points:
+
+#### Option 1: From AI2's `stage1-step0` (recommended — reproduces AI2's run)
+
+This puts MaxText at exactly the same weights as the PyTorch reference, so
+the loss curve can be overlaid against AI2's published WandB curve. AI2
+also publishes intermediate checkpoints at every 1000-step boundary on the
+[`allenai/Olmo-3-1025-7B`](https://huggingface.co/allenai/Olmo-3-1025-7B/refs)
+HF repo (`stage1-step0`, `stage1-step1000`, …, `stage1-step1413814`); the
+same procedure works for any of them — just swap the `--revision` flag.
+
+1. Convert the HF snapshot to Orbax (one-time, ~7 min wall on a 16-core VM,
+   peak ~26 GB RAM; needs `huggingface_hub` auth via `HF_TOKEN`):
+
+   ```bash
+   export HF_TOKEN=...
+   python -m maxtext.checkpoint_conversion.to_maxtext \
+     model_name=olmo3-7b-pt scan_layers=True \
+     --revision=stage1-step0 \
+     --lazy_load_tensors=True --save_dtype=bfloat16
+   ```
+
+   The script writes an Orbax checkpoint under
+   `<output>/<run_name>/0/items/` (default `<output>` is `/tmp/maxtext`;
+   override with `--base_output_directory=...`).
+
+2. Upload the converted checkpoint to GCS so all pods can read it:
+
+   ```bash
+   gsutil -m cp -r <output>/0/items gs://<your-bucket>/olmo/checkpoints/stage1-step0/0/items
+   ```
+
+3. Point the launcher at it via `LOAD_PARAMETERS_PATH`:
+
+   ```bash
+   export LOAD_PARAMETERS_PATH=gs://<your-bucket>/olmo/checkpoints/stage1-step0/0/items
+   bash src/maxtext/trainers/pre_train/scripts/olmo/xpk_olmo3_7b_stage1.sh submit
+   ```
+
+   AI2's published checkpoints are parameters only — Adam state is freshly
+   initialized on the MaxText side. The cold-start init is ignored once
+   `OUTPUT_DIR/RUN_NAME/checkpoints/` has any in-run checkpoints to
+   resume from.
+
+#### Option 2: Random MaxText init
+
+Leave `LOAD_PARAMETERS_PATH` unset and the launcher falls through to
+MaxText's standard random init from the `olmo3-7b-pt` model config — no
+conversion step needed. Useful as a sanity check that MaxText's init
+scheme is well-formed independent of the AI2-converted checkpoint (in
+practice the init transient resolves by step ~200, after which the curve
+tracks the AI2-init curve within data-shuffle noise).
+
+```bash
+unset LOAD_PARAMETERS_PATH
+bash src/maxtext/trainers/pre_train/scripts/olmo/xpk_olmo3_7b_stage1.sh submit
+```
+
+**Runner image** (XPK only). Build + push once:
+
+```bash
+sudo bash src/dependencies/scripts/docker_build_dependency_image.sh \
+  MODE=stable WORKFLOW=pre-training
+sudo bash src/dependencies/scripts/docker_upload_runner.sh \
+  CLOUD_IMAGE_NAME=maxtext-olmo3 PROJECT=$XPK_PROJECT
+```
+
+Override the resulting image with `XPK_DOCKER_IMAGE` (defaults to
+`gcr.io/${XPK_PROJECT}/maxtext-olmo3:latest`).
+
+## Resume
+
+Keep `XPK_RUN_NAME` and `XPK_BASE_OUTPUT_DIR` stable across submissions.
+Orbax picks up the latest checkpoint under `${OUTPUT_DIR}/${RUN_NAME}/checkpoints/`;
+the OLMo grain sampler resumes its data position via stateless
+`initial_step = step × per-host-batch` (no Grain-iterator-state in the
+checkpoint).
+
+`resume_until_done` polls the latest checkpoint step, resubmits a fresh
+workload on preemption, and exits when checkpoint step ≥ `STEPS_OVERRIDE` or
+after `MAX_RETRIES` failed attempts. Tune for preemption-prone clusters:
+
+| Env var | Default | Use |
+|---|---|---|
+| `MAX_RETRIES` | 10 | Cap on resubmit attempts before giving up. |
+| `RETRY_BACKOFF_SECONDS` | 300 | Sleep between resubmits. Bump if Kueue admission is slow. |
+
+## Loss-overlay validation
+
+For a partial-run overlay against AI2's published WandB curve, set
+`LR_SCHEDULE_STEPS=1414078` (AI2's stage-1 schedule horizon at 4.19M
+tokens/step) independently of `STEPS`. This keeps warmup absolute and the
+cosine shape matched even on a short run.

--- a/src/maxtext/trainers/pre_train/scripts/olmo/run_olmo3_7b_stage1.sh
+++ b/src/maxtext/trainers/pre_train/scripts/olmo/run_olmo3_7b_stage1.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+#
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# OLMo 3 7B pre-training launcher for MaxText. Hyperparameters mirror
+# OLMo-core's pretrain-1.py (global batch ≈4M tokens, peak LR 3e-4 cosine to
+# 0.1×, 2k warmup, β=(0.9, 0.95), ε=1e-8, WD 0.1, grad-clip 1.0, z-loss 1e-5,
+# logits in fp32, skip-step-on-spike). Reference run:
+# https://wandb.ai/ai2-llm/Olmo-3-1025-7B
+#
+# Required env:
+#   INDEX_PATH            JSON index from tools/data_generation/build_olmo_npy_index.py
+#   GCS_BASE              gs:// prefix recorded in the index (e.g. gs://my-bucket/)
+#   LOCAL_MOUNT           gcsfuse mount of GCS_BASE on this host
+#   OUTPUT_DIR            base_output_directory (checkpoints + logs)
+#   HF_TOKEN              tokenizer download (or HF_SECRETS=<file>)
+#
+# Optional (one of):
+#   LOAD_PARAMETERS_PATH  cold-start init weights (Orbax dir; e.g. converted
+#                         AI2 stage1-stepN snapshot). Ignored on resume. If
+#                         unset, MaxText uses fresh random init from the
+#                         olmo3-7b-pt model config.
+#
+# Optional (with defaults):
+#   RUN_NAME, TARGET_GLOBAL_BATCH (=512), PER_DEVICE_BATCH, TOTAL_DEVICES,
+#   GRAD_ACCUM_STEPS (=1), STEPS, WARMUP_STEPS (=2000), LR_SCHEDULE_STEPS
+#   (=STEPS), LEARNING_RATE (=3e-4), COSINE_FINAL_FRAC (=0.1), CHECKPOINT_PERIOD,
+#   DATA_SEED (=42), VENV_PATH, MOUNT_GCSFUSE (=0).
+#
+# Usage:
+#   INDEX_PATH=... GCS_BASE=gs://... LOCAL_MOUNT=... OUTPUT_DIR=... \
+#   LOAD_PARAMETERS_PATH=gs://.../stage1-step0/0/items HF_SECRETS=~/.hf_token.sh \
+#   bash src/maxtext/trainers/pre_train/scripts/olmo/run_olmo3_7b_stage1.sh
+#
+# Resume: keep RUN_NAME and OUTPUT_DIR stable. Orbax picks up the latest
+# checkpoint; the OLMo grain sampler resumes its data position via stateless
+# initial_step = step × per-host-batch.
+
+set -euo pipefail
+
+# Lives at src/maxtext/trainers/pre_train/scripts/olmo/; walk up five levels to repo root.
+MAXTEXT_ROOT="$(cd "$(dirname "$0")/../../../../.." && pwd)"
+
+VENV_PATH="${VENV_PATH:-${MAXTEXT_ROOT}/maxtext_venv}"
+HF_SECRETS="${HF_SECRETS:-}"
+INDEX_PATH="${INDEX_PATH:?INDEX_PATH is required (path to olmo index JSON)}"
+GCS_BASE="${GCS_BASE:?GCS_BASE is required (e.g. gs://my-bucket/)}"
+LOCAL_MOUNT="${LOCAL_MOUNT:?LOCAL_MOUNT is required (gcsfuse mount path of GCS_BASE)}"
+OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR is required (base_output_directory)}"
+# Optional: if unset, MaxText random-inits from the olmo3-7b-pt config.
+LOAD_PARAMETERS_PATH="${LOAD_PARAMETERS_PATH:-}"
+
+RUN_NAME="${RUN_NAME:-olmo3_7b_stage1}"
+
+# Force exactly one trailing slash on both halves of the path-remap pair —
+# the OLMo data source does a literal `replacement + path[len(prefix):]`,
+# so trailing slashes must match (otherwise gs://bucket/dataset/foo →
+# /mnt/local/dataset/foo silently becomes /mnt/localdataset/foo).
+GCS_BASE="${GCS_BASE%/}/"
+LOCAL_MOUNT="${LOCAL_MOUNT%/}/"
+
+# Hyperparameters (defaults match OLMo-core pretrain-1.py).
+TARGET_GLOBAL_BATCH="${TARGET_GLOBAL_BATCH:-512}"
+GRAD_ACCUM_STEPS="${GRAD_ACCUM_STEPS:-1}"
+SEQ_LEN="${SEQ_LEN:-8192}"
+STEPS="${STEPS:-1414078}"  # AI2 stage-1 horizon: 5.928T tokens at 4.19M tokens/step
+WARMUP_STEPS="${WARMUP_STEPS:-2000}"
+# Cosine schedule horizon. Defaults to STEPS for full-horizon runs; for
+# partial runs that overlay against a reference curve, set this to the
+# reference horizon (e.g. 1193317 for OLMo-3 pretrain-1's 5T-token schedule
+# at 4.19M tokens/step) so warmup stays absolute and cosine shape matches.
+LR_SCHEDULE_STEPS="${LR_SCHEDULE_STEPS:-${STEPS}}"
+LEARNING_RATE="${LEARNING_RATE:-3.0e-4}"
+COSINE_FINAL_FRAC="${COSINE_FINAL_FRAC:-0.1}"
+ADAM_B1="${ADAM_B1:-0.9}"
+ADAM_B2="${ADAM_B2:-0.95}"
+ADAM_EPS="${ADAM_EPS:-1.0e-8}"
+ADAM_WD="${ADAM_WD:-0.1}"
+GRAD_CLIP="${GRAD_CLIP:-1.0}"
+Z_LOSS="${Z_LOSS:-1.0e-5}"
+CHECKPOINT_PERIOD="${CHECKPOINT_PERIOD:-1000}"
+DATA_SEED="${DATA_SEED:-42}"
+TOKENIZER_PATH="${TOKENIZER_PATH:-allenai/Olmo-3-7B-Instruct}"
+
+# Activate venv if present; otherwise rely on system Python (e.g. inside an
+# XPK runner image where MaxText deps are already installed).
+# shellcheck disable=SC1090,SC1091
+if [[ -d "${VENV_PATH}" ]]; then
+  source "${VENV_PATH}/bin/activate"
+fi
+if [[ -n "${HF_SECRETS:-}" && -f "${HF_SECRETS}" ]]; then
+  # shellcheck disable=SC1090
+  source "${HF_SECRETS}"
+fi
+: "${HF_TOKEN:?HF_TOKEN must be set (or HF_SECRETS pointing at a file that exports it)}"
+export PYTHONPATH="${MAXTEXT_ROOT}/src:${PYTHONPATH:-}"
+export PYTHONUNBUFFERED=1
+
+# Ironwood-tuned XLA flags (loss-neutral; MFU 27% → 41% → 44.5%).
+# Initial set from AI-Hypercomputer's tpu-recipes/ironwood/llama3.1-70b/8k-bf16-tpu7x-4x4x4
+# (gets us to 41%); extended set sourced from a Borg-launched llama3.1-8b run that
+# hit 47% on gf_4x4x4 — extends sparse-core collective offload to all-gather/2d-all-
+# gather/reduce-scatter (FSDP path), bumps scoped VMEM 60→64 MB, sets DVFS p-state=7,
+# disables async collective fusion (interferes with SC offload). Append rather than
+# replace so a caller can still inject extra flags.
+export LIBTPU_INIT_ARGS="${LIBTPU_INIT_ARGS:-} \
+  --xla_tpu_scoped_vmem_limit_kib=65536 \
+  --xla_tpu_bf16_emission_mode=NATIVE_EMISSION \
+  --xla_tpu_dvfs_p_state=7 \
+  --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true \
+  --xla_tpu_enable_sparse_core_collective_offload_all_gather=true \
+  --xla_tpu_enable_sparse_core_collective_offload_2d_all_gather=true \
+  --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true \
+  --xla_tpu_use_tc_device_shape_on_sc=True \
+  --xla_sc_disable_megacore_partitioning=True \
+  --xla_tpu_enable_async_collective_fusion_fuse_all_gather=false"
+
+# Optional gcsfuse mount; the XPK wrapper sets MOUNT_GCSFUSE=1 so each pod
+# mounts its own copy at startup.
+if [[ "${MOUNT_GCSFUSE:-0}" = "1" ]]; then
+  bucket="${GCS_BASE#gs://}"; bucket="${bucket%/}"
+  echo "Mounting gs://${bucket} at ${LOCAL_MOUNT} via gcsfuse..."
+  bash "${MAXTEXT_ROOT}/src/dependencies/scripts/setup_gcsfuse.sh" \
+    DATASET_GCS_BUCKET="${bucket}" MOUNT_PATH="${LOCAL_MOUNT}"
+fi
+
+# Decide per-device batch from target global batch and visible devices.
+# bash-level jax.device_count() returns LOCAL devices only in multi-host XPK
+# jobs (e.g. 32 instead of 128 on tpu7x-4x4x4); pass TOTAL_DEVICES to override.
+if [[ -n "${TOTAL_DEVICES:-}" ]]; then
+  NUM_DEVICES="${TOTAL_DEVICES}"
+else
+  NUM_DEVICES=$(python3 -c 'import jax; print(jax.device_count())')
+fi
+if [[ -z "${PER_DEVICE_BATCH:-}" ]]; then
+  total_slots=$(( NUM_DEVICES * GRAD_ACCUM_STEPS ))
+  if (( TARGET_GLOBAL_BATCH % total_slots != 0 )); then
+    echo "ERROR: TARGET_GLOBAL_BATCH=${TARGET_GLOBAL_BATCH} is not divisible by " \
+         "num_devices×grad_accum=${NUM_DEVICES}×${GRAD_ACCUM_STEPS}=${total_slots}." >&2
+    exit 1
+  fi
+  PER_DEVICE_BATCH=$(( TARGET_GLOBAL_BATCH / total_slots ))
+fi
+
+EFFECTIVE_GLOBAL=$(( PER_DEVICE_BATCH * NUM_DEVICES * GRAD_ACCUM_STEPS ))
+if (( EFFECTIVE_GLOBAL != TARGET_GLOBAL_BATCH )); then
+  echo "ERROR: per_device(${PER_DEVICE_BATCH}) × devices(${NUM_DEVICES}) × " \
+       "grad_accum(${GRAD_ACCUM_STEPS}) = ${EFFECTIVE_GLOBAL}, expected " \
+       "${TARGET_GLOBAL_BATCH}." >&2
+  exit 1
+fi
+
+# warmup_steps_fraction is scaled by the schedule horizon (LR_SCHEDULE_STEPS),
+# not the run length (STEPS), so the LR curve matches the reference for any
+# prefix of training.
+WARMUP_FRAC=$(python3 -c "print(${WARMUP_STEPS}/${LR_SCHEDULE_STEPS})")
+
+echo "=== OLMo 3 7B Stage 1 ==="
+echo "  run_name           : ${RUN_NAME}"
+echo "  output_dir         : ${OUTPUT_DIR}/${RUN_NAME}"
+echo "  init weights       : ${LOAD_PARAMETERS_PATH:-<random init>}"
+echo "  index              : ${INDEX_PATH}"
+echo "  data path remap    : ${GCS_BASE} → ${LOCAL_MOUNT}"
+echo "  num_devices        : ${NUM_DEVICES}"
+echo "  per_device_batch   : ${PER_DEVICE_BATCH}"
+echo "  grad_accum_steps   : ${GRAD_ACCUM_STEPS}"
+echo "  global_batch       : ${EFFECTIVE_GLOBAL} instances ($(( EFFECTIVE_GLOBAL * SEQ_LEN )) tokens)"
+echo "  seq_len            : ${SEQ_LEN}"
+echo "  steps              : ${STEPS}"
+echo "  peak LR            : ${LEARNING_RATE}"
+echo "  cosine final frac  : ${COSINE_FINAL_FRAC}"
+echo "  warmup steps/frac  : ${WARMUP_STEPS} / ${WARMUP_FRAC}  (over schedule_steps=${LR_SCHEDULE_STEPS})"
+echo "  adam β1,β2,ε       : ${ADAM_B1}, ${ADAM_B2}, ${ADAM_EPS}"
+echo "  weight decay       : ${ADAM_WD} (excluded for token_embedder/embedding)"
+echo "  grad clip          : ${GRAD_CLIP}"
+echo "  z-loss multiplier  : ${Z_LOSS}"
+echo "  ckpt period        : ${CHECKPOINT_PERIOD}"
+echo
+
+# Note on dtypes: relies on base.yml defaults (dtype=bfloat16,
+# weight_dtype=float32) which match AI2's OLMo-core mixed-precision setup —
+# bf16 forward/backward, fp32 master weights, fp32 Adam state. Overriding
+# weight_dtype=bfloat16 silently demotes Adam's m,v to bf16 and loses a
+# fraction of every tiny early-warmup update.
+python -m maxtext.trainers.pre_train.train \
+  "${MAXTEXT_ROOT}/src/maxtext/configs/base.yml" \
+  model_name=olmo3-7b-pt \
+  run_name="${RUN_NAME}" \
+  base_output_directory="${OUTPUT_DIR}" \
+  load_parameters_path="${LOAD_PARAMETERS_PATH}" \
+  dataset_type=olmo_grain \
+  olmo_index_path="${INDEX_PATH}" \
+  olmo_path_remap_from="${GCS_BASE}" \
+  olmo_path_remap_to="${LOCAL_MOUNT}" \
+  olmo_apply_ngram_filter=True \
+  data_shuffle_seed="${DATA_SEED}" \
+  per_device_batch_size="${PER_DEVICE_BATCH}" \
+  gradient_accumulation_steps="${GRAD_ACCUM_STEPS}" \
+  max_target_length="${SEQ_LEN}" \
+  steps="${STEPS}" \
+  learning_rate="${LEARNING_RATE}" \
+  learning_rate_schedule_steps="${LR_SCHEDULE_STEPS}" \
+  learning_rate_final_fraction="${COSINE_FINAL_FRAC}" \
+  warmup_steps_fraction="${WARMUP_FRAC}" \
+  adam_b1="${ADAM_B1}" \
+  adam_b2="${ADAM_B2}" \
+  adam_eps="${ADAM_EPS}" \
+  adam_weight_decay="${ADAM_WD}" \
+  adamw_mask='["token_embedder/embedding"]' \
+  gradient_clipping_threshold="${GRAD_CLIP}" \
+  z_loss_multiplier="${Z_LOSS}" \
+  cast_logits_to_fp32=True \
+  logits_dot_in_fp32=True \
+  skip_step_on_spikes=True \
+  enable_checkpointing=True \
+  async_checkpointing=True \
+  checkpoint_period="${CHECKPOINT_PERIOD}" \
+  save_checkpoint_on_completion=True \
+  tokenizer_type=huggingface \
+  tokenizer_path="${TOKENIZER_PATH}" \
+  remat_policy=custom \
+  decoder_layer_input=device \
+  context=device \
+  query_proj=device \
+  key_proj=device \
+  value_proj=device \
+  qkv_proj=device \
+  out_proj=device \
+  mlpwi_0=device \
+  mlpwo=device \
+  use_iota_embed=True \
+  use_tokamax_splash=True \
+  attention=flash \
+  sa_block_q=2048 \
+  sa_block_kv=2048 \
+  sa_block_kv_compute=2048 \
+  sa_block_q_dkv=2048 \
+  sa_block_kv_dkv=2048 \
+  sa_block_kv_dkv_compute=2048 \
+  sa_q_layout=SEQ_MINOR \
+  sa_k_layout=SEQ_MINOR \
+  sa_v_layout=HEAD_DIM_MINOR \
+  sa_use_fused_bwd_kernel=True

--- a/src/maxtext/trainers/pre_train/scripts/olmo/xpk_olmo3_7b_stage1.sh
+++ b/src/maxtext/trainers/pre_train/scripts/olmo/xpk_olmo3_7b_stage1.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+#
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# XPK wrapper for run_olmo3_7b_stage1.sh. Submits a multi-host TPU workload
+# that runs the launcher inside the MaxText runner image. Stays thin — the
+# inner script is the source of truth for hyperparameters; this script only
+# handles cluster/storage/image plumbing and forwards env vars.
+#
+# Pattern mirrors src/maxtext/trainers/post_train/distillation/scripts/run_distill_xpk.sh.
+#
+# Usage:
+#   bash src/maxtext/trainers/pre_train/scripts/olmo/xpk_olmo3_7b_stage1.sh submit
+#   bash src/maxtext/trainers/pre_train/scripts/olmo/xpk_olmo3_7b_stage1.sh monitor
+#   bash src/maxtext/trainers/pre_train/scripts/olmo/xpk_olmo3_7b_stage1.sh resume_until_done
+#
+# Required env:
+#   XPK_CLUSTER, XPK_PROJECT, XPK_ZONE, XPK_DEVICE_TYPE, XPK_BASE_OUTPUT_DIR
+#   OLMO_INDEX_PATH      JSON index from build_olmo_npy_index.py (in-container path)
+#   OLMO_GCS_BASE        gs:// prefix recorded in the index
+#   HF_TOKEN             tokenizer download (or HF_SECRETS=<file>)
+#
+# Optional (one of):
+#   LOAD_PARAMETERS_PATH cold-start init weights (Orbax dir; e.g. converted
+#                        AI2 stage1-stepN snapshot). If unset, MaxText
+#                        random-inits from olmo3-7b-pt.
+#
+# Optional (with defaults):
+#   XPK_DOCKER_IMAGE    gcr.io/${XPK_PROJECT}/maxtext-olmo3:latest
+#                       Image must be PUSHED to GCR/GAR. Build+push:
+#                         sudo bash src/dependencies/scripts/docker_build_dependency_image.sh \
+#                           MODE=stable WORKFLOW=pre-training
+#                         sudo bash src/dependencies/scripts/docker_upload_runner.sh \
+#                           CLOUD_IMAGE_NAME=maxtext-olmo3 PROJECT=$XPK_PROJECT
+#                       (after `sudo gcloud auth configure-docker gcr.io`)
+#   XPK_WORKLOAD        olmo3-s1-NNNN  (DNS-label safe; keep stable across resumes)
+#   XPK_PRIORITY        medium
+#   XPK_NUM_SLICES      1
+#   XPK_RUN_NAME        olmo3_7b_stage1  (subdir under XPK_BASE_OUTPUT_DIR)
+#   XPK_TOTAL_DEVICES   128  (tpu7x-4x4x4); update if XPK_DEVICE_TYPE changes
+#   OLMO_LOCAL_MOUNT    /tmp/olmo-data  (gcsfuse mount path inside container)
+#   TARGET_GLOBAL_BATCH 512  (instances; ×8192 seq = 4.19M tokens)
+#   STEPS               1420000  (≈6T tokens / 4M per step)
+#   WARMUP_STEPS        2000  (absolute, in schedule space)
+#   LR_SCHEDULE_STEPS   STEPS — for partial overlay runs, set to the reference
+#                       horizon (e.g. 1193317 for OLMo-3 pretrain-1's 5T-token
+#                       schedule) so warmup stays absolute and cosine matches.
+#   LEARNING_RATE       3.0e-4
+#   COSINE_FINAL_FRAC   0.1
+#   CHECKPOINT_PERIOD   1000
+#   DATA_SEED           42
+#   STEPS_OVERRIDE      empty — only used by resume_until_done as termination target
+#   MAX_RETRIES         10  — only used by resume_until_done
+#   RETRY_BACKOFF_SECONDS 300 — sleep between resubmits in resume_until_done
+#   HF_SECRETS          empty — file that exports HF_TOKEN (kept off shell history)
+#
+# Restart policy:
+#   L1 (pod):       GKE restarts crashed pods; trainer auto-resumes via Orbax.
+#   L2 (workload):  resume_until_done deletes + resubmits with the same
+#                   XPK_WORKLOAD/XPK_BASE_OUTPUT_DIR (Orbax restores state).
+#   L3 (human):     resume_until_done exits non-zero after MAX_RETRIES.
+
+set -euo pipefail
+
+MODE="${1:-submit}"
+
+require_env() {
+  local missing=()
+  for v in "$@"; do
+    [ -z "${!v:-}" ] && missing+=("$v")
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "ERROR: required env vars not set: ${missing[*]}" >&2
+    exit 1
+  fi
+}
+
+# -------------------------- defaults --------------------------
+: "${XPK_DOCKER_IMAGE:=gcr.io/${XPK_PROJECT:-PROJECT_UNSET}/maxtext-olmo3:latest}"
+# Workload names are DNS labels: lowercase, [a-z0-9-] only. Fixed-width 4-digit
+# suffix disambiguates concurrent submits; override XPK_WORKLOAD to keep the
+# same name across resumes (Orbax picks up the latest checkpoint).
+: "${XPK_WORKLOAD:=olmo3-s1-$(printf '%04d' $((RANDOM % 10000)))}"
+: "${XPK_PRIORITY:=medium}"
+: "${XPK_NUM_SLICES:=1}"
+: "${XPK_RUN_NAME:=olmo3_7b_stage1}"
+: "${OLMO_LOCAL_MOUNT:=/tmp/olmo-data}"
+: "${XPK_TOTAL_DEVICES:=128}"
+: "${TARGET_GLOBAL_BATCH:=512}"
+: "${STEPS:=1414078}"
+: "${WARMUP_STEPS:=2000}"
+: "${LR_SCHEDULE_STEPS:=${STEPS}}"
+: "${LEARNING_RATE:=3.0e-4}"
+: "${COSINE_FINAL_FRAC:=0.1}"
+: "${CHECKPOINT_PERIOD:=1000}"
+: "${DATA_SEED:=42}"
+: "${MAX_RETRIES:=10}"
+# Sleep between preemption-recovery resubmits. Bumped from the original 60s so
+# Kueue has time to free capacity after a preemption wave; override to taste.
+: "${RETRY_BACKOFF_SECONDS:=300}"
+: "${HF_SECRETS:=}"
+
+# Container-side index path. Absolute paths pass through (typical: a gcsfuse-
+# mounted bucket like /tmp/olmo-data/...); relative paths are resolved against
+# /deps (the runner image's WORKDIR, where the repo source is copied).
+if [[ "${OLMO_INDEX_PATH:-}" = /* ]]; then
+  OLMO_INDEX_PATH_IN_CONTAINER="${OLMO_INDEX_PATH}"
+else
+  OLMO_INDEX_PATH_IN_CONTAINER="/deps/${OLMO_INDEX_PATH:-}"
+fi
+
+# Read HF_TOKEN at submit time so it can be forwarded; the container can't see
+# the host's home dir.
+if [ -z "${HF_TOKEN:-}" ] && [ -n "$HF_SECRETS" ] && [ -f "$HF_SECRETS" ]; then
+  # shellcheck disable=SC1090
+  source "$HF_SECRETS"
+fi
+
+LAST_WORKLOAD_FILE="${XPK_LAST_WORKLOAD_FILE:-${HOME}/.xpk_last_workload_olmo}"
+
+# -------------------------- submit --------------------------
+submit_workload() {
+  echo "Workload:    $XPK_WORKLOAD"
+  echo "Cluster:     $XPK_CLUSTER ($XPK_PROJECT, $XPK_ZONE)"
+  echo "Device:      $XPK_DEVICE_TYPE x ${XPK_NUM_SLICES} slice(s)"
+  echo "Image:       $XPK_DOCKER_IMAGE"
+  echo "Output dir:  $XPK_BASE_OUTPUT_DIR/$XPK_RUN_NAME"
+  echo "Index:       $OLMO_INDEX_PATH_IN_CONTAINER"
+  echo "Data bucket: $OLMO_GCS_BASE → $OLMO_LOCAL_MOUNT (gcsfuse)"
+  echo
+
+  # MOUNT_GCSFUSE=1 tells the inner launcher to invoke setup_gcsfuse.sh — each
+  # pod mounts its own copy at startup, no cluster-side configuration required.
+  # VENV_PATH=/__skip_venv__ skips the venv lookup so the launcher falls
+  # through to the runner image's system Python.
+  xpk workload create \
+    --cluster "$XPK_CLUSTER" \
+    --workload "$XPK_WORKLOAD" \
+    --priority="$XPK_PRIORITY" \
+    --tpu-type="$XPK_DEVICE_TYPE" \
+    --num-slices="$XPK_NUM_SLICES" \
+    --project="$XPK_PROJECT" \
+    --zone="$XPK_ZONE" \
+    --docker-image="$XPK_DOCKER_IMAGE" \
+    --command "set -euo pipefail; \
+export PYTHONPATH=/deps/src; \
+export HF_TOKEN='${HF_TOKEN}'; \
+export INDEX_PATH='${OLMO_INDEX_PATH_IN_CONTAINER}'; \
+export GCS_BASE='${OLMO_GCS_BASE}'; \
+export LOCAL_MOUNT='${OLMO_LOCAL_MOUNT}'; \
+export OUTPUT_DIR='${XPK_BASE_OUTPUT_DIR}'; \
+export RUN_NAME='${XPK_RUN_NAME}'; \
+export LOAD_PARAMETERS_PATH='${LOAD_PARAMETERS_PATH}'; \
+export TARGET_GLOBAL_BATCH='${TARGET_GLOBAL_BATCH}'; \
+export TOTAL_DEVICES='${XPK_TOTAL_DEVICES}'; \
+export STEPS='${STEPS}'; \
+export WARMUP_STEPS='${WARMUP_STEPS}'; \
+export LR_SCHEDULE_STEPS='${LR_SCHEDULE_STEPS}'; \
+export LEARNING_RATE='${LEARNING_RATE}'; \
+export COSINE_FINAL_FRAC='${COSINE_FINAL_FRAC}'; \
+export CHECKPOINT_PERIOD='${CHECKPOINT_PERIOD}'; \
+export DATA_SEED='${DATA_SEED}'; \
+export MOUNT_GCSFUSE=1; \
+export VENV_PATH=/__skip_venv__; \
+bash /deps/src/maxtext/trainers/pre_train/scripts/olmo/run_olmo3_7b_stage1.sh"
+
+  echo "$XPK_WORKLOAD" > "$LAST_WORKLOAD_FILE"
+}
+
+# -------------------------- monitor --------------------------
+# Stream pod logs for the most recently submitted workload (or one passed as
+# the second positional arg).
+monitor_workload() {
+  local workload="${2:-$(cat "$LAST_WORKLOAD_FILE" 2>/dev/null || true)}"
+  if [ -z "$workload" ]; then
+    echo "ERROR: no workload to monitor (none recorded in $LAST_WORKLOAD_FILE)." >&2
+    exit 1
+  fi
+  echo "Monitoring $workload"
+
+  while true; do
+    local phases
+    phases=$(kubectl get pods -l "jobset.sigs.k8s.io/jobset-name=${workload}" \
+              -o jsonpath='{.items[*].status.phase}' 2>/dev/null || echo "")
+    if echo "$phases" | grep -q Running; then break; fi
+    if [ -n "$phases" ] && ! echo "$phases" | grep -qE "Pending|ContainerCreating"; then
+      echo "No Running pod; phases: $phases"
+      local one
+      one=$(kubectl get pods -l "jobset.sigs.k8s.io/jobset-name=${workload}" \
+            -o name 2>/dev/null | head -1)
+      [ -n "$one" ] && kubectl logs "$one" --all-containers 2>&1 | tail -40
+      exit 1
+    fi
+    echo "waiting for Running (phases: ${phases:-none})..."; sleep 15
+  done
+
+  local n max out_log
+  n=$(kubectl get pods -l "jobset.sigs.k8s.io/jobset-name=${workload}" -o name | wc -l)
+  max=$((n * 4))
+  out_log="${HOME}/training-${workload}.log"
+  echo "Streaming logs from $n pods (--max-log-requests=${max}) → ${out_log}"
+  kubectl logs -f -l "jobset.sigs.k8s.io/jobset-name=${workload}" \
+    --all-containers --max-log-requests="$max" --prefix \
+    2>&1 | tee "$out_log"
+}
+
+# -------------------------- resume_until_done --------------------------
+# Auto-resubmit loop. Each iteration submits with the SAME XPK_WORKLOAD and
+# OUTPUT_DIR, so the trainer auto-restores from the latest checkpoint. Exits
+# when checkpoint step ≥ STEPS_OVERRIDE or after MAX_RETRIES.
+resume_until_done() {
+  if [ -z "${STEPS_OVERRIDE:-}" ]; then
+    echo "ERROR: STEPS_OVERRIDE must be set so the loop knows when to stop." >&2
+    exit 1
+  fi
+  local target="$STEPS_OVERRIDE"
+  local retry=0
+
+  while [ "$retry" -lt "$MAX_RETRIES" ]; do
+    echo "=== resume attempt $((retry + 1)) / $MAX_RETRIES (target steps: $target) ==="
+    submit_workload
+
+    # Wait for the workload to leave the running state. Kueue can evict the
+    # whole JobSet on preemption, in which case `terminalState` is never set
+    # and the resource is eventually deleted — without the NotFound check the
+    # loop would hang forever waiting on a dead workload.
+    local zero_active_count=0
+    while true; do
+      sleep 60
+      # Probe existence first; NotFound means Kueue deleted it.
+      if ! kubectl get jobset "$XPK_WORKLOAD" >/dev/null 2>&1; then
+        echo "Workload $XPK_WORKLOAD deleted (likely Kueue preemption)."
+        break
+      fi
+      local terminal
+      terminal=$(kubectl get jobset "$XPK_WORKLOAD" \
+        -o jsonpath='{.status.terminalState}' 2>/dev/null || echo "")
+      if [ -n "$terminal" ]; then
+        echo "Workload $XPK_WORKLOAD reached terminal state: $terminal"
+        break
+      fi
+      # Suspended-by-Kueue (preempted but not yet deleted): active=0 across
+      # all replicatedJobs with no terminalState. After 2 consecutive minutes
+      # of zero-active, treat as preempted so we can resubmit instead of
+      # waiting forever.
+      local actives
+      actives=$(kubectl get jobset "$XPK_WORKLOAD" \
+        -o jsonpath='{.status.replicatedJobsStatus[*].active}' 2>/dev/null \
+        | tr ' ' '\n' | grep -E '^[1-9]' | head -1)
+      if [ -z "$actives" ]; then
+        zero_active_count=$((zero_active_count + 1))
+        if [ "$zero_active_count" -ge 2 ]; then
+          echo "Workload $XPK_WORKLOAD has zero active pods for 2+ min; treating as preempted."
+          break
+        fi
+      else
+        zero_active_count=0
+      fi
+    done
+
+    local last_step
+    last_step=$(gcloud storage ls "${XPK_BASE_OUTPUT_DIR}/${XPK_RUN_NAME}/checkpoints/" 2>/dev/null \
+                 | grep -oE '/[0-9]+/$' | tr -d '/' | sort -n | tail -1)
+    last_step=${last_step:-0}
+    echo "Latest checkpoint step on disk: ${last_step}"
+
+    if [ "$last_step" -ge "$target" ]; then
+      echo "Reached target step ${target}. Done."
+      return 0
+    fi
+
+    xpk workload delete --workload="$XPK_WORKLOAD" \
+      --cluster="$XPK_CLUSTER" --project="$XPK_PROJECT" --zone="$XPK_ZONE" --force \
+      >/dev/null 2>&1 || true
+
+    retry=$((retry + 1))
+    echo "Resubmitting from step ${last_step} (attempt $((retry + 1))/${MAX_RETRIES}) in ${RETRY_BACKOFF_SECONDS}s..."
+    sleep "$RETRY_BACKOFF_SECONDS"
+  done
+
+  echo "ERROR: max_retries=${MAX_RETRIES} reached without completing ${target} steps." >&2
+  return 1
+}
+
+# -------------------------- dispatch --------------------------
+case "$MODE" in
+  submit|monitor|resume_until_done)
+    require_env XPK_CLUSTER XPK_PROJECT XPK_ZONE XPK_DEVICE_TYPE \
+                XPK_BASE_OUTPUT_DIR OLMO_INDEX_PATH OLMO_GCS_BASE \
+                HF_TOKEN
+    : "${LOAD_PARAMETERS_PATH:=}"  # optional; empty → MaxText random init
+    case "$MODE" in
+      submit)            submit_workload ;;
+      monitor)           monitor_workload "$@" ;;
+      resume_until_done) resume_until_done ;;
+    esac
+    ;;
+  *)
+    echo "Unknown mode: $MODE (use submit|monitor|resume_until_done)" >&2
+    exit 1
+    ;;
+esac

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -420,6 +420,7 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
   z_loss = aux.get("z_loss", 0.0)
   moe_bias_updates = aux.get("moe_bias_updates")
   mtp_loss = aux.get("mtp_loss", 0.0)
+  new_opt_state = None
 
   if isinstance(model, nn.Module):
     if config.gradient_clipping_threshold > 0:
@@ -535,6 +536,13 @@ def train_step(model, config, state_mesh_shardings, params_shardings, state, dat
     else:
       model_params = nnx.state(new_state.model, nnx.Param)
       scalar_metrics["learning/param_norm"] = max_utils.l2norm_pytree(model_params)
+
+  # Surface skip-step rejections as a TB metric. Linen path only — the NNX
+  # branch doesn't apply skip-step, so new_opt_state stays None.
+  if config.skip_step_on_spikes:
+    is_skipped = new_opt_state.get("is_skipped") if isinstance(new_opt_state, dict) else None
+    if is_skipped is not None:
+      scalar_metrics["optim/step_skipped"] = is_skipped.astype(jnp.float32)
   if config.use_dpo:
     scalar_metrics["learning/dpo_loss"] = aux["dpo_loss"]
     scalar_metrics["learning/dpo_reward_accuracy"] = aux["reward_accuracy"]


### PR DESCRIPTION
# Description

 - Add `run_olmo3_7b_stage1.sh` and `xpk_olmo3_7b_stage1.sh` under `src/maxtext/trainers/pre_train/scripts/olmo/` for reproducing AI2's OLMo-3 7B stage-1 pretraining. Hyperparameters mirror OLMo-core's
    [`OLMo-3-1025-7B-pretrain-1.py`](https://github.com/allenai/OLMo-core/blob/main/src/scripts/official/OLMo3/OLMo-3-1025-7B-pretrain-1.py):
    global batch ≈4M tokens, peak LR 3e-4 cosine to 0.1×, 2k warmup, β=(0.9, 0.95), z-loss 1e-5, skip-step-on-spike.
  
- Add `optim/step_skipped` scalar to the pre-train metrics block so spike rejections are visible in TensorBoard. No-op when `skip_step_on_spikes=False`; safe on the NNX path (guarded by `isinstance(new_opt_state, dict)`).
  
- README walks through the two supported starting points: AI2's `stage1-stepN` HF revisions (via `to_maxtext` conversion) and MaxText's  random init.


# Tests

Verified on tpu7x-4x8x8 (512 chips), currently at step ~735k of the full 1,414,078-step horizon, loss tracking AI2's published WandB curve within ±0.01 nat across all sampled landmarks.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
