### PR TITLE
Add nnx weight init logic when vocab tiling is enabled

### DIFF
--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -1159,7 +1159,8 @@ class Decoder(nn.Module):
 
     # When initializing with vLLM RPA attention, we need to run the output head to
     # initialize any parameters associated with it.
-    if self.is_initializing() and cfg.attention == "vllm_rpa":
+    # Same case applicable to vocab tiling
+    if self.is_initializing() and (cfg.num_vocab_tiling > 1 or cfg.attention == "vllm_rpa"):
       _ = self.apply_output_head(shared_embedding, hidden_state, deterministic, model_mode)
 
     # When invoking from vLLM with RPA attention, logit computation is deferred to a later stage.


### PR DESCRIPTION
# Description

Before the added logic, NNX fails to initialize `params/params/decoder/decoder_norm/scale` when `num_vocab_tiling > 1` and leads to checkpointing issue. This PR fixes this issue.

# Tests

This PR does not change memory usage, see https://diff.googleplex.com/#key=6yWvheQfng4n.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
