### PR TITLE
Fix: Remove train_iter from grain processing test

### DIFF
--- a/tests/unit/grain_data_processing_test.py
+++ b/tests/unit/grain_data_processing_test.py
@@ -464,7 +464,6 @@ class GrainTFRecordPreTokenizedProcessingTest(GrainTFRecordProcessingTest):
         tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "tokenizer.default"),
         enable_checkpointing=False,
     )
-    self.train_iter = grain_data_processing.make_grain_train_iterator(self.config, self.mesh, self.process_indices)
 
 
 @pytest.mark.external_training


### PR DESCRIPTION
# Description

Seeing these test failure for CI tests:

```
FAILED tests/unit/grain_data_processing_test.py::GrainTFRecordPreTokenizedProcessingTest::test_batch_determinism - AttributeError: property 'train_iter' of 'GrainTFRecordPreTokenizedProcessingTest' object has no setter
FAILED tests/unit/grain_data_processing_test.py::GrainTFRecordPreTokenizedProcessingTest::test_for_loop_repeatable - AttributeError: property 'train_iter' of 'GrainTFRecordPreTokenizedProcessingTest' object has no setter
FAILED tests/unit/grain_data_processing_test.py::GrainTFRecordPreTokenizedProcessingTest::test_train_ds - AttributeError: property 'train_iter' of 'GrainTFRecordPreTokenizedProcessingTest' object has no setter
```

`self.train_iter = ...` was removed in https://github.com/AI-Hypercomputer/maxtext/pull/3860, but a new test was added at the same time in https://github.com/AI-Hypercomputer/maxtext/pull/3879. Removing this from the new test also


# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
