### PR TITLE
Gemma and Gemma 2 Native Serving Registration

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/__init__.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/__init__.py
@@ -30,4 +30,6 @@ def register():
   """
   logger.info("Registering MaxTextForCausalLM model with tpu_inference and vllm.")
   register_model("MaxTextForCausalLM", MaxTextForCausalLM)
-  logger.info("Successfully registered MaxTextForCausalLM model.")
+  register_model("GemmaForCausalLM", MaxTextForCausalLM)
+  register_model("Gemma2ForCausalLM", MaxTextForCausalLM)
+  logger.info("Successfully registered MaxTextForCausalLM, Gemma2ForCausalLM, and GemmaForCausalLM model.")


### PR DESCRIPTION
Maps GemmaForCausalLM and Gemma2ForCausalLM to the high-performance JAX-native adapter, preventing vLLM from falling back to PyTorch and crashing or running inefficiently.
