### PR TITLE
Skip GCS-dependent tokenizer unit tests under decoupled offline mode

### DIFF
--- a/tests/unit/tokenizer_test.py
+++ b/tests/unit/tokenizer_test.py
@@ -18,6 +18,7 @@ import numpy as np
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.input_pipeline import input_pipeline_utils
 from maxtext.trainers.tokenizer import train_tokenizer
+from maxtext.common.gcloud_stub import is_decoupled
 
 import unittest
 import pytest
@@ -25,6 +26,7 @@ import subprocess
 import os
 
 
+@unittest.skipIf(is_decoupled(), "Bypassed in offline decoupled runs (no GCS/internet)")
 class TrainTokenizerTest(unittest.TestCase):
   """Tests for train_tokenizer.py using data from Parquet files"""
 
@@ -69,6 +71,7 @@ class TrainTokenizerTest(unittest.TestCase):
     self.assertEqual(np.asarray(self.source_tokenizer.decode(tokens)), np.asarray(self.test_tokenizer.decode(tokens)))
 
 
+@unittest.skipIf(is_decoupled(), "Bypassed in offline decoupled runs (no GCS/internet)")
 class TikTokenTest(unittest.TestCase):
   """Tests for TikToken"""
 
@@ -96,6 +99,7 @@ class TikTokenTest(unittest.TestCase):
     self.assertEqual(np.asarray(self.source_tokenizer.decode(tokens)), np.asarray(text))
 
 
+@unittest.skipIf(is_decoupled(), "Bypassed in offline decoupled runs (no GCS/internet)")
 class HFTokenizerTest(unittest.TestCase):
   """Tests for HFTokenizer"""
 


### PR DESCRIPTION
# Description

This PR adds code-level skip decorators to `TrainTokenizerTest`, `TikTokenTest`, and `HFTokenizerTest` in `tests/unit/tokenizer_test.py` when running in decoupled offline mode (`DECOUPLE_GCLOUD=TRUE`).

### **Problem & Context**
These unit tests are hardcoded to train and verify tokenizers on GCS parquet datasets (`gs://maxtext-dataset/...`) and copy models using the `gcloud` CLI in a subprocess. 

In an air-gapped GKE container running offline:
* GCS access is stubbed out, causing `FileNotFoundError` when JAX tries to glob the buckets.
* The minimal container image lacks the Google Cloud SDK (`gcloud` CLI), causing `FileNotFoundError: 'gcloud'` when spawning the download subprocess.

### **Solution**
Bypass these cloud-dependent tests dynamically using `@unittest.skipIf(is_decoupled(), ...)` when offline decoupled mode is enabled. This allows the decoupled test suite to execute completely green out-of-the-box in offline environments, without affecting standard online runs.

---

# Tests

This change has been fully verified on a physical TPU7x VM slice.

### **Commands to Reproduce & Verify:**
```bash
export DECOUPLE_GCLOUD=TRUE
python3 -m pytest tests/unit/tokenizer_test.py -vv
```

**Expected Output:**
All 5 collection errors are resolved and the classes are cleanly skipped:
```python
tests/unit/tokenizer_test.py::TrainTokenizerTest SKIPPED
tests/unit/tokenizer_test.py::TikTokenTest SKIPPED
tests/unit/tokenizer_test.py::HFTokenizerTest SKIPPED
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
