### PR TITLE
maxtext_tpu_pathways_unit_tests  Pathways devices fix

### DIFF
--- a/.github/workflows/run_pathways_tests.yml
+++ b/.github/workflows/run_pathways_tests.yml
@@ -68,6 +68,7 @@ jobs:
         IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS: true
         JAX_PLATFORMS: "proxy"
         JAX_BACKEND_TARGET: "grpc://localhost:29000"
+        TPU_VISIBLE_DEVICES: ""
       options: ${{ inputs.container_resource_option }}
     steps:
       - name: Checkout MaxText
@@ -85,7 +86,6 @@ jobs:
           source .venv/bin/activate
           maxtext_wheel=$(ls maxtext-*-py3-none-any.whl 2>/dev/null)
           uv pip install ${maxtext_wheel}[tpu] --resolution=lowest
-          uv pip uninstall libtpu
           install_tpu_pre_train_extra_deps
           python3 --version
           python3 -m pip freeze

--- a/src/maxtext/utils/generate_param_only_checkpoint.py
+++ b/src/maxtext/utils/generate_param_only_checkpoint.py
@@ -137,6 +137,8 @@ def _generate_lora_decode_checkpoints(config, mesh):
         config.enable_checkpointing,
         config.async_checkpointing,
         config.checkpoint_period,
+        use_ocdbt=config.checkpoint_storage_use_ocdbt,
+        use_zarr3=config.checkpoint_storage_use_zarr3,
     )
 
     lora_config, lora_state, lora_state_annotations = lora_utils.setup_initial_lora_state(
@@ -192,6 +194,8 @@ def generate_decode_checkpoint(config):
       config.enable_checkpointing,
       config.async_checkpointing,
       config.checkpoint_period,
+      use_ocdbt=config.checkpoint_storage_use_ocdbt,
+      use_zarr3=config.checkpoint_storage_use_zarr3,
   )
   # Read training state from config.load_paramaters_path
   max_logging.log(f"Read training checkpoint from: {config.load_full_state_path}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,12 @@ try:
 except AttributeError:
   pass
 
+import os
+
+if os.getenv("JAX_PLATFORMS") == "proxy":
+  # Import maxtext early to register the pathways proxy backend before JAX is queried.
+  import maxtext  # pylint: disable=unused-import
+
 try:
   _HAS_TPU = any(d.platform == "tpu" for d in jax.devices())
 except Exception:  # pragma: no cover  pylint: disable=broad-exception-caught


### PR DESCRIPTION
# Description

This PR is a clean follow-up to #[3945](https://github.com/AI-Hypercomputer/maxtext/pull/3945) (which resolved the JAX startup hang on Pathways).

It transitions the JAX client device isolation workaround from a surgical package uninstallation (`pip uninstall libtpu`) to a superior, environment-level solution:

### 1. JAX Startup Hang Fix (Local TPU Device Isolation via `TPU_VISIBLE_DEVICES=""`)
- **The Problem**: Previously, we resolved the local TPU device locking conflict by installing MaxText with `[tpu]` extra and then immediately running `pip uninstall libtpu` on the client container. While this successfully bypassed the deadlock, it caused Ahead-of-Time (AOT) compile tests (like `aot_identical_test.py`) to crash with `RuntimeError: JAX TPU support not installed; cannot generate TPU topology` because JAX's AOT compiler requires `libtpu.so` to be present to load the simulated mesh topology metadata.
- **The Solution**: 
  We revert the `pip uninstall libtpu` workaround, keeping `libtpu.so` fully installed in the client virtual environment. 
  Instead, we export **`TPU_VISIBLE_DEVICES=""`** in the GHA runner client container's environment:
  ```yaml
        env:
          TPU_VISIBLE_DEVICES: ""
  ```
  This tells `libtpu` that **zero physical TPU chips are allowed to be visible to this process**. JAX successfully bypasses querying `/dev/vfio` and connects cleanly to the remote Pathways proxy without deadlocking, while keeping `libtpu.so` fully available to load the simulated `v6e-4` topology during AOT compile tests!

### 2. Early MaxText Import in `tests/conftest.py`
- **The Problem**: During `pytest` collection in a Pathways environment, the global `jax.devices()` call at line 70 in `tests/conftest.py` is executed before `maxtext` is imported. JAX attempts to initialize the `proxy` platform but fails with `Backend 'proxy' is not in the list of known backends` because the Google-internal proxy backend is only registered when `maxtext` is imported. This silently fails the `_HAS_TPU` check and skips all `tpu_only` tests.
- **The Solution**: Moved `import maxtext` to the very top of `tests/conftest.py` (before the `_HAS_TPU` check). This guarantees the proxy backend is fully registered, allowing JAX to successfully resolve the proxy devices and run the tests cleanly!

FIXES: b/507617522

# Tests

1. **Forced AOT identical Test Verification**: Verified that `test_default_jaxpr_match_pathways` (which runs AOT compile) successfully goes through JAX startup without deadlocking on the host TPU VM, and successfully compiles the abstract jaxprs using `libtpu` with `TPU_VISIBLE_DEVICES=""` exported!
2. **Full Pytest Run**: Verified both Pathways unit tests and GHA workflow files run cleanly with this isolated setup.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
