### PR TITLE
Improve Docker upload usability and fix .dockerignore parsing

### DIFF
--- a/docs/build_maxtext.md
+++ b/docs/build_maxtext.md
@@ -137,15 +137,44 @@ build_maxtext_docker_image DEVICE=gpu MODE=nightly JAX_VERSION=$JAX_VERSION
 build_maxtext_docker_image WORKFLOW=post-training
 ```
 
-## Upload MaxText Docker Image to Artifact Registry
+## Upload MaxText Docker Image to Registry
+
+You can upload your built Docker image to either Google Artifact Registry (recommended) or Google Container Registry (GCR, legacy).
+
+### Option 1: Upload to Artifact Registry (Recommended)
+
+To upload to Artifact Registry, provide the **full path** of the target image (including the registry location, project, and repository) in `CLOUD_IMAGE_NAME`. The script will automatically tag it as `:latest` if no tag is specified.
 
 ```bash
-# Make sure to set `CLOUD_IMAGE_NAME` with your desired image name.
-export CLOUD_IMAGE_NAME=<IMAGE_NAME>
+# 1. Define the full Artifact Registry path
+export CLOUD_IMAGE_NAME=<LOCATION>-docker.pkg.dev/<PROJECT_ID>/<REPOSITORY_NAME>/<IMAGE_NAME>
+
+# 2. Upload the image (must be run inside your activated venv)
 upload_maxtext_docker_image CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME?}
 ```
 
-> **Note:** You will need the [**Artifact Registry Writer**](https://docs.cloud.google.com/artifact-registry/docs/access-control#permissions) role to push Docker images to your project's Artifact Registry and to allow the cluster to pull them during workload execution. If you don't have this permission, contact your project administrator to grant you this role through "Google Cloud Console -> IAM -> Grant access".
+### Option 2: Upload to Container Registry (GCR)
+
+If you provide just a simple image name, the script will default to uploading to GCR under your current active gcloud project (`gcr.io/<PROJECT_ID>/<IMAGE_NAME>:latest`).
+
+```bash
+# 1. Define a simple image name
+export CLOUD_IMAGE_NAME=<IMAGE_NAME>
+
+# 2. Upload the image (must be run inside your activated venv)
+upload_maxtext_docker_image CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME?}
+```
+
+> [!IMPORTANT]
+> **Virtual Environment Reminder:** The `upload_maxtext_docker_image` command is a console script installed inside your virtual environment. If you open a new terminal session to upload the image, you **must re-activate your virtual environment** first:
+>
+> ```bash
+> source ${VENV_NAME?}/bin/activate
+> ```
+>
+> If you get a `command not found: upload_maxtext_docker_image` error, it means your virtual environment is not activated.
+
+> **Note on Permissions:** You will need the [**Artifact Registry Writer**](https://docs.cloud.google.com/artifact-registry/docs/access-control#permissions) role to push Docker images to Artifact Registry. If you don't have this permission, contact your project administrator to grant you this role through "Google Cloud Console -> IAM -> Grant access".
 
 ## Troubleshooting
 

--- a/src/dependencies/scripts/docker_upload_runner.sh
+++ b/src/dependencies/scripts/docker_upload_runner.sh
@@ -121,7 +121,34 @@ docker build --no-cache --build-arg BASEIMAGE=${LOCAL_IMAGE_NAME} \
              -f "$PACKAGE_DIR"'/dependencies/dockerfiles/maxtext_runner.Dockerfile' \
              -t ${LOCAL_IMAGE_NAME_RUNNER} .
 
-docker tag ${LOCAL_IMAGE_NAME_RUNNER} gcr.io/$PROJECT/${CLOUD_IMAGE_NAME}:latest
-docker push gcr.io/$PROJECT/${CLOUD_IMAGE_NAME}:latest
+# Determine the full target image path
+export FULL_IMAGE_PATH=""
+if [[ "${CLOUD_IMAGE_NAME}" == *"/"* ]]; then
+  # If it contains '/', assume it's a full path (e.g., us-docker.pkg.dev/project/repo/image)
+  export FULL_IMAGE_PATH="${CLOUD_IMAGE_NAME}"
+else
+  # Otherwise, default to GCR
+  export FULL_IMAGE_PATH="gcr.io/${PROJECT}/${CLOUD_IMAGE_NAME}"
+fi
 
-echo "All done, check out your artifacts at: gcr.io/$PROJECT/${CLOUD_IMAGE_NAME}"
+# Append :latest if no tag is specified
+if [[ "${FULL_IMAGE_PATH}" != *":"* ]]; then
+  export FULL_IMAGE_PATH="${FULL_IMAGE_PATH}:latest"
+fi
+
+echo "Tagging local image ${LOCAL_IMAGE_NAME_RUNNER} as ${FULL_IMAGE_PATH}..."
+docker tag ${LOCAL_IMAGE_NAME_RUNNER} ${FULL_IMAGE_PATH}
+
+echo "Pushing image to registry..."
+docker push ${FULL_IMAGE_PATH}
+
+# Since 'set -e' is active, if we reach this point, the push was successful.
+echo ""
+echo "========================================================================================================="
+echo "✅ SUCCESS: MaxText Docker image uploaded successfully!"
+echo "========================================================================================================="
+echo "Your image is available at:"
+echo "👉 ${FULL_IMAGE_PATH}"
+echo ""
+echo "You can copy-paste the path above directly into your XPK or GKE workload configurations."
+echo "========================================================================================================="


### PR DESCRIPTION
# Description

This PR improves the usability, registry flexibility, and visual feedback of the MaxText Docker image upload workflow. It introduces support for custom Artifact Registry paths (moving away from the deprecated legacy GCR default) and provides clear visual success verification in the terminal, while updating the documentation to prevent common virtual environment pitfalls.

### Why this change is being made & the problem being solved
During MaxText 2.0 RL UXR testing (reported in **b/497837783**), users experienced several friction points when building and uploading Docker images:
1.  **Hardcoded GCR:** The upload script was hardcoded to use the legacy `gcr.io` registry. Pushing to modern Artifact Registries (`*.pkg.dev`) required manual scripting workarounds.
2.  **No Verification:** The upload process ended with verbose `docker push` stream logs, leaving users unsure if their upload actually succeeded or where the image ended up.
3.  **Virtual Environment Trap:** Users frequently opened new terminal sessions to perform the upload and got stuck because they forgot to re-activate their virtual environment (`venv`), resulting in confusing `command not found: upload_maxtext_docker_image` errors.

### Why this is a good solution
This solution dynamically supports both legacy GCR and modern Artifact Registry paths by automatically parsing the input format. Instead of adding fragile cloud-side metadata queries that are prone to rate-limiting or permission issues, it leverages the script's standard `set -e` boundaries to guarantee upload success. If the script finishes, the push succeeded, and it outputs a high-visibility terminal success banner displaying the exact image path for users to copy-paste into their subsequent XPK/GKE steps.

### Specific implementation details
*   **Dynamic Path Parsing (`docker_upload_runner.sh`):** Updated the script to check if `CLOUD_IMAGE_NAME` contains `/`. If it does, it is treated as a full registry path; if not, it safely falls back to GCR (`gcr.io/<PROJECT>/<IMAGE_NAME>`) to preserve backwards compatibility. It also automatically appends `:latest` if no custom tag is present in the path.
*   **Visual Success Banner (`docker_upload_runner.sh`):** Replaced the silent/verbose exit with a prominent, formatted success box highlighting the target registry path.
*   **Placeholder Consistency (`build_maxtext.md`):** Updated the documentation to explain GCR vs. Artifact Registry options, using consistent `<...>` angle-bracket placeholders.
*   **Virtual Environment Callout (`build_maxtext.md`):** Added a high-visibility `[!IMPORTANT]` reminder detailing how to re-activate the `venv` if a new terminal session is opened, directly addressing the UXR friction point.

### Shortcomings and Future Improvements
The script still defaults to `gcr.io` when a simple image name is provided to prevent breaking existing user workflows. In a future major version, we should deprecate GCR entirely and default simple names to a project's default Artifact Registry repository.

FIXED: b/497837783


# Tests

1.  **Syntax & Logic Verification:** Verified the modified `docker_upload_runner.sh` syntax and diff on a TPU v6e VM.
2.  **Simulated Upload Path Resolution:** Tested the path detection logic locally with various input structures:
    *   *Input:* `my-image` ➡️ Resolves to `gcr.io/<PROJECT>/my-image:latest` (Backwards-compatible fallback)
    *   *Input:* `us-docker.pkg.dev/my-project/my-repo/my-image` ➡️ Resolves to `us-docker.pkg.dev/my-project/my-repo/my-image:latest` (Artifact Registry support)
    *   *Input:* `us-docker.pkg.dev/my-project/my-repo/my-image:v1` ➡️ Resolves to `us-docker.pkg.dev/my-project/my-repo/my-image:v1` (Preserves custom tags)
3.  **Visual Verification:** Verified that the success banner prints correctly and highlights the exact final image path clearly at the end of execution.

### Instructions to reproduce
On a configured development environment (e.g., your TPU VM):
```bash
# 1. Activate your venv
source <VENV_NAME>/bin/activate

# 2. Test GCR fallback upload (simple name)
export CLOUD_IMAGE_NAME=maxtext-test-gcr
upload_maxtext_docker_image CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}

# 3. Test Artifact Registry upload (full path)
export CLOUD_IMAGE_NAME=us-docker.pkg.dev/<PROJECT_ID>/<REPOSITORY_NAME>/maxtext-test-ar
upload_maxtext_docker_image CLOUD_IMAGE_NAME=${CLOUD_IMAGE_NAME}
```

Verify that both commands complete successfully and output the clean terminal confirmation banner displaying the target registry path.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
