### PR TITLE
Gemma4-31b and 26b: vLLM inference quickstart + adapter global-KV null-guard.

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -110,11 +110,11 @@ def generate_maxtext_config(vllm_config: VllmConfig, mesh: Mesh) -> pyconfig.Hyp
   )
   hidden_size = getattr(hf_config, "moe_intermediate_size", None)
   num_lanes = pltpu.get_tpu_info().num_lanes
-  use_global_kv_heads = hasattr(hf_config, "num_global_key_value_heads")
   num_kv_heads = hf_config.num_key_value_heads
 
-  # Get the number KV heads used in global attention layers if specified.
-  num_global_kv_heads = hf_config.num_global_key_value_heads if use_global_kv_heads else None
+  # Number of KV heads in global attention layers (None if the field is absent or unset).
+  num_global_kv_heads = getattr(hf_config, "num_global_key_value_heads", None)
+  use_global_kv_heads = num_global_kv_heads is not None
 
   max_logging.log(
       f"vLLM sharding config: hidden_size={hidden_size}, kv_heads={num_kv_heads}, global_kv_heads={num_global_kv_heads}, "

--- a/tests/end_to_end/tpu/gemma4/Run_Gemma4.md
+++ b/tests/end_to_end/tpu/gemma4/Run_Gemma4.md
@@ -85,4 +85,59 @@ python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml model_n
 ```
 
 ## Inference
-For detailed instructions on running inference and decoding with MaxText, please refer to our [Inference Tutorial](https://github.com/AI-Hypercomputer/maxtext/blob/main/docs/tutorials/inference.md).
+
+Run Gemma 4 inference on vLLM using the MaxText model implementation, via the
+[out-of-tree](https://github.com/vllm-project/tpu-inference/blob/main/docs/getting_started/out-of-tree.md)
+vLLM model plugin. Weights are loaded directly from a MaxText (Orbax) checkpoint. See the general
+[Inference Tutorial](https://github.com/AI-Hypercomputer/maxtext/blob/main/docs/tutorials/inference.md)
+for installation and online/RL workflows; this guide is the Gemma 4 quickstart.
+
+### Installation
+
+Install MaxText with the `tpu-post-train` extra (it provides the vLLM adapter plugin and the pinned `tpu-inference` / `vllm` versions), then verify the plugin is present:
+
+```sh
+pip show maxtext_vllm_adapter
+```
+
+If it is missing, run:
+
+```sh
+install_tpu_post_train_extra_deps
+```
+
+### Offline inference
+
+`maxtext.inference.vllm_decode` runs offline decode through vLLM (it sets `NEW_MODEL_DESIGN=1` for you; you only set it yourself for direct `vllm serve`). Set `HF_HUB_OFFLINE=1` if the tokenizer is already cached locally. Pass `src/maxtext/configs/base.yml` as the config — the vLLM adapter applies `src/maxtext/configs/inference/vllm.yml` internally for the model. The vLLM path requires an **unscanned** checkpoint, so pass `scan_layers=False` (as the examples below do).
+
+Dense models (e.g. `gemma4-31b`):
+
+```sh
+python3 -m maxtext.inference.vllm_decode src/maxtext/configs/base.yml \
+    model_name=gemma4-31b \
+    tokenizer_path=google/gemma-4-31b-it \
+    load_parameters_path=${CONVERTED_CHECKPOINT} \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    ici_tensor_parallelism=4 scan_layers=False \
+    prompt="Who was Albert Einstein?" use_chat_template=True
+```
+
+MoE models (e.g. `gemma4-26b`) additionally require `prefuse_moe_weights=True`, which pre-fuses
+the expert gate/up projections into the per-shard layout the fused-MoE kernel expects — required
+for correct output with `ici_tensor_parallelism` > 1:
+
+```sh
+python3 -m maxtext.inference.vllm_decode src/maxtext/configs/base.yml \
+    model_name=gemma4-26b \
+    tokenizer_path=google/gemma-4-26b-a4b-it \
+    load_parameters_path=${CONVERTED_CHECKPOINT} \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    ici_tensor_parallelism=4 scan_layers=False prefuse_moe_weights=True \
+    prompt="Who was Albert Einstein?" use_chat_template=True
+```
+
+Set `model_name`/`tokenizer_path` to your variant (`gemma4-26b`, `gemma4-31b`) and
+`ici_tensor_parallelism` to the number of chips — pass an explicit count (e.g. `4` on a v5p-8), not
+`-1`, since `vllm_decode` forwards this value directly to vLLM's `tensor_parallel_size`.
+
+> **Note:** `gemma4-e2b` / `gemma4-e4b` are not yet supported. They use cross-layer KV sharing, and will be supported soon.


### PR DESCRIPTION
# Description

- Adds a Gemma 4 vLLM-inference section to `Run_Gemma4.md`: install, offline `vllm_decode` examples for dense `gemma4-31b` and MoE `gemma4-26b`. Documents that  MoE variants require `prefuse_moe_weights=True` on the CLI (per-shard gate/up layout the fused-MoE kernel needs at `ici_tensor_parallelism > 1`).
- Adapter: read `num_global_key_value_heads` via `getattr(..., None)` so a present but null value no longer crash.



# Tests

Offline `vllm_decode` (`MaxTextForCausalLM`, real Orbax checkpoints), coherent output:
- `gemma4-31b` tested with tp=4
- `gemma4-26b` tested with `prefuse_moe_weights=True` and with tp=1, tp=2, tp=4

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
