### PR TITLE
Update WorkloadBenchmarkV2Schema to match BigQuery table benchmark_dataset_v2.run_summary's schema

### DIFF
--- a/benchmarks/benchmark_db_writer/schema/workload_benchmark_v2/workload_benchmark_v2_schema.py
+++ b/benchmarks/benchmark_db_writer/schema/workload_benchmark_v2/workload_benchmark_v2_schema.py
@@ -28,6 +28,31 @@ from benchmarks.benchmark_db_writer import bigquery_types
 
 
 @dataclasses.dataclass
+class StepWithValue:
+  """Helper dataclass for repeated step-value pairs."""
+
+  step: Optional[int] = None
+  value: Optional[float] = None
+
+
+@dataclasses.dataclass
+class MetricValue:
+  """Helper dataclass for metric values in key-value pairs."""
+
+  string_value: Optional[str] = None
+  float_value: Optional[float] = None
+  int_value: Optional[int] = None
+
+
+@dataclasses.dataclass
+class MetricRecord:
+  """Helper dataclass for repeated key-value metrics."""
+
+  key: Optional[str] = None
+  value: Optional[MetricValue] = None
+
+
+@dataclasses.dataclass
 class WorkloadBenchmarkV2Schema:
   """Dataclass representing the schema for the 'run_summary' BQ table.
 
@@ -94,7 +119,7 @@ class WorkloadBenchmarkV2Schema:
   metrics_tflops_per_second: Optional[float] = None
 
   hardware_num_superblocks: Optional[str] = None
-  hardware_num_slices: Optional[int] = None
+  hardware_num_slices: Optional[str] = None
   hardware_topology: Optional[str] = None
   hardware_num_cores: Optional[int] = None
   result_error: Optional[str] = None
@@ -109,7 +134,6 @@ class WorkloadBenchmarkV2Schema:
   logs_cloud_logs: Optional[str] = None
   logs_comments: Optional[str] = None
   logs_other: Optional[str] = None
-
   checkpointing_async: Optional[bool] = None
   checkpointing_interval_every_n_steps: Optional[int] = None
   checkpointing_size_in_gibs: Optional[float] = None
@@ -132,6 +156,22 @@ class WorkloadBenchmarkV2Schema:
   source_bucket: Optional[str] = None
 
   cluster_name: Optional[str] = None
+
+  bundle_name: Optional[str] = None
+  metrics_overall_goodput: Optional[float] = None
+  bug_id: Optional[int] = None
+  storage_info: Optional[dict] = None
+  run_group: Optional[str] = None
+  logs_xprof_uri: Optional[str] = None
+  tags: Optional[str] = None
+  run_name: Optional[str] = None
+  recipe_type: Optional[str] = None
+  run_mode: Optional[int] = None
+  metrics_step_wise_training_loss: list[StepWithValue] = dataclasses.field(default_factory=list)
+  metrics_step_wise_eval_loss: list[StepWithValue] = dataclasses.field(default_factory=list)
+  metrics_step_wise_raw_grad_norm: list[StepWithValue] = dataclasses.field(default_factory=list)
+  metrics_mlperf: list[MetricRecord] = dataclasses.field(default_factory=list)
+  metrics_goodput: list[MetricRecord] = dataclasses.field(default_factory=list)
 
   reviewer_ldap: str = ""
   update_timestamp: Optional[bigquery_types.TimeStamp] = datetime.datetime.now()


### PR DESCRIPTION
The bigquery table at ml-workload-benchmarks.benchmark_dataset_v2.run_summary no longer matches the schema to be written to it.

- Added missing fields from `run_summary` to `workload_benchmark_v2`'s schema.
- Added dataclasses `StepWithValue`, `MetricValue`, and `MetricRecord` to support REPEATED field types.
- Updated `hardware_num_slices` type from `Optional[int]` to `Optional[str]` to match BigQuery `STRING` type.

Fixes: b/516900128
BUGS: b/424213059

TAG=agy
CONV=404b1122-f202-4922-87f0-d821f63b0deb

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.
Tested with the existing ‎[DataclassBigQueryWriter.check_schema()](https://github.com/AI-Hypercomputer/maxtext/blob/cbafb8f7579a904252b250bd247641a0ceee2d22/benchmarks/benchmark_db_writer/dataclass_bigquery_writer.py#L176) function [here](https://paste.googleplex.com/4579650515894272)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
