### PR TITLE
docs: QLoRA Documentation and Notebooks

### DIFF
--- a/.github/workflows/run_jupyter_notebooks.yml
+++ b/.github/workflows/run_jupyter_notebooks.yml
@@ -109,7 +109,7 @@ jobs:
           # Run Hugging Face authentication
           hf auth login --token "$HF_TOKEN"
 
-          for notebook in "$MAXTEXT_NOTEBOOKS_ROOT"/{sft,rl}*.ipynb; do
+          for notebook in "$MAXTEXT_NOTEBOOKS_ROOT"/{sft,rl,lora}*.ipynb; do
             filename=$(basename "$notebook")
             # TODO: Update runnner to v6e-8 as RL with LLama3.1-8b doesn't fit on v6e-4
             if [[ "$filename" == "sft_llama3_demo_gpu.ipynb" || "$filename" == "maxtext_with_gepa.ipynb" ]]; then

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -63,6 +63,13 @@ Interactive development guides for running MaxText on Google Colab or local Jupy
 A step-by-step guide for the community to help expand MaxText's model library.
 :::
 
+:::{grid-item-card} 🎗️ LoRA Model Bringup
+:link: guides/lora_model_bringup
+:link-type: doc
+
+Learn how to integrate Low-Rank Adaptation (LoRA) support for a new model architecture.
+:::
+
 :::{grid-item-card} 🎓 Distillation
 :link: guides/distillation
 :link-type: doc
@@ -89,6 +96,7 @@ guides/checkpointing_solutions.md
 guides/monitoring_and_debugging.md
 guides/run_python_notebook.md
 guides/model_bringup.md
+guides/lora_model_bringup.md
 guides/distillation.md
 guides/eval_framework.md
 ```

--- a/docs/guides/lora_model_bringup.md
+++ b/docs/guides/lora_model_bringup.md
@@ -1,0 +1,113 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+# Adding a New Model for LoRA Fine-Tuning
+
+This guide explains how to add Low-Rank Adaptation (LoRA) support for a new model architecture in MaxText.
+
+MaxText leverages [Tunix](https://github.com/google/tunix) and [Qwix](https://github.com/google/qwix) to support Parameter-Efficient Fine-Tuning (PEFT) on JAX/NNX model definitions. Since the architecture uses modular APIs, adding LoRA support for a new model is highly streamlined.
+
+______________________________________________________________________
+
+## 1. Step-by-Step Bring-up Guide for NNX LoRA
+
+To enable LoRA support for a new model, follow these two simple steps:
+
+### Step 1.1: Verify Base Model Support
+
+The target model architecture must already be implemented and supported as a base model in MaxText.
+
+- The JAX/NNX model definition should be located under `src/maxtext/models/` (e.g., \[gemma3.py\](../../src/maxtext/models/gemma3.py)).
+- The model configurations must be registered and runnable for baseline pre-training or full fine-tuning.
+
+### Step 1.2: Define Trainable LoRA Target Modules
+
+Add a recommended target pattern for your model architecture prefix in \[src/maxtext/configs/post_train/lora_module_path.yml\](../../src/maxtext/configs/post_train/lora_module_path.yml):
+
+```yaml
+your_model_prefix: "decoder/layers/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))"
+```
+
+> [!NOTE]
+> MaxText's `_get_lora_module_path` in `lora_utils.py` automatically handles both **scanned** (e.g., `layers/0/self_attention/...`) and **unscanned** (e.g., `layers/self_attention/...`) layer formats by injecting an optional layer index regex. You only need to define standard, unscanned paths.
+
+If no prefix matches your model name, MaxText falls back to the `default` pattern:
+
+```yaml
+default: "decoder/layers/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))"
+```
+
+______________________________________________________________________
+
+## 2. Integrating Custom Weight Mappings (When is it needed?)
+
+Determining whether you need to implement custom weight mappings depends entirely on your downstream workflow:
+
+### Scenario A: SFT Training & Conversion to PEFT (No Mapping Needed)
+
+If you only need to run SFT fine-tuning with LoRA and then export the adapter back to Hugging Face format using `to_huggingface.py`, **you do not need to write any custom weight mappings.**
+
+- The conversion utility automatically maps, scales, and formats the LoRA adapter parameters back into standard Hugging Face PEFT format based on the base model's existing weight mapping.
+
+### Scenario B: Decoding with the MaxText vLLM Adapter (Mapping is Required)
+
+If you want to perform decoding or run high-performance serving on your adapted model using the **MaxText vLLM adapter** (e.g., via `vllm_decode`), **you must define and register a custom weight mapping.** This allows the vLLM JAX wrapper to dynamically map and feed weights to the vLLM engine.
+
+To add weight mapping for vLLM decode:
+
+1. **Create a Weight Mapping Config**:
+   Create a new file in \[src/maxtext/integration/tunix/weight_mapping/\](../../src/maxtext/integration/tunix/weight_mapping/) (e.g., `your_model.py`) defining a mapping dataclass. You can refer to \[gemma3.py\](../../src/maxtext/integration/tunix/weight_mapping/gemma3.py) or \[llama3.py\](../../src/maxtext/integration/tunix/weight_mapping/llama3.py) as templates.
+
+   Your class should specify:
+
+   - `to_hf_mapping()`: Maps MaxText base parameters to Hugging Face parameters and specifies their sharding axes.
+   - `to_hf_hook_fns()`: Custom hook functions for complex weight transformations (e.g., RoPE reordering or query scaling).
+   - `lora_to_hf_mappings()`: Custom mapping for LoRA weights if they require different handling.
+
+2. **Register the Mapping**:
+   Register your new class in \[src/maxtext/integration/tunix/weight_mapping/__init__.py\](../../src/maxtext/integration/tunix/weight_mapping/__init__.py) inside the `StandaloneVllmWeightMapping` class:
+
+   ```python
+   # Inside StandaloneVllmWeightMapping
+   if name.startswith("your_model_name"):
+       return YOUR_MODEL_VLLM_MAPPING
+   ```
+
+______________________________________________________________________
+
+## 3. Verifying Your Custom LoRA Targets
+
+If you are developing or bringing up your model architecture interactively (e.g., in a Python interpreter or Jupyter notebook), you can verify which layers are wrapped with LoRA adapters by inspecting the model's module graph:
+
+```python
+import re
+from flax import nnx
+from maxtext.utils import model_creation_utils, lora_utils
+
+# 1. Create model, mesh, and load config
+model, mesh = model_creation_utils.from_pretrained(mt_config)
+
+# 2. Extract lora path regex and compile
+compiled_module_path = re.compile(lora_utils._get_lora_module_path(mt_config))
+
+# 3. Iterate over modules to see exactly which ones matched your pattern
+for path, _ in nnx.iter_modules(model):
+    module_path = "/".join(str(p) for p in path)
+    if compiled_module_path.search(module_path):
+        print(f"Matched and wrapped with LoRA: {module_path}")
+```
+
+This programmatic verification allows you to inspect and traverse parameters interactively during development.

--- a/docs/guides/model_bringup.md
+++ b/docs/guides/model_bringup.md
@@ -134,6 +134,10 @@ Please ensure all items on the following checklist are completed before finalizi
 
 - [ ] Create a user guide and post an announcement in the MaxText repo.
 
+5. (Optional) LoRA Support
+
+- [ ] Integrate LoRA support for the newly onboarded model by following the [LoRA Model Bringup Guide](lora_model_bringup.md).
+
 ## Community Q&A (FAQ)
 
 **Q: How do I debug code inside a JAX JIT function?**

--- a/docs/tutorials/post_training_index.md
+++ b/docs/tutorials/post_training_index.md
@@ -28,6 +28,7 @@ MaxText was co-designed with key Google led innovations to provide a unified pos
   - [SFT on Multi-Host TPUs](./posttraining/sft_on_multi_host.md)
 - **LoRA (Low-Rank Adaptation)**
   - [LoRA on Single-Host TPUs](./posttraining/lora.md)
+  - [LoRA on Multi-Host TPUs](./posttraining/lora_on_multi_host.md)
 - **DPO (Direct Preference Optimization) and ORPO (Odds-Ratio Policy Optimization)**
   - [DPO/ORPO on Single-Host TPUs](./posttraining/dpo.md)
 - **Multimodal SFT**
@@ -76,6 +77,7 @@ posttraining/rl_on_multi_host.md
 posttraining/rl_qwen3_30b.md
 posttraining/knowledge_distillation.md
 posttraining/lora.md
+posttraining/lora_on_multi_host.md
 posttraining/multimodal.md
 posttraining/full_finetuning.md
 posttraining/gepa_optimization.md

--- a/docs/tutorials/posttraining/lora.md
+++ b/docs/tutorials/posttraining/lora.md
@@ -60,7 +60,6 @@ export DATASET_NAME=<DATASET_NAME> # e.g., openai/gsm8k
 export TRAIN_SPLIT=<TRAIN_SPLIT> # e.g., train
 export HF_DATA_DIR=<DATASET_PATH> # e.g., main
 export TRAIN_DATA_COLUMNS=<DATA_COLUMNS> # e.g., ['question','answer']
-export CHAT_TEMPLATE_PATH=<TEMPLATE_PATH> # e.g., maxtext/examples/chat_templates/math_qa.json
 
 # -- LoRA Conversion configuration (Optional) --
 export HF_LORA_ADAPTER_PATH=<HF_LORA_ADAPTER_PATH> # e.g., 'username/adapter-name'
@@ -118,7 +117,6 @@ python3 -m maxtext.trainers.post_train.sft.train_sft \
     per_device_batch_size="${PER_DEVICE_BATCH_SIZE?}" \
     max_target_length="${MAX_TARGET_LENGTH?}" \
     learning_rate="${LEARNING_RATE?}" \
-    chat_template_path="${CHAT_TEMPLATE_PATH?}" \
     enable_nnx=True \
     pure_nnx_decoder=True \
     lora.enable_lora=True \
@@ -176,7 +174,6 @@ python3 -m maxtext.trainers.post_train.sft.train_sft \
     per_device_batch_size="${PER_DEVICE_BATCH_SIZE?}" \
     max_target_length="${MAX_TARGET_LENGTH?}" \
     learning_rate="${LEARNING_RATE?}" \
-    chat_template_path="${CHAT_TEMPLATE_PATH?}" \
     enable_nnx=True \
     pure_nnx_decoder=True \
     lora.enable_lora=True \

--- a/docs/tutorials/posttraining/lora_on_multi_host.md
+++ b/docs/tutorials/posttraining/lora_on_multi_host.md
@@ -1,0 +1,316 @@
+<!--
+ Copyright 2023–2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+# LoRA Fine-tuning on multi-host TPUs
+
+**Low-Rank Adaptation (LoRA)** is a Parameter-Efficient Fine-Tuning (PEFT) technique designed to optimize large language models while minimizing resource consumption.
+
+Unlike traditional full-parameter fine-tuning, LoRA:
+
+- **Freezes the pre-trained model weights**, preserving the original knowledge.
+- **Injects trainable rank decomposition matrices** into the Transformer layers.
+
+This tutorial provides step-by-step instructions for setting up the multi-host TPU environment and performing LoRA fine-tuning on a Hugging Face dataset using MaxText. In this tutorial we use a multi-host TPU such as `v6e-256`.
+
+We use [Tunix](https://github.com/google/tunix), a JAX-based library, to power these post-training tasks.
+
+Let's get started!
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- Access to a Google Cloud Project with TPU quotas.
+- A Hugging Face account with an access token for downloading models.
+- Permissions for Google Artifact Registry (Artifact Registry Writer role).
+- Prerequisites for XPK installed (follow [official documentation](https://github.com/AI-Hypercomputer/xpk/blob/main/docs/installation.md#1-prerequisites)).
+- A Pathways-ready GKE cluster (see [create GKE cluster](https://docs.cloud.google.com/ai-hypercomputer/docs/workloads/pathways-on-cloud/create-gke-cluster)).
+- **Docker** installed and configured for sudoless use. Follow the steps to [configure sudoless Docker](https://docs.docker.com/engine/install/linux-postinstall/).
+
+## Build and upload MaxText Docker image
+
+For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../../build_maxtext.md).
+
+## Environment configuration
+
+Set up the following environment variables to configure your training run. Replace placeholders with your actual values.
+
+```bash
+# -- Model configuration --
+# The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
+# full list of supported models.
+export MODEL=<MODEL_NAME> # e.g., 'gemma4-26b'
+
+# Your Hugging Face access token. Required to download gated models like Gemma.
+# You can generate one at https://huggingface.co/settings/tokens.
+export HF_TOKEN=<HF_TOKEN>
+
+# -- MaxText configuration --
+# Use a GCS bucket you own to store logs and checkpoints. Ideally in the same
+# region as your TPUs to minimize latency and costs.
+# You can list your buckets and their locations in the
+# [Cloud Console](https://console.cloud.google.com/storage/browser) or via
+# `gcloud storage buckets list --format="table(name, location)"`.
+export BASE_OUTPUT_DIRECTORY=<GCS_BUCKET> # e.g., gs://my-bucket/maxtext-runs
+
+# An arbitrary string to identify this specific run.
+# We recommend to include the model, user, and timestamp.
+# Note: Kubernetes requires workload names to be valid DNS labels (lowercase, no underscores or periods).
+export RUN_NAME=<RUN_NAME>
+
+# -- Workload configuration --
+# Your GCP project ID. Find it on the [Cloud Console Dashboard](https://console.cloud.google.com/home/dashboard).
+# If you've already set it in your local config, you can retrieve it via:
+# gcloud config get-value project
+export PROJECT_ID=<PROJECT_ID>
+
+# The GCP location (listed as "Location" in the UI) and name of your
+# TPU-enabled GKE cluster. Both can be found on the
+# [Cloud Console](https://console.cloud.google.com/kubernetes/list).
+export ZONE=<ZONE> # e.g., 'us-central1'
+export GKE_CLUSTER=<CLUSTER_NAME>
+
+# For a full list of MaxText-supported TPU types, see: `src/maxtext/utils/accelerator_to_spec_map.py`. To see the TPU type
+# of your cluster:
+
+# 1. Connect to the cluster (required for kubectl commands later):
+# gcloud container clusters get-credentials ${GKE_CLUSTER?} --location ${ZONE?} --project ${PROJECT_ID?}
+
+# 2. Find your TPU type (e.g., 'v6e-256') by checking the accelerator labels on your nodes:
+# kubectl get nodes -l cloud.google.com/gke-tpu-accelerator -o jsonpath='{.items[*].metadata.labels.cloud\.google\.com/gke-tpu-accelerator}' | tr ' ' '\n' | sort -u
+export TPU_TYPE=<TPU_TYPE>
+export NUM_SLICES=<NUM_SLICES>
+
+# The Docker image you pushed in the prerequisite step
+export CLOUD_IMAGE_NAME=<IMAGE_NAME>
+export DOCKER_IMAGE="gcr.io/${PROJECT_ID?}/${CLOUD_IMAGE_NAME?}"
+
+# -- Fine-Tuning configuration --
+export STEPS=<STEPS> # e.g., 1000
+export PER_DEVICE_BATCH_SIZE=<BATCH_SIZE_PER_DEVICE> # e.g., 1
+export LORA_RANK=<LORA_RANK> # e.g., 16
+export LORA_ALPHA=<LORA_ALPHA> # e.g., 32.0
+export LEARNING_RATE=<LEARNING_RATE> # e.g., 3e-6
+export MAX_TARGET_LENGTH=<MAX_TARGET_LENGTH> # e.g., 1024
+
+# -- Dataset configuration --
+export DATASET_NAME=<DATASET_NAME> # e.g., openai/gsm8k
+export TRAIN_SPLIT=<TRAIN_SPLIT> # e.g., train
+export HF_DATA_DIR=<DATASET_PATH> # e.g., main
+export TRAIN_DATA_COLUMNS=<DATA_COLUMNS> # e.g., ['question','answer']
+
+# -- LoRA Conversion configuration (Optional) --
+export HF_LORA_ADAPTER_PATH=<HF_LORA_ADAPTER_PATH> # e.g., 'username/adapter-name'
+```
+
+## Customizing Trainable Layers (Optional)
+
+By default, MaxText determines which layers to apply LoRA to based on the model's architecture by reading `src/maxtext/configs/post_train/lora_module_path.yml`.
+
+If you need to fine-tune specific components (e.g., targeting only Attention layers to optimize memory usage), you can override these defaults through the following hierarchy:
+
+### Configuration Hierarchy
+
+1. **Command Line Argument**: Pass the `lora_module_path` argument directly in your training command.
+2. **Task-Specific Config (`sft.yml`)**: Define the `lora_module_path` parameter in `src/maxtext/configs/post_train/sft.yml`.
+3. **Global Defaults**: Automatic detection via the model-to-regex mapping defined in `lora_module_path.yml`.
+
+## Get MaxText model checkpoint
+
+This section explains how to prepare your model checkpoint for use with MaxText. You have two options: using an existing MaxText checkpoint or converting a Hugging Face checkpoint.
+
+### Option 1: Using an existing MaxText checkpoint
+
+If you already have a MaxText-compatible model checkpoint, simply set the following environment variable and move on to the next section.
+
+```bash
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
+```
+
+**Note:** Make sure that `MAXTEXT_CKPT_PATH` has the checkpoints created using the correct storage flags:
+
+```bash
+checkpoint_storage_use_zarr3=False
+checkpoint_storage_use_ocdbt=False
+```
+
+### Option 2: Converting a Hugging Face checkpoint
+
+Refer to the steps in [Hugging Face to MaxText](https://maxtext.readthedocs.io/en/maxtext-v0.2.1/guides/checkpointing_solutions/convert_checkpoint.html#hugging-face-to-maxtext) to convert a hugging face checkpoint to MaxText. Make sure you have correct checkpoint files converted and saved. Similar as Option 1, you can set the following environment and move on.
+
+```bash
+export MAXTEXT_CKPT_PATH=<CKPT_PATH> # gs://my-bucket/my-checkpoint-directory/0/items
+```
+
+## Submit workload on GKE cluster
+
+This section provides the command to run LoRA Fine-Tuning on a GKE cluster.
+
+### Run a Fresh LoRA Fine-Tuning on Hugging Face Dataset
+
+```bash
+xpk workload create-pathways \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
+--zone=${ZONE?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload=${RUN_NAME?} \
+--tpu-type=${TPU_TYPE?} \
+--num-slices=${NUM_SLICES?} \
+--command="JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE=1 \
+python3 -m maxtext.trainers.post_train.sft.train_sft \
+  run_name=${RUN_NAME?} \
+  base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
+  model_name=${MODEL?} \
+  load_parameters_path=${MAXTEXT_CKPT_PATH?} \
+  hf_access_token=${HF_TOKEN?} \
+  hf_path=${DATASET_NAME?} \
+  train_split=${TRAIN_SPLIT?} \
+  hf_data_dir=${HF_DATA_DIR?} \
+  train_data_columns=${TRAIN_DATA_COLUMNS?} \
+  steps=${STEPS?} \
+  per_device_batch_size=${PER_DEVICE_BATCH_SIZE?} \
+  max_target_length=${MAX_TARGET_LENGTH?} \
+  learning_rate=${LEARNING_RATE?} \
+  chat_template_path=${CHAT_TEMPLATE_PATH?} \
+  enable_nnx=True \
+  pure_nnx_decoder=True \
+  lora.enable_lora=True \
+  lora.lora_rank=${LORA_RANK?} \
+  lora.lora_alpha=${LORA_ALPHA?} \
+  checkpoint_storage_use_zarr3=False \
+  checkpoint_storage_use_ocdbt=False \
+  enable_single_controller=True"
+```
+
+Once the fine-tuning is completed, you can access your model checkpoints at `${BASE_OUTPUT_DIRECTORY}/${RUN_NAME}/checkpoints`.
+
+### (Optional) Resume from a previous LoRA checkpoint
+
+If you want to resume training from a previous run or further fine-tune an existing LoRA adapter, you can specify the LoRA checkpoint path.
+
+#### Step 1: Convert HF LoRA adapter to MaxText format
+
+If your LoRA adapter is currently in Hugging Face format, you must convert it to MaxText format before it can be loaded. Use the integrated conversion utility:
+
+```sh
+xpk workload create \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
+--zone=${ZONE?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload=${RUN_NAME?} \
+--tpu-type=${TPU_TYPE?} \
+--num-slices=${NUM_SLICES?} \
+--command="python3 -m maxtext.checkpoint_conversion.to_maxtext \
+  model_name=${MODEL?} \
+  hf_lora_adapter_path=${HF_LORA_ADAPTER_PATH?} \
+  base_output_directory=${BASE_OUTPUT_DIRECTORY?}/converted_adapter \
+  hf_access_token=${HF_TOKEN?} \
+  hardware=cpu \
+  skip_jax_distributed_system=True"
+```
+
+#### Step 2: Set the restore path
+
+Point `LORA_RESTORE_PATH` to the converted MaxText adapter directory (the directory containing the `0/items` or Orbax files).
+
+- **load_parameters_path**: Points to the frozen base model weights (the original model).
+- **lora_restore_path**: Points to the previous LoRA adapter weights you wish to load.
+
+```sh
+export LORA_RESTORE_PATH=<LORA_RESTORE_PATH> # e.g., gs://my-bucket/run-1/checkpoints/0/items or /path/to/run-1/checkpoints/0/items
+```
+
+#### Step 3: Run LoRA Fine-Tuning with the Restore Path
+
+Once your environment variables and checkpoints are ready, you can start the LoRA fine-tuning process.
+
+Execute the following command to begin training:
+
+```bash
+xpk workload create-pathways \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
+--zone=${ZONE?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload=${RUN_NAME?} \
+--tpu-type=${TPU_TYPE?} \
+--num-slices=${NUM_SLICES?} \
+--command="JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE=1 \
+python3 -m maxtext.trainers.post_train.sft.train_sft \
+  run_name=${RUN_NAME?} \
+  base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
+  model_name=${MODEL?} \
+  load_parameters_path=${MAXTEXT_CKPT_PATH?} \
+  hf_access_token=${HF_TOKEN?} \
+  hf_path=${DATASET_NAME?} \
+  train_split=${TRAIN_SPLIT?} \
+  hf_data_dir=${HF_DATA_DIR?} \
+  train_data_columns=${TRAIN_DATA_COLUMNS?} \
+  steps=${STEPS?} \
+  per_device_batch_size=${PER_DEVICE_BATCH_SIZE?} \
+  max_target_length=${MAX_TARGET_LENGTH?} \
+  lora.lora_restore_path=${LORA_RESTORE_PATH?} \
+  learning_rate=${LEARNING_RATE?} \
+  chat_template_path=${CHAT_TEMPLATE_PATH?} \
+  enable_nnx=True \
+  pure_nnx_decoder=True \
+  lora.enable_lora=True \
+  lora.lora_rank=${LORA_RANK?} \
+  lora.lora_alpha=${LORA_ALPHA?} \
+  checkpoint_storage_use_zarr3=False \
+  checkpoint_storage_use_ocdbt=False \
+  enable_single_controller=True"
+```
+
+Your fine-tuned model checkpoints will be saved here: `$BASE_OUTPUT_DIRECTORY/$RUN_NAME/checkpoints`.
+
+## (Optional) Convert Fine-tuned LoRA to Hugging Face Format
+
+After completing the fine-tuning process, your LoRA weights are stored in MaxText/Orbax format. To use these weights with the Hugging Face ecosystem (e.g., for inference or sharing), convert them back using the `to_huggingface.py` script.
+
+```sh
+xpk workload create \
+--cluster=${GKE_CLUSTER?} \
+--project=${PROJECT_ID?} \
+--zone=${ZONE?} \
+--docker-image=${DOCKER_IMAGE?} \
+--workload="${RUN_NAME?}-to-hf" \
+--tpu-type=${TPU_TYPE?} \
+--num-slices=1 \
+--command="python3 -m maxtext.checkpoint_conversion.to_huggingface \
+    model_name=${MODEL?} \
+    lora.lora_restore_path=${BASE_OUTPUT_DIRECTORY?}/${RUN_NAME?}/checkpoints/<STEPS>/model_params \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY?}/hf_lora_adapter \
+    hf_access_token=${HF_TOKEN?}"
+    
+```
+
+- `lora.lora_restore_path`: Point this to the specific checkpoint directory (e.g., `.../checkpoints/1000/items`) that you want to export.
+- `base_output_directory`: The local or GCS directory where the Hugging Face `adapter_model.safetensors` and `adapter_config.json` will be saved.
+- `lora.lora_rank` / `lora.lora_alpha`: Must match the values used during the training phase to ensure the `adapter_config.json` is generated correctly.
+
+## A Note on Multi-Host Resharding
+
+When running LoRA fine-tuning in a **multi-host environment** (e.g., a TPU pod with 64 hosts managing 256 TPUs, such as Pathways), special care must be taken when resharding arrays.
+
+In a single-host environment, the host has a global view of all devices, so a standard `jax.device_put` can easily distribute slices of data to all local TPUs. However, in a multi-host setup:
+
+- **Addressability:** A host only has a local view of its directly attached devices and cannot push data directly to TPUs managed by other hosts.
+- **Memory Constraints:** If every host tries to load the entire weight matrix into RAM just to extract its local piece, the host CPUs will run out of memory (OOM).
+
+To solve this, MaxText uses `jax.make_array_from_callback` for a "safe reshard." Instead of pushing data *to* the devices, this flips the paradigm. It creates a global `jax.Array` construct where each host locally executes a callback (`lambda idx: val[idx]`) to load **only the specific slice** of the data that its attached TPUs need. This completely bypasses cross-host `device_put` limitations and prevents OOMs since each host only indexes what it requires.

--- a/src/maxtext/examples/lora_llama3_demo.ipynb
+++ b/src/maxtext/examples/lora_llama3_demo.ipynb
@@ -1,0 +1,610 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6d342dea",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/AI-Hypercomputer/maxtext/blob/main/src/maxtext/examples/lora_llama3_demo.ipynb)\n",
+    "\n",
+    "# Llama3.1-8B Low-Rank Adaptation (LoRA) Demo\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c6366a0",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "\n",
+    "This notebook performs LoRA SFT training and evaluation workflow on [OpenAI's GSM8K dataset](https://huggingface.co/datasets/openai/gsm8k).\n",
+    " The primary goal is to demonstrate the end-to-end process of:\n",
+    " 1. Pre-SFT Evaluation: Calculating baseline accuracy for the model before training.\n",
+    " 2. Efficient LoRA SFT: Fine-tune the model using MaxText & Tunix SFT trainer.\n",
+    " 3. Post-SFT Evaluation: Re-running the evaluation loop after training to measure the performance gain achieved by LoRA SFT.\n",
+    " \n",
+    " This notebook can run on the **public TPU v5e-1**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7850d11a",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "Before running this notebook, make sure your environment is set up for the method you are using. Follow the [Run MaxText Python Notebooks on TPUs](https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html) guide and complete all steps for your chosen method (Google Colab, VS Code, or Local Jupyter Lab) before proceeding.\n",
+    "\n",
+    "If you run into issues, refer to the [Common Pitfalls & Debugging](https://maxtext.readthedocs.io/en/latest/guides/run_python_notebook.html#common-pitfalls-debugging) section of the guide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "883318ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "  import google.colab\n",
+    "  print(\"Running the notebook on Google Colab\")\n",
+    "  IN_COLAB = True\n",
+    "except ImportError:\n",
+    "    print(\"Running the notebook on Visual Studio or JupyterLab\")\n",
+    "    IN_COLAB = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "178292ce",
+   "metadata": {},
+   "source": [
+    "## Installation: MaxText and Post training Dependencies\n",
+    "\n",
+    "**Running the notebook on Visual Studio or JupyterLab:** Before proceeding, create a virtual environment and install the required post-training dependencies by following `Option 3: Installing [tpu-post-train]` in the [MaxText installation guide](https://maxtext.readthedocs.io/en/latest/install_maxtext.html#from-source). Once the environment is set up, ensure the notebook is running within it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2db1ce49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if IN_COLAB:\n",
+    "    # Clone the MaxText repository\n",
+    "    !git clone https://github.com/AI-Hypercomputer/maxtext.git\n",
+    "    %cd maxtext\n",
+    "\n",
+    "    # Install uv, a fast Python package installer\n",
+    "    !pip install uv\n",
+    "    \n",
+    "    # Install MaxText and post-training dependencies\n",
+    "    !uv pip install -e .[tpu-post-train] --resolution=lowest\n",
+    "    !install_tpu_post_train_extra_deps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2469fb7",
+   "metadata": {},
+   "source": [
+    "**Session restart Instructions for Colab:**\n",
+    "1.  Navigate to the menu at the top of the screen.\n",
+    "2.  Click on **Runtime**.\n",
+    "3.  Select **Restart session** from the dropdown menu.\n",
+    "\n",
+    "You will be asked to confirm the action in a pop-up dialog. Click on **Yes**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ae63b92",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0bffabd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import os\n",
+    "import sys\n",
+    "import subprocess\n",
+    "import transformers\n",
+    "\n",
+    "from maxtext.configs import pyconfig\n",
+    "from maxtext.examples.sft_qwen3_demo_utils import evaluate_model, get_test_dataset\n",
+    "from maxtext.integration.tunix.tunix_adapter import TunixMaxTextAdapter\n",
+    "from maxtext.utils.globals import MAXTEXT_PKG_DIR\n",
+    "from maxtext.trainers.post_train.sft import train_sft\n",
+    "from maxtext.checkpoint_conversion.to_huggingface import _get_lora_delta\n",
+    "\n",
+    "# Suppress vLLM logging with a severity level below ERROR\n",
+    "os.environ[\"VLLM_LOGGING_LEVEL\"] = \"ERROR\"\n",
+    "from tunix.rl.rollout import base_rollout\n",
+    "from tunix.rl.rollout.vllm_rollout import VllmRollout\n",
+    "\n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "from datetime import datetime\n",
+    "from flax import nnx\n",
+    "from etils import epath\n",
+    "\n",
+    "print(f\"MaxText installation path: {MAXTEXT_PKG_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6ab18aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not jax.distributed.is_initialized():\n",
+    "  jax.distributed.initialize()\n",
+    "print(f\"JAX version: {jax.__version__}\")\n",
+    "print(f\"JAX devices: {jax.devices()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e60700f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if IN_COLAB:\n",
+    "    from huggingface_hub import notebook_login\n",
+    "    notebook_login()\n",
+    "else:\n",
+    "    from huggingface_hub import login\n",
+    "    login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0be0aa2",
+   "metadata": {},
+   "source": [
+    "## Model Configurations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04953dce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_NAME = \"llama3.1-8b-Instruct\"\n",
+    "TOKENIZER_PATH = \"meta-llama/Llama-3.1-8B-Instruct\"\n",
+    "tokenizer = transformers.AutoTokenizer.from_pretrained(TOKENIZER_PATH)\n",
+    "# This is the directory where the fine-tuned model checkpoint will be saved\n",
+    "BASE_OUTPUT_DIRECTORY = f\"{MAXTEXT_PKG_DIR}/lora_llama3.1-8b_output\"\n",
+    "\n",
+    "# set the path to the model checkpoint (excluding `/0/items`) or leave empty to download from HuggingFace\n",
+    "MODEL_CHECKPOINT_PATH = \"\"\n",
+    "if not MODEL_CHECKPOINT_PATH:\n",
+    "   MODEL_CHECKPOINT_PATH = f\"{BASE_OUTPUT_DIRECTORY}/llama3.1-8b_checkpoint\"\n",
+    "   print(\"Model checkpoint will be downloaded from HuggingFace at: \",  MODEL_CHECKPOINT_PATH)\n",
+    "   print(\"Set MODEL_CHECKPOINT_PATH if you do not wish to download the checkpoint.\")\n",
+    "\n",
+    "\n",
+    "RUN_NAME = datetime.now().strftime(\"%Y-%m-%d-%H-%m-%S\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "389f42cb",
+   "metadata": {},
+   "source": [
+    "## Download Llama3.1-8B Model Checkpoint from Hugging Face"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf6cdced",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not epath.Path(MODEL_CHECKPOINT_PATH).exists():\n",
+    "    # Install torch for the conversion script\n",
+    "    print(\"Installing torch...\")\n",
+    "    subprocess.run(\n",
+    "        [\n",
+    "            sys.executable, \"-m\", \"pip\", \"install\",\n",
+    "            \"torch\", \"--index-url\", \"https://download.pytorch.org/whl/cpu\"\n",
+    "        ],\n",
+    "        check=True\n",
+    "    )\n",
+    "\n",
+    "    print(\"Converting checkpoint from HuggingFace...\")\n",
+    "    env = os.environ.copy()\n",
+    "    env[\"JAX_PLATFORMS\"] = \"cpu\"\n",
+    "\n",
+    "    subprocess.run(\n",
+    "        [\n",
+    "            sys.executable,\n",
+    "            \"-m\", \"maxtext.checkpoint_conversion.to_maxtext\",\n",
+    "            f\"{MAXTEXT_PKG_DIR}/configs/base.yml\",\n",
+    "            f\"model_name={MODEL_NAME}\",\n",
+    "            f\"base_output_directory={MODEL_CHECKPOINT_PATH}\",\n",
+    "            \"use_multimodal=false\",\n",
+    "            \"scan_layers=true\",\n",
+    "            \"skip_jax_distributed_system=True\",\n",
+    "        ],\n",
+    "        check=True,\n",
+    "        env=env\n",
+    "    )\n",
+    "    \n",
+    "    MODEL_CHECKPOINT_PATH = os.path.join(MODEL_CHECKPOINT_PATH, \"0/items\")\n",
+    "else:\n",
+    "    print(f\"Model checkpoint exists at {MODEL_CHECKPOINT_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2b990b5",
+   "metadata": {},
+   "source": [
+    "## Dataset Configurations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b66e23b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATASET_NAME = \"openai/gsm8k\"\n",
+    "TRAIN_DATA_SPLIT = \"train\"\n",
+    "TEST_DATA_SPLIT = \"test\"\n",
+    "HF_DATA_DIR = \"main\"\n",
+    "TRAIN_DATA_COLUMNS = [\"question\", \"answer\"]\n",
+    "DATA_TEMPLATE_PATH = f\"{MAXTEXT_PKG_DIR}/examples/chat_templates/math_qa.json\"\n",
+    "if not os.path.exists(DATA_TEMPLATE_PATH):\n",
+    "    raise FileNotFoundError(f\"Data template not found: {DATA_TEMPLATE_PATH}\")\n",
+    "FORMATTING_FUNC_PATH = \"maxtext.input_pipeline.instruction_data_processing.math_qa_formatting\"\n",
+    "FORMATTING_FUNC_KWARGS = {\"template_path\": f\"{DATA_TEMPLATE_PATH}\"}\n",
+    "NUM_TEST_SAMPLES = 20  # Total number of samples to test\n",
+    "BATCH_SIZE = 1  # Number of test samples to process in a batch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "293f355d",
+   "metadata": {},
+   "source": [
+    "## MaxText Configurations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ebc4929",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "config = pyconfig.initialize_pydantic(\n",
+    "    [\n",
+    "        \"\",\n",
+    "        f\"{MAXTEXT_PKG_DIR}/configs/post_train/sft.yml\",\n",
+    "        f\"run_name={RUN_NAME}\",\n",
+    "        f\"base_output_directory={BASE_OUTPUT_DIRECTORY}\",\n",
+    "        f\"model_name={MODEL_NAME}\",\n",
+    "        f\"load_parameters_path={MODEL_CHECKPOINT_PATH}\", \n",
+    "        f\"tokenizer_path={TOKENIZER_PATH}\",\n",
+    "        f\"hf_path={DATASET_NAME}\",\n",
+    "        f\"train_split={TRAIN_DATA_SPLIT}\",\n",
+    "        f\"hf_data_dir={HF_DATA_DIR}\",\n",
+    "        f\"train_data_columns={TRAIN_DATA_COLUMNS}\",\n",
+    "        \"steps=200\",\n",
+    "        \"per_device_batch_size=1\",\n",
+    "        \"max_target_length=512\",\n",
+    "        \"learning_rate=5e-5\", \n",
+    "        \"weight_dtype=bfloat16\",\n",
+    "        \"dtype=bfloat16\",\n",
+    "        \"enable_nnx=true\",\n",
+    "        \"pure_nnx_decoder=true\",\n",
+    "        \"scan_layers=true\",\n",
+    "        \"lora.enable_lora=true\",\n",
+    "        \"lora.lora_rank=16\",\n",
+    "        \"lora.lora_alpha=32.0\", \n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41e4e3d4",
+   "metadata": {},
+   "source": [
+    "## Initial Setup & Data Preparation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc002261",
+   "metadata": {},
+   "source": [
+    "### Create Test Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f4bbc36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_evaluation = os.environ.get(\"RUN_EVALUATION\", \"false\").lower() == \"true\"\n",
+    "run_evaluation = True\n",
+    "if run_evaluation:\n",
+    "    test_dataset = get_test_dataset(config, tokenizer, DATA_TEMPLATE_PATH)\n",
+    "    test_dataset = test_dataset[:NUM_TEST_SAMPLES]\n",
+    "    test_dataset = test_dataset.to_iter_dataset().batch(BATCH_SIZE, drop_remainder=True)\n",
+    "    TOTAL_BATCHES = NUM_TEST_SAMPLES // BATCH_SIZE\n",
+    "    print(\n",
+    "        f\"Processing {NUM_TEST_SAMPLES} examples with a batch size of {BATCH_SIZE}. This will result in {TOTAL_BATCHES} total batches for the test run.\"\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Please set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "472518e6",
+   "metadata": {},
+   "source": [
+    "### Create LoRA SFT Trainer State"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f1ded1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainer, mesh = train_sft.setup_trainer_state(config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4674a185",
+   "metadata": {},
+   "source": [
+    "### Create vLLM Rollout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04293db6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if run_evaluation:\n",
+    "    tunix_model = TunixMaxTextAdapter(trainer.model)\n",
+    "    vllm_rollout = VllmRollout(\n",
+    "        model=tunix_model,\n",
+    "        tokenizer=tokenizer,\n",
+    "        cache_config_or_size=1280,\n",
+    "        mesh=mesh,\n",
+    "        rollout_config=base_rollout.RolloutConfig(\n",
+    "            rollout_vllm_model_version=TOKENIZER_PATH,\n",
+    "            rollout_vllm_hbm_utilization=0.3,\n",
+    "            rollout_vllm_init_with_random_weights=True,\n",
+    "            rollout_vllm_tpu_backend_type=\"jax\",\n",
+    "            data_type=jax.numpy.bfloat16,\n",
+    "            max_tokens_to_generate=512\n",
+    "        ),\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Please set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "465fcc52",
+   "metadata": {},
+   "source": [
+    "## Evaluation before LoRA SFT Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15252835",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if run_evaluation:\n",
+    "    print(\"Running Pre-SFT Evaluation...\")\n",
+    "    score = evaluate_model(test_dataset, vllm_rollout, debug=False)\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Please set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c5642a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if run_evaluation:\n",
+    "    print(\"========================= Score for PRE-SFT Evaluation =========================\")\n",
+    "    print(f\"Percentage of test samples where the model produced the correct numerical answer: {score['correct']}%\")\n",
+    "    print(\n",
+    "        f\"Percentage of test samples where the model produced the numerical answer within 10%: {score['partially_correct']}%\"\n",
+    "    )\n",
+    "    print(\n",
+    "        f\"Percentage of test samples where the model's output adheres to the expected structure: {score['correct_format']}%\"\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Please set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "863bd8e5",
+   "metadata": {},
+   "source": [
+    "## LoRA SFT Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0ebcaed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Starting LoRA SFT Training...\")\n",
+    "trainer = train_sft.train_model(config, trainer, mesh)\n",
+    "print(\"LoRA SFT Training Complete!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6f01e65",
+   "metadata": {},
+   "source": [
+    "## Evaluation after LoRA SFT Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a482aaad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if run_evaluation:\n",
+    "    print(\"Starting weight merge process before evaluation...\")\n",
+    "\n",
+    "    # --- WHY WE MERGE ---\n",
+    "    # vLLM/VllmRollout initializes with the frozen BASE MODEL and cannot see \n",
+    "    # the separate LoRA weights in the trainer. We fold LoRA into the base weights \n",
+    "    # to ensure the evaluation reflects the fine-tuned performance.\n",
+    "\n",
+    "    # --- 1. Data Preparation ---\n",
+    "    # Split the NNX model to extract the pure parameter dictionary\n",
+    "    _, state = nnx.split(trainer.model)\n",
+    "    flat_params = state.to_pure_dict()\n",
+    "    scaling = config.lora.lora_alpha / config.lora.lora_rank\n",
+    "\n",
+    "    # Move parameters to CPU to run merging arithmetic on host CPU RAM, avoiding TPU HBM OOM\n",
+    "    print(\"Moving trainer weights to CPU RAM for safe weight merge...\")\n",
+    "    flat_params = jax.device_put(flat_params, jax.devices(\"cpu\")[0])\n",
+    "    \n",
+    "    # Create an \"Official Format\" dictionary to align with MaxText's internal naming\n",
+    "    # This ensures _get_lora_delta can correctly map 'kernel' to 'lora_a/b'\n",
+    "    official_dict = {}\n",
+    "    for path, val in jax.tree_util.tree_flatten_with_path(flat_params)[0]:\n",
+    "        # Handle JAX Path objects and strip formatting to get clean string keys\n",
+    "        p_names = [str(p.key if hasattr(p, 'key') else str(p).strip(\"['']\")) for p in path]\n",
+    "        official_key = \"params-\" + \"-\".join(p_names)\n",
+    "        official_dict[official_key] = val\n",
+    "\n",
+    "    merge_count = 0\n",
+    "    \n",
+    "    # --- 2. Core Merging Logic ---\n",
+    "    # Iterate through parameters and apply LoRA delta using the official MaxText utility\n",
+    "    for off_key, val in official_dict.items():\n",
+    "        if off_key.endswith(\"-kernel\"):\n",
+    "            # Calculate the low-rank delta (A * B * scaling)\n",
+    "            delta = _get_lora_delta(off_key, official_dict, scaling)\n",
+    "            \n",
+    "            if delta is not None:\n",
+    "                # Perform the merge: W_merged = W_base + Delta\n",
+    "                # Includes automatic reshaping for multi-dimensional (Scanned) layers\n",
+    "                merged_val = val + delta.reshape(val.shape) if delta.size == val.size else val + delta\n",
+    "                \n",
+    "                # Navigate back through the nested dictionary to update the value\n",
+    "                original_path = off_key.replace(\"params-\", \"\").split(\"-\")\n",
+    "                curr = flat_params\n",
+    "                for p in original_path[:-1]:\n",
+    "                    curr = curr[p]\n",
+    "                curr[original_path[-1]] = merged_val\n",
+    "                \n",
+    "                merge_count += 1\n",
+    "                print(f\"[Merged on CPU] {off_key}\")\n",
+    "\n",
+    "    # --- 3. Update Model & PROOF OF MERGE ---\n",
+    "    # Move merged parameters back to TPU device before updating model\n",
+    "    print(\"Moving merged weights back to TPU device...\")\n",
+    "    flat_params = jax.device_put(flat_params)\n",
+    "    nnx.update(trainer.model, nnx.State(flat_params))\n",
+    "    # Check the merge_count to confirm if LoRA weights have been successfully applied.\n",
+    "    print(f\"Weight merging completed! Total modules processed: {merge_count}\")\n",
+    "\n",
+    "    # Extract the updated state and filter out LoRA variables for vLLM compatibility\n",
+    "    full_updated_state = nnx.state(trainer.model)\n",
+    "    clean_state_dict = {\n",
+    "        k: v for k, v in full_updated_state.items() \n",
+    "        if \"lora\" not in str(k)\n",
+    "    }\n",
+    "    clean_state_to_sync = nnx.State(clean_state_dict)\n",
+    "\n",
+    "    # --- 4. vLLM Synchronization & Evaluation ---\n",
+    "    print(\"Syncing merged parameters with vLLM and starting evaluation...\")\n",
+    "    vllm_rollout.update_params(clean_state_to_sync)\n",
+    "    score = evaluate_model(test_dataset, vllm_rollout, debug=False)\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Please set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05139cf6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if run_evaluation:\n",
+    "    print(\"========================= Score for POST-SFT Evaluation =========================\")\n",
+    "    print(f\"Percentage of test samples where the model produced the correct numerical answer: {score['correct']}%\")\n",
+    "    print(\n",
+    "        f\"Percentage of test samples where the model produced the numerical answer within 10%: {score['partially_correct']}%\"\n",
+    "    )\n",
+    "    print(\n",
+    "        f\"Percentage of test samples where the model's output adheres to the expected structure: {score['correct_format']}%\"\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Evaluation on test dataset is skipped. Please set `RUN_EVALUATION=True` to run evaluation.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (3.12.11)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Description

 This PR adds comprehensive documentation and tutorials for running LoRA/QLoRA fine-tuning, specifically focusing on multi-host TPU environments.

  As PEFT techniques become more prevalent for large models, users need clear, step-by-step guidance on how to leverage MaxText and Tunix for multi-host tuning.

  This PR includes:
   - A new dedicated Markdown tutorial (docs/tutorials/posttraining/lora_on_multi_host.md) detailing the prerequisites, environment setup, and execution steps for multi-host TPU tuning.
   - A fully documented Jupyter Notebook (src/maxtext/examples/lora_llama3_demo.ipynb) that walks through setup, pre-SFT evaluation (using vLLM rollouts), the Tunix LoRA SFT training loop, and post-SFT evaluation with weight
     merging.
   - Minor path corrections in the existing lora.md tutorial.

# Tests

  - Documentation only.
  - The Jupyter notebook has been run manually to ensure that all cells execute correctly (assuming the required dependencies and TPUs are available).


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
