### PR TITLE
Fix failing CI test

### DIFF
--- a/.github/workflows/run_pathways_tests.yml
+++ b/.github/workflows/run_pathways_tests.yml
@@ -106,6 +106,10 @@ jobs:
           .venv/bin/python3 -m pytest ${{ inputs.pytest_addopts }} -v -m "${FINAL_PYTEST_MARKER}" -k "not AotHloIdenticalTest and not CompileThenLoad" --durations=0
         env:
           PYTHONPATH: "${{ github.workspace }}/src"
+      - name: Cleanup git safe.directory
+        if: always()
+        shell: bash
+        run: git config --global --unset-all safe.directory 2>/dev/null || true
     services:
       resource_manager:
         image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260413-jax_0.9.2


### PR DESCRIPTION
# Description

The maxtext_tpu_pathways_integration_tests job intermittently fails on scheduled main branch runs ([example: run #13487](https://github.com/AI-Hypercomputer/maxtext/actions/runs/26449304437/job/77870655874)) despite all tests passing. The failure occurs in the Post Checkout MaxText cleanup step after the Pathways test run completes, the container's login shell (/bin/sh -l) becomes unavailable, causing actions/checkout's post-step to fail when it tries to exec:


Error execing #!/bin/sh -l
cd /__w/maxtext/maxtext && exec env "STATE_isPost=true" "STATE_setSafeDirectory=true" ...
This triggers a false CI failure and blocks the "All Required Tests Passed" gate.

Fix
Add an if: always() cleanup step at the end of the job that pre-emptively removes the git safe.directory entry that actions/checkout added. Since this runs in explicit bash (not a login shell), it avoids the container environment issue. The checkout post-step then has less cleanup to do, reducing the chance of the exec failure.

# Tests

git config --global --unset-all safe.directory 2>/dev/null || true
echo $? 
0

gh workflow run "MaxText Package Tests" --repo AI-Hypercomputer/maxtext --ref ci_test
✓ Created workflow_dispatch event for build_and_test_maxtext.yml at ci_test

To see runs for this workflow, try: gh run list --workflow="build_and_test_maxtext.yml"

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
