### PR TITLE
Fix pathways integration tests being skipped on TPU proxy backend

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,45 +194,27 @@ def pytest_configure(config):
     config.addinivalue_line("markers", m)
 
 
-def _get_system_hardware_platform() -> str:
-  """Determines the system hardware platform strictly from environment variables without JAX init."""
-  # 1. Check JAX_PLATFORMS env var
-  jax_platforms = os.getenv("JAX_PLATFORMS", "").lower()
-  if "tpu" in jax_platforms:
-    return "tpu"
-  if "cuda" in jax_platforms or "gpu" in jax_platforms:
-    return "gpu"
-
-  # 2. Check active CUDA visible devices
-  if os.getenv("CUDA_VISIBLE_DEVICES") is not None:
-    return "gpu"
-
-  # 3. Check TPU runtime variables
-  if os.getenv("TPU_NAME") is not None or os.getenv("TPU_CHIPS") is not None:
-    return "tpu"
-
-  # Default to CPU
-  return "cpu"
-
-
 @pytest.fixture(autouse=True)
 def handle_skip_on_tpu7x(request):
   """Dynamically skip tests marked with skip_on_tpu7x if running on TPU7x."""
   if request.node.get_closest_marker("skip_on_tpu7x"):
-    if _get_system_hardware_platform() == "tpu":
-      try:
-        is_tpu7x = any("TPU7x" in d.device_kind for d in jax.devices())
-      except Exception:  # pylint: disable=broad-exception-caught
-        is_tpu7x = False
-      if is_tpu7x:
-        pytest.skip("AOT tests do not support TPU7x platform")
+    try:
+      is_tpu7x = any("TPU7x" in d.device_kind for d in jax.devices())
+    except Exception:  # pylint: disable=broad-exception-caught
+      is_tpu7x = False
+    if is_tpu7x:
+      pytest.skip("AOT tests do not support TPU7x platform")
 
 
 @pytest.fixture(autouse=True)
 def handle_cpu_only(request):
   """Dynamically skip cpu_only tests on TPU or GPU hardware."""
   if request.node.get_closest_marker("cpu_only"):
-    if _get_system_hardware_platform() in ("tpu", "gpu"):
+    try:
+      has_accelerator = any(d.platform in ("tpu", "gpu") for d in jax.devices())
+    except Exception:  # pylint: disable=broad-exception-caught
+      has_accelerator = False
+    if has_accelerator:
       pytest.skip("Skipped: cpu_only test bypassed on hardware accelerator testbeds")
 
 
@@ -240,7 +222,11 @@ def handle_cpu_only(request):
 def handle_tpu_only(request):
   """Dynamically skip tpu_only tests if running on non-TPU hardware."""
   if request.node.get_closest_marker("tpu_only"):
-    if _get_system_hardware_platform() != "tpu":
+    try:
+      has_tpu = any(d.platform == "tpu" for d in jax.devices())
+    except Exception:  # pylint: disable=broad-exception-caught
+      has_tpu = False
+    if not has_tpu:
       pytest.skip("Skipped: requires TPU hardware, none detected")
 
 
@@ -248,5 +234,9 @@ def handle_tpu_only(request):
 def handle_gpu_only(request):
   """Dynamically skip gpu_only tests if running on non-GPU hardware."""
   if request.node.get_closest_marker("gpu_only"):
-    if _get_system_hardware_platform() != "gpu":
+    try:
+      has_gpu = any(d.platform == "gpu" for d in jax.devices())
+    except Exception:  # pylint: disable=broad-exception-caught
+      has_gpu = False
+    if not has_gpu:
       pytest.skip("Skipped: requires GPU hardware, none detected")


### PR DESCRIPTION
# Description

This PR fixes a critical issue where a lot of CI tests  were being skipped.

### The Core Issue
[PR #3980](https://github.com/AI-Hypercomputer/maxtext/pull/3980) introduced an environment-variable-based platform check helper `_get_system_hardware_platform()` to avoid initializing JAX during PyTest's collection (import) phase, preventing early PJRT/CUDA context locks on GPU runners.

However, this environment-variable-based check fell back to `"cpu"` on:
1. **Pathways proxy runs**, where `JAX_PLATFORMS` is set to `"proxy"` (which does not contain `"tpu"`).
2. **Standard Cloud TPU VM runs**, where none of the custom environment variables (`JAX_PLATFORMS`, `TPU_NAME`, or `TPU_CHIPS`) are defined inside the test container.

Consequently, the `handle_tpu_only` fixture defaulted the platform to CPU and skipped all `@pytest.mark.tpu_only` tests on both execution runners.

### The Fix
Instead of parsing fragile environment configurations, we leverage the fact that `conftest.py`'s hardware-skipping autouse fixtures (`handle_tpu_only`, `handle_gpu_only`, `handle_cpu_only`, `handle_skip_on_tpu7x`) run during PyTest's **test execution phase**, not the collection phase.

# Tests

Passed and skipped CI tests counts similar to those ran against main before PR #3980 was merged

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
