### PR TITLE
Clean up Python files: pyink formatting and pylint fixes

### DIFF
--- a/benchmarks/recipes/parser_utils.py
+++ b/benchmarks/recipes/parser_utils.py
@@ -156,7 +156,7 @@ def add_arguments(parser: argparse.ArgumentParser):
       action="store_true",
       default=False,
       help="Skip xpk health checks and system dependency validation during workload execution",
-)
+  )
 
   # Other configurations
   parser.add_argument("--xpk_path", type=str, default="~/xpk", help="Path to xpk.")

--- a/src/maxtext/common/gcp_workload_monitor.py
+++ b/src/maxtext/common/gcp_workload_monitor.py
@@ -131,8 +131,8 @@ class GCPWorkloadMonitor:
       # Send data to Google Cloud Monitoring
       if self.client is not None:
         self.client.create_time_series(
-          request={"name": f"projects/{self.project_id}", "time_series": [series]},
-          timeout=30,
+            request={"name": f"projects/{self.project_id}", "time_series": [series]},
+            timeout=30,
         )
         max_logging.log("Heartbeat metric successfully sent to GCP.")
     except GoogleAPIError as e:
@@ -174,8 +174,8 @@ class GCPWorkloadMonitor:
       # Send data to Google Cloud Monitoring
       if self.client is not None:
         self.client.create_time_series(
-          request={"name": f"projects/{self.project_id}", "time_series": [series]},
-          timeout=30,
+            request={"name": f"projects/{self.project_id}", "time_series": [series]},
+            timeout=30,
         )
         max_logging.log("Performance metric successfully sent to GCP.")
     except GoogleAPIError as e:

--- a/src/maxtext/eval/datasets/base.py
+++ b/src/maxtext/eval/datasets/base.py
@@ -40,6 +40,7 @@ class SampleRequest(NamedTuple):
 
 class BenchmarkDataset(abc.ABC):
   """Abstract base class for benchmark datasets."""
+
   name: str
 
   @abc.abstractmethod

--- a/src/maxtext/eval/datasets/mlperf.py
+++ b/src/maxtext/eval/datasets/mlperf.py
@@ -18,9 +18,7 @@ from __future__ import annotations
 
 from maxtext.eval.datasets.base import BenchmarkDataset, SampleRequest
 
-_SYSTEM_PROMPT = (
-    "You are a helpful assistant. Summarize the following conversation."
-)
+_SYSTEM_PROMPT = "You are a helpful assistant. Summarize the following conversation."
 
 
 class MlperfOpenOrcaDataset(BenchmarkDataset):

--- a/src/maxtext/eval/reporting/gcs_reporter.py
+++ b/src/maxtext/eval/reporting/gcs_reporter.py
@@ -23,6 +23,7 @@ from maxtext.utils.gcs_utils import upload_blob
 
 logger = logging.getLogger(__name__)
 
+
 def upload_results(local_path: str, gcs_path: str) -> None:
   """Upload local_path to gcs_path.
 

--- a/src/maxtext/eval/reporting/json_reporter.py
+++ b/src/maxtext/eval/reporting/json_reporter.py
@@ -66,9 +66,10 @@ def write_results(
 
   if results_path.startswith("gs://"):
     from maxtext.utils.gcs_utils import upload_blob  # pylint: disable=import-outside-toplevel
+
     tmp_dir = tempfile.mkdtemp(prefix="eval_results_")
     local_path = os.path.join(tmp_dir, filename)
-    with open(local_path, "w") as f:
+    with open(local_path, "w", encoding="utf-8") as f:
       json.dump(results, f, indent=2)
     gcs_dest = f"{results_path.rstrip('/')}/{filename}"
     upload_blob(gcs_dest, local_path)
@@ -76,7 +77,7 @@ def write_results(
   else:
     os.makedirs(results_path, exist_ok=True)
     local_path = os.path.join(results_path, filename)
-    with open(local_path, "w") as f:
+    with open(local_path, "w", encoding="utf-8") as f:
       json.dump(results, f, indent=2)
     logger.info("Results written to %s", local_path)
 

--- a/src/maxtext/eval/runner/common.py
+++ b/src/maxtext/eval/runner/common.py
@@ -88,6 +88,7 @@ def maybe_upload_to_gcs(output: dict, gcs_results_path: str | None) -> None:
   """Upload the results JSON to GCS if gcs_results_path is provided."""
   if gcs_results_path:
     from maxtext.eval.reporting.gcs_reporter import upload_results  # pylint: disable=import-outside-toplevel
+
     upload_results(output["local_path"], gcs_results_path)
 
 
@@ -103,23 +104,17 @@ def add_server_args(parser: argparse.ArgumentParser) -> None:
   )
   parser.add_argument("--run_name", required=True, help="Run name/identifier.")
   parser.add_argument("--max_model_len", type=int, required=True, help="vLLM max context length.")
-  parser.add_argument(
-      "--tensor_parallel_size", type=int, default=4, help="vLLM tensor parallelism."
-  )
+  parser.add_argument("--tensor_parallel_size", type=int, default=4, help="vLLM tensor parallelism.")
   parser.add_argument("--server_host", default="localhost", help="vLLM server bind host.")
   parser.add_argument("--server_port", type=int, default=8000, help="vLLM server port.")
-  parser.add_argument(
-      "--max_num_batched_tokens", type=int, help="vLLM tokens per scheduler step."
-  )
+  parser.add_argument("--max_num_batched_tokens", type=int, help="vLLM tokens per scheduler step.")
   parser.add_argument("--max_num_seqs", type=int, help="vLLM max concurrent sequences.")
   parser.add_argument("--hf_mode", action="store_true", help="HF safetensors mode.")
   parser.add_argument(
       "--expert_parallel_size",
       type=int,
       default=0,
-      help=(
-          "Chips allocated to the expert mesh axis (EP). "
-      ),
+      help=("Chips allocated to the expert mesh axis (EP). "),
   )
   parser.add_argument(
       "--data_parallel_size",
@@ -131,14 +126,10 @@ def add_server_args(parser: argparse.ArgumentParser) -> None:
       "--hbm_memory_utilization",
       type=float,
       default=0.3,
-      help=(
-          "Fraction of HBM reserved for KV cache."
-      ),
+      help=("Fraction of HBM reserved for KV cache."),
   )
   parser.add_argument("--hf_token", help="HuggingFace token for gated models.")
-  parser.add_argument(
-      "--gcs_results_path", help="Optional secondary GCS path to upload the results JSON."
-  )
+  parser.add_argument("--gcs_results_path", help="Optional secondary GCS path to upload the results JSON.")
   parser.add_argument(
       "--log_level",
       default="INFO",

--- a/src/maxtext/eval/runner/eval_runner.py
+++ b/src/maxtext/eval/runner/eval_runner.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 def _load_config(config_path: str) -> dict:
-  with open(config_path) as f:
+  with open(config_path, encoding="utf-8") as f:
     return yaml.safe_load(f) or {}
 
 
@@ -44,6 +44,7 @@ def _merge_config(base: dict, overrides: dict) -> dict:
 
 
 def _derive_from_maxtext_config(maxtext_config_path: str) -> dict:
+  """Derive config settings from a MaxText config."""
   raw = _load_config(maxtext_config_path)
   prefill_len = raw.get("max_prefill_predict_length")
   target_len = raw.get("max_target_length")
@@ -71,11 +72,8 @@ def _build_results_path(cfg: dict) -> str:
   base_output_directory = cfg.get("base_output_directory", "").rstrip("/")
   run_name = cfg.get("run_name", "")
   if not base_output_directory or not run_name:
-    raise ValueError(
-        "Cannot build eval results_path."
-    )
+    raise ValueError("Cannot build eval results_path.")
   return f"{base_output_directory}/{run_name}/eval_results"
-
 
 
 def run_eval(cfg: dict, hf_token: str | None = None) -> dict:
@@ -127,6 +125,7 @@ def run_eval(cfg: dict, hf_token: str | None = None) -> dict:
   with build_server_manager(cfg, token) as server:
     import jax as _jax  # pylint: disable=import-outside-toplevel
     from jax.experimental import multihost_utils as _multihost_utils  # pylint: disable=import-outside-toplevel
+
     is_rank0 = _jax.process_index() == 0
 
     if is_rank0:
@@ -192,6 +191,7 @@ def run_eval(cfg: dict, hf_token: str | None = None) -> dict:
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
+  """Build argument parser."""
   parser = argparse.ArgumentParser(
       description="MaxText model evaluation runner.",
       formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -251,10 +251,7 @@ def main() -> None:
       if k not in base_cfg:
         base_cfg[k] = v
 
-  cli_overrides = {
-      k: v for k, v in vars(args).items()
-      if k not in ("config", "base_config", "log_level", "hf_token")
-  }
+  cli_overrides = {k: v for k, v in vars(args).items() if k not in ("config", "base_config", "log_level", "hf_token")}
   cfg = _merge_config(base_cfg, cli_overrides)
 
   if "max_tokens" not in cfg and "max_tokens_default" in cfg:

--- a/src/maxtext/eval/runner/harness_runner.py
+++ b/src/maxtext/eval/runner/harness_runner.py
@@ -112,11 +112,9 @@ def run_harness(cfg: dict, hf_token: str | None = None) -> dict:
   backend = cfg.get("backend", "lm_eval")
   if backend == "evalchemy":
     try:
-      import evalchemy as _evalchemy  # noqa: F401  registers custom tasks with lm_eval
+      import evalchemy as _evalchemy  # pylint: disable=unused-import  # registers custom tasks with lm_eval
     except ImportError as exc:
-      raise ImportError(
-          "Install evalchemy."
-      ) from exc
+      raise ImportError("Install evalchemy.") from exc
 
   model_name = cfg["model_name"]
   hf_path = cfg["hf_path"]
@@ -128,18 +126,18 @@ def run_harness(cfg: dict, hf_token: str | None = None) -> dict:
   token = resolve_token(cfg, hf_token)
 
   lm_model_type = "local-chat-completions" if backend == "evalchemy" else "local-completions"
+  raw_results: dict = {}
 
   with build_server_manager(cfg, token) as server:
     import jax as _jax
     from jax.experimental import multihost_utils as _multihost_utils
+
     is_rank0 = _jax.process_index() == 0
 
     if is_rank0:
       warmup_server(base_url=server.base_url, model=model_name)
 
-      completions_path = (
-          "/v1/chat/completions" if backend == "evalchemy" else "/v1/completions"
-      )
+      completions_path = "/v1/chat/completions" if backend == "evalchemy" else "/v1/completions"
       model_args_parts = [
           f"model={model_name}",
           f"base_url={server.base_url}{completions_path}",
@@ -195,6 +193,7 @@ def run_harness(cfg: dict, hf_token: str | None = None) -> dict:
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
+  """Build argument parser."""
   parser = argparse.ArgumentParser(
       description="MaxText lm-eval / evalchemy runner.",
       formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -219,22 +218,17 @@ def _build_arg_parser() -> argparse.ArgumentParser:
           "Any task registered in lm-eval or evalchemy is accepted (e.g. gsm8k, mmlu, gpqa_diamond, ifeval, math_500)."
       ),
   )
-  parser.add_argument(
-      "--num_fewshot", type=int, default=0, help="Few-shot examples per task."
-  )
-  parser.add_argument(
-      "--num_samples", type=int, help="Limit samples per task (None = full dataset)."
-  )
+  parser.add_argument("--num_fewshot", type=int, default=0, help="Few-shot examples per task.")
+  parser.add_argument("--num_samples", type=int, help="Limit samples per task (None = full dataset).")
   return parser
 
 
 def main() -> None:
-  import logging as _logging  # pylint: disable=import-outside-toplevel
   parser = _build_arg_parser()
   args = parser.parse_args()
 
-  _logging.basicConfig(
-      level=getattr(_logging, args.log_level),
+  logging.basicConfig(
+      level=getattr(logging, args.log_level),
       format="%(asctime)s %(levelname)s %(name)s: %(message)s",
   )
 

--- a/src/maxtext/eval/runner/run.py
+++ b/src/maxtext/eval/runner/run.py
@@ -86,14 +86,17 @@ def main() -> None:
 
   if pre_args.runner == "eval":
     from maxtext.eval.runner.eval_runner import main as _main  # pylint: disable=import-outside-toplevel
+
     _main()
   elif pre_args.runner == "lm_eval":
     from maxtext.eval.runner.harness_runner import main as _main  # pylint: disable=import-outside-toplevel
+
     _main()
   else:  # evalchemy
     if "--backend" not in remaining:
       sys.argv += ["--backend", "evalchemy"]
     from maxtext.eval.runner.harness_runner import main as _main  # pylint: disable=import-outside-toplevel
+
     _main()
 
 

--- a/src/maxtext/eval/runner/server_manager.py
+++ b/src/maxtext/eval/runner/server_manager.py
@@ -29,10 +29,12 @@ logger = logging.getLogger(__name__)
 
 _HEALTH_ENDPOINT = "/health"
 
+
 def _build_app(llm: Any) -> Any:
   """Return a FastAPI app that wraps an in-process vLLM LLM instance."""
   import fastapi  # pylint: disable=import-outside-toplevel
   from vllm.sampling_params import SamplingParams  # pylint: disable=import-outside-toplevel
+
   globals()["fastapi"] = fastapi
 
   app = fastapi.FastAPI()
@@ -110,12 +112,14 @@ def _build_app(llm: Any) -> Any:
         }
 
       text_out = (prompts[idx] + gen.text) if echo else gen.text
-      choices.append({
-          "text": text_out,
-          "index": idx,
-          "logprobs": logprobs_payload,
-          "finish_reason": gen.finish_reason or "stop",
-      })
+      choices.append(
+          {
+              "text": text_out,
+              "index": idx,
+              "logprobs": logprobs_payload,
+              "finish_reason": gen.finish_reason or "stop",
+          }
+      )
 
     return {
         "id": f"cmpl-{uuid.uuid4().hex}",
@@ -164,12 +168,14 @@ def _build_app(llm: Any) -> Any:
         "object": "chat.completion",
         "created": int(time.time()),
         "model": model_name,
-        "choices": [{
-            "index": 0,
-            "message": {"role": "assistant", "content": gen.text},
-            "finish_reason": gen.finish_reason or "stop",
-            "logprobs": None,
-        }],
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": gen.text},
+                "finish_reason": gen.finish_reason or "stop",
+                "logprobs": None,
+            }
+        ],
         "usage": {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
@@ -261,6 +267,7 @@ class VllmServerManager:
     os.environ.setdefault("NEW_MODEL_DESIGN", "1")
     os.environ.setdefault("SKIP_JAX_PRECOMPILE", "1")
     from vllm import LLM  # pylint: disable=import-outside-toplevel
+
     if self.env:
       os.environ.update(self.env)
 
@@ -301,15 +308,9 @@ class VllmServerManager:
 
     if self.additional_vllm_kwargs:
       for _k, _v in self.additional_vllm_kwargs.items():
-        if (
-            _k == "additional_config"
-            and isinstance(_v, dict)
-            and isinstance(vllm_kwargs.get("additional_config"), dict)
-        ):
+        if _k == "additional_config" and isinstance(_v, dict) and isinstance(vllm_kwargs.get("additional_config"), dict):
           for _sub_k, _sub_v in _v.items():
-            if isinstance(_sub_v, dict) and isinstance(
-                vllm_kwargs["additional_config"].get(_sub_k), dict
-            ):
+            if isinstance(_sub_v, dict) and isinstance(vllm_kwargs["additional_config"].get(_sub_k), dict):
               vllm_kwargs["additional_config"][_sub_k].update(_sub_v)
             else:
               vllm_kwargs["additional_config"][_sub_k] = _sub_v
@@ -326,6 +327,7 @@ class VllmServerManager:
     self._llm = LLM(**vllm_kwargs)
 
     import jax as _jax  # pylint: disable=import-outside-toplevel
+
     logger.info("Rank %d: vLLM LLM ready.", _jax.process_index())
 
     if _jax.process_index() == 0:
@@ -349,6 +351,7 @@ class VllmServerManager:
       self._wait_until_healthy()
 
   def _wait_until_healthy(self) -> None:
+    """Wait until the HTTP server returns 200 OK on /health."""
     deadline = time.time() + self.startup_timeout
     health_url = f"{self.base_url}{_HEALTH_ENDPOINT}"
     while time.time() < deadline:
@@ -362,9 +365,7 @@ class VllmServerManager:
       if self._server_thread is not None and not self._server_thread.is_alive():
         raise RuntimeError("vLLM HTTP server thread died before becoming healthy.")
       time.sleep(2)
-    raise TimeoutError(
-        f"vLLM HTTP server did not become healthy within {self.startup_timeout}s."
-    )
+    raise TimeoutError(f"vLLM HTTP server did not become healthy within {self.startup_timeout}s.")
 
   def stop(self) -> None:
     """Stop the HTTP server and release the LLM."""

--- a/src/maxtext/eval/scoring/registry.py
+++ b/src/maxtext/eval/scoring/registry.py
@@ -41,10 +41,7 @@ def get_scorer(benchmark_name: str) -> Callable[..., dict]:
   """
   key = benchmark_name.lower()
   if key not in SCORER_REGISTRY:
-    raise KeyError(
-        f"No scorer registered for benchmark '{benchmark_name}'. "
-        f"Available: {sorted(SCORER_REGISTRY)}. "
-    )
+    raise KeyError(f"No scorer registered for benchmark '{benchmark_name}'. " f"Available: {sorted(SCORER_REGISTRY)}. ")
   return SCORER_REGISTRY[key]
 
 

--- a/src/maxtext/eval/scoring/rouge_scorer.py
+++ b/src/maxtext/eval/scoring/rouge_scorer.py
@@ -43,9 +43,7 @@ def score_batch(
     ValueError: If responses and references have different lengths.
   """
   if len(responses) != len(references):
-    raise ValueError(
-        f"Length mismatch: {len(responses)} responses vs {len(references)} references."
-    )
+    raise ValueError(f"Length mismatch: {len(responses)} responses vs {len(references)} references.")
 
   import evaluate  # pylint: disable=import-outside-toplevel
 

--- a/src/maxtext/inference/maxengine/maxengine_config.py
+++ b/src/maxtext/inference/maxengine/maxengine_config.py
@@ -24,7 +24,6 @@ from maxtext.inference.maxengine import maxengine
 config_lib, engine_api, _token_utils, _tokenizer_api, _token_params_ns = jetstream()
 
 
-
 # TODO: merge it with the above create_maxengine().
 def create_exp_maxengine(devices: Any, config: Any):
   if is_decoupled():

--- a/src/maxtext/kernels/attention/jax_flash_attention.py
+++ b/src/maxtext/kernels/attention/jax_flash_attention.py
@@ -77,13 +77,15 @@ def flash_attention_block_masked(
   v_head_dim_size = v.shape[-1]
   data_type = q.dtype
   q_groups = num_q_heads // num_kv_heads
-  q = q.reshape((
-      batch_size,
-      num_kv_heads,
-      q_groups,
-      q_seq_len,
-      qk_head_dim_size,
-  ))
+  q = q.reshape(
+      (
+          batch_size,
+          num_kv_heads,
+          q_groups,
+          q_seq_len,
+          qk_head_dim_size,
+      )
+  )
 
   # Calculate the number of key/value and query blocks.
   num_kv_blocks = kv_seq_len // block_kv
@@ -91,24 +93,18 @@ def flash_attention_block_masked(
 
   # Before applying the segment mask, we need to broadcast the mask in batch
   # dimension since we have same logic for all batches.
-  mask_full = jnp.broadcast_to(
-      mask[None, :, :], (batch_size, q_seq_len, kv_seq_len)
-  )
+  mask_full = jnp.broadcast_to(mask[None, :, :], (batch_size, q_seq_len, kv_seq_len))
 
   if segment_ids is not None:
     segment_ids_q = segment_ids.q[:, :, None]
     segment_ids_kv = segment_ids.kv[:, None, :]
     mask_full = jnp.logical_and(mask_full, segment_ids_q == segment_ids_kv)
-  mask_blocked = jax.jit(mask_blocker, static_argnums=[1, 2])(
-      mask_full, block_q, block_kv
-  )
+  mask_blocked = jax.jit(mask_blocker, static_argnums=[1, 2])(mask_full, block_q, block_kv)
 
   # Initialize `l` (logsumexp) and `m` (max_logits) for the online softmax.
   # `l` is initialized to 0 since no blocks have been processed yet and the sum
   # is 0.
-  l = jnp.zeros(
-      (batch_size, num_kv_heads, q_groups, q_seq_len), dtype=data_type
-  )
+  l = jnp.zeros((batch_size, num_kv_heads, q_groups, q_seq_len), dtype=data_type)
   # `m` is initialized to the mask_value so that the first block's maximum logit
   # correctly becomes the running maximum.
   m = jnp.full(
@@ -144,15 +140,9 @@ def flash_attention_block_masked(
       # Calculates the attention computation (Q@K.T)@V with online softmax for
       # the current query and key/value blocks.
       def compute_attention_block(output, l, m):
-        output_i_slice = jax.lax.dynamic_slice_in_dim(
-            output, i * block_q, block_q, axis=-2
-        )
-        l_i_slice = jax.lax.dynamic_slice_in_dim(
-            l, i * block_q, block_q, axis=-1
-        )
-        m_i_slice = jax.lax.dynamic_slice_in_dim(
-            m, i * block_q, block_q, axis=-1
-        )
+        output_i_slice = jax.lax.dynamic_slice_in_dim(output, i * block_q, block_q, axis=-2)
+        l_i_slice = jax.lax.dynamic_slice_in_dim(l, i * block_q, block_q, axis=-1)
+        m_i_slice = jax.lax.dynamic_slice_in_dim(m, i * block_q, block_q, axis=-1)
         s_i_j = jnp.einsum(
             "bxhqc,bxkc->bxhqk",
             q_slice,
@@ -183,9 +173,9 @@ def flash_attention_block_masked(
         l_i_new = m_i_difference * l_i_slice + m_i_j_difference * l_i_j
 
         divider = l_i_new[..., None]
-        numerator = l_i_slice[..., None] * m_i_difference[
+        numerator = l_i_slice[..., None] * m_i_difference[..., None] * output_i_slice + m_i_j_difference[
             ..., None
-        ] * output_i_slice + m_i_j_difference[..., None] * jnp.einsum(
+        ] * jnp.einsum(
             "bxhqk,bxkc->bxhqc",
             p_i_j,
             v_j_slice,
@@ -193,15 +183,9 @@ def flash_attention_block_masked(
         )
 
         output_i_slice_new = numerator / divider
-        output = jax.lax.dynamic_update_index_in_dim(
-            output, output_i_slice_new, i * block_q, axis=-2
-        )
-        l = jax.lax.dynamic_update_index_in_dim(
-            l, l_i_new, i * block_q, axis=-1
-        )
-        m = jax.lax.dynamic_update_index_in_dim(
-            m, m_i_new, i * block_q, axis=-1
-        )
+        output = jax.lax.dynamic_update_index_in_dim(output, output_i_slice_new, i * block_q, axis=-2)
+        l = jax.lax.dynamic_update_index_in_dim(l, l_i_new, i * block_q, axis=-1)
+        m = jax.lax.dynamic_update_index_in_dim(m, m_i_new, i * block_q, axis=-1)
         return output, l, m
 
       def identity(output, l, m):
@@ -210,9 +194,7 @@ def flash_attention_block_masked(
         return output, l, m
 
       batch_size = mask_blocked.shape[0]
-      mask_i_j_slice = jax.lax.dynamic_slice(
-          mask_blocked, (0, i, j), (batch_size, 1, 1)
-      )
+      mask_i_j_slice = jax.lax.dynamic_slice(mask_blocked, (0, i, j), (batch_size, 1, 1))
       # The compute_attention_block should be executed if at least one element
       # in the slice is non-zero, meaning at least one batch requires work for
       # this block.
@@ -227,15 +209,11 @@ def flash_attention_block_masked(
 
       return output, l, m
 
-    output, l, m = jax.lax.fori_loop(
-        0, num_q_blocks, inner_loop_body, (output, l, m), unroll=True
-    )
+    output, l, m = jax.lax.fori_loop(0, num_q_blocks, inner_loop_body, (output, l, m), unroll=True)
 
     return (output, l, m)
 
-  output, l, m = jax.lax.fori_loop(
-      0, num_kv_blocks, outer_loop_body, (output, l, m), unroll=True
-  )
+  output, l, m = jax.lax.fori_loop(0, num_kv_blocks, outer_loop_body, (output, l, m), unroll=True)
 
   # Reshape the output to drop the size one dimension at index 2,
   # which corresponds to `num_q_heads // num_kv_heads` when
@@ -268,17 +246,11 @@ def mask_blocker(mask: jnp.ndarray, block_q: int, block_kv: int) -> jnp.ndarray:
   batch_size, q_seq_len, kv_seq_len = mask.shape
 
   if q_seq_len % block_q != 0:
-    raise ValueError(
-        f"q_seq_len {q_seq_len} must be divisible by block_q {block_q}"
-    )
+    raise ValueError(f"q_seq_len {q_seq_len} must be divisible by block_q {block_q}")
   if kv_seq_len % block_kv != 0:
-    raise ValueError(
-        f"kv_seq_len {kv_seq_len} must be divisible by block_kv {block_kv}"
-    )
+    raise ValueError(f"kv_seq_len {kv_seq_len} must be divisible by block_kv {block_kv}")
   q_blocks = q_seq_len // block_q
   kv_blocks = kv_seq_len // block_kv
 
-  blocked_mask = mask.reshape(
-      batch_size, q_blocks, block_q, kv_blocks, block_kv
-  )
+  blocked_mask = mask.reshape(batch_size, q_blocks, block_q, kv_blocks, block_kv)
   return jnp.count_nonzero(blocked_mask, axis=(2, 4)).astype(jnp.int32)

--- a/tests/assets/logits_generation/generate_sft_golden_data.py
+++ b/tests/assets/logits_generation/generate_sft_golden_data.py
@@ -40,7 +40,7 @@ from trl import SFTConfig, SFTTrainer
 
 from maxtext.configs import pyconfig
 from maxtext.utils.globals import MAXTEXT_PKG_DIR, MAXTEXT_TEST_ASSETS_ROOT, MAXTEXT_ASSETS_ROOT
-from tests.integration.sft_trainer_correctness_test import get_maxtext_logits, get_token_log_probs, prepare_maxtext_inputs
+from tests.post_training.integration.sft_trainer_correctness_test import get_maxtext_logits, get_token_log_probs, prepare_maxtext_inputs
 
 
 DATA = {

--- a/tests/unit/eval/test_build_app.py
+++ b/tests/unit/eval/test_build_app.py
@@ -77,8 +77,8 @@ class TestBuildApp(unittest.TestCase):
     self._vllm_patcher.start()
     self._sp_patcher.start()
 
-    from maxtext.eval.runner.server_manager import _build_app
-    from starlette.testclient import TestClient
+    from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
+    from starlette.testclient import TestClient  # pylint: disable=import-outside-toplevel
 
     self.app = _build_app(self.mock_llm)
     self.client = TestClient(self.app)
@@ -111,8 +111,8 @@ class TestBuildApp(unittest.TestCase):
     ]
     mock_llm.get_tokenizer.return_value = self.mock_llm.get_tokenizer()
 
-    from maxtext.eval.runner.server_manager import _build_app
-    from starlette.testclient import TestClient
+    from maxtext.eval.runner.server_manager import _build_app  # pylint: disable=import-outside-toplevel
+    from starlette.testclient import TestClient  # pylint: disable=import-outside-toplevel
 
     app = _build_app(mock_llm)
     client = TestClient(app)

--- a/tests/unit/eval/test_eval_runner.py
+++ b/tests/unit/eval/test_eval_runner.py
@@ -27,6 +27,7 @@ from maxtext.eval.runner.eval_runner import (
 
 
 class TestMergeConfig(unittest.TestCase):
+  """Tests for _merge_config."""
 
   def test_override_takes_precedence(self):
     base = {"concurrency": 64, "temperature": 0.0}
@@ -52,6 +53,7 @@ class TestMergeConfig(unittest.TestCase):
 
 
 class TestBuildResultsPath(unittest.TestCase):
+  """Tests for _build_results_path."""
 
   def test_standard_path(self):
     cfg = {"base_output_directory": "gs://bucket/", "run_name": "run1"}
@@ -82,12 +84,12 @@ class TestBuildResultsPath(unittest.TestCase):
 
 
 class TestDeriveFromMaxtextConfig(unittest.TestCase):
+  """Tests for _derive_from_maxtext_config."""
 
   def _write_yaml(self, content: str) -> str:
-    f = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False)
-    f.write(textwrap.dedent(content))
-    f.close()
-    return f.name
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
+      f.write(textwrap.dedent(content))
+      return f.name
 
   def test_derives_max_model_len(self):
     path = self._write_yaml("max_target_length: 1024\n")
@@ -96,9 +98,7 @@ class TestDeriveFromMaxtextConfig(unittest.TestCase):
     os.unlink(path)
 
   def test_derives_max_tokens_default(self):
-    path = self._write_yaml(
-        "max_target_length: 1024\nmax_prefill_predict_length: 256\n"
-    )
+    path = self._write_yaml("max_target_length: 1024\nmax_prefill_predict_length: 256\n")
     derived = _derive_from_maxtext_config(path)
     self.assertEqual(derived["max_tokens_default"], 768)
     os.unlink(path)
@@ -110,9 +110,7 @@ class TestDeriveFromMaxtextConfig(unittest.TestCase):
     os.unlink(path)
 
   def test_derives_run_name_and_base_output_directory(self):
-    path = self._write_yaml(
-        "base_output_directory: gs://b/\nrun_name: myrun\n"
-    )
+    path = self._write_yaml("base_output_directory: gs://b/\nrun_name: myrun\n")
     derived = _derive_from_maxtext_config(path)
     self.assertEqual(derived["base_output_directory"], "gs://b/")
     self.assertEqual(derived["run_name"], "myrun")

--- a/tests/unit/eval/test_lm_eval_runner.py
+++ b/tests/unit/eval/test_lm_eval_runner.py
@@ -78,7 +78,6 @@ class TestMapResults(unittest.TestCase):
     self.assertAlmostEqual(scores["mmlu_accuracy"], 80.0, places=1)
     self.assertAlmostEqual(scores["gpqa_diamond_accuracy"], 35.0, places=1)
 
-
   def test_missing_task_returns_nothing(self):
     raw = {"results": {}}
     scores = _map_results(raw, ["mmlu"])

--- a/tests/unit/eval/test_scorers.py
+++ b/tests/unit/eval/test_scorers.py
@@ -36,9 +36,9 @@ class TestRougeScorer(unittest.TestCase):
 
   def _run_score_batch(self, responses, references, mock_metric):
     """Import score_batch with evaluate and nltk.sent_tokenize patched, return result dict."""
-    with patch("evaluate.load", return_value=mock_metric), \
-         patch("nltk.sent_tokenize", side_effect=lambda s: [s]):
-      from maxtext.eval.scoring.rouge_scorer import score_batch
+    with patch("evaluate.load", return_value=mock_metric), patch("nltk.sent_tokenize", side_effect=lambda s: [s]):
+      from maxtext.eval.scoring.rouge_scorer import score_batch  # pylint: disable=import-outside-toplevel
+
       return score_batch(responses, references)
 
   def test_perfect_match(self):
@@ -64,11 +64,7 @@ class TestRougeScorer(unittest.TestCase):
     mock_metric = self._make_mock_rouge_metric()
     result = self._run_score_batch(["hello"], ["hello"], mock_metric)
     self.assertIn("gen_num", result)
-    has_rouge_keys = (
-        "rouge1" in result
-        and "rouge2" in result
-        and ("rougeL" in result or "rougeLsum" in result)
-    )
+    has_rouge_keys = "rouge1" in result and "rouge2" in result and ("rougeL" in result or "rougeLsum" in result)
     self.assertTrue(has_rouge_keys)
 
   def test_partial_overlap(self):

--- a/tests/unit/eval/test_server_manager.py
+++ b/tests/unit/eval/test_server_manager.py
@@ -22,28 +22,31 @@ from maxtext.eval.runner.server_manager import VllmServerManager
 
 
 def _make_manager(**kwargs) -> VllmServerManager:
-  defaults = dict(
-      model_path="/fake/model",
-      host="localhost",
-      port=8000,
-      tensor_parallel_size=4,
-      max_model_len=4096,
-  )
+  defaults = {
+      "model_path": "/fake/model",
+      "host": "localhost",
+      "port": 8000,
+      "tensor_parallel_size": 4,
+      "max_model_len": 4096,
+  }
   defaults.update(kwargs)
   return VllmServerManager(**defaults)
 
 
 def _start_capturing_llm_kwargs(mgr: VllmServerManager, rank: int = 0) -> dict:
+  """Start manager and capture LLM kwargs."""
   mock_llm_cls = mock.MagicMock()
   mock_vllm = mock.MagicMock()
   mock_vllm.LLM = mock_llm_cls
   mock_uvicorn = mock.MagicMock()
 
-  with mock.patch.dict("sys.modules", {"vllm": mock_vllm, "uvicorn": mock_uvicorn}), \
-       mock.patch("jax.process_index", return_value=rank), \
-       mock.patch("threading.Thread", return_value=mock.MagicMock()), \
-       mock.patch("maxtext.eval.runner.server_manager._build_app", return_value=mock.MagicMock()), \
-       mock.patch.object(mgr, "_wait_until_healthy"):
+  with (
+      mock.patch.dict("sys.modules", {"vllm": mock_vllm, "uvicorn": mock_uvicorn}),
+      mock.patch("jax.process_index", return_value=rank),
+      mock.patch("threading.Thread", return_value=mock.MagicMock()),
+      mock.patch("maxtext.eval.runner.server_manager._build_app", return_value=mock.MagicMock()),
+      mock.patch.object(mgr, "_wait_until_healthy"),
+  ):
     mgr.start()
 
   return mock_llm_cls.call_args.kwargs
@@ -132,12 +135,14 @@ class TestVllmServerManagerConfig(unittest.TestCase):
     mock_vllm = mock.MagicMock()
     mock_vllm.LLM = mock_llm_cls
 
-    with mock.patch.dict("sys.modules", {"vllm": mock_vllm, "uvicorn": mock.MagicMock()}), \
-         mock.patch("jax.process_index", return_value=0), \
-         mock.patch("threading.Thread", return_value=mock.MagicMock()), \
-         mock.patch("maxtext.eval.runner.server_manager._build_app", return_value=mock.MagicMock()), \
-         mock.patch.object(mgr, "_wait_until_healthy"), \
-         mock.patch.dict("os.environ", {}, clear=False):
+    with (
+        mock.patch.dict("sys.modules", {"vllm": mock_vllm, "uvicorn": mock.MagicMock()}),
+        mock.patch("jax.process_index", return_value=0),
+        mock.patch("threading.Thread", return_value=mock.MagicMock()),
+        mock.patch("maxtext.eval.runner.server_manager._build_app", return_value=mock.MagicMock()),
+        mock.patch.object(mgr, "_wait_until_healthy"),
+        mock.patch.dict("os.environ", {}, clear=False),
+    ):
       mgr.start()
 
     self.assertEqual(env_at_init.get("_TEST_EVAL_TOKEN"), "abc123")
@@ -151,16 +156,19 @@ class TestVllmServerManagerHttp(unittest.TestCase):
   """Tests that the HTTP server is started only on rank-0."""
 
   def _start_capturing_thread_calls(self, mgr, rank):
+    """Start manager and capture thread calls."""
     mock_llm_cls = mock.MagicMock()
     mock_vllm = mock.MagicMock()
     mock_vllm.LLM = mock_llm_cls
     mock_thread_cls = mock.MagicMock(return_value=mock.MagicMock())
 
-    with mock.patch.dict("sys.modules", {"vllm": mock_vllm, "uvicorn": mock.MagicMock()}), \
-         mock.patch("jax.process_index", return_value=rank), \
-         mock.patch("threading.Thread", mock_thread_cls), \
-         mock.patch("maxtext.eval.runner.server_manager._build_app", return_value=mock.MagicMock()), \
-         mock.patch.object(mgr, "_wait_until_healthy"):
+    with (
+        mock.patch.dict("sys.modules", {"vllm": mock_vllm, "uvicorn": mock.MagicMock()}),
+        mock.patch("jax.process_index", return_value=rank),
+        mock.patch("threading.Thread", mock_thread_cls),
+        mock.patch("maxtext.eval.runner.server_manager._build_app", return_value=mock.MagicMock()),
+        mock.patch.object(mgr, "_wait_until_healthy"),
+    ):
       mgr.start()
 
     return mock_thread_cls
@@ -179,6 +187,9 @@ class TestVllmServerManagerHttp(unittest.TestCase):
 
 
 class TestVllmServerManagerLifecycle(unittest.TestCase):
+  """Tests for VllmServerManager lifecycle."""
+
+  # pylint: disable=protected-access
 
   def test_stop_signals_uvicorn_should_exit(self):
     mgr = _make_manager()

--- a/tests/unit/qwen3_next_vs_reference_test.py
+++ b/tests/unit/qwen3_next_vs_reference_test.py
@@ -41,13 +41,9 @@ import torch.nn.functional as F
 # Note: Some function/class names might be slightly adapted (e.g., _PT suffix) to avoid collisions.
 # ----------------------------------------------------------------------
 def create_causal_mask_PT(q_seq_len: int, kv_seq_len: int, dtype=torch.float32):
-  mask = torch.triu(
-      torch.ones(q_seq_len, kv_seq_len, dtype=torch.bool), diagonal=1
-  )
+  mask = torch.triu(torch.ones(q_seq_len, kv_seq_len, dtype=torch.bool), diagonal=1)
   masked_fill_value = -torch.finfo(dtype).max / 2
-  return torch.zeros(q_seq_len, kv_seq_len, dtype=dtype).masked_fill(
-      mask, masked_fill_value
-  )
+  return torch.zeros(q_seq_len, kv_seq_len, dtype=dtype).masked_fill(mask, masked_fill_value)
 
 
 def eager_attention_forward(
@@ -68,12 +64,8 @@ def eager_attention_forward(
     causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
     attn_weights = attn_weights + causal_mask
 
-  attn_weights = nn.functional.softmax(
-      attn_weights, dim=-1, dtype=torch.float32
-  ).to(query.dtype)
-  attn_weights = nn.functional.dropout(
-      attn_weights, p=dropout, training=module.training
-  )
+  attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+  attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
   attn_output = torch.matmul(attn_weights, value_states)
   attn_output = attn_output.transpose(1, 2).contiguous()
 
@@ -105,12 +97,8 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
   batch, num_key_value_heads, slen, head_dim = hidden_states.shape
   if n_rep == 1:
     return hidden_states
-  hidden_states = hidden_states[:, :, None, :, :].expand(
-      batch, num_key_value_heads, n_rep, slen, head_dim
-  )
-  return hidden_states.reshape(
-      batch, num_key_value_heads * n_rep, slen, head_dim
-  )
+  hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+  return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
 def l2norm_torch(x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):
@@ -156,13 +144,8 @@ def torch_chunk_gated_delta_rule(
     key = l2norm_torch(key, dim=-1, eps=1e-6)
 
   # Transpose (B, S, H, K) -> (B, H, S, K)
-  query, key, value = [
-      x.transpose(1, 2).contiguous().to(torch.float32)
-      for x in (query, key, value)
-  ]
-  beta, g = [
-      x.transpose(1, 2).contiguous().to(torch.float32) for x in (beta, g)
-  ]
+  query, key, value = [x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value)]
+  beta, g = [x.transpose(1, 2).contiguous().to(torch.float32) for x in (beta, g)]
 
   batch_size, num_heads, sequence_length, k_head_dim = key.shape
   v_head_dim = value.shape[-1]
@@ -182,8 +165,7 @@ def torch_chunk_gated_delta_rule(
   k_beta = key * beta.unsqueeze(-1)
   # reshape to chunks
   query, key, value, k_beta, v_beta = [
-      x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1])
-      for x in (query, key, value, k_beta, v_beta)
+      x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1]) for x in (query, key, value, k_beta, v_beta)
   ]
   g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
   mask = torch.triu(
@@ -216,19 +198,14 @@ def torch_chunk_gated_delta_rule(
   # for each chunk
   for i in range(0, total_sequence_length // chunk_size):
     q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
-    attn = (q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]).masked_fill_(
-        mask, 0
-    )
+    attn = (q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]).masked_fill_(mask, 0)
     v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state
     v_new = v_i - v_prime
     attn_inter = (q_i * g[:, :, i, :, None].exp()) @ last_recurrent_state
     core_attn_out[:, :, i] = attn_inter + attn @ v_new
     last_recurrent_state = (
         last_recurrent_state * g[:, :, i, -1, None, None].exp()
-        + (
-            k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]
-        ).transpose(-1, -2)
-        @ v_new
+        + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(-1, -2) @ v_new
     )
 
   if not output_final_state:
@@ -314,48 +291,24 @@ class Qwen3NextRotaryEmbedding_PT(nn.Module):
     """
     base = config.rope_parameters["rope_theta"]
     partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
-    head_dim = (
-        getattr(config, "head_dim", None)
-        or config.hidden_size // config.num_attention_heads
-    )
+    head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
     dim = int(head_dim * partial_rotary_factor)
 
     attention_factor = 1.0  # Unused in this type of RoPE
 
     # Compute the inverse frequencies
-    inv_freq = 1.0 / (
-        base
-        ** (
-            torch.arange(0, dim, 2, dtype=torch.int64).to(
-                device=device, dtype=torch.float
-            )
-            / dim
-        )
-    )
+    inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim))
     return inv_freq, attention_factor
 
   @torch.no_grad()
   def forward(self, x, position_ids):
     """Pytorch impl for partial ROPE forward pass"""
-    inv_freq_expanded = (
-        self.inv_freq[None, :, None]
-        .float()
-        .expand(position_ids.shape[0], -1, 1)
-        .to(x.device)
-    )
+    inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
     position_ids_expanded = position_ids[:, None, :].float()
 
-    device_type = (
-        x.device.type
-        if isinstance(x.device.type, str) and x.device.type != "mps"
-        else "cpu"
-    )
-    with torch.autocast(
-        device_type=device_type, enabled=False
-    ):  # Force float32
-      freqs = (
-          inv_freq_expanded.float() @ position_ids_expanded.float()
-      ).transpose(1, 2)
+    device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+    with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+      freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
       emb = torch.cat((freqs, freqs), dim=-1)
       cos = emb.cos() * self.attention_scaling
       sin = emb.sin() * self.attention_scaling
@@ -374,20 +327,10 @@ class Qwen3NextMLP_PT(nn.Module):
     super().__init__()
     self.config = config
     self.hidden_size = config.hidden_size
-    self.intermediate_size = (
-        config.intermediate_size
-        if intermediate_size is None
-        else intermediate_size
-    )
-    self.gate_proj = nn.Linear(
-        self.hidden_size, self.intermediate_size, bias=False
-    )
-    self.up_proj = nn.Linear(
-        self.hidden_size, self.intermediate_size, bias=False
-    )
-    self.down_proj = nn.Linear(
-        self.intermediate_size, self.hidden_size, bias=False
-    )
+    self.intermediate_size = config.intermediate_size if intermediate_size is None else intermediate_size
+    self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+    self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+    self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
     self.act_fn = F.silu
 
   def forward(self, x):
@@ -404,11 +347,7 @@ class Qwen3NextExperts_PT(nn.ModuleList):
     super().__init__()
     self.num_experts = config.num_experts
     for _ in range(config.num_experts):
-      self.append(
-          Qwen3NextMLP_PT(
-              config, intermediate_size=config.moe_intermediate_size
-          )
-      )
+      self.append(Qwen3NextMLP_PT(config, intermediate_size=config.moe_intermediate_size))
 
   def forward(
       self,
@@ -418,21 +357,13 @@ class Qwen3NextExperts_PT(nn.ModuleList):
   ) -> torch.Tensor:
     """Forward pass for the expert layers."""
     final_hidden_states = torch.zeros_like(hidden_states)
-    expert_mask = torch.nn.functional.one_hot(
-        top_k_index, num_classes=self.num_experts
-    ).permute(2, 1, 0)
+    expert_mask = torch.nn.functional.one_hot(top_k_index, num_classes=self.num_experts).permute(2, 1, 0)
     expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
     for expert_idx in expert_hit:
       idx, top_x = torch.where(expert_mask[expert_idx].squeeze(0))
-      current_state = hidden_states[None, top_x].reshape(
-          -1, hidden_states.shape[-1]
-      )
-      current_hidden_states = (
-          self[expert_idx](current_state) * top_k_weights[top_x, idx, None]
-      )
-      final_hidden_states.index_add_(
-          0, top_x, current_hidden_states.to(hidden_states.dtype)
-      )
+      current_state = hidden_states[None, top_x].reshape(-1, hidden_states.shape[-1])
+      current_hidden_states = self[expert_idx](current_state) * top_k_weights[top_x, idx, None]
+      final_hidden_states.index_add_(0, top_x, current_hidden_states.to(hidden_states.dtype))
     return final_hidden_states
 
 
@@ -449,9 +380,7 @@ class Qwen3NextSparseMoeBlock_PT(nn.Module):
     self.experts = Qwen3NextExperts_PT(config)
     self.num_experts_per_tok = config.num_experts_per_tok
     self.norm_topk_prob = config.norm_topk_prob
-    self.shared_expert = Qwen3NextMLP_PT(
-        config, intermediate_size=config.shared_expert_intermediate_size
-    )
+    self.shared_expert = Qwen3NextMLP_PT(config, intermediate_size=config.shared_expert_intermediate_size)
     self.shared_expert_gate = torch.nn.Linear(config.hidden_size, 1, bias=False)
 
   def route_tokens_to_experts(self, hidden_states, router_logits):
@@ -466,9 +395,7 @@ class Qwen3NextSparseMoeBlock_PT(nn.Module):
       corresponding routing weights.
     """
     routing_weights = F.softmax(router_logits, dim=-1, dtype=torch.float)
-    routing_weights, selected_experts = torch.topk(
-        routing_weights, self.num_experts_per_tok, dim=-1
-    )
+    routing_weights, selected_experts = torch.topk(routing_weights, self.num_experts_per_tok, dim=-1)
     if self.norm_topk_prob:
       routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
     routing_weights = routing_weights.to(hidden_states.dtype)
@@ -480,20 +407,11 @@ class Qwen3NextSparseMoeBlock_PT(nn.Module):
     hidden_states_reshaped = hidden_states.view(-1, hidden_dim)
     shared_expert_output = self.shared_expert(hidden_states_reshaped)
     router_logits = self.gate(hidden_states_reshaped)
-    selected_experts, routing_weights = self.route_tokens_to_experts(
-        hidden_states_reshaped, router_logits
-    )
-    expert_output = self.experts(
-        hidden_states_reshaped, selected_experts, routing_weights
-    )
-    shared_expert_output = (
-        F.sigmoid(self.shared_expert_gate(hidden_states_reshaped))
-        * shared_expert_output
-    )
+    selected_experts, routing_weights = self.route_tokens_to_experts(hidden_states_reshaped, router_logits)
+    expert_output = self.experts(hidden_states_reshaped, selected_experts, routing_weights)
+    shared_expert_output = F.sigmoid(self.shared_expert_gate(hidden_states_reshaped)) * shared_expert_output
     expert_output += shared_expert_output
-    expert_output = expert_output.reshape(
-        batch_size, sequence_length, hidden_dim
-    )
+    expert_output = expert_output.reshape(batch_size, sequence_length, hidden_dim)
     return expert_output, router_logits
 
 
@@ -515,9 +433,7 @@ class Qwen3NextRMSNormGated_PT(nn.Module):
     input_dtype = hidden_states.dtype
     hidden_states = hidden_states.to(torch.float32)
     variance = hidden_states.pow(2).mean(-1, keepdim=True)
-    hidden_states = hidden_states * torch.rsqrt(
-        variance + self.variance_epsilon
-    )
+    hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
     hidden_states = self.weight * hidden_states
     if gate is not None:
       hidden_states = hidden_states * F.silu(gate.to(torch.float32))
@@ -558,19 +474,13 @@ class Qwen3NextGatedDeltaNet_PT(nn.Module):
 
     projection_size_qkvz = self.key_dim * 2 + self.value_dim * 2
     projection_size_ba = self.num_v_heads * 2
-    self.in_proj_qkvz = nn.Linear(
-        self.hidden_size, projection_size_qkvz, bias=False
-    )
-    self.in_proj_ba = nn.Linear(
-        self.hidden_size, projection_size_ba, bias=False
-    )
+    self.in_proj_qkvz = nn.Linear(self.hidden_size, projection_size_qkvz, bias=False)
+    self.in_proj_ba = nn.Linear(self.hidden_size, projection_size_ba, bias=False)
 
     self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads))
     A = torch.empty(self.num_v_heads).uniform_(0, 16)
     self.A_log = nn.Parameter(torch.log(A))
-    self.norm = Qwen3NextRMSNormGated_PT(
-        self.head_v_dim, eps=self.layer_norm_epsilon
-    )
+    self.norm = Qwen3NextRMSNormGated_PT(self.head_v_dim, eps=self.layer_norm_epsilon)
     self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
 
   def forward(self, hidden_states):
@@ -585,23 +495,15 @@ class Qwen3NextGatedDeltaNet_PT(nn.Module):
         [self.key_dim, self.key_dim, self.value_dim, self.value_dim],
         dim=-1,
     )
-    b, a = torch.split(
-        projected_states_ba, [self.num_v_heads, self.num_v_heads], dim=-1
-    )
+    b, a = torch.split(projected_states_ba, [self.num_v_heads, self.num_v_heads], dim=-1)
 
     mixed_qkv = torch.cat((q, k, v), dim=-1).transpose(1, 2)
     qkv_conv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len]).transpose(1, 2)
-    q_conv, k_conv, v_conv = torch.split(
-        qkv_conv, [self.key_dim, self.key_dim, self.value_dim], dim=-1
-    )
+    q_conv, k_conv, v_conv = torch.split(qkv_conv, [self.key_dim, self.key_dim, self.value_dim], dim=-1)
 
-    query = q_conv.reshape(
-        batch_size, seq_len, self.num_k_heads, self.head_k_dim
-    )
+    query = q_conv.reshape(batch_size, seq_len, self.num_k_heads, self.head_k_dim)
     key = k_conv.reshape(batch_size, seq_len, self.num_k_heads, self.head_k_dim)
-    value = v_conv.reshape(
-        batch_size, seq_len, self.num_v_heads, self.head_v_dim
-    )
+    value = v_conv.reshape(batch_size, seq_len, self.num_v_heads, self.head_v_dim)
 
     beta = b.sigmoid()
     g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias.float())
@@ -617,9 +519,7 @@ class Qwen3NextGatedDeltaNet_PT(nn.Module):
         use_qk_l2norm_in_kernel=self.config.use_qk_norm_in_gdn,  # Use renamed config
     )
 
-    z_reshaped = z.reshape(
-        batch_size, seq_len, self.num_v_heads, self.head_v_dim
-    )
+    z_reshaped = z.reshape(batch_size, seq_len, self.num_v_heads, self.head_v_dim)
     gated_output = self.norm(core_attn_out, z_reshaped)
     gated_output = gated_output.reshape(batch_size, seq_len, -1)
     output = self.out_proj(gated_output)
@@ -642,14 +542,10 @@ class Qwen3NextFullAttention_PT(nn.Module):
     self.config = config
     self.layer_idx = layer_idx
     self.hidden_size = config.hidden_size
-    self.head_dim = getattr(
-        config, "head_dim", config.hidden_size // config.num_attention_heads
-    )
+    self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
     self.num_heads = config.num_attention_heads
     self.num_key_value_heads = config.num_key_value_heads
-    self.num_key_value_groups = (
-        config.num_attention_heads // config.num_key_value_heads
-    )
+    self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
     self.scaling = self.head_dim**-0.5
     self.attention_dropout = config.attention_dropout
 
@@ -697,22 +593,16 @@ class Qwen3NextFullAttention_PT(nn.Module):
     gate = gate.reshape(*input_shape, -1)
 
     query_states = self.q_norm(query_states.view(hidden_shape)).transpose(1, 2)
-    key_states = self.k_norm(
-        self.k_proj(hidden_states).view(hidden_shape)
-    ).transpose(1, 2)
+    key_states = self.k_norm(self.k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
     value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
     cos, sin = position_embeddings
-    query_states, key_states = apply_rotary_pos_emb(
-        query_states, key_states, cos, sin
-    )
+    query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
     if past_key_values is not None:
       # sin and cos are specific to RoPE models; cache_position needed for the static cache
       cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
-      key_states, value_states = past_key_values.update(
-          key_states, value_states, self.layer_idx, cache_kwargs
-      )
+      key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
     attn_output = eager_attention_forward(
         self,
@@ -742,50 +632,52 @@ class TestQwen3Next(unittest.TestCase):
     """Set up a complete configuration and test environment for all Qwen3-Next tests."""
     super().setUp()
     # This setup now includes all necessary parameters for both linear attention and MoE tests.
-    self.cfg = pyconfig.initialize([
-        None,
-        get_test_config_path(),
-        # Base settings for the test
-        "run_name=qwen3_next_test",
-        "dtype=float32",
-        "weight_dtype=float32",
-        "matmul_precision=highest",
-        "float32_logits=True",
-        "decoder_block=qwen3_next",
-        "attention=dot_product",
-        # Model dimensions
-        "base_emb_dim=128",
-        "base_num_query_heads=4",
-        "base_num_kv_heads=4",
-        "head_dim=32",
-        # Gated Delta Net Dims (Using renamed parameters)
-        "gdn_num_value_heads=4",
-        "gdn_num_key_heads=4",
-        "gdn_key_head_dim=32",
-        "gdn_value_head_dim=32",
-        "gdn_conv_kernel_dim=4",
-        "gdn_chunk_size=64",
-        "use_qk_norm_in_gdn=True",  # Use renamed parameter
-        "normalization_layer_epsilon=1e-6",
-        # MoE Test Configs (with a small number of experts)
-        "base_mlp_dim=256",
-        "num_experts=8",
-        "num_experts_per_tok=2",
-        "base_moe_mlp_dim=256",  # moe_mlp_dim will be calculated from this
-        "norm_topk_prob=True",
-        "shard_exp_on_fsdp=False",
-        "mlp_activations=['silu', 'linear']",
-        "dropout_rate=0.0",
-        # Force the test to use the 'dense_matmul' path in the MoE layer,
-        # as the 'sparse_matmul' path was found to be numerically incorrect compared to the reference.
-        "sparse_matmul=False",
-        # To be able to run on cpu machines
-        "skip_jax_distributed_system=True",
-        # For FullAttention Layer
-        "attention_bias=False",
-        "rope_max_timescale=10000.0",
-        "partial_rotary_factor=0.25",
-    ])
+    self.cfg = pyconfig.initialize(
+        [
+            None,
+            get_test_config_path(),
+            # Base settings for the test
+            "run_name=qwen3_next_test",
+            "dtype=float32",
+            "weight_dtype=float32",
+            "matmul_precision=highest",
+            "float32_logits=True",
+            "decoder_block=qwen3_next",
+            "attention=dot_product",
+            # Model dimensions
+            "base_emb_dim=128",
+            "base_num_query_heads=4",
+            "base_num_kv_heads=4",
+            "head_dim=32",
+            # Gated Delta Net Dims (Using renamed parameters)
+            "gdn_num_value_heads=4",
+            "gdn_num_key_heads=4",
+            "gdn_key_head_dim=32",
+            "gdn_value_head_dim=32",
+            "gdn_conv_kernel_dim=4",
+            "gdn_chunk_size=64",
+            "use_qk_norm_in_gdn=True",  # Use renamed parameter
+            "normalization_layer_epsilon=1e-6",
+            # MoE Test Configs (with a small number of experts)
+            "base_mlp_dim=256",
+            "num_experts=8",
+            "num_experts_per_tok=2",
+            "base_moe_mlp_dim=256",  # moe_mlp_dim will be calculated from this
+            "norm_topk_prob=True",
+            "shard_exp_on_fsdp=False",
+            "mlp_activations=['silu', 'linear']",
+            "dropout_rate=0.0",
+            # Force the test to use the 'dense_matmul' path in the MoE layer,
+            # as the 'sparse_matmul' path was found to be numerically incorrect compared to the reference.
+            "sparse_matmul=False",
+            # To be able to run on cpu machines
+            "skip_jax_distributed_system=True",
+            # For FullAttention Layer
+            "attention_bias=False",
+            "rope_max_timescale=10000.0",
+            "partial_rotary_factor=0.25",
+        ]
+    )
     # Update the SimpleNamespace config used by PT models too
     self.pt_internal_cfg = SimpleNamespace(
         hidden_size=self.cfg.emb_dim,
@@ -829,16 +721,12 @@ class TestQwen3Next(unittest.TestCase):
   def test_rms_norm_gated(self):
     """Tests the Qwen3NextRMSNormGated layer."""
     print("Running test_rms_norm_gated...")
-    hidden_states_pt = torch.randn(
-        self.batch_size, self.seq_len, self.hidden_size
-    )
+    hidden_states_pt = torch.randn(self.batch_size, self.seq_len, self.hidden_size)
     gate_pt = torch.randn(self.batch_size, self.seq_len, self.hidden_size)
     weight_pt = torch.rand(self.hidden_size)
 
     # PyTorch reference
-    pt_model = Qwen3NextRMSNormGated_PT(
-        self.hidden_size, eps=self.cfg.normalization_layer_epsilon
-    )
+    pt_model = Qwen3NextRMSNormGated_PT(self.hidden_size, eps=self.cfg.normalization_layer_epsilon)
     pt_model.weight.data = weight_pt
     pt_model.eval()
     with torch.no_grad():
@@ -932,15 +820,8 @@ class TestQwen3Next(unittest.TestCase):
         )
         * 0.1
     )
-    g_jax = (
-        jax.random.normal(
-            key_g, (self.batch_size, self.seq_len, num_heads), dtype=jnp.float32
-        )
-        * 0.1
-    )
-    beta_jax = jax.random.uniform(
-        key_beta, (self.batch_size, self.seq_len, num_heads), dtype=jnp.float32
-    )
+    g_jax = jax.random.normal(key_g, (self.batch_size, self.seq_len, num_heads), dtype=jnp.float32) * 0.1
+    beta_jax = jax.random.uniform(key_beta, (self.batch_size, self.seq_len, num_heads), dtype=jnp.float32)
 
     q_torch = torch.from_numpy(np.asarray(q_jax).copy())
     k_torch = torch.from_numpy(np.asarray(k_jax).copy())
@@ -980,14 +861,10 @@ class TestQwen3Next(unittest.TestCase):
         atol=target_atol,
         rtol=target_rtol,
         err_msg=(
-            "JAX and PyTorch outputs are NOT close without L2Norm within"
-            f" atol={target_atol}, rtol={target_rtol}!"
+            "JAX and PyTorch outputs are NOT close without L2Norm within" f" atol={target_atol}, rtol={target_rtol}!"
         ),
     )
-    print(
-        "JAX and PyTorch outputs are close without L2Norm within"
-        f" atol={target_atol}, rtol={target_rtol}!"
-    )
+    print("JAX and PyTorch outputs are close without L2Norm within" f" atol={target_atol}, rtol={target_rtol}!")
 
     # Test with L2Norm (pass True using the original PT arg name)
     torch_output_norm, _ = torch_chunk_gated_delta_rule(
@@ -1017,27 +894,17 @@ class TestQwen3Next(unittest.TestCase):
         np.asarray(jax_output_norm),
         atol=target_atol,
         rtol=target_rtol,
-        err_msg=(
-            "JAX and PyTorch outputs are NOT close with L2Norm within"
-            f" atol={target_atol}, rtol={target_rtol}!"
-        ),
+        err_msg=("JAX and PyTorch outputs are NOT close with L2Norm within" f" atol={target_atol}, rtol={target_rtol}!"),
     )
-    print(
-        "JAX and PyTorch outputs are close with L2Norm within"
-        f" atol={target_atol}, rtol={target_rtol}!"
-    )
+    print("JAX and PyTorch outputs are close with L2Norm within" f" atol={target_atol}, rtol={target_rtol}!")
     print("test_chunk_gated_delta_rule_logic passed!")
 
   def test_gated_delta_net_structure(self):
     """Tests the structure and output shape of Qwen3NextGatedDeltaNet."""
     print("Running test_gated_delta_net_structure...")
-    hidden_states_jax = jnp.ones(
-        (self.batch_size, self.seq_len, self.hidden_size), dtype=self.cfg.dtype
-    )
+    hidden_states_jax = jnp.ones((self.batch_size, self.seq_len, self.hidden_size), dtype=self.cfg.dtype)
 
-    jax_model = qwen3.Qwen3NextGatedDeltaNet(
-        config=self.cfg, rngs=self.nnx_rngs
-    )
+    jax_model = qwen3.Qwen3NextGatedDeltaNet(config=self.cfg, rngs=self.nnx_rngs)
 
     @jax.jit
     def run_jax(hidden_states):
@@ -1046,9 +913,7 @@ class TestQwen3Next(unittest.TestCase):
 
     output_jax = run_jax(hidden_states_jax)
 
-    self.assertEqual(
-        output_jax.shape, (self.batch_size, self.seq_len, self.hidden_size)
-    )
+    self.assertEqual(output_jax.shape, (self.batch_size, self.seq_len, self.hidden_size))
 
     print("test_gated_delta_net_structure passed!")
 
@@ -1056,14 +921,10 @@ class TestQwen3Next(unittest.TestCase):
     """Tests the custom Qwen3NextRMSNorm layer against its PyTorch reference."""
     print("Running test_qwen3_next_rms_norm...")
     # 1. Set up the PyTorch reference model and inputs.
-    hidden_states_pt = torch.randn(
-        self.batch_size, self.seq_len, self.hidden_size
-    )
+    hidden_states_pt = torch.randn(self.batch_size, self.seq_len, self.hidden_size)
     weight_pt = torch.rand(self.hidden_size)
 
-    pt_model = Qwen3NextRMSNorm_PT(
-        self.hidden_size, eps=self.cfg.normalization_layer_epsilon
-    )
+    pt_model = Qwen3NextRMSNorm_PT(self.hidden_size, eps=self.cfg.normalization_layer_epsilon)
     pt_model.weight.data = weight_pt
     pt_model.eval()
 
@@ -1114,97 +975,43 @@ class TestQwen3Next(unittest.TestCase):
     # 2. Set up the PyTorch reference model and get the expected output
     pt_model = Qwen3NextSparseMoeBlock_PT(pt_config)
     pt_model.eval()
-    hidden_states_pt = torch.randn(
-        self.batch_size, self.seq_len, self.cfg.emb_dim
-    )
+    hidden_states_pt = torch.randn(self.batch_size, self.seq_len, self.cfg.emb_dim)
     with torch.no_grad():
       expected_output, _ = pt_model(hidden_states_pt)
 
     # 3. Construct the JAX params tree, ensuring weights are correctly transposed
     pt_experts = pt_model.experts
-    stacked_gate_proj = torch.stack(
-        [expert.gate_proj.weight.T for expert in pt_experts]
-    )
-    stacked_up_proj = torch.stack(
-        [expert.up_proj.weight.T for expert in pt_experts]
-    )
-    stacked_down_proj = torch.stack(
-        [expert.down_proj.weight.T for expert in pt_experts]
-    )
+    stacked_gate_proj = torch.stack([expert.gate_proj.weight.T for expert in pt_experts])
+    stacked_up_proj = torch.stack([expert.up_proj.weight.T for expert in pt_experts])
+    stacked_down_proj = torch.stack([expert.down_proj.weight.T for expert in pt_experts])
 
     # Map PyTorch weights to JAX NNX module attributes
     jax_params = {
         "routed_experts": {
-            "gate": {
-                "kernel": nnx.Param(
-                    jnp.array(pt_model.gate.weight.T.detach().numpy())
-                )
-            },
+            "gate": {"kernel": nnx.Param(jnp.array(pt_model.gate.weight.T.detach().numpy()))},
             "wi_0": nnx.Param(jnp.array(stacked_gate_proj.detach().numpy())),
             "wi_1": nnx.Param(jnp.array(stacked_up_proj.detach().numpy())),
             "wo": nnx.Param(jnp.array(stacked_down_proj.detach().numpy())),
         },
         "shared_expert": {
             "wi": {  # Assuming fused_mlp=True in config for shared_expert
-                "0": {
-                    "kernel": nnx.Param(
-                        jnp.array(
-                            pt_model.shared_expert.gate_proj.weight.T.detach().numpy()
-                        )
-                    )
-                },
-                "1": {
-                    "kernel": nnx.Param(
-                        jnp.array(
-                            pt_model.shared_expert.up_proj.weight.T.detach().numpy()
-                        )
-                    )
-                },
+                "0": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.gate_proj.weight.T.detach().numpy()))},
+                "1": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.up_proj.weight.T.detach().numpy()))},
             },
-            "wo": {
-                "kernel": nnx.Param(
-                    jnp.array(
-                        pt_model.shared_expert.down_proj.weight.T.detach().numpy()
-                    )
-                )
-            },
+            "wo": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.down_proj.weight.T.detach().numpy()))},
         },
-        "shared_expert_gate": {
-            "kernel": nnx.Param(
-                jnp.array(pt_model.shared_expert_gate.weight.T.detach().numpy())
-            )
-        },
+        "shared_expert_gate": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert_gate.weight.T.detach().numpy()))},
     }
     # Adjust shared_expert structure if not fused
     if not self.cfg.fused_mlp:
       jax_params["shared_expert"] = {
-          "wi_0": {
-              "kernel": nnx.Param(
-                  jnp.array(
-                      pt_model.shared_expert.gate_proj.weight.T.detach().numpy()
-                  )
-              )
-          },
-          "wi_1": {
-              "kernel": nnx.Param(
-                  jnp.array(
-                      pt_model.shared_expert.up_proj.weight.T.detach().numpy()
-                  )
-              )
-          },
-          "wo": {
-              "kernel": nnx.Param(
-                  jnp.array(
-                      pt_model.shared_expert.down_proj.weight.T.detach().numpy()
-                  )
-              )
-          },
+          "wi_0": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.gate_proj.weight.T.detach().numpy()))},
+          "wi_1": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.up_proj.weight.T.detach().numpy()))},
+          "wo": {"kernel": nnx.Param(jnp.array(pt_model.shared_expert.down_proj.weight.T.detach().numpy()))},
       }
 
     # 4. Set up and run the full JAX Qwen3NextSparseMoeBlock
-    jax_model = qwen3.Qwen3NextSparseMoeBlock(
-        config=self.cfg, mesh=self.mesh, quant=None, rngs=self.nnx_rngs
-    )
+    jax_model = qwen3.Qwen3NextSparseMoeBlock(config=self.cfg, mesh=self.mesh, quant=None, rngs=self.nnx_rngs)
     nnx.update(jax_model, jax_params)
     hidden_states_jax = jnp.array(hidden_states_pt.numpy())
 
@@ -1236,16 +1043,12 @@ class TestQwen3Next(unittest.TestCase):
     # Add MaxText config ref to PT model instance for internal use
     pt_model.config = self.cfg
 
-    hidden_states_pt = torch.randn(
-        self.batch_size, self.seq_len, self.cfg.emb_dim
-    )
+    hidden_states_pt = torch.randn(self.batch_size, self.seq_len, self.cfg.emb_dim)
     with torch.no_grad():
       expected_output = pt_model(hidden_states_pt)
 
     # 2. Setup JAX model and map weights
-    jax_model = qwen3.Qwen3NextGatedDeltaNet(
-        config=self.cfg, rngs=self.nnx_rngs
-    )
+    jax_model = qwen3.Qwen3NextGatedDeltaNet(config=self.cfg, rngs=self.nnx_rngs)
 
     conv1d_weight_pt = pt_model.conv1d.weight.detach().numpy()
     # Transpose PT (out, in/groups, kw) -> JAX (kw, in/groups, out)
@@ -1253,29 +1056,13 @@ class TestQwen3Next(unittest.TestCase):
     conv1d_weight_jax = np.transpose(conv1d_weight_pt, (2, 1, 0))
 
     params = {
-        "in_proj_qkvz": {
-            "kernel": nnx.Param(
-                jnp.array(pt_model.in_proj_qkvz.weight.T.detach().numpy())
-            )
-        },
-        "in_proj_ba": {
-            "kernel": nnx.Param(
-                jnp.array(pt_model.in_proj_ba.weight.T.detach().numpy())
-            )
-        },
+        "in_proj_qkvz": {"kernel": nnx.Param(jnp.array(pt_model.in_proj_qkvz.weight.T.detach().numpy()))},
+        "in_proj_ba": {"kernel": nnx.Param(jnp.array(pt_model.in_proj_ba.weight.T.detach().numpy()))},
         "conv1d": {"kernel": nnx.Param(jnp.array(conv1d_weight_jax))},
         "A_log": nnx.Param(jnp.array(pt_model.A_log.detach().numpy())),
         "dt_bias": nnx.Param(jnp.array(pt_model.dt_bias.detach().numpy())),
-        "norm": {
-            "weight": nnx.Param(
-                jnp.array(pt_model.norm.weight.detach().numpy())
-            )
-        },
-        "out_proj": {
-            "kernel": nnx.Param(
-                jnp.array(pt_model.out_proj.weight.T.detach().numpy())
-            )
-        },
+        "norm": {"weight": nnx.Param(jnp.array(pt_model.norm.weight.detach().numpy()))},
+        "out_proj": {"kernel": nnx.Param(jnp.array(pt_model.out_proj.weight.T.detach().numpy()))},
     }
     nnx.update(jax_model, params)
     hidden_states_jax = jnp.array(hidden_states_pt.numpy())
@@ -1299,53 +1086,52 @@ class TestQwen3Next(unittest.TestCase):
 
   def _run_full_attention_jax_vs_pytorch_attention(self, attention_type):
     """Compares JAX and PyTorch Full Attention implementations."""
-    print(
-        "Running test_full_attention_jax_vs_pytorch with"
-        f" attention={attention_type}..."
-    )
+    print("Running test_full_attention_jax_vs_pytorch with" f" attention={attention_type}...")
 
     # Re-initialize config with the specified attention type
-    cfg = pyconfig.initialize([
-        None,
-        get_test_config_path(),
-        # Base settings for the test
-        "run_name=qwen3_next_test",
-        "dtype=float32",
-        "weight_dtype=float32",
-        "matmul_precision=highest",
-        "float32_logits=True",
-        "decoder_block=qwen3_next",
-        f"attention={attention_type}",  # Override attention type
-        # Model dimensions
-        "base_emb_dim=128",
-        "base_num_query_heads=4",
-        "base_num_kv_heads=4",
-        "head_dim=32",
-        # Gated Delta Net Dims (Using renamed parameters)
-        "gdn_num_value_heads=4",
-        "gdn_num_key_heads=4",
-        "gdn_key_head_dim=32",
-        "gdn_value_head_dim=32",
-        "gdn_conv_kernel_dim=4",
-        "gdn_chunk_size=64",
-        "use_qk_norm_in_gdn=True",  # Use renamed parameter
-        "normalization_layer_epsilon=1e-6",
-        # MoE Test Configs (with a small number of experts)
-        "base_mlp_dim=256",
-        "num_experts=8",
-        "num_experts_per_tok=2",
-        "base_moe_mlp_dim=256",  # moe_mlp_dim will be calculated from this
-        "norm_topk_prob=True",
-        "shard_exp_on_fsdp=False",
-        "mlp_activations=['silu', 'linear']",
-        "dropout_rate=0.0",
-        "sparse_matmul=False",
-        "skip_jax_distributed_system=True",
-        # For FullAttention Layer
-        "attention_bias=False",
-        "rope_max_timescale=10000.0",
-        "partial_rotary_factor=0.25",
-    ])
+    cfg = pyconfig.initialize(
+        [
+            None,
+            get_test_config_path(),
+            # Base settings for the test
+            "run_name=qwen3_next_test",
+            "dtype=float32",
+            "weight_dtype=float32",
+            "matmul_precision=highest",
+            "float32_logits=True",
+            "decoder_block=qwen3_next",
+            f"attention={attention_type}",  # Override attention type
+            # Model dimensions
+            "base_emb_dim=128",
+            "base_num_query_heads=4",
+            "base_num_kv_heads=4",
+            "head_dim=32",
+            # Gated Delta Net Dims (Using renamed parameters)
+            "gdn_num_value_heads=4",
+            "gdn_num_key_heads=4",
+            "gdn_key_head_dim=32",
+            "gdn_value_head_dim=32",
+            "gdn_conv_kernel_dim=4",
+            "gdn_chunk_size=64",
+            "use_qk_norm_in_gdn=True",  # Use renamed parameter
+            "normalization_layer_epsilon=1e-6",
+            # MoE Test Configs (with a small number of experts)
+            "base_mlp_dim=256",
+            "num_experts=8",
+            "num_experts_per_tok=2",
+            "base_moe_mlp_dim=256",  # moe_mlp_dim will be calculated from this
+            "norm_topk_prob=True",
+            "shard_exp_on_fsdp=False",
+            "mlp_activations=['silu', 'linear']",
+            "dropout_rate=0.0",
+            "sparse_matmul=False",
+            "skip_jax_distributed_system=True",
+            # For FullAttention Layer
+            "attention_bias=False",
+            "rope_max_timescale=10000.0",
+            "partial_rotary_factor=0.25",
+        ]
+    )
 
     # 1. Config for PyTorch
     pt_config = SimpleNamespace(
@@ -1383,38 +1169,26 @@ class TestQwen3Next(unittest.TestCase):
 
     # Target jax_model.attention.query
     pt_q_proj_w = pt_state_dict["q_proj.weight"].T.numpy()
-    jax_q_proj_w = pt_q_proj_w.reshape(
-        cfg.emb_dim, cfg.num_query_heads, cfg.head_dim * 2
-    )
+    jax_q_proj_w = pt_q_proj_w.reshape(cfg.emb_dim, cfg.num_query_heads, cfg.head_dim * 2)
     jax_q_params = {"kernel": nnx.Param(jnp.array(jax_q_proj_w))}
     if cfg.attention_bias:
-      jax_q_params["bias"] = nnx.Param(
-          jnp.array(pt_state_dict["q_proj.bias"].numpy())
-      )
+      jax_q_params["bias"] = nnx.Param(jnp.array(pt_state_dict["q_proj.bias"].numpy()))
     nnx.update(jax_model.attention.query, jax_q_params)
 
     # Target jax_model.attention.key
     pt_k_proj_w = pt_state_dict["k_proj.weight"].T.numpy()
-    jax_k_proj_w = pt_k_proj_w.reshape(
-        cfg.emb_dim, cfg.num_kv_heads, cfg.head_dim
-    )
+    jax_k_proj_w = pt_k_proj_w.reshape(cfg.emb_dim, cfg.num_kv_heads, cfg.head_dim)
     jax_k_params = {"kernel": nnx.Param(jnp.array(jax_k_proj_w))}
     if cfg.attention_bias:
-      jax_k_params["bias"] = nnx.Param(
-          jnp.array(pt_state_dict["k_proj.bias"].numpy())
-      )
+      jax_k_params["bias"] = nnx.Param(jnp.array(pt_state_dict["k_proj.bias"].numpy()))
     nnx.update(jax_model.attention.key, jax_k_params)
 
     # Target jax_model.attention.value
     pt_v_proj_w = pt_state_dict["v_proj.weight"].T.numpy()
-    jax_v_proj_w = pt_v_proj_w.reshape(
-        cfg.emb_dim, cfg.num_kv_heads, cfg.head_dim
-    )
+    jax_v_proj_w = pt_v_proj_w.reshape(cfg.emb_dim, cfg.num_kv_heads, cfg.head_dim)
     jax_v_params = {"kernel": nnx.Param(jnp.array(jax_v_proj_w))}
     if cfg.attention_bias:
-      jax_v_params["bias"] = nnx.Param(
-          jnp.array(pt_state_dict["v_proj.bias"].numpy())
-      )
+      jax_v_params["bias"] = nnx.Param(jnp.array(pt_state_dict["v_proj.bias"].numpy()))
     nnx.update(jax_model.attention.value, jax_v_params)
 
     # Target jax_model.attention.out
@@ -1423,43 +1197,27 @@ class TestQwen3Next(unittest.TestCase):
     jax_o_proj_w = pt_o_proj_w
     jax_o_params = {"kernel": nnx.Param(jnp.array(jax_o_proj_w))}
     if cfg.attention_bias:
-      jax_o_params["bias"] = nnx.Param(
-          jnp.array(pt_state_dict["o_proj.bias"].numpy())
-      )
+      jax_o_params["bias"] = nnx.Param(jnp.array(pt_state_dict["o_proj.bias"].numpy()))
     nnx.update(jax_model.attention.out, jax_o_params)
 
     # Target jax_model.attention.query_norm and key_norm
     if jax_model.attention.query_norm is not None:
       nnx.update(
           jax_model.attention.query_norm,
-          {
-              "weight": nnx.Param(
-                  jnp.array(pt_state_dict["q_norm.weight"].numpy())
-              )
-          },
+          {"weight": nnx.Param(jnp.array(pt_state_dict["q_norm.weight"].numpy()))},
       )
     if jax_model.attention.key_norm is not None:
       nnx.update(
           jax_model.attention.key_norm,
-          {
-              "weight": nnx.Param(
-                  jnp.array(pt_state_dict["k_norm.weight"].numpy())
-              )
-          },
+          {"weight": nnx.Param(jnp.array(pt_state_dict["k_norm.weight"].numpy()))},
       )
 
     # 5. Prepare Inputs
-    hidden_states_np = np.random.randn(
-        self.batch_size, self.seq_len, cfg.emb_dim
-    ).astype(np.float32)
+    hidden_states_np = np.random.randn(self.batch_size, self.seq_len, cfg.emb_dim).astype(np.float32)
     hidden_states_pt = torch.from_numpy(hidden_states_np)
     hidden_states_jax = jnp.array(hidden_states_np)
 
-    position_ids_pt = (
-        torch.arange(0, self.seq_len, dtype=torch.long)
-        .unsqueeze(0)
-        .repeat(self.batch_size, 1)
-    )
+    position_ids_pt = torch.arange(0, self.seq_len, dtype=torch.long).unsqueeze(0).repeat(self.batch_size, 1)
     decoder_positions_jax = jnp.array(position_ids_pt.numpy())
 
     # Causal mask for PyTorch
@@ -1467,9 +1225,7 @@ class TestQwen3Next(unittest.TestCase):
     attention_mask_pt = attention_mask_pt[None, None, :, :]
 
     # Segment IDs for JAX (for causal mask)
-    decoder_segment_ids_jax = jnp.ones(
-        (self.batch_size, self.seq_len), dtype=jnp.int32
-    )
+    decoder_segment_ids_jax = jnp.ones((self.batch_size, self.seq_len), dtype=jnp.int32)
 
     # 6. Get PyTorch cos, sin
     cos_pt, sin_pt = rotary_emb_pt(hidden_states_pt, position_ids_pt)
@@ -1494,9 +1250,7 @@ class TestQwen3Next(unittest.TestCase):
           model_mode="train",
       )
 
-    jax_output = run_jax(
-        hidden_states_jax, decoder_segment_ids_jax, decoder_positions_jax
-    )
+    jax_output = run_jax(hidden_states_jax, decoder_segment_ids_jax, decoder_positions_jax)
 
     # 9. Compare
     pt_out_np = pt_output.detach().numpy()


### PR DESCRIPTION
# Description

## Overview
This pull request addresses code quality and formatting consistency across all Python files in the MaxText repository, ensuring full compliance with pre-commit linting standards (`pyink`, `pylint`, and `codespell`).
All changes are purely cosmetic and structural formatting fixes. No underlying execution logic or existing documentation comments were altered.
## Key Changes
* **Automated Code Formatting**: Ran `pyink` repository-wide to ensure consistent line lengths, indentation, and spacing.
* **Robust File Handling**: Specified explicit `encoding="utf-8"` in `open()` calls (`json_reporter.py`, `eval_runner.py`) and refactored temporary file handling to use `with` context managers (`test_eval_runner.py`).
* **Docstring & Import Corrections**:
  * Corrected a broken import path in `generate_sft_golden_data.py` (`tests.post_training.integration.sft_trainer_correctness_test`).
  * Added missing docstrings to helper functions (`_derive_from_maxtext_config`, `_build_arg_parser`, `_wait_until_healthy`) and test classes to satisfy `pylint`.
  * Replaced keyword calls to `dict()` with standard dictionary literals (`{}`) for better runtime performance as recommended by `pylint: use-dict-literal`.
  * Added targeted `# pylint: disable` annotations where appropriate (e.g., for test fixtures requiring `import-outside-toplevel` or internal `protected-access`).

# Tests

GitHub CI.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
