### PR TITLE
Fix Pathways TPU integration test hang by installing maxtext without [tpu] extra on client (b/507617522)

### DIFF
--- a/.github/workflows/build_and_test_maxtext.yml
+++ b/.github/workflows/build_and_test_maxtext.yml
@@ -208,7 +208,6 @@ jobs:
 
   maxtext_tpu_pathways_integration_tests:
     needs: build_and_upload_maxtext_package
-    if: false # Skipping for now because of https://github.com/AI-Hypercomputer/maxtext/issues/3765
     uses: ./.github/workflows/run_pathways_tests.yml
     strategy:
         fail-fast: false

--- a/.github/workflows/run_pathways_tests.yml
+++ b/.github/workflows/run_pathways_tests.yml
@@ -85,6 +85,7 @@ jobs:
           source .venv/bin/activate
           maxtext_wheel=$(ls maxtext-*-py3-none-any.whl 2>/dev/null)
           uv pip install ${maxtext_wheel}[tpu] --resolution=lowest
+          uv pip uninstall libtpu
           install_tpu_pre_train_extra_deps
           python3 --version
           python3 -m pip freeze

--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -793,6 +793,10 @@ def maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator, step
       # Linen TrainState has .step attribute
       actual_step = int(state.step) - 1
 
+  if checkpoint_manager.latest_step() == actual_step:
+    max_logging.log(f"Checkpoint for step {actual_step} already exists, skipping save.")
+    return
+
   if config.pure_nnx:
     # Convert nnx.State to dict.
     state = state.to_pure_dict()

--- a/tests/unit/train_state_nnx_checkpoint_test.py
+++ b/tests/unit/train_state_nnx_checkpoint_test.py
@@ -29,6 +29,8 @@ from flax.training import train_state
 import optax
 import orbax.checkpoint as ocp
 
+import pytest
+
 from maxtext.common import checkpointing
 from maxtext.layers import train_state_nnx
 
@@ -65,6 +67,7 @@ def _replicate_for_orbax(pytree):
   return jax.tree.map(lambda x: jax.device_put(x, sharding) if isinstance(x, jax.Array) else x, pytree)
 
 
+@pytest.mark.cpu_only
 class TestTrainStateNNXCheckpoint(unittest.TestCase):
   """Class to test NNX checkpoint."""
 
@@ -303,6 +306,7 @@ class TestTrainStateNNXCheckpoint(unittest.TestCase):
       shutil.rmtree(temp_dir)
 
 
+@pytest.mark.cpu_only
 class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
   """Verify maybe_save_checkpoint's fallback step matches the last completed step.
 
@@ -406,6 +410,45 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
     captured = self._invoke_maybe_save(state, pure_nnx=False)
     # Linen path must not invoke to_pure_dict(); state is forwarded as-is.
     self.assertIs(captured["state"], state)
+
+  def test_maybe_save_checkpoint_skips_if_already_saved(self):
+    """Verify maybe_save_checkpoint skips saving if latest_step matches actual_step."""
+    state = self._build_nnx_state(self.N_STEPS)
+    actual_step = self.N_STEPS - 1
+
+    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False)
+    mgr = mock.MagicMock()
+    mgr.reached_preemption.return_value = False
+    # Mock latest_step to return the same actual_step
+    mgr.latest_step.return_value = actual_step
+
+    save_checkpoint_mock = mock.MagicMock()
+
+    with mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock):
+      checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=None)
+
+    # Assert that save_checkpoint was NOT called!
+    save_checkpoint_mock.assert_not_called()
+
+  def test_maybe_save_checkpoint_saves_if_not_already_saved(self):
+    """Verify maybe_save_checkpoint saves if latest_step does not match actual_step."""
+    state = self._build_nnx_state(self.N_STEPS)
+    actual_step = self.N_STEPS - 1
+
+    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False)
+    mgr = mock.MagicMock()
+    mgr.reached_preemption.return_value = False
+    # Mock latest_step to return a different step (or None)
+    mgr.latest_step.return_value = actual_step - 1
+
+    save_checkpoint_mock = mock.MagicMock()
+    save_checkpoint_mock.return_value = False
+
+    with mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock):
+      checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=None)
+
+    # Assert that save_checkpoint WAS called!
+    save_checkpoint_mock.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR fixes the flaky/hanging Pathways TPU integration tests ([Issue #3765](https://github.com/AI-Hypercomputer/maxtext/issues/3765) / [b/507617522](http://b/507617522)) and re-enables them in GitHub Actions.
It implements three distinct fixes to address the hangs, crashes, and coverage gaps observed in GHA:

### 1. JAX Startup Hang Fix (Local TPU Device Lockup)

The primary hang was caused by a **local TPU resource locking conflict** on the self-hosted GHA runner VM:
- **Why this happens in GHA**: In this integration workflow, we are trying to test the Pathways controller (client) logic **directly on a TPU VM** alongside the backend `worker` container. The `worker` container starts first, running with `--privileged` and locking all local host TPU devices (`/dev/vfio/*`). When the client JAX process starts and dynamically loads `libtpu.so` (pulled in by the `[tpu]` extra), it queries the local host TPUs and blocks indefinitely in the kernel waiting for the device lock held by the worker.
- **Why this does NOT happen in production**: In standard production Pathways deployments (e.g. on Borg or multi-host clusters), the Pathways controller (client) runs on a **dedicated VM/task that has NO physical TPUs attached**. Since there are no local TPUs to query, `libtpu.so` gracefully fails to initialize local hardware and instantly falls back to CPU/Proxy without hanging.

**Solution**:
MaxText relies on the `[tpu]` optional extra to install all of its JAX, Flax, and testing dependencies (installing without extras results in an empty dependency set, failing with `No module named pytest`). 
To resolve this, we **install MaxText with the `[tpu]` extra, and then immediately and surgically uninstall the `libtpu` package** before running any tests in GHA:
```yaml
          uv pip install ${maxtext_wheel}[tpu] --resolution=lowest
          uv pip uninstall libtpu
```
This removes `libtpu.so` from the client venv, preventing JAX from attempting to load the local TPUs and allowing it to cleanly connect to the remote Pathways proxy. We also set `IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS=true` on the client.

### 2. Checkpointing Double-Save Fix (Orbax 'already exists' crash)
With the startup hang resolved, we encountered a checkpointing failure in the GHA CI during `checkpointing_test.py` (`test_autoselected_attention`) due to a logical double-save bug:
- When `steps=1` is requested and `checkpoint_period=3` is set, step 0 is a multiple of the period (`0 % 3 == 0`). JAX saves the checkpoint at the end of step 0 (`.../checkpoints/0`) inside the training loop.
- After the training loop completes, `train.py` tries to save a "completion" checkpoint for the final step (which is still step 0) with `force=False`.
- Because `ocdbt` is disabled for single-controller runs on Pathways, Orbax uses standard directory checkpointers, which throw a fatal `directory already exists` error if `force=False` is used and the directory exists.
- This fatal crash aborts the training process abruptly before writing the final `saved_metrics.txt` metrics file.

**Solution**:
We added a check at the start of `maybe_save_checkpoint` in `src/maxtext/common/checkpointing.py` to skip saving if the checkpoint for the current step has already been successfully saved in this run:
```python
  if checkpoint_manager.latest_step() == actual_step:
    max_logging.log(f"Checkpoint for step {actual_step} already exists, skipping save.")
    return
```
This cleanly skips the duplicate save, allowing the program to complete normally and write the test metrics.

### 3. Re-enabling GHA Integration Tests
Removed `if: false` from `maxtext_tpu_pathways_integration_tests` in `.github/workflows/build_and_test_maxtext.yml` so that the integration tests actually run in GHA CI.

FIXES: b/507617522
FIXES: #3765

# Tests

I thoroughly verified all fixes directly on a physical GCE TPU v6e-4 VM (`darisoy-gvnic-test`) by replicating the GHA services environment locally using Docker:

1. **Startup Hang Verification**: Verified JAX connects cleanly to the local Pathways proxy and successfully lists the remote devices when the client is isolated from the local TPUs.
2. **Checkpointing Fix Verification**: 
   - Mounted the real `grain` dataset via GCSfuse to `/tmp/gcsfuse` using `setup_gcsfuse.sh`.
   - Ran the specific checkpointing test `tests/integration/checkpointing_test.py::test_autoselected_attention` in Pathways mode.
   - **The test ran to completion and fully passed** in **4 minutes and 39 seconds**! The double-save conflict is completely resolved, and the saved vs restored loss values compared successfully:
     ```
     saved loss:  10.887110710144043
     restored loss:  10.869868278503418
     PASSED
     ================= 1 passed, 158 warnings in 279.44s (0:04:39) ==================
     ```
3. **Full Pytest Run**: Ran the full integration tests (`tests/integration/train_tests.py`) with the startup workaround. All 10 tests passed successfully in ~4 minutes with zero hangs.
4. **Unit Tests**: Added 2 new mock-based unit tests to `tests/unit/train_state_nnx_checkpoint_test.py` to cover both branches of the new logical check. Ran the entire unit test suite on the VM and all **11 tests passed cleanly in 7.6 seconds**:
   ```
   Ran 11 tests in 7.634s
   OK
   ```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
