### PR TITLE
Allow identical config overrides and handle configuration exceptions …

### DIFF
--- a/src/maxtext/configs/pyconfig.py
+++ b/src/maxtext/configs/pyconfig.py
@@ -125,11 +125,27 @@ def yaml_key_to_env_key(s: str) -> str:
   return _MAX_PREFIX + s.upper()
 
 
-def validate_no_keys_overridden_twice(keys1: list[str], keys2: list[str]):
-  overridden_keys = [k for k in keys1 if k in keys2]
-  if overridden_keys:
+def validate_no_keys_overridden_twice(model_loaded_cfg: omegaconf.DictConfig, overrides_cfg: omegaconf.DictConfig):
+  """Validates that no keys are overridden by both model config and overrides with different values."""
+  overridden_keys = [k for k in model_loaded_cfg.keys() if k in overrides_cfg.keys()]
+  really_overridden_keys = []
+  for k in overridden_keys:
+    try:
+      model_val = omegaconf.OmegaConf.to_container(omegaconf.OmegaConf.create({k: model_loaded_cfg[k]}), resolve=True)[k]
+    except Exception:  # pylint: disable=broad-exception-caught
+      model_val = model_loaded_cfg[k]
+
+    try:
+      override_val = omegaconf.OmegaConf.to_container(omegaconf.OmegaConf.create({k: overrides_cfg[k]}), resolve=True)[k]
+    except Exception:  # pylint: disable=broad-exception-caught
+      override_val = overrides_cfg[k]
+
+    if model_val != override_val:
+      really_overridden_keys.append(k)
+
+  if really_overridden_keys:
     raise ValueError(
-        f"Keys {overridden_keys} are overridden by both model config and CLI/kwargs."
+        f"Keys {really_overridden_keys} are overridden by both model config and CLI/kwargs with different values."
         "This is not allowed, unless setting `override_model_config=True`."
     )
 
@@ -310,14 +326,58 @@ class HyperParameters:
     return self._flat_config
 
 
+def _handle_config_exception(e: Exception):
+  """Handles configuration exceptions, prints to stderr, writes log, and exits or raises."""
+  # Format a clear and concise error message
+  err_msg = f"MAXTEXT CONFIG ERROR: {str(e)}"
+
+  # Log in highly visible format
+  max_logging.error("=" * 80)
+  max_logging.error(err_msg)
+  max_logging.error("=" * 80)
+
+  # Try writing to /dev/termination-log for Kubernetes
+  try:
+    with open("/dev/termination-log", "w", encoding="utf-8") as f:
+      f.write(err_msg)
+  except Exception:  # pylint: disable=broad-exception-caught
+    pass
+
+  # Exit with code 2 if not running in a test framework
+  if "pytest" not in sys.modules and "unittest" not in sys.modules:
+    sys.exit(2)
+  else:
+    raise e
+
+
 def initialize(argv: list[str] | None = None, **kwargs) -> HyperParameters:
   """Initializes the configuration by loading YAML files, and applying CLI, env, and kwarg overrides."""
-  pydantic_config = initialize_pydantic(argv, **kwargs)
-  config = HyperParameters(pydantic_config)
-  return config
+  try:
+    pydantic_config = _initialize_pydantic(argv, **kwargs)
+    config = HyperParameters(pydantic_config)
+    return config
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    if isinstance(e, (SystemExit, KeyboardInterrupt)):
+      raise e
+    _handle_config_exception(e)
+    raise e
 
 
 def initialize_pydantic(argv: list[str] | None = None, **kwargs) -> MaxTextConfig:
+  """Initializes the configuration by loading YAML files, and applying CLI, env, and overrides.
+
+  Returns the pydantic MaxTextConfig class.
+  """
+  try:
+    return _initialize_pydantic(argv, **kwargs)
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    if isinstance(e, (SystemExit, KeyboardInterrupt)):
+      raise e
+    _handle_config_exception(e)
+    raise e
+
+
+def _initialize_pydantic(argv: list[str] | None = None, **kwargs) -> MaxTextConfig:
   """Initializes the configuration by loading YAML files, and applying CLI, env, and kwarg overrides.
   Returns pydantic MaxTextConfig class whereas `initialize` returns the og `HyperParameters`
   """
@@ -373,7 +433,7 @@ def initialize_pydantic(argv: list[str] | None = None, **kwargs) -> MaxTextConfi
       else:
         model_cfg = model_loaded_cfg
         # Validate that no keys are overridden by both model config and CLI/kwargs
-        validate_no_keys_overridden_twice(model_loaded_cfg.keys(), overrides_cfg.keys())
+        validate_no_keys_overridden_twice(model_loaded_cfg, overrides_cfg)
     else:
       logger.warning("Model config for '%s' not found at %s", model_name, model_config_path)
 

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -162,6 +162,17 @@ class PyconfigTest(unittest.TestCase):
     config = pyconfig.initialize_pydantic(["/custom_rl/module.py", "run_name=test", "skip_jax_distributed_system=True"])
     self.assertEqual(config.run_name, "test")
 
+  def test_identical_override_allowed(self):
+    """Test that overriding a model config key with an identical value is allowed."""
+    config = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        model_name="qwen3-8b",
+        override_model_config=False,
+        tokenizer_type="huggingface",  # Defined as huggingface in qwen3-8b
+    )
+    self.assertEqual(config.tokenizer_type, "huggingface")
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
…cleanly with code 2 and Kubernetes termination logging

This PR addresses two issues in MaxText's configuration initialization and validation:

1. Previously, calling a model config with a command-line override would hard-reject the execution if the key was defined by both, even if the provided override value was completely identical (such as tokenizer_type="huggingface" when running qwen3 models). This PR modifies validate_no_keys_overridden_twice to compare the resolved values. Overrides are now allowed if the override value matches the model configuration value exactly. A ValueError is only raised if the values differ and override_model_config=False.

2. When a deterministic config validation error occurs during startup, JobSet/Kubernetes would previously crash-loop and exhaust maxRestarts because config validation errors looked like infrastructure/general flakes (exiting with code 1).
This PR catches configuration validation errors, prints a highly visible error banner to sys.stderr, writes the specific failure message to /dev/termination-log for Kubernetes status propagation, and exits with standard exit code 2 (reserved for CLI syntax and config errors). Standard behavior is bypassed when running in test environments (pytest/unittest) to allow original validation exceptions to propagate for assertions.

# Tests

Tested on TPU VM

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
