### PR TITLE
Upgrade libcusparse to 13-2 to support CUDA 13 base image

### DIFF
--- a/src/dependencies/dockerfiles/maxtext_gpu_dependencies.Dockerfile
+++ b/src/dependencies/dockerfiles/maxtext_gpu_dependencies.Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y google-cloud-sdk
 ENV PATH="/usr/local/google-cloud-sdk/bin:${PATH}"
 
 # Upgrade libcusprase to work with Jax
-RUN apt-get update && apt-get install -y libcusparse-12-6
+RUN apt-get update && apt-get install -y libcusparse-13-2
 
 ARG MODE
 ENV ENV_MODE=$MODE

--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -51,7 +51,6 @@ Example Usage:
 
 import argparse
 from functools import partial
-import importlib.util
 import json
 import os
 import sys
@@ -78,20 +77,10 @@ import numpy as np
 from orbax.checkpoint import type_handlers
 from safetensors import safe_open
 
-
-def _lazy_import(name: str):
-  spec = importlib.util.find_spec(name)
-  if spec is None:
-    return None
-  loader = importlib.util.LazyLoader(spec.loader)
-  spec.loader = loader
-  module = importlib.util.module_from_spec(spec)
-  sys.modules[name] = module
-  loader.exec_module(module)
-  return module
-
-
-torch = _lazy_import("torch")
+try:
+  import torch
+except ImportError:
+  torch = None
 
 
 absl.logging.set_verbosity(absl.logging.INFO)  # for max_logging.log

--- a/tests/integration/checkpoint_conversion_test.py
+++ b/tests/integration/checkpoint_conversion_test.py
@@ -21,11 +21,19 @@ import tempfile
 import unittest
 import pytest
 
+from maxtext.checkpoint_conversion import to_maxtext
+
 pytestmark = [pytest.mark.integration_test]
 
 
 class Qwen3CheckpointConversionTest(unittest.TestCase):
   """Tests HuggingFace to Orbax checkpoint conversion."""
+
+  @pytest.mark.cpu_only
+  def test_import_to_maxtext(self):
+    # This test validates that to_maxtext can be imported without errors,
+    # and ensures its top-level statements are covered by Codecov.
+    self.assertIsNotNone(to_maxtext)
 
   @pytest.mark.cpu_only
   def test_qwen3_30b_a3b_roundtrip_conversion(self):


### PR DESCRIPTION
# Description

This PR upgrades the `libcusparse` package version installed in the GPU dependencies Dockerfile to support the recently updated CUDA 13 base image, resolving the daily Docker build failures.
**Why is this change being made?**
The daily GitHub Actions workflow **Build Images (#1002)** started failing for GPU jobs (`maxtext_gpu_jax_stable` and `maxtext_gpu_jax_nightly`) because the package `libcusparse-12-6` could not be located. 
**Problem solved and context:**
The base image `ghcr.io/nvidia/jax:base` was recently upgraded to use **Ubuntu 24.04 (Noble)** and **CUDA 13.2.1** (upgraded from CUDA 12). Consequently, CUDA 12 packages (like `libcusparse-12-6`) are no longer available in the repositories. 


**Specific Implementation:**
- **Issue 1 Fix:** Diagnostic package search (`apt-cache search libcusparse`) inside the `ghcr.io/nvidia/jax:base` image confirmed that the correct runtime package name for CUDA 13.2 is **`libcusparse-13-2`**. We updated `src/dependencies/dockerfiles/maxtext_gpu_dependencies.Dockerfile` to install `libcusparse-13-2` instead of `libcusparse-12-6`.
- **Issue 2 Fix:** Eagerly imported `torch` in the top-level imports section of `to_maxtext.py` instead of lazy loading it, resolving the import resolution conflict.

FIXES: b/510149167
FIXES: #3823

# Tests

The changes were verified as follows:
1. **Base Image Inspection:** Verified inside a running instance of the base image `ghcr.io/nvidia/jax:base` that `libcusparse-13-2` is the correct and installable package name:
   ```bash
   docker run --rm ghcr.io/nvidia/jax:base apt-cache search libcusparse
   ```


Output:

```
libcusparse-13-2 - CUSPARSE native runtime libraries
libcusparse-dev-13-2 - CUSPARSE native dev links, headers
```

2. Workflow Path Validation: Confirmed `.github/workflows/UploadDockerImages.yml` correctly builds the Dockerfile from the package wheel, which will automatically propagate this fix during the next scheduled workflow.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
