### PR TITLE
pre-populate MODEL and remove --zone from multi-host RL tutorial

### DIFF
--- a/docs/tutorials/posttraining/rl_on_multi_host.md
+++ b/docs/tutorials/posttraining/rl_on_multi_host.md
@@ -79,7 +79,7 @@ placeholders with your actual values.
 # -- Model configuration --
 # The MaxText model name. See `src/maxtext/configs/types.py` for `ModelName` for a
 # full list of supported models.
-export MODEL=<MODEL_NAME> # e.g. 'llama3.1-70b-Instruct'
+export MODEL=<MODEL_NAME> # e.g. 'llama3.1-70b-Instruct' # replace with another model from src/maxtext/configs/types.py if needed
 
 # Your Hugging Face access token. Required to download gated models like Llama.
 # You can generate one at https://huggingface.co/settings/tokens.
@@ -167,7 +167,6 @@ xpk workload create-pathways --workload ${RUN_NAME?} \
 --docker-image ${DOCKER_IMAGE?} --cluster ${GKE_CLUSTER?} \
 --tpu-type=${TPU_TYPE?} --num-slices=1 \
 --project=${PROJECT_ID?} --priority=high \
---zone=${ZONE?} \
 --command "HF_TOKEN=${HF_TOKEN?} TF_CPP_MIN_LOG_LEVEL=0 JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE='1' \
 python3 -m maxtext.trainers.post_train.rl.train_rl \
   model_name=${MODEL?} \
@@ -185,7 +184,6 @@ xpk workload create-pathways --workload ${RUN_NAME?} \
 --docker-image ${DOCKER_IMAGE?} --cluster ${GKE_CLUSTER?} \
 --tpu-type=${TPU_TYPE?} --num-slices=1 \
 --project=${PROJECT_ID?} --priority=high \
---zone=${ZONE?} \
 --command "HF_TOKEN=${HF_TOKEN?} TF_CPP_MIN_LOG_LEVEL=0 JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 ENABLE_PATHWAYS_PERSISTENCE='1' \
 python3 -m maxtext.trainers.post_train.rl.train_rl \
   model_name=${MODEL?} \


### PR DESCRIPTION
Pre-populate MODEL with the tutorial's specific model name so users don't need to hunt through types.py. Remove --zone from xpk commands, consistent with the existing note that XPK v0.14+ auto-discovers cluster location.

# Tests

N/A 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
