### PR TITLE
Fix: synthesize segment_ids in TunixMaxTextAdapter to mask pad attention

### DIFF
--- a/src/maxtext/integration/tunix/tunix_adapter.py
+++ b/src/maxtext/integration/tunix/tunix_adapter.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from typing import Any, Optional, Tuple
 
+import jax.numpy as jnp
 from flax import nnx
 from jax import Array
 from maxtext.checkpoint_conversion.utils.hf_model_configs import HF_MODEL_CONFIGS  # pylint: disable=ungrouped-imports
@@ -38,6 +39,7 @@ class TunixMaxTextAdapter(nnx.Module):
       base_model: Transformer,
       use_standalone_mappings: bool = True,
       use_no_op_mappings: bool = False,
+      pad_id: Optional[int] = None,
   ):
     super().__init__()
     self.base = base_model
@@ -47,6 +49,15 @@ class TunixMaxTextAdapter(nnx.Module):
         use_standalone_mappings,
     )
     self.use_no_op_mappings = use_no_op_mappings
+    # When `pad_id` is provided AND tunix passes `decoder_segment_ids=None`,
+    # synthesize per-token segment_ids (1 for non-pad, 0 for pad). MaxText's
+    # segment-based attention mask then blocks queries at non-pad positions
+    # from attending to pad-position keys. Without this, the adapter forwards
+    # `decoder_segment_ids=None` and MaxText falls back to causal-only masking,
+    # so padded tokens get attended to as if they were real input — silently
+    # corrupting trainer log-probs on every batch. (Rollout-side vLLM does the
+    # right thing because it batches without padding via its scheduler.)
+    self._pad_id = pad_id
 
   # ------------------------------------------------------------------ #
   # Tunix call signature
@@ -63,6 +74,8 @@ class TunixMaxTextAdapter(nnx.Module):
     """Forward compatible with Tunix Trainers default loss.
     Returns logits, None.
     """
+    if decoder_segment_ids is None and self._pad_id is not None:
+      decoder_segment_ids = (input_tokens != self._pad_id).astype(jnp.int32)
     logits = self.base(
         decoder_input_tokens=input_tokens,
         decoder_positions=positions,

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -601,8 +601,21 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
       argv, kwargs
   )
 
+  # Create model tokenizer first so we can plumb its pad_id into the model
+  # adapter (used to synthesize segment_ids that mask pad positions from
+  # attention — without this the trainer attends to pad tokens and produces
+  # corrupted log-probs).
+  model_tokenizer = AutoTokenizer.from_pretrained(
+      trainer_config.tokenizer_path,
+      token=trainer_config.hf_access_token or None,
+  )
+
   reference_model, reference_mesh, actor_model, actor_mesh, rollout_mesh = model_creation_utils.create_models_and_meshes(
-      trainer_config, sampler_config, trainer_devices, sampler_devices
+      trainer_config,
+      sampler_config,
+      trainer_devices,
+      sampler_devices,
+      tokenizer_pad_id=model_tokenizer.pad_token_id,
   )
 
   if not trainer_config.debug.rl:
@@ -619,12 +632,6 @@ def _rl_train_impl(argv: Sequence[str], kwargs: dict):
     epath.Path(trainer_config.checkpoint_dir).mkdir(parents=True)
 
   max_train_steps = get_max_train_steps(trainer_config)
-
-  # Create model tokenizer
-  model_tokenizer = AutoTokenizer.from_pretrained(
-      trainer_config.tokenizer_path,
-      token=trainer_config.hf_access_token or None,
-  )
 
   train_dataset, test_dataset = prepare_datasets(trainer_config, model_tokenizer)
 

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -719,14 +719,23 @@ def setup_configs_and_devices(argv: list[str] | None = None, kwargs: dict | None
   return trainer_config, sampler_config, trainer_devices, sampler_devices
 
 
-def create_models_and_meshes(trainer_config, sampler_config, trainer_devices, sampler_devices):
+def create_models_and_meshes(trainer_config, sampler_config, trainer_devices, sampler_devices, tokenizer_pad_id=None):
   """Create reference and actor models and their respective meshes.
   This API is particularly useful for Reinforcement Learning (RL) where we need 2 models (wrapped in TunixMaxTextAdapter
   so that they are compatible with default Tunix APIs) and meshes for reference, actor and rollout (which can be disjoint
   in case of disaggreggated RL training).
+
+  `tokenizer_pad_id`: optional pad token id. When provided, plumbs through to
+  TunixMaxTextAdapter so it can synthesize segment_ids that mask pad positions
+  from attention (otherwise trainer attends to pad tokens, corrupting log-probs).
   """
   max_logging.log("Creating reference model and also meshes for reference and rollout")
-  reference_model, reference_mesh = from_pretrained(trainer_config, devices=trainer_devices, wrap_with_tunix_adapter=True)
+  reference_model, reference_mesh = from_pretrained(
+      trainer_config,
+      devices=trainer_devices,
+      wrap_with_tunix_adapter=True,
+      tokenizer_pad_id=tokenizer_pad_id,
+  )
   devices_array = maxtext_utils.create_device_mesh(sampler_config, sampler_devices)
   rollout_mesh = Mesh(devices_array, sampler_config.mesh_axes)
 
@@ -738,18 +747,33 @@ def create_models_and_meshes(trainer_config, sampler_config, trainer_devices, sa
       # TunixMaxTextAdapter wraps MaxText models to be compatible with Tunix's default APIs
       # The weight mappings for vllm (which is interfaced to from MaxText via Tunix) are model specific.
       # The mappings are defined inside src/maxtext/integration/tunix/weight_mapping
-      actor_model = TunixMaxTextAdapter(base_model=actor_base_model, use_no_op_mappings=use_no_op_mappings)
+      actor_model = TunixMaxTextAdapter(
+          base_model=actor_base_model,
+          use_no_op_mappings=use_no_op_mappings,
+          pad_id=tokenizer_pad_id,
+      )
       actor_model.config = None
     actor_mesh = reference_mesh
   else:
     max_logging.log("Creating policy model with same config as reference model on trainer mesh")
-    actor_model, actor_mesh = from_pretrained(trainer_config, devices=trainer_devices, wrap_with_tunix_adapter=True)
+    actor_model, actor_mesh = from_pretrained(
+        trainer_config,
+        devices=trainer_devices,
+        wrap_with_tunix_adapter=True,
+        tokenizer_pad_id=tokenizer_pad_id,
+    )
 
   return reference_model, reference_mesh, actor_model, actor_mesh, rollout_mesh
 
 
 def from_pretrained(
-    config, mesh=None, devices=None, model_mode=MODEL_MODE_TRAIN, rng_key=None, wrap_with_tunix_adapter=False
+    config,
+    mesh=None,
+    devices=None,
+    model_mode=MODEL_MODE_TRAIN,
+    rng_key=None,
+    wrap_with_tunix_adapter=False,
+    tokenizer_pad_id=None,
 ):
   """Creates a NNX model with sharded parameters, possibly loading from a checkpoint."""
   original_mesh = mesh
@@ -1041,7 +1065,11 @@ def from_pretrained(
     if wrap_with_tunix_adapter:
       with mesh:
         use_no_op_mappings = "maxtext_config" in config.vllm_additional_config
-        model = TunixMaxTextAdapter(base_model=model, use_no_op_mappings=use_no_op_mappings)
+        model = TunixMaxTextAdapter(
+            base_model=model,
+            use_no_op_mappings=use_no_op_mappings,
+            pad_id=tokenizer_pad_id,
+        )
         model.config = None
 
     if original_mesh:

--- a/tests/post_training/unit/tunix_adapter_test.py
+++ b/tests/post_training/unit/tunix_adapter_test.py
@@ -1,0 +1,140 @@
+# Copyright 2023–2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for TunixMaxTextAdapter segment_ids synthesis (CPU-only)."""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+import jax.numpy as jnp
+import numpy as np
+
+from maxtext.integration.tunix import tunix_adapter as tunix_adapter_module
+from maxtext.integration.tunix.tunix_adapter import TunixMaxTextAdapter
+
+
+pytestmark = [pytest.mark.post_training]
+
+
+_STUB_MODEL_NAME = "_stub_model"
+
+
+class _CallableStubBase:
+  """Stub MaxText Transformer that records the kwargs it is called with."""
+
+  def __init__(self):
+    self.config = SimpleNamespace(model_name=_STUB_MODEL_NAME)
+    self.captured = {}
+
+  def __call__(self, *, decoder_input_tokens, decoder_positions, decoder_segment_ids):
+    self.captured["decoder_input_tokens"] = decoder_input_tokens
+    self.captured["decoder_positions"] = decoder_positions
+    self.captured["decoder_segment_ids"] = decoder_segment_ids
+    # Return dummy logits shaped [B, L, V=2] so the adapter has something to forward.
+    b, l = decoder_input_tokens.shape
+    return jnp.zeros((b, l, 2), dtype=jnp.float32)
+
+
+class TunixAdapterSegmentIdsTest(unittest.TestCase):
+  """Verify the pad-id-based segment_ids synthesis path in TunixMaxTextAdapter."""
+
+  def setUp(self):
+    super().setUp()
+    # Stub out VllmWeightMapping and HF_MODEL_CONFIGS so the adapter constructor
+    # can run without standing up a real MaxText model or touching the HF model
+    # registry. Patches are scoped to one test via addCleanup.
+    weight_mapping_patcher = mock.patch.object(tunix_adapter_module, "VllmWeightMapping")
+    weight_mapping_patcher.start()
+    self.addCleanup(weight_mapping_patcher.stop)
+
+    hf_configs_patcher = mock.patch.dict(
+        tunix_adapter_module.HF_MODEL_CONFIGS,
+        {_STUB_MODEL_NAME: SimpleNamespace(to_dict=lambda: {})},
+    )
+    hf_configs_patcher.start()
+    self.addCleanup(hf_configs_patcher.stop)
+
+    self.base = _CallableStubBase()
+
+  @pytest.mark.cpu_only
+  def test_synthesizes_segment_ids_when_pad_id_set_and_seg_ids_none(self):
+    """pad_id is set + caller passes decoder_segment_ids=None -> adapter
+    synthesizes segment_ids = (input_tokens != pad_id)."""
+    pad_id = 99
+    adapter = TunixMaxTextAdapter(base_model=self.base, pad_id=pad_id)
+
+    # Input mixes left-padding and right-padding (mirrors typical RL batch
+    # shape where prompts are left-padded and completions are right-padded).
+    input_tokens = jnp.array([[10, 11, 12, 99, 99], [99, 99, 20, 21, 22]], dtype=jnp.int32)
+    positions = jnp.broadcast_to(jnp.arange(5, dtype=jnp.int32), (2, 5))
+
+    adapter(input_tokens, positions, None, None, decoder_segment_ids=None)
+
+    seg = self.base.captured["decoder_segment_ids"]
+    self.assertIsNotNone(seg, "Adapter should have synthesized segment_ids, not forwarded None.")
+
+    expected = jnp.array([[1, 1, 1, 0, 0], [0, 0, 1, 1, 1]], dtype=jnp.int32)
+    np.testing.assert_array_equal(np.asarray(seg), np.asarray(expected))
+    self.assertEqual(seg.dtype, jnp.int32)
+
+  @pytest.mark.cpu_only
+  def test_does_not_synthesize_when_pad_id_is_none(self):
+    """pad_id omitted -> adapter forwards decoder_segment_ids=None unchanged
+    (backward-compatibility for callers that don't set pad_id)."""
+    adapter = TunixMaxTextAdapter(base_model=self.base, pad_id=None)
+
+    input_tokens = jnp.array([[10, 11, 12, 99, 99]], dtype=jnp.int32)
+    positions = jnp.arange(5, dtype=jnp.int32)[None, :]
+
+    adapter(input_tokens, positions, None, None, decoder_segment_ids=None)
+
+    self.assertIsNone(self.base.captured["decoder_segment_ids"])
+
+  @pytest.mark.cpu_only
+  def test_passes_through_explicit_segment_ids_unchanged(self):
+    """Caller-provided decoder_segment_ids should pass through verbatim
+    regardless of pad_id."""
+    adapter = TunixMaxTextAdapter(base_model=self.base, pad_id=99)
+
+    input_tokens = jnp.array([[10, 11, 12, 99, 99]], dtype=jnp.int32)
+    positions = jnp.arange(5, dtype=jnp.int32)[None, :]
+    explicit_seg = jnp.array([[7, 7, 7, 7, 7]], dtype=jnp.int32)
+
+    adapter(input_tokens, positions, None, None, decoder_segment_ids=explicit_seg)
+
+    np.testing.assert_array_equal(np.asarray(self.base.captured["decoder_segment_ids"]), np.asarray(explicit_seg))
+
+  @pytest.mark.cpu_only
+  def test_returns_logits_and_none_tuple(self):
+    """Adapter's __call__ contract: return (logits, None) to match Tunix's
+    expected interface."""
+    adapter = TunixMaxTextAdapter(base_model=self.base, pad_id=99)
+
+    input_tokens = jnp.array([[10, 11, 12, 99, 99]], dtype=jnp.int32)
+    positions = jnp.arange(5, dtype=jnp.int32)[None, :]
+
+    result = adapter(input_tokens, positions, None, None, decoder_segment_ids=None)
+
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(len(result), 2)
+    logits, second = result
+    self.assertIsNone(second)
+    self.assertEqual(logits.shape, (1, 5, 2))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
When tunix invokes the model with `decoder_segment_ids=None`, MaxText falls back to causal-only attention masking. With left/right-padded batches this silently lets queries at non-pad positions attend to pad-position keys, producing corrupted log-probs in the trainer forward (rollout-side vLLM is fine — its scheduler avoids padded sequences).

Add an optional `pad_id` constructor arg to TunixMaxTextAdapter. When set AND tunix passes `decoder_segment_ids=None`, synthesize per-token segment_ids = (input_tokens != pad_id), so MaxText's segment-based mask blocks attention across pad/non-pad boundaries.

Plumb the tokenizer's pad_token_id through model_creation_utils so the RL training path (train_rl.py) picks it up automatically.

Behavior is opt-in: existing callers that omit `pad_id` see no change.

Empirical impact (Qwen3-1.7B GRPO on GSM8K, GPU recipe LR=2e-6 beta=0.04):
- with this fix:    step-50 vtc_mean_reward 0.5601 -> 0.6970 (+0.137)
- without this fix: step-50 vtc_mean_reward 0.5601 -> 0.5545 (-0.005)
The fix is load-bearing for matching GPU's training trajectory.

## Checklist
- [x] Tested locally on TPU v6e 8×8 with Qwen3-1.7B GSM8K (100 outer steps, multi-seed)
- [x] Verified `max_seq_mult_prob_error` drops from ~200k–1.4M to ~1.02 after fix
- [x] Verified end-to-end RL recipe reproduces GPU reference (mean_reward ~0.81 at step 100)
- [x] Backward compatible: callers that don't pass `pad_id` see no behavior change
- [x] No effect on non-RL paths (only `TunixMaxTextAdapter` integration code touched)
