### PR TITLE
Add grpc authentication to maxengine_server

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1015,6 +1015,8 @@ inference_metadata_file: "" # path to a json file
 inference_server: "MaxtextInterleavedServer"  # inference server to start
 prefill_slice: "v5e-16" # slice to use for prefill in disaggregation mode
 generate_slice: "v5e-16" # slice to use for generatation in disaggregation mode
+grpc_tls_certificate_path: "" # Path to the TLS certificate file for gRPC server
+grpc_tls_private_key_path: "" # Path to the TLS private key file for gRPC server
 inference_benchmark_test: false
 enable_model_warmup: false
 enable_llm_inference_pool: false          # Bool to launch inference server for llm_inference_gateway with their specified APIs

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1689,6 +1689,8 @@ class InferenceServer(BaseModel):
   inference_server: str = Field("MaxtextInterleavedServer", description="Inference server to start.")
   prefill_slice: str = Field("v5e-16", description="Slice to use for prefill in disaggregation mode.")
   generate_slice: str = Field("v5e-16", description="Slice to use for generatation in disaggregation mode.")
+  grpc_tls_certificate_path: str = Field("", description="Path to the TLS certificate file for gRPC server.")
+  grpc_tls_private_key_path: str = Field("", description="Path to the TLS private key file for gRPC server.")
 
 
 class InferenceBenchmark(BaseModel):

--- a/src/maxtext/inference/maxengine/maxengine_server.py
+++ b/src/maxtext/inference/maxengine/maxengine_server.py
@@ -66,6 +66,7 @@ def main(config):
 
   # Import the real server_lib now that it's known present.
   from jetstream.core import server_lib  # type: ignore  # pylint: disable=import-outside-toplevel
+  import grpc  # pylint: disable=import-outside-toplevel
   import pathwaysutils  # pylint: disable=unused-import,import-outside-toplevel
 
   pathwaysutils.initialize()
@@ -78,15 +79,32 @@ def main(config):
   if config.prometheus_port != 0:
     metrics_server_config = config_lib.MetricsServerConfig(port=config.prometheus_port)
 
+  # Configure gRPC credentials. To enable secure TLS serving (e.g., for AIVS compliance or production),
+  # provide both `grpc_tls_certificate_path` (X.509 public cert) and `grpc_tls_private_key_path`.
+  # Otherwise, defaults to insecure credentials for local unit testing and development.
+  if config.grpc_tls_certificate_path or config.grpc_tls_private_key_path:
+    if not (config.grpc_tls_certificate_path and config.grpc_tls_private_key_path):
+      raise ValueError(
+          "Invalid TLS configuration: Both 'grpc_tls_certificate_path' and "
+          "'grpc_tls_private_key_path' must be provided to enable secure serving."
+      )
+    with open(config.grpc_tls_private_key_path, "rb") as f:
+      private_key = f.read()
+    with open(config.grpc_tls_certificate_path, "rb") as f:
+      certificate = f.read()
+    credentials = grpc.ssl_server_credentials([(private_key, certificate)])
+  else:
+    credentials = grpc.insecure_server_credentials()
+
   # We separate credential from run so that we can unit test it with
   # local credentials.
-  # TODO: Add grpc credentials for OSS.
   # pylint: disable=unexpected-keyword-arg
   jetstream_server = server_lib.run(
       threads=256,
       port=9000,
       config=server_config,
       devices=devices,
+      credentials=credentials,
       metrics_server_config=metrics_server_config,
       enable_jax_profiler=config.enable_jax_profiler if config.enable_jax_profiler else False,
       jax_profiler_port=config.jax_profiler_port if config.jax_profiler_port else 9999,

--- a/tests/unit/maxengine_server_test.py
+++ b/tests/unit/maxengine_server_test.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for maxengine_server."""
+
+import os
+import unittest
+from unittest import mock
+import pytest
+
+pytest.importorskip("jetstream.core.server_lib", reason="jetstream.core.server_lib not fully installed")
+
+import jetstream.core.server_lib  # pylint: disable=unused-import
+
+from maxtext.configs import pyconfig
+from maxtext.inference.maxengine import maxengine_server
+from maxtext.utils.globals import MAXTEXT_CONFIGS_DIR
+
+
+@pytest.mark.cpu_only
+class MaxEngineServerTest(unittest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    # Initialize basic test configurations
+
+    self.base_config_path = os.path.join(MAXTEXT_CONFIGS_DIR, "base.yml")
+    self.config = pyconfig.initialize(
+        ["", self.base_config_path],
+        run_name="test_server",
+        enable_checkpointing=False,
+    )
+
+  @mock.patch("maxtext.inference.maxengine.maxengine_server.gcloud_stub")
+  @mock.patch("maxtext.inference.maxengine.maxengine_server.maxengine_config")
+  @mock.patch("jetstream.core.server_lib")
+  @mock.patch("grpc.insecure_server_credentials")
+  def test_main_insecure_default(self, mock_insecure_creds, mock_server_lib, mock_maxengine_config, mock_gcloud_stub):
+    mock_config_lib = mock.MagicMock()
+    mock_gcloud_stub.jetstream.return_value = (
+        mock_config_lib,
+        mock.MagicMock(),
+        mock.MagicMock(),
+        mock.MagicMock(),
+        mock.MagicMock(),
+    )
+    mock_gcloud_stub.is_decoupled.return_value = False
+
+    maxengine_server.main(self.config)
+    # Verify insecure credentials were instantiated and run
+    mock_insecure_creds.assert_called_once()
+    mock_server_lib.run.assert_called_once()
+    kwargs = mock_server_lib.run.call_args[1]
+    self.assertEqual(kwargs["credentials"], mock_insecure_creds.return_value)
+
+  @mock.patch("maxtext.inference.maxengine.maxengine_server.gcloud_stub")
+  @mock.patch("maxtext.inference.maxengine.maxengine_server.maxengine_config")
+  @mock.patch("jetstream.core.server_lib")
+  @mock.patch("builtins.open", new_callable=mock.mock_open, read_data=b"test_key_cert_data")
+  @mock.patch("grpc.ssl_server_credentials")
+  def test_main_secure_tls(self, mock_ssl_creds, mock_open, mock_server_lib, mock_maxengine_config, mock_gcloud_stub):
+    # Re-initialize config with secure TLS enabled
+    self.config = pyconfig.initialize(
+        ["", self.base_config_path],
+        run_name="test_server",
+        enable_checkpointing=False,
+        grpc_tls_certificate_path="/path/to/cert",
+        grpc_tls_private_key_path="/path/to/key",
+    )
+
+    mock_config_lib = mock.MagicMock()
+    mock_gcloud_stub.jetstream.return_value = (
+        mock_config_lib,
+        mock.MagicMock(),
+        mock.MagicMock(),
+        mock.MagicMock(),
+        mock.MagicMock(),
+    )
+    mock_gcloud_stub.is_decoupled.return_value = False
+
+    maxengine_server.main(self.config)
+    # Verify cert and private key files were read
+    mock_open.assert_has_calls(
+        [
+            mock.call("/path/to/key", "rb"),
+            mock.call("/path/to/cert", "rb"),
+        ],
+        any_order=True,
+    )
+    # Verify SSL credentials were constructed and provided to the server run method
+    mock_ssl_creds.assert_called_once_with([(b"test_key_cert_data", b"test_key_cert_data")])
+    mock_server_lib.run.assert_called_once()
+    kwargs = mock_server_lib.run.call_args[1]
+    self.assertEqual(kwargs["credentials"], mock_ssl_creds.return_value)
+
+  def test_main_partially_configured_tls_raises_error(self):
+    # 1. Missing private key
+    self.config = pyconfig.initialize(
+        ["", self.base_config_path],
+        run_name="test_server",
+        enable_checkpointing=False,
+        grpc_tls_certificate_path="/path/to/cert",
+        grpc_tls_private_key_path="",
+    )
+    with self.assertRaises(ValueError) as ctx:
+      maxengine_server.main(self.config)
+    self.assertIn(
+        "Both 'grpc_tls_certificate_path' and 'grpc_tls_private_key_path' must be provided",
+        str(ctx.exception),
+    )
+
+    # 2. Missing certificate
+    self.config = pyconfig.initialize(
+        ["", self.base_config_path],
+        run_name="test_server",
+        enable_checkpointing=False,
+        grpc_tls_certificate_path="",
+        grpc_tls_private_key_path="/path/to/key",
+    )
+    with self.assertRaises(ValueError) as ctx:
+      maxengine_server.main(self.config)
+    self.assertIn(
+        "Both 'grpc_tls_certificate_path' and 'grpc_tls_private_key_path' must be provided",
+        str(ctx.exception),
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

Adds `grpc_tls_certificate_path` and `grpc_tls_private_key_path` configuration options to `InferenceServer` and updates `maxengine_server.py` to support secure gRPC TLS connections when configured.

- Enables users to configure gRPC server credentials with TLS certificates and private keys for secure serving environments.
- Defaults to insecure credentials when TLS paths are not provided, preserving seamless local unit testing and development workflows.

FIXES: b/510375382

# Tests

Ran configuration unit tests on TPU VM:
```bash
pytest tests/unit/configs_test.py tests/unit/configs_value_test.py
```

All tests passed successfully.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).