### PR TITLE
Fix shared expert FLOPs under-count for Gemma4 MoE

### DIFF
--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -40,6 +40,7 @@ from maxtext.kernels.ragged.ragged_sort import ring_ragged_sort
 from maxtext.kernels.ragged.ragged_sort import ring_ragged_unsort
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
+from maxtext.utils import maxtext_utils
 from maxtext.utils.sharding import create_sharding, maybe_shard_with_logical, maybe_shard_with_pspec
 from maxtext.utils.sharding import logical_to_mesh_axes
 import numpy as np
@@ -2405,9 +2406,7 @@ class RoutedAndSharedMoE(nnx.Module):
         rngs=self.rngs,
     )
 
-    shared_expert_mlp_dim = (
-        self.config.mlp_dim if self.config.decoder_block == ctypes.DecoderBlockType.GEMMA4 else self.config.moe_mlp_dim
-    )
+    shared_expert_mlp_dim = maxtext_utils.get_shared_expert_mlp_dim(self.config)
     self.shared_experts = linears.MlpBlock(
         mesh=self.mesh,
         in_features=self.moe_expert_input_dim,

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -681,13 +681,23 @@ def calculate_ffn_mamtul_tflops_per_device(config, mlp_dim, in_dim=None):
   return ffn1_flops + ffn2_flops
 
 
+def get_shared_expert_mlp_dim(config):
+  """Returns the MLP dimension used by the shared expert.
+
+  GEMMA4 shared experts use mlp_dim, while other MoE blocks use moe_mlp_dim. See moe.py.
+  """
+  return config.mlp_dim if config.decoder_block == DecoderBlockType.GEMMA4 else config.moe_mlp_dim
+
+
 def calculate_routed_and_shared_ffn_tflops_per_device(config):
   """Helper function to calculate DeepSeek-style ffn TFLOP"""
   gate_flops = 2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.num_experts
   # Due to the mixed decoder layers, the flops is multiplied by num of layers for both dense and moe
   num_dense_layers, num_moe_layers = get_dense_moe_layers(config)
   dense_ffn_flops = calculate_ffn_mamtul_tflops_per_device(config, config.mlp_dim) * num_dense_layers
-  shared_experts_flops = calculate_ffn_mamtul_tflops_per_device(config, config.moe_mlp_dim) * config.shared_experts
+  shared_experts_flops = (
+      calculate_ffn_mamtul_tflops_per_device(config, get_shared_expert_mlp_dim(config)) * config.shared_experts
+  )
   routed_experts_flops = calculate_ffn_mamtul_tflops_per_device(config, config.moe_mlp_dim) * config.num_experts_per_tok
   moe_ffn_flops = (gate_flops + shared_experts_flops + routed_experts_flops) * num_moe_layers
   total_ffn_flops = dense_ffn_flops + moe_ffn_flops
@@ -1113,7 +1123,9 @@ def calculate_tflops_training_per_device(config, log=True):
           DecoderBlockType.QWEN3_NEXT,
           DecoderBlockType.GEMMA4,
       ):
-        shared_flops = calculate_ffn_mamtul_tflops_per_device(config, config.moe_mlp_dim) * config.shared_experts
+        shared_flops = (
+            calculate_ffn_mamtul_tflops_per_device(config, get_shared_expert_mlp_dim(config)) * config.shared_experts
+        )
         routed_flops = calculate_ffn_mamtul_tflops_per_device(config, config.moe_mlp_dim) * config.num_experts_per_tok
         last_layer_ffn_flops = gate_flops + shared_flops + routed_flops
       else:

--- a/tests/unit/flop_calculation_test.py
+++ b/tests/unit/flop_calculation_test.py
@@ -959,6 +959,12 @@ class FlopCalculation(parameterized.TestCase):
 
   # ========== Parameterized Tests for Multiple Standard Models ==========
 
+  # Published active-param counts (billions). Anchors the reference against
+  # external ground truth so symmetric ref/code bugs don't cancel out silently.
+  PUBLISHED_ACTIVE_PARAMS_B = {
+      "gemma4-26b": 3.82,
+  }
+
   def _verify_flops(self, model_name, max_target_length=1):
     """
     Verifies that for a given sequence length, the total compute matches exactly what we
@@ -981,10 +987,11 @@ class FlopCalculation(parameterized.TestCase):
 
     # 2. Calculate FFN (Feed-Forward Network) parameters
     dense_ffn_params = (config.emb_dim * config.mlp_dim * 2 + config.mlp_dim * config.emb_dim) * num_dense
+    shared_expert_mlp_dim = maxtext_utils.get_shared_expert_mlp_dim(config)
     moe_ffn_params = (
         (config.emb_dim * config.num_experts)  # gate (router module)
         + (
-            (config.emb_dim * config.moe_mlp_dim * 2 + config.moe_mlp_dim * config.emb_dim) * config.shared_experts
+            (config.emb_dim * shared_expert_mlp_dim * 2 + shared_expert_mlp_dim * config.emb_dim) * config.shared_experts
         )  # shared experts
         + (
             (config.emb_dim * config.moe_mlp_dim * 2 + config.moe_mlp_dim * config.emb_dim) * config.num_experts_per_tok
@@ -1104,6 +1111,17 @@ class FlopCalculation(parameterized.TestCase):
 
     # 5% margin for approximations and any edge cases
     self.assertAlmostEqual(tflops, expected_total_flops, delta=max(expected_total_flops * 0.05, 0.001))
+
+    # Anchor active_params against published value (2% tol) when known.
+    expected_active_b = self.PUBLISHED_ACTIVE_PARAMS_B.get(model_name)
+    if expected_active_b is not None:
+      expected_active = expected_active_b * 1e9
+      self.assertAlmostEqual(
+          active_params,
+          expected_active,
+          delta=expected_active * 0.02,
+          msg=f"{model_name}: computed {active_params / 1e9:.3f}B active, expected {expected_active_b:.2f}B",
+      )
 
   def _verify_short_sequence_flops(self, model_name):
     """Verifies short sequence flops."""


### PR DESCRIPTION
# Description

For Gemma4, RoutedAndSharedMoE builds the shared expert at mlp_dim, not moe_mlp_dim. The TFLOP accounting code hard-coded  moe_mlp_dim, under-counting gemma4-26b's shared-expert FLOPs by 3x and pulling reported MFU down ~9%.


# Tests

The unit test had the same bug in its reference computation, so both  sides were wrong by the same factor and the diff cancelled out. 

I fixed both, and anchor the test against a published active-param count (gemma4-26b = 3.82B) so this class of symmetric bug is caught going forward.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
