### PR TITLE
Configure Gemini failure investigator budget, invoke on labels and scheduled run failures

### DIFF
--- a/.gemini/commands/gemini-investigate.toml
+++ b/.gemini/commands/gemini-investigate.toml
@@ -10,6 +10,8 @@ You are a world-class autonomous software diagnostics agent. Your purpose is to 
 
 *Optimizing Investigation Efficiency:* Perform cheap, lightweight actions first (reading local log files, searching git history, checking previous issues/diffs) before initiating deep analysis of codebase modules or downloading heavy build artifacts.
 
+*Turn Budgeting:* You have a maximum budget of 100 tool execution turns. You must keep track of how many tool calls you have made. Once you reach 95 tool calls, you must immediately stop investigating and output a final summary of whatever information you have gathered so far.
+
 1. **Read & Parse failed_logs.txt:**
    - Locate the failing test functions, classes, or scripts.
    - Extract the exact error messages and tracebacks.

--- a/.github/workflows/build_and_test_maxtext.yml
+++ b/.github/workflows/build_and_test_maxtext.yml
@@ -304,3 +304,18 @@ jobs:
         uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  investigate_failure:
+    name: Investigate failed build # investigates failure of scheduled run and comments on tracking issue
+    needs: [tpu-tests, gpu-tests, cpu-tests, maxtext_jupyter_notebooks, maxtext_tpu_pathways_unit_tests, maxtext_tpu_pathways_integration_tests, notify_failure]
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule' }}
+    uses: ./.github/workflows/gemini-investigate.yml
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      issues: 'write'
+      pull-requests: 'write'
+      actions: 'read'
+    with:
+      failed_run_id: '${{ github.run_id }}'
+    secrets: inherit

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -50,7 +50,7 @@ jobs:
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.fork == false &&
         github.event.action == 'labeled' &&
-        contains(github.event.label.name, 'gemini-review')
+        (contains(github.event.label.name, 'gemini-review') || contains(github.event.label.name, 'gemini-investigate'))
       ) || (
         github.event.sender.type == 'User' &&
         startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') &&
@@ -95,6 +95,8 @@ jobs:
 
             if (payload.action === 'labeled' && payload.label && payload.label.name.includes('gemini-review')) {
               core.setOutput('command', 'review');
+            } else if (payload.action === 'labeled' && payload.label && payload.label.name.includes('gemini-investigate')) {
+              core.setOutput('command', 'investigate');
             } else if (request.startsWith("@gemini-cli /review")) {
               core.setOutput('command', 'review');
               core.setOutput('additional_context', '');

--- a/.github/workflows/gemini-investigate.yml
+++ b/.github/workflows/gemini-investigate.yml
@@ -87,7 +87,7 @@ jobs:
           settings: |-
             {
               "model": {
-                "maxSessionTurns": 50
+                "maxSessionTurns": 100
               },
               "mcpServers": {
                 "github": {


### PR DESCRIPTION
This PR adds tool calling budget management such that the agent doesn't just fails when running out of budget but stops more gracefully with whatever it found out so far. 

In addition, it adds a way to invoke the investigator via a new "gemini-investigate" label.

Finally, on scheduled run, the agent is invoked automatically and its findings added to the Github issue tracking the test failure.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
