### PR TITLE
Fix TPU kernel OOB memory access 

### DIFF
--- a/src/maxtext/kernels/attention/ragged_attention.py
+++ b/src/maxtext/kernels/attention/ragged_attention.py
@@ -219,6 +219,7 @@ def ragged_mqa(
     block_size: int = 256,
     mask_value: float = DEFAULT_MASK_VALUE,
     cost_estimate: pl.CostEstimate | None = None,
+    interpret: bool = False,
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
   """Ragged multi query attention.
 
@@ -245,7 +246,7 @@ def ragged_mqa(
     length = lengths_ref[b]
     not_done = i * block_size < length
     am_last_batch = b == batch_size - 1
-    last_good_block = lax.div(length, block_size) - 1
+    last_good_block = jnp.maximum(0, lax.div(length, block_size) - 1)
     b_next = jnp.where(not_done, b, jnp.where(am_last_batch, b, b + 1))
     i_next = jnp.where(not_done, i, jnp.where(am_last_batch, last_good_block, 0))
     return b_next, i_next, 0
@@ -277,6 +278,7 @@ def ragged_mqa(
           jax.ShapeDtypeStruct((batch_size, num_heads, head_dim), jnp.float32),
       ],
       cost_estimate=cost_estimate,
+      interpret=interpret,
   )(lengths, q, k, v)
   return out, m[..., 0], l[..., 0]
 
@@ -286,6 +288,7 @@ def ragged_mqa(
     static_argnames=[
         "block_size",
         "mask_value",
+        "interpret",
     ],
 )
 def ragged_mha(
@@ -296,6 +299,7 @@ def ragged_mha(
     *,
     block_size: int = 256,
     mask_value: float = DEFAULT_MASK_VALUE,
+    interpret: bool = False,
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
   """Ragged multi head attention.
 
@@ -325,12 +329,17 @@ def ragged_mha(
           block_size=block_size,
           mask_value=mask_value,
           cost_estimate=cost_estimate,
+          interpret=interpret,
       ),
       in_axes=(1, 1, 1, None),
       out_axes=2,
   )(query, key, value, lengths)
   m = jnp.expand_dims(m, axis=-1)
   l = jnp.expand_dims(l, axis=-1)
+  # The outer layer (Attention block in attention_op.py) expects unnormalized
+  # outputs to support multi-chunk (prefill + decode) cache merging and final
+  # normalization. Since the Pallas kernel internally normalizes, we scale it
+  # back here by the denominator (l) to return unnormalized states.
   o = o * l
   return o, m, l
 
@@ -340,6 +349,7 @@ def ragged_mha(
     static_argnames=[
         "block_size",
         "mask_value",
+        "interpret",
     ],
 )
 def ragged_gqa(
@@ -350,6 +360,7 @@ def ragged_gqa(
     *,
     block_size: int = 256,
     mask_value: float = DEFAULT_MASK_VALUE,
+    interpret: bool = False,
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
   """Ragged group query attention.
 
@@ -383,6 +394,7 @@ def ragged_gqa(
           block_size=block_size,
           mask_value=mask_value,
           cost_estimate=cost_estimate,
+          interpret=interpret,
       ),
       in_axes=(1, 1, 1, None),
       out_axes=1,
@@ -391,5 +403,9 @@ def ragged_gqa(
   m = jnp.reshape(m, (batch_size, 1, num_heads_q, 1))
   l = jnp.reshape(l, (batch_size, 1, num_heads_q, 1))
   o = jnp.reshape(o, (batch_size, 1, num_heads_q, head_dim))
+  # The outer layer (Attention block in attention_op.py) expects unnormalized
+  # outputs to support multi-chunk (prefill + decode) cache merging and final
+  # normalization. Since the Pallas kernel internally normalizes, we scale it
+  # back here by the denominator (l) to return unnormalized states.
   o = o * l
   return o, m, l

--- a/tests/unit/kernels_test.py
+++ b/tests/unit/kernels_test.py
@@ -109,5 +109,76 @@ class RaggedAttentionTest(unittest.TestCase):
     )
 
 
+@pytest.mark.cpu_only
+class RaggedAttentionCpuTest(unittest.TestCase):
+  """Tests for ragged attention kernel on CPU (interpret mode)."""
+
+  batch_size = 2  # Smaller size for faster CPU interpretation
+  num_kv_heads = 2
+  num_query_heads = 4
+  max_target_length = 32  # Smaller size for CPU
+  head_dim = 32  # Smaller size for CPU
+
+  dtype = jnp.float32
+
+  def test_ragged_mqa_cpu(self):
+    key = jax.random.key(0)
+    k1, k2, k3 = jax.random.split(key, 3)
+
+    q = jax.random.normal(k1, (self.batch_size, 1, self.head_dim), dtype=self.dtype)
+    k = jax.random.normal(k2, (self.batch_size, self.max_target_length, self.head_dim), dtype=self.dtype)
+    v = jax.random.normal(k3, (self.batch_size, self.max_target_length, self.head_dim), dtype=self.dtype)
+    lengths = jnp.array(np.random.randint(1, self.max_target_length, self.batch_size), dtype=jnp.int32)
+
+    ragged_out, _, _ = ragged_mqa(q, k, v, lengths, block_size=16, interpret=True)
+    reference_out, _, _ = reference_mqa(q, k, v, lengths)
+    self.assertTrue(
+        jnp.max(abs(ragged_out - reference_out)) < 1.5e-1,
+        msg=f"Max difference: {jnp.max(abs(ragged_out - reference_out))} > 1e-1",
+    )
+
+  def test_ragged_mha_cpu(self):
+    key = jax.random.key(0)
+    k1, k2, k3 = jax.random.split(key, 3)
+
+    q = jax.random.normal(k1, (self.batch_size, 1, self.num_query_heads, self.head_dim), dtype=self.dtype)
+    k = jax.random.normal(
+        k2, (self.batch_size, self.max_target_length, self.num_query_heads, self.head_dim), dtype=self.dtype
+    )
+    v = jax.random.normal(
+        k3, (self.batch_size, self.max_target_length, self.num_query_heads, self.head_dim), dtype=self.dtype
+    )
+    lengths = jnp.array(np.random.randint(1, self.max_target_length, self.batch_size), dtype=jnp.int32)
+
+    ragged_out, _, ragged_denom = ragged_mha(q, k, v, lengths, block_size=16, interpret=True)
+    ragged_out = ragged_out / ragged_denom
+    reference_out, _, _ = reference_mha(q, k, v, lengths)
+    self.assertTrue(
+        jnp.max(abs(ragged_out - reference_out)) < 1.5e-1,
+        msg=f"Max difference: {jnp.max(abs(ragged_out - reference_out))} > 1e-1",
+    )
+
+  def test_ragged_gqa_cpu(self):
+    key = jax.random.key(0)
+    k1, k2, k3 = jax.random.split(key, 3)
+
+    q = jax.random.normal(k1, (self.batch_size, 1, self.num_query_heads, self.head_dim), dtype=self.dtype)
+    k = jax.random.normal(
+        k2, (self.batch_size, self.max_target_length, self.num_kv_heads, self.head_dim), dtype=self.dtype
+    )
+    v = jax.random.normal(
+        k3, (self.batch_size, self.max_target_length, self.num_kv_heads, self.head_dim), dtype=self.dtype
+    )
+    lengths = jnp.array(np.random.randint(1, self.max_target_length, self.batch_size), dtype=jnp.int32)
+
+    ragged_out, _, ragged_denom = ragged_gqa(q, k, v, lengths, block_size=16, interpret=True)
+    ragged_out = ragged_out / ragged_denom
+    reference_out, _, _ = reference_gqa(jnp.squeeze(q), jnp.swapaxes(k, 1, 2), jnp.swapaxes(v, 1, 2), lengths)
+    self.assertTrue(
+        jnp.max(abs(ragged_out - reference_out)) < 1.5e-1,
+        msg=f"Max difference: {jnp.max(abs(ragged_out - reference_out))} > 1e-1",
+    )
+
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description

This PR fixes a critical TPU hardware crash (Denial of Service / Machine Check Exception) caused by a negative prefetch index in MaxText ragged attention kernels, and establishes full CPU-only CI test coverage using JAX Pallas Interpret mode.

### Proposed Changes & Implementation:

1.  **Negative Prefetch Index Prevention:** Clamped `last_good_block` in `ragged_attention.py` to `0` using `jnp.maximum(0, ...)` to ensure empty sequence paddings safely access valid bounds, preventing out-of-bounds TPU hardware crashes (`CWE-125`).
2.  **Preserved Intermediate Scaling & Documented:** Retained the intermediate `o = o * l` unnormalization inside `ragged_mha` and `ragged_gqa` because the outer MaxText `Attention` layer (`attention_op.py`) explicitly relies on unnormalized outputs to perform multi-chunk prefill/decode cache merging and final normalization. Added clear explanatory inline comments to document this architectural requirement.
3.  **Unified CPU Interpret Mode:** Exposed `interpret` parameter in MHA/GQA wrappers to support CPU-based testing and added full unit test coverage on CPU.

BUG=510376806

---

# Tests

The changes were verified using both live TPU hardware (`tpu7x-8` VM) and CPU-based Pallas Interpret mode.

### 1. TPU-Based Verification
The unit tests in `tests/unit/kernels_test.py` correctly align scales using the division workaround (`ragged_out / ragged_denom`) to verify unnormalized outputs against reference implementations.

Command run inside the virtual environment on TPU VM:
```bash
source maxtext_venv/bin/activate
pytest tests/unit/kernels_test.py -k "not Cpu"
```
**Result:** **`3 passed`** (TPU execution verified).

### 2. CPU-Based Verification & Coverage (Ragged Attention)
To ensure code coverage in CPU-only CI environments, we added a new test suite `RaggedAttentionCpuTest` in `tests/unit/kernels_test.py`. This suite forces JAX Pallas to run in **Interpret Mode** on CPU (bypassing TPU compilation).

Command run locally or in CPU-only CI:
```bash
JAX_PLATFORMS=cpu pytest tests/unit/kernels_test.py -k "Cpu"
```
**Result:** **`3 passed`** (CPU interpret mode verified). This provides full test coverage for `ragged_attention.py` in standard GitHub CI runners.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
