### PR TITLE
[WIP] Consolidate mmutils

### DIFF
--- a/src/maxtext/multimodal/processor.py
+++ b/src/maxtext/multimodal/processor.py
@@ -12,233 +12,120 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Multimodal data preprocessor router."""
+"""Multimodal data preprocessor router.
+
+This module routes all multimodal preprocessing, prompt formatting, and token 
+manipulation calls to the appropriate model-specific processor class.
+
+Routing Mappings:
+  - Model: "gemma3-*" -> processor_gemma3.Gemma3Processor
+  - Model: "gemma4-*" -> processor_gemma4.Gemma4Processor
+  - Model: "llama4-*" -> processor_llama4.Llama4Processor
+  - Model: "qwen3-omni-*" or "qwen3.5-*" -> processor_qwen3_omni.Qwen3OmniProcessor
+"""
 
 from maxtext.multimodal import utils as mm_utils
+from maxtext.multimodal.utils import BaseMultimodalProcessor
+from maxtext.utils import max_logging
+from maxtext.multimodal.processor_gemma3 import Gemma3Processor
+from maxtext.multimodal.processor_gemma4 import Gemma4Processor
+from maxtext.multimodal.processor_llama4 import Llama4Processor
+from maxtext.multimodal.processor_qwen3_omni import Qwen3OmniProcessor
+
+_REGISTERED_PROCESSORS = [
+    Gemma3Processor,
+    Gemma4Processor,
+    Llama4Processor,
+    Qwen3OmniProcessor,
+]
 
 
-def preprocess_mm_data(config):
-  """Preprocesses multimodal data based on the provided configuration.
-  Routes to the appropriate preprocessing function based on the model name.
+def get_processor(model_name: str) -> BaseMultimodalProcessor:
+  """Returns the appropriate processor instance for the given model name.
 
-  Args:
-    config: A `pyconfig.Config` object containing configuration parameters.
-
-  Returns:
-    A `PreprocessorOutput` object containing the processed multimodal data.
+  If no specific processor matches, returns a fallback BaseMultimodalProcessor
+  instance.
   """
-  processor_outputs = mm_utils.PreprocessorOutput()
-
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
-    from maxtext.multimodal.processor_gemma3 import preprocess_mm_data_gemma3  # pylint: disable=import-outside-toplevel
-
-    images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
-    processor_outputs = preprocess_mm_data_gemma3(images)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
-    from maxtext.multimodal.processor_gemma4 import preprocess_mm_data_gemma4  # pylint: disable=import-outside-toplevel
-
-    images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
-    processor_outputs = preprocess_mm_data_gemma4(images)
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
-    from maxtext.multimodal.processor_llama4 import preprocess_mm_data_llama4  # pylint: disable=import-outside-toplevel
-
-    images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
-    processor_outputs = preprocess_mm_data_llama4(images)
-  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
-    from maxtext.multimodal.processor_qwen3_omni import preprocess_mm_data_qwen3_omni  # pylint: disable=import-outside-toplevel
-
-    processor_outputs = preprocess_mm_data_qwen3_omni(config)
-  else:
-    raise ValueError(f"Model {config.model_name} not supported for multimodal preprocessing.")
-
-  return processor_outputs
+  for processor_cls in _REGISTERED_PROCESSORS:
+    if processor_cls.supports_model(model_name):
+      max_logging.log(f"Multimodal Router: Instantiating {processor_cls.__name__} for model {model_name}")
+      return processor_cls(model_name)
+  max_logging.log(
+      f"Multimodal Router: No specific processor found for {model_name}. Falling back to BaseMultimodalProcessor."
+  )
+  return BaseMultimodalProcessor(model_name)
 
 
-def preprocess_image_for_training(image, model_name):
+def preprocess_mm_data(config, **kwargs) -> mm_utils.PreprocessorOutput:
+  """Preprocesses multimodal data based on the provided configuration."""
+  return get_processor(config.model_name).preprocess_mm_data(config, **kwargs)
+
+
+def preprocess_image_for_training(image, model_name, **kwargs) -> mm_utils.PreprocessorOutput:
   """Preprocesses a single image for training based on the model name."""
-  if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
-    from maxtext.multimodal.processor_gemma3 import preprocess_mm_data_gemma3  # pylint: disable=import-outside-toplevel
-
-    return preprocess_mm_data_gemma3(image)
-  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
-    from maxtext.multimodal.processor_gemma4 import preprocess_mm_data_gemma4  # pylint: disable=import-outside-toplevel
-
-    return preprocess_mm_data_gemma4(image)
-  elif model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
-    from maxtext.multimodal.processor_llama4 import preprocess_mm_data_llama4  # pylint: disable=import-outside-toplevel
-
-    return preprocess_mm_data_llama4(image)
-  elif model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
-    from maxtext.multimodal.processor_qwen3_omni import preprocess_mm_data_qwen3_omni_for_training  # pylint: disable=import-outside-toplevel
-
-    return preprocess_mm_data_qwen3_omni_for_training(image)
-  else:
-    raise ValueError(f"Model {model_name} not supported for image preprocessing.")
+  return get_processor(model_name).preprocess_image_for_training(image, **kwargs)
 
 
-def get_image_offsets(config, processor_output: mm_utils.PreprocessorOutput | None):
-  """Get the increase in total token count after inserting image token placeholders"""
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
-    from maxtext.multimodal.processor_gemma3 import get_image_offsets_gemma3  # pylint: disable=import-outside-toplevel
-
-    return get_image_offsets_gemma3(processor_output)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
-    from maxtext.multimodal.processor_gemma4 import get_image_offsets_gemma4  # pylint: disable=import-outside-toplevel
-
-    return get_image_offsets_gemma4(processor_output)
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
-    from maxtext.multimodal.processor_llama4 import get_image_offsets_llama4  # pylint: disable=import-outside-toplevel
-
-    return get_image_offsets_llama4(processor_output)
-  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
-    from maxtext.multimodal.processor_qwen3_omni import get_mm_offsets_qwen3_omni  # pylint: disable=import-outside-toplevel
-
-    return get_mm_offsets_qwen3_omni(config, processor_output)
-  else:
-    return 0
+def get_image_offsets(config, processor_output: mm_utils.PreprocessorOutput | None, **kwargs) -> int:
+  """Get the increase in total token count after inserting image tokens."""
+  return get_processor(config.model_name).get_image_offsets(config, processor_output, **kwargs)
 
 
-def reformat_prompt(prompt, image_placeholder, model_name, num_images, video_placeholder="<|video|>", num_videos=0):
+def reformat_prompt(
+    prompt,
+    image_placeholder,
+    model_name,
+    num_images,
+    **kwargs,
+) -> str:
   """Reformat prompt for different models."""
-  if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
-    from maxtext.multimodal.processor_gemma3 import reformat_prompt_gemma3  # pylint: disable=import-outside-toplevel
-
-    return reformat_prompt_gemma3(prompt, image_placeholder, num_images)
-  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
-    from maxtext.multimodal.processor_gemma4 import reformat_prompt_gemma4  # pylint: disable=import-outside-toplevel
-
-    return reformat_prompt_gemma4(prompt, image_placeholder, num_images)
-  elif model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
-    from maxtext.multimodal.processor_llama4 import reformat_prompt_llama4  # pylint: disable=import-outside-toplevel
-
-    return reformat_prompt_llama4(prompt, image_placeholder, num_images)
-  elif model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
-    from maxtext.multimodal.processor_qwen3_omni import reformat_prompt_qwen3_omni  # pylint: disable=import-outside-toplevel
-
-    return reformat_prompt_qwen3_omni(
-        prompt=prompt,
-        image_placeholder=image_placeholder,
-        num_images=num_images,
-        video_placeholder=video_placeholder,
-        num_videos=num_videos,
-    )
-  else:
-    return prompt
+  return get_processor(model_name).reformat_prompt(
+      prompt=prompt,
+      image_placeholder=image_placeholder,
+      num_images=num_images,
+      **kwargs,
+  )
 
 
-def reformat_response(response, model_name):
+def reformat_response(response, model_name, **kwargs) -> str:
   """Reformat response for different models."""
-  if model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
-    formatted_response = f"{response}<|eot|>"
-    return formatted_response
-  elif model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
-    formatted_response = f"{response}<end_of_turn>"
-    return formatted_response
-  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
-    formatted_response = f"{response}<end_of_turn>"
-    return formatted_response
-  elif model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
-    formatted_response = f"{response}<|im_end|>"
-    return formatted_response
-  else:
-    return response
+  return get_processor(model_name).reformat_response(response, **kwargs)
 
 
-def prepare_text_for_image_fusion(tokens, config, processor_output=None):
+def prepare_text_for_image_fusion(
+    tokens,
+    config,
+    processor_output=None,
+    **kwargs,
+):
   """Prepare text by adding extra tokens for image fusion based on the model."""
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
-    from maxtext.multimodal.processor_gemma3 import add_extra_tokens_for_images_gemma3  # pylint: disable=import-outside-toplevel
-
-    return add_extra_tokens_for_images_gemma3(tokens, max_num_images=processor_output.num_images)
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
-    from maxtext.multimodal.processor_gemma4 import add_extra_tokens_for_images_gemma4  # pylint: disable=import-outside-toplevel
-
-    return add_extra_tokens_for_images_gemma4(tokens, max_num_images=processor_output.num_images)
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
-    from maxtext.multimodal.processor_llama4 import add_extra_tokens_for_images_llama4  # pylint: disable=import-outside-toplevel
-
-    return add_extra_tokens_for_images_llama4(tokens, processor_output)
-  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
-    from maxtext.multimodal.processor_qwen3_omni import add_extra_tokens_for_qwen3_omni  # pylint: disable=import-outside-toplevel
-
-    return add_extra_tokens_for_qwen3_omni(tokens, config, processor_output)
-  else:
-    raise ValueError(f"Model {config.model_name} does not support multimodal inference.")
+  return get_processor(config.model_name).prepare_text_for_image_fusion(tokens, config, processor_output, **kwargs)
 
 
-def get_dummy_image_shape_for_init(model_name, batch_size=1, num_image_per_sequence=1):
+def get_dummy_image_shape_for_init(
+    model_name,
+    batch_size=1,
+    num_image_per_sequence=1,
+    **kwargs,
+) -> tuple:
   """Return the shape of the dummy image for specific model's initialization."""
-  image_shape = ()
-  if model_name.startswith("gemma3"):
-    from maxtext.multimodal.processor_gemma3 import get_dummy_image_shape_for_init_gemma3  # pylint: disable=import-outside-toplevel
-
-    image_shape = get_dummy_image_shape_for_init_gemma3(batch_size, num_image_per_sequence)
-  elif model_name.startswith("gemma4"):
-    from maxtext.multimodal.processor_gemma4 import get_dummy_image_shape_for_init_gemma4  # pylint: disable=import-outside-toplevel
-
-    image_shape = get_dummy_image_shape_for_init_gemma4(batch_size, num_image_per_sequence)
-  elif model_name.startswith("llama4"):
-    from maxtext.multimodal.processor_llama4 import get_dummy_image_shape_for_init_llama4  # pylint: disable=import-outside-toplevel
-
-    image_shape = get_dummy_image_shape_for_init_llama4(batch_size, num_image_per_sequence)
-  elif model_name.startswith("qwen3-omni-30b-a3b") or model_name.startswith("qwen3.5-397b-a17b"):
-    from maxtext.multimodal.processor_qwen3_omni import get_dummy_image_shape_for_init_qwen3_omni  # pylint: disable=import-outside-toplevel
-
-    image_shape = get_dummy_image_shape_for_init_qwen3_omni(batch_size)
-  return image_shape
+  return get_processor(model_name).get_dummy_image_shape_for_init(
+      batch_size=batch_size,
+      num_image_per_sequence=num_image_per_sequence,
+      **kwargs,
+  )
 
 
-def get_dummy_audio_shape_for_init(config):
-  """Return the shape of the dummy audio for specific model's initialization.
-
-  Args:
-    config: Model configuration containing audio parameters
-
-  Returns:
-    Tuple representing audio shape: (batch, num_mel_bins, audio_length)
-    Returns empty tuple if audio is not configured for the model
-  """
-  audio_shape = ()
-  if config.model_name.startswith("qwen3-omni"):
-    from maxtext.multimodal.processor_qwen3_omni import get_dummy_audio_shape_for_init_qwen3_omni  # pylint: disable=import-outside-toplevel
-
-    audio_shape = get_dummy_audio_shape_for_init_qwen3_omni(config)
-
-  return audio_shape
+def get_dummy_audio_shape_for_init(config, **kwargs) -> tuple:
+  """Return the shape of the dummy audio for specific model's initialization."""
+  return get_processor(config.model_name).get_dummy_audio_shape_for_init(config, **kwargs)
 
 
-def get_bidirectional_mask_vision(config, decoder_input_tokens):
-  """Get the bidirectional mask for specific models."""
-  bidirectional_mask_vision = None
-  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
-    from maxtext.multimodal.processor_gemma3 import GEMMA_TOKEN_PLACEHOLDER  # pylint: disable=import-outside-toplevel
-
-    bidirectional_mask_vision = decoder_input_tokens == GEMMA_TOKEN_PLACEHOLDER
-  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
-    from maxtext.multimodal.processor_gemma4 import GEMMA4_TOKEN_PLACEHOLDER  # pylint: disable=import-outside-toplevel
-
-    bidirectional_mask_vision = decoder_input_tokens == GEMMA4_TOKEN_PLACEHOLDER
-  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
-    from maxtext.multimodal.processor_llama4 import LLAMA4_PATCH_TOKEN  # pylint: disable=import-outside-toplevel
-
-    bidirectional_mask_vision = decoder_input_tokens == LLAMA4_PATCH_TOKEN
-  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
-    from maxtext.multimodal.processor_qwen3_omni import QWEN3_OMNI_IMAGE_TOKEN, QWEN3_OMNI_VIDEO_TOKEN  # pylint: disable=import-outside-toplevel
-
-    # Create bidirectional_mask for vision/video token merging
-    bidirectional_mask_vision = (decoder_input_tokens == QWEN3_OMNI_IMAGE_TOKEN) | (
-        decoder_input_tokens == QWEN3_OMNI_VIDEO_TOKEN
-    )
-    # Create image/video mask for deepstack visual embedding injection
-  return bidirectional_mask_vision
+def get_bidirectional_mask_vision(config, decoder_input_tokens, **kwargs):
+  """Get the bidirectional mask for vision tokens."""
+  return get_processor(config.model_name).get_bidirectional_mask_vision(config, decoder_input_tokens, **kwargs)
 
 
-def get_bidirectional_mask_audio(config, decoder_input_tokens):
-  """Get the bidirectional mask for specific models."""
-  bidirectional_mask_audio = None
-  if config.model_name in ["qwen3-omni-30b-a3b"]:
-    from maxtext.multimodal.processor_qwen3_omni import QWEN3_OMNI_AUDIO_TOKEN  # pylint: disable=import-outside-toplevel
-
-    # Create bidirectional_mask for audio token merging
-    bidirectional_mask_audio = decoder_input_tokens == QWEN3_OMNI_AUDIO_TOKEN
-  return bidirectional_mask_audio
+def get_bidirectional_mask_audio(config, decoder_input_tokens, **kwargs):
+  """Get the bidirectional mask for audio tokens."""
+  return get_processor(config.model_name).get_bidirectional_mask_audio(config, decoder_input_tokens, **kwargs)

--- a/src/maxtext/multimodal/processor_gemma3.py
+++ b/src/maxtext/multimodal/processor_gemma3.py
@@ -270,3 +270,50 @@ def get_dummy_image_shape_for_init_gemma3(batch_size=1, num_image_per_sequence=1
       mm_utils.NUM_IMAGE_CHANNELS,
   )
   return image_shape
+
+
+class Gemma3Processor(mm_utils.BaseMultimodalProcessor):
+  """Gemma3 multimodal data processor."""
+
+  # pylint: disable=unused-argument
+
+  @classmethod
+  def supports_model(cls, model_name: str) -> bool:
+    return model_name.startswith("gemma3")
+
+  def preprocess_mm_data(self, config, **kwargs) -> mm_utils.PreprocessorOutput:
+    images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
+    return preprocess_mm_data_gemma3(images)
+
+  def preprocess_image_for_training(self, image, **kwargs) -> mm_utils.PreprocessorOutput:
+    return preprocess_mm_data_gemma3(image)
+
+  def get_image_offsets(self, config, processor_output: mm_utils.PreprocessorOutput | None, **kwargs) -> int:
+    return get_image_offsets_gemma3(processor_output)
+
+  def reformat_prompt(
+      self,
+      prompt: str,
+      image_placeholder: str,
+      num_images: int,
+      **kwargs,
+  ) -> str:
+    return reformat_prompt_gemma3(prompt, image_placeholder, num_images)
+
+  def reformat_response(self, response: str, **kwargs) -> str:
+    return f"{response}<end_of_turn>"
+
+  def prepare_text_for_image_fusion(
+      self,
+      tokens,
+      config,
+      processor_output: mm_utils.PreprocessorOutput | None = None,
+      **kwargs,
+  ):
+    return add_extra_tokens_for_images_gemma3(tokens, max_num_images=processor_output.num_images)
+
+  def get_dummy_image_shape_for_init(self, batch_size: int = 1, num_image_per_sequence: int = 1, **kwargs) -> tuple:
+    return get_dummy_image_shape_for_init_gemma3(batch_size, num_image_per_sequence)
+
+  def get_bidirectional_mask_vision(self, config, decoder_input_tokens, **kwargs):
+    return decoder_input_tokens == GEMMA_TOKEN_PLACEHOLDER

--- a/src/maxtext/multimodal/processor_gemma4.py
+++ b/src/maxtext/multimodal/processor_gemma4.py
@@ -189,3 +189,50 @@ def get_dummy_image_shape_for_init_gemma4(batch_size=1, num_image_per_sequence=1
       mm_utils.NUM_IMAGE_CHANNELS,
   )
   return image_shape
+
+
+class Gemma4Processor(mm_utils.BaseMultimodalProcessor):
+  """Gemma4 multimodal data processor."""
+
+  # pylint: disable=unused-argument
+
+  @classmethod
+  def supports_model(cls, model_name: str) -> bool:
+    return model_name.startswith("gemma4")
+
+  def preprocess_mm_data(self, config, **kwargs) -> mm_utils.PreprocessorOutput:
+    images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
+    return preprocess_mm_data_gemma4(images)
+
+  def preprocess_image_for_training(self, image, **kwargs) -> mm_utils.PreprocessorOutput:
+    return preprocess_mm_data_gemma4(image)
+
+  def get_image_offsets(self, config, processor_output: mm_utils.PreprocessorOutput | None, **kwargs) -> int:
+    return get_image_offsets_gemma4(processor_output)
+
+  def reformat_prompt(
+      self,
+      prompt: str,
+      image_placeholder: str,
+      num_images: int,
+      **kwargs,
+  ) -> str:
+    return reformat_prompt_gemma4(prompt, image_placeholder, num_images)
+
+  def reformat_response(self, response: str, **kwargs) -> str:
+    return f"{response}<end_of_turn>"
+
+  def prepare_text_for_image_fusion(
+      self,
+      tokens,
+      config,
+      processor_output: mm_utils.PreprocessorOutput | None = None,
+      **kwargs,
+  ):
+    return add_extra_tokens_for_images_gemma4(tokens, max_num_images=processor_output.num_images)
+
+  def get_dummy_image_shape_for_init(self, batch_size: int = 1, num_image_per_sequence: int = 1, **kwargs) -> tuple:
+    return get_dummy_image_shape_for_init_gemma4(batch_size, num_image_per_sequence)
+
+  def get_bidirectional_mask_vision(self, config, decoder_input_tokens, **kwargs):
+    return decoder_input_tokens == GEMMA4_TOKEN_PLACEHOLDER

--- a/src/maxtext/multimodal/processor_llama4.py
+++ b/src/maxtext/multimodal/processor_llama4.py
@@ -523,3 +523,50 @@ def get_dummy_image_shape_for_init_llama4(batch_size=1, num_image_per_sequence=1
       LLAMA4_TILE_SIZE,
   )
   return image_shape
+
+
+class Llama4Processor(mm_utils.BaseMultimodalProcessor):
+  """Llama4 multimodal data processor."""
+
+  # pylint: disable=unused-argument
+
+  @classmethod
+  def supports_model(cls, model_name: str) -> bool:
+    return model_name.startswith("llama4")
+
+  def preprocess_mm_data(self, config, **kwargs) -> mm_utils.PreprocessorOutput:
+    images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
+    return preprocess_mm_data_llama4(images)
+
+  def preprocess_image_for_training(self, image, **kwargs) -> mm_utils.PreprocessorOutput:
+    return preprocess_mm_data_llama4(image)
+
+  def get_image_offsets(self, config, processor_output: mm_utils.PreprocessorOutput | None, **kwargs) -> int:
+    return get_image_offsets_llama4(processor_output)
+
+  def reformat_prompt(
+      self,
+      prompt: str,
+      image_placeholder: str,
+      num_images: int,
+      **kwargs,
+  ) -> str:
+    return reformat_prompt_llama4(prompt, image_placeholder, num_images)
+
+  def reformat_response(self, response: str, **kwargs) -> str:
+    return f"{response}<|eot|>"
+
+  def prepare_text_for_image_fusion(
+      self,
+      tokens,
+      config,
+      processor_output: mm_utils.PreprocessorOutput | None = None,
+      **kwargs,
+  ):
+    return add_extra_tokens_for_images_llama4(tokens, processor_output)
+
+  def get_dummy_image_shape_for_init(self, batch_size: int = 1, num_image_per_sequence: int = 1, **kwargs) -> tuple:
+    return get_dummy_image_shape_for_init_llama4(batch_size, num_image_per_sequence)
+
+  def get_bidirectional_mask_vision(self, config, decoder_input_tokens, **kwargs):
+    return decoder_input_tokens == LLAMA4_PATCH_TOKEN

--- a/src/maxtext/multimodal/processor_qwen3_omni.py
+++ b/src/maxtext/multimodal/processor_qwen3_omni.py
@@ -1146,3 +1146,63 @@ def get_mm_offsets_qwen3_omni(config, processor_output):
       total_offset += int(audio_len) - 1  # -1 for the original <|audio_pad|> token
 
   return total_offset
+
+
+class Qwen3OmniProcessor(mm_utils.BaseMultimodalProcessor):
+  """Qwen3-Omni multimodal data processor."""
+
+  # pylint: disable=unused-argument
+
+  @classmethod
+  def supports_model(cls, model_name: str) -> bool:
+    return model_name.startswith("qwen3-omni") or model_name.startswith("qwen3.5-397b-a17b")
+
+  def preprocess_mm_data(self, config, **kwargs) -> mm_utils.PreprocessorOutput:
+    return preprocess_mm_data_qwen3_omni(config)
+
+  def preprocess_image_for_training(self, image, **kwargs) -> mm_utils.PreprocessorOutput:
+    return preprocess_mm_data_qwen3_omni_for_training(image)
+
+  def get_image_offsets(self, config, processor_output: mm_utils.PreprocessorOutput | None, **kwargs) -> int:
+    return get_mm_offsets_qwen3_omni(config, processor_output)
+
+  def reformat_prompt(
+      self,
+      prompt: str,
+      image_placeholder: str,
+      num_images: int,
+      video_placeholder: str = "<|video|>",
+      num_videos: int = 0,
+      **kwargs,
+  ) -> str:
+    return reformat_prompt_qwen3_omni(
+        prompt=prompt,
+        image_placeholder=image_placeholder,
+        num_images=num_images,
+        video_placeholder=video_placeholder,
+        num_videos=num_videos,
+    )
+
+  def reformat_response(self, response: str, **kwargs) -> str:
+    return f"{response}<|im_end|>"
+
+  def prepare_text_for_image_fusion(
+      self,
+      tokens,
+      config,
+      processor_output: mm_utils.PreprocessorOutput | None = None,
+      **kwargs,
+  ):
+    return add_extra_tokens_for_qwen3_omni(tokens, config, processor_output)
+
+  def get_dummy_image_shape_for_init(self, batch_size: int = 1, num_image_per_sequence: int = 1, **kwargs) -> tuple:
+    return get_dummy_image_shape_for_init_qwen3_omni(batch_size)
+
+  def get_dummy_audio_shape_for_init(self, config, **kwargs) -> tuple:
+    return get_dummy_audio_shape_for_init_qwen3_omni(config)
+
+  def get_bidirectional_mask_vision(self, config, decoder_input_tokens, **kwargs):
+    return (decoder_input_tokens == QWEN3_OMNI_IMAGE_TOKEN) | (decoder_input_tokens == QWEN3_OMNI_VIDEO_TOKEN)
+
+  def get_bidirectional_mask_audio(self, config, decoder_input_tokens, **kwargs):
+    return decoder_input_tokens == QWEN3_OMNI_AUDIO_TOKEN

--- a/src/maxtext/multimodal/utils.py
+++ b/src/maxtext/multimodal/utils.py
@@ -16,7 +16,7 @@
 
 import os
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional, Union, Any
 
 import numpy as np
 import jax
@@ -789,3 +789,86 @@ def load_audio(data_path: str, sample_rate: int = 16000) -> np.ndarray:
     return audio
   except Exception as e:
     raise RuntimeError(f"Failed to load audio from {data_path}: {e}") from e
+
+
+class BaseMultimodalProcessor:
+  """Base class for multimodal data processors.
+
+  This class defines the unified interface for all multimodal operations (e.g.,
+  image/audio preprocessing, prompt formatting, token offsets). It provides
+  default or fallback implementations when a model does not implement specific
+  features.
+
+  Why there are unused arguments:
+    Because this is a polymorphic interface used to support extremely diverse
+    architectures (e.g., vision-only vs audio-vision models), some methods must
+    declare parameters (like config) that are only needed by a subset of
+    subclasses. Subclasses safely ignore parameters they do not need.
+
+  How routing is handled:
+    The router function `get_processor(config_or_model_name)` (in `processor.py`)
+    inspects the active model name and routes calls to the registered subclass
+    instance (e.g., `Gemma3Processor`, `Qwen3OmniProcessor`) that returns True for
+    `supports_model(model_name)`.
+  """
+  # pylint: disable=unused-argument,useless-return
+
+  def __init__(self, model_name: str):
+    self.model_name = model_name
+
+  @classmethod
+  def supports_model(cls, model_name: str) -> bool:
+    """Returns True if this processor class supports the given model name."""
+    return False
+
+  def preprocess_mm_data(self, config, **kwargs) -> PreprocessorOutput:
+    """Preprocesses multimodal data based on the provided configuration."""
+    raise ValueError(f"Model {self.model_name} not supported for multimodal preprocessing.")
+
+  def preprocess_image_for_training(self, image, **kwargs) -> PreprocessorOutput:
+    """Preprocesses a single image for training."""
+    raise ValueError(f"Model {self.model_name} not supported for image preprocessing.")
+
+  def get_image_offsets(self, config, processor_output: PreprocessorOutput | None, **kwargs) -> int:
+    """Get the increase in total token count after inserting image tokens."""
+    return 0
+
+  def reformat_prompt(
+      self,
+      prompt: str,
+      image_placeholder: str,
+      num_images: int,
+      **kwargs,
+  ) -> str:
+    """Reformat prompt for different models."""
+    return prompt
+
+  def reformat_response(self, response: str, **kwargs) -> str:
+    """Reformat response for different models."""
+    return response
+
+  def prepare_text_for_image_fusion(
+      self,
+      tokens,
+      config,
+      processor_output: PreprocessorOutput | None = None,
+      **kwargs,
+  ) -> Any:
+    """Prepare text by adding extra tokens for image fusion."""
+    raise ValueError(f"Model {self.model_name} does not support multimodal inference.")
+
+  def get_dummy_image_shape_for_init(self, batch_size: int = 1, num_image_per_sequence: int = 1, **kwargs) -> tuple:
+    """Return the shape of the dummy image for model initialization."""
+    return ()
+
+  def get_dummy_audio_shape_for_init(self, config, **kwargs) -> tuple:
+    """Return the shape of the dummy audio for model initialization."""
+    return ()
+
+  def get_bidirectional_mask_vision(self, config, decoder_input_tokens, **kwargs) -> Any:
+    """Get the bidirectional mask for vision tokens."""
+    return None
+
+  def get_bidirectional_mask_audio(self, config, decoder_input_tokens, **kwargs) -> Any:
+    """Get the bidirectional mask for audio tokens."""
+    return None


### PR DESCRIPTION
# Description

**One-liner**: The multimodal calling code only interacts with the generic BaseMultimodalProcessor interface, which dynamically routes calls to execute model-specific (e.g. Gemma3Processor) specific logic at runtime if that model is configured.

This PR refactors the multimodal preprocessing pipeline from a procedural, monolithic routing structure to an elegant polymorphic Strategy Pattern class hierarchy using `BaseMultimodalProcessor`. 
Previously, `processor.py` maintained **10 separate `if/elif` switch statements** to handle model-specific preprocessing, prompt formatting, dummy shapes, and token offsets. This resulted in tight logical coupling, violated the Open-Closed Principle (OCP), and made adding new models highly fragile.
This refactor introduces `BaseMultimodalProcessor` and delegates the model-specific logic to dedicated subclasses (`Gemma3Processor`, `Gemma4Processor`, `Llama4Processor`, `Qwen3OmniProcessor`), leaving `processor.py` strictly responsible for routing.

## Refactor Impact & Architecture Benefits
1. **Single Responsibility Principle (SRP)**: Model-specific processing logic is completely encapsulated in cohesive subclasses. `processor.py` acts solely as an instantiation factory and dispatch router.
2. **Open-Closed Principle (OCP) & Extensibility**: Adding a new multimodal model no longer requires editing 10 separate functions inside `processor.py`. You simply define a new class inheriting from `BaseMultimodalProcessor` and register it in one list.
3. **Graceful Text-Only Fallback**: `BaseMultimodalProcessor` acts as a silent, safe "no-op" handler for standard text-only models (returning `0` offsets, `()` shapes, and `None` masks) during dry model initialization, while guaranteeing early, loud `ValueError` failures if a real multimodal run is attempted on unsupported architectures.
4. **Linter & Code Health**: Cleaned up linter bypasses by using class-level `# pylint: disable=unused-argument,useless-return` rules, leaving the abstract interface and subclass implementations highly readable and documentation-friendly.
5. **Developer Clarity**: 
   * Added a comprehensive routing "cheat sheet" inside the docstring of `processor.py` (now explicitly including Gemma3, Gemma4, Llama4, Qwen3 Omni, and Qwen3.5).
   * Integrated runtime initialization logging (`max_logging.log`) inside the router to output exactly which processor class has been instantiated during startup.
---
## How to Add a New Model (Developer Roadmap)
If a developer wants to add support for a new multimodal model (e.g., `mymodel`):
1. **Create Class**: Define your subclass under `src/maxtext/multimodal/processor_mymodel.py`:
   ```python
   from maxtext.multimodal import utils as mm_utils
   class MyModelProcessor(mm_utils.BaseMultimodalProcessor):
     """MyModel multimodal data processor."""
   ```
2. **Implement Match Rule**: Add the model matching logic:
   ```python
   @classmethod
   def supports_model(cls, model_name: str) -> bool:
     return model_name.startswith("mymodel")
   ```
3. **Override Methods**: Override *only* the methods your model needs. Omitted methods cleanly fall back to safe default no-ops in the base class.
4. **Register**: Import and add your class to `_REGISTERED_PROCESSORS` inside `processor.py`:
   ```python
   _REGISTERED_PROCESSORS = [
       ...,
       MyModelProcessor,
   ]
   ```
The router will automatically instantiate your class and print a clean startup log showing it has successfully loaded.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
