### PR TITLE
Checkpoint_conversion: import GCS via gcloud_stub for decoupled mode

### DIFF
--- a/src/maxtext/checkpoint_conversion/utils/utils.py
+++ b/src/maxtext/checkpoint_conversion/utils/utils.py
@@ -36,8 +36,6 @@ from jax import tree
 from jax.experimental import multihost_utils
 from jaxtyping import Array
 
-from google.cloud.storage import Client, transfer_manager
-
 from safetensors import safe_open
 from safetensors.numpy import save_file as numpy_save_file
 from safetensors.numpy import save as numpy_save
@@ -50,8 +48,13 @@ from transformers import AutoModelForCausalLM
 
 from flax.training import train_state
 from maxtext.common import checkpointing
+from maxtext.common.gcloud_stub import gcs_storage
 from maxtext.utils import max_logging
 import orbax.checkpoint as ocp
+
+_storage = gcs_storage()
+Client = _storage.Client
+transfer_manager = _storage.transfer_manager
 
 
 SAFE_TENSORS_CONFIG_FILE = "config.json"

--- a/src/maxtext/common/gcloud_stub.py
+++ b/src/maxtext/common/gcloud_stub.py
@@ -237,11 +237,27 @@ def _gcs_stubs():  # pragma: no cover - simple no-op placeholders
     def list_blobs(self, *a, **k):  # pylint: disable=unused-argument
       return iter([])
 
-  return SimpleNamespace(Client=_StubClient, _IS_STUB=True)
+  def _stub_upload_many_from_filenames(*_a, **_k):
+    """No-op stub for transfer_manager.upload_many_from_filenames."""
+    return []
+
+  transfer_manager_stub = SimpleNamespace(
+      upload_many_from_filenames=_stub_upload_many_from_filenames,
+      _IS_STUB=True,
+  )
+
+  return SimpleNamespace(Client=_StubClient, transfer_manager=transfer_manager_stub, _IS_STUB=True)
 
 
 def gcs_storage():
-  """Return google.cloud.storage module or stub when decoupled or missing."""
+  """Return google.cloud.storage module (with transfer_manager attached) or stub.
+
+  The returned object always exposes both ``.Client`` and ``.transfer_manager``
+  so callers can use ``storage.transfer_manager.upload_many_from_filenames(...)``
+  without an extra import. ``transfer_manager`` is a submodule of
+  ``google.cloud.storage`` and is not auto-imported by ``from google.cloud
+  import storage``; we explicitly import and attach it here.
+  """
   # In decoupled mode always prefer the stub, even if the library is installed,
   # to avoid accidental GCS calls in tests or local runs.
   if is_decoupled():  # fast path
@@ -250,7 +266,9 @@ def gcs_storage():
 
   try:  # pragma: no cover - attempt real import when not decoupled
     from google.cloud import storage  # type: ignore  # pylint: disable=import-outside-toplevel
+    from google.cloud.storage import transfer_manager  # type: ignore  # pylint: disable=import-outside-toplevel
 
+    setattr(storage, "transfer_manager", transfer_manager)
     setattr(storage, "_IS_STUB", False)
     return storage
   except Exception:  # ModuleNotFoundError / ImportError for partial installs  # pylint: disable=broad-exception-caught


### PR DESCRIPTION
# Description

`src/maxtext/checkpoint_conversion/utils/utils.py` does a top-level `from google.cloud.storage import Client, transfer_manager`. When tests run with `DECOUPLE_GCLOUD=TRUE` (and `google-cloud-storage` is not installed in that environment), pytest collection fails on this file with `ModuleNotFoundError` before `tests/conftest.py` can apply the `decoupled` marker filter to deselect the test, so the whole collection aborts.
This PR routes the import through the existing `gcloud_stub.gcs_storage()` helper (same pattern already used by `src/maxtext/utils/gcs_utils.py`), so the module imports cleanly in decoupled mode while behaving identically in normal mode.
- `gcloud_stub.gcs_storage()`: also imports and attaches the `transfer_manager` submodule (it isn't auto-imported by `from google.cloud import storage`). `_gcs_stubs()` is extended with a matching no-op `transfer_manager` stub exposing `upload_many_from_filenames`.
- `checkpoint_conversion/utils/utils.py`: drops the direct `from google.cloud.storage import ...` and binds `Client` / `transfer_manager` at module top via `gcs_storage()`. No call sites change, the public symbol surface (`Client`, `transfer_manager`) is preserved.

(cherry picked from commit 698624b35843a728f49c6bc20e50f53a1b2839d4)

# Tests

- [x] Module imports cleanly in a venv without `google-cloud-storage`: `python3 -c 'from maxtext.checkpoint_conversion.utils import utils; print(utils.Client, utils.transfer_manager)'`.
- [x] `pytest --collect-only -m 'not cpu_only and not tpu_only and not post_training and decoupled and not scheduled_only' --ignore=tests/post_training` collects 719/1064 tests with exit 0 (was 1 collection error before the fix).
- [x] In a venv where `google-cloud-storage` is installed, `gcs_storage()` returns the real module with both `.Client` and `.transfer_manager` attributes.
- CI green on this branch.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
