### PR TITLE
Supports batching in vLLM offline inference script

### DIFF
--- a/src/maxtext/inference/vllm_decode.py
+++ b/src/maxtext/inference/vllm_decode.py
@@ -124,7 +124,7 @@ def decode_with_vllm(config: Config) -> None:
       token=config.hf_access_token,
   )
 
-  prompts = [config.prompt]
+  prompts = [config.prompt] * int(config.per_device_batch_size)
   if config.use_chat_template:
     # Format the prompt using chat template if specified
     messages = [


### PR DESCRIPTION
# Description

Support batching in vLLM offline inference script

This change enables batching in the `vllm_decode.py` offline inference script by duplicating the input prompt based on the `per_device_batch_size` configuration parameter. 

Details:
- Replaces the hardcoded single-prompt list with a list multiplied by `per_device_batch_size`.
- Explicitly casts `per_device_batch_size` to `int` to prevent `TypeError` when the parameter defaults to a float (e.g., `12.0` in `base.yml`).
- Allows users to benchmark vLLM offline inference throughput with larger batch sizes by overriding `per_device_batch_size` on the command line.

# Tests

I verified this change by running the `vllm_decode` script on a TPU v5e-8 VM with `per_device_batch_size` set to different values, confirming that it batches correctly and generates outputs.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).