### PR TITLE
Refactor grain_data_processing_test and improve time

### DIFF
--- a/tests/unit/grain_data_processing_test.py
+++ b/tests/unit/grain_data_processing_test.py
@@ -35,7 +35,7 @@ from tests.utils.test_helpers import get_test_base_output_directory, get_test_co
 
 
 class GrainBaseProcessingTest:
-  """Base mixin with shared test methods for all grain data processing tests.
+  """Base mixin with test_train_ds for all grain data processing tests.
 
   Does not inherit from unittest.TestCase to prevent the test runner from
   discovering and executing it directly. Concrete subclasses must also inherit
@@ -70,6 +70,14 @@ class GrainBaseProcessingTest:
         },
     )
 
+
+class GrainDeterminismMixin:
+  """Mixin with determinism tests. Mix into format base classes, not variant subclasses.
+
+  Variant subclasses should inherit only from the setup mixin and GrainBaseProcessingTest
+  so that they pick up test_train_ds but not these determinism tests.
+  """
+
   def test_batch_determinism(self):
     batch1 = next(self.train_iter)
     train_iter = grain_data_processing.make_grain_train_iterator(self.config, self.mesh, self.process_indices)
@@ -94,17 +102,15 @@ class GrainBaseProcessingTest:
     self.assertTrue((train_batch1["targets"] == train_batch2["targets"]).all())  # pytype: disable=unsupported-operands
 
 
-class GrainArrayRecordProcessingTest(GrainBaseProcessingTest, unittest.TestCase):
-  """Test grain data processing with ArrayRecord format.
+class _GrainArrayRecordSetup:
+  """Private setup mixin for ArrayRecord tests: provides setUp and _make_config.
 
-  In decoupled mode, reads directly from GCS. Otherwise, reads from GCSFUSE mounted path
+  No test methods here — inherit this alongside GrainBaseProcessingTest (and
+  optionally GrainDeterminismMixin) to compose the desired test surface.
   """
 
-  @classmethod
-  def setUpClass(cls):
-    super().setUpClass()
-
   def setUp(self):
+    """Common setup for ArrayRecrd format"""
     super().setUp()
     temp_dir = tempfile.gettempdir()
     decoupled = is_decoupled()
@@ -174,12 +180,30 @@ class GrainArrayRecordProcessingTest(GrainBaseProcessingTest, unittest.TestCase)
     }
     return pyconfig.initialize([sys.argv[0], get_test_config_path()], **kwargs)
 
+
+class GrainArrayRecordProcessingTest(
+    _GrainArrayRecordSetup, GrainDeterminismMixin, GrainBaseProcessingTest, unittest.TestCase
+):
+  """Test grain data processing with ArrayRecord format.
+
+  In decoupled mode, reads directly from GCS. Otherwise, reads from GCSFUSE mounted path.
+  Inherits test_train_ds, test_batch_determinism, and test_for_loop_repeatable.
+  Variant subclasses should inherit _GrainArrayRecordSetup + GrainBaseProcessingTest
+  directly to get only test_train_ds.
+  """
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+
   @pytest.mark.external_serving  # Skipped in decoupled mode due to rocBLAS scratch buffer TF issues on GPU
   def test_batch_determinism(self):
     super().test_batch_determinism()
 
 
-class GrainArrayRecordProcessingWithMultiSourceBlendingTest(GrainArrayRecordProcessingTest):
+class GrainArrayRecordProcessingWithMultiSourceBlendingTest(
+    _GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase
+):
 
   def setUp(self):
     super().setUp()
@@ -187,7 +211,7 @@ class GrainArrayRecordProcessingWithMultiSourceBlendingTest(GrainArrayRecordProc
     self.config = self._make_config(grain_train_files=train_files_weighted)
 
 
-class GrainArrayRecordProcessingWithMixtureConfigTest(GrainArrayRecordProcessingTest):
+class GrainArrayRecordProcessingWithMixtureConfigTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
 
   def setUp(self):
     super().setUp()
@@ -238,29 +262,16 @@ class GrainArrayRecordProcessingWithMixtureConfigTest(GrainArrayRecordProcessing
 
 # TODO(aireenmei): Migrate this test to XLML
 @pytest.mark.skip(reason="Flaky test")
-class GrainArrayRecordAutoTuneTest(GrainArrayRecordProcessingTest):
+class GrainArrayRecordAutoTuneTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with auto-tuning enabled (grain_worker_count=-1)."""
 
   def setUp(self):
     super().setUp()
     self.config = self._make_config(grain_ram_budget_mb=512, grain_worker_count=-1)  # Enable auto-tuning
 
-  @pytest.mark.skip(
-      reason=(
-          "Auto-tuning tries multiple numbers of workers during the first few batches "
-          "and it affects batch determinism at first."
-      )
-  )
-  def test_batch_determinism(self):
-    super().test_batch_determinism()
 
-  @pytest.mark.skip(reason="Flaky test - see b/475255774.")
-  def test_for_loop_repeatable(self):
-    super().test_for_loop_repeatable()
-
-
-class GrainArrayRecordTiktokenTest(GrainArrayRecordProcessingTest):
-  """Test grain data processing with best_fit packing strategy."""
+class GrainArrayRecordTiktokenTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
+  """Test grain data processing with tiktoken tokenizer."""
 
   def setUp(self):
     super().setUp()
@@ -269,18 +280,9 @@ class GrainArrayRecordTiktokenTest(GrainArrayRecordProcessingTest):
         tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "tokenizer_llama3.tiktoken"),
     )
 
-  # Only runs test_train_ds from parent class, skip other tests
-  @pytest.mark.skip(reason="skip for tokenizer testing")
-  def test_batch_determinism(self):
-    pass
 
-  @pytest.mark.skip(reason="skip for tokenizer testing")
-  def test_for_loop_repeatable(self):
-    pass
-
-
-class GrainArrayRecordHFTokenizerTest(GrainArrayRecordProcessingTest):
-  """Test grain data processing with best_fit packing strategy."""
+class GrainArrayRecordHFTokenizerTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
+  """Test grain data processing with HuggingFace tokenizer."""
 
   def setUp(self):
     super().setUp()
@@ -289,17 +291,8 @@ class GrainArrayRecordHFTokenizerTest(GrainArrayRecordProcessingTest):
         tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "qwen3-tokenizer"),
     )
 
-  # Only runs test_train_ds from parent class, skip other tests
-  @pytest.mark.skip(reason="skip for tokenizer testing")
-  def test_batch_determinism(self):
-    pass
 
-  @pytest.mark.skip(reason="skip for tokenizer testing")
-  def test_for_loop_repeatable(self):
-    pass
-
-
-class GrainArrayRecordBestFitPackingTest(GrainArrayRecordProcessingTest):
+class GrainArrayRecordBestFitPackingTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with best_fit packing strategy."""
 
   def setUp(self):
@@ -307,17 +300,15 @@ class GrainArrayRecordBestFitPackingTest(GrainArrayRecordProcessingTest):
     self.config = self._make_config(grain_packing_type="best_fit")
 
 
-class GrainParquetProcessingTest(GrainBaseProcessingTest, unittest.TestCase):
-  """Test grain data processing with Parquet format.
+class _GrainParquetSetup:
+  """Private setup mixin for Parquet tests.
 
-  In decoupled mode, reads directly from GCS. Otherwise, reads from GCSFUSE mounted path
+  No test methods here — inherit this alongside GrainBaseProcessingTest (and
+  optionally GrainDeterminismMixin) to compose the desired test surface.
   """
 
-  @classmethod
-  def setUpClass(cls):
-    super().setUpClass()
-
   def setUp(self):
+    """Common setup for Parquet format."""
     super().setUp()
     temp_dir = tempfile.gettempdir()
     decoupled = is_decoupled()
@@ -341,9 +332,8 @@ class GrainParquetProcessingTest(GrainBaseProcessingTest, unittest.TestCase):
       )
       base_output_directory = "gs://max-experiments/"
 
-    config_file = get_test_config_path()
     self.config = pyconfig.initialize(
-        [sys.argv[0], config_file],
+        [sys.argv[0], get_test_config_path()],
         per_device_batch_size=1,
         run_name="test",
         mesh_axes=["data"],
@@ -369,18 +359,91 @@ class GrainParquetProcessingTest(GrainBaseProcessingTest, unittest.TestCase):
         self.mesh,
     )
 
+  def _make_config(self, **overrides):
+    """Re-initialize config with base params, applying any overrides."""
+    kwargs = {
+        "per_device_batch_size": 1,
+        "run_name": "test",
+        "mesh_axes": ["data"],
+        "logical_axis_rules": [["batch", "data"]],
+        "data_sharding": ["data"],
+        "base_output_directory": self.config.base_output_directory,
+        "dataset_type": "grain",
+        "grain_file_type": "parquet",
+        "grain_train_files": self.config.grain_train_files,
+        "grain_worker_count": 1,
+        "grain_per_worker_buffer_size": 1,
+        "tokenizer_path": os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "tokenizer.default"),
+        "enable_checkpointing": False,
+        "max_target_length": 128,
+        **overrides,
+    }
+    return pyconfig.initialize([sys.argv[0], get_test_config_path()], **kwargs)
 
-class GrainTFRecordProcessingTest(GrainBaseProcessingTest, unittest.TestCase):
-  """Test grain data processing with TFRecord format.
 
-  In decoupled mode, reads directly from GCS. Otherwise, reads from GCSFUSE mounted path
+class GrainParquetProcessingTest(_GrainParquetSetup, GrainDeterminismMixin, GrainBaseProcessingTest, unittest.TestCase):
+  """Test grain data processing with Parquet format.
+
+  In decoupled mode, reads directly from GCS. Otherwise, reads from GCSFUSE mounted path.
+  Inherits test_train_ds, test_batch_determinism, and test_for_loop_repeatable.
+  Variant subclasses should inherit _GrainParquetSetup + GrainBaseProcessingTest
+  directly to get only test_train_ds.
   """
 
   @classmethod
   def setUpClass(cls):
     super().setUpClass()
 
+
+@pytest.mark.external_training
+class GrainSFTParquetProcessingTest(_GrainParquetSetup, unittest.TestCase):
+  """Tests the SFT pipeline end-to-end using the real ultrachat_200k parquet dataset."""
+
   def setUp(self):
+    super().setUp()
+    self.config = self._make_config(
+        grain_train_files="gs://maxtext-dataset/hf/ultrachat_200k/train_sft-*.parquet",
+        base_output_directory="gs://max-experiments/",
+        use_sft=True,
+        sft_train_on_completion_only=True,
+        train_data_columns=["messages"],
+        tokenizer_type="huggingface",
+        tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "qwen3-tokenizer"),
+        packing=True,
+    )
+    self.train_iter = grain_data_processing.make_grain_train_iterator(self.config, self.mesh, self.process_indices)
+
+  def test_train_ds(self):
+    expected_shape = [jax.device_count(), self.config.max_target_length]
+    batch = next(self.train_iter)
+
+    # Assert all the required packing and target tensors were generated
+    self.assertEqual(
+        {k: list(v.shape) for k, v in batch.items()},
+        {
+            "inputs": expected_shape,
+            "inputs_position": expected_shape,
+            "inputs_segmentation": expected_shape,
+            "targets": expected_shape,
+            "targets_position": expected_shape,
+            "targets_segmentation": expected_shape,
+        },
+    )
+
+    # check to see that if prompts are masked, targets will differ from inputs
+    has_masked_tokens = np.any(batch["inputs"] != batch["targets"])
+    self.assertTrue(bool(has_masked_tokens), "Targets array should differ from inputs array due to prompt masking.")
+
+
+class _GrainTFRecordSetup:
+  """Private setup mixin for TFRecord tests.
+
+  No test methods here — inherit this alongside GrainBaseProcessingTest (and
+  optionally GrainDeterminismMixin) to compose the desired test surface.
+  """
+
+  def setUp(self):
+    """Common setup for TFRecord format"""
     super().setUp()
     temp_dir = tempfile.gettempdir()
     decoupled = is_decoupled()
@@ -434,8 +497,43 @@ class GrainTFRecordProcessingTest(GrainBaseProcessingTest, unittest.TestCase):
         self.mesh,
     )
 
+  def _make_config(self, **overrides):
+    """Re-initialize config with base params, applying any overrides."""
+    kwargs = {
+        "per_device_batch_size": 1,
+        "run_name": "test",
+        "mesh_axes": ["data"],
+        "logical_axis_rules": [["batch", "data"]],
+        "data_sharding": ["data"],
+        "base_output_directory": self.config.base_output_directory,
+        "dataset_type": "grain",
+        "grain_file_type": "tfrecord",
+        "grain_train_files": self.config.grain_train_files,
+        "grain_worker_count": 1,
+        "grain_per_worker_buffer_size": 1,
+        "tokenizer_path": os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "tokenizer.default"),
+        "enable_checkpointing": False,
+        "max_target_length": 128,
+        **overrides,
+    }
+    return pyconfig.initialize([sys.argv[0], get_test_config_path()], **kwargs)
 
-class GrainTFRecordPreTokenizedProcessingTest(GrainTFRecordProcessingTest):
+
+class GrainTFRecordProcessingTest(_GrainTFRecordSetup, GrainDeterminismMixin, GrainBaseProcessingTest, unittest.TestCase):
+  """Test grain data processing with TFRecord format.
+
+  In decoupled mode, reads directly from GCS. Otherwise, reads from GCSFUSE mounted path.
+  Inherits test_train_ds, test_batch_determinism, and test_for_loop_repeatable.
+  Variant subclasses should inherit _GrainTFRecordSetup + GrainBaseProcessingTest
+  directly to get only test_train_ds.
+  """
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+
+
+class GrainTFRecordPreTokenizedProcessingTest(_GrainTFRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with a pre-tokenized TFRecord dataset (tokenize_train_data=False).
 
   Uses c4/en/3.0.5 validation_tokenized_5662seqs split, which stores token IDs
@@ -446,90 +544,12 @@ class GrainTFRecordPreTokenizedProcessingTest(GrainTFRecordProcessingTest):
     super().setUp()
     base = get_test_dataset_path() if is_decoupled() else os.path.join(tempfile.gettempdir(), "gcsfuse")
     grain_train_file = os.path.join(base, "c4", "en", "3.0.5", "c4-validation_tokenized_5662seqs.tfrecord-00000-of-00001")
-    self.config = pyconfig.initialize(
-        [sys.argv[0], get_test_config_path()],
-        per_device_batch_size=1,
-        run_name="test",
-        mesh_axes=["data"],
-        logical_axis_rules=[["batch", "data"]],
-        data_sharding=["data"],
-        base_output_directory=self.config.base_output_directory,
-        dataset_type="grain",
-        grain_file_type="tfrecord",
+    self.config = self._make_config(
         grain_train_files=grain_train_file,
-        grain_worker_count=1,
-        grain_per_worker_buffer_size=1,
         tokenize_train_data=False,
         train_data_columns=["ids"],
-        tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "tokenizer.default"),
-        enable_checkpointing=False,
+        packing=False,
     )
-
-
-@pytest.mark.external_training
-class GrainSFTParquetProcessingTest(unittest.TestCase):
-  """Tests the SFT pipeline end-to-end using the real ultrachat_200k parquet dataset."""
-
-  def setUp(self):
-    super().setUp()
-
-    grain_train_file = "gs://maxtext-dataset/hf/ultrachat_200k/train_sft-*.parquet"
-    base_output_directory = "gs://max-experiments/"
-    config_file = get_test_config_path()
-
-    self.config = pyconfig.initialize(
-        [sys.argv[0], config_file],
-        per_device_batch_size=1,
-        run_name="test",
-        mesh_axes=["data"],
-        logical_axis_rules=[["batch", "data"]],
-        data_sharding=["data"],
-        base_output_directory=base_output_directory,
-        dataset_type="grain",
-        grain_file_type="parquet",
-        grain_train_files=grain_train_file,
-        use_sft=True,  # Triggers your new SFT pipeline
-        sft_train_on_completion_only=True,
-        train_data_columns=["messages"],
-        tokenizer_type="huggingface",
-        tokenizer_path=os.path.join(MAXTEXT_ASSETS_ROOT, "tokenizers", "qwen3-tokenizer"),
-        max_target_length=128,
-        packing=True,
-        grain_worker_count=1,
-        grain_per_worker_buffer_size=1,
-        enable_checkpointing=False,
-    )
-    self.mesh_shape_1d = (len(jax.devices()),)
-    self.mesh = Mesh(mesh_utils.create_device_mesh(self.mesh_shape_1d), self.config.mesh_axes)
-    self.process_indices = input_pipeline_interface.get_process_loading_real_data(
-        self.config.data_sharding,
-        self.config.global_batch_size_to_load,
-        self.config.global_batch_size_to_train_on,
-        self.config.max_target_length,
-        self.mesh,
-    )
-    self.train_iter = grain_data_processing.make_grain_train_iterator(self.config, self.mesh, self.process_indices)
-
-  def test_train_ds(self):
-    expected_shape = [jax.device_count(), self.config.max_target_length]
-    batch = next(self.train_iter)
-
-    # Assert all the required packing and target tensors were generated
-    self.assertEqual(
-        {k: list(v.shape) for k, v in batch.items()},
-        {
-            "inputs": expected_shape,
-            "inputs_position": expected_shape,
-            "inputs_segmentation": expected_shape,
-            "targets": expected_shape,
-            "targets_position": expected_shape,
-            "targets_segmentation": expected_shape,
-        },
-    )
-
-    # check to see that if prompts are masked, targets will differ from inputs
-    has_masked_tokens = np.any(batch["inputs"] != batch["targets"])
-    self.assertTrue(bool(has_masked_tokens), "Targets array should differ from inputs array due to prompt masking.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

As data pipeline unit tests in grain_data_processing_test.py grow, it take a lot of time from the CI runner. The base test includes three tests: test_train_ds, test_batch_determinism, test_for_loop_repeatable. And all the variants inherit these three test. Since it's unlikely for the config variants to change the determinism and for_loop_repeatable behavior, this PR refactor introduces _Grain{format}Setup, GrainBaseProcessingTest, GrainDeterminismMixin class, and have the config variant test only inherit _Grain{format}Setup and GrainBaseProcessingTest to reduce the time for running determinism tests.

# Tests
When running locally (CI runner time will be different but expect similar percentage)
Before this PR, all tests in grain_data_processing_test.py takes 7:08 min, [log](https://paste.googleplex.com/6324990598316032)
After this PR, all tests in grain_data_processing_test.py takes 4:15 min, [log](https://paste.googleplex.com/5186187737300992)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
