### PR TITLE
Add Gemma 4 E2B / E4B (text) support to MaxText

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,7 @@ addopts =
     --ignore=tests/unit/dequantize_pack_quantized_int4_test.py
     --ignore=tests/unit/gemma3_layers_test.py
     --ignore=tests/unit/gemma4_layers_test.py
+    --ignore=tests/unit/gemma4_small_layers_test.py
     --ignore=tests/unit/gpt_vs_reference_test.py
     --ignore=tests/unit/llama4_layers_test.py
     --ignore=tests/unit/hf_checkpoint_conversion_test.py

--- a/src/maxtext/checkpoint_conversion/utils/hf_model_configs.py
+++ b/src/maxtext/checkpoint_conversion/utils/hf_model_configs.py
@@ -144,14 +144,137 @@ gemma4_31b_dict["text_config"].update(
 )
 
 
+gemma4_e2b_dict = {
+    "architectures": ["Gemma4ForConditionalGeneration"],
+    "audio_config": None,
+    "audio_token_id": 258881,
+    "boa_token_id": 256000,
+    "boi_token_id": 255999,
+    "dtype": "bfloat16",
+    "eoa_token_id": 258883,
+    "eoa_token_index": 258883,
+    "eoi_token_id": 258882,
+    "eos_token_id": [1, 106],
+    "image_token_id": 258880,
+    "initializer_range": 0.02,
+    "model_type": "gemma4",
+    "text_config": {
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "attention_k_eq_v": False,
+        "bos_token_id": 2,
+        "dtype": "bfloat16",
+        "enable_moe_block": False,
+        "eos_token_id": 1,
+        "expert_intermediate_size": None,
+        "final_logit_softcapping": 30.0,
+        "global_head_dim": 512,
+        "head_dim": 256,
+        "hidden_activation": "gelu_pytorch_tanh",
+        "hidden_size": 1536,
+        "hidden_size_per_layer_input": 256,
+        "initializer_range": 0.02,
+        "intermediate_size": 6144,
+        "layer_types": [
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ]
+        * 7,
+        "max_position_embeddings": 131072,
+        "model_type": "gemma4_text",
+        "num_attention_heads": 8,
+        "num_experts": None,
+        "num_global_key_value_heads": None,
+        "num_hidden_layers": 35,
+        "num_key_value_heads": 1,
+        "num_kv_shared_layers": 20,
+        "pad_token_id": 0,
+        "rms_norm_eps": 1e-06,
+        "rope_parameters": {
+            "full_attention": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1_000_000.0,
+                "rope_type": "proportional",
+            },
+            "sliding_attention": {"rope_theta": 10_000.0, "rope_type": "default"},
+        },
+        "sliding_window": 512,
+        "tie_word_embeddings": True,
+        "top_k_experts": None,
+        "use_bidirectional_attention": None,
+        "use_cache": True,
+        "use_double_wide_mlp": True,
+        "vocab_size": 262144,
+        "vocab_size_per_layer_input": 262144,
+    },
+    "tie_word_embeddings": True,
+    "transformers_version": "5.5.0.dev0",
+    "video_token_id": 258884,
+    "vision_config": {
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "default_output_length": 280,
+        "dtype": "bfloat16",
+        "global_head_dim": 64,
+        "head_dim": 64,
+        "hidden_activation": "gelu_pytorch_tanh",
+        "hidden_size": 768,
+        "intermediate_size": 3072,
+        "max_position_embeddings": 131072,
+        "model_type": "gemma4_vision",
+        "num_attention_heads": 12,
+        "num_hidden_layers": 16,
+        "num_key_value_heads": 12,
+        "patch_size": 16,
+        "pooling_kernel_size": 3,
+        "position_embedding_size": 10240,
+        "rms_norm_eps": 1e-06,
+        "rope_parameters": {"rope_theta": 100.0, "rope_type": "default"},
+        "standardize": False,
+        "use_clipped_linears": True,
+    },
+    "vision_soft_tokens_per_image": 280,
+}
+
+
+gemma4_e4b_dict = gemma4_e2b_dict.copy()
+gemma4_e4b_dict["text_config"] = gemma4_e2b_dict["text_config"].copy()
+gemma4_e4b_dict["text_config"].update(
+    {
+        "hidden_size": 2560,
+        "intermediate_size": 10240,
+        "layer_types": [
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ]
+        * 7,
+        "num_hidden_layers": 42,
+        "num_key_value_heads": 2,
+        "num_kv_shared_layers": 18,
+        "use_double_wide_mlp": False,
+    }
+)
+
+
 try:
   # Will execute successfully if Transformers is updated with Gemma 4 support
   gemma4_26b_config = transformers.Gemma4Config(**gemma4_26b_dict)
   gemma4_31b_config = transformers.Gemma4Config(**gemma4_31b_dict)
+  gemma4_e2b_config = transformers.Gemma4Config(**gemma4_e2b_dict)
+  gemma4_e4b_config = transformers.Gemma4Config(**gemma4_e4b_dict)
 except AttributeError:
   # Graceful fallback to raw dict-based PTConfig if Gemma 4 natively is missing
   gemma4_26b_config = PTConfig(**gemma4_26b_dict)  # pytype: disable=wrong-arg-types
   gemma4_31b_config = PTConfig(**gemma4_31b_dict)  # pytype: disable=wrong-arg-types
+  gemma4_e2b_config = PTConfig(**gemma4_e2b_dict)  # pytype: disable=wrong-arg-types
+  gemma4_e4b_config = PTConfig(**gemma4_e4b_dict)  # pytype: disable=wrong-arg-types
 
 
 gemma3_4b_config = transformers.Gemma3Config(
@@ -1185,6 +1308,8 @@ HF_MODEL_CONFIGS = {
     "gemma3-27b": gemma3_27b_config,
     "gemma4-26b": gemma4_26b_config,
     "gemma4-31b": gemma4_31b_config,
+    "gemma4-e2b": gemma4_e2b_config,
+    "gemma4-e4b": gemma4_e4b_config,
     "qwen2.5-1.5b": qwen25_1_5b_config,
     "qwen2.5-7b": qwen25_7b_config,
     "qwen2.5-14b": qwen25_14b_config,

--- a/src/maxtext/checkpoint_conversion/utils/hf_shape.py
+++ b/src/maxtext/checkpoint_conversion/utils/hf_shape.py
@@ -284,6 +284,92 @@ def GEMMA4_HF_WEIGHTS_TO_SHAPE(config):
   return shapes
 
 
+def GEMMA4_SMALL_HF_WEIGHTS_TO_SHAPE(config):
+  """Generates HF parameter shapes for Gemma 4 small (E2B / E4B).
+
+  Differs from GEMMA4_HF_WEIGHTS_TO_SHAPE in that it:
+    * derives global-vs-sliding from the per-model ``layer_types`` list
+      (E2B has period-5, E4B has period-6),
+    * emits the Per-Layer-Embedding parameters when ``hidden_size_per_layer_input`` > 0,
+    * omits k_proj/v_proj/k_norm/v_norm shapes on KV-shared layers, and
+    * doubles ``intermediate_size`` on shared layers when ``use_double_wide_mlp``
+      is set (E2B).
+  """
+  shapes = {}
+
+  text_cfg = config.get("text_config", config)
+  vision_cfg = config.get("vision_config", {})
+  text_base = "model.language_model" if vision_cfg else "model"
+
+  hidden_size = text_cfg["hidden_size"]
+  intermediate_size = text_cfg["intermediate_size"]
+  num_hidden_layers = text_cfg["num_hidden_layers"]
+  num_attention_heads = text_cfg["num_attention_heads"]
+  num_key_value_heads = text_cfg["num_key_value_heads"]
+  num_global_key_value_heads = text_cfg.get("num_global_key_value_heads") or num_key_value_heads
+  head_dim = text_cfg["head_dim"]
+  global_head_dim = text_cfg.get("global_head_dim", head_dim)
+  vocab_size = text_cfg["vocab_size"]
+  layer_types = text_cfg.get("layer_types", [])
+
+  ple_dim = text_cfg.get("hidden_size_per_layer_input", 0) or 0
+  vocab_ple = text_cfg.get("vocab_size_per_layer_input", 0) or 0
+  num_kv_shared = text_cfg.get("num_kv_shared_layers", 0) or 0
+  first_shared = max(0, num_hidden_layers - num_kv_shared) if num_kv_shared > 0 else num_hidden_layers
+  use_double_wide_mlp = bool(text_cfg.get("use_double_wide_mlp", False))
+
+  shapes[f"{text_base}.embed_tokens.weight"] = [vocab_size, hidden_size]
+  shapes[f"{text_base}.norm.weight"] = [hidden_size]
+
+  if ple_dim > 0:
+    shapes[f"{text_base}.embed_tokens_per_layer.weight"] = [vocab_ple, num_hidden_layers * ple_dim]
+    shapes[f"{text_base}.per_layer_model_projection.weight"] = [num_hidden_layers * ple_dim, hidden_size]
+    shapes[f"{text_base}.per_layer_projection_norm.weight"] = [ple_dim]
+
+  for i in range(num_hidden_layers):
+    hf_prefix = f"{text_base}.layers.{i}"
+    is_global = i < len(layer_types) and layer_types[i] == "full_attention"
+    is_shared = num_kv_shared > 0 and i >= first_shared
+
+    if is_global:
+      q_dim = num_attention_heads * global_head_dim
+      kv_dim = num_global_key_value_heads * global_head_dim
+      norm_dim = global_head_dim
+    else:
+      q_dim = num_attention_heads * head_dim
+      kv_dim = num_key_value_heads * head_dim
+      norm_dim = head_dim
+
+    shapes[f"{hf_prefix}.self_attn.q_proj.weight"] = [q_dim, hidden_size]
+    shapes[f"{hf_prefix}.self_attn.o_proj.weight"] = [hidden_size, q_dim]
+    shapes[f"{hf_prefix}.self_attn.q_norm.weight"] = [norm_dim]
+    if not is_shared:
+      shapes[f"{hf_prefix}.self_attn.k_proj.weight"] = [kv_dim, hidden_size]
+      shapes[f"{hf_prefix}.self_attn.v_proj.weight"] = [kv_dim, hidden_size]
+      shapes[f"{hf_prefix}.self_attn.k_norm.weight"] = [norm_dim]
+      # v_norm only when scale is enabled in MaxText; param_mapping suppresses
+      # this key otherwise, so emit the shape unconditionally — extras are ignored.
+      shapes[f"{hf_prefix}.self_attn.v_norm.weight"] = [norm_dim]
+
+    shapes[f"{hf_prefix}.input_layernorm.weight"] = [hidden_size]
+    shapes[f"{hf_prefix}.post_attention_layernorm.weight"] = [hidden_size]
+    shapes[f"{hf_prefix}.pre_feedforward_layernorm.weight"] = [hidden_size]
+    shapes[f"{hf_prefix}.post_feedforward_layernorm.weight"] = [hidden_size]
+    shapes[f"{hf_prefix}.layer_scalar"] = [1]
+
+    mlp_dim = intermediate_size * 2 if (is_shared and use_double_wide_mlp) else intermediate_size
+    shapes[f"{hf_prefix}.mlp.gate_proj.weight"] = [mlp_dim, hidden_size]
+    shapes[f"{hf_prefix}.mlp.up_proj.weight"] = [mlp_dim, hidden_size]
+    shapes[f"{hf_prefix}.mlp.down_proj.weight"] = [hidden_size, mlp_dim]
+
+    if ple_dim > 0:
+      shapes[f"{hf_prefix}.per_layer_input_gate.weight"] = [ple_dim, hidden_size]
+      shapes[f"{hf_prefix}.per_layer_projection.weight"] = [hidden_size, ple_dim]
+      shapes[f"{hf_prefix}.post_per_layer_input_norm.weight"] = [hidden_size]
+
+  return shapes
+
+
 def GEMMA2_HF_WEIGHTS_TO_SHAPE(config):
   """Returns mapping between HuggingFace weights path and weights shape.
 
@@ -920,6 +1006,8 @@ HF_SHAPE = {
     "gemma3-27b": GEMMA3_HF_WEIGHTS_TO_SHAPE,
     "gemma4-26b": GEMMA4_HF_WEIGHTS_TO_SHAPE,
     "gemma4-31b": GEMMA4_HF_WEIGHTS_TO_SHAPE,
+    "gemma4-e2b": GEMMA4_SMALL_HF_WEIGHTS_TO_SHAPE,
+    "gemma4-e4b": GEMMA4_SMALL_HF_WEIGHTS_TO_SHAPE,
     "qwen2.5-1.5b": QWEN_HF_WEIGHTS_TO_SHAPE,
     "qwen2.5-7b": QWEN_HF_WEIGHTS_TO_SHAPE,
     "qwen2.5-14b": QWEN_HF_WEIGHTS_TO_SHAPE,

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -2528,6 +2528,236 @@ def GEMMA4_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False
   return mapping
 
 
+def GEMMA4_SMALL_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
+  """MaxText↔HF weight-path map for Gemma 4 small (E2B / E4B).
+
+  The small variants thread per-layer state (PLE input + donor K/V) through
+  the layer loop, so scanned blocks are not supported.
+  """
+  if scan_layers:
+    raise NotImplementedError("Scan layers is not supported for the gemma4_small decoder block.")
+
+  tcfg = config.get("text_config", config)
+  nlayers = tcfg["num_hidden_layers"]
+  num_kv_shared = tcfg.get("num_kv_shared_layers", 0) or 0
+  first_shared = max(0, nlayers - num_kv_shared) if num_kv_shared > 0 else nlayers
+  vcfg = config.get("vision_config", {})
+  text_base = "model.language_model" if vcfg else "model"
+
+  mapping = {
+      "params-token_embedder-embedding": f"{text_base}.embed_tokens.weight",
+      "params-decoder-decoder_norm-scale": f"{text_base}.norm.weight",
+  }
+
+  ple_dim = tcfg.get("hidden_size_per_layer_input", 0) or 0
+  if ple_dim > 0:
+    mapping.update(
+        {
+            "params-decoder-per_layer_embedder-embed_tokens_per_layer": (f"{text_base}.embed_tokens_per_layer.weight"),
+            "params-decoder-per_layer_embedder-per_layer_model_projection-kernel": (
+                f"{text_base}.per_layer_model_projection.weight"
+            ),
+            "params-decoder-per_layer_embedder-per_layer_projection_norm-scale": (
+                f"{text_base}.per_layer_projection_norm.weight"
+            ),
+        }
+    )
+
+  for lyr in range(nlayers):
+    prefix = f"params-decoder-layers_{lyr}"
+    hf_prefix = f"{text_base}.layers.{lyr}"
+    is_shared = lyr >= first_shared > 0
+    mapping.update(
+        {
+            f"{prefix}-pre_self_attention_norm-scale": f"{hf_prefix}.input_layernorm.weight",
+            f"{prefix}-post_self_attention_norm-scale": f"{hf_prefix}.post_attention_layernorm.weight",
+            f"{prefix}-pre_ffw_norm-scale": f"{hf_prefix}.pre_feedforward_layernorm.weight",
+            f"{prefix}-post_ffw_norm-scale": f"{hf_prefix}.post_feedforward_layernorm.weight",
+            f"{prefix}-self_attention-query-kernel": f"{hf_prefix}.self_attn.q_proj.weight",
+            f"{prefix}-self_attention-query_norm-scale": f"{hf_prefix}.self_attn.q_norm.weight",
+            f"{prefix}-self_attention-out-kernel": f"{hf_prefix}.self_attn.o_proj.weight",
+            f"{prefix}-mlp-wi_0-kernel": f"{hf_prefix}.mlp.gate_proj.weight",
+            f"{prefix}-mlp-wi_1-kernel": f"{hf_prefix}.mlp.up_proj.weight",
+            f"{prefix}-mlp-wo-kernel": f"{hf_prefix}.mlp.down_proj.weight",
+            f"{prefix}-layer_scalar": f"{hf_prefix}.layer_scalar",
+        }
+    )
+    if not is_shared:
+      mapping.update(
+          {
+              f"{prefix}-self_attention-key-kernel": f"{hf_prefix}.self_attn.k_proj.weight",
+              f"{prefix}-self_attention-value-kernel": f"{hf_prefix}.self_attn.v_proj.weight",
+              f"{prefix}-self_attention-key_norm-scale": f"{hf_prefix}.self_attn.k_norm.weight",
+              f"{prefix}-self_attention-value_norm-scale": f"{hf_prefix}.self_attn.v_norm.weight"
+              if maxtext_config.v_norm_with_scale
+              else None,
+          }
+      )
+    if ple_dim > 0:
+      mapping.update(
+          {
+              f"{prefix}-per_layer_input_gate-kernel": f"{hf_prefix}.per_layer_input_gate.weight",
+              f"{prefix}-per_layer_projection-kernel": f"{hf_prefix}.per_layer_projection.weight",
+              f"{prefix}-post_per_layer_input_norm-scale": f"{hf_prefix}.post_per_layer_input_norm.weight",
+          }
+      )
+
+  # TODO: gemma4-small multimodal not yet supported — vision-encoder mappings below are dead.
+  if maxtext_config.use_multimodal and vcfg:
+    nvis = vcfg.get("num_hidden_layers", 0)
+    mapping.update(
+        {
+            "params-vision_encoder-Gemma4VisionEncoderLayer_0-vision_entry-input_projection-kernel": (
+                "model.vision_tower.patch_embedder.input_proj.weight"
+            ),
+            "params-vision_encoder-Gemma4VisionEncoderLayer_0-vision_entry-pos_emb_param": (
+                "model.vision_tower.patch_embedder.position_embedding_table"
+            ),
+            "params-vision_encoder-Gemma4VisionProjector_0-projection-kernel": (
+                "model.embed_vision.embedding_projection.weight"
+            ),
+        }
+    )
+    if vcfg.get("standardize", False):
+      mapping.update(
+          {
+              "params-vision_encoder-Gemma4VisionEncoderLayer_0-std_scale": "model.vision_tower.std_scale",
+              "params-vision_encoder-Gemma4VisionEncoderLayer_0-std_bias": "model.vision_tower.std_bias",
+          }
+      )
+    else:
+      # E2B / E4B ship with ``standardize=false`` and do not store
+      # ``std_scale`` / ``std_bias`` in the safetensors. Point at any
+      # always-present key so the loader doesn't error; the hook below
+      # ignores the input and synthesizes identity values (scale=1, bias=0)
+      # so the standardize op becomes a no-op, matching HF.
+      placeholder_hf_key = "model.vision_tower.encoder.layers.0.input_layernorm.weight"
+      mapping.update(
+          {
+              "params-vision_encoder-Gemma4VisionEncoderLayer_0-std_scale": placeholder_hf_key,
+              "params-vision_encoder-Gemma4VisionEncoderLayer_0-std_bias": placeholder_hf_key,
+          }
+      )
+    for i in range(nvis):
+      prefix = f"params-vision_encoder-Gemma4VisionEncoderLayer_0-layer_{i}"
+      hf_prefix = f"model.vision_tower.encoder.layers.{i}"
+      mapping.update(
+          {
+              f"{prefix}-attention-query-kernel": f"{hf_prefix}.self_attn.q_proj.linear.weight",
+              f"{prefix}-attention-key-kernel": f"{hf_prefix}.self_attn.k_proj.linear.weight",
+              f"{prefix}-attention-value-kernel": f"{hf_prefix}.self_attn.v_proj.linear.weight",
+              f"{prefix}-attention-out-kernel": f"{hf_prefix}.self_attn.o_proj.linear.weight",
+              f"{prefix}-attention-query_norm-scale": f"{hf_prefix}.self_attn.q_norm.weight",
+              f"{prefix}-attention-key_norm-scale": f"{hf_prefix}.self_attn.k_norm.weight",
+              f"{prefix}-pre_attention_norm-scale": f"{hf_prefix}.input_layernorm.weight",
+              f"{prefix}-post_attention_norm-scale": f"{hf_prefix}.post_attention_layernorm.weight",
+              f"{prefix}-pre_ffw_norm-scale": f"{hf_prefix}.pre_feedforward_layernorm.weight",
+              f"{prefix}-post_ffw_norm-scale": f"{hf_prefix}.post_feedforward_layernorm.weight",
+              f"{prefix}-mlp-wi_0-kernel": f"{hf_prefix}.mlp.gate_proj.linear.weight",
+              f"{prefix}-mlp-wi_1-kernel": f"{hf_prefix}.mlp.up_proj.linear.weight",
+              f"{prefix}-mlp-wo-kernel": f"{hf_prefix}.mlp.down_proj.linear.weight",
+          }
+      )
+
+  return {k: v for k, v in mapping.items() if v is not None}
+
+
+def GEMMA4_SMALL_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
+  """Param-transformation hooks for Gemma 4 small (E2B / E4B)."""
+  if scan_layers:
+    raise NotImplementedError("Scan layers is not supported for the gemma4_small decoder block.")
+
+  tcfg = config.get("text_config", config)
+  nlayers = tcfg["num_hidden_layers"]
+  num_kv_shared = tcfg.get("num_kv_shared_layers", 0) or 0
+  first_shared = max(0, nlayers - num_kv_shared) if num_kv_shared > 0 else nlayers
+  ple_dim = tcfg.get("hidden_size_per_layer_input", 0) or 0
+  vcfg = config.get("vision_config", {})
+  hooks = {}
+
+  def pad_hf_embedding_layer(input_tensor, target_shape):
+    normalizer = np.dtype("float32").type(tcfg["hidden_size"] ** 0.5)
+    if saving_to_hf:
+      target_tensor = input_tensor[: target_shape[0], : target_shape[1]]
+      target_tensor = target_tensor / normalizer
+      return target_tensor.astype(input_tensor.dtype)
+    target_tensor = np.zeros(target_shape, dtype=input_tensor.dtype)
+    target_tensor[: input_tensor.shape[0], : input_tensor.shape[1]] = input_tensor
+    target_tensor = target_tensor * normalizer
+    return target_tensor.astype(input_tensor.dtype)
+
+  def reshape_kernel(input_tensor, target_shape):
+    if saving_to_hf:
+      flipped_target_shape = np.flip(np.array(target_shape))
+      return input_tensor.reshape(flipped_target_shape).T
+    return input_tensor.T.reshape(target_shape)
+
+  def scale_rmsnorm_layer(input_tensor, target_shape):
+    # Gemma 4 folds the +1 shift into the checkpoint scale, so no offset.
+    return input_tensor.reshape(target_shape)
+
+  hooks["params-token_embedder-embedding"] = pad_hf_embedding_layer
+  hooks["params-decoder-decoder_norm-scale"] = scale_rmsnorm_layer
+
+  def reshape_to_target(input_tensor, target_shape):
+    return input_tensor.reshape(target_shape)
+
+  if ple_dim > 0:
+    # PLE token-identity table is 2-D and stored with the same flat layout as HF,
+    # so no hook is needed (apply_hook_fns defaults to identity).
+    hooks["params-decoder-per_layer_embedder-per_layer_model_projection-kernel"] = reshape_kernel
+    hooks["params-decoder-per_layer_embedder-per_layer_projection_norm-scale"] = scale_rmsnorm_layer
+
+  for lyr in range(nlayers):
+    prefix = f"params-decoder-layers_{lyr}"
+    is_shared = lyr >= first_shared > 0
+    for n in (
+        "pre_self_attention_norm",
+        "post_self_attention_norm",
+        "pre_ffw_norm",
+        "post_ffw_norm",
+    ):
+      hooks[f"{prefix}-{n}-scale"] = scale_rmsnorm_layer
+    for k in ("query-kernel", "out-kernel"):
+      hooks[f"{prefix}-self_attention-{k}"] = reshape_kernel
+    hooks[f"{prefix}-self_attention-query_norm-scale"] = scale_rmsnorm_layer
+    if not is_shared:
+      for k in ("key-kernel", "value-kernel"):
+        hooks[f"{prefix}-self_attention-{k}"] = reshape_kernel
+      hooks[f"{prefix}-self_attention-key_norm-scale"] = scale_rmsnorm_layer
+      if maxtext_config.v_norm_with_scale:
+        hooks[f"{prefix}-self_attention-value_norm-scale"] = scale_rmsnorm_layer
+    for k in ("wi_0-kernel", "wi_1-kernel", "wo-kernel"):
+      hooks[f"{prefix}-mlp-{k}"] = reshape_kernel
+    hooks[f"{prefix}-layer_scalar"] = reshape_to_target
+    if ple_dim > 0:
+      for k in ("per_layer_input_gate-kernel", "per_layer_projection-kernel"):
+        hooks[f"{prefix}-{k}"] = reshape_kernel
+      hooks[f"{prefix}-post_per_layer_input_norm-scale"] = scale_rmsnorm_layer
+
+  # TODO: gemma4-small multimodal not yet supported — vision-encoder hooks below are dead.
+  # When it lands: standardize=false branch synthesizes ones/zeros so the standardize op is
+  # a no-op (E2B / E4B don't ship std_scale / std_bias in their safetensors).
+  if maxtext_config.use_multimodal and vcfg:
+    big_hooks = GEMMA4_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=saving_to_hf)
+    for key, fn in big_hooks.items():
+      if key.startswith("params-vision_encoder-"):
+        hooks[key] = fn
+
+    if not vcfg.get("standardize", False):
+
+      def make_ones(_input, target_shape):
+        return np.ones(target_shape, dtype=np.float32)
+
+      def make_zeros(_input, target_shape):
+        return np.zeros(target_shape, dtype=np.float32)
+
+      hooks["params-vision_encoder-Gemma4VisionEncoderLayer_0-std_scale"] = make_ones
+      hooks["params-vision_encoder-Gemma4VisionEncoderLayer_0-std_bias"] = make_zeros
+
+  return hooks
+
+
 def GEMMA4_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
   """Creates parameter transformation functions for Gemma4."""
   tcfg = config.get("text_config", config)
@@ -2915,6 +3145,8 @@ PARAM_MAPPING = {
     "gemma3-27b": GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma4-26b": GEMMA4_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma4-31b": GEMMA4_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "gemma4-e2b": GEMMA4_SMALL_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "gemma4-e4b": GEMMA4_SMALL_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen2.5-1.5b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen2.5-7b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen2.5-14b": QWEN_MAXTEXT_TO_HF_PARAM_MAPPING,
@@ -2961,6 +3193,8 @@ HOOK_FNS = {
     "gemma3-27b": GEMMA3_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "gemma4-26b": GEMMA4_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "gemma4-31b": GEMMA4_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "gemma4-e2b": GEMMA4_SMALL_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "gemma4-e4b": GEMMA4_SMALL_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen2.5-1.5b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen2.5-7b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "qwen2.5-14b": QWEN_MAXTEXT_TO_HF_PARAM_HOOK_FN,

--- a/src/maxtext/common/common_types.py
+++ b/src/maxtext/common/common_types.py
@@ -97,6 +97,7 @@ class DecoderBlockType(enum.Enum):
   GEMMA2 = "gemma2"
   GEMMA3 = "gemma3"
   GEMMA4 = "gemma4"
+  GEMMA4_SMALL = "gemma4_small"
   QWEN2 = "qwen2"
   QWEN3 = "qwen3"
   QWEN3_MOE = "qwen3_moe"

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -371,6 +371,19 @@ v_norm_with_scale: True
 qk_norm_with_scale: True
 mla_naive_kvcache: True
 
+# Gemma 4 small (E2B / E4B) specific config fields.
+# When `hidden_size_per_layer_input` is positive, each decoder layer adds an
+# extra "Per-Layer-Embedding" sub-block at the end (see models/gemma4_small.py).
+hidden_size_per_layer_input: 0
+vocab_size_per_layer_input: 0
+# Number of *trailing* decoder layers that reuse K/V from the last non-shared
+# layer of the same attention type (sliding↔sliding, full↔full). Those layers
+# do not have their own k/v projections.
+num_kv_shared_layers: 0
+# When True, KV-shared layers double their MLP intermediate size to compensate
+# for the lost K/V parameters.
+use_double_wide_mlp: False
+
 
 # Adding Mixture of Block Attention Support (MoBA): https://github.com/MoonshotAI/MoBA/blob/master/MoBA_Tech_Report.pdf
 moba: False

--- a/src/maxtext/configs/models/gemma4-e2b.yml
+++ b/src/maxtext/configs/models/gemma4-e2b.yml
@@ -1,0 +1,59 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# model config for gemma4-E2B (text + image)
+
+base_num_decoder_layers: 35
+base_emb_dim: 1536
+base_num_query_heads: 8
+base_num_kv_heads: 1
+base_mlp_dim: 6144
+mlp_activations: ["gelu","linear"]
+head_dim: 256
+global_head_dim: 512
+vocab_size: 262144
+decoder_block: "gemma4_small"
+normalization_layer_epsilon: 1e-6
+logits_via_embedding: True
+use_post_attn_norm: true
+use_post_ffw_norm: true
+sliding_window_size: 512
+v_norm_with_scale: false
+
+# Per-layer embedding + KV sharing; E2B widens the MLP on shared layers.
+hidden_size_per_layer_input: 256
+vocab_size_per_layer_input: 262144
+num_kv_shared_layers: 20
+use_double_wide_mlp: true
+
+local_rope_max_timescale: 10000
+global_rope_max_timescale: 1000000
+rope_max_timescale: 1000000
+global_rope_proportion: 0.25
+local_rope_proportion: 1.0
+final_logits_soft_cap: 30.0
+
+# Vision encoder flags — multimodal not yet supported for E2B / E4B.
+rope_theta_for_vit: 100
+image_size_for_vit: [672, 960]
+num_channels_for_vit: 3
+patch_size_for_vit: 16
+conv_stride_for_vit: 16
+hidden_size_for_vit: 768
+intermediate_size_for_vit: 3072
+num_hidden_layers_for_vit: 16
+num_attention_heads_for_vit: 12
+image_placeholder: "<|image|>"
+vision_output_length: 280
+num_position_embeddings_for_vit: 10240

--- a/src/maxtext/configs/models/gemma4-e4b.yml
+++ b/src/maxtext/configs/models/gemma4-e4b.yml
@@ -1,0 +1,60 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# model config for gemma4-E4B (text + image)
+
+base_num_decoder_layers: 42
+base_emb_dim: 2560
+base_num_query_heads: 8
+base_num_kv_heads: 2
+base_mlp_dim: 10240
+mlp_activations: ["gelu","linear"]
+head_dim: 256
+global_head_dim: 512
+vocab_size: 262144
+decoder_block: "gemma4_small"
+normalization_layer_epsilon: 1e-6
+logits_via_embedding: True
+use_post_attn_norm: true
+use_post_ffw_norm: true
+sliding_window_size: 512
+v_norm_with_scale: false
+
+# Per-layer embedding + KV sharing; E4B does not widen the MLP on shared
+# layers (E2B does).
+hidden_size_per_layer_input: 256
+vocab_size_per_layer_input: 262144
+num_kv_shared_layers: 18
+use_double_wide_mlp: false
+
+local_rope_max_timescale: 10000
+global_rope_max_timescale: 1000000
+rope_max_timescale: 1000000
+global_rope_proportion: 0.25
+local_rope_proportion: 1.0
+final_logits_soft_cap: 30.0
+
+# Vision encoder flags — multimodal not yet supported for E2B / E4B.
+rope_theta_for_vit: 100
+image_size_for_vit: [672, 960]
+num_channels_for_vit: 3
+patch_size_for_vit: 16
+conv_stride_for_vit: 16
+hidden_size_for_vit: 768
+intermediate_size_for_vit: 3072
+num_hidden_layers_for_vit: 16
+num_attention_heads_for_vit: 12
+image_placeholder: "<|image|>"
+vision_output_length: 280
+num_position_embeddings_for_vit: 10240

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -239,6 +239,8 @@ ModelName = Literal[
     "gemma3-27b",
     "gemma4-26b",
     "gemma4-31b",
+    "gemma4-e2b",
+    "gemma4-e4b",
     "qwen2.5-1.5b",
     "qwen2.5-7b",
     "qwen2.5-14b",
@@ -558,6 +560,34 @@ class Attention(BaseModel):
   global_num_kv_heads: int = Field(
       0,
       description="If greater than 0, sets the number of KV heads for global attention.",
+  )
+  hidden_size_per_layer_input: NonNegativeInt = Field(
+      0,
+      description=(
+          "Per-Layer-Embedding (PLE) inner dim used by Gemma 4 small models. "
+          "When > 0, each decoder layer adds an extra PLE sub-block at the end."
+      ),
+  )
+  vocab_size_per_layer_input: NonNegativeInt = Field(
+      0,
+      description=(
+          "Vocab size of the per-layer input embedding table used by Gemma 4 small models. "
+          "Defaults to 0 (disabled); typically set equal to `vocab_size`."
+      ),
+  )
+  num_kv_shared_layers: NonNegativeInt = Field(
+      0,
+      description=(
+          "Number of trailing decoder layers that reuse K/V from the last non-shared layer "
+          "of the same attention type (sliding↔sliding, full↔full). Used by Gemma 4 small."
+      ),
+  )
+  use_double_wide_mlp: bool = Field(
+      False,
+      description=(
+          "When True, KV-shared layers double their MLP intermediate size to compensate for "
+          "the missing K/V projections. Used by Gemma 4 small."
+      ),
   )
   attention_sink: bool = Field(False, description="If True, enables attention sinks.")
   float32_qk_product: bool = Field(False, description="In dot-product attention, cast query-key product to fp32.")
@@ -2887,7 +2917,16 @@ class MaxTextConfig(
         raise ValueError("Loss-free load balancing is only supported for the DeepSeek decoder block.")
       self.validate_ragged_buffer_factor()
 
+    # Gemma 4 small (E2B / E4B) uses per-layer KV sharing, which is incompatible with nn.scan.
+    if self.model_name in ("gemma4-e2b", "gemma4-e4b") and self.scan_layers:
+      raise ValueError(
+          f"{self.model_name} requires scan_layers=False (per-layer KV sharing is incompatible with nn.scan)."
+      )
     if self.use_multimodal:
+      # Gemma 4 small (E2B / E4B) only supports text for now; multimodal
+      # support is pending clipped-linears in the vision encoder.
+      if self.model_name in ("gemma4-e2b", "gemma4-e4b"):
+        raise ValueError(f"Multimodal is not yet supported for {self.model_name}; only text inputs are supported.")
       valid_mm_models = (
           "gemma3-4b",
           "gemma3-12b",
@@ -3063,6 +3102,12 @@ class MaxTextConfig(
       raise ValueError("`share_kv_projections` is not compatible with `fused_qkv`.")
     if self.share_kv_projections and self.attention_type == "mla":
       raise ValueError("`share_kv_projections` is not compatible with `attention_type='mla'`.")
+
+    if self.num_kv_shared_layers > 0:
+      if self.fused_qkv:
+        raise ValueError("`num_kv_shared_layers > 0` is not compatible with `fused_qkv`.")
+      if self.share_kv_projections:
+        raise ValueError("`num_kv_shared_layers > 0` is not compatible with `share_kv_projections`.")
 
     # I. FINAL TYPE CONVERSIONS AND DERIVED LISTS
     ici_map = {

--- a/src/maxtext/layers/attentions.py
+++ b/src/maxtext/layers/attentions.py
@@ -319,6 +319,7 @@ class Attention(nnx.Module):
       use_v_norm: bool = False,
       rope_max_timescale: float | None = None,
       partial_rotary_factor: float | None = None,
+      share_kv_layer: bool = False,
       rngs: nnx.Rngs | None = None,
   ):
     """Initializes the Attention module.
@@ -364,6 +365,9 @@ class Attention(nnx.Module):
       use_v_norm: Whether to apply normalization to value.
       rope_max_timescale: The maximum timescale for RoPE.
       partial_rotary_factor: The factor for partial rotary embedding.
+      share_kv_layer: If True, this layer reuses K / V from an earlier (donor) layer of the same
+          attention type; k_proj / v_proj / k_norm / v_norm are not created and RoPE-on-K is
+          skipped. The caller must pass `shared_key` / `shared_value` to `__call__`.
       rngs: RNG state for initialization, passed by the nnx.to_linen wrapper.
     """
 
@@ -422,6 +426,7 @@ class Attention(nnx.Module):
     self.use_v_norm = use_v_norm
     self.rope_max_timescale = rope_max_timescale if rope_max_timescale is not None else self.config.rope_max_timescale
     self.partial_rotary_factor = partial_rotary_factor
+    self.share_kv_layer = share_kv_layer
 
     self.is_qwen2 = self.config.decoder_block == DecoderBlockType.QWEN2
     self.is_qwen3_hybrid = self.config.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5)
@@ -512,16 +517,19 @@ class Attention(nnx.Module):
           with_scale=with_scale,
           rngs=self.rngs,
       )
-      self.key_norm = qk_norm_cls(
-          num_features=k_features,
-          dtype=self.config.dtype,
-          weight_dtype=self.config.weight_dtype,
-          shard_mode=self.config.shard_mode,
-          epsilon=self.config.normalization_layer_epsilon,
-          kernel_axes=("norm",),
-          with_scale=with_scale,
-          rngs=self.rngs,
-      )
+      if self.share_kv_layer:
+        self.key_norm = None
+      else:
+        self.key_norm = qk_norm_cls(
+            num_features=k_features,
+            dtype=self.config.dtype,
+            weight_dtype=self.config.weight_dtype,
+            shard_mode=self.config.shard_mode,
+            epsilon=self.config.normalization_layer_epsilon,
+            kernel_axes=("norm",),
+            with_scale=with_scale,
+            rngs=self.rngs,
+        )
     elif self.is_qwen3_hybrid:
       self.query_norm = Qwen3NextRMSNorm(
           num_features=self.config.head_dim,
@@ -541,7 +549,7 @@ class Attention(nnx.Module):
       self.query_norm = None
       self.key_norm = None
 
-    if self.use_v_norm:
+    if self.use_v_norm and not self.share_kv_layer:
       with_scale = self.config.v_norm_with_scale
       self.value_norm = RMSNorm(
           num_features=self.head_dim,
@@ -569,9 +577,10 @@ class Attention(nnx.Module):
       self.qkv_proj = self.init_qkv_w(inputs_shape=inputs_q_shape)
     else:
       self.query = self.init_query_w(inputs_q_shape=inputs_q_shape)
-      self.key = self.init_kv_w(inputs_kv_shape=inputs_kv_shape)
-      if not self.share_kv_projections:
-        self.value = self.init_kv_w(inputs_kv_shape=inputs_kv_shape)
+      if not self.share_kv_layer:
+        self.key = self.init_kv_w(inputs_kv_shape=inputs_kv_shape)
+        if not self.share_kv_projections:
+          self.value = self.init_kv_w(inputs_kv_shape=inputs_kv_shape)
     self.out = self.init_out_w(output_dim=inputs_q_shape[-1])
 
   def init_query_w(self, inputs_q_shape: Tuple) -> nnx.Module:
@@ -738,6 +747,39 @@ class Attention(nnx.Module):
   def out_projection(self, out: Array, out_sharding: NamedSharding | None = None) -> Array:
     """out projection"""
     return self.out(out, out_sharding=out_sharding)
+
+  def compute_shared_kv(
+      self,
+      inputs_kv: Array,
+      inputs_positions: Array | None = None,
+      rope_kwargs: dict | None = None,
+  ) -> tuple[Array, Array]:
+    """Computes the rotated, normed K / V for this layer.
+
+    Used by KV-donor layers in models with cross-layer KV sharing (e.g. Gemma 4
+    small): the donor calls this once, passes the result into its own
+    ``__call__`` as ``shared_key`` / ``shared_value`` to avoid double-computing,
+    and forwards the same tensors to downstream shared layers.
+    """
+    if self.share_kv_layer:
+      raise ValueError("compute_shared_kv cannot be called on a share_kv_layer=True layer.")
+    if self.config.fused_qkv:
+      raise ValueError("compute_shared_kv is incompatible with fused_qkv.")
+    qkv_sharding = create_sharding(self.mesh, self.input_axis_names)
+    key = self.kv_projection(inputs_kv, proj_name="key", out_sharding=qkv_sharding)
+    value = (
+        key if self.share_kv_projections else self.kv_projection(inputs_kv, proj_name="value", out_sharding=qkv_sharding)
+    )
+    is_llama4_decoder_block = self.config.decoder_block == DecoderBlockType.LLAMA4
+    if (self.use_qk_norm and not is_llama4_decoder_block) or self.is_qwen3_hybrid:
+      key = self.key_norm(key)
+    if self.use_v_norm:
+      value = self.value_norm(value)
+    if not self.is_nope_layer:
+      key = self.apply_rotary_embedding(key, inputs_positions=inputs_positions, rope_kwargs=rope_kwargs)
+    if self.use_qk_norm and is_llama4_decoder_block and not self.is_nope_layer:
+      key = L2Norm(eps=self.config.normalization_layer_epsilon)(key)
+    return key, value
 
   def convert_dense_general_inputs_shape(
       self,
@@ -1046,6 +1088,8 @@ class Attention(nnx.Module):
       rope_kwargs: dict | None = None,
       kv_cache: Optional[Array] = None,
       attention_metadata: Optional[dict[str, Any]] = None,
+      shared_key: Array | None = None,
+      shared_value: Array | None = None,
   ):
     """Applies Attention on the input data.
 
@@ -1090,9 +1134,19 @@ class Attention(nnx.Module):
     inputs_kv = self._maybe_shard_with_logical(inputs_kv, input_axis_names)
     qkv_sharding = create_sharding(self.mesh, input_axis_names)
 
+    use_shared_kv = shared_key is not None and shared_value is not None
+    if self.share_kv_layer and not use_shared_kv:
+      raise ValueError("share_kv_layer=True requires both shared_key and shared_value to be provided.")
+    if use_shared_kv and self.config.fused_qkv:
+      raise ValueError("shared_key / shared_value are incompatible with fused_qkv.")
+
     # apply projection.
     if self.config.fused_qkv:
       query, key, value = self.qkv_projection(inputs_q, proj_name="qkv_proj")
+    elif use_shared_kv:
+      # Donor layer already produced rotated, normed K/V — use them directly.
+      query = self.query_projection(inputs_q, out_sharding=qkv_sharding)
+      key, value = shared_key, shared_value
     else:
       query = self.query_projection(inputs_q, out_sharding=qkv_sharding)
       key = self.kv_projection(inputs_kv, proj_name="key", out_sharding=qkv_sharding)
@@ -1113,9 +1167,10 @@ class Attention(nnx.Module):
     # Apply Qwen3Next specific RMS Norm
     if (self.use_qk_norm and not is_llama4_decoder_block) or self.is_qwen3_hybrid:
       query = self.query_norm(query)
-      key = self.key_norm(key)
+      if not use_shared_kv:
+        key = self.key_norm(key)
 
-    if self.use_v_norm:
+    if self.use_v_norm and not use_shared_kv:
       value = self.value_norm(value)
 
     # NOTE: is_nope_layer should be used in attention mask and also used in attention tuning
@@ -1124,12 +1179,14 @@ class Attention(nnx.Module):
 
     if use_rope:
       query = self.apply_rotary_embedding(query, inputs_positions=inputs_positions, rope_kwargs=rope_kwargs)
-      key = self.apply_rotary_embedding(key, inputs_positions=inputs_positions, rope_kwargs=rope_kwargs)
+      if not use_shared_kv:
+        key = self.apply_rotary_embedding(key, inputs_positions=inputs_positions, rope_kwargs=rope_kwargs)
 
     if use_qk_norm and is_llama4_decoder_block:
       l2_norm = L2Norm(eps=self.config.normalization_layer_epsilon)
       query = l2_norm(query)
-      key = l2_norm(key)
+      if not use_shared_kv:
+        key = l2_norm(key)
 
     # apply query_pre_attn_scalar if it's present.
     if self.query_pre_attn_scalar and self.query_pre_attn_scalar != 1.0:

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -47,6 +47,7 @@ from maxtext.models import (
     gemma2,
     gemma3,
     gemma4,
+    gemma4_small,
     gpt3,
     gpt_oss,
     llama2,
@@ -468,6 +469,10 @@ class Decoder(nn.Module):
         return [gemma3.Gemma3DecoderLayerToLinen]
       case DecoderBlockType.GEMMA4:
         return [gemma4.Gemma4ScannableBlockToLinen] if self.config.scan_layers else [gemma4.Gemma4DecoderLayerToLinen]
+      case DecoderBlockType.GEMMA4_SMALL:
+        # PLE input + KV-share donor threading requires per-layer-index state,
+        # which is not expressible inside ``nn.scan``.
+        return [gemma4_small.Gemma4SmallDecoderLayerToLinen]
       case DecoderBlockType.GPT3:
         return [gpt3.Gpt3DecoderLayerToLinen]
       case DecoderBlockType.GPT_OSS:
@@ -537,6 +542,7 @@ class Decoder(nn.Module):
         DecoderBlockType.GEMMA2,
         DecoderBlockType.GEMMA3,
         DecoderBlockType.GEMMA4,
+        DecoderBlockType.GEMMA4_SMALL,
         DecoderBlockType.QWEN2,
         DecoderBlockType.QWEN3,
         DecoderBlockType.QWEN3_MOE,
@@ -650,6 +656,8 @@ class Decoder(nn.Module):
             "gemma3-27b",
             "gemma4-26b",
             "gemma4-31b",
+            "gemma4-e2b",
+            "gemma4-e4b",
             "llama4-17b-16e",
             "llama4-17b-128e",
             "qwen3-omni-30b-a3b",
@@ -1084,6 +1092,21 @@ class Decoder(nn.Module):
               if kv_caches is not None and kv_cache is not None:
                 kv_caches[index] = kv_cache
             global_layer_idx_offset += num_layers
+        elif cfg.decoder_block == DecoderBlockType.GEMMA4_SMALL:
+          y = self._apply_gemma4_small_layers(
+              y,
+              decoder_input_tokens,
+              decoder_segment_ids,
+              decoder_positions,
+              deterministic,
+              model_mode,
+              multimodal_input=multimodal_input,
+              kv_caches=kv_caches,
+              attention_metadata=attention_metadata,
+              previous_chunk=previous_chunk,
+              page_state=page_state,
+              slot=slot,
+          )
         else:
           for lyr in range(cfg.num_decoder_layers):
             RemattedBlockLayer = RemattedBlockLayers[0]
@@ -1332,6 +1355,102 @@ class Decoder(nn.Module):
       y = layer(y, *broadcast_args)
       if cfg.scan_layers:
         y = y[0]
+
+    return y
+
+  def _apply_gemma4_small_layers(
+      self,
+      y,
+      decoder_input_tokens,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      multimodal_input=None,
+      kv_caches=None,
+      attention_metadata=None,
+      previous_chunk=None,
+      page_state=None,
+      slot=None,
+  ):
+    """Apply Gemma 4 small (E2B / E4B) decoder layers.
+
+    Threads per-call state through the layer loop:
+      * ``per_layer_inputs`` from PLE, sliced per layer.
+      * ``shared_kv_states``: donor-layer-index → (key, value) for
+        downstream KV-shared layers to consume.
+
+    Scan-over-layers and pipeline parallelism are not supported.
+    """
+    cfg = self.config
+    mesh = self.mesh
+    bidirectional_mask_value = multimodal_input.bidirectional_mask if multimodal_input is not None else None
+
+    per_layer_inputs = None
+    if cfg.hidden_size_per_layer_input > 0 and cfg.vocab_size_per_layer_input > 0:
+      per_layer_inputs = gemma4_small.PLEToLinen(
+          config=cfg,
+          mesh=mesh,
+          name="per_layer_embedder",
+      )(decoder_input_tokens, y)
+
+    layer_types = gemma4_small.build_layer_types(cfg.num_decoder_layers, cfg.model_name)
+    num_kv_shared = cfg.num_kv_shared_layers
+    shared_kv_states: dict[int, tuple[jax.Array, jax.Array]] = {}
+
+    for lyr in range(cfg.num_decoder_layers):
+      attention_type = layer_types[lyr]
+      donor_idx = gemma4_small.kv_donor_layer_idx(lyr, layer_types, num_kv_shared)
+      is_donor = gemma4_small.is_kv_donor_layer(lyr, layer_types, num_kv_shared)
+
+      shared_key = None
+      shared_value = None
+      if donor_idx is not None:
+        if donor_idx not in shared_kv_states:
+          raise RuntimeError(
+              f"KV-shared layer {lyr} references donor {donor_idx} but no donor K/V "
+              f"have been recorded yet. This indicates the layer iteration order is wrong."
+          )
+        shared_key, shared_value = shared_kv_states[donor_idx]
+
+      layer = gemma4_small.Gemma4SmallDecoderLayerToLinen(
+          config=cfg,
+          mesh=mesh,
+          name=f"layers_{lyr}",
+          quant=self.quant,
+          model_mode=self.model_mode,
+          attention_type=attention_type,
+          layer_idx=lyr,
+      )
+
+      # Donor layers expose their rotated, normed K / V to downstream
+      # shared layers via the decoder layer's compute_shared_kv method.
+      if is_donor:
+        donor_k, donor_v = layer(y, decoder_positions, nnx_method="compute_shared_kv")
+        shared_kv_states[lyr] = (donor_k, donor_v)
+        # Reuse the just-computed K / V in the layer's own forward pass to
+        # avoid double-computing the K / V projection / norm / RoPE.
+        shared_key, shared_value = donor_k, donor_v
+
+      ple_slice = per_layer_inputs[..., lyr, :] if per_layer_inputs is not None else None
+
+      kv_cache = kv_caches[lyr] if kv_caches is not None else None
+      y = layer(
+          y,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          previous_chunk=previous_chunk,
+          page_state=page_state,
+          slot=slot,
+          bidirectional_mask=bidirectional_mask_value,
+          kv_cache=kv_cache,
+          attention_metadata=attention_metadata,
+          per_layer_input=ple_slice,
+          shared_key=shared_key,
+          shared_value=shared_value,
+      )
 
     return y
 

--- a/src/maxtext/layers/encoders.py
+++ b/src/maxtext/layers/encoders.py
@@ -58,7 +58,7 @@ class VisionEncoder(nnx.Module):
       setattr(self, encoder_name, qwen3.Qwen3OmniMoeVisionEncoder(config=self.config, mesh=self.mesh, rngs=self.rngs))
       setattr(self, projector_name, qwen3.Qwen3OmniMoeVisionProjector(config=self.config, rngs=self.rngs))
       return encoder_name, projector_name
-    elif self.config.model_name in ["gemma4-26b", "gemma4-31b"]:
+    elif self.config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
       from maxtext.models import gemma4_vision  # pylint: disable=import-outside-toplevel
 
       encoder_name = "Gemma4VisionEncoderLayer_0"

--- a/src/maxtext/models/gemma4_small.py
+++ b/src/maxtext/models/gemma4_small.py
@@ -1,0 +1,463 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Specialized layers for Gemma 4 small (E2B and E4B)."""
+
+import jax
+from jax.ad_checkpoint import checkpoint_name
+from jax.sharding import Mesh
+import jax.numpy as jnp
+
+from flax import linen as nn
+from flax import nnx
+
+from maxtext.common.common_types import Config, AttentionType, MODEL_MODE_PREFILL
+from maxtext.layers import initializers
+from maxtext.layers import nnx_wrappers
+from maxtext.layers import quantizations
+from maxtext.layers.attentions import Attention
+from maxtext.layers.linears import DenseGeneral, MlpBlock
+from maxtext.layers.normalizations import RMSNorm
+from maxtext.layers.quantizations import AqtQuantization as Quant
+from maxtext.utils import max_utils
+
+
+# E2B repeats 4 sliding + 1 global (period 5); E4B repeats 5 sliding + 1 global
+# (period 6). E4B is also used as the default for unrecognized model names.
+GEMMA4_E2B_ATTENTION_PATTERN = (
+    AttentionType.LOCAL_SLIDING,
+    AttentionType.LOCAL_SLIDING,
+    AttentionType.LOCAL_SLIDING,
+    AttentionType.LOCAL_SLIDING,
+    AttentionType.GLOBAL,
+)
+GEMMA4_E4B_ATTENTION_PATTERN = (
+    AttentionType.LOCAL_SLIDING,
+    AttentionType.LOCAL_SLIDING,
+    AttentionType.LOCAL_SLIDING,
+    AttentionType.LOCAL_SLIDING,
+    AttentionType.LOCAL_SLIDING,
+    AttentionType.GLOBAL,
+)
+
+
+def get_attention_pattern(model_name):
+  """Returns the repeating sliding/global attention pattern for a small variant."""
+  if model_name == "gemma4-e2b":
+    return GEMMA4_E2B_ATTENTION_PATTERN
+  return GEMMA4_E4B_ATTENTION_PATTERN
+
+
+def get_attention_type(layer_id, model_name=None):
+  """Returns the attention type for ``layer_id`` under the variant's pattern."""
+  pattern = get_attention_pattern(model_name)
+  return pattern[layer_id % len(pattern)]
+
+
+def build_layer_types(num_layers, model_name):
+  """Returns the per-layer attention-type tuple for the full decoder stack."""
+  return tuple(get_attention_type(i, model_name) for i in range(num_layers))
+
+
+def first_kv_shared_layer_idx(num_layers: int, num_kv_shared_layers: int) -> int:
+  """Index of the first KV-shared layer, or ``num_layers`` if none."""
+  if num_kv_shared_layers <= 0:
+    return num_layers
+  return max(0, num_layers - num_kv_shared_layers)
+
+
+def is_kv_shared_layer(layer_idx: int, num_layers: int, num_kv_shared_layers: int) -> bool:
+  """Returns True iff layer ``layer_idx`` reuses K/V from an earlier layer."""
+  if num_kv_shared_layers <= 0:
+    return False
+  first = first_kv_shared_layer_idx(num_layers, num_kv_shared_layers)
+  return layer_idx >= first > 0
+
+
+def kv_donor_layer_idx(
+    layer_idx: int,
+    layer_types: tuple[AttentionType, ...],
+    num_kv_shared_layers: int,
+) -> int | None:
+  """Index of the layer that owns the K/V used by ``layer_idx``.
+
+  A shared layer reuses K/V from the last non-shared layer of the same
+  attention type.
+  """
+  num_layers = len(layer_types)
+  if not is_kv_shared_layer(layer_idx, num_layers, num_kv_shared_layers):
+    return None
+  first = first_kv_shared_layer_idx(num_layers, num_kv_shared_layers)
+  layer_type = layer_types[layer_idx]
+  for j in range(first - 1, -1, -1):
+    if layer_types[j] == layer_type:
+      return j
+  return None
+
+
+def is_kv_donor_layer(
+    layer_idx: int,
+    layer_types: tuple[AttentionType, ...],
+    num_kv_shared_layers: int,
+) -> bool:
+  """Returns True iff this layer's K/V are reused by some shared layer."""
+  num_layers = len(layer_types)
+  if layer_idx < 0 or layer_idx >= num_layers:
+    return False
+  if num_kv_shared_layers <= 0:
+    return False
+  for j in range(num_layers):
+    if kv_donor_layer_idx(j, layer_types, num_kv_shared_layers) == layer_idx:
+      return True
+  return False
+
+
+class Gemma4SmallPLE(nnx.Module):
+  """Builds the ``[B, S, num_layers, D_ple]`` per-layer-input tensor."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      *,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+
+    num_layers = config.num_decoder_layers
+    ple_dim = config.hidden_size_per_layer_input
+    vocab_ple = config.vocab_size_per_layer_input
+
+    self.embed_tokens_per_layer = nnx.Param(
+        nn.initializers.normal(stddev=ple_dim**-0.5)(
+            rngs.params(),
+            (vocab_ple, num_layers * ple_dim),
+            config.weight_dtype,
+        ),
+        sharding=("vocab", "embed_vocab"),
+    )
+
+    self.per_layer_model_projection = DenseGeneral(
+        in_features_shape=config.emb_dim,
+        out_features_shape=num_layers * ple_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("embed", "mlp"),
+        shard_mode=config.shard_mode,
+        matmul_precision=config.matmul_precision,
+        rngs=rngs,
+    )
+
+    self.per_layer_projection_norm = RMSNorm(
+        num_features=ple_dim,
+        epsilon=config.normalization_layer_epsilon,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        rngs=rngs,
+    )
+
+    # Plain Python floats — storing them as jnp arrays would let nnx promote
+    # them to Variables, which then collide with the param tree on restore.
+    self._ple_dim = ple_dim
+    self._num_layers = num_layers
+    self._embed_scale_value = float(ple_dim) ** 0.5
+    self._proj_scale_value = float(config.emb_dim) ** -0.5
+
+  def __call__(self, input_ids: jax.Array, inputs_embeds: jax.Array) -> jax.Array:
+    """Returns ``per_layer_inputs`` of shape ``[B, S, L, D_ple]``."""
+    cfg = self.config
+
+    embed_scale = jnp.asarray(self._embed_scale_value, cfg.dtype)
+    proj_scale = jnp.asarray(self._proj_scale_value, cfg.dtype)
+    inv_sqrt2 = jnp.asarray(2.0**-0.5, cfg.dtype)
+
+    embedding = jnp.asarray(self.embed_tokens_per_layer.value, cfg.dtype)
+    identity = embedding[input_ids.astype(jnp.int32)] * embed_scale
+    identity = identity.reshape(*input_ids.shape, self._num_layers, self._ple_dim)
+
+    context = self.per_layer_model_projection(inputs_embeds.astype(cfg.dtype))
+    context = context * proj_scale
+    context = context.reshape(*inputs_embeds.shape[:-1], self._num_layers, self._ple_dim)
+    context = self.per_layer_projection_norm(context)
+
+    out = (identity + context) * inv_sqrt2
+    return out.astype(cfg.dtype)
+
+
+PLEToLinen = nnx_wrappers.to_linen_class(
+    Gemma4SmallPLE,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)
+
+
+class Gemma4SmallDecoderLayer(nnx.Module):
+  """Transformer decoder layer for Gemma 4 small (E2B / E4B)."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      model_mode: str,
+      rngs: nnx.Rngs,
+      quant: None | Quant = None,
+      attention_type: AttentionType = AttentionType.LOCAL_SLIDING,
+      layer_idx: int = 0,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.quant = quant
+    self.attention_type = attention_type
+    self.layer_idx = layer_idx
+
+    num_layers = config.num_decoder_layers
+    self.is_shared = is_kv_shared_layer(layer_idx, num_layers, config.num_kv_shared_layers)
+
+    # Global layers may use larger head_dim and a different RoPE base.
+    num_kv_heads = config.num_kv_heads
+    head_dim = config.head_dim
+    if attention_type == AttentionType.GLOBAL:
+      if config.global_num_kv_heads:
+        num_kv_heads = config.global_num_kv_heads
+      if config.global_head_dim:
+        head_dim = config.global_head_dim
+      partial_rotary_factor = config.global_rope_proportion
+      max_timescale = (
+          config.global_rope_max_timescale if config.global_rope_max_timescale > 0 else config.rope_max_timescale
+      )
+    else:
+      partial_rotary_factor = config.local_rope_proportion
+      max_timescale = (
+          config.local_rope_max_timescale if config.local_rope_max_timescale > 0 else config.rope_max_timescale
+      )
+
+    self.num_kv_heads = num_kv_heads
+    self.head_dim = head_dim
+
+    self.pre_self_attention_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        rngs=rngs,
+    )
+    self.post_self_attention_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        rngs=rngs,
+    )
+    self.pre_ffw_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        rngs=rngs,
+    )
+    self.post_ffw_norm = RMSNorm(
+        num_features=config.emb_dim,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        kernel_axes=("norm",),
+        rngs=rngs,
+    )
+
+    batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+    dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
+
+    self.self_attention = Attention(
+        config=config,
+        num_query_heads=config.num_query_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        max_target_length=config.max_target_length,
+        max_prefill_predict_length=config.max_prefill_predict_length,
+        attention_kernel=config.attention,
+        inputs_q_shape=dummy_inputs_shape,
+        inputs_kv_shape=dummy_inputs_shape,
+        mesh=mesh,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        dropout_rate=config.dropout_rate,
+        float32_qk_product=config.float32_qk_product,
+        float32_logits=config.float32_logits,
+        quant=quant,
+        kv_quant=quantizations.configure_kv_quant(config),
+        attention_type=attention_type,
+        sliding_window_size=config.sliding_window_size,
+        attn_logits_soft_cap=config.attn_logits_soft_cap,
+        use_qk_norm=True,
+        use_v_norm=True,
+        # HF Gemma 4 attention is unscaled (scaling=1.0); weights absorb 1/sqrt(d).
+        query_pre_attn_scalar=1.0,
+        rope_max_timescale=max_timescale,
+        partial_rotary_factor=partial_rotary_factor,
+        share_kv_layer=self.is_shared,
+        model_mode=model_mode,
+        rngs=rngs,
+    )
+
+    # E2B widens the MLP on KV-shared layers to compensate for the missing
+    # K/V parameters; E4B leaves it alone.
+    mlp_dim = config.mlp_dim
+    if self.is_shared and config.use_double_wide_mlp:
+      mlp_dim = mlp_dim * 2
+    self.mlp = MlpBlock(
+        in_features=config.emb_dim,
+        intermediate_dim=mlp_dim,
+        activations=config.mlp_activations,
+        intermediate_dropout_rate=config.dropout_rate,
+        dtype=config.dtype,
+        weight_dtype=config.weight_dtype,
+        config=config,
+        quant=quant,
+        model_mode=model_mode,
+        mesh=mesh,
+        rngs=rngs,
+    )
+
+    ple_dim = config.hidden_size_per_layer_input
+    if ple_dim > 0:
+      self.per_layer_input_gate = DenseGeneral(
+          in_features_shape=config.emb_dim,
+          out_features_shape=ple_dim,
+          dtype=config.dtype,
+          weight_dtype=config.weight_dtype,
+          kernel_axes=("embed", "mlp"),
+          shard_mode=config.shard_mode,
+          matmul_precision=config.matmul_precision,
+          rngs=rngs,
+      )
+      self.per_layer_projection = DenseGeneral(
+          in_features_shape=ple_dim,
+          out_features_shape=config.emb_dim,
+          dtype=config.dtype,
+          weight_dtype=config.weight_dtype,
+          kernel_axes=("mlp", "embed"),
+          shard_mode=config.shard_mode,
+          matmul_precision=config.matmul_precision,
+          rngs=rngs,
+      )
+      self.post_per_layer_input_norm = RMSNorm(
+          num_features=config.emb_dim,
+          epsilon=config.normalization_layer_epsilon,
+          dtype=config.dtype,
+          weight_dtype=config.weight_dtype,
+          kernel_axes=("norm",),
+          rngs=rngs,
+      )
+    else:
+      self.per_layer_input_gate = None
+      self.per_layer_projection = None
+      self.post_per_layer_input_norm = None
+
+    self.layer_scalar = nnx.Param(jnp.ones((1,), dtype=config.weight_dtype), sharding=(None,))
+
+    if model_mode == MODEL_MODE_PREFILL:
+      self.activation_axis_names = ("activation_batch", "prefill_activation_norm_length", "activation_embed")
+    else:
+      self.activation_axis_names = ("activation_batch", "activation_norm_length", "activation_embed")
+
+  def compute_shared_kv(self, inputs: jax.Array, decoder_positions: jax.Array) -> tuple[jax.Array, jax.Array]:
+    """Returns the rotated, normed K / V for this (non-shared) layer.
+
+    Used by the decoder loop on donor layers, so the K / V can be threaded into
+    downstream KV-shared layers via ``shared_key`` / ``shared_value``.
+    """
+    if self.is_shared:
+      raise ValueError("compute_shared_kv must not be called on a KV-shared layer.")
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
+    h = self.pre_self_attention_norm(inputs)
+    return self.self_attention.compute_shared_kv(h, inputs_positions=decoder_positions)
+
+  def __call__(
+      self,
+      inputs: jax.Array,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      previous_chunk=None,
+      page_state=None,
+      slot=None,
+      bidirectional_mask=None,
+      kv_cache=None,
+      attention_metadata=None,
+      per_layer_input: jax.Array | None = None,
+      shared_key: jax.Array | None = None,
+      shared_value: jax.Array | None = None,
+  ):
+    cfg = self.config
+
+    if isinstance(inputs, tuple):
+      inputs = inputs[0]
+    inputs = nn.with_logical_constraint(inputs, self.activation_axis_names)
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
+
+    # Bidirectional image-token mask is only meaningful in local-sliding
+    # layers (matches gemma4.py).
+    if self.attention_type != AttentionType.LOCAL_SLIDING:
+      bidirectional_mask = None
+
+    residual = inputs
+    h = self.pre_self_attention_norm(inputs)
+    h = nn.with_logical_constraint(h, self.activation_axis_names)
+
+    attn_out, kv_cache = self.self_attention(
+        h,
+        h,
+        decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        deterministic=deterministic,
+        model_mode=model_mode,
+        bidirectional_mask=bidirectional_mask,
+        kv_cache=kv_cache,
+        attention_metadata=attention_metadata,
+        shared_key=shared_key,
+        shared_value=shared_value,
+    )
+    attn_out = self.post_self_attention_norm(attn_out)
+    attn_out = nn.with_logical_constraint(attn_out, self.activation_axis_names)
+    h = residual + attn_out
+
+    residual = h
+    mlp_in = self.pre_ffw_norm(h)
+    mlp_out = self.mlp(mlp_in, deterministic=deterministic)
+    mlp_out = self.post_ffw_norm(mlp_out)
+    mlp_out = nn.with_logical_constraint(mlp_out, self.activation_axis_names)
+    h = residual + mlp_out
+
+    if self.per_layer_input_gate is not None and per_layer_input is not None:
+      residual = h
+      gate = self.per_layer_input_gate(h)
+      gate = jax.nn.gelu(gate.astype(jnp.float32), approximate=True).astype(cfg.dtype)
+      gated = gate * per_layer_input.astype(cfg.dtype)
+      proj = self.per_layer_projection(gated)
+      proj = self.post_per_layer_input_norm(proj)
+      proj = nn.with_logical_constraint(proj, self.activation_axis_names)
+      h = residual + proj
+
+    h = h * jnp.asarray(self.layer_scalar.value, cfg.dtype)
+    h = nn.with_logical_constraint(h, self.activation_axis_names)
+
+    return h
+
+
+Gemma4SmallDecoderLayerToLinen = nnx_wrappers.to_linen_class(
+    Gemma4SmallDecoderLayer,
+    base_metadata_fn=initializers.variable_to_logically_partitioned,
+)

--- a/src/maxtext/multimodal/processor.py
+++ b/src/maxtext/multimodal/processor.py
@@ -34,7 +34,7 @@ def preprocess_mm_data(config):
 
     images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
     processor_outputs = preprocess_mm_data_gemma3(images)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b"]:
+  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
     from maxtext.multimodal.processor_gemma4 import preprocess_mm_data_gemma4  # pylint: disable=import-outside-toplevel
 
     images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
@@ -60,7 +60,7 @@ def preprocess_image_for_training(image, model_name):
     from maxtext.multimodal.processor_gemma3 import preprocess_mm_data_gemma3  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_gemma3(image)
-  elif model_name in ["gemma4-26b", "gemma4-31b"]:
+  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
     from maxtext.multimodal.processor_gemma4 import preprocess_mm_data_gemma4  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_gemma4(image)
@@ -82,7 +82,7 @@ def get_image_offsets(config, processor_output: mm_utils.PreprocessorOutput | No
     from maxtext.multimodal.processor_gemma3 import get_image_offsets_gemma3  # pylint: disable=import-outside-toplevel
 
     return get_image_offsets_gemma3(processor_output)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b"]:
+  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
     from maxtext.multimodal.processor_gemma4 import get_image_offsets_gemma4  # pylint: disable=import-outside-toplevel
 
     return get_image_offsets_gemma4(processor_output)
@@ -104,7 +104,7 @@ def reformat_prompt(prompt, image_placeholder, model_name, num_images, video_pla
     from maxtext.multimodal.processor_gemma3 import reformat_prompt_gemma3  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_gemma3(prompt, image_placeholder, num_images)
-  elif model_name in ["gemma4-26b", "gemma4-31b"]:
+  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
     from maxtext.multimodal.processor_gemma4 import reformat_prompt_gemma4  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_gemma4(prompt, image_placeholder, num_images)
@@ -134,7 +134,7 @@ def reformat_response(response, model_name):
   elif model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
     formatted_response = f"{response}<end_of_turn>"
     return formatted_response
-  elif model_name in ["gemma4-26b", "gemma4-31b"]:
+  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
     formatted_response = f"{response}<end_of_turn>"
     return formatted_response
   elif model_name in ["qwen3-omni-30b-a3b"]:
@@ -150,7 +150,7 @@ def prepare_text_for_image_fusion(tokens, config, processor_output=None):
     from maxtext.multimodal.processor_gemma3 import add_extra_tokens_for_images_gemma3  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_images_gemma3(tokens, max_num_images=processor_output.num_images)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b"]:
+  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
     from maxtext.multimodal.processor_gemma4 import add_extra_tokens_for_images_gemma4  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_images_gemma4(tokens, max_num_images=processor_output.num_images)
@@ -214,7 +214,7 @@ def get_bidirectional_mask_vision(config, decoder_input_tokens):
     from maxtext.multimodal.processor_gemma3 import GEMMA_TOKEN_PLACEHOLDER  # pylint: disable=import-outside-toplevel
 
     bidirectional_mask_vision = decoder_input_tokens == GEMMA_TOKEN_PLACEHOLDER
-  elif config.model_name in ["gemma4-26b", "gemma4-31b"]:
+  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
     from maxtext.multimodal.processor_gemma4 import GEMMA4_TOKEN_PLACEHOLDER  # pylint: disable=import-outside-toplevel
 
     bidirectional_mask_vision = decoder_input_tokens == GEMMA4_TOKEN_PLACEHOLDER

--- a/src/maxtext/utils/globals.py
+++ b/src/maxtext/utils/globals.py
@@ -52,6 +52,8 @@ HF_IDS = {
     "gemma3-27b": "google/gemma-3-27b-it",
     "gemma4-26b": "google/gemma-4-26b-a4b-it",
     "gemma4-31b": "google/gemma-4-31b-it",
+    "gemma4-e2b": "google/gemma-4-E2B-it",
+    "gemma4-e4b": "google/gemma-4-E4B-it",
     "qwen2.5-1.5b": "Qwen/Qwen2.5-1.5B-Instruct",
     "qwen2.5-7b": "Qwen/Qwen2.5-7B-Instruct",
     "qwen2.5-14b": "Qwen/Qwen2.5-14B-Instruct",

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -38,6 +38,7 @@ import orbax.checkpoint.experimental.emergency.replicator_checkpoint_manager as 
 
 from maxtext.configs import pyconfig
 from maxtext.common.common_types import (
+    AttentionType,
     DecoderBlockType,
     MODEL_MODE_PREFILL,
     MODEL_MODE_AUTOREGRESSIVE,
@@ -399,6 +400,89 @@ def calculate_gemma4_tflops_training_per_device(
   )
 
   learnable_weight_tflops = total_learnable_flops * 3 / 10**12
+
+  return attention_tflops, learnable_weight_tflops
+
+
+def calculate_gemma4_small_tflops_training_per_device(config, embedding_flops):
+  """Training TFLOPs for Gemma 4 small (E2B / E4B).
+
+  Differs from the dense Gemma 4 path in three ways:
+    1. The last ``num_kv_shared_layers`` decoder layers reuse K/V from an
+       earlier layer and own no k_proj / v_proj.
+    2. With ``use_double_wide_mlp`` (E2B), those shared layers also widen the
+       MLP intermediate dim by 2x.
+    3. A Per-Layer-Embedding block adds a global projection plus a per-layer
+       gate / projection pair on top of every decoder layer.
+  """
+  # Local import avoids any chance of an import cycle (gemma4_small imports
+  # from maxtext.layers, which doesn't reach this module today).
+  from maxtext.models import gemma4_small  # pylint: disable=import-outside-toplevel
+
+  b = config.per_device_batch_size
+  s = config.max_target_length
+  num_layers = config.num_decoder_layers
+  num_kv_shared = config.num_kv_shared_layers
+
+  layer_types = gemma4_small.build_layer_types(num_layers, config.model_name)
+  first_shared = gemma4_small.first_kv_shared_layer_idx(num_layers, num_kv_shared)
+
+  global_head_dim = config.global_head_dim or config.head_dim
+  global_num_kv_heads = config.global_num_kv_heads or config.num_kv_heads
+  num_activations = len(config.mlp_activations)
+  window = min(config.sliding_window_size, s)
+
+  # Per-layer FLOP closures parameterized by attention type.
+  def attention_flops_for(attn_type):
+    if attn_type == AttentionType.GLOBAL:
+      # Causal global attention: factor of 2 (lower-triangular half).
+      return 2 * b * s * s * config.num_query_heads * global_head_dim
+    # Sliding-window: exact closed-form for the causal-and-windowed mask.
+    return 4 * b * (s * window - 0.5 * window**2) * config.num_query_heads * config.head_dim
+
+  def qo_flops_for(attn_type):
+    head_dim = global_head_dim if attn_type == AttentionType.GLOBAL else config.head_dim
+    q = 2 * b * s * config.emb_dim * config.num_query_heads * head_dim
+    o = 2 * b * s * config.emb_dim * config.num_query_heads * head_dim
+    return q + o
+
+  def kv_flops_for(attn_type):
+    if attn_type == AttentionType.GLOBAL:
+      kv_heads, head_dim = global_num_kv_heads, global_head_dim
+    else:
+      kv_heads, head_dim = config.num_kv_heads, config.head_dim
+    return 2 * b * s * config.emb_dim * (2 * kv_heads) * head_dim
+
+  attention_flops = 0
+  projection_flops = 0
+  ffn_per_layer = (
+      2 * b * s * config.mlp_dim * config.emb_dim * num_activations  # gate / up
+      + 2 * b * s * config.mlp_dim * config.emb_dim  # down
+  )
+  ffn_flops = 0
+
+  for lyr_idx, attn_type in enumerate(layer_types):
+    attention_flops += attention_flops_for(attn_type)
+    projection_flops += qo_flops_for(attn_type)
+    is_shared = num_kv_shared > 0 and lyr_idx >= first_shared
+    if not is_shared:
+      projection_flops += kv_flops_for(attn_type)
+    if is_shared and config.use_double_wide_mlp:
+      ffn_flops += 2 * ffn_per_layer
+    else:
+      ffn_flops += ffn_per_layer
+
+  # Per-Layer-Embedding block (skipped when ple_dim == 0).
+  ple_flops = 0
+  ple_dim = config.hidden_size_per_layer_input
+  if ple_dim > 0:
+    # One global projection emb_dim -> num_layers * ple_dim.
+    ple_flops += 2 * b * s * config.emb_dim * (num_layers * ple_dim)
+    # Per-layer gate (emb_dim -> ple_dim) and projection (ple_dim -> emb_dim).
+    ple_flops += num_layers * (2 * b * s * config.emb_dim * ple_dim + 2 * b * s * ple_dim * config.emb_dim)
+
+  attention_tflops = attention_flops * 3 / 10**12
+  learnable_weight_tflops = (projection_flops + ffn_flops + ple_flops + embedding_flops) * 3 / 10**12
 
   return attention_tflops, learnable_weight_tflops
 
@@ -952,6 +1036,12 @@ def calculate_tflops_training_per_device(config, log=True):
     attention_tflops, learnable_weight_tflops = calculate_gemma4_tflops_training_per_device(
         config, total_ffn_flops_all_layers, embedding_flops, attention_pattern_length=6
     )
+  elif config.decoder_block == DecoderBlockType.GEMMA4_SMALL:
+    # The small path derives its own attention pattern from
+    # gemma4_small.get_attention_pattern(config.model_name) and accounts for
+    # KV sharing, double-wide MLP on shared layers, and the per-layer-embedding
+    # block.
+    attention_tflops, learnable_weight_tflops = calculate_gemma4_small_tflops_training_per_device(config, embedding_flops)
   elif config.decoder_block == DecoderBlockType.DEEPSEEK:
     learnable_weight_tflops = (
         (total_ffn_flops_all_layers + (qkv_flops + projection_flops) * config.num_decoder_layers + embedding_flops)

--- a/tests/end_to_end/tpu/gemma4/Run_Gemma4.md
+++ b/tests/end_to_end/tpu/gemma4/Run_Gemma4.md
@@ -18,9 +18,18 @@
 
 Gemma is a family of open models built by Google DeepMind. [Gemma 4](https://ai.google.dev/gemma) models are multimodal, handling text and image input and generating text output. This release includes open-weights models in both pre-trained and instruction-tuned variants, featuring a context window of up to 256K tokens and multilingual support in over 140 languages.
 
-Gemma 4 in MaxText is available in two sizes with Dense (31B) and Mixture-of-Experts (MoE) (26B A4B) architectures, and is well-suited for tasks like text generation, coding, and reasoning. The models are designed for enhanced performance and efficiency, capable of running on environments ranging from laptops and servers.
+Gemma 4 in MaxText is available in four sizes — two small variants (E2B, E4B) and the larger Dense (31B) / Mixture-of-Experts (MoE) (26B A4B) configurations — and is well-suited for tasks like text generation, coding, and reasoning. The models are designed for enhanced performance and efficiency, capable of running on environments ranging from laptops and servers.
 
 We provide examples for checkpoint conversion scripts at [tests/end_to_end/tpu/gemma4](https://github.com/AI-Hypercomputer/maxtext/tree/main/tests/end_to_end/tpu/gemma4).
+
+## E2B / E4B small variants
+
+E2B and E4B are the **edge-device** ("E") variants — both **dense** (no MoE) — built for on-device deployment. The configs at `src/maxtext/configs/models/gemma4-e2b.yml` and `src/maxtext/configs/models/gemma4-e4b.yml` introduce two architecture features beyond the dense Gemma 4 path:
+
+- **Per-Layer Embedding (PLE).** Each decoder layer consumes a per-layer slice of an extra embedding tensor injected by `Gemma4SmallPLE`. Controlled by `hidden_size_per_layer_input` and `vocab_size_per_layer_input`.
+- **KV sharing.** The last `num_kv_shared_layers` layers reuse the K / V projections from the most recent non-shared layer of the same attention type (sliding↔sliding, full↔full). E2B additionally widens the MLP on shared layers (`use_double_wide_mlp: true`).
+
+Both features are tied to per-layer state that is not expressible inside `nn.scan`, so E2B / E4B require `scan_layers=false`. Multimodal is currently gated off for these variants; the model validator raises a clear error if you try to enable `use_multimodal=true`.
 
 ## Pre-training
 You can train from scratch to generate a new checkpoint. One example command to run pretraining Gemma4-26B model is as follows:
@@ -51,6 +60,22 @@ python3 -m maxtext.checkpoint_conversion.to_maxtext src/maxtext/configs/base.yml
 ```
 
 This will convert the checkpoints and save them to a Google Cloud Storage (GCS) bucket.
+
+### E2B / E4B conversion (text-only)
+
+For the small variants, drop `use_multimodal=true` — multimodal is not supported. Conversion scripts live at `tests/end_to_end/tpu/gemma4/e2b/convert_gemma4.sh` (instruction-tuned) and `tests/end_to_end/tpu/gemma4/e2b/convert_gemma4_base.sh` (pre-trained base), and the same pair under `tests/end_to_end/tpu/gemma4/e4b/`. They follow the same shape as the larger Gemma 4 scripts. Example:
+
+```sh
+python3 -m maxtext.checkpoint_conversion.to_maxtext src/maxtext/configs/base.yml \
+    model_name=gemma4-e2b \
+    hf_access_token=${HF_TOKEN} \
+    --hf_model_path=${HF_MODEL} \
+    base_output_directory=${MODEL_BUCKET}/e2b/converted/${idx} \
+    use_multimodal=false \
+    scan_layers=false
+```
+
+Each `convert_gemma4.sh` script ends with a `forward_pass_logit_checker` run that loads the just-saved MaxText checkpoint and the original HF model on the fly and asserts that the two produce equivalent logits (`--max_kl_div=0.03`). The round-trip is the recommended smoke test after touching the model code, the param map, or either YAML.
 
 ## Fine-tuning
 After the conversion, you will have a MaxText compatible checkpoint which allows you to fine-tune it with different datasets. For more comprehensive guides, please refer to our tutorials on [Multimodal Supervised Fine-Tuning](https://github.com/AI-Hypercomputer/maxtext/blob/main/docs/tutorials/posttraining/multimodal.md#supervised-fine-tuning) and [Supervised Fine-Tuning](https://github.com/AI-Hypercomputer/maxtext/blob/main/docs/tutorials/posttraining/sft.md). One example command to fine-tune a Gemma4-26B model is as follows:

--- a/tests/end_to_end/tpu/gemma4/e2b/convert_gemma4.sh
+++ b/tests/end_to_end/tpu/gemma4/e2b/convert_gemma4.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# End-to-end conversion + forward-pass logit check for Gemma 4 E2B (text-only).
+#
+# Multimodal is gated off for E2B / E4B by `MaxTextConfig.validate_model_size`
+# and is not exercised here. See `tests/end_to_end/tpu/gemma4/Run_Gemma4.md`
+# for an overview.
+
+set -ex
+idx=$(date +%Y-%m-%d-%H-%M)
+
+MODEL_NAME='gemma4-e2b'
+export MODEL_VARIATION='e2b-it'
+TOKENIZER_PATH='google/gemma-4-E2B-it'
+USE_SCAN_LAYERS=false  # Per-layer KV sharing is incompatible with nn.scan.
+
+# Installing torch for deps in forward_pass_logit_checker.py
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# After downloading checkpoints, copy them to GCS bucket at $MODEL_BUCKET
+export MODEL_BUCKET='gs://maxtext-gemma/gemma4'
+export HF_MODEL='path/to/your/hf/gemma-4-E2B-it'
+
+# HF -> MaxText conversion:
+python3 -m maxtext.checkpoint_conversion.to_maxtext "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    model_name=${MODEL_NAME} \
+    hf_access_token=${HF_TOKEN} \
+    --hf_model_path=${HF_MODEL} \
+    base_output_directory=${MODEL_BUCKET}/${MODEL_VARIATION}/converted/${idx} \
+    use_multimodal=false \
+    scan_layers=${USE_SCAN_LAYERS}
+
+export MAXTEXT_CKPT_PATH=${MODEL_BUCKET}/${MODEL_VARIATION}/converted/${idx}/0/items
+
+# Forward-pass logit check: runs HF on the fly and compares to MaxText.
+python3 -m tests.utils.forward_pass_logit_checker "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    tokenizer_path=${TOKENIZER_PATH} \
+    load_parameters_path=${MAXTEXT_CKPT_PATH} \
+    model_name=${MODEL_NAME} \
+    use_multimodal=false \
+    scan_layers=${USE_SCAN_LAYERS} \
+    per_device_batch_size=1 \
+    dtype=float32 \
+    attention=dot_product \
+    --max_kl_div=0.03 \
+    --run_hf_model=true \
+    --hf_model_path=${HF_MODEL}

--- a/tests/end_to_end/tpu/gemma4/e2b/convert_gemma4_base.sh
+++ b/tests/end_to_end/tpu/gemma4/e2b/convert_gemma4_base.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# End-to-end conversion + forward-pass logit check for Gemma 4 E2B (pre-trained).
+#
+# Multimodal is gated off for E2B / E4B by `MaxTextConfig.validate_model_size`
+# and is not exercised here. See `tests/end_to_end/tpu/gemma4/Run_Gemma4.md`
+# for an overview.
+
+set -ex
+idx=$(date +%Y-%m-%d-%H-%M)
+
+MODEL_NAME='gemma4-e2b'
+export MODEL_VARIATION='e2b'
+TOKENIZER_PATH='google/gemma-4-E2B'
+USE_SCAN_LAYERS=false  # Per-layer KV sharing is incompatible with nn.scan.
+
+# Installing torch for deps in forward_pass_logit_checker.py
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# After downloading checkpoints, copy them to GCS bucket at $MODEL_BUCKET
+export MODEL_BUCKET='gs://maxtext-gemma/gemma4'
+export HF_MODEL='path/to/your/hf/gemma-4-E2B'
+
+# HF -> MaxText conversion:
+python3 -m maxtext.checkpoint_conversion.to_maxtext "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    model_name=${MODEL_NAME} \
+    hf_access_token=${HF_TOKEN} \
+    --hf_model_path=${HF_MODEL} \
+    base_output_directory=${MODEL_BUCKET}/${MODEL_VARIATION}/converted/${idx} \
+    use_multimodal=false \
+    scan_layers=${USE_SCAN_LAYERS}
+
+export MAXTEXT_CKPT_PATH=${MODEL_BUCKET}/${MODEL_VARIATION}/converted/${idx}/0/items
+
+# Forward-pass logit check: runs HF on the fly and compares to MaxText.
+python3 -m tests.utils.forward_pass_logit_checker "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    tokenizer_path=${TOKENIZER_PATH} \
+    load_parameters_path=${MAXTEXT_CKPT_PATH} \
+    model_name=${MODEL_NAME} \
+    use_multimodal=false \
+    scan_layers=${USE_SCAN_LAYERS} \
+    per_device_batch_size=1 \
+    dtype=float32 \
+    attention=dot_product \
+    --max_kl_div=0.03 \
+    --run_hf_model=true \
+    --hf_model_path=${HF_MODEL}

--- a/tests/end_to_end/tpu/gemma4/e4b/convert_gemma4.sh
+++ b/tests/end_to_end/tpu/gemma4/e4b/convert_gemma4.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# End-to-end conversion + forward-pass logit check for Gemma 4 E4B (instruction-tuned).
+#
+# Multimodal is gated off for E2B / E4B by `MaxTextConfig.validate_model_size`
+# and is not exercised here. See `tests/end_to_end/tpu/gemma4/Run_Gemma4.md`
+# for an overview.
+
+set -ex
+idx=$(date +%Y-%m-%d-%H-%M)
+
+MODEL_NAME='gemma4-e4b'
+export MODEL_VARIATION='e4b-it'
+TOKENIZER_PATH='google/gemma-4-E4B-it'
+USE_SCAN_LAYERS=false  # Per-layer KV sharing is incompatible with nn.scan.
+
+# Installing torch for deps in forward_pass_logit_checker.py
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# After downloading checkpoints, copy them to GCS bucket at $MODEL_BUCKET
+export MODEL_BUCKET='gs://maxtext-gemma/gemma4'
+export HF_MODEL='path/to/your/hf/gemma-4-E4B-it'
+
+# HF -> MaxText conversion:
+python3 -m maxtext.checkpoint_conversion.to_maxtext "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    model_name=${MODEL_NAME} \
+    hf_access_token=${HF_TOKEN} \
+    --hf_model_path=${HF_MODEL} \
+    base_output_directory=${MODEL_BUCKET}/${MODEL_VARIATION}/converted/${idx} \
+    use_multimodal=false \
+    scan_layers=${USE_SCAN_LAYERS}
+
+export MAXTEXT_CKPT_PATH=${MODEL_BUCKET}/${MODEL_VARIATION}/converted/${idx}/0/items
+
+# Forward-pass logit check: runs HF on the fly and compares to MaxText.
+python3 -m tests.utils.forward_pass_logit_checker "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    tokenizer_path=${TOKENIZER_PATH} \
+    load_parameters_path=${MAXTEXT_CKPT_PATH} \
+    model_name=${MODEL_NAME} \
+    use_multimodal=false \
+    scan_layers=${USE_SCAN_LAYERS} \
+    per_device_batch_size=1 \
+    dtype=float32 \
+    attention=dot_product \
+    --max_kl_div=0.03 \
+    --run_hf_model=true \
+    --hf_model_path=${HF_MODEL}

--- a/tests/end_to_end/tpu/gemma4/e4b/convert_gemma4_base.sh
+++ b/tests/end_to_end/tpu/gemma4/e4b/convert_gemma4_base.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# End-to-end conversion + forward-pass logit check for Gemma 4 E4B (pre-trained).
+#
+# Multimodal is gated off for E2B / E4B by `MaxTextConfig.validate_model_size`
+# and is not exercised here. See `tests/end_to_end/tpu/gemma4/Run_Gemma4.md`
+# for an overview.
+
+set -ex
+idx=$(date +%Y-%m-%d-%H-%M)
+
+MODEL_NAME='gemma4-e4b'
+export MODEL_VARIATION='e4b'
+TOKENIZER_PATH='google/gemma-4-E4B'
+USE_SCAN_LAYERS=false  # Per-layer KV sharing is incompatible with nn.scan.
+
+# Installing torch for deps in forward_pass_logit_checker.py
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# After downloading checkpoints, copy them to GCS bucket at $MODEL_BUCKET
+export MODEL_BUCKET='gs://maxtext-gemma/gemma4'
+export HF_MODEL='path/to/your/hf/gemma-4-E4B'
+
+# HF -> MaxText conversion:
+python3 -m maxtext.checkpoint_conversion.to_maxtext "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    model_name=${MODEL_NAME} \
+    hf_access_token=${HF_TOKEN} \
+    --hf_model_path=${HF_MODEL} \
+    base_output_directory=${MODEL_BUCKET}/${MODEL_VARIATION}/converted/${idx} \
+    use_multimodal=false \
+    scan_layers=${USE_SCAN_LAYERS}
+
+export MAXTEXT_CKPT_PATH=${MODEL_BUCKET}/${MODEL_VARIATION}/converted/${idx}/0/items
+
+# Forward-pass logit check: runs HF on the fly and compares to MaxText.
+python3 -m tests.utils.forward_pass_logit_checker "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"/base.yml \
+    tokenizer_path=${TOKENIZER_PATH} \
+    load_parameters_path=${MAXTEXT_CKPT_PATH} \
+    model_name=${MODEL_NAME} \
+    use_multimodal=false \
+    scan_layers=${USE_SCAN_LAYERS} \
+    per_device_batch_size=1 \
+    dtype=float32 \
+    attention=dot_product \
+    --max_kl_div=0.03 \
+    --run_hf_model=true \
+    --hf_model_path=${HF_MODEL}

--- a/tests/unit/configs_test.py
+++ b/tests/unit/configs_test.py
@@ -140,6 +140,8 @@ GEMMA_CONFIGS = [
     os.path.join(CONFIGS_DIR, "models", "gemma3-4b.yml"),
     os.path.join(CONFIGS_DIR, "models", "gemma3-12b.yml"),
     os.path.join(CONFIGS_DIR, "models", "gemma3-27b.yml"),
+    os.path.join(CONFIGS_DIR, "models", "gemma4-e2b.yml"),
+    os.path.join(CONFIGS_DIR, "models", "gemma4-e4b.yml"),
 ]
 
 

--- a/tests/unit/flop_calculation_test.py
+++ b/tests/unit/flop_calculation_test.py
@@ -659,6 +659,140 @@ class FlopCalculation(parameterized.TestCase):
 
     self.assertAlmostEqual(learnable_weight_tflops, expected_learnable_tflops, places=5)
 
+  def test_calculate_gemma4_small_tflops_e2b(self):
+    """E2B: KV sharing (20 of 35 layers), double-wide MLP on shared, period-5 pattern, PLE."""
+    config = MagicMock()
+    config.model_name = "gemma4-e2b"
+    config.per_device_batch_size = 1
+    config.max_target_length = 2048
+    config.sliding_window_size = 512
+    config.num_query_heads = 8
+    config.num_kv_heads = 1
+    config.head_dim = 256
+    config.global_head_dim = 512
+    config.global_num_kv_heads = 0  # falls back to num_kv_heads
+    config.num_decoder_layers = 35
+    config.num_kv_shared_layers = 20
+    config.use_double_wide_mlp = True
+    config.emb_dim = 1536
+    config.mlp_dim = 6144
+    config.mlp_activations = ["gelu", "linear"]
+    config.hidden_size_per_layer_input = 256
+
+    embedding_flops = 12345
+    attn_tflops, learn_tflops = maxtext_utils.calculate_gemma4_small_tflops_training_per_device(config, embedding_flops)
+
+    b = config.per_device_batch_size
+    s = config.max_target_length
+    w = min(config.sliding_window_size, s)
+    h = config.num_query_heads
+    d = config.head_dim
+    gd = config.global_head_dim
+
+    # E2B period-5 -> 7 global, 28 local; KV sharing starts at layer 15
+    # so layers 15..34 are shared. Global layers are i=4,9,14,19,24,29,34
+    # -> 4 of those 7 global are shared, 3 are unshared.
+    # Local 28 total, 16 shared, 12 unshared.
+    num_global = 7
+    num_local = 28
+    num_global_unshared = 3
+    num_local_unshared = 12
+
+    expected_attn = num_global * 2 * b * s * s * h * gd + num_local * 4 * b * (s * w - 0.5 * w**2) * h * d
+    expected_attn_tflops = expected_attn * 3 / 10**12
+    self.assertAlmostEqual(attn_tflops, expected_attn_tflops, places=5)
+
+    qo_global_per_layer = 2 * (2 * b * s * config.emb_dim * h * gd)
+    qo_local_per_layer = 2 * (2 * b * s * config.emb_dim * h * d)
+    kv_global = 2 * b * s * config.emb_dim * (2 * config.num_kv_heads) * gd
+    kv_local = 2 * b * s * config.emb_dim * (2 * config.num_kv_heads) * d
+
+    projection_flops = (
+        num_global * qo_global_per_layer
+        + num_local * qo_local_per_layer
+        + num_global_unshared * kv_global
+        + num_local_unshared * kv_local
+    )
+
+    ffn_per_layer = 2 * b * s * config.mlp_dim * config.emb_dim * 3  # gate+up (2 acts) + down
+    num_unshared = config.num_decoder_layers - config.num_kv_shared_layers
+    # use_double_wide_mlp doubles ffn on shared layers
+    ffn_flops = num_unshared * ffn_per_layer + config.num_kv_shared_layers * 2 * ffn_per_layer
+
+    ple = config.hidden_size_per_layer_input
+    ple_flops = 2 * b * s * config.emb_dim * (config.num_decoder_layers * ple) + config.num_decoder_layers * (
+        2 * 2 * b * s * config.emb_dim * ple
+    )
+
+    expected_learn = (projection_flops + ffn_flops + ple_flops + embedding_flops) * 3 / 10**12
+    self.assertAlmostEqual(learn_tflops, expected_learn, places=5)
+
+  def test_calculate_gemma4_small_tflops_e4b(self):
+    """E4B: KV sharing (18 of 42 layers), no double-wide MLP, period-6, PLE."""
+    config = MagicMock()
+    config.model_name = "gemma4-e4b"
+    config.per_device_batch_size = 1
+    config.max_target_length = 2048
+    config.sliding_window_size = 512
+    config.num_query_heads = 8
+    config.num_kv_heads = 2
+    config.head_dim = 256
+    config.global_head_dim = 512
+    config.global_num_kv_heads = 0
+    config.num_decoder_layers = 42
+    config.num_kv_shared_layers = 18
+    config.use_double_wide_mlp = False
+    config.emb_dim = 2560
+    config.mlp_dim = 10240
+    config.mlp_activations = ["gelu", "linear"]
+    config.hidden_size_per_layer_input = 256
+
+    embedding_flops = 99999
+    attn_tflops, learn_tflops = maxtext_utils.calculate_gemma4_small_tflops_training_per_device(config, embedding_flops)
+
+    b = config.per_device_batch_size
+    s = config.max_target_length
+    w = min(config.sliding_window_size, s)
+    h = config.num_query_heads
+    d = config.head_dim
+    gd = config.global_head_dim
+
+    # E4B period-6 -> 7 global, 35 local; sharing starts at layer 24.
+    # Global layers are i=5,11,17,23,29,35,41 -> 3 of those 7 global are shared,
+    # 4 unshared. Local 35 total, 15 shared, 20 unshared.
+    num_global = 7
+    num_local = 35
+    num_global_unshared = 4
+    num_local_unshared = 20
+
+    expected_attn = num_global * 2 * b * s * s * h * gd + num_local * 4 * b * (s * w - 0.5 * w**2) * h * d
+    expected_attn_tflops = expected_attn * 3 / 10**12
+    self.assertAlmostEqual(attn_tflops, expected_attn_tflops, places=5)
+
+    qo_global_per_layer = 2 * (2 * b * s * config.emb_dim * h * gd)
+    qo_local_per_layer = 2 * (2 * b * s * config.emb_dim * h * d)
+    kv_global = 2 * b * s * config.emb_dim * (2 * config.num_kv_heads) * gd
+    kv_local = 2 * b * s * config.emb_dim * (2 * config.num_kv_heads) * d
+
+    projection_flops = (
+        num_global * qo_global_per_layer
+        + num_local * qo_local_per_layer
+        + num_global_unshared * kv_global
+        + num_local_unshared * kv_local
+    )
+
+    ffn_per_layer = 2 * b * s * config.mlp_dim * config.emb_dim * 3
+    # No double-wide -> all 42 layers use plain ffn_per_layer
+    ffn_flops = config.num_decoder_layers * ffn_per_layer
+
+    ple = config.hidden_size_per_layer_input
+    ple_flops = 2 * b * s * config.emb_dim * (config.num_decoder_layers * ple) + config.num_decoder_layers * (
+        2 * 2 * b * s * config.emb_dim * ple
+    )
+
+    expected_learn = (projection_flops + ffn_flops + ple_flops + embedding_flops) * 3 / 10**12
+    self.assertAlmostEqual(learn_tflops, expected_learn, places=5)
+
   def test_calculate_routed_and_shared_ffn_tflops_per_device(self):
     """Test calculate_routed_and_shared_ffn_tflops_per_device."""
     config = MagicMock()

--- a/tests/unit/gemma4_small_layers_test.py
+++ b/tests/unit/gemma4_small_layers_test.py
@@ -1,0 +1,415 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Torch-parity tests for Gemma 4 small (E2B / E4B) text-side layers.
+
+Companion to ``gemma4_layers_test.py`` (which covers the vision side). Compares
+the MaxText implementation of:
+
+  - ``Gemma4SmallPLE`` against torch's ``Gemma4TextModel.get_per_layer_inputs`` /
+    ``project_per_layer_inputs`` pipeline,
+  - ``maxtext.layers.attentions.Attention`` (with and without ``share_kv_layer``)
+    against torch's ``Gemma4TextAttention``,
+
+using random-input forward passes with weights copied from torch.
+"""
+
+import os
+import unittest
+
+import numpy as np
+import torch
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh
+
+from flax import nnx
+
+from maxtext.configs import pyconfig
+from maxtext.common import common_types
+from maxtext.common.common_types import AttentionType
+from maxtext.layers.attentions import Attention
+from maxtext.models import gemma4_small
+from maxtext.utils.globals import MAXTEXT_REPO_ROOT
+from tests.utils.multimodal_test_utils import assert_all_close_jax_torch, copy_rmsnorm_weights
+
+from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+from transformers.models.gemma4.modeling_gemma4 import (
+    Gemma4TextAttention as TorchGemma4TextAttention,
+    Gemma4TextModel as TorchGemma4TextModel,
+    Gemma4TextRotaryEmbedding as TorchGemma4TextRotaryEmbedding,
+)
+
+
+torch.set_grad_enabled(False)
+
+
+# ---------------------------------------------------------------------------
+# Test config — small E2B-shaped variant, dimensions trimmed to keep tests fast.
+# ---------------------------------------------------------------------------
+
+_BASE_CONFIG_PATH = os.path.join(MAXTEXT_REPO_ROOT, "src", "maxtext", "configs", "base.yml")
+
+# Small dimensions that still exercise GQA, KV sharing, partial RoPE.
+_NUM_LAYERS = 6
+_NUM_KV_SHARED = 3  # last 3 of 6 layers share K/V
+_NUM_Q_HEADS = 4
+_NUM_KV_HEADS = 1
+_HEAD_DIM = 32
+_GLOBAL_HEAD_DIM = 64
+_HIDDEN_SIZE = 128
+_PLE_DIM = 32
+_VOCAB = 256
+
+
+def _build_jax_config():
+  """Builds a MaxText config that mirrors the gemma4-e2b decoder block."""
+  return pyconfig.initialize(
+      ["", _BASE_CONFIG_PATH],
+      model_name="gemma4-e2b",
+      scan_layers=False,
+      use_multimodal=False,
+      override_model_config=True,
+      # Override shapes for fast tests:
+      base_num_decoder_layers=_NUM_LAYERS,
+      base_num_query_heads=_NUM_Q_HEADS,
+      base_num_kv_heads=_NUM_KV_HEADS,
+      base_emb_dim=_HIDDEN_SIZE,
+      base_mlp_dim=4 * _HIDDEN_SIZE,
+      head_dim=_HEAD_DIM,
+      global_head_dim=_GLOBAL_HEAD_DIM,
+      vocab_size=_VOCAB,
+      vocab_size_per_layer_input=_VOCAB,
+      hidden_size_per_layer_input=_PLE_DIM,
+      num_kv_shared_layers=_NUM_KV_SHARED,
+      max_target_length=64,
+      max_prefill_predict_length=8,
+      attention="dot_product",  # avoid splash on CPU
+      dtype="float32",
+      weight_dtype="float32",
+      float32_qk_product=True,
+      float32_logits=True,
+      matmul_precision="highest",
+      dropout_rate=0.0,
+  )
+
+
+def _build_torch_text_config(jax_config):
+  """Builds a torch ``Gemma4TextConfig`` that matches the JAX config shapes."""
+  # Period-5 pattern → with 6 layers: [L, L, L, L, G, L]. We keep it simple and
+  # reuse the e2b pattern; layer 4 is the GLOBAL layer in this test.
+  # Put the only GLOBAL layer in the non-shared region so we can exercise a
+  # global donor; the rest are sliding. With num_kv_shared=3 and 6 layers, the
+  # non-shared region is indices 0..2.
+  layer_types = ["sliding_attention"] * jax_config.num_decoder_layers
+  layer_types[2] = "full_attention"
+  return Gemma4TextConfig(
+      hidden_size=jax_config.emb_dim,
+      intermediate_size=jax_config.mlp_dim,
+      num_hidden_layers=jax_config.num_decoder_layers,
+      num_attention_heads=jax_config.num_query_heads,
+      num_key_value_heads=jax_config.num_kv_heads,
+      num_global_key_value_heads=jax_config.num_kv_heads,
+      head_dim=jax_config.head_dim,
+      global_head_dim=jax_config.global_head_dim,
+      vocab_size=jax_config.vocab_size,
+      vocab_size_per_layer_input=jax_config.vocab_size_per_layer_input,
+      hidden_size_per_layer_input=jax_config.hidden_size_per_layer_input,
+      num_kv_shared_layers=jax_config.num_kv_shared_layers,
+      layer_types=layer_types,
+      sliding_window=jax_config.sliding_window_size,
+      max_position_embeddings=64,
+      rms_norm_eps=jax_config.normalization_layer_epsilon,
+      rope_parameters={
+          "full_attention": {
+              "partial_rotary_factor": jax_config.global_rope_proportion,
+              "rope_theta": float(jax_config.global_rope_max_timescale),
+              "rope_type": "proportional",
+          },
+          "sliding_attention": {
+              "rope_theta": float(jax_config.local_rope_max_timescale),
+              "rope_type": "default",
+          },
+      },
+      attention_dropout=0.0,
+      attention_bias=False,
+      use_bidirectional_attention=None,
+      attention_k_eq_v=False,
+      use_double_wide_mlp=jax_config.use_double_wide_mlp,
+      tie_word_embeddings=True,
+  )
+
+
+# ---------------------------------------------------------------------------
+# Weight copying helpers (torch -> JAX).
+# ---------------------------------------------------------------------------
+
+
+def _copy_attention_weights(torch_attn, jax_attn, *, num_q_heads, num_kv_heads, head_dim, hidden_size):
+  """Copy a torch Gemma4TextAttention's weights into a JAX ``Attention`` module."""
+  q_w = torch_attn.q_proj.weight.detach().cpu().numpy()  # (num_q*hd, H)
+  o_w = torch_attn.o_proj.weight.detach().cpu().numpy()  # (H, num_q*hd)
+  jax_attn.query.kernel.value = jnp.asarray(q_w.T.reshape(hidden_size, num_q_heads, head_dim))
+  jax_attn.out.kernel.value = jnp.asarray(o_w.T.reshape(num_q_heads, head_dim, hidden_size))
+  copy_rmsnorm_weights(torch_attn.q_norm, jax_attn.query_norm)
+
+  if not torch_attn.is_kv_shared_layer:
+    k_w = torch_attn.k_proj.weight.detach().cpu().numpy()  # (num_kv*hd, H)
+    v_w = torch_attn.v_proj.weight.detach().cpu().numpy()  # (num_kv*hd, H)
+    jax_attn.key.kernel.value = jnp.asarray(k_w.T.reshape(hidden_size, num_kv_heads, head_dim))
+    jax_attn.value.kernel.value = jnp.asarray(v_w.T.reshape(hidden_size, num_kv_heads, head_dim))
+    copy_rmsnorm_weights(torch_attn.k_norm, jax_attn.key_norm)
+    # torch v_norm has with_scale=False (no learnable param), so nothing to copy.
+
+
+def _make_jax_attention(jax_config, mesh, *, attention_type, num_kv_heads, head_dim, share_kv_layer):
+  """Construct a JAX ``Attention`` module configured like a gemma4-small layer."""
+  seq_len = jax_config.max_target_length
+  dummy_shape = (1, seq_len, jax_config.emb_dim)
+  partial_rotary_factor = (
+      jax_config.global_rope_proportion if attention_type == AttentionType.GLOBAL else jax_config.local_rope_proportion
+  )
+  rope_max_timescale = (
+      jax_config.global_rope_max_timescale
+      if attention_type == AttentionType.GLOBAL
+      else jax_config.local_rope_max_timescale
+  )
+  return Attention(
+      config=jax_config,
+      num_query_heads=jax_config.num_query_heads,
+      num_kv_heads=num_kv_heads,
+      head_dim=head_dim,
+      max_target_length=seq_len,
+      max_prefill_predict_length=jax_config.max_prefill_predict_length,
+      attention_kernel="dot_product",
+      inputs_q_shape=dummy_shape,
+      inputs_kv_shape=dummy_shape,
+      mesh=mesh,
+      dtype=jnp.float32,
+      weight_dtype=jnp.float32,
+      dropout_rate=0.0,
+      float32_qk_product=True,
+      float32_logits=True,
+      attention_type=attention_type,
+      sliding_window_size=jax_config.sliding_window_size,
+      use_qk_norm=True,
+      use_v_norm=True,
+      query_pre_attn_scalar=1.0,
+      rope_max_timescale=rope_max_timescale,
+      partial_rotary_factor=partial_rotary_factor,
+      share_kv_layer=share_kv_layer,
+      rngs=nnx.Rngs(0),
+  )
+
+
+# ---------------------------------------------------------------------------
+# Tests.
+# ---------------------------------------------------------------------------
+
+
+class Gemma4SmallParityBase(unittest.TestCase):
+  """Common config + mesh setup for Gemma 4 small parity tests."""
+
+  @classmethod
+  def setUpClass(cls):
+    np.random.seed(42)
+    torch.manual_seed(42)
+    cls.jax_config = _build_jax_config()
+    cls.torch_config = _build_torch_text_config(cls.jax_config)
+    cls.torch_config._attn_implementation = "eager"  # pylint: disable=protected-access
+    cls.mesh = Mesh(np.array(jax.devices()[:1]), axis_names=("data",))
+
+
+class TestGemma4SmallPLE(Gemma4SmallParityBase):
+  """Parity for the Per-Layer-Embedding block."""
+
+  def test_ple_matches_torch(self):
+    torch_model = TorchGemma4TextModel(self.torch_config)
+    torch_model.eval()
+
+    jax_ple = gemma4_small.Gemma4SmallPLE(
+        config=self.jax_config,
+        mesh=self.mesh,
+        rngs=nnx.Rngs(0),
+    )
+
+    # Copy torch weights into JAX (token-identity embedding, projection, norm).
+    jax_ple.embed_tokens_per_layer.value = jnp.asarray(torch_model.embed_tokens_per_layer.weight.detach().cpu().numpy())
+    jax_ple.per_layer_model_projection.kernel.value = jnp.asarray(
+        torch_model.per_layer_model_projection.weight.detach().cpu().numpy().T
+    )
+    copy_rmsnorm_weights(torch_model.per_layer_projection_norm, jax_ple.per_layer_projection_norm)
+
+    batch_size, seq_len = 2, 8
+    input_ids_np = np.random.randint(0, self.torch_config.vocab_size_per_layer_input, size=(batch_size, seq_len))
+    inputs_embeds_np = np.random.randn(batch_size, seq_len, self.torch_config.hidden_size).astype(np.float32)
+
+    torch_pli = torch_model.get_per_layer_inputs(torch.from_numpy(input_ids_np).long(), None)
+    torch_out = torch_model.project_per_layer_inputs(torch.from_numpy(inputs_embeds_np), torch_pli)
+
+    jax_out = jax_ple(jnp.asarray(input_ids_np), jnp.asarray(inputs_embeds_np))
+
+    assert_all_close_jax_torch(jax_out, torch_out, rtol=1e-4, atol=1e-4, error_msg="Gemma4SmallPLE output differs")
+
+
+class TestGemma4SmallAttentionDonor(Gemma4SmallParityBase):
+  """Parity for a non-shared (donor) gemma4-small attention layer."""
+
+  def _run_for_layer(self, layer_idx, attention_type, head_dim):
+    """Forward-parity check for a single non-shared attention layer."""
+    torch_attn = TorchGemma4TextAttention(self.torch_config, layer_idx=layer_idx).eval()
+    self.assertFalse(torch_attn.is_kv_shared_layer)
+
+    jax_attn = _make_jax_attention(
+        self.jax_config,
+        self.mesh,
+        attention_type=attention_type,
+        num_kv_heads=self.jax_config.num_kv_heads,
+        head_dim=head_dim,
+        share_kv_layer=False,
+    )
+    _copy_attention_weights(
+        torch_attn,
+        jax_attn,
+        num_q_heads=self.jax_config.num_query_heads,
+        num_kv_heads=self.jax_config.num_kv_heads,
+        head_dim=head_dim,
+        hidden_size=self.jax_config.emb_dim,
+    )
+
+    batch_size, seq_len = 1, 8
+    hidden_np = np.random.randn(batch_size, seq_len, self.jax_config.emb_dim).astype(np.float32)
+    positions_np = np.broadcast_to(np.arange(seq_len), (batch_size, seq_len)).astype(np.int32)
+
+    torch_rope = TorchGemma4TextRotaryEmbedding(self.torch_config).eval()
+    cos, sin = torch_rope(
+        torch.from_numpy(hidden_np), torch.from_numpy(positions_np).long(), layer_type=torch_attn.layer_type
+    )
+    # Make attention mask: lower-triangular for causal; torch eager expects float mask.
+    mask = torch.full((batch_size, 1, seq_len, seq_len), torch.finfo(torch.float32).min)
+    mask = torch.triu(mask, diagonal=1)
+    torch_out, _ = torch_attn(
+        hidden_states=torch.from_numpy(hidden_np),
+        position_embeddings=(cos, sin),
+        attention_mask=mask,
+        shared_kv_states={},
+    )
+
+    jax_out, _ = jax_attn(
+        jnp.asarray(hidden_np),
+        jnp.asarray(hidden_np),
+        inputs_positions=jnp.asarray(positions_np),
+        deterministic=True,
+        model_mode=common_types.MODEL_MODE_TRAIN,
+    )
+    assert_all_close_jax_torch(
+        jax_out, torch_out, rtol=1e-3, atol=1e-3, error_msg=f"Donor attn parity (layer {layer_idx}) differs"
+    )
+
+  def test_sliding_donor_matches_torch(self):
+    # Layer 0 is a sliding (non-shared) layer.
+    self._run_for_layer(0, AttentionType.LOCAL_SLIDING, self.jax_config.head_dim)
+
+  def test_global_donor_matches_torch(self):
+    # Layer 2 is the only GLOBAL layer in our 6-layer config (and is non-shared).
+    self._run_for_layer(2, AttentionType.GLOBAL, self.jax_config.global_head_dim)
+
+
+class TestGemma4SmallAttentionShared(Gemma4SmallParityBase):
+  """Parity for a KV-shared (consumer) gemma4-small attention layer."""
+
+  def test_shared_layer_matches_torch(self):
+    # Donor for the shared sliding layers: last non-shared sliding layer.
+    # In our 6-layer / 3-shared config, first_shared=3 and the non-shared
+    # region is [L, L, G] (indices 0, 1, 2). Layer 1 is the sliding donor;
+    # layer 3 is the first shared sliding layer.
+    donor_idx, shared_idx = 1, 3
+    head_dim = self.jax_config.head_dim
+    attention_type = AttentionType.LOCAL_SLIDING
+
+    # Build torch donor + shared layers and run forward to capture donor K/V.
+    torch_donor = TorchGemma4TextAttention(self.torch_config, layer_idx=donor_idx).eval()
+    torch_shared = TorchGemma4TextAttention(self.torch_config, layer_idx=shared_idx).eval()
+    self.assertFalse(torch_donor.is_kv_shared_layer)
+    self.assertTrue(torch_shared.is_kv_shared_layer)
+
+    batch_size, seq_len = 1, 8
+    hidden_np = np.random.randn(batch_size, seq_len, self.jax_config.emb_dim).astype(np.float32)
+    positions_np = np.broadcast_to(np.arange(seq_len), (batch_size, seq_len)).astype(np.int32)
+
+    torch_rope = TorchGemma4TextRotaryEmbedding(self.torch_config).eval()
+    cos, sin = torch_rope(
+        torch.from_numpy(hidden_np), torch.from_numpy(positions_np).long(), layer_type=torch_donor.layer_type
+    )
+    mask = torch.full((batch_size, 1, seq_len, seq_len), torch.finfo(torch.float32).min)
+    mask = torch.triu(mask, diagonal=1)
+
+    # Run torch donor first so it populates shared_kv_states for the consumer.
+    shared_kv_states = {}
+    torch_donor(
+        hidden_states=torch.from_numpy(hidden_np),
+        position_embeddings=(cos, sin),
+        attention_mask=mask,
+        shared_kv_states=shared_kv_states,
+    )
+    self.assertIn(torch_donor.layer_type, shared_kv_states)
+    torch_shared_out, _ = torch_shared(
+        hidden_states=torch.from_numpy(hidden_np),
+        position_embeddings=(cos, sin),
+        attention_mask=mask,
+        shared_kv_states=shared_kv_states,
+    )
+
+    # Build JAX shared attention layer (share_kv_layer=True).
+    jax_shared = _make_jax_attention(
+        self.jax_config,
+        self.mesh,
+        attention_type=attention_type,
+        num_kv_heads=self.jax_config.num_kv_heads,
+        head_dim=head_dim,
+        share_kv_layer=True,
+    )
+    # Copy Q-side weights (Q proj, Q norm, O proj) — K/V modules don't exist.
+    _copy_attention_weights(
+        torch_shared,
+        jax_shared,
+        num_q_heads=self.jax_config.num_query_heads,
+        num_kv_heads=self.jax_config.num_kv_heads,
+        head_dim=head_dim,
+        hidden_size=self.jax_config.emb_dim,
+    )
+
+    # Translate torch donor K / V (shape [B, num_kv_heads, S, head_dim]) into
+    # JAX layout ([B, S, num_kv_heads, head_dim]).
+    donor_k, donor_v = shared_kv_states[torch_donor.layer_type]
+    jax_shared_key = jnp.asarray(donor_k.detach().cpu().numpy().transpose(0, 2, 1, 3))
+    jax_shared_value = jnp.asarray(donor_v.detach().cpu().numpy().transpose(0, 2, 1, 3))
+
+    jax_shared_out, _ = jax_shared(
+        jnp.asarray(hidden_np),
+        jnp.asarray(hidden_np),
+        inputs_positions=jnp.asarray(positions_np),
+        deterministic=True,
+        model_mode=common_types.MODEL_MODE_TRAIN,
+        shared_key=jax_shared_key,
+        shared_value=jax_shared_value,
+    )
+
+    assert_all_close_jax_torch(
+        jax_shared_out, torch_shared_out, rtol=1e-3, atol=1e-3, error_msg="Shared-layer attn parity differs"
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/gemma4_small_test.py
+++ b/tests/unit/gemma4_small_test.py
@@ -1,0 +1,106 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Gemma 4 small (E2B / E4B) layer-pattern helpers."""
+
+import unittest
+
+from maxtext.common.common_types import AttentionType
+from maxtext.models import gemma4_small
+
+
+L = AttentionType.LOCAL_SLIDING
+G = AttentionType.GLOBAL
+
+
+class Gemma4SmallAttentionPatternTest(unittest.TestCase):
+  """Per-variant attention-type pattern dispatch."""
+
+  def test_e2b_attention_pattern_period_5(self):
+    self.assertEqual(gemma4_small.get_attention_pattern("gemma4-e2b"), (L, L, L, L, G))
+
+  def test_e4b_attention_pattern_period_6(self):
+    self.assertEqual(gemma4_small.get_attention_pattern("gemma4-e4b"), (L, L, L, L, L, G))
+
+  def test_default_pattern_period_6(self):
+    self.assertEqual(len(gemma4_small.get_attention_pattern(None)), 6)
+
+
+class Gemma4SmallLayerTypesTest(unittest.TestCase):
+  """Per-layer attention-type list across the full stack."""
+
+  def test_e2b_full_layer_types(self):
+    layer_types = gemma4_small.build_layer_types(35, "gemma4-e2b")
+    self.assertEqual(len(layer_types), 35)
+    self.assertEqual(layer_types[0], L)
+    # 35 = 7 * 5, so layers 4, 9, ..., 34 are GLOBAL.
+    for i in range(4, 35, 5):
+      self.assertEqual(layer_types[i], G)
+
+  def test_e4b_full_layer_types(self):
+    layer_types = gemma4_small.build_layer_types(42, "gemma4-e4b")
+    self.assertEqual(len(layer_types), 42)
+    for i in range(42):
+      expected = G if i % 6 == 5 else L
+      self.assertEqual(layer_types[i], expected, f"layer {i}")
+
+
+class Gemma4SmallKvSharingTest(unittest.TestCase):
+  """KV-sharing donor / shared-layer mapping."""
+
+  def test_e2b_first_kv_shared_layer(self):
+    self.assertEqual(gemma4_small.first_kv_shared_layer_idx(35, 20), 15)
+    self.assertFalse(gemma4_small.is_kv_shared_layer(14, 35, 20))
+    self.assertTrue(gemma4_small.is_kv_shared_layer(15, 35, 20))
+    self.assertTrue(gemma4_small.is_kv_shared_layer(34, 35, 20))
+
+  def test_e4b_first_kv_shared_layer(self):
+    self.assertEqual(gemma4_small.first_kv_shared_layer_idx(42, 18), 24)
+    self.assertFalse(gemma4_small.is_kv_shared_layer(23, 42, 18))
+    self.assertTrue(gemma4_small.is_kv_shared_layer(24, 42, 18))
+
+  def test_e2b_kv_donor_mapping(self):
+    # E2B has 15 non-shared layers with pattern (L,L,L,L,G). Layer 13 is the
+    # last LOCAL_SLIDING and layer 14 the last GLOBAL before sharing starts.
+    layer_types = gemma4_small.build_layer_types(35, "gemma4-e2b")
+    self.assertEqual(gemma4_small.kv_donor_layer_idx(15, layer_types, 20), 13)
+    self.assertEqual(gemma4_small.kv_donor_layer_idx(19, layer_types, 20), 14)
+    self.assertIsNone(gemma4_small.kv_donor_layer_idx(0, layer_types, 20))
+    self.assertIsNone(gemma4_small.kv_donor_layer_idx(14, layer_types, 20))
+
+  def test_e4b_kv_donor_mapping(self):
+    # E4B has 24 non-shared layers with pattern (L,L,L,L,L,G). Layer 22 is
+    # the last LOCAL_SLIDING and layer 23 the last GLOBAL before sharing.
+    layer_types = gemma4_small.build_layer_types(42, "gemma4-e4b")
+    self.assertEqual(gemma4_small.kv_donor_layer_idx(24, layer_types, 18), 22)
+    self.assertEqual(gemma4_small.kv_donor_layer_idx(29, layer_types, 18), 23)
+    self.assertIsNone(gemma4_small.kv_donor_layer_idx(23, layer_types, 18))
+
+  def test_donor_layer_flag(self):
+    layer_types = gemma4_small.build_layer_types(35, "gemma4-e2b")
+    self.assertTrue(gemma4_small.is_kv_donor_layer(13, layer_types, 20))
+    self.assertTrue(gemma4_small.is_kv_donor_layer(14, layer_types, 20))
+    self.assertFalse(gemma4_small.is_kv_donor_layer(12, layer_types, 20))
+
+  def test_no_kv_sharing_when_num_kv_shared_zero(self):
+    layer_types = gemma4_small.build_layer_types(10, None)
+    self.assertEqual(gemma4_small.first_kv_shared_layer_idx(10, 0), 10)
+    for i in range(10):
+      self.assertFalse(gemma4_small.is_kv_shared_layer(i, 10, 0))
+      self.assertIsNone(gemma4_small.kv_donor_layer_idx(i, layer_types, 0))
+      self.assertFalse(gemma4_small.is_kv_donor_layer(i, layer_types, 0))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

Adds Gemma 4 small variants — **E2B** and **E4B** (text-only) — to MaxText.

These are the smaller members of the Gemma 4 family. They share the
broader Gemma 4 attention / norm structure but introduce two new features
that drive their parameter efficiency:

- **Per-Layer Embeddings (PLE).** Each decoder layer consumes a per-layer
  slice of an extra embedding tensor injected by a new `Gemma4SmallPLE`
  block. Controlled by `hidden_size_per_layer_input` /
  `vocab_size_per_layer_input`.
- **KV sharing.** The last `num_kv_shared_layers` decoder layers reuse
  K / V from the most recent non-shared layer of the same attention type
  (sliding↔sliding, full↔full). E2B additionally widens the MLP on those
  shared layers (`use_double_wide_mlp: true`) to compensate for the
  missing parameters.

Both features carry per-layer state that is not expressible inside
`nn.scan`, so a new `GEMMA4_SMALL` `DecoderBlockType` is added with its
own non-scanned execution path (`Decoder._apply_gemma4_small_layers`).
The model validator enforces `scan_layers=False` for these variants.

### What's included

- New model file `src/maxtext/models/gemma4_small.py` (PLE + attention
  with optional KV sharing + decoder layer).
- New configs `configs/models/gemma4-e2b.yml` and `gemma4-e4b.yml`.
- HF round-trip: `hf_model_configs.py`, `hf_shape.py`,
  `param_mapping.py` updated to handle PLE params, KV-shared layers, and
  the (optional) double-wide MLP.
- TFLOP/MFU accounting: `calculate_gemma4_small_tflops_training_per_device`.
- Config plumbing: `DecoderBlockType.GEMMA4_SMALL`, four new
  `Attention` fields in `configs/types.py`, base.yml defaults, and
  validation that rejects `scan_layers=true` / `use_multimodal=true` for
  E2B / E4B.

### Out of scope

- **Multimodal.** E2B / E4B ship a vision tower in their HF configs, but
  MaxText support for the gemma4-small vision encoder (clipped linears
  in particular) is not in this PR. `use_multimodal=true` is rejected by
  the validator with a clear error.
- **Scanned layers.** Per-layer KV sharing isn't expressible under
  `nn.scan`; rejected by the validator.

# Tests

- New unit tests:
  - `tests/unit/gemma4_small_test.py` — attention-pattern dispatch,
    layer-type tuples, KV donor/shared-layer mapping for both variants.
  - `tests/unit/flop_calculation_test.py::test_calculate_gemma4_small_tflops_*` —
    closed-form TFLOP accounting matching the layer/donor structure.
  - `tests/unit/configs_test.py` — E2B / E4B yml configs are loaded by
    the existing config-instantiation sweep.
- End-to-end forward-pass logit checks:
  - `tests/end_to_end/tpu/gemma4/e2b/{convert_gemma4,convert_gemma4_pt}.sh`
  - `tests/end_to_end/tpu/gemma4/e4b/{convert_gemma4,convert_gemma4_pt}.sh`
  - Each converts the HF checkpoint with `to_maxtext`, then runs
    `forward_pass_logit_checker` against the HF model with
    `--max_kl_div=0.03`. This is the recommended smoke test after
    touching the model code, param map, or either YAML.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
