### PR TITLE
[Qwen3.5] Fix caching bug in GDN layer for autoregressive mode

### DIFF
--- a/benchmarks/api_server/maxtext_server.py
+++ b/benchmarks/api_server/maxtext_server.py
@@ -279,13 +279,20 @@ def _collect_batched_requests():
   """Waits for and collects a batch of requests from the queue."""
   batched_items = []
   start_time = time.time()
-  while len(batched_items) < LLM.batch_size and (time.time() - start_time) < BATCH_TIMEOUT_S:
+
+  while len(batched_items) < LLM.batch_size:
+    elapsed = time.time() - start_time
+    remaining = BATCH_TIMEOUT_S - elapsed
+
+    if remaining <= 0:
+      break
+
     try:
-      item = request_queue.get(timeout=0.01)
+      item = request_queue.get(timeout=remaining)
       batched_items.append(item)
     except queue.Empty:
-      if batched_items:
-        break  # Process what we have if timeout is reached
+      break  # We hit the full BATCH_TIMEOUT_S
+
   return batched_items
 
 

--- a/src/maxtext/inference/kvcache.py
+++ b/src/maxtext/inference/kvcache.py
@@ -174,6 +174,9 @@ def kv_cache_as_linen(
     key_axis_order: AxisIdxes = (2, 0, 1, 3),
     use_chunked_prefill: bool = False,
     model_mode: str = MODEL_MODE_PREFILL,
+    is_gdn: bool = False,
+    conv_kernel_size: int = 0,
+    conv_dim: int = 0,
     name: str | None = None,
 ):
   """Initializes the KVCache module and returns it as a Linen module.
@@ -224,6 +227,9 @@ def kv_cache_as_linen(
       key_axis_order=key_axis_order,
       use_chunked_prefill=use_chunked_prefill,
       model_mode=model_mode,
+      is_gdn=is_gdn,
+      conv_kernel_size=conv_kernel_size,
+      conv_dim=conv_dim,
       metadata_fn=variable_to_logically_partitioned,
       name=name,
       abstract_init=False,
@@ -265,6 +271,9 @@ class KVCache(BaseCache):
       key_axis_order: AxisIdxes = (2, 0, 1, 3),
       use_chunked_prefill: bool = False,
       model_mode: str = MODEL_MODE_PREFILL,
+      is_gdn: bool = False,
+      conv_kernel_size: int = 0,
+      conv_dim: int = 0,
       *,
       # Not used in KVCache but passed in by nnx_wrappers.to_linen.
       # TODO: Remove when bridge no longer needed
@@ -314,6 +323,9 @@ class KVCache(BaseCache):
     self.key_axis_order = key_axis_order
     self.model_mode = model_mode
     self.use_chunked_prefill = use_chunked_prefill
+    self.is_gdn = is_gdn
+    self.conv_kernel_size = conv_kernel_size
+    self.conv_dim = conv_dim
 
     if model_mode in (MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE):
       self._initialize_prefill_caches(model_mode)
@@ -349,8 +361,25 @@ class KVCache(BaseCache):
   def _initialize_prefill_caches(self, model_mode):
     """Get a shaped abstraction of the state"""
 
-    cache_length = self.max_prefill_length
     dtype = self._get_cached_kv_dtype()
+
+    if self.is_gdn:
+      cache_batch_axis_name = CACHE_BATCH_PREFILL if model_mode == MODEL_MODE_PREFILL else CACHE_BATCH
+
+      self.cached_prefill_key = nnx.Cache(
+          jnp.zeros((self.batch, self.key_heads, self.key_head_size, self.value_head_size), dtype=dtype),
+          out_sharding=(cache_batch_axis_name, CACHE_HEADS, None, None),
+      )
+      self.cached_prefill_value = nnx.Cache(
+          jnp.zeros((self.batch, self.conv_kernel_size - 1, self.conv_dim), dtype=dtype),
+          out_sharding=(cache_batch_axis_name, None, None),
+      )
+      self.cache_prefill_segment_id = None
+      self.cached_prefill_key_scale = None
+      self.cached_prefill_value_scale = None
+      return
+
+    cache_length = self.max_prefill_length
 
     if model_mode == MODEL_MODE_PREFILL:
       cache_logical_axis_names = self.prefill_cache_logical_axis_names
@@ -411,6 +440,33 @@ class KVCache(BaseCache):
     """get ar cache vars"""
 
     dtype = self._get_cached_kv_dtype()
+
+    if self.is_gdn:
+      # GDN models read/write continuous state via prefill cache ONLY.
+      self.cached_ar_key = None
+      self.cached_ar_value = None
+
+      # Initialize required dummy variables to satisfy uniform engine inspection loops
+      segment_id_axis_names = (
+          (CACHE_BATCH_PREFILL, CACHE_SEQUENCE) if model_mode == MODEL_MODE_PREFILL else (CACHE_BATCH, CACHE_SEQUENCE)
+      )
+      self.cache_ar_segment_id = nnx.Cache(
+          jnp.zeros((self.batch, 1), dtype=jnp.int32),
+          out_sharding=segment_id_axis_names,
+      )
+      self.cached_ar_lengths = nnx.Cache(
+          jnp.zeros((self.batch,), dtype=jnp.int32),
+          out_sharding=(CACHE_BATCH,),
+      )
+      self.cached_ar_key_scale = None
+      self.cached_ar_value_scale = None
+      self.cache_ar_index = nnx.Cache(
+          jnp.zeros((1,), dtype=jnp.int32),
+          out_sharding=(),
+      )
+      return
+
+    # Standard Self-Attention AR Cache allocation begins here
     if self.max_target_length <= self.max_prefill_length:
       raise ValueError(
           f"max_target_length: {self.max_target_length} should be greater than max_prefill_length:"
@@ -489,6 +545,26 @@ class KVCache(BaseCache):
         out_sharding=(),
     )
 
+  def get_gdn_states(self) -> tuple[jax.Array, jax.Array]:
+    """Retrieves the recurrent state and conv state for GDN layers."""
+    # MaxEngine transfers state from prefill to AR via the prefill cache.
+    # To ensure continuity on the transition, we must read from the prefill cache.
+    assert self.is_gdn, "get_gdn_states called on a non-GDN cache object."
+    return self.cached_prefill_key.get_value(), self.cached_prefill_value.get_value()
+
+  def update_gdn_states(self, new_recurrent_state: Array, new_conv_state: Array) -> None:
+    """Updates the recurrent state and conv state for GDN layers."""
+    assert self.is_gdn, "update_gdn_states called on a non-GDN cache object."
+    cache_batch_axis_name = CACHE_BATCH_PREFILL if self.model_mode == MODEL_MODE_PREFILL else CACHE_BATCH
+
+    # ALWAYS update prefill cache since it is our true state container,
+    # not just during MODEL_MODE_PREFILL. This ensures AR updates persist.
+    if getattr(self, "cached_prefill_key", None) is not None:
+      self.cached_prefill_key.set_value(
+          nn.with_logical_constraint(new_recurrent_state, (cache_batch_axis_name, CACHE_HEADS, None, None))
+      )
+      self.cached_prefill_value.set_value(nn.with_logical_constraint(new_conv_state, (cache_batch_axis_name, None, None)))
+
   def _get_ar_cache_vars(self):
     return self.ar_key_vars, self.ar_value_vars, self.cache_ar_segment_id, self.cache_ar_index, self.cached_ar_lengths
 
@@ -557,6 +633,7 @@ class KVCache(BaseCache):
     )
 
     if decoder_segment_ids is not None:
+      assert cached_prefill_segment_id_var is not None
       # Need zero out the remain values to prevent wrong mask in autoregressive.
       previous_segment_id = cached_prefill_segment_id_var.get_value()[:, :next_pos]
       cached_prefill_segment_id_var.set_value(jnp.zeros_like(cached_prefill_segment_id_var.get_value(), dtype=jnp.int32))
@@ -639,6 +716,7 @@ class KVCache(BaseCache):
     cached_prefill_value_vars[0].set_value(value_shaped_for_cache)
 
     if decoder_segment_ids is not None:
+      assert cached_prefill_segment_id_var is not None
       cached_prefill_segment_id_var.set_value(decoder_segment_ids)
     return key, value, decoder_segment_ids
 
@@ -754,6 +832,7 @@ class KVCache(BaseCache):
   def get_cached_values(self, cache_vars, target_dtype, cache_axis_order) -> jax.Array | KVTensor:
     """get cached values"""
     cache_var, cache_scale_var = cache_vars
+    assert cache_var is not None
     cache_value = cache_var.get_value()
     if cache_scale_var is not None:
       scale_value = cache_scale_var.get_value()
@@ -829,6 +908,8 @@ class KVCache(BaseCache):
 
     cached_prefill_key_vars, cached_prefill_value_vars, cached_prefill_segment_id_var = self._get_prefill_cache_vars()
 
+    assert cached_prefill_segment_id_var is not None
+
     cached_prefill = (
         self.get_cached_values(cached_prefill_key_vars, key.dtype, self.prefill_cache_axis_order),
         self.get_cached_values(cached_prefill_value_vars, value.dtype, self.prefill_cache_axis_order),
@@ -878,76 +959,6 @@ class KVCache(BaseCache):
       return self.kv_cache_autoregressive(key, value, use_ragged_attention)
     else:
       raise ValueError(f"Model Mode isn't supported! {model_mode=}")
-
-
-class GatedDeltaNetCache(BaseCache):
-  """Cache for Linear Attention (Gated Delta Net).
-
-  Stores the fixed-size recurrent state and the sliding window state for convolution.
-  """
-
-  def __init__(
-      self,
-      batch: int,
-      num_heads: int,
-      k_head_dim: int,
-      v_head_dim: int,
-      conv_kernel_size: int,
-      conv_dim: int,
-      dtype: DType,
-      cache_batch_axis_name: str = CACHE_BATCH,
-      cache_heads_axis_name: str = CACHE_HEADS,
-  ):
-    super().__init__()
-    self.batch = batch
-    self.dtype = dtype
-
-    # 1. Recurrent State (S) for the Delta Rule
-    # Shape: [Batch, Heads, K_Dim, V_Dim]
-    # We maintain the running state matrix.
-    self.recurrent_state = nnx.Cache(
-        jnp.zeros((int(batch), num_heads, k_head_dim, v_head_dim), dtype=dtype),
-        # Sharding: Batch, Heads, None (K), None (V)
-        out_sharding=(cache_batch_axis_name, cache_heads_axis_name, None, None),
-    )
-
-    # 2. Convolution State for the 1D Conv
-    # Shape: [Batch, Kernel_Size - 1, Conv_Dim]
-    # We store the last (K-1) inputs to perform the sliding window conv during decoding.
-    self.conv_state = nnx.Cache(
-        jnp.zeros((int(batch), conv_kernel_size - 1, conv_dim), dtype=dtype),
-        # Sharding: Batch, None (Time), None (Dim)
-        out_sharding=(cache_batch_axis_name, None, None),
-    )
-
-  def __call__(self):
-    """Returns the cache variables for the layer to use."""
-    return self
-
-
-def gated_delta_net_cache_as_linen(
-    *,
-    batch: int,
-    num_heads: int,
-    head_dim: int,
-    conv_kernel_size: int,
-    conv_dim: int,
-    dtype: DType,
-    name: str | None = None,
-):
-  """Initializes the GatedDeltaNetCache and returns it as a Linen module."""
-  return nnx_wrappers.to_linen(
-      GatedDeltaNetCache,
-      batch=batch,
-      num_heads=num_heads,
-      head_dim=head_dim,
-      conv_kernel_size=conv_kernel_size,
-      conv_dim=conv_dim,
-      dtype=dtype,
-      metadata_fn=variable_to_logically_partitioned,
-      name=name,
-      abstract_init=False,
-  )
 
 
 def mla_kv_cache_as_linen(

--- a/src/maxtext/inference/maxengine/maxengine.py
+++ b/src/maxtext/inference/maxengine/maxengine.py
@@ -1808,7 +1808,7 @@ class MaxEngine(_BaseEngine):
       )
       dummy_image = jnp.ones(
           mm_processor.get_dummy_image_shape_for_init(
-              model_name=self.config.model_name, batch_size=self.config.per_device_batch_size
+              model_name=self.config.model_name, batch_size=int(self.config.per_device_batch_size * self.mesh.size)
           ),
           dtype=jnp.int32,
       )

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -1136,12 +1136,8 @@ class Decoder(nn.Module):
             if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
               layer_kwargs = {"layer_idx": lyr}
             kv_cache = None
-            if kv_caches is not None and cfg.decoder_block not in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
+            if kv_caches is not None:
               kv_cache = kv_caches[lyr]
-            elif kv_caches is not None and cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
-              # For Qwen3Next & Qwen3.5, kv_caches is a dictionary of lists of caches.
-              if (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
-                kv_cache = (kv_caches["key_cache"][lyr], kv_caches["value_cache"][lyr])
 
             if cfg.decoder_block == DecoderBlockType.GPT_OSS:
               layer_kwargs = {"attention_type": gpt_oss.get_attention_type(layer_id=lyr)}
@@ -1163,11 +1159,7 @@ class Decoder(nn.Module):
                 **layer_call_kwargs,
             )
             if kv_caches is not None and returned_cache is not None:
-              if cfg.decoder_block not in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):
-                kv_caches[lyr] = returned_cache
-              elif (lyr + 1) % cfg.inhomogeneous_layer_cycle_interval == 0:
-                kv_caches["key_cache"][lyr] = returned_cache[0]
-                kv_caches["value_cache"][lyr] = returned_cache[1]
+              kv_caches[lyr] = returned_cache
 
             if deepstack_visual_embeds is not None and lyr < len(deepstack_visual_embeds):
               visual_embeds = deepstack_visual_embeds[lyr]

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -29,7 +29,7 @@ import jax.numpy as jnp
 from flax import linen as nn
 from flax import nnx
 
-from maxtext.common.common_types import AttentionType, Config, DType, Array, BATCH, EMBED, MODEL_MODE_TRAIN, LENGTH
+from maxtext.common.common_types import AttentionType, Config, DType, Array, BATCH, EMBED, MODEL_MODE_TRAIN, LENGTH, MODEL_MODE_AUTOREGRESSIVE
 from maxtext.layers import attentions
 from maxtext.layers import initializers as max_initializers
 from maxtext.layers import moe
@@ -42,7 +42,6 @@ from maxtext.layers.attentions import Attention
 from maxtext.layers.linears import DenseGeneral, MlpBlock
 from maxtext.layers.moe import RoutedMoE
 from maxtext.layers.initializers import nd_dense_init, variable_to_logically_partitioned
-
 from maxtext.utils import max_utils
 from maxtext.inference import kvcache
 
@@ -357,6 +356,72 @@ def jax_chunk_gated_delta_rule(
   return o, (final_h if initial_state is not None else None)
 
 
+def jax_ar_gated_delta_rule(
+    query: Array,
+    key: Array,
+    value: Array,
+    g: Array,
+    beta: Array,
+    initial_state: Array,
+    use_qk_norm_in_gdn: bool = False,
+    compute_dtype: jnp.dtype = jnp.bfloat16,
+) -> tuple[Array, Array]:
+  """Highly optimized step for Autoregressive Decoding (seq_len == 1)."""
+  # Shapes: q, k (B, 1, H, K_dim) | v (B, 1, H, V_dim) | g, beta (B, 1, H)
+  initial_dtype = query.dtype
+
+  if use_qk_norm_in_gdn:
+    query = l2norm(query, dim=-1, eps=1e-6)
+    key = l2norm(key, dim=-1, eps=1e-6)
+
+  query = query.astype(compute_dtype)
+  key = key.astype(compute_dtype)
+  value = value.astype(compute_dtype)
+  beta = beta.astype(compute_dtype)
+  g = g.astype(jnp.float32)
+
+  # Strip the seq_len=1 dimension to avoid broadcast overhead
+  q = query.squeeze(1)
+  k = key.squeeze(1)
+  v = value.squeeze(1)
+  g = g.squeeze(1)
+  beta = beta.squeeze(1)
+
+  scale = jax.lax.rsqrt(jnp.array(q.shape[-1], dtype=jnp.float32)).astype(compute_dtype)
+  q = q * scale
+
+  g_exp = jnp.exp(g)[..., None]
+  beta_exp = beta[..., None]
+
+  k_beta = k * beta_exp
+  v_beta = v * beta_exp
+
+  state = initial_state.astype(jnp.float32)
+
+  # v_prime = state @ (k_beta * exp(g))
+  k_cumdecay = (k_beta.astype(jnp.float32) * g_exp)[..., None, :]  # (B, H, 1, K)
+  v_prime = jnp.matmul(k_cumdecay, state, precision=jax.lax.Precision.HIGHEST).squeeze(-2)
+
+  v_new = v_beta.astype(jnp.float32) - v_prime
+
+  # Core Output
+  q_g = (q.astype(jnp.float32) * g_exp)[..., None, :]  # (B, H, 1, K)
+  attn_inter = jnp.matmul(q_g, state, precision=jax.lax.Precision.HIGHEST).squeeze(-2)
+
+  attn_intra = jnp.sum(q.astype(jnp.float32) * k.astype(jnp.float32), axis=-1, keepdims=True)
+  core_attn_out = attn_inter + attn_intra * v_new
+
+  # State Update: new_state = state * exp(g) + k^T @ v_new
+  new_state = state * g_exp[..., None] + jnp.matmul(
+      k.astype(jnp.float32)[..., None], v_new[..., None, :], precision=jax.lax.Precision.HIGHEST
+  )
+
+  # Restore sequence dimension
+  core_attn_out = core_attn_out[:, None, :, :].astype(initial_dtype)
+
+  return core_attn_out, new_state
+
+
 class Qwen3NextGatedDeltaNet(nnx.Module):
   """
   This module implements the full end-to-end logic of a Gated Delta Network layer.
@@ -381,7 +446,15 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
   2. output = Linear_out(y)
   """
 
-  def __init__(self, config: Config, dtype: DType = jnp.float32, model_mode: str = MODEL_MODE_TRAIN, *, rngs: nnx.Rngs):
+  def __init__(
+      self,
+      config: Config,
+      inputs_shape: tuple,
+      dtype: DType = jnp.float32,
+      model_mode: str = MODEL_MODE_TRAIN,
+      *,
+      rngs: nnx.Rngs,
+  ):
     """
     Args:
       config: MaxText configuration object.
@@ -402,15 +475,27 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     self.v_heads_per_k_head = self.num_v_heads // self.num_k_heads
 
     if model_mode != MODEL_MODE_TRAIN:
-      self.cache = kvcache.GatedDeltaNetCache(
-          batch=config.per_device_batch_size,
-          num_heads=self.num_v_heads,
-          k_head_dim=self.head_k_dim,
-          v_head_dim=self.head_v_dim,
-          conv_kernel_size=self.config.gdn_conv_kernel_dim,
-          conv_dim=conv_dim,
+      runtime_batch_size = inputs_shape[0]
+
+      self.cache = kvcache.KVCache(
+          max_prefill_length=cfg.max_prefill_predict_length,
+          max_target_length=cfg.max_target_length,
+          batch=runtime_batch_size,
+          key_seq_len=1,
+          value_seq_len=1,
+          key_heads=self.num_v_heads,
+          value_heads=self.num_v_heads,
+          key_head_size=self.head_k_dim,
+          value_head_size=self.head_v_dim,
           dtype=dtype,
+          is_gdn=True,
+          conv_kernel_size=conv_kernel_size,
+          conv_dim=conv_dim,
+          model_mode=model_mode,
+          rngs=rngs,
       )
+    else:
+      self.cache = None
 
     # Submodule instantiations
     self.in_proj_qkvz = DenseGeneral(
@@ -478,10 +563,12 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       kv_cache=None,
       decoder_segment_ids: None | Array = None,
       **kwargs,
-  ) -> Array:
+  ) -> tuple[Array, Any | None]:
     # hidden_states: (B, S, E)
     cfg = self.config
     batch, seq_len, _ = hidden_states.shape
+
+    active_cache = kv_cache if kv_cache is not None else self.cache
 
     # =========================================================================
     # STEP A: Input Projections
@@ -554,33 +641,44 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     conv_kernel_size = self.config.gdn_conv_kernel_dim
 
     conv_state = None
-    if model_mode != MODEL_MODE_TRAIN:
-      # Retrieve state from self.cache
-      conv_state = self.cache.conv_state[...]
+    recurrent_state = None
+    next_conv_state = None
+    if model_mode != MODEL_MODE_TRAIN and active_cache is not None:
+      recurrent_state, conv_state = active_cache.get_gdn_states()
+      orig_cache_batch = conv_state.shape[0]
+
+      # 1. Safely shrink/expand conv_state to match incoming qkv (e.g. 16 -> 1)
       if conv_state.shape[0] != batch:
-        # Assumes zero-initialized state for testing
         if conv_state.shape[0] == 1:
           conv_state = jnp.broadcast_to(conv_state, (batch,) + conv_state.shape[1:])
+        elif conv_state.shape[0] < batch:
+          pad_amt = batch - conv_state.shape[0]
+          conv_state = jnp.pad(conv_state, ((0, pad_amt), (0, 0), (0, 0)))
         else:
           conv_state = conv_state[:batch]
 
-      # Concatenate previous state with new input
+      # 2. Safely shrink/expand recurrent_state to match incoming qkv
+      if recurrent_state.shape[0] != batch:
+        if recurrent_state.shape[0] == 1:
+          recurrent_state = jnp.broadcast_to(recurrent_state, (batch,) + recurrent_state.shape[1:])
+        elif recurrent_state.shape[0] < batch:
+          pad_amt = batch - recurrent_state.shape[0]
+          recurrent_state = jnp.pad(recurrent_state, ((0, pad_amt), (0, 0), (0, 0), (0, 0)))
+        else:
+          recurrent_state = recurrent_state[:batch]
+
       conv_input = jnp.concatenate([conv_state, qkv], axis=1)
 
       if decoder_segment_ids is not None:
-        valid_lens = jnp.sum(decoder_segment_ids != 0, axis=1)  # Shape: (B,)
+        valid_lens = jnp.sum(decoder_segment_ids != 0, axis=1)
 
         def extract_state(c_in, v_len):
           return jax.lax.dynamic_slice_in_dim(c_in, v_len, conv_kernel_size - 1, axis=0)
 
-        new_conv_state = jax.vmap(extract_state)(conv_input, valid_lens)
+        next_conv_state = jax.vmap(extract_state)(conv_input, valid_lens)
       else:
-        new_conv_state = conv_input[:, -(conv_kernel_size - 1) :, :]
-
-      # Update self.cache in place
-      self.cache.conv_state.set_value(new_conv_state)
+        next_conv_state = conv_input[:, -(conv_kernel_size - 1) :, :]
     else:
-      # Train: pad with zeros
       conv_input = jnp.pad(qkv, ((0, 0), (conv_kernel_size - 1, 0), (0, 0)))
 
     # Perform the convolution.
@@ -592,7 +690,6 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     q_conv, k_conv, v_conv = jnp.split(qkv_conv, [self.key_dim, 2 * self.key_dim], axis=-1)
 
     # Reshape for multi-head processing
-    batch, seq_len, _ = hidden_states.shape
     # query shape: (B, S, H_k, D_k)
     query = q_conv.reshape(batch, seq_len, self.num_k_heads, self.head_k_dim)
     # key shape: (B, S, H_k, D_k)
@@ -623,35 +720,50 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
       query = jnp.repeat(query, repeats, axis=2)
       # key shape after repeat: (B, S, H_v, D_k)
       key = jnp.repeat(key, repeats, axis=2)
-    elif self.num_k_heads > self.num_v_heads and self.num_k_heads % self.num_v_heads == 0:
-      pass
 
-    recurrent_state = None
-    if model_mode != MODEL_MODE_TRAIN:
-      # Retrieve state from self.cache
-      recurrent_state = self.cache.recurrent_state[...]
+    if seq_len == 1 and model_mode == MODEL_MODE_AUTOREGRESSIVE:
+      core_attn_out, next_recurrent_state = jax_ar_gated_delta_rule(
+          query,
+          key,
+          value,
+          g,
+          beta,
+          initial_state=recurrent_state,
+          use_qk_norm_in_gdn=cfg.use_qk_norm_in_gdn,
+          compute_dtype=cfg.dtype,
+      )
+    else:
+      core_attn_out, next_recurrent_state = jax_chunk_gated_delta_rule(
+          query,
+          key,
+          value,
+          g,
+          beta,
+          chunk_size=cfg.gdn_chunk_size,
+          initial_state=recurrent_state,
+          use_qk_norm_in_gdn=cfg.use_qk_norm_in_gdn,
+          compute_dtype=cfg.dtype,
+      )
 
-      if recurrent_state.shape[0] != batch:
-        if recurrent_state.shape[0] == 1:
-          recurrent_state = jnp.broadcast_to(recurrent_state, (batch,) + recurrent_state.shape[1:])
+    if model_mode != MODEL_MODE_TRAIN and active_cache is not None:
+      assert next_conv_state is not None
+      assert next_recurrent_state is not None
+      if next_conv_state.shape[0] != orig_cache_batch:
+        if next_conv_state.shape[0] == 1:
+          next_conv_state = jnp.broadcast_to(next_conv_state, (orig_cache_batch,) + next_conv_state.shape[1:])
+          next_recurrent_state = jnp.broadcast_to(
+              next_recurrent_state, (orig_cache_batch,) + next_recurrent_state.shape[1:]
+          )
+        elif next_conv_state.shape[0] < orig_cache_batch:
+          pad_amt = orig_cache_batch - next_conv_state.shape[0]
+          next_conv_state = jnp.pad(next_conv_state, ((0, pad_amt), (0, 0), (0, 0)))
+          next_recurrent_state = jnp.pad(next_recurrent_state, ((0, pad_amt), (0, 0), (0, 0), (0, 0)))
         else:
-          recurrent_state = recurrent_state[:batch]
+          next_conv_state = next_conv_state[:orig_cache_batch]
+          next_recurrent_state = next_recurrent_state[:orig_cache_batch]
 
-    core_attn_out, recurrent_state_out = jax_chunk_gated_delta_rule(
-        query,
-        key,
-        value,
-        g,
-        beta,
-        chunk_size=cfg.gdn_chunk_size,
-        initial_state=recurrent_state,
-        use_qk_norm_in_gdn=cfg.use_qk_norm_in_gdn,
-        compute_dtype=cfg.dtype,
-    )
-
-    if model_mode != MODEL_MODE_TRAIN:
-      # Update self.cache in place for both prefill and decode
-      self.cache.recurrent_state.set_value(recurrent_state_out)
+    if model_mode != MODEL_MODE_TRAIN and active_cache is not None:
+      active_cache.update_gdn_states(next_recurrent_state, next_conv_state)
 
     # =========================================================================
     # STEP D: Final Output Stage
@@ -669,7 +781,31 @@ class Qwen3NextGatedDeltaNet(nnx.Module):
     # Final output shape: (B, S, E)
     output = self.out_proj(gated_output)
 
-    return output
+    return output, active_cache
+
+  def init_kv_caches(self, batch_size: int):
+    """Initializes KVCache dynamically using the traced runtime batch size."""
+    cfg = self.config
+    conv_dim = self.key_dim * 2 + self.value_dim
+    conv_kernel_size = cfg.gdn_conv_kernel_dim
+
+    return kvcache.KVCache(
+        max_prefill_length=cfg.max_prefill_predict_length,
+        max_target_length=cfg.max_target_length,
+        batch=batch_size,
+        key_seq_len=1,
+        value_seq_len=1,
+        key_heads=self.num_v_heads,
+        value_heads=self.num_v_heads,
+        key_head_size=self.head_k_dim,
+        value_head_size=self.head_v_dim,
+        dtype=self.dtype,
+        is_gdn=True,
+        conv_kernel_size=conv_kernel_size,
+        conv_dim=conv_dim,
+        model_mode=self.model_mode,
+        rngs=self.rngs,
+    )
 
 
 class Qwen3NextFullAttention(nnx.Module):
@@ -986,7 +1122,11 @@ class Qwen3NextDecoderLayer(nnx.Module):
           rngs=rngs,
       )
     else:
-      self.attention = Qwen3NextGatedDeltaNet(config=cfg, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs)
+      batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+      dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
+      self.attention = Qwen3NextGatedDeltaNet(
+          config=cfg, inputs_shape=dummy_inputs_shape, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs
+      )
 
     # Second LayerNorm, applied before the MoE block.
     self.post_attention_layernorm = Qwen3NextRMSNorm(
@@ -1033,13 +1173,12 @@ class Qwen3NextDecoderLayer(nnx.Module):
           attention_metadata=attention_metadata,
       )
     else:
-      attention_output = cast(Qwen3NextGatedDeltaNet, self.attention)(
+      attention_output, new_kv_cache = cast(Qwen3NextGatedDeltaNet, self.attention)(
           hidden_states,
           model_mode=model_mode,
-          kv_cache=None,
+          kv_cache=kv_cache,
           decoder_segment_ids=decoder_segment_ids,
       )
-      new_kv_cache = None
 
     # First residual connection after attention
     hidden_states = residual + attention_output

--- a/src/maxtext/models/qwen3_5.py
+++ b/src/maxtext/models/qwen3_5.py
@@ -29,7 +29,7 @@ from maxtext.layers import initializers as max_initializers
 from maxtext.layers import nnx_wrappers
 from maxtext.layers.normalizations import Qwen3NextRMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
-
+from maxtext.utils import max_utils
 
 from maxtext.models.qwen3 import (
     Qwen3NextGatedDeltaNet,
@@ -156,7 +156,11 @@ class Qwen3_5DecoderLayer(nnx.Module):
           rngs=rngs,
       )
     else:
-      self.attention = Qwen3_5GatedDeltaNet(config=cfg, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs)
+      batch_size, seq_len = max_utils.get_batch_seq_len_for_mode(config, model_mode)
+      dummy_inputs_shape = (batch_size, seq_len, config.emb_dim)
+      self.attention = Qwen3_5GatedDeltaNet(
+          config=cfg, inputs_shape=dummy_inputs_shape, dtype=cfg.dtype, model_mode=model_mode, rngs=rngs
+      )
 
     # Second LayerNorm, applied before the MoE block.
     self.post_attention_layernorm = Qwen3NextRMSNorm(
@@ -203,13 +207,12 @@ class Qwen3_5DecoderLayer(nnx.Module):
           attention_metadata=attention_metadata,
       )
     else:
-      attention_output = cast(Qwen3_5GatedDeltaNet, self.attention)(
+      attention_output, new_kv_cache = cast(Qwen3_5GatedDeltaNet, self.attention)(
           hidden_states,
           model_mode=model_mode,
-          kv_cache=None,
+          kv_cache=kv_cache,
           decoder_segment_ids=decoder_segment_ids,
       )
-      new_kv_cache = None
 
     # First residual connection after attention
     hidden_states = residual + attention_output

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -1949,13 +1949,14 @@ class Qwen3NextGatedDeltaNetTest(unittest.TestCase):
     # 2. Init GDN Layer
     gdn = Qwen3NextGatedDeltaNet(
         config=cfg,
+        inputs_shape=lnx.shape,
         dtype=cfg.dtype,
         model_mode=MODEL_MODE_PREFILL,
         rngs=self.nnx_rng,
     )
 
     # 3. Full / Train mode
-    gdn_full = gdn(
+    gdn_full, _ = gdn(
         lnx,
         model_mode=MODEL_MODE_TRAIN,
     )
@@ -1963,7 +1964,7 @@ class Qwen3NextGatedDeltaNetTest(unittest.TestCase):
     # 4. Prefill mode
     lnx_prefill = lnx[:, 0:prefill_length, :]
 
-    gdn_prefill = gdn(
+    gdn_prefill, _ = gdn(
         lnx_prefill,
         model_mode=MODEL_MODE_PREFILL,
     )
@@ -1976,7 +1977,7 @@ class Qwen3NextGatedDeltaNetTest(unittest.TestCase):
     for idx in range(prefill_length, decode_total_length):
       lnx_idx = lnx[:, idx : idx + 1, :]
 
-      gdn_idx = gdn(
+      gdn_idx, _ = gdn(
           lnx_idx,
           model_mode=MODEL_MODE_AUTOREGRESSIVE,
       )


### PR DESCRIPTION
# Description

Previously when we enabled caching in the GDN layer for Qwen3-Next model bringup, there was a bug in autoregressive mode when running inference with api_server, our benchmarking tool. There was an issue with how api_server was managing the GDN caches resulting in repeated token output in decoding. 

Now, I have fixed this bug by reusing the existing kvcache class in kvcache.py for storing the GDN recurrent_state and conv_state. It seems like the kvcache class is well integrated with api_server in terms of batching, padding, updating, etc. 

For new models with special cache structures, for the fastest way to functional decoding, it seems like reusing the kvcache class as much as possible is the best solution since it is already integrated within our inference framework.

Also, in the GDN layer I have rewritten the gated delta rule function for autoregressive mode. This is because the algorithm by default splits the token into chunk_sizes of 64. However, for autoregressive mode, seq_len=1. Our current gated delta rule did not account for this and we had wasted padding of 63 tokens!. Adding a new gated delta rule function specifically for this has led to performance boost in decoding speed allowing us to run benchmarks.

# Tests

I have run standard decode.py and have also run an inference benchmark on api_server for Qwen3.5, which uses the GDN

decode.py output: https://paste.googleplex.com/6084567757881344

For the MMLU-Pro run of Qwen3.5-35b, the details are in b/502303541

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
