### PR TITLE
Qwen3.5 vision layers ckpt conversion and decode

### DIFF
--- a/benchmarks/multimodal/multimodal_eval.py
+++ b/benchmarks/multimodal/multimodal_eval.py
@@ -230,6 +230,7 @@ def main(config, local_args):
             second_per_grids=processor_output.video_second_per_grid,  # pytype: disable=attribute-error
             spatial_merge_size=config.spatial_merge_size_for_vit,  # pytype: disable=attribute-error
             position_id_per_seconds=config.position_id_per_seconds,
+            config=config,
         )
 
     if true_length > max_prefill_predict_length:

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -1042,6 +1042,64 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=Fals
               ): f"model.language_model.layers.{i}.mlp.experts.gate_up_proj",
           }
       )
+
+  # Vision mapping for Qwen3.5
+  if maxtext_config.use_multimodal and "vision_config" in config:
+    vision_config = config["vision_config"]
+    n_vision_layers = vision_config["depth"]
+
+    # Vision patch embedding
+    mapping["params-vision_encoder-Qwen3_5MoeVisionEncoder_0-patch_embed-proj-kernel"] = (
+        "model.visual.patch_embed.proj.weight"
+    )
+    mapping["params-vision_encoder-Qwen3_5MoeVisionEncoder_0-patch_embed-proj-bias"] = (
+        "model.visual.patch_embed.proj.bias"
+    )
+
+    # Vision positional embedding
+    mapping["params-vision_encoder-Qwen3_5MoeVisionEncoder_0-pos_embed_interpolate-pos_embed"] = (
+        "model.visual.pos_embed.weight"
+    )
+
+    # Vision blocks
+    for i in range(n_vision_layers):
+      prefix = f"params-vision_encoder-Qwen3_5MoeVisionEncoder_0-blocks_{i}"
+      hf_prefix = f"model.visual.blocks.{i}"
+
+      # Layer norms
+      mapping[f"{prefix}-ln1-scale"] = f"{hf_prefix}.norm1.weight"
+      mapping[f"{prefix}-ln1-bias"] = f"{hf_prefix}.norm1.bias"
+      mapping[f"{prefix}-ln2-scale"] = f"{hf_prefix}.norm2.weight"
+      mapping[f"{prefix}-ln2-bias"] = f"{hf_prefix}.norm2.bias"
+
+      # Attention
+      mapping[f"{prefix}-attn-attn-query-kernel"] = f"{hf_prefix}.attn.qkv.weight"
+      mapping[f"{prefix}-attn-attn-query-bias"] = f"{hf_prefix}.attn.qkv.bias"
+      mapping[f"{prefix}-attn-attn-key-kernel"] = f"{hf_prefix}.attn.qkv.weight"
+      mapping[f"{prefix}-attn-attn-key-bias"] = f"{hf_prefix}.attn.qkv.bias"
+      mapping[f"{prefix}-attn-attn-value-kernel"] = f"{hf_prefix}.attn.qkv.weight"
+      mapping[f"{prefix}-attn-attn-value-bias"] = f"{hf_prefix}.attn.qkv.bias"
+      mapping[f"{prefix}-attn-attn-out-kernel"] = f"{hf_prefix}.attn.proj.weight"
+      mapping[f"{prefix}-attn-attn-out-bias"] = f"{hf_prefix}.attn.proj.bias"
+
+      # MLP
+      mapping[f"{prefix}-mlp-kernel"] = f"{hf_prefix}.mlp.linear_fc1.weight"
+      mapping[f"{prefix}-mlp-bias"] = f"{hf_prefix}.mlp.linear_fc1.bias"
+      mapping[f"{prefix}-mlp_out-kernel"] = f"{hf_prefix}.mlp.linear_fc2.weight"
+      mapping[f"{prefix}-mlp_out-bias"] = f"{hf_prefix}.mlp.linear_fc2.bias"
+
+    # Vision projector (final merger)
+    mapping["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-ln_q-scale"] = "model.visual.merger.norm.weight"
+    mapping["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-ln_q-bias"] = "model.visual.merger.norm.bias"
+    mapping["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-mlp_0-kernel"] = (
+        "model.visual.merger.linear_fc1.weight"
+    )
+    mapping["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-mlp_0-bias"] = "model.visual.merger.linear_fc1.bias"
+    mapping["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-mlp_2-kernel"] = (
+        "model.visual.merger.linear_fc2.weight"
+    )
+    mapping["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-mlp_2-bias"] = "model.visual.merger.linear_fc2.bias"
+
   return mapping
 
 
@@ -1213,6 +1271,92 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
 
     hooks[(f"{mlp_prefix}-routed_experts-wi_0", f"{mlp_prefix}-routed_experts-wi_1")] = process_wi_0_wi_1
     hooks[f"{mlp_prefix}-routed_experts-wo"] = transpose_expert
+
+  # Vision hooks for Qwen3.5
+  vision_config = config.get("vision_config", None)
+  if vision_config and maxtext_config.use_multimodal:
+    n_vision_layers = vision_config["depth"]
+    hidden_size = vision_config["hidden_size"]
+
+    def reshape_kernel_vision(input_tensor, target_shape):
+      if saving_to_hf:
+        flipped_target_shape = np.flip(np.array(target_shape))
+        return input_tensor.reshape(flipped_target_shape).T
+      else:
+        return input_tensor.T.reshape(target_shape)
+
+    def reshape_conv3d_patch_embed(input_tensor, target_shape):
+      if saving_to_hf:
+        return input_tensor.transpose(4, 3, 0, 1, 2)
+      else:
+        return input_tensor.transpose(2, 3, 4, 1, 0)
+
+    def split_qkv_query(input_tensor, target_shape):
+      if saving_to_hf:
+        raise NotImplementedError("Use fusion hook for MaxText->HF")
+      else:
+        q_weight = input_tensor[:hidden_size, :]
+        return q_weight.T.reshape(target_shape)
+
+    def split_qkv_key(input_tensor, target_shape):
+      if saving_to_hf:
+        raise NotImplementedError("Use fusion hook for MaxText->HF")
+      else:
+        k_weight = input_tensor[hidden_size : 2 * hidden_size, :]
+        return k_weight.T.reshape(target_shape)
+
+    def split_qkv_value(input_tensor, target_shape):
+      if saving_to_hf:
+        raise NotImplementedError("Use fusion hook for MaxText->HF")
+      else:
+        v_weight = input_tensor[2 * hidden_size :, :]
+        return v_weight.T.reshape(target_shape)
+
+    def split_qkv_bias_query(input_tensor, target_shape):
+      if saving_to_hf:
+        raise NotImplementedError("Use fusion hook for MaxText->HF")
+      else:
+        q_bias = input_tensor[:hidden_size]
+        return q_bias.reshape(target_shape)
+
+    def split_qkv_bias_key(input_tensor, target_shape):
+      if saving_to_hf:
+        raise NotImplementedError("Use fusion hook for MaxText->HF")
+      else:
+        k_bias = input_tensor[hidden_size : 2 * hidden_size]
+        return k_bias.reshape(target_shape)
+
+    def split_qkv_bias_value(input_tensor, target_shape):
+      if saving_to_hf:
+        raise NotImplementedError("Use fusion hook for MaxText->HF")
+      else:
+        v_bias = input_tensor[2 * hidden_size :]
+        return v_bias.reshape(target_shape)
+
+    def reshape_vision_attn_out(input_tensor, target_shape):
+      if saving_to_hf:
+        return input_tensor.reshape(hidden_size, hidden_size).T
+      else:
+        return input_tensor.T.reshape(target_shape)
+
+    # Apply vision hooks
+    hooks["params-vision_encoder-Qwen3_5MoeVisionEncoder_0-patch_embed-proj-kernel"] = reshape_conv3d_patch_embed
+
+    for i in range(n_vision_layers):
+      prefix = f"params-vision_encoder-Qwen3_5MoeVisionEncoder_0-blocks_{i}"
+      hooks[f"{prefix}-attn-attn-query-kernel"] = split_qkv_query
+      hooks[f"{prefix}-attn-attn-query-bias"] = split_qkv_bias_query
+      hooks[f"{prefix}-attn-attn-key-kernel"] = split_qkv_key
+      hooks[f"{prefix}-attn-attn-key-bias"] = split_qkv_bias_key
+      hooks[f"{prefix}-attn-attn-value-kernel"] = split_qkv_value
+      hooks[f"{prefix}-attn-attn-value-bias"] = split_qkv_bias_value
+      hooks[f"{prefix}-attn-attn-out-kernel"] = reshape_vision_attn_out
+      hooks[f"{prefix}-mlp-kernel"] = reshape_kernel_vision
+      hooks[f"{prefix}-mlp_out-kernel"] = reshape_kernel_vision
+
+    # Vision projector
+    hooks["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-mlp_0-kernel"] = reshape_kernel_vision
+    hooks["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-mlp_2-kernel"] = reshape_kernel_vision
 
   return hooks
 

--- a/src/maxtext/configs/models/qwen3.5-35b-a3b.yml
+++ b/src/maxtext/configs/models/qwen3.5-35b-a3b.yml
@@ -48,3 +48,23 @@ partial_rotary_factor: 0.25
 
 # General Model Settings
 enable_dropout: False
+
+# Vision Encoder Configuration (need to set use_multimodal=true)
+# Based on Qwen3.5 MoE Vision Model Config
+image_size_for_vit: 768
+hidden_size_for_vit: 1152
+intermediate_size_for_vit: 4304
+num_attention_heads_for_vit: 16
+num_hidden_layers_for_vit: 27
+num_channels_for_vit: 3
+patch_size_for_vit: 16
+temporal_patch_size_for_vit: 2
+spatial_merge_size_for_vit: 2
+out_hidden_size_for_vit: 2048  # Projects to decoder emb_dim (2048)
+num_position_embeddings_for_vit: 2304
+deepstack_visual_indexes_for_vit: []  # No deepstack for Qwen3.5 VL
+rope_theta_for_vit: 10000
+
+# MRoPE Settings (Multi-dimensional RoPE for multimodal)
+use_mrope: true
+mrope_section: [11, 11, 10]

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -262,8 +262,8 @@ ModelName = Literal[
     "qwen3-next-80b-a3b",
     "qwen3-omni-30b-a3b",
     "qwen3-custom-30b-a3b",
-    "qwen3.5-397b-a17b",
     "qwen3.5-35b-a3b",
+    "qwen3.5-397b-a17b",
     "gpt3-175b",
     "gpt3-22b",
     "gpt3-6b",
@@ -2927,6 +2927,7 @@ class MaxTextConfig(
           "llama4-17b-16e",
           "llama4-17b-128e",
           "qwen3-omni-30b-a3b",
+          "qwen3.5-35b-a3b",
           "qwen3.5-397b-a17b",
       )
       if self.model_name not in valid_mm_models and self.model_name != "default":

--- a/src/maxtext/inference/decode.py
+++ b/src/maxtext/inference/decode.py
@@ -154,6 +154,7 @@ def main(argv: Sequence[str]) -> None:
           second_per_grids=processor_outputs.video_second_per_grid,  # pytype: disable=attribute-error
           spatial_merge_size=config.spatial_merge_size_for_vit,  # pytype: disable=attribute-error
           position_id_per_seconds=config.position_id_per_seconds,
+          config=config,
       )
 
   assert (

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -660,6 +660,7 @@ class Decoder(nn.Module):
             "llama4-17b-16e",
             "llama4-17b-128e",
             "qwen3-omni-30b-a3b",
+            "qwen3.5-35b-a3b",
             "qwen3.5-397b-a17b",
         ]:
           y = mm_utils.merge_mm_embeddings(
@@ -673,7 +674,7 @@ class Decoder(nn.Module):
           raise ValueError(f"Unsupported model_name for multimodal: {cfg.model_name}")
 
       if video_embeddings is not None and cfg.use_multimodal:
-        if cfg.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
+        if cfg.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
           y = mm_utils.merge_mm_embeddings(
               text_embeddings=y,
               multimodal_embeddings=video_embeddings,

--- a/src/maxtext/layers/encoders.py
+++ b/src/maxtext/layers/encoders.py
@@ -70,7 +70,7 @@ class VisionEncoder(nnx.Module):
           self, projector_name, gemma4_vision.Gemma4VisionProjector(config=self.config, mesh=self.mesh, rngs=self.rngs)
       )
       return encoder_name, projector_name
-    elif self.config.model_name in ["qwen3.5-397b-a17b"]:
+    elif self.config.model_name in ["qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
       from maxtext.models import qwen3_5_vision  # pylint: disable=import-outside-toplevel
 
       encoder_name = "Qwen3_5MoeVisionEncoder_0"

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -734,6 +734,8 @@ class Qwen3NextFullAttention(nnx.Module):
         use_qk_norm=cfg.use_qk_norm,
         query_pre_attn_scalar=scaling_factor,
         model_mode=model_mode,
+        use_mrope=cfg.use_mrope,
+        mrope_section=cfg.mrope_section,
         rngs=rngs,
     )
 

--- a/src/maxtext/multimodal/processor.py
+++ b/src/maxtext/multimodal/processor.py
@@ -44,7 +44,7 @@ def preprocess_mm_data(config):
 
     images = [mm_utils.load_image_from_path(p) for p in config.image_path.split(",")]
     processor_outputs = preprocess_mm_data_llama4(images)
-  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
+  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
     from maxtext.multimodal.processor_qwen3_omni import preprocess_mm_data_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     processor_outputs = preprocess_mm_data_qwen3_omni(config)
@@ -68,7 +68,7 @@ def preprocess_image_for_training(image, model_name):
     from maxtext.multimodal.processor_llama4 import preprocess_mm_data_llama4  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_llama4(image)
-  elif model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
+  elif model_name in ["qwen3-omni-30b-a3b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
     from maxtext.multimodal.processor_qwen3_omni import preprocess_mm_data_qwen3_omni_for_training  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_qwen3_omni_for_training(image)
@@ -90,7 +90,7 @@ def get_image_offsets(config, processor_output: mm_utils.PreprocessorOutput | No
     from maxtext.multimodal.processor_llama4 import get_image_offsets_llama4  # pylint: disable=import-outside-toplevel
 
     return get_image_offsets_llama4(processor_output)
-  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
+  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
     from maxtext.multimodal.processor_qwen3_omni import get_mm_offsets_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     return get_mm_offsets_qwen3_omni(config, processor_output)
@@ -112,7 +112,7 @@ def reformat_prompt(prompt, image_placeholder, model_name, num_images, video_pla
     from maxtext.multimodal.processor_llama4 import reformat_prompt_llama4  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_llama4(prompt, image_placeholder, num_images)
-  elif model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
+  elif model_name in ["qwen3-omni-30b-a3b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
     from maxtext.multimodal.processor_qwen3_omni import reformat_prompt_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     return reformat_prompt_qwen3_omni(
@@ -137,7 +137,7 @@ def reformat_response(response, model_name):
   elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
     formatted_response = f"{response}<end_of_turn>"
     return formatted_response
-  elif model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
+  elif model_name in ["qwen3-omni-30b-a3b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
     formatted_response = f"{response}<|im_end|>"
     return formatted_response
   else:
@@ -158,7 +158,7 @@ def prepare_text_for_image_fusion(tokens, config, processor_output=None):
     from maxtext.multimodal.processor_llama4 import add_extra_tokens_for_images_llama4  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_images_llama4(tokens, processor_output)
-  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
+  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
     from maxtext.multimodal.processor_qwen3_omni import add_extra_tokens_for_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     return add_extra_tokens_for_qwen3_omni(tokens, config, processor_output)
@@ -181,7 +181,7 @@ def get_dummy_image_shape_for_init(model_name, batch_size=1, num_image_per_seque
     from maxtext.multimodal.processor_llama4 import get_dummy_image_shape_for_init_llama4  # pylint: disable=import-outside-toplevel
 
     image_shape = get_dummy_image_shape_for_init_llama4(batch_size, num_image_per_sequence)
-  elif model_name.startswith("qwen3-omni-30b-a3b") or model_name.startswith("qwen3.5-397b-a17b"):
+  elif model_name.startswith("qwen3-omni-30b-a3b") or model_name.startswith("qwen3.5"):
     from maxtext.multimodal.processor_qwen3_omni import get_dummy_image_shape_for_init_qwen3_omni  # pylint: disable=import-outside-toplevel
 
     image_shape = get_dummy_image_shape_for_init_qwen3_omni(batch_size)
@@ -222,13 +222,15 @@ def get_bidirectional_mask_vision(config, decoder_input_tokens, is_video: bool =
     from maxtext.multimodal.processor_llama4 import LLAMA4_PATCH_TOKEN  # pylint: disable=import-outside-toplevel
 
     bidirectional_mask_vision = decoder_input_tokens == LLAMA4_PATCH_TOKEN
-  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-397b-a17b"]:
-    from maxtext.multimodal.processor_qwen3_omni import QWEN3_OMNI_IMAGE_TOKEN, QWEN3_OMNI_VIDEO_TOKEN  # pylint: disable=import-outside-toplevel
+  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
+    from maxtext.multimodal.processor_qwen3_omni import QwenTokens  # pylint: disable=import-outside-toplevel
+
+    tokens = QwenTokens(config)
 
     if is_video:
-      bidirectional_mask_vision = decoder_input_tokens == QWEN3_OMNI_VIDEO_TOKEN
+      bidirectional_mask_vision = decoder_input_tokens == tokens.video_pad
     else:
-      bidirectional_mask_vision = decoder_input_tokens == QWEN3_OMNI_IMAGE_TOKEN
+      bidirectional_mask_vision = decoder_input_tokens == tokens.image_pad
   return bidirectional_mask_vision
 
 
@@ -236,8 +238,10 @@ def get_bidirectional_mask_audio(config, decoder_input_tokens):
   """Get the bidirectional mask for specific models."""
   bidirectional_mask_audio = None
   if config.model_name in ["qwen3-omni-30b-a3b"]:
-    from maxtext.multimodal.processor_qwen3_omni import QWEN3_OMNI_AUDIO_TOKEN  # pylint: disable=import-outside-toplevel
+    from maxtext.multimodal.processor_qwen3_omni import QwenTokens  # pylint: disable=import-outside-toplevel
+
+    tokens = QwenTokens(config)
 
     # Create bidirectional_mask for audio token merging
-    bidirectional_mask_audio = decoder_input_tokens == QWEN3_OMNI_AUDIO_TOKEN
+    bidirectional_mask_audio = decoder_input_tokens == tokens.audio_pad
   return bidirectional_mask_audio

--- a/src/maxtext/multimodal/processor_qwen3_omni.py
+++ b/src/maxtext/multimodal/processor_qwen3_omni.py
@@ -57,16 +57,59 @@ N_FFT = 400  # Number of FFT points for spectrogram computation.
 HOP_LENGTH = 160  # Number of samples between successive frames.
 DITHER = 0.0  # Amount of dithering to apply to audio signal.
 
-# Qwen3OmniMoe-specific processing
-QWEN3_OMNI_VISION_START_TOKEN = 151652  # <|vision_start|>
-QWEN3_OMNI_VISION_END_TOKEN = 151653  # <|vision_end|>
-QWEN3_OMNI_IMAGE_TOKEN = 151655  # <|image_pad|>
-QWEN3_OMNI_VIDEO_TOKEN = 151656  # <|video_pad|>
-QWEN3_OMNI_AUDIO_START_TOKEN = 151669  # <|audio_start|>
-QWEN3_OMNI_AUDIO_END_TOKEN = 151670  # <|audio_end|>
-QWEN3_OMNI_AUDIO_TOKEN = 151675  # <|audio_pad|>
 QWEN3_TEMPORAL_PATCH_SIZE = 2
 QWEN3_OMNI_IMAGE_SIZE = 768
+
+
+QWEN_SPECIAL_TOKEN_CONFIGS = {
+    "qwen3-omni-30b-a3b": {
+        "vision_start": 151652,  # <|vision_start|>
+        "vision_end": 151653,  # <|vision_end|>
+        "image_pad": 151655,  # <|image_pad|>
+        "video_pad": 151656,  # <|video_pad|>
+        "audio_start": 151669,  # <|audio_start|>
+        "audio_end": 151670,  # <|audio_end|>
+        "audio_pad": 151675,  # <|audio_pad|>
+    },
+    "qwen3.5": {
+        "vision_start": 248053,  # <|vision_start|>
+        "vision_end": 248054,  # <|vision_end|>
+        "image_pad": 248056,  # <|image_pad|>
+        "video_pad": 248057,  # <|video_pad|>
+        "audio_start": 248070,  # <|audio_start|>
+        "audio_end": 248071,  # <|audio_end|>
+        "audio_pad": 248076,  # <|audio_pad|>
+    },
+}
+
+
+class QwenTokens:
+  """Helper class to manage special token IDs for Qwen models.
+
+  Token attributes are set dynamically from QWEN_SPECIAL_TOKEN_CONFIGS, so adding a new
+  token type only requires updating that dict — no changes here needed.
+  """
+
+  _DEFAULT_MODEL = "qwen3-omni-30b-a3b"
+
+  vision_start: int | None = None
+  vision_end: int | None = None
+  image_pad: int | None = None
+  video_pad: int | None = None
+  audio_start: int | None = None
+  audio_end: int | None = None
+  audio_pad: int | None = None
+
+  def __init__(self, config=None):
+    # If config is None, will fall back to default Qwen3-Omni tokens.
+    self.model_name = getattr(config, "model_name", None) or self._DEFAULT_MODEL
+    # Match by prefix (e.g. "qwen3.5" covers qwen3.5 family), fall back to default.
+    token_config = next(
+        (v for k, v in QWEN_SPECIAL_TOKEN_CONFIGS.items() if self.model_name.startswith(k)),
+        QWEN_SPECIAL_TOKEN_CONFIGS[self._DEFAULT_MODEL],
+    )
+    # Sets model-specific token attributes from QWEN_SPECIAL_TOKEN_CONFIGS above.
+    self.__dict__.update(token_config)
 
 
 @dataclass
@@ -600,6 +643,9 @@ def add_extra_tokens_for_qwen3_omni(tokens, config, processor_output):
 
   tokens = tokens.flatten()  # Ensure 1D
 
+  # Get dynamic tokens based on config
+  qwen_tokens = QwenTokens(config)
+
   # Merge lengths for computing number of tokens
   merge_length = spatial_merge_size**2
 
@@ -616,19 +662,19 @@ def add_extra_tokens_for_qwen3_omni(tokens, config, processor_output):
     token = token_list[i]
 
     # Handle image tokens
-    if token == QWEN3_OMNI_IMAGE_TOKEN and image_grid_thw is not None and image_idx < len(image_grid_thw):
+    if token == qwen_tokens.image_pad and image_grid_thw is not None and image_idx < len(image_grid_thw):
       grid = image_grid_thw[image_idx]
       num_image_tokens = int((grid[0] * grid[1] * grid[2]) // merge_length)
-      new_tokens.extend([QWEN3_OMNI_IMAGE_TOKEN] * num_image_tokens)
+      new_tokens.extend([qwen_tokens.image_pad] * num_image_tokens)
       image_idx += 1
 
     # Handle audio-in-video: <|vision_start|><|video_pad|><|vision_end|>
     elif (
         config.use_audio_in_video
-        and token == QWEN3_OMNI_VISION_START_TOKEN
+        and token == qwen_tokens.vision_start
         and i + 2 < len(token_list)
-        and token_list[i + 1] == QWEN3_OMNI_VIDEO_TOKEN
-        and token_list[i + 2] == QWEN3_OMNI_VISION_END_TOKEN
+        and token_list[i + 1] == qwen_tokens.video_pad
+        and token_list[i + 2] == qwen_tokens.vision_end
         and video_grid_thw is not None
         and video_idx < len(video_grid_thw)
     ):
@@ -650,46 +696,46 @@ def add_extra_tokens_for_qwen3_omni(tokens, config, processor_output):
       video_token_indices = np.broadcast_to(video_token_indices, (num_frames, height, width)).flatten()
       video_token_indices = video_token_indices * second_per_grids[video_idx] * position_id_per_seconds
 
-      new_tokens.append(QWEN3_OMNI_VISION_START_TOKEN)
-      new_tokens.append(QWEN3_OMNI_AUDIO_START_TOKEN)
+      new_tokens.append(qwen_tokens.vision_start)
+      new_tokens.append(qwen_tokens.audio_start)
 
       video_data_idx = 0
       audio_data_idx = 0
 
       while video_data_idx < len(video_token_indices) and audio_data_idx < len(audio_token_indices):
         if video_token_indices[video_data_idx] <= audio_token_indices[audio_data_idx]:
-          new_tokens.append(QWEN3_OMNI_VIDEO_TOKEN)
+          new_tokens.append(qwen_tokens.video_pad)
           video_data_idx += 1
         else:
-          new_tokens.append(QWEN3_OMNI_AUDIO_TOKEN)
+          new_tokens.append(qwen_tokens.audio_pad)
           audio_data_idx += 1
 
       while video_data_idx < len(video_token_indices):
-        new_tokens.append(QWEN3_OMNI_VIDEO_TOKEN)
+        new_tokens.append(qwen_tokens.video_pad)
         video_data_idx += 1
 
       while audio_data_idx < len(audio_token_indices):
-        new_tokens.append(QWEN3_OMNI_AUDIO_TOKEN)
+        new_tokens.append(qwen_tokens.audio_pad)
         audio_data_idx += 1
 
-      new_tokens.append(QWEN3_OMNI_AUDIO_END_TOKEN)
-      new_tokens.append(QWEN3_OMNI_VISION_END_TOKEN)
+      new_tokens.append(qwen_tokens.audio_pad)
+      new_tokens.append(qwen_tokens.vision_end)
 
       video_idx += 1
       audio_idx += 1
       i += 2
 
     # Handle video tokens (without audio-in-video)
-    elif token == QWEN3_OMNI_VIDEO_TOKEN and video_grid_thw is not None and video_idx < len(video_grid_thw):
+    elif token == qwen_tokens.video_pad and video_grid_thw is not None and video_idx < len(video_grid_thw):
       grid = video_grid_thw[video_idx]
       num_video_tokens = int((grid[0] * grid[1] * grid[2]) // merge_length)
-      new_tokens.extend([QWEN3_OMNI_VIDEO_TOKEN] * num_video_tokens)
+      new_tokens.extend([qwen_tokens.video_pad] * num_video_tokens)
       video_idx += 1
 
     # Handle audio tokens (standalone, not in video)
-    elif token == QWEN3_OMNI_AUDIO_TOKEN and audio_lengths is not None and audio_idx < len(audio_lengths):
+    elif token == qwen_tokens.audio_pad and audio_lengths is not None and audio_idx < len(audio_lengths):
       num_audio_tokens = int(audio_lengths[audio_idx])
-      new_tokens.extend([QWEN3_OMNI_AUDIO_TOKEN] * num_audio_tokens)
+      new_tokens.extend([qwen_tokens.audio_pad] * num_audio_tokens)
       audio_idx += 1
 
     # All other tokens pass through unchanged
@@ -858,6 +904,7 @@ def get_rope_index(
     second_per_grids: np.ndarray | None = None,
     spatial_merge_size: int = 2,
     position_id_per_seconds: int = 25,
+    config=None,  # None defaults to Qwen3-Omni special tokens
 ) -> tuple[np.ndarray, np.ndarray]:
   """Calculate 3D RoPE position indices for multimodal sequences.
 
@@ -895,6 +942,7 @@ def get_rope_index(
   Raises:
     ValueError: If multimodal tokens are present but grid info is missing.
   """
+  qwen_tokens = QwenTokens(config)
   batch_size, seq_len = input_ids.shape
 
   # Handle text-only case (no multimodal content)
@@ -929,16 +977,16 @@ def get_rope_index(
     valid_input_ids = input_ids[i][attention_mask_bool[i]]
 
     # Count multimodal elements in this sequence
-    vision_start_indices = np.where(valid_input_ids == QWEN3_OMNI_VISION_START_TOKEN)[0]
+    vision_start_indices = np.where(valid_input_ids == qwen_tokens.vision_start)[0]
     vision_tokens = valid_input_ids[vision_start_indices + 1] if len(vision_start_indices) > 0 else np.array([])
 
-    audio_nums = np.sum(valid_input_ids == QWEN3_OMNI_AUDIO_START_TOKEN).item()
-    image_nums = np.sum(vision_tokens == QWEN3_OMNI_IMAGE_TOKEN).item() if len(vision_tokens) > 0 else 0
+    audio_nums = np.sum(valid_input_ids == qwen_tokens.audio_start).item()
+    image_nums = np.sum(vision_tokens == qwen_tokens.image_pad).item() if len(vision_tokens) > 0 else 0
     video_nums = (
         (
-            np.sum(vision_tokens == QWEN3_OMNI_AUDIO_START_TOKEN).item()
+            np.sum(vision_tokens == qwen_tokens.audio_start).item()
             if use_audio_in_video
-            else np.sum(vision_tokens == QWEN3_OMNI_VIDEO_TOKEN).item()
+            else np.sum(vision_tokens == qwen_tokens.video_pad).item()
         )
         if len(vision_tokens) > 0
         else 0
@@ -961,19 +1009,19 @@ def get_rope_index(
       st_idx = llm_pos_ids_list[-1].max().item() + 1 if len(llm_pos_ids_list) > 0 else 0
 
       # Find next vision or audio start token
-      if (QWEN3_OMNI_IMAGE_TOKEN in input_tokens or QWEN3_OMNI_VIDEO_TOKEN in input_tokens) and (
+      if (qwen_tokens.image_pad in input_tokens or qwen_tokens.video_pad in input_tokens) and (
           remain_videos > 0 or remain_images > 0
       ):
         try:
-          ed_vision_start = input_tokens.index(QWEN3_OMNI_VISION_START_TOKEN, st)
+          ed_vision_start = input_tokens.index(qwen_tokens.vision_start, st)
         except ValueError:
           ed_vision_start = len(input_tokens) + 1
       else:
         ed_vision_start = len(input_tokens) + 1
 
-      if QWEN3_OMNI_AUDIO_TOKEN in input_tokens and remain_audios > 0:
+      if qwen_tokens.audio_pad in input_tokens and remain_audios > 0:
         try:
-          ed_audio_start = input_tokens.index(QWEN3_OMNI_AUDIO_START_TOKEN, st)
+          ed_audio_start = input_tokens.index(qwen_tokens.audio_start, st)
         except ValueError:
           ed_audio_start = len(input_tokens) + 1
       else:
@@ -1011,7 +1059,7 @@ def get_rope_index(
         remain_audios -= 1
 
       # Image Only
-      elif min_ed == ed_vision_start and input_tokens[ed_vision_start + 1] == QWEN3_OMNI_IMAGE_TOKEN:
+      elif min_ed == ed_vision_start and input_tokens[ed_vision_start + 1] == qwen_tokens.image_pad:
         grid_t = image_grid_thw[image_idx, 0].item()
         grid_hs = image_grid_thw[:, 1]
         grid_ws = image_grid_thw[:, 2]
@@ -1026,7 +1074,7 @@ def get_rope_index(
         remain_images -= 1
 
       # Video Only
-      elif min_ed == ed_vision_start and input_tokens[ed_vision_start + 1] == QWEN3_OMNI_VIDEO_TOKEN:
+      elif min_ed == ed_vision_start and input_tokens[ed_vision_start + 1] == qwen_tokens.video_pad:
         grid_t = video_grid_thw[video_idx, 0].item()
         grid_hs = video_grid_thw[:, 1]
         grid_ws = video_grid_thw[:, 2]


### PR DESCRIPTION
# Description

This PR supports Qwen3.5-35B model's vision tower checkpoint conversion and enables decode. The JAX layers have been implemented in #3962 , mostly inherited from Qwen3-Omni. The deltas in this PR:

1. Added vision configs for `qwen3.5-25b-a3b.yml`.
2. Added vision tower parameter mapping for Qwen3.5 in `param_mapping.py` for weights conversion.
3. Register `qwen3.5-25b-a3b` throughout the multimodal workflow.
4. Reuse Qwen3-Omni preprocessing utils since they are almost identical.
5. **Important Updates**: Introduce `QwenTokens`, since Qwen3.5 changed the token_ids for some special multimodal tokens. `QwenTokens` will default to Qwen3-Omni so it doesn't impact existing flows. 

# Tests

Checkpoint conversion:
```
# Command:
export JAX_PLATFORMS=cpu
python -m maxtext.checkpoint_conversion.to_maxtext src/maxtext/configs/base.yml model_name=qwen3.5-35b-a3b base_output_directory=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3.5-35b-a3b/unscanned/2026-06-01-15-15 use_multimodal=true scan_layers=false hf_access_token=<your_token>
```

Multimodal decode:
```
# Command
python -m maxtext.inference.decode maxtext/configs/base.yml model_name=qwen3.5-35b-a3b tokenizer_path=Qwen/Qwen3.5-35B-A3B tokenizer_type=huggingface load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3.5-35b-a3b/unscanned/2026-06-01-15-15/0/items per_device_batch_size=1 run_name=ht_test_decode_full steps=1 async_checkpointing=false scan_layers=false use_multimodal=true prompt=\'Describe\ this\ image\ in\ one\ sentence.\' image_path=\'tests/assets/test_image.jpg\' max_prefill_predict_length=512 max_target_length=542 attention=\'dot_product\' hf_access_token=<your_token> add_bos=False

# Result
Input `<|im_start|>user
<|vision_start|><|image_pad|><|vision_end|>Describe this image in one sentence.<|im_end|>
<|im_start|>assistant
` -> `<think>

</think>

This vibrant cityscape showcases Seattle’s iconic skyline under a bright blue sky, with the Space Needle standing tall among modern skyscrapers,`
```

```
python -m maxtext.inference.decode maxtext/configs/base.yml model_name=qwen3.5-35b-a3b tokenizer_path=Qwen/Qwen3.5-35B-A3B tokenizer_type=huggingface load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3.5-35b-a3b/unscanned/2026-06-01-15-15/0/items per_device_batch_size=1 run_name=ht_test_decode_full steps=1 async_checkpointing=false scan_layers=false use_multimodal=true prompt=\'Describe\ this\ video\ in\ one\ sentence.\' video_path=\'tests/assets/video_image.jpg\' max_prefill_predict_length=1250 max_target_length=1280 attention=\'dot_product\' hf_access_token=<your_token> add_bos=False


Input `<|im_start|>user
<|vision_start|><|video_pad|><|vision_end|>Describe this video in one sentence.<|im_end|>
<|im_start|>assistant
` -> `<think>

</think>

This video features a surreal, animated Tyrannosaurus Rex with multiple heads—each roaring independently—emerging from lush green foliage in`
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
