### PR TITLE
Remove tf from post-training

### DIFF
--- a/src/maxtext/experimental/rl/grpo_trainer.py
+++ b/src/maxtext/experimental/rl/grpo_trainer.py
@@ -45,7 +45,12 @@ from typing import Sequence, Callable, Iterator
 
 from absl import app
 
-import tensorflow as tf
+try:
+  import tensorflow as tf
+
+  _TF_AVAILABLE = True
+except ImportError:
+  _TF_AVAILABLE = False
 
 import numpy as np
 
@@ -932,9 +937,10 @@ def main(argv: Sequence[str]) -> None:
   """
   pathwaysutils.initialize()
   jax.config.update("jax_default_prng_impl", "unsafe_rbg")
-  # TF allocates extraneous GPU memory when using TFDS data
-  # this leads to CUDA OOMs. WAR for now is to hide GPUs from TF
-  tf.config.set_visible_devices([], "GPU")
+  if _TF_AVAILABLE:
+    # TF allocates extraneous GPU memory when using TFDS data
+    # this leads to CUDA OOMs. WAR for now is to hide GPUs from TF
+    tf.config.set_visible_devices([], "GPU")
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
     os.environ["LIBTPU_INIT_ARGS"] = (
@@ -965,7 +971,8 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update("jax_use_shardy_partitioner", config.shardy)
   max_utils.print_system_information()
   train_utils.validate_train_config(config)
-  os.environ["TFDS_DATA_DIR"] = config.dataset_path
+  if _TF_AVAILABLE:
+    os.environ["TFDS_DATA_DIR"] = config.dataset_path
   vertex_tensorboard_manager = VertexTensorboardManager()
   if config.use_vertex_tensorboard or os.environ.get("UPLOAD_DATA_TO_TENSORBOARD"):
     vertex_tensorboard_manager.configure_vertex_tensorboard(config)

--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -28,7 +28,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
-import tensorflow as tf
+from etils import epath
 from array_record.python import array_record_module
 from orbax import checkpoint
 
@@ -87,7 +87,7 @@ class OfflineArrayRecordIterator:
   def __init__(self, data_dir: str, epochs: int = 100):
     self.filepath = data_dir
 
-    if not tf.io.gfile.exists(self.filepath):
+    if not epath.Path(self.filepath).exists():
       raise FileNotFoundError(f"Offline distillation file not found: {self.filepath}")
 
     self.reader = array_record_module.ArrayRecordReader(self.filepath)

--- a/src/maxtext/trainers/post_train/distillation/save_top_k_teacher_logits.py
+++ b/src/maxtext/trainers/post_train/distillation/save_top_k_teacher_logits.py
@@ -29,7 +29,7 @@ from typing import Sequence
 import argparse
 import time
 import sys
-import tensorflow as tf
+from etils import epath
 import re
 
 import jax
@@ -60,17 +60,18 @@ def get_start_step(config, local_args):
     return 0
 
   output_dir = local_args.gcs_upload_path if local_args.gcs_upload_path else local_args.local_tmp_dir
-  if not tf.io.gfile.exists(output_dir):
-    tf.io.gfile.makedirs(output_dir)
+  output_path = epath.Path(output_dir)
+  if not output_path.exists():
+    output_path.mkdir(parents=True, exist_ok=True)
     return 0
 
-  existing_files = tf.io.gfile.glob(os.path.join(output_dir, "teacher_top_k_part_*.array_record"))
+  existing_files = list(output_path.glob("teacher_top_k_part_*.array_record"))
   if not existing_files:
     return 0
 
   # Find the highest part number from the filenames
   max_part_num = max(
-      (int(m.group(1)) for f in existing_files if (m := re.search(r"part_(\d+).array_record", os.path.basename(f)))),
+      (int(m.group(1)) for f in existing_files if (m := re.search(r"part_(\d+).array_record", f.name))),
       default=-1,
   )
 
@@ -126,7 +127,7 @@ def generate_and_save_data(config, local_args):
           # Upload the previous file
           gcs_file_path = os.path.join(gcs_upload_path, os.path.basename(local_output_path))
           max_logging.log(f"Uploading {local_output_path} to {gcs_file_path}")
-          tf.io.gfile.copy(local_output_path, gcs_file_path, overwrite=True)
+          epath.Path(gcs_file_path).write_bytes(epath.Path(local_output_path).read_bytes())
           os.remove(local_output_path)
           max_logging.log("Upload complete.")
 
@@ -183,7 +184,7 @@ def generate_and_save_data(config, local_args):
     if gcs_upload_path:
       gcs_file_path = os.path.join(gcs_upload_path, os.path.basename(local_output_path))
       max_logging.log(f"Uploading final chunk to: {gcs_file_path}")
-      tf.io.gfile.copy(local_output_path, gcs_file_path, overwrite=True)
+      epath.Path(gcs_file_path).write_bytes(epath.Path(local_output_path).read_bytes())
       os.remove(local_output_path)
       max_logging.log("GCS Upload complete.")
 

--- a/src/maxtext/trainers/post_train/distillation/verify_saved_logits.py
+++ b/src/maxtext/trainers/post_train/distillation/verify_saved_logits.py
@@ -27,7 +27,7 @@ import sys
 import argparse
 import safetensors.numpy
 from absl import app
-import tensorflow as tf
+from etils import epath
 from array_record.python import array_record_module
 from maxtext.utils import max_logging
 
@@ -35,11 +35,11 @@ from maxtext.utils import max_logging
 def verify_array_records(output_dir, expected_steps, expected_k, expected_keys):
   """Verifies the contents of ArrayRecord files containing top-k teacher logits."""
 
-  file_pattern = f"{output_dir}/*.array_record"
-  files = tf.io.gfile.glob(file_pattern)
+  file_pattern = "*.array_record"
+  files = list(epath.Path(output_dir).glob(file_pattern))
 
   if not files:
-    assert False, f"Error: No ArrayRecord files found matching {file_pattern}"
+    assert False, f"Error: No ArrayRecord files found in {output_dir}"
 
   max_logging.log(f"Found {len(files)} ArrayRecord files. Starting verification...")
 
@@ -48,7 +48,7 @@ def verify_array_records(output_dir, expected_steps, expected_k, expected_keys):
 
   for file_path in files:
     max_logging.log(f"Verifying: {file_path}")
-    reader = array_record_module.ArrayRecordReader(file_path)
+    reader = array_record_module.ArrayRecordReader(str(file_path))
     num_records_in_file = reader.num_records()
 
     if num_records_in_file == 0:

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -722,7 +722,7 @@ class TrainDistillTest(unittest.TestCase):
     mock_iter = object()  # No save method
 
     config = mock.Mock()
-    config.dataset_type = "tfds"  # Not grain
+    config.dataset_type = "synthetic"  # Not grain
     config.checkpoint_dir = self.test_dir
 
     # Use real options
@@ -958,7 +958,7 @@ class TrainDistillTest(unittest.TestCase):
 
     config = mock.Mock()
     config.checkpoint_dir = self.test_dir
-    config.dataset_type = "tfds"
+    config.dataset_type = "synthetic"
     config.lora_enabled = False
 
     # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
# Description

As we plan to remove tensorflow dependency, migrate the tf usage from the following post-training modules.

# Tests



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
