### PR TITLE
Add roundtrip ckpt conversion tests in CI

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -51,6 +51,7 @@ Example Usage:
 
 import argparse
 from functools import partial
+import importlib.util
 import json
 import os
 import sys
@@ -59,7 +60,6 @@ import time
 from typing import Any, Callable, List, Sequence
 import absl
 import ml_dtypes
-import torch
 import flax.linen as nn
 from huggingface_hub import hf_hub_download, list_repo_files
 import jax
@@ -77,6 +77,21 @@ from maxtext.utils.globals import HF_IDS
 import numpy as np
 from orbax.checkpoint import type_handlers
 from safetensors import safe_open
+
+
+def _lazy_import(name: str):
+  spec = importlib.util.find_spec(name)
+  if spec is None:
+    return None
+  loader = importlib.util.LazyLoader(spec.loader)
+  spec.loader = loader
+  module = importlib.util.module_from_spec(spec)
+  sys.modules[name] = module
+  loader.exec_module(module)
+  return module
+
+
+torch = _lazy_import("torch")
 
 
 absl.logging.set_verbosity(absl.logging.INFO)  # for max_logging.log
@@ -807,7 +822,7 @@ def _setup_merge_mode_getter(tensor_getter, config, hf_lora_adapter_path, revisi
 def main(
     args: Sequence[str],
     lazy_load_tensors: bool = False,
-    eager_load_method: str = "transformers",
+    eager_load_method: str = "safetensors",
     hf_model_path: str | None = None,
     revision: str | None = None,
     save_dtype: str = "bfloat16",
@@ -894,9 +909,9 @@ def main(
       #      (e.g., Multi-Token Prediction weights (`layers.61`) in DeepSeek-V3).
       #
       # Recommendation:
-      # - Use 'transformers' as the default for backward compatibility of mapping.
-      # - 'safetensors' is an interchangeable and valid alternative for most models,
-      #   and is strictly required if the model or specific weights lack Transformers support.
+      # - Use 'safetensors' as the default. Since transformers 5.8.0, model initialization
+      #   changed and the 'transformers' method may produce different key structures.
+      # - Use 'transformers' only if explicitly needed for backward-compatible key mapping.
       if eager_load_method == "transformers":
         max_logging.log("Eager load with Transformers backend, from_pretrained with auto dtype")
         # For auto mode, loaded dtype is the same as `dtype` specified in config.json (or `torch_dtype` for older version)

--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -911,7 +911,7 @@ def main(
       # Recommendation:
       # - Use 'safetensors' as the default. Since transformers 5.8.0, model initialization
       #   changed and the 'transformers' method may produce different key structures.
-      # - Use 'transformers' only if explicitly needed for backward-compatible key mapping.
+      # - Use 'transformers' only if explicitly needed for backward-compatible key mapping (e.g. Gemma3).
       if eager_load_method == "transformers":
         max_logging.log("Eager load with Transformers backend, from_pretrained with auto dtype")
         # For auto mode, loaded dtype is the same as `dtype` specified in config.json (or `torch_dtype` for older version)

--- a/src/maxtext/configs/pyconfig.py
+++ b/src/maxtext/configs/pyconfig.py
@@ -295,7 +295,10 @@ class HyperParameters:
     # This is necessary for proper pickling/unpickling support
     flat_config = object.__getattribute__(self, "_flat_config")
     if attr in flat_config:
-      return flat_config[attr]
+      val = flat_config[attr]
+      if isinstance(val, dict) and attr in ("debug", "rl", "lora"):
+        return getattr(object.__getattribute__(self, "_pydantic_config"), attr)
+      return val
     raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'")
 
   def __setattr__(self, attr: str, value: Any) -> None:

--- a/tests/integration/checkpoint_conversion_test.py
+++ b/tests/integration/checkpoint_conversion_test.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test for checkpoint conversion."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+import pytest
+
+pytestmark = [pytest.mark.integration_test]
+
+
+class Qwen3CheckpointConversionTest(unittest.TestCase):
+  """Tests HuggingFace to Orbax checkpoint conversion."""
+
+  @pytest.mark.cpu_only
+  def test_qwen3_30b_a3b_roundtrip_conversion(self):
+    model_name = "qwen3-30b-a3b"
+    base_num_decoder_layers = 2
+    with tempfile.TemporaryDirectory() as tmpdir:
+      to_mt_cmd = [
+          sys.executable,
+          "-m",
+          "maxtext.checkpoint_conversion.to_maxtext",
+          f"model_name={model_name}",
+          f"base_output_directory={tmpdir}",
+          f"base_num_decoder_layers={base_num_decoder_layers}",
+          "override_model_config=True",
+          "scan_layers=False",
+          "hardware=cpu",
+          "skip_jax_distributed_system=True",
+          "checkpoint_storage_use_ocdbt=False",
+          "checkpoint_storage_use_zarr3=False",
+          "--save_dtype=bfloat16",
+          "--lazy_load_tensors=True",
+      ]
+      env = os.environ.copy()
+      env["JAX_PLATFORMS"] = "cpu"
+      env["HF_HOME"] = tmpdir
+
+      print("Running checkpoint conversion command:", " ".join(to_mt_cmd))
+      # Inherit stdout and stderr from the parent process to stream logs in real time
+      subprocess.run(to_mt_cmd, env=env, check=True)
+
+      # Verify output directory exists and contains items
+      # Output structure: tmpdir/0/items
+      expected_dir = os.path.join(tmpdir, "0", "items")
+      self.assertTrue(os.path.exists(expected_dir), f"Expected checkpoint directory {expected_dir} does not exist.")
+      self.assertTrue(len(os.listdir(expected_dir)) > 0, f"Checkpoint directory {expected_dir} is empty.")
+
+      # Roundtrip conversion back to HuggingFace format
+      expected_hf_dir = os.path.join(tmpdir, "hf_safetensor", "qwen3-30b-a3b")
+      to_hf_cmd = [
+          sys.executable,
+          "-m",
+          "maxtext.checkpoint_conversion.to_huggingface",
+          f"model_name={model_name}",
+          f"load_parameters_path={expected_dir}",
+          f"base_output_directory={expected_hf_dir}",
+          f"base_num_decoder_layers={base_num_decoder_layers}",
+          "override_model_config=True",
+          "scan_layers=false",
+          "weight_dtype=bfloat16",
+          "hardware=cpu",
+          "skip_jax_distributed_system=True",
+          "--override_model_architecture=True",
+      ]
+      print("Running roundtrip checkpoint conversion command (to HF):", " ".join(to_hf_cmd))
+      subprocess.run(to_hf_cmd, env=env, check=True)
+
+      # Verify HF output directory exists and contains safetensors/config files
+      self.assertTrue(
+          os.path.exists(expected_hf_dir), f"Expected HF checkpoint directory {expected_hf_dir} does not exist."
+      )
+      self.assertTrue(len(os.listdir(expected_hf_dir)) > 0, f"HF checkpoint directory {expected_hf_dir} is empty.")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description
- Make `import torch` lazy import in `to_maxtext`, so we can run torch-free conversion in CI.
- Add a 2-layered qwen3-30b-a3b ckpt-conversion-roundtrip cpu-only test in CI. 
-- We lazy-load safetensors so only 2-out-of-16 chunks were actually loaded for `to_maxtext` conversion. 
-- Within the tmpdir, we convert maxtext Orbax ckpt back to HF for `to_huggingface` conversion.
-- All converted MaxText/HF ckpts will be auto removed from tmpdir.
-- Success criteria: (1) Subprocess finishes without errors (2) Result ckpts exist in the tmpdir. We didn't enforce logits check in the CI because that will actually require torch dependency. But I've tested forward_pass_logit_checker offline.
- Fix [b/513636729](https://b.corp.google.com/issues/513636729), introduced in [cl/914979909](https://critique.corp.google.com/cl/914979909). 

# Tests

```
# to maxtext
python -m maxtext.checkpoint_conversion.to_maxtext src/maxtext/configs/base.yml model_name=qwen3-30b-a3b base_output_directory=/dev/shm/mini base_num_decoder_layers=2 override_model_config=True scan_layers=false hf_access_token=\<token\> hardware=cpu skip_jax_distributed_system=True checkpoint_storage_use_ocdbt=False checkpoint_storage_use_zarr3=False --eager_load_method=safetensors --save_dtype=bfloat16 --lazy_load_tensors=True

# to huggingface
python -m maxtext.checkpoint_conversion.to_huggingface model_name=qwen3-30b-a3b load_parameters_path=/dev/shm/mini/0/items base_output_directory=/dev/shm/mini/hf_safetensor/qwen3-30b-a3b base_num_decoder_layers=2 override_model_config=True scan_layers=false weight_dtype=bfloat16 hardware=cpu skip_jax_distributed_system=True hf_access_token=\<token\> --override_model_architecture=True

# logits check (roundtrip above)
python -m tests.utils.forward_pass_logit_checker maxtext/configs/base.yml run_name=ht_test model_name=qwen3-30b-a3b tokenizer_path=Qwen/Qwen3-30B-A3B-Thinking-2507 load_parameters_path=/dev/shm/mini/0/items base_num_decoder_layers=2 override_model_config=True scan_layers=false max_prefill_predict_length=4 ici_tensor_parallelism=4 hf_access_token=\<token\> --run_hf_model=True --hf_model_path=Qwen/Qwen3-30B-A3B-Thinking-2507 --hf_model_path=/dev/shm/mini/hf_safetensor/qwen3-30b-a3b --max_kl_div=0.015
```

2-layerd mini checkpoint with matching gibberish logits: [Logs](https://paste.googleplex.com/5895969509081088)

Tests active in CI: https://screenshot.googleplex.com/4ZhRPiqJZLxTXk5

For this single test on my v5p-8 VM, it took ~2.5 minutes and the peak memory was ~12G.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
