### PR TITLE
Plumb rl.loss_agg_mode to tunix GrpoConfig

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -54,6 +54,9 @@ rl:
   grpo_epsilon: 0.2
   loss_algo: 'grpo' # grpo or gspo-token
 
+  # Specifies the method for aggregating loss across the batch.
+  loss_agg_mode: 'sequence-mean-token-mean'  # 'token-mean' | 'sequence-mean' | 'sequence-mean-token-mean'
+
   # ====== Agentic Rollout ======
   # If true, uses the async AgenticGRPOLearner, which overlaps rollout generation
   # with training for faster throughput via online vLLM inference.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1963,6 +1963,10 @@ class RL(BaseModel):
   grpo_beta: float = Field(0.08, description="Coefficient for the KL divergence penalty (β).")
   grpo_epsilon: float = Field(0.2, description="Epsilon value for clipping in the GRPO loss.")
   loss_algo: Literal["grpo", "gspo-token"] = Field("grpo", description="Loss algorithm, i.e., 'grpo' or 'gspo-token'.")
+  loss_agg_mode: Literal["token-mean", "sequence-mean", "sequence-mean-token-mean"] = Field(
+      "sequence-mean-token-mean",
+      description="Specifies the method for aggregating loss across the batch.",
+  )
   use_agentic_rollout: bool = Field(
       False,
       description="If True, uses the asynchronous AgenticGRPOLearner for online vLLM rollouts.",

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -571,6 +571,7 @@ def create_rl_components(
         beta=trainer_config.rl.grpo_beta,
         epsilon=trainer_config.rl.grpo_epsilon,
         loss_algo=trainer_config.rl.loss_algo,
+        loss_agg_mode=trainer_config.rl.loss_agg_mode,
     )
     rl_trainer = GrpoLearner(
         rl_cluster=rl_cluster,


### PR DESCRIPTION
tunix's `GrpoConfig` defaults `loss_agg_mode` to `'sequence-mean-token-mean'`, but GPU NeMo-RL stacks use `'token-mean'`. With group-normalized advantages the two modes produce materially different losses (~10× gradient magnitude difference), breaking GPU↔TPU recipe parity when reproducing a GPU recipe on TPU.

This PR exposes the existing tunix knob via the maxtext RL config so users can override on the cmdline: `rl.loss_agg_mode=token-mean`.

Changes:
- New Pydantic field `rl.loss_agg_mode` (Literal: `"token-mean"`, `"sequence-mean"`, `"sequence-mean-token-mean"`)
- Default `'sequence-mean-token-mean'` in `rl.yml` matches tunix's default → backward compatible (no behavior change for users who don't set it)
- Plumbed through to `GrpoConfig(...)` construction in `train_rl.py`

Empirical impact (Qwen3-1.7B GRPO on GSM8K, GPU recipe LR=2e-6 β=0.04, 50 outer steps):
- Without override (default `sequence-mean-token-mean`): grad_norm ~0.5 → underflows, training stalls
- With `rl.loss_agg_mode=token-mean`: grad_norm ~5 → matches GPU stack, training converges normally

## Checklist
- [x] Tested locally on TPU v6e 8×8 with Qwen3-1.7B GSM8K
- [x] Verified token-mean override produces gradient magnitude matching GPU reference
- [x] Backward compatible: default value preserves existing tunix behavior
- [x] No effect on non-RL paths (only RL Pydantic config + GRPO training driver touched)
