### PR TITLE
[MaxTwin] prepare distill pipeline for xm use

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -322,7 +322,7 @@ class DistillationStrategy(abc.ABC):
       teacher_output: "DistillationForwardOutput",
       labels: jax.Array,
       step: jax.Array | None = None,
-  ) -> tuple[jax.Array, dict[str, jax.Array]]:
+  ) -> tuple[jax.Array, dict[str, tuple[jax.Array, jax.Array]]]:
     """Computes the distillation loss.
 
     Args:
@@ -342,7 +342,7 @@ class DistillationStrategy(abc.ABC):
       self,
       student_output: "DistillationForwardOutput",
       labels: jax.Array,
-  ) -> tuple[jax.Array, dict[str, jax.Array]]:
+  ) -> tuple[jax.Array, dict[str, tuple[jax.Array, jax.Array]]]:
     """Computes the evaluation loss (typically just the task loss).
 
     Args:
@@ -568,6 +568,7 @@ class CombinedDistillationStrategy(DistillationStrategy):
 
     feature_loss = jnp.array(0.0, dtype=jnp.float32)
     if self.beta_feature > 0.0:
+      assert s_features is not None and t_features is not None
       if self.layer_indices is not None:
         s_features_sliced = jnp.take(s_features, self.layer_indices, axis=0)
         t_features_sliced = jnp.take(t_features, self.layer_indices, axis=0)
@@ -675,7 +676,7 @@ class MaxTextCheckpointManager(tunix_checkpoint_manager.CheckpointManager):
       self,
       raw_iterator: Any | None,
       root_directory: str | None,
-      student_config: Any | None,
+      student_config: Any,
       options: checkpoint.CheckpointManagerOptions | None = None,
   ):
     super().__init__(root_directory=root_directory, options=options)

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -45,6 +45,8 @@ import jax
 import jax.numpy as jnp
 import optax
 import re
+import os
+import pathwaysutils
 from orbax import checkpoint
 
 # MaxText Imports
@@ -210,6 +212,8 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
   This class overrides `_prepare_inputs` to ensure MaxText-specific fields
   (positions, segment_ids) are passed to the model.
   """
+
+  checkpoint_manager: distillation_utils.MaxTextCheckpointManager | None
 
   def __init__(
       self,
@@ -506,10 +510,9 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
         )
 
     # 1. Ensure clean resource release of the base class's manager
-    # pylint: disable=access-member-before-definition
-    if self.checkpoint_manager:
-      self.checkpoint_manager.close()
-    # pylint: enable=access-member-before-definition
+    cm = self.checkpoint_manager
+    if cm is not None:
+      cm.close()
 
     # 2. Assign the specialized manager
     self.checkpoint_manager = distillation_utils.MaxTextCheckpointManager(
@@ -873,6 +876,14 @@ def main(argv: Sequence[str]) -> None:
   Args:
     argv: List of command-line arguments. Expects [script_name, config_file, ...].
   """
+
+  pathwaysutils.initialize()
+  jax.config.update("jax_default_prng_impl", "unsafe_rbg")
+  if "xla_tpu_spmd_rng_bit_generator_unsafe" not in os.environ.get("LIBTPU_INIT_ARGS", ""):
+    os.environ["LIBTPU_INIT_ARGS"] = (
+        os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
+    )
+
   # 1. Parse Global Config to extract Overrides
   global_config = pyconfig.initialize(argv)
   _save_run_manifest(argv, global_config)


### PR DESCRIPTION
# Description

This PR updates the distillation trainer to support execution via XManager (XM) and aligns its initialization logic with other standard MaxText trainers 

Why is this change being made: To enable distillation workloads to run effectively within the XManager and Pathways ecosystems, ensuring consistent environment setup and performance optimizations ([ source](https://github.com/AI-Hypercomputer/maxtext/compare/vladk/maxtwin_xm_support?expand=1&content_ref=pathwaysutils+initialize)).  
Problem being solved: The distillation pipeline previously lacked explicit Pathways initialization and specific JAX/XLA configurations required for robust performance on TPU-based clusters ([ source](https://github.com/AI-Hypercomputer/maxtext/compare/vladk/maxtwin_xm_support?expand=1&content_ref=os+environ+libtpu_init_args+os+environ+get+libtpu_init_args+xla_tpu_spmd_rng_bit_generator_unsafe+true)).  

Implementation details:
- Copied Borg-required calls to pathwaysutils.initialize() and some initialization logic from other Maxtext trainers.
- A number of type hint fixes in distillation_utils.py to be able to build the package internally with blaze - Made student_config a required parameter in MaxTextCheckpointManager.

# Tests

The real test will be the internal xm launcher for the distill training run - to be patched.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
