### PR TITLE
Skip Zero-1 testcase on TPU7x platforms in decoupled offline mode to prevent compiler crash

### DIFF
--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -500,6 +500,8 @@ class TrainTests(unittest.TestCase):
 
   @pytest.mark.integration_test
   @pytest.mark.tpu_only
+  # TODO(b/517509898): Skip ZeRo-1 compiler Segfault on TPU7x SparseCore platforms
+  @pytest.mark.skip_on_tpu7x
   def test_tpu_zero1_gradient_accumulation(self):
     zero1_ga = [  # tests Zero-1 optimizer sharding with gradient accumulation
         None,


### PR DESCRIPTION
# Description

This PR adds the native `@pytest.mark.skip_on_tpu7x` skip decorator to `test_tpu_zero1_gradient_accumulation` inside `tests/integration/train_tests.py`.

### **Problem & Context**
When running ZeRo-1 weight sharding tests under JAX `0.10.0` in containerized offline decoupled environments on TPU7x SparseCore platforms, the XLA compiler attempts to partition the weights against unpopulated TPU worker hostnames. This mismatch triggers an out-of-bounds memory write inside the `libtpu` C++ compiler backend, resulting in an abrupt Python Segmentation Fault (`SIGSEGV`).

This test executes and passes successfully on older TPU platforms (v4/v5e/v6e) as those HLO compiler paths do not invoke the specialized TPUv7x SparseCore sharding allocation constraints.

### **Solution**
Bypass this compiler-restricted test case cleanly on all TPU7x SparseCore executions using the native `@pytest.mark.skip_on_tpu7x` decorator. We've also created a bug internally tracking this issue: b/517509898

---

# Tests

This change has been successfully verified on a TPU7x-8 VM 
### **Commands to Reproduce & Verify:**
```bash
python3 -m pytest tests/integration/train_tests.py -k "test_tpu_zero1_gradient_accumulation" -vv
```

**Expected Output:**
The testcase is gracefully and cleanly skipped natively:
```python
tests/integration/train_tests.py::TrainTests::test_tpu_zero1_gradient_accumulation SKIPPED (skip test if running on TPU7x platform)
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
