### PR TITLE
Fix TrainDistillTest failure by removing obsolete OfflineArrayRecordIterator mock

### DIFF
--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -1047,7 +1047,6 @@ class TrainDistillTest(unittest.TestCase):
     if hasattr(trainer2.checkpoint_manager, "wait_until_finished"):
       trainer2.checkpoint_manager.wait_until_finished()
 
-  @mock.patch("maxtext.trainers.post_train.distillation.train_distill.distillation_utils.OfflineArrayRecordIterator")
   @mock.patch("maxtext.trainers.post_train.distillation.train_distill.MaxTextDistillationTrainer")
   @mock.patch("maxtext.trainers.post_train.distillation.train_distill.input_pipeline_interface.create_data_iterator")
   @mock.patch("maxtext.trainers.post_train.distillation.train_distill.get_maxtext_model")
@@ -1062,7 +1061,6 @@ class TrainDistillTest(unittest.TestCase):
       mock_get_model,
       mock_create_iterator,
       mock_trainer_cls,
-      mock_offline_iter_cls,
   ):
     """Verifies offline mode (offline_data_dir is set) skips teacher model loading."""
     # 1. Configs


### PR DESCRIPTION
# Description

Remove the outdated mock of `distillation_utils.OfflineArrayRecordIterator` in `test_main_offline_mode_skips_teacher_loading`.

In commit 73293704ef336eea91c780ff73f4864213de5674, offline distillation was refactored to use MaxText's standard input pipeline (Grain) instead of the custom array record reader. This removed `OfflineArrayRecordIterator` from `distillation_utils.py`. However, the mock in `train_distill_test.py` was left in place, resulting in `AttributeError` failures during test setup. Removing the obsolete mock restores the test suite to a passing state.

FIXES: b/518933738

# Tests

CI tests passing now

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
