### PR TITLE
Updates 'full' remat policy to use `nothing_saveable`

### DIFF
--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -436,7 +436,7 @@ class Decoder(nn.Module):
         )
       else:
         assert cfg.remat_policy == "full", "Remat policy needs to be on list of remat policies"
-        policy = None
+        policy = jax.checkpoint_policies.nothing_saveable
     return policy
 
   def get_decoder_layers(self):


### PR DESCRIPTION
Maps `'full'` remat policy to `jax.checkpoint_policies.nothing_saveable` to fix previous mapping to `None`, which JAX interpreted as "save all activations."