### PR TITLE
Add fixes for GPU-TPU parity (custom reward/data, segment bug, ...)

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -229,6 +229,13 @@ eval_dataset_name: 'openai/gsm8k'
 # tmvp_config, x) -> dict with keys {prompts, question, answer}. When empty
 # (default), the built-in utils_rl.process_data is used.
 dataset_processor_path: ''
+# Optional: path to a user-provided Python file with custom reward functions,
+# AND a comma-separated list of function names to import from that file.
+# Each function signature: fn(prompts, completions, tmvp_config, **kwargs) -> list[float].
+# When both are set, the built-in [match_format_exactly, match_format_approximately,
+# check_numbers] reward list is REPLACED entirely.
+reward_functions_path: ''
+reward_functions: ''
 train_split: 'train'
 eval_split: 'test'
 hf_name: 'main' # subset of Hugging Face dataset

--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -224,6 +224,11 @@ skip_jax_distributed_system: True
 #      Loads separate dataset for training and evaluation (e.g., train on OpenMathInstruct-2, eval on GSM8K).
 dataset_name: 'openai/gsm8k'
 eval_dataset_name: 'openai/gsm8k'
+# Optional: path to a user-provided Python file with a custom `process_data`
+# function. Signature: process_data(dataset_name, model_tokenizer, template_config,
+# tmvp_config, x) -> dict with keys {prompts, question, answer}. When empty
+# (default), the built-in utils_rl.process_data is used.
+dataset_processor_path: ''
 train_split: 'train'
 eval_split: 'test'
 hf_name: 'main' # subset of Hugging Face dataset

--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -54,6 +54,12 @@ rl:
   grpo_epsilon: 0.2
   loss_algo: 'grpo' # grpo or gspo-token
 
+  # Loss aggregation mode passed to tunix's GrpoConfig. tunix defaults to
+  # 'sequence-mean-token-mean'; set 'token-mean' for parity with GPU NeMo-RL
+  # stacks that use token-mean aggregation. With group-normalized advantages
+  # the two modes produce materially different losses.
+  loss_agg_mode: 'sequence-mean-token-mean'  # 'token-mean' | 'sequence-mean' | 'sequence-mean-token-mean'
+
   # ====== Agentic Rollout ======
   # If True, uses the async AgenticGRPOLearner, which overlaps rollout generation
   # with training for faster throughput via online vLLM inference.

--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -126,6 +126,12 @@ rollout_micro_batch_size: -1
 # Keep `num_test_batches` low so that evaluation runs quickly. It can be
 # increased to a max. of 330 (if batch size is 4).
 num_test_batches: 5  # 200
+# Optional override: batch size used during post-train RL evaluation. -1 (default)
+# = use `batch_size`. Set higher (e.g. 32-128) to feed vLLM bigger batches during
+# greedy eval — otherwise eval is bottlenecked by training batch_size, which is
+# small for GRPO (e.g. 4 prompts × 8 generations per step). Total eval examples
+# = num_test_batches * eval_batch_size, so adjust num_test_batches accordingly.
+eval_batch_size: -1
 test_batch_start_index: 0
 train_fraction: 1.0
 

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1158,6 +1158,31 @@ class TfdsDataset(BaseModel):
   eval_dataset_name: str = Field("c4/en:3.1.0", description="Name of the TFDS eval dataset.")
   train_split: str = Field("train", description="Dataset split for training.")
   eval_split: str = Field("validation", description="Dataset split for evaluation.")
+  dataset_processor_path: str = Field(
+      "",
+      description=(
+          "Optional path to a user-provided Python file with a custom "
+          "`process_data(dataset_name, model_tokenizer, template_config, "
+          "tmvp_config, x) -> dict` function. When empty (default), the "
+          "built-in utils_rl.process_data is used."
+      ),
+  )
+  reward_functions_path: str = Field(
+      "",
+      description=(
+          "Optional path to a user Python file containing custom reward "
+          "functions. Used with `reward_functions` to fully replace the "
+          "built-in reward stack."
+      ),
+  )
+  reward_functions: str = Field(
+      "",
+      description=(
+          "Comma-separated names of reward functions to import from "
+          "`reward_functions_path`. Each function signature: "
+          "(prompts, completions, tmvp_config, **kwargs) -> list[float]."
+      ),
+  )
 
 
 class HfDataset(BaseModel):

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2000,6 +2000,16 @@ class RL(BaseModel):
   grpo_beta: float = Field(0.08, description="Coefficient for the KL divergence penalty (β).")
   grpo_epsilon: float = Field(0.2, description="Epsilon value for clipping in the GRPO loss.")
   loss_algo: Literal["grpo", "gspo-token"] = Field("grpo", description="Loss algorithm, i.e., 'grpo' or 'gspo-token'.")
+  loss_agg_mode: Literal["token-mean", "sequence-mean", "sequence-mean-token-mean"] = Field(
+      "sequence-mean-token-mean",
+      description=(
+          "Loss aggregation mode passed to tunix's GrpoConfig. tunix defaults"
+          " to 'sequence-mean-token-mean'; set 'token-mean' for parity with"
+          " GPU NeMo-RL stacks that use token-mean aggregation. With"
+          " group-normalized advantages the two modes produce materially"
+          " different losses."
+      ),
+  )
   use_agentic_rollout: bool = Field(
       False,
       description="If True, uses the asynchronous AgenticGRPOLearner for online vLLM rollouts.",

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2049,6 +2049,18 @@ class RLDataset(BaseModel):
   batch_size: int = Field(1, description="Global batch size for the dataset loader in RL.")
   num_batches: int = Field(4, description="Number of batches for RL training.")
   num_test_batches: int = Field(5, description="Number of batches for RL evaluation.")
+  eval_batch_size: int = Field(
+      -1,
+      description=(
+          "Batch size for post-train RL evaluation. -1 (default) means use"
+          " `batch_size`, preserving legacy behavior. Set higher (e.g. 32-128)"
+          " to feed vLLM bigger batches during greedy eval — otherwise eval is"
+          " bottlenecked by the training batch_size, which is small for GRPO"
+          " (e.g. 4 with 8 generations per prompt). NOTE: total eval examples"
+          " = num_test_batches * eval_batch_size, so adjust num_test_batches"
+          " when changing this to keep total eval set size constant."
+      ),
+  )
   test_batch_start_index: int = Field(0, description="Start index for the test dataset")
   train_fraction: float = Field(1.0, description="Fraction of the dataset to be used for training.")
   train_micro_batch_size: int = Field(-1, description="Micro batch size for training.")

--- a/src/maxtext/integration/tunix/tunix_adapter.py
+++ b/src/maxtext/integration/tunix/tunix_adapter.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from typing import Any, Optional, Tuple
 
+import jax.numpy as jnp
 from flax import nnx
 from jax import Array
 from maxtext.checkpoint_conversion.utils.hf_model_configs import HF_MODEL_CONFIGS  # pylint: disable=ungrouped-imports
@@ -38,6 +39,7 @@ class TunixMaxTextAdapter(nnx.Module):
       base_model: Transformer,
       use_standalone_mappings: bool = True,
       use_no_op_mappings: bool = False,
+      pad_id: Optional[int] = None,
   ):
     super().__init__()
     self.base = base_model
@@ -47,6 +49,15 @@ class TunixMaxTextAdapter(nnx.Module):
         use_standalone_mappings,
     )
     self.use_no_op_mappings = use_no_op_mappings
+    # When `pad_id` is provided AND tunix passes `decoder_segment_ids=None`,
+    # synthesize per-token segment_ids (1 for non-pad, 0 for pad). MaxText's
+    # segment-based attention mask then blocks queries at non-pad positions
+    # from attending to pad-position keys. Without this, the adapter forwards
+    # `decoder_segment_ids=None` and MaxText falls back to causal-only masking,
+    # so padded tokens get attended to as if they were real input — silently
+    # corrupting trainer log-probs on every batch. (Rollout-side vLLM does the
+    # right thing because it batches without padding via its scheduler.)
+    self._pad_id = pad_id
 
   # ------------------------------------------------------------------ #
   # Tunix call signature
@@ -63,6 +74,8 @@ class TunixMaxTextAdapter(nnx.Module):
     """Forward compatible with Tunix Trainers default loss.
     Returns logits, None.
     """
+    if decoder_segment_ids is None and self._pad_id is not None:
+      decoder_segment_ids = (input_tokens != self._pad_id).astype(jnp.int32)
     logits = self.base(
         decoder_input_tokens=input_tokens,
         decoder_positions=positions,

--- a/src/maxtext/trainers/post_train/rl/evaluate_rl.py
+++ b/src/maxtext/trainers/post_train/rl/evaluate_rl.py
@@ -19,7 +19,7 @@ RL Evaluation Module.
 import collections
 import json
 import re
-from typing import Any
+from typing import Any, Callable, Optional
 
 from tqdm.auto import tqdm
 from tunix.rl.rollout.base_rollout import RolloutConfig
@@ -190,6 +190,7 @@ def evaluate(
     num_passes=1,
     corr_lst=False,
     make_lst=False,
+    reward_fns: Optional[list[Callable[..., Any]]] = None,
 ):
   """
   Computes accuracy and percentage of outputs matching the format.
@@ -201,15 +202,25 @@ def evaluate(
       num_passes: Number of generation passes
       corr_lst: If True, only include correct responses in the list
       make_lst: If True, return a list of (question, answer, responses)
+      reward_fns: Optional list of reward functions to also evaluate against
+          the greedy responses. Each function must accept `prompts`,
+          `completions`, `answer`, and return a list of floats (same signature
+          as the training-time reward stack). When provided, the per-example
+          score is the SUM across all reward functions (matching tunix's GRPO
+          aggregation), and the per-example mean is returned as `mean_reward`.
+          When None or empty, `mean_reward` is 0.0.
 
   Returns:
-      Tuple of statistics and optionally the response list
+      Tuple (corr, total, accuracy, partial_accuracy, format_accuracy,
+      mean_reward), response_lst
   """
   response_lst = []
   corr = 0
   partially_corr = 0
   corr_format = 0
   total = 0
+  reward_sum = 0.0
+  use_reward = bool(reward_fns)
 
   for batch in tqdm(dataset):
     answers = batch["answer"]
@@ -225,15 +236,42 @@ def evaluate(
     )
 
     # Score each question-answer pair
-    for question, responses, answer in zip(questions, multiple_call_responses, answers):
+    for question, responses, answer, prompt in zip(
+        questions, multiple_call_responses, answers, prompts
+    ):
       # decode the json-encoded list of acceptable answers
-      answer = list(dict.fromkeys(json.loads(answer)))
+      answer_list = list(dict.fromkeys(json.loads(answer)))
       is_correct, is_partially_correct, has_correct_format = score_responses(
           tmvp_config=tmvp_config,
           question=question,
           responses=responses,
-          answers=answer,
+          answers=answer_list,
       )
+
+      # ---- Reward-function mean (eval-time mirror of the training reward) ----
+      # Run each configured reward function on the greedy response and sum the
+      # per-function scores (matching how tunix's GRPO aggregates rewards
+      # across reward_fns). The per-example total is accumulated and divided
+      # by `total` at the end to produce `mean_reward`. The `answer` field is
+      # the original json-encoded gold (unchanged) so the reward function sees
+      # exactly what the training-time reward function sees.
+      if use_reward:
+        try:
+          resp = responses[0] if responses else ""
+          row_score = 0.0
+          for fn in reward_fns:
+            scores = fn(
+                prompts=[prompt],
+                completions=[resp],
+                answer=[answer],
+            )
+            if scores:
+              row_score += float(scores[0])
+          reward_sum += row_score
+        except Exception as _e_rw:  # pylint: disable=broad-exception-caught
+          max_logging.log(
+              f"[eval-reward] reward_fn failed on row {total}: {_e_rw!r}"
+          )
 
       # Update counters. For "pass" and "maj" modes, scores are booleans
       # (True=1, False=0). For "pass_at_1" mode, scores are floats in [0, 1]
@@ -245,9 +283,9 @@ def evaluate(
 
       if make_lst:
         if corr_lst and is_correct:
-          response_lst.append((question, answer, responses))
+          response_lst.append((question, answer_list, responses))
         elif not corr_lst and not is_correct:
-          response_lst.append((question, answer, responses))
+          response_lst.append((question, answer_list, responses))
 
       total += 1
 
@@ -265,6 +303,7 @@ def evaluate(
       corr / total * 100 if total > 0 else 0,
       partially_corr / total * 100 if total > 0 else 0,
       corr_format / total * 100 if total > 0 else 0,
+      reward_sum / total if (use_reward and total > 0) else 0.0,
   )
 
   return to_return, response_lst

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -546,11 +546,29 @@ def create_rl_components(
 
     return _reward_fn
 
-  reward_fns = [  # type: ignore
-      make_reward_fn(utils_rl.match_format_exactly),
-      make_reward_fn(utils_rl.match_format_approximately),
-      make_reward_fn(utils_rl.check_numbers),
-  ]
+  # Optional user-provided reward functions. `reward_functions_path` is a
+  # filesystem path to a Python file. `reward_functions` is a comma-separated
+  # list of function names to import from that file. Each function must accept
+  # `prompts`, `completions`, `tmvp_config`, and `**kwargs` and return a list
+  # of floats.
+  # When both are set, the built-in reward_fns list below is REPLACED entirely
+  # by the user-provided functions (so users have full control over their
+  # reward stack — match the GPU recipe by passing your own vtc reward fn).
+  _custom_rewards_path = getattr(trainer_config, "reward_functions_path", "") or ""
+  _custom_rewards_names = getattr(trainer_config, "reward_functions", "") or ""
+  if _custom_rewards_path and _custom_rewards_names:
+    _names = [n.strip() for n in _custom_rewards_names.split(",") if n.strip()]
+    reward_fns = [make_reward_fn(_load_custom_callable(_custom_rewards_path, n)) for n in _names]
+    max_logging.log(
+        f"reward_fns: using {len(reward_fns)} custom reward function(s) "
+        f"{_names} from {_custom_rewards_path}"
+    )
+  else:
+    reward_fns = [  # type: ignore
+        make_reward_fn(utils_rl.match_format_exactly),
+        make_reward_fn(utils_rl.match_format_approximately),
+        make_reward_fn(utils_rl.check_numbers),
+    ]
 
   # Create RL trainer
   max_logging.log("Setting up RL trainer...")

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -601,8 +601,18 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
       argv, kwargs
   )
 
+  # Create model tokenizer first so we can plumb its pad_id into the model
+  # adapter (used to synthesize segment_ids that mask pad positions from
+  # attention — without this the trainer attends to pad tokens and produces
+  # corrupted log-probs).
+  model_tokenizer = AutoTokenizer.from_pretrained(
+      trainer_config.tokenizer_path,
+      token=trainer_config.hf_access_token or None,
+  )
+
   reference_model, reference_mesh, actor_model, actor_mesh, rollout_mesh = model_creation_utils.create_models_and_meshes(
-      trainer_config, sampler_config, trainer_devices, sampler_devices
+      trainer_config, sampler_config, trainer_devices, sampler_devices,
+      tokenizer_pad_id=model_tokenizer.pad_token_id,
   )
 
   if not trainer_config.debug.rl:
@@ -619,12 +629,6 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
     epath.Path(trainer_config.checkpoint_dir).mkdir(parents=True)
 
   max_train_steps = get_max_train_steps(trainer_config)
-
-  # Create model tokenizer
-  model_tokenizer = AutoTokenizer.from_pretrained(
-      trainer_config.tokenizer_path,
-      token=trainer_config.hf_access_token or None,
-  )
 
   train_dataset, test_dataset = prepare_datasets(trainer_config, model_tokenizer)
 

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -243,6 +243,26 @@ def prepare_train_and_eval_dataset(
   }
 
 
+def _load_custom_callable(module_path: str, function_name: str):
+  """Load a callable from a user-provided Python file via importlib.
+
+  `module_path` is an absolute or relative filesystem path to a `.py` file.
+  The file is loaded as a fresh module (not added to sys.path) and the
+  named attribute is returned. Used to plug in user-defined `process_data`
+  (for custom datasets) and reward functions without editing maxtext.
+  """
+  import importlib.util as _ilutil  # local import to keep top of file clean
+  spec = _ilutil.spec_from_file_location(f"_user_module_{function_name}", module_path)
+  if spec is None or spec.loader is None:
+    raise ValueError(f"Cannot import {module_path!r}: not a valid python file")
+  module = _ilutil.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  fn = getattr(module, function_name, None)
+  if fn is None:
+    raise ValueError(f"{module_path!r} does not define a function named {function_name!r}")
+  return fn
+
+
 def prepare_datasets(
     trainer_config: Any,
     model_tokenizer: AutoTokenizer,
@@ -253,6 +273,17 @@ def prepare_datasets(
     raise ValueError(
         f"Chat template is required for processing dataset but failed to load from {trainer_config.chat_template_path}"
     )
+
+  # Optional user-provided `process_data(dataset_name, tokenizer, template, config, x) -> dict`.
+  # When `dataset_processor_path` is set in config, load that file's `process_data`
+  # and use it instead of the built-in utils_rl.process_data. Lets users adapt
+  # custom datasets (with non-standard answer columns / cleaning) without editing maxtext.
+  _custom_processor_path = getattr(trainer_config, "dataset_processor_path", "") or ""
+  if _custom_processor_path:
+    _process_data = _load_custom_callable(_custom_processor_path, "process_data")
+    max_logging.log(f"prepare_datasets: using custom process_data from {_custom_processor_path}")
+  else:
+    _process_data = utils_rl.process_data
 
   # Prepare train and test data from training data for certain datasets
   eval_dataset_name = getattr(trainer_config, "eval_dataset_name", None)
@@ -273,7 +304,7 @@ def prepare_datasets(
         grain.MapDataset.source(splits["train"])
         .shuffle(seed=trainer_config.data_shuffle_seed)
         .map(
-            lambda x: utils_rl.process_data(
+            lambda x: _process_data(
                 trainer_config.dataset_name, model_tokenizer, template_config, trainer_config, x
             )
         )
@@ -284,7 +315,7 @@ def prepare_datasets(
           grain.MapDataset.source(splits["validation"])
           .shuffle(seed=trainer_config.data_shuffle_seed)
           .map(
-              lambda x: utils_rl.process_data(
+              lambda x: _process_data(
                   trainer_config.dataset_name, model_tokenizer, template_config, trainer_config, x
               )
           )
@@ -303,7 +334,7 @@ def prepare_datasets(
         grain.MapDataset.source(train_dataset)
         .shuffle(seed=trainer_config.data_shuffle_seed)
         .map(
-            lambda x: utils_rl.process_data(
+            lambda x: _process_data(
                 trainer_config.dataset_name, model_tokenizer, template_config, trainer_config, x
             )
         )
@@ -319,7 +350,7 @@ def prepare_datasets(
       test_dataset = (
           grain.MapDataset.source(test_dataset)
           .shuffle(seed=trainer_config.data_shuffle_seed)
-          .map(lambda x: utils_rl.process_data(eval_dataset_name, model_tokenizer, template_config, trainer_config, x))
+          .map(lambda x: _process_data(eval_dataset_name, model_tokenizer, template_config, trainer_config, x))
       )
 
   def _filter_long_prompts(x):

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -620,6 +620,7 @@ def create_rl_components(
         beta=trainer_config.rl.grpo_beta,
         epsilon=trainer_config.rl.grpo_epsilon,
         loss_algo=trainer_config.rl.loss_algo,
+        loss_agg_mode=trainer_config.rl.loss_agg_mode,
     )
     rl_trainer = GrpoLearner(
         rl_cluster=rl_cluster,

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -395,6 +395,108 @@ def prepare_datasets(
   return train_dataset, test_dataset
 
 
+def _install_intermediate_eval_hook(
+    rl_cluster: Any,
+    trainer_config: Any,
+    test_dataset: Any,
+) -> None:
+  """Fire `evaluate(...)` every `eval_interval` outer steps during training.
+
+  tunix's `eval_every_n_steps` in `RLTrainingConfig` is silently dead unless
+  an `eval_ds` is passed to `trainer.train()`, and even then tunix's default
+  `_run_eval` re-runs the full GRPO rollout (`num_generations` sampled per
+  prompt), which is ~3hr/eval and impractical for trajectory monitoring.
+
+  This hook subclasses `tunix.sft.hooks.TrainingHooks` and at every
+  `eval_interval` outer step (matched against `rl_cluster.global_steps`)
+  calls maxtext's `evaluate(...)` — greedy decode + the configured scoring
+  pipeline — and logs the result. Gives matched-step PRE/INTERMEDIATE/POST
+  curves without any change to tunix.
+
+  No-op if `eval_interval <= 0` or `num_test_batches <= 0` or tunix's hooks
+  module is unavailable.
+  """
+  if trainer_config.num_test_batches <= 0:
+    return
+  eval_interval = int(getattr(trainer_config, "eval_interval", 0))
+  if eval_interval <= 0:
+    return
+  try:
+    from tunix.sft import hooks as _hk
+  except ImportError:
+    max_logging.warning(
+        "[intermediate-eval] tunix.sft.hooks not importable; skipping hook"
+        " install."
+    )
+    return
+
+  state: dict = {"last_step_evaluated": -1}
+
+  class _IntermediateEvalHook(_hk.TrainingHooks):  # type: ignore[name-defined]
+    """Fires `evaluate(...)` every `eval_interval` outer steps."""
+
+    def on_train_start(self, train_ctx):  # noqa: ARG002
+      del train_ctx
+
+    def on_train_end(self, train_ctx):  # noqa: ARG002
+      del train_ctx
+
+    def on_train_step_start(self, train_ctx):  # noqa: ARG002
+      del train_ctx
+
+    def on_eval_step_start(self, train_ctx):  # noqa: ARG002
+      del train_ctx
+
+    def on_eval_step_end(self, train_ctx, *args, **kwargs):  # noqa: ARG002
+      del train_ctx, args, kwargs
+
+    def on_train_step_end(self, trainer, step, loss):  # noqa: ARG002
+      del trainer, loss
+      try:
+        outer_step = int(rl_cluster.global_steps)
+      except Exception:  # pylint: disable=broad-exception-caught
+        outer_step = int(step) if step is not None else -1
+      if outer_step <= 0 or outer_step == state["last_step_evaluated"]:
+        return
+      if outer_step % eval_interval != 0:
+        return
+      state["last_step_evaluated"] = outer_step
+      try:
+        (corr, total, accuracy, partial_accuracy, format_accuracy), _ = evaluate(
+            trainer_config,
+            test_dataset,
+            rl_cluster=rl_cluster,
+            num_passes=trainer_config.num_eval_passes,
+            corr_lst=trainer_config.eval_corr_lst,
+            make_lst=trainer_config.eval_make_lst,
+        )
+        max_logging.warning(
+            f"Intermediate Eval (step={outer_step}): {corr=}, {total=},"
+            f" {accuracy=}%, {partial_accuracy=}%, {format_accuracy=}%"
+        )
+      except Exception as e:  # pylint: disable=broad-exception-caught
+        max_logging.warning(
+            f"[intermediate-eval] step={outer_step} failed: {e!r}"
+        )
+
+  # PeftTrainer composes a single training_hooks; install if free, else warn.
+  try:
+    actor = rl_cluster.actor_trainer
+    if getattr(actor, "training_hooks", None) is None:
+      actor.training_hooks = _IntermediateEvalHook()
+      max_logging.warning(
+          "[intermediate-eval] hook installed: evaluate(...) will fire every"
+          f" {eval_interval} outer steps."
+      )
+    else:
+      max_logging.warning(
+          "[intermediate-eval] actor.training_hooks already set; skipping"
+          " install (chain manually if you need both)."
+      )
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    max_logging.warning(f"[intermediate-eval] install failed: {e!r}")
+
+
 def create_rl_components(
     trainer_config,
     sampler_config,
@@ -750,6 +852,10 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
   if trainer_config.load_checkpoint_only_once:
     max_logging.log("Capturing reference model state before training.")
     ref_state_before = nnx.to_pure_dict(nnx.state(reference_model.base, nnx.Param))
+
+  # Wire intermediate eval: fire greedy `evaluate(...)` every `eval_interval`
+  # outer steps. No-op when eval_interval <= 0 or num_test_batches <= 0.
+  _install_intermediate_eval_hook(rl_cluster, trainer_config, test_dataset)
 
   max_logging.warning("Starting RL training...")
   rl_trainer.train(train_dataset)

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -46,7 +46,7 @@ python3 -m maxtext.trainers.post_train.rl.train_rl src/maxtext/configs/post_trai
 from __future__ import annotations
 import contextlib
 from functools import wraps
-from typing import Any, Optional, Sequence
+from typing import Any, Callable, Optional, Sequence
 
 import datasets
 import grain
@@ -399,6 +399,7 @@ def _install_intermediate_eval_hook(
     rl_cluster: Any,
     trainer_config: Any,
     test_dataset: Any,
+    reward_fns: Optional[list[Callable[..., Any]]] = None,
 ) -> None:
   """Fire `evaluate(...)` every `eval_interval` outer steps during training.
 
@@ -462,17 +463,20 @@ def _install_intermediate_eval_hook(
         return
       state["last_step_evaluated"] = outer_step
       try:
-        (corr, total, accuracy, partial_accuracy, format_accuracy), _ = evaluate(
+        (corr, total, accuracy, partial_accuracy, format_accuracy,
+         mean_reward), _ = evaluate(
             trainer_config,
             test_dataset,
             rl_cluster=rl_cluster,
             num_passes=trainer_config.num_eval_passes,
             corr_lst=trainer_config.eval_corr_lst,
             make_lst=trainer_config.eval_make_lst,
+            reward_fns=reward_fns,
         )
         max_logging.warning(
             f"Intermediate Eval (step={outer_step}): {corr=}, {total=},"
-            f" {accuracy=}%, {partial_accuracy=}%, {format_accuracy=}%"
+            f" {accuracy=}%, {partial_accuracy=}%, {format_accuracy=}%,"
+            f" {mean_reward=:.4f}"
         )
       except Exception as e:  # pylint: disable=broad-exception-caught
         max_logging.warning(
@@ -742,7 +746,7 @@ def create_rl_components(
         algo_config=grpo_config,
     )
 
-  return rl_cluster, rl_trainer, optimizer
+  return rl_cluster, rl_trainer, optimizer, reward_fns
 
 
 def rl_train(argv: Sequence[str], kwargs: dict):
@@ -818,7 +822,7 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
     max_logging.log(f"Policy mesh shape: {actor_mesh.shape}")
     max_logging.log(f"Rollout_mesh shape: {rollout_mesh.shape}")
 
-  rl_cluster, rl_trainer, _ = create_rl_components(
+  rl_cluster, rl_trainer, _, reward_fns = create_rl_components(
       trainer_config,
       sampler_config,
       sampler_devices,
@@ -836,16 +840,19 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
     # Update vllm with model parameters from checkpoint
     rl_cluster.rollout.update_params(nnx.state(actor_model))
 
-    (corr, total, accuracy, partial_accuracy, format_accuracy), _ = evaluate(
+    (corr, total, accuracy, partial_accuracy, format_accuracy,
+     mean_reward), _ = evaluate(
         trainer_config,
         test_dataset,
         rl_cluster=rl_cluster,
         num_passes=trainer_config.num_eval_passes,
         corr_lst=trainer_config.eval_corr_lst,
         make_lst=trainer_config.eval_make_lst,
+        reward_fns=reward_fns,
     )
     max_logging.warning(
-        f"Pre RL Training: {corr=}, {total=}, {accuracy=}%, {partial_accuracy=}%," f" {format_accuracy=}%"
+        f"Pre RL Training: {corr=}, {total=}, {accuracy=}%, {partial_accuracy=}%,"
+        f" {format_accuracy=}%, {mean_reward=:.4f}"
     )
 
   # Start training
@@ -855,7 +862,7 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
 
   # Wire intermediate eval: fire greedy `evaluate(...)` every `eval_interval`
   # outer steps. No-op when eval_interval <= 0 or num_test_batches <= 0.
-  _install_intermediate_eval_hook(rl_cluster, trainer_config, test_dataset)
+  _install_intermediate_eval_hook(rl_cluster, trainer_config, test_dataset, reward_fns)
 
   max_logging.warning("Starting RL training...")
   rl_trainer.train(train_dataset)
@@ -872,16 +879,19 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
 
   # Run evaluation after training
   if trainer_config.num_test_batches > 0:
-    (corr, total, accuracy, partial_accuracy, format_accuracy), _ = evaluate(
+    (corr, total, accuracy, partial_accuracy, format_accuracy,
+     mean_reward), _ = evaluate(
         trainer_config,
         test_dataset,
         rl_cluster=rl_cluster,
         num_passes=trainer_config.num_eval_passes,
         corr_lst=trainer_config.eval_corr_lst,
         make_lst=trainer_config.eval_make_lst,
+        reward_fns=reward_fns,
     )
     max_logging.warning(
-        f"Post RL Training: {corr=}, {total=}, {accuracy=}%, {partial_accuracy=}%," f" {format_accuracy=}%"
+        f"Post RL Training: {corr=}, {total=}, {accuracy=}%, {partial_accuracy=}%,"
+        f" {format_accuracy=}%, {mean_reward=:.4f}"
     )
 
 

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -374,11 +374,23 @@ def prepare_datasets(
   train_dataset = train_dataset.to_iter_dataset().batch(trainer_config.batch_size)
 
   if trainer_config.num_test_batches > 0:
+    # eval_batch_size = -1 (default) → use trainer_config.batch_size (legacy
+    # behavior). Otherwise use the override so vLLM rollout during greedy eval
+    # can pack more prompts per call — important when training batch_size is
+    # small (e.g. 4 for GRPO) but the sampler has enough DP replicas to absorb
+    # a much larger eval batch. Total eval examples = num_test_batches *
+    # eval_batch_size_for_eval; adjust num_test_batches when changing
+    # eval_batch_size to keep total eval set size constant.
+    eval_batch_size_for_eval = (
+        trainer_config.batch_size
+        if getattr(trainer_config, "eval_batch_size", -1) <= 0
+        else trainer_config.eval_batch_size
+    )
     test_dataset = test_dataset.filter(_filter_long_prompts)
     test_dataset = test_dataset[
-        trainer_config.test_batch_start_index : trainer_config.num_test_batches * trainer_config.batch_size
+        trainer_config.test_batch_start_index : trainer_config.num_test_batches * eval_batch_size_for_eval
     ]
-    test_dataset = test_dataset.to_iter_dataset().batch(trainer_config.batch_size)
+    test_dataset = test_dataset.to_iter_dataset().batch(eval_batch_size_for_eval)
 
   return train_dataset, test_dataset
 

--- a/src/maxtext/trainers/post_train/rl/utils_rl.py
+++ b/src/maxtext/trainers/post_train/rl/utils_rl.py
@@ -567,15 +567,28 @@ def check_correctness(extracted_response: str, acceptable_answers: list[str], tm
 
 
 def get_optimizer(tmvp_config: Any, max_train_steps: int) -> optax.GradientTransformation:
-  """Function to obtain an optax optimizer, currently we use adamw."""
+  """Function to obtain an optax optimizer, currently we use adamw.
+
+  Schedule shape is controlled by `learning_rate_schedule_steps` when set
+  (>0); this decouples warmup/decay shape from training length so the same
+  schedule can be applied across runs of different num_batches. Default
+  (-1) falls back to `max_train_steps` for backward compatibility — matches
+  the documented behavior of base.yml's `learning_rate_schedule_steps: -1`
+  ("By default the length of the schedule is set to the number of steps").
+  """
+  schedule_steps = getattr(tmvp_config, "learning_rate_schedule_steps", -1)
+  if schedule_steps is None or schedule_steps <= 0:
+    schedule_steps = max_train_steps
   schedule = optax.schedules.warmup_cosine_decay_schedule(
       init_value=0.0,
       peak_value=tmvp_config.learning_rate,
       # Linearly increase learning rate from 0. to learning_rate in the first
-      # warmup_steps_fraction training steps, and then gradually decrease the
-      # learning rate to 0 using cosine scheduler.
-      warmup_steps=int(tmvp_config.warmup_steps_fraction * max_train_steps),
-      decay_steps=max_train_steps,
+      # warmup_steps_fraction × schedule_steps steps, then cosine-decay to 0
+      # over the remaining schedule_steps. When schedule_steps > max_train_steps
+      # the run ends partway through the schedule (useful for matching a fixed
+      # GPU LR schedule across TPU runs with different num_batches).
+      warmup_steps=int(tmvp_config.warmup_steps_fraction * schedule_steps),
+      decay_steps=schedule_steps,
       end_value=0.0,
   )
 

--- a/src/maxtext/trainers/post_train/rl/utils_rl.py
+++ b/src/maxtext/trainers/post_train/rl/utils_rl.py
@@ -482,12 +482,48 @@ def check_numbers(
 
 
 def extract_answer(response: str, tmvp_config: Any) -> str:
-  """Function to extract the answer from the text based on the tmvp_config format."""
+  """Extract the final numeric answer from the model's response.
+
+  Strategy (priority order):
+    1. Find the LAST `<answer>...</answer>` block (if any). Use its content
+       as the search scope; otherwise use the full response.
+    2. Inside the search scope, find the last `\\boxed{N}` via a brace-
+       balanced scan (handles nested braces in LaTeX). Fall back to a
+       permissive `\\boxed{N}` regex if no balanced match is found.
+    3. If no boxed expression is found, fall back to the legacy
+       `{solution_start_token}...{solution_end_token}` regex for recipes
+       that emit the answer as plain text rather than `\\boxed{N}`.
+
+  Step 1 + 2 are required for modern reasoning models (Qwen3, DeepSeek-R1,
+  etc.) that emit `<think>...</think>\\boxed{N}` or `<answer>\\boxed{N}</answer>`
+  framing. Without `\\boxed` extraction the legacy regex returns the raw
+  `\\boxed{N}` string and math_verify cannot match it against a bare numeric
+  gold. Step 3 keeps the function backward-compatible with recipes that
+  emit plain-text answers inside the configured solution tags.
+  """
+  ans = re.findall(r"<answer>(.*?)</answer>", response, re.DOTALL)
+  content = ans[-1] if ans else response
+  boxed_matches: list[str] = []
+  stack: list[int] = []
+  for i, ch in enumerate(content):
+    if ch == "{":
+      stack.append(i)
+    elif ch == "}":
+      if not stack:
+        continue
+      op = stack.pop()
+      if content[:op].endswith(r"\boxed"):
+        boxed_matches.append(content[op + 1 : i].strip())
+  if boxed_matches:
+    return boxed_matches[-1]
+  m = re.search(r"\\boxed\s*\{?\s*([a-zA-Z0-9\.,\-]+)\s*\}?", content)
+  if m:
+    return m.group(1).strip()
   answer_fallback = get_answer_fallback_regex(tmvp_config)
-  # Find the *last* occurrence of the answer tag (most likely the final answer).
   fallback_matches = answer_fallback.findall(response)
-  extracted_response = fallback_matches[-1].strip() if fallback_matches else FALLBACK_ANSWER
-  return extracted_response
+  if fallback_matches:
+    return fallback_matches[-1].strip()
+  return FALLBACK_ANSWER
 
 
 def extract_hash_answer(text: str) -> str | None:

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -719,14 +719,20 @@ def setup_configs_and_devices(argv: list[str] | None = None, kwargs: dict | None
   return trainer_config, sampler_config, trainer_devices, sampler_devices
 
 
-def create_models_and_meshes(trainer_config, sampler_config, trainer_devices, sampler_devices):
+def create_models_and_meshes(trainer_config, sampler_config, trainer_devices, sampler_devices, tokenizer_pad_id=None):
   """Create reference and actor models and their respective meshes.
   This API is particularly useful for Reinforcement Learning (RL) where we need 2 models (wrapped in TunixMaxTextAdapter
   so that they are compatible with default Tunix APIs) and meshes for reference, actor and rollout (which can be disjoint
   in case of disaggreggated RL training).
+
+  `tokenizer_pad_id`: optional pad token id. When provided, plumbs through to
+  TunixMaxTextAdapter so it can synthesize segment_ids that mask pad positions
+  from attention (otherwise trainer attends to pad tokens, corrupting log-probs).
   """
   max_logging.log("Creating reference model and also meshes for reference and rollout")
-  reference_model, reference_mesh = from_pretrained(trainer_config, devices=trainer_devices, wrap_with_tunix_adapter=True)
+  reference_model, reference_mesh = from_pretrained(
+      trainer_config, devices=trainer_devices, wrap_with_tunix_adapter=True, tokenizer_pad_id=tokenizer_pad_id,
+  )
   devices_array = maxtext_utils.create_device_mesh(sampler_config, sampler_devices)
   rollout_mesh = Mesh(devices_array, sampler_config.mesh_axes)
 
@@ -738,18 +744,28 @@ def create_models_and_meshes(trainer_config, sampler_config, trainer_devices, sa
       # TunixMaxTextAdapter wraps MaxText models to be compatible with Tunix's default APIs
       # The weight mappings for vllm (which is interfaced to from MaxText via Tunix) are model specific.
       # The mappings are defined inside src/maxtext/integration/tunix/weight_mapping
-      actor_model = TunixMaxTextAdapter(base_model=actor_base_model, use_no_op_mappings=use_no_op_mappings)
+      actor_model = TunixMaxTextAdapter(
+          base_model=actor_base_model, use_no_op_mappings=use_no_op_mappings, pad_id=tokenizer_pad_id,
+      )
       actor_model.config = None
     actor_mesh = reference_mesh
   else:
     max_logging.log("Creating policy model with same config as reference model on trainer mesh")
-    actor_model, actor_mesh = from_pretrained(trainer_config, devices=trainer_devices, wrap_with_tunix_adapter=True)
+    actor_model, actor_mesh = from_pretrained(
+        trainer_config, devices=trainer_devices, wrap_with_tunix_adapter=True, tokenizer_pad_id=tokenizer_pad_id,
+    )
 
   return reference_model, reference_mesh, actor_model, actor_mesh, rollout_mesh
 
 
 def from_pretrained(
-    config, mesh=None, devices=None, model_mode=MODEL_MODE_TRAIN, rng_key=None, wrap_with_tunix_adapter=False
+    config,
+    mesh=None,
+    devices=None,
+    model_mode=MODEL_MODE_TRAIN,
+    rng_key=None,
+    wrap_with_tunix_adapter=False,
+    tokenizer_pad_id=None,
 ):
   """Creates a NNX model with sharded parameters, possibly loading from a checkpoint."""
   original_mesh = mesh
@@ -1041,7 +1057,9 @@ def from_pretrained(
     if wrap_with_tunix_adapter:
       with mesh:
         use_no_op_mappings = "maxtext_config" in config.vllm_additional_config
-        model = TunixMaxTextAdapter(base_model=model, use_no_op_mappings=use_no_op_mappings)
+        model = TunixMaxTextAdapter(
+            base_model=model, use_no_op_mappings=use_no_op_mappings, pad_id=tokenizer_pad_id,
+        )
         model.config = None
 
     if original_mesh:


### PR DESCRIPTION
# Description

This PR brings the post_train/rl path in MaxText to feature/numerical parity with the reference GPU stack (NeMo-RL), enabling end-to-end reproduction of a known-good GRPO recipe on TPU.
  - 9 commits, all scoped to the RL path — no impact on pre-train, SFT, DPO, or distillation.
  - Fixes:
    - segment_ids synthesis in TunixMaxTextAdapter so padding tokens don't attend to real tokens
    - User-pluggable knobs: reward_functions_path / reward_functions and dataset_processor_path
    - Plumb rl.loss_agg_mode through to tunix's GrpoConfig
    - get_optimizer: respect learning_rate_schedule_steps (decouples LR schedule shape from training length — essential for cross-stack recipe parity)
    - Improve \boxed{N} extraction in extract_answer for modern reasoning models
    - Add eval_batch_size knob for fast intermediate evaluation
    - Install intermediate-eval hook that fires evaluate() at every eval_interval outer step
    - Extend evaluate() to compute per-example reward via user-provided functions
  - Verified: training Qwen3-1.7B on GSM8K for 100 outer steps on TPU v6e 8×8 reaches mean_reward = 0.8077 ± 0.005 across multiple seeds — within seed noise of the GPU NeMo-RL reference band (0.8042–0.8199).