### PR TITLE
Fix robust .dockerignore parsing in docker_upload_runner.sh

### DIFF
--- a/src/dependencies/scripts/docker_upload_runner.sh
+++ b/src/dependencies/scripts/docker_upload_runner.sh
@@ -57,6 +57,10 @@ if [ -f .dockerignore ]; then
   while IFS= read -r pattern; do
     # Ignore empty lines and comments
     if [[ -n "$pattern" && ! "$pattern" =~ ^# ]]; then
+      # Strip leading ./ if present
+      pattern="${pattern#./}"
+      # Strip trailing / if present
+      pattern="${pattern%/}"
       EXCLUDE_PATHS+=(-o -path "./$pattern")
     fi
   done < .dockerignore
@@ -74,9 +78,16 @@ DANGLING_LINKS=$(find -L . "${PRUNE_ARGS[@]}" -type l -print)
 if [ -n "$DANGLING_LINKS" ]; then
   echo "ERROR: Found dangling symbolic links in the build context:"
   echo "$DANGLING_LINKS"
+  echo ""
   echo "These can cause 'failed to compute cache key' errors during 'docker build'."
-  echo "Please remove or fix them before building the Docker image."
-  echo "Alternatively, run the command again from a clean, empty directory to bypass your local file state entirely."
+  echo "To fix this, please either:"
+  echo "  1. Remove or fix these links."
+  echo "  2. Add the following lines to your .dockerignore file:"
+  while IFS= read -r link; do
+    if [ -n "$link" ]; then
+      echo "     ${link#./}"
+    fi
+  done <<< "$DANGLING_LINKS"
   exit 1
 fi
 
@@ -85,9 +96,16 @@ ABSOLUTE_LINKS=$(find . "${PRUNE_ARGS[@]}" -type l -lname '/*' -print)
 if [ -n "$ABSOLUTE_LINKS" ]; then
   echo "ERROR: Found symbolic links with absolute paths in the build context:"
   echo "$ABSOLUTE_LINKS"
-  echo "Docker cannot follow absolute paths outside of the build context, which can cause 'failed to compute cache key' errors."
-  echo "Please remove these links or add the files to .dockerignore before building the Docker image."
-  echo "Do not include the ./ file prefix in .dockerignore"
+  echo ""
+  echo "Docker cannot follow absolute paths outside of the build context, which causes 'failed to compute cache key' errors."
+  echo "To fix this, please either:"
+  echo "  1. Remove these links from your local directory."
+  echo "  2. Add the following lines to your .dockerignore file:"
+  while IFS= read -r link; do
+    if [ -n "$link" ]; then
+      echo "     ${link#./}"
+    fi
+  done <<< "$ABSOLUTE_LINKS"
   exit 1
 fi
 


### PR DESCRIPTION
# Description

This PR enhances the MaxText Docker build/upload workflow by robustly handling ignore patterns and providing clear, copy-pasteable guidance when build context errors occur in `docker_upload_runner.sh`.

### Why this change is being made
During MaxText 2.0 RL UXR testing (reported in b/497839527), users encountered immediate failures during the Docker build context preparation step due to absolute symbolic links (often found inside local Python virtual environments). Attempting to exclude these paths by adding them to `.dockerignore` with a `./` prefix (e.g. `./venv/bin/python`) still resulted in failures, and the script's error messages lacked guidance on how to resolve them.

### The Problem
1. **Parser Prefix Conflict**: The `.dockerignore` parser in `docker_upload_runner.sh` blindly prepended `./` to all ignore patterns (e.g., turning `./venv` into `././venv`). This caused `find` pattern matching to fail, which prevented paths from being pruned.
2. **Lack of Guidance**: When symbolic link checks failed, the errors were generic and did not show users the exact formats they needed to append to `.dockerignore` to resolve the block.

### The Solution
1. **Robust Ignoring**: Automatically strip any leading `./` and trailing `/` characters from patterns read from `.dockerignore` before constructing `find` path matching parameters. This allows entries like `./venv/`, `venv/`, `./venv`, and `venv` to all work correctly.
2. **Actionable Error Messages**: Both absolute and dangling symbolic link check failures now parse the paths found and print **exact, copy-pasteable `.dockerignore` suggestions** that users can copy directly into their `.dockerignore` file to bypass the error immediately.

FIXES: b/497839527

# Tests

### Manual Verification on TPU VM
Tested manually on a TPU v6e-4 VM (`darisoy-gvnic-test`):
1. **Setup reproducing case**: Created a dummy symbolic link with an absolute target inside the repository root:
   ```bash
   ln -s /etc/hosts ./absolute_symlink_test
   ```
2. **Verify failure output & suggestions**:
   Ran the script with `./absolute_symlink_test` *not* in `.dockerignore`. The script correctly printed the list of paths and outputted a clear copy-pasteable suggestion:
   ```
   ERROR: Found symbolic links with absolute paths in the build context:
   ./absolute_symlink_test
   
   Docker cannot follow absolute paths outside of the build context, which causes 'failed to compute cache key' errors.
   To fix this, please either:
     1. Remove these links from your local directory.
     2. Add the following lines to your .dockerignore file:
        absolute_symlink_test
   ```
3. **Verify ignore resolution**:
   Added `./absolute_symlink_test` to `.dockerignore`. Re-ran the command, and verified that the script now successfully prunes the link, bypassing the check cleanly and completing successfully.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
