### PR TITLE
Move save_weights_to_checkpoint to shared utils

### DIFF
--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_deepseek_family_ckpt.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_deepseek_family_ckpt.py
@@ -41,7 +41,7 @@ from tqdm import tqdm
 
 from safetensors import safe_open
 
-from maxtext.checkpoint_conversion.standalone_scripts import llama_or_mistral_ckpt
+from maxtext.checkpoint_conversion.utils.utils import save_weights_to_checkpoint
 from maxtext.inference.inference_utils import str2bool
 from maxtext.utils import max_logging
 
@@ -873,7 +873,7 @@ def main() -> None:
   os.environ["JAX_PLATFORMS"] = "cpu"
   os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={args.simulated_cpu_devices_count}"
   mem_info = psutil.Process()
-  llama_or_mistral_ckpt.save_weights_to_checkpoint(
+  save_weights_to_checkpoint(
       args.maxtext_model_path,
       _convert_to_jax_weights(args.base_model_path, args.model_size, mem_info, args.enable_mtp),
       args.simulated_cpu_devices_count,

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_deepseek_family_unscanned_ckpt.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_deepseek_family_unscanned_ckpt.py
@@ -38,7 +38,7 @@ import psutil
 from tqdm import tqdm
 
 from maxtext.checkpoint_conversion.standalone_scripts import convert_deepseek_family_ckpt as ds_ckpt
-from maxtext.checkpoint_conversion.standalone_scripts import llama_or_mistral_ckpt
+from maxtext.checkpoint_conversion.utils.utils import save_weights_to_checkpoint
 from maxtext.inference.inference_utils import str2bool
 from maxtext.utils import max_logging
 from safetensors import safe_open
@@ -386,7 +386,7 @@ def main() -> None:
   os.environ["JAX_PLATFORMS"] = "cpu"
   os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={args.simulated_cpu_devices_count}"
   mem_info = psutil.Process()
-  llama_or_mistral_ckpt.save_weights_to_checkpoint(
+  save_weights_to_checkpoint(
       args.maxtext_model_path,
       _convert_to_jax_weights(args.base_model_path, args.model_size, mem_info),
       args.simulated_cpu_devices_count,

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_gpt_oss_ckpt.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_gpt_oss_ckpt.py
@@ -37,9 +37,8 @@ import psutil
 from safetensors import safe_open
 from tqdm import tqdm
 
-from maxtext.checkpoint_conversion.standalone_scripts.llama_or_mistral_ckpt import save_weights_to_checkpoint
 from maxtext.checkpoint_conversion.standalone_scripts.convert_gpt_oss_unscanned_ckpt import MODEL_PARAMS_DICT, _hf_to_maxtext_mapping, _pt_to_np
-from maxtext.checkpoint_conversion.utils.utils import MemoryMonitorTqdm, print_peak_memory
+from maxtext.checkpoint_conversion.utils.utils import MemoryMonitorTqdm, print_peak_memory, save_weights_to_checkpoint
 from maxtext.inference.inference_utils import str2bool
 from maxtext.utils import max_logging
 

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_gpt_oss_unscanned_ckpt.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_gpt_oss_unscanned_ckpt.py
@@ -37,7 +37,7 @@ from safetensors import safe_open
 import torch
 from tqdm import tqdm
 
-from maxtext.checkpoint_conversion.standalone_scripts.llama_or_mistral_ckpt import save_weights_to_checkpoint
+from maxtext.checkpoint_conversion.utils.utils import save_weights_to_checkpoint
 from maxtext.inference.inference_utils import str2bool
 from maxtext.utils import max_logging
 

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_qwen3_moe.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_qwen3_moe.py
@@ -32,7 +32,7 @@ import torch
 from safetensors import safe_open
 from tqdm import tqdm
 
-from maxtext.checkpoint_conversion.standalone_scripts import llama_or_mistral_ckpt
+from maxtext.checkpoint_conversion.utils.utils import save_weights_to_checkpoint
 from maxtext.inference.inference_utils import str2bool
 from maxtext.utils import max_logging
 
@@ -271,7 +271,7 @@ def main(args):
   max_logging.log(f"Starting conversion for Qwen3-MoE model size: {args.model_size}")
   jax_weights = convert_hf_to_maxtext(args.base_model_path, model_params)
   max_logging.log(f"Conversion complete. Saving MaxText checkpoint to {args.maxtext_model_path}")
-  llama_or_mistral_ckpt.save_weights_to_checkpoint(
+  save_weights_to_checkpoint(
       args.maxtext_model_path, jax_weights, args.simulated_cpu_devices_count, args.use_ocdbt, args.use_zarr3
   )
   max_logging.log("Checkpoint saved successfully.")

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_qwen3_next_scanned.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_qwen3_next_scanned.py
@@ -35,7 +35,7 @@ from safetensors import safe_open
 from functools import partial
 from tqdm import tqdm
 
-from maxtext.checkpoint_conversion.standalone_scripts import llama_or_mistral_ckpt
+from maxtext.checkpoint_conversion.utils.utils import save_weights_to_checkpoint
 from maxtext.inference.inference_utils import str2bool
 from maxtext.utils import max_logging
 
@@ -407,7 +407,7 @@ def main(args):
   jax_weights = convert_hf_to_maxtext(args.base_model_path, model_params, args)
   max_logging.log(f"Conversion complete. Saving MaxText checkpoint to {args.maxtext_model_path}")
 
-  llama_or_mistral_ckpt.save_weights_to_checkpoint(
+  save_weights_to_checkpoint(
       args.maxtext_model_path, jax_weights, args.simulated_cpu_devices_count, args.use_ocdbt, args.use_zarr3
   )
   max_logging.log("Checkpoint saved successfully.")

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/convert_qwen3_next_unscanned.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/convert_qwen3_next_unscanned.py
@@ -38,8 +38,8 @@ import torch
 from tqdm import tqdm
 from typing import Any, Dict
 
-from maxtext.checkpoint_conversion.standalone_scripts.llama_or_mistral_ckpt import save_weights_to_checkpoint
 from maxtext.checkpoint_conversion.standalone_scripts.convert_qwen3_next_scanned import MODEL_PARAMS_DICT
+from maxtext.checkpoint_conversion.utils.utils import save_weights_to_checkpoint
 from maxtext.inference.inference_utils import str2bool
 from maxtext.utils import max_logging
 

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/llama4_ckpt_unscanned.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/llama4_ckpt_unscanned.py
@@ -55,7 +55,8 @@ from safetensors import safe_open
 import torch
 from tqdm import tqdm
 
-from maxtext.checkpoint_conversion.standalone_scripts.llama_or_mistral_ckpt import save_weights_to_checkpoint, MODEL_PARAMS_DICT
+from maxtext.checkpoint_conversion.standalone_scripts.llama_or_mistral_ckpt import MODEL_PARAMS_DICT
+from maxtext.checkpoint_conversion.utils.utils import save_weights_to_checkpoint
 from maxtext.inference.inference_utils import str2bool
 from maxtext.utils import max_logging
 

--- a/src/maxtext/checkpoint_conversion/standalone_scripts/llama_or_mistral_ckpt.py
+++ b/src/maxtext/checkpoint_conversion/standalone_scripts/llama_or_mistral_ckpt.py
@@ -48,7 +48,6 @@ import ml_dtypes
 import psutil
 
 from tqdm import tqdm
-import time
 
 import numpy as np
 
@@ -56,13 +55,8 @@ os.environ["JAX_PLATFORMS"] = "cpu"
 
 import torch
 
-import jax
-from jax import tree
-
-from flax.training import train_state
-
+from maxtext.checkpoint_conversion.utils.utils import save_weights_to_checkpoint
 from maxtext.inference.inference_utils import str2bool
-from maxtext.common import checkpointing
 from maxtext.utils import gcs_utils
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
@@ -1629,150 +1623,6 @@ def convert_to_jax_weights(base_model_path: str, model_size: str, huggingface_ck
     return _convert_huggingface_to_jax_weights(base_model_path, model_size, model_params, mem_info)
 
   return _convert_pytorch_to_jax_weights(base_model_path, model_size, model_params, mem_info)
-
-
-def shard_checkpoint(jax_weights, device_count, mem_info):
-  """Shards the checkpoint weights across the simulated devices.
-
-  Args:
-    jax_weights: Pytree of model weights (numpy arrays).
-    device_count: The number of simulated devices.
-    mem_info: Process object to track memory usage.
-
-  Returns:
-    Pytree of sharded JAX arrays.
-  """
-  # Setup mesh & sharding specs
-  if len(jax.devices()) != device_count:
-    max_logging.log(
-        "WARNING: hardware/simulated device mismatch. "
-        f"Actual JAX devices: {len(jax.devices())}, Requested count: {device_count}."
-    )
-  max_logging.log(f"Shard weights across {len(jax.devices())} devices")
-  max_logging.log("Note: Axis 0 sharding is the default and will not be logged individually.")
-  # Pre-define sharding specs
-  mesh = jax.sharding.Mesh(jax.devices(), "checkpoint_sharding_axis")
-  # No sharding (replicated specifically for 0D scalars)
-  s0 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
-  # Sharding along axis 0
-  s1 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec("checkpoint_sharding_axis"))
-  # Sharding along axis 1
-  s2 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None, "checkpoint_sharding_axis"))
-  # No sharding (replicated)
-  s3 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None))
-
-  def checkpoint_device_put(arr):
-    """Determines correct sharding spec based on shape and shards the input array.
-
-    Args:
-      arr: A numpy array (or jax array).
-
-    Returns:
-      A sharded jax array.
-    """
-    if not isinstance(arr, (np.ndarray, jax.Array)):
-      # materialize lazy tensor
-      arr = np.array(arr)
-
-    if len(arr.shape) == 0:
-      max_logging.log("0D scalar detected, replicating")
-      return jax.device_put(arr, device=s0)
-    elif arr.shape[0] % device_count == 0:
-      # Sharding axis 0: Omit log for brevity per the summary log above.
-      return jax.device_put(arr, device=s1)
-    elif len(arr.shape) > 1 and arr.shape[1] % device_count == 0:
-      max_logging.log(f"Sharding axis 1. Tensor shape {arr.shape}")
-      return jax.device_put(arr, device=s2)
-    else:
-      max_logging.log(f"Not sharding. Tensor shape {arr.shape}")
-      return jax.device_put(arr, device=s3)
-
-  # Weight sharding
-  start = time.time()
-  # convert all weights to jax.numpy with sharding if applicable
-  jax_weights_flat, jax_weights_struct = tree.flatten(jax_weights)
-  del jax_weights
-  gc.collect()
-
-  jax_weights_new = []
-  jax_weights_flat.reverse()
-  num_weights = len(jax_weights_flat)
-  for _ in tqdm(range(num_weights)):
-    jax_weight = jax_weights_flat.pop()
-    jax_weights_new.append(checkpoint_device_put(jax_weight))
-    del jax_weight
-    gc.collect()
-    logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
-
-  jax_weights = tree.unflatten(jax_weights_struct, jax_weights_new)
-  max_logging.log(f"Elapse for checkpoint sharding: {(time.time() - start) / 60:.2f} min")
-
-  return jax_weights
-
-
-def save_weights_to_checkpoint(
-    maxtext_model_path: str,
-    jax_weights: dict,
-    device_count: int,
-    use_ocdbt: bool,
-    use_zarr3: bool,
-):
-  """Saves model weights to a MaxText-compatible checkpoint with optional sharding.
-
-  This function handles the conversion of NumPy weights into sharded JAX arrays
-  across a specified number of simulated devices. If the device count is 1,
-  the sharding and JAX conversion steps are skipped.
-
-  Args:
-      maxtext_model_path: The destination directory or URI for the MaxText checkpoint.
-      jax_weights: A dictionary mapping parameter names to weight arrays (typically NumPy).
-      device_count: The number of simulated devices to shard across. If 1, weights
-          are saved in their original format.
-      use_ocdbt: If True, enables the Optimized Checkpoint Database with Transactions
-          (OCDBT) format for improved metadata handling.
-      use_zarr3: If True, uses the Zarr3 storage format for the underlying array data.
-  """
-  mem_info = psutil.Process()
-  logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
-  gc.collect()
-
-  # Weight sharding
-  if device_count > 1:
-    jax_weights = shard_checkpoint(jax_weights, device_count, mem_info)
-  else:
-    # If number of simulated devices is 1, SKIP sharding and SKIP jax conversion.
-    max_logging.log("Single device: Skip sharding")
-
-  # Save checkpoint
-  start = time.time()
-  # dummy configs for the checkpoint_manager
-  step_number_to_save_new_ckpt = 0
-  enable_checkpointing = True
-  async_checkpointing = False
-  save_interval_steps = 1
-
-  checkpoint_manager = checkpointing.create_orbax_checkpoint_manager(
-      maxtext_model_path,
-      enable_checkpointing,
-      async_checkpointing,
-      save_interval_steps,
-      use_ocdbt=use_ocdbt,
-      use_zarr3=use_zarr3,
-  )
-  if checkpoint_manager is None:
-    raise RuntimeError("Failed to create Orbax checkpoint manager.")
-
-  state_new = train_state.TrainState(
-      step=step_number_to_save_new_ckpt, apply_fn=None, params={"params": jax_weights}, tx=None, opt_state={}  # type: ignore
-  )
-
-  logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
-  if checkpointing.save_checkpoint(checkpoint_manager, step_number_to_save_new_ckpt, state_new):
-    max_logging.log(f"saved a checkpoint at step {step_number_to_save_new_ckpt}")
-  # Upon preemption, exit when and only when all ongoing saves are complete.
-  checkpoint_manager.wait_until_finished()
-
-  max_logging.log(f"Elapse for checkpoint save: {(time.time() - start) / 60:.2f} min")
 
 
 def list_folders_pathlib(directory: str):

--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -66,10 +66,9 @@ import jax
 from maxtext.configs import pyconfig
 from maxtext.configs.types import DType
 from maxtext.common.common_types import MODEL_MODE_TRAIN
-from maxtext.checkpoint_conversion.standalone_scripts.llama_or_mistral_ckpt import save_weights_to_checkpoint
 from maxtext.checkpoint_conversion.utils.hf_model_configs import HF_MODEL_CONFIGS
 from maxtext.checkpoint_conversion.utils.param_mapping import HOOK_FNS, PARAM_MAPPING
-from maxtext.checkpoint_conversion.utils.utils import MemoryMonitorTqdm, apply_hook_fns, load_hf_dict_from_transformers, load_hf_dict_from_safetensors, print_peak_memory, print_ram_usage, validate_and_filter_param_map_keys
+from maxtext.checkpoint_conversion.utils.utils import MemoryMonitorTqdm, apply_hook_fns, load_hf_dict_from_transformers, load_hf_dict_from_safetensors, print_peak_memory, print_ram_usage, save_weights_to_checkpoint, validate_and_filter_param_map_keys
 from maxtext.inference.inference_utils import str2bool
 from maxtext.layers import quantizations
 from maxtext.models import models

--- a/src/maxtext/checkpoint_conversion/utils/utils.py
+++ b/src/maxtext/checkpoint_conversion/utils/utils.py
@@ -15,7 +15,9 @@
 """Checkpoint conversion utility functions."""
 
 import contextlib
+import gc
 import io
+import logging
 import os
 import tempfile
 import time
@@ -30,6 +32,7 @@ import pathlib
 from etils import epath
 
 import jax
+from jax import tree
 from jax.experimental import multihost_utils
 from jaxtyping import Array
 
@@ -45,6 +48,8 @@ from huggingface_hub import HfApi, repo_exists, snapshot_download
 from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 from transformers import AutoModelForCausalLM
 
+from flax.training import train_state
+from maxtext.common import checkpointing
 from maxtext.utils import max_logging
 import orbax.checkpoint as ocp
 
@@ -1016,3 +1021,147 @@ def load_hf_dict_from_safetensors(model_id_or_path, token, revision, framework="
       for key in f.keys():
         hf_state_dict[key] = f.get_tensor(key)
   return hf_state_dict
+
+
+def shard_jax_weights(jax_weights, device_count, mem_info):
+  """Shards the checkpoint weights across the simulated devices.
+
+  Args:
+    jax_weights: Pytree of model weights (numpy arrays).
+    device_count: The number of simulated devices.
+    mem_info: Process object to track memory usage.
+
+  Returns:
+    Pytree of sharded JAX arrays.
+  """
+  # Setup mesh & sharding specs
+  if len(jax.devices()) != device_count:
+    max_logging.log(
+        "WARNING: hardware/simulated device mismatch. "
+        f"Actual JAX devices: {len(jax.devices())}, Requested count: {device_count}."
+    )
+  max_logging.log(f"Shard weights across {len(jax.devices())} devices")
+  max_logging.log("Note: Axis 0 sharding is the default and will not be logged individually.")
+  # Pre-define sharding specs
+  mesh = jax.sharding.Mesh(jax.devices(), "checkpoint_sharding_axis")
+  # No sharding (replicated specifically for 0D scalars)
+  s0 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+  # Sharding along axis 0
+  s1 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec("checkpoint_sharding_axis"))
+  # Sharding along axis 1
+  s2 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None, "checkpoint_sharding_axis"))
+  # No sharding (replicated)
+  s3 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None))
+
+  def checkpoint_device_put(arr):
+    """Determines correct sharding spec based on shape and shards the input array.
+
+    Args:
+      arr: A numpy array (or jax array).
+
+    Returns:
+      A sharded jax array.
+    """
+    if not isinstance(arr, (np.ndarray, jax.Array)):
+      # materialize lazy tensor
+      arr = np.array(arr)
+
+    if len(arr.shape) == 0:
+      max_logging.log("0D scalar detected, replicating")
+      return jax.device_put(arr, device=s0)
+    elif arr.shape[0] % device_count == 0:
+      # Sharding axis 0: Omit log for brevity per the summary log above.
+      return jax.device_put(arr, device=s1)
+    elif len(arr.shape) > 1 and arr.shape[1] % device_count == 0:
+      max_logging.log(f"Sharding axis 1. Tensor shape {arr.shape}")
+      return jax.device_put(arr, device=s2)
+    else:
+      max_logging.log(f"Not sharding. Tensor shape {arr.shape}")
+      return jax.device_put(arr, device=s3)
+
+  # Weight sharding
+  start = time.time()
+  # convert all weights to jax.numpy with sharding if applicable
+  jax_weights_flat, jax_weights_struct = tree.flatten(jax_weights)
+  del jax_weights
+  gc.collect()
+
+  jax_weights_new = []
+  jax_weights_flat.reverse()
+  num_weights = len(jax_weights_flat)
+  for _ in tqdm(range(num_weights)):
+    jax_weight = jax_weights_flat.pop()
+    jax_weights_new.append(checkpoint_device_put(jax_weight))
+    del jax_weight
+    gc.collect()
+    logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
+
+  jax_weights = tree.unflatten(jax_weights_struct, jax_weights_new)
+  max_logging.log(f"Elapse for checkpoint sharding: {(time.time() - start) / 60:.2f} min")
+
+  return jax_weights
+
+
+def save_weights_to_checkpoint(
+    maxtext_model_path: str,
+    jax_weights: dict,
+    device_count: int,
+    use_ocdbt: bool,
+    use_zarr3: bool,
+):
+  """Saves model weights to a MaxText-compatible checkpoint with optional sharding.
+
+  This function handles the conversion of NumPy weights into sharded JAX arrays
+  across a specified number of simulated devices. If the device count is 1,
+  the sharding and JAX conversion steps are skipped.
+
+  Args:
+      maxtext_model_path: The destination directory or URI for the MaxText checkpoint.
+      jax_weights: A dictionary mapping parameter names to weight arrays (typically NumPy).
+      device_count: The number of simulated devices to shard across. If 1, weights
+          are saved in their original format.
+      use_ocdbt: If True, enables the Optimized Checkpoint Database with Transactions
+          (OCDBT) format for improved metadata handling.
+      use_zarr3: If True, uses the Zarr3 storage format for the underlying array data.
+  """
+  mem_info = psutil.Process()
+  logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
+  gc.collect()
+
+  # Weight sharding
+  if device_count > 1:
+    jax_weights = shard_jax_weights(jax_weights, device_count, mem_info)
+  else:
+    # If number of simulated devices is 1, SKIP sharding and SKIP jax conversion.
+    max_logging.log("Single device: Skip sharding")
+
+  # Save checkpoint
+  start = time.time()
+  # dummy configs for the checkpoint_manager
+  step_number_to_save_new_ckpt = 0
+  enable_checkpointing = True
+  async_checkpointing = False
+  save_interval_steps = 1
+
+  checkpoint_manager = checkpointing.create_orbax_checkpoint_manager(
+      maxtext_model_path,
+      enable_checkpointing,
+      async_checkpointing,
+      save_interval_steps,
+      use_ocdbt=use_ocdbt,
+      use_zarr3=use_zarr3,
+  )
+  if checkpoint_manager is None:
+    raise RuntimeError("Failed to create Orbax checkpoint manager.")
+
+  state_new = train_state.TrainState(
+      step=step_number_to_save_new_ckpt, apply_fn=None, params={"params": jax_weights}, tx=None, opt_state={}  # type: ignore
+  )
+
+  logging.debug("Memory usage: %f GB", mem_info.memory_info().rss / (1024**3))
+  if checkpointing.save_checkpoint(checkpoint_manager, step_number_to_save_new_ckpt, state_new):
+    max_logging.log(f"saved a checkpoint at step {step_number_to_save_new_ckpt}")
+  # Upon preemption, exit when and only when all ongoing saves are complete.
+  checkpoint_manager.wait_until_finished()
+
+  max_logging.log(f"Elapse for checkpoint save: {(time.time() - start) / 60:.2f} min")


### PR DESCRIPTION
# Description

Move `save_weights_to_checkpoint` and rename/move `shard_checkpoint -> shard_jax_weights` in `checkpoint_conversion.utils.utils.py`, and update all affected dependencies ([10 files](https://screenshot.googleplex.com/BYCMGeGsHz48z68) have all been covered).

Now these functions can be easily shared among other scripts.

No any other changes rather than rename/move ([diff](https://diff.googleplex.com/#key=wnFCY89WDvF2))

# Tests

```
# to maxtext conversion
python -m maxtext.checkpoint_conversion.to_maxtext src/maxtext/configs/base.yml model_name=qwen3-4b base_output_directory=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-4b/scanned/2026-05-12 scan_layers=true hf_access_token=<your_token> weight_dtype=bfloat16 hardware=cpu skip_jax_distributed_system=True checkpoint_storage_use_ocdbt=False checkpoint_storage_use_zarr3=False --eager_load_method=safetensors

# logits check
python -m tests.utils.forward_pass_logit_checker maxtext/configs/base.yml run_name=ht_test model_name=qwen3-4b tokenizer_path=Qwen/Qwen3-4B load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-4b/scanned/2026-05-14/0/items scan_layers=True max_prefill_predict_length=4 ici_tensor_parallelism=4 hf_access_token=<your_token> --run_hf_model=True --hf_model_path=Qwen/Qwen3-4B --max_kl_div=0.015
```

[Logs](https://paste.googleplex.com/5569316285186048)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
