### PR TITLE
Add skip_warmup flag for evaluation runner

### DIFF
--- a/src/maxtext/eval/runner/common.py
+++ b/src/maxtext/eval/runner/common.py
@@ -129,6 +129,7 @@ def add_server_args(parser: argparse.ArgumentParser) -> None:
       help=("Fraction of HBM reserved for KV cache."),
   )
   parser.add_argument("--hf_token", help="HuggingFace token for gated models.")
+  parser.add_argument("--skip_warmup", action="store_true", help="Skip the server warmup phase.")
   parser.add_argument("--gcs_results_path", help="Optional secondary GCS path to upload the results JSON.")
   parser.add_argument(
       "--log_level",

--- a/src/maxtext/eval/runner/eval_runner.py
+++ b/src/maxtext/eval/runner/eval_runner.py
@@ -132,7 +132,8 @@ def run_eval(cfg: dict, hf_token: str | None = None) -> dict:
       base_url = server.base_url
 
       # Warmup server.
-      warmup_server(base_url=base_url, model=model_name, sample_requests=requests)
+      if not cfg.get("skip_warmup"):
+        warmup_server(base_url=base_url, model=model_name, sample_requests=requests)
 
       # Generate responses.
       logger.info("Generating responses for %d prompts.", len(prompts))
@@ -214,6 +215,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
   parser.add_argument("--server_host", help="vLLM server host.")
   parser.add_argument("--server_port", type=int, help="vLLM server port.")
   parser.add_argument("--hf_mode", action="store_true", help="Use HF safetensors mode.")
+  parser.add_argument("--skip_warmup", action="store_true", help="Skip the server warmup phase.")
   parser.add_argument(
       "--enable_expert_parallel",
       action="store_true",

--- a/src/maxtext/eval/runner/harness_runner.py
+++ b/src/maxtext/eval/runner/harness_runner.py
@@ -135,7 +135,8 @@ def run_harness(cfg: dict, hf_token: str | None = None) -> dict:
     is_rank0 = _jax.process_index() == 0
 
     if is_rank0:
-      warmup_server(base_url=server.base_url, model=model_name)
+      if not cfg.get("skip_warmup"):
+        warmup_server(base_url=server.base_url, model=model_name)
 
       completions_path = "/v1/chat/completions" if backend == "evalchemy" else "/v1/completions"
       model_args_parts = [


### PR DESCRIPTION
# Description

This commit introduces a new `--skip_warmup` flag in the evaluation runner to gracefully bypass the warmup phase when requested. The flag has been threaded through the configuration to both `run_eval` and `run_harness`, replacing a hardcoded loop workaround.

Context:  Warmup.py script sends exactly 1 request to the API and The tpu_inference backend  padded the request to 8 (the hardware's minimum requirement) with 7 dummy request, The TPU generates the output, returns the 7 dummy IDs to the vLLM scheduler, and the scheduler crashes with KeyError because it only ever knew about the 1 request (error log: https://paste.googleplex.com/6589084479913984). As a temporary fix for evaluation, we add one option to bypass this step. 


# Tests

Ran an evaluation script with --skip_warmup enabled and verified that the warmup phase was entirely skipped and results were successfully generated, checked that the config state properly logs "skip_warmup": true in the output JSON.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
