### PR TITLE
Fix RTD variables synchronization

### DIFF
--- a/docs/_static/js/editable_commands.js
+++ b/docs/_static/js/editable_commands.js
@@ -88,10 +88,25 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
 
-    // If the user deletes everything and clicks away, restore the original placeholder
+    // Synchronize changes to other spans with the same placeholder
+    span.addEventListener('input', function () {
+      const placeholder = this.getAttribute('data-placeholder');
+      const newValue = this.textContent;
+
+      document.querySelectorAll(`.inline-input[data-placeholder="${placeholder}"]`).forEach(otherSpan => {
+        if (otherSpan !== this) {
+          otherSpan.textContent = newValue;
+        }
+      });
+    });
+
+    // If the user deletes everything and clicks away, restore the original placeholder for all matching spans
     span.addEventListener('blur', function () {
       if (this.textContent.trim() === '') {
-        this.textContent = this.getAttribute('data-placeholder');
+        const placeholder = this.getAttribute('data-placeholder');
+        document.querySelectorAll(`.inline-input[data-placeholder="${placeholder}"]`).forEach(otherSpan => {
+          otherSpan.textContent = placeholder;
+        });
       }
     });
 


### PR DESCRIPTION
# Description

This PR implements real-time synchronization for interactive placeholders (like `<VENV_NAME>`) in the MaxText documentation.

Previously, editing a placeholder in one command block did not update other occurrences of the same placeholder on the page. This PR addresses this by adding synchronization logic, ensuring a smoother experience when customizing setup commands.

### Changes:
- Added an `input` event listener to the editable spans in `editable_commands.js` to propagate changes to all other spans sharing the same `data-placeholder` attribute in real-time.
- Updated the `blur` event listener to restore the default placeholder value across all matching instances if the edited field is left empty.

FIXES: b/514373826

# Tests

Manually verified the changes by building and serving the documentation locally on a TPU VM:

1. Built the Sphinx documentation:
   ```bash
   cd docs
   sphinx-build -b html . _build/html
   ```

2. Served the HTML locally:
```bash
python3 -m http.server -d _build/html 8000
```

3, Verified interactive behavior in the browser (at http://localhost:8000/install_maxtext.html):
Editing `<VENV_NAME>` in one command block successfully updated all other `<VENV_NAME>` instances on the page.
Clearing the edited field and clicking away successfully restored all instances to the default `<VENV_NAME>` placeholder.

## Verification Video
You can view the verification screen recording here:
[Screen Recording (go/scrcast)](http://go/scrcast/NTIyNjk4MTk2Nzc5MDA4MHxmMzRjYTkzMy1mYQ)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
