### PR TITLE
Add MoE router similarity and expert fraction distillation metrics

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1324,6 +1324,10 @@ class Distillation(BaseModel):
   distill_beta_schedule: Literal["constant", "linear", "cosine"] = Field(
       "constant", description="Schedule type for beta annealing ('constant', 'linear', or 'cosine')."
   )
+  record_router_similarity_metrics: bool = Field(
+      False,
+      description="If True, computes and logs per-layer router selection similarity metrics between student and teacher.",
+  )
 
   # --- Learn to init related parameters --
   learn_to_init_mode: bool = Field(False, description="Runs in the learn-to-init mode only")

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -2298,6 +2298,10 @@ class RoutedMoE(nnx.Module):
     routing_inputs = inputs if gate_inputs is None else gate_inputs.astype(gate_dtype)
     gate_logits, pre_bias_logits = self.gate(routing_inputs)
 
+    if getattr(self.config, "record_router_similarity_metrics", False):
+      _, top_k_indices = self.get_topk(gate_logits, pre_bias_logits, self.rngs)
+      self.router_selections = nnx.Intermediate(top_k_indices)
+
     wo_kernel = jnp.asarray(self.wo[...], self.dtype)
 
     fused_kernel = None

--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -54,6 +54,8 @@ class DistillationForwardOutput:
   moe_lb_loss: jax.Array | None = None
   #: top-k indices for sparse offline distillation
   top_k_indices: jax.Array | None = None
+  #: router selections
+  router_selections: jax.Array | None = None
 
 
 @flax.struct.dataclass(frozen=True)
@@ -340,6 +342,8 @@ class CombinedDistillationStrategy(DistillationStrategy):
       beta_end: float | None = None,
       beta_schedule: Literal["constant", "linear", "cosine"] = "constant",
       max_steps: int = 1,
+      num_experts: int = 1,
+      record_router_similarity_metrics: bool = False,
   ):
     """Initializes the Combined distillation strategy.
 
@@ -364,6 +368,8 @@ class CombinedDistillationStrategy(DistillationStrategy):
         beta_end: Target beta_feature value at end of training. None keeps beta fixed.
         beta_schedule: Schedule type for beta annealing.
         max_steps: Total training steps, used for schedule computation.
+        num_experts: Number of experts in the model (used for distribution tracking).
+        record_router_similarity_metrics: Whether to record router similarity metrics per layer.
     """
 
     super().__init__(
@@ -377,6 +383,8 @@ class CombinedDistillationStrategy(DistillationStrategy):
     self.alpha = alpha
     self.beta_feature = beta_feature
     self.layer_indices = jnp.array(layer_indices) if layer_indices is not None else None
+    self.num_experts = num_experts
+    self.record_router_similarity_metrics = record_router_similarity_metrics
 
     # Schedule parameters
     self.alpha_end = alpha_end
@@ -459,6 +467,72 @@ class CombinedDistillationStrategy(DistillationStrategy):
     )
     beta_feature = compute_schedule(step, self.max_steps, self.beta_feature, self.beta_end, self.beta_schedule)
     return alpha, temperature, beta_feature
+
+  def _record_router_similarity_metrics(
+      self,
+      student_output: DistillationForwardOutput,
+      teacher_output: Optional[DistillationForwardOutput],
+      mask: jax.Array,
+      metrics: dict[str, tuple[jax.Array, jax.Array]],
+      prefix: str,
+      use_sharding_constraints: bool = False,
+  ):
+    """Helper to record router similarity metrics per layer (shape [L, B, T, K])."""
+    if not (
+        self.record_router_similarity_metrics
+        and self.num_experts > 1
+        and teacher_output is not None
+        and student_output.router_selections is not None
+        and teacher_output.router_selections is not None
+    ):
+      return
+
+    s_top1 = student_output.router_selections[..., 0]
+    t_top1 = teacher_output.router_selections[..., 0]
+    top1_match = (s_top1 == t_top1).astype(jnp.float32)
+
+    s_expanded = jnp.expand_dims(student_output.router_selections, axis=-1)
+    t_expanded = jnp.expand_dims(teacher_output.router_selections, axis=-2)
+    matches = s_expanded == t_expanded
+    overlap_counts = jnp.sum(jnp.any(matches, axis=-1), axis=-1).astype(jnp.float32)
+    k_val = student_output.router_selections.shape[-1]
+
+    num_layers = student_output.router_selections.shape[0]
+
+    for layer_idx in range(num_layers):
+      layer_top1_match = top1_match[layer_idx]
+      layer_overlap_counts = overlap_counts[layer_idx]
+      layer_mask = mask
+
+      metrics[f"{prefix}/layer_{layer_idx}_router_similarity_top1"] = (
+          jnp.sum(layer_top1_match * layer_mask),
+          jnp.sum(layer_mask),
+      )
+
+      metrics[f"{prefix}/layer_{layer_idx}_router_similarity_top{k_val}"] = (
+          jnp.sum((layer_overlap_counts / k_val) * layer_mask),
+          jnp.sum(layer_mask),
+      )
+
+  def _record_expert_fractions(
+      self,
+      router_selections: jax.Array,
+      mask: jax.Array,
+      metrics: dict[str, tuple[jax.Array, jax.Array]],
+      prefix: str,
+  ):
+    """Helper to record expert selection fractions across all layers (shape [L, B, T, K])."""
+    L, B, T, K = router_selections.shape
+
+    flat_mask = jnp.broadcast_to(mask[None, :, :, None], (L, B, T, K))
+
+    one_hot = jax.nn.one_hot(router_selections, num_classes=self.num_experts)
+
+    total_tokens_per_expert = jnp.sum(one_hot * flat_mask[..., None], axis=(0, 1, 2, 3))
+    total_valid_tokens = jnp.sum(flat_mask)
+
+    for i in range(self.num_experts):
+      metrics[f"{prefix}_expert_{i}_fraction"] = (total_tokens_per_expert[i], total_valid_tokens)
 
   def compute_loss(
       self,
@@ -602,12 +676,24 @@ class CombinedDistillationStrategy(DistillationStrategy):
         METRIC_ALPHA: (alpha, one),
         METRIC_BETA_FEATURE: (beta_feature, one),
     }
+
+    if self.num_experts > 1:
+      if student_output.router_selections is not None:
+        self._record_expert_fractions(student_output.router_selections, mask, metrics, prefix="distill/student")
+      if teacher_output.router_selections is not None:
+        self._record_expert_fractions(teacher_output.router_selections, mask, metrics, prefix="distill/teacher")
+
+      self._record_router_similarity_metrics(
+          student_output, teacher_output, mask, metrics, prefix="distill", use_sharding_constraints=True
+      )
+
     return total_loss, metrics
 
   def compute_eval_loss(
       self,
       student_output: DistillationForwardOutput,
       labels: jax.Array,
+      teacher_output: Optional["DistillationForwardOutput"] = None,
   ) -> tuple[jax.Array, dict[str, tuple[jax.Array, jax.Array]]]:
     """Computes Eval Loss. Returns (loss, metrics) with (sum, count) metric pairs."""
     s_logits = student_output.logits.astype(jnp.float32)
@@ -622,8 +708,17 @@ class CombinedDistillationStrategy(DistillationStrategy):
 
     metrics = {
         "eval/hard_loss": (ce_sum, valid_count),
-        "eval/student_perplexity": (jnp.exp(jnp.minimum(task_loss, _PPL_CE_CAP)), jnp.array(1.0, dtype=jnp.float32)),
+        "eval/student_perplexity": (
+            jnp.exp(jnp.minimum(task_loss, _PPL_CE_CAP)),
+            jnp.array(1.0, dtype=jnp.float32),
+        ),
     }
+
+    if self.num_experts > 1:
+      self._record_router_similarity_metrics(
+          student_output, teacher_output, mask, metrics, prefix="eval", use_sharding_constraints=False
+      )
+
     return task_loss, metrics
 
   def create_labels(self, targets, targets_segmentation=None, **kwargs):

--- a/src/maxtext/trainers/post_train/distillation/train_distill.py
+++ b/src/maxtext/trainers/post_train/distillation/train_distill.py
@@ -156,14 +156,22 @@ def create_forward_fn(config: pyconfig.HyperParameters) -> Callable[..., distill
       out_projection_activations = maxtext_utils.get_intermediate_value(model, "out_projection_activations", clear=True)
 
     moe_lb_loss = None
-    if config.num_experts > 1 and config.load_balance_loss_weight > 0.0:
+    router_selections = None
+    if config.num_experts > 1:
       intermediate_outputs = nnx.pop(model, nnx.Intermediate)
-      total_moe_lb_losses = maxtext_utils.collect_intermediates_by_suffix(intermediate_outputs, "moe_lb_loss")
-      if total_moe_lb_losses:
-        moe_lb_loss = jnp.mean(jnp.concatenate(total_moe_lb_losses))
+      if config.load_balance_loss_weight > 0.0:
+        total_moe_lb_losses = maxtext_utils.collect_intermediates_by_suffix(intermediate_outputs, "moe_lb_loss")
+        if total_moe_lb_losses:
+          moe_lb_loss = jnp.mean(jnp.concatenate(total_moe_lb_losses))
+      selections = maxtext_utils.collect_intermediates_by_suffix(intermediate_outputs, "router_selections")
+      if selections:
+        router_selections = jnp.stack(selections)
 
     retval = distillation_utils.DistillationForwardOutput(
-        logits=logits, out_projection_activations=out_projection_activations, moe_lb_loss=moe_lb_loss
+        logits=logits,
+        out_projection_activations=out_projection_activations,
+        moe_lb_loss=moe_lb_loss,
+        router_selections=router_selections,
     )
     return retval
 
@@ -347,7 +355,7 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
     return loss, aux
 
   def _eval_step(self, model, inputs):
-    """Evaluation only needs the student."""
+    """Evaluation runs student (and teacher, if available) to compute metrics."""
     inputs = self.gen_model_input_fn(inputs)
 
     student_output = self.strategy.student_forward_fn(
@@ -358,8 +366,23 @@ class MaxTextDistillationTrainer(peft_trainer.PeftTrainer):
         decoder_segment_ids=inputs.get("decoder_segment_ids"),
         cache=None,
     )
+
+    teacher_output = None
+    if "teacher_output" in inputs:
+      teacher_output = inputs["teacher_output"]
+    elif model.teacher_model is not None:
+      teacher_output = self.strategy.teacher_forward_fn(
+          model=model.teacher_model,
+          input_tokens=inputs["input_tokens"],
+          positions=inputs["positions"],
+          attention_mask=inputs.get("attention_mask"),
+          decoder_segment_ids=inputs.get("decoder_segment_ids"),
+          cache=None,
+      )
+      teacher_output = jax.tree.map(jax.lax.stop_gradient, teacher_output)
+
     labels = self.strategy.create_labels(inputs["targets"], targets_segmentation=inputs.get("targets_segmentation", None))
-    return self.strategy.compute_eval_loss(student_output, labels)
+    return self.strategy.compute_eval_loss(student_output, labels, teacher_output=teacher_output)
 
   def _log_metrics(self, loss, step=None, additional_metrics=None, **kwargs):
     """Adds per-device TFLOPs to the standard Tunix metrics.
@@ -614,6 +637,8 @@ def build_training_components(
       beta_end=student_config.distill_beta_end,
       beta_schedule=student_config.distill_beta_schedule,
       max_steps=student_config.steps,
+      num_experts=student_config.num_experts,
+      record_router_similarity_metrics=student_config.record_router_similarity_metrics,
   )
 
   # Prepare optimizer

--- a/tests/post_training/unit/distillation_metrics_test.py
+++ b/tests/post_training/unit/distillation_metrics_test.py
@@ -580,7 +580,79 @@ class DistillationMetricsTest(unittest.TestCase):
     loss_huge_pad = run(1e6)
     np.testing.assert_allclose(loss_zero_pad, loss_huge_pad, rtol=1e-5, atol=1e-6)
 
-  # --- 8. compute_eval_loss returns (sum, count) ------------------------
+  def test_router_similarity_metrics(self):
+    """Verifies Top-1 and Top-K router similarity metrics ignore pad tokens and are per-layer."""
+    vocab_size, batch_size, seq_len, num_experts = 4, 1, 3, 4
+    targets = jnp.array([[1, 2, 0]], dtype=jnp.int32)
+    labels = _one_hot_labels(targets, vocab_size, pad_id=0)
+
+    # L, B, T, K
+    # Pad token is at T=2.
+    s_router = jnp.array(
+        [
+            # Layer 0:
+            [
+                [[0, 1], [2, 3], [0, 0]],  # Student
+            ],
+            # Layer 1:
+            [
+                [[1, 2], [3, 0], [0, 0]],
+            ],
+        ]
+    )
+
+    t_router = jnp.array(
+        [
+            # Layer 0:
+            [
+                [[0, 1], [3, 2], [1, 1]],  # Teacher: exact match token 0. Top-K match token 1.
+            ],
+            # Layer 1:
+            [
+                [[0, 2], [1, 2], [2, 2]],  # Teacher: Top-K partial match token 0. Zero match token 1.
+            ],
+        ]
+    )
+
+    s_logits = jnp.zeros((batch_size, seq_len, vocab_size), dtype=jnp.float32)
+    s_out = distillation_utils.DistillationForwardOutput(logits=s_logits, router_selections=s_router)
+    t_out = distillation_utils.DistillationForwardOutput(logits=s_logits, router_selections=t_router)
+
+    strategy = distillation_utils.CombinedDistillationStrategy(
+        student_forward_fn=lambda *_a, **_k: None,
+        teacher_forward_fn=lambda *_a, **_k: None,
+        pad_id=0,
+        temperature=1.0,
+        alpha=0.5,
+        vocab_size=vocab_size,
+        max_steps=1,
+        num_experts=num_experts,
+        record_router_similarity_metrics=True,
+    )
+
+    _, m = strategy.compute_loss(s_out, t_out, labels, step=None)
+
+    # Valid tokens: 2
+
+    # Layer 0:
+    # Token 0: [0, 1] vs [0, 1] -> Top1 match (1), Top-K match (2/2 = 1)
+    # Token 1: [2, 3] vs [3, 2] -> Top1 mismatch (0), Top-K match (2/2 = 1)
+    # Token 2 is pad
+    l0_top1_expected = 1.0 / 2.0
+    l0_topk_expected = 2.0 / 2.0
+
+    np.testing.assert_allclose(_mean(m["distill/layer_0_router_similarity_top1"]), l0_top1_expected)
+    np.testing.assert_allclose(_mean(m["distill/layer_0_router_similarity_top2"]), l0_topk_expected)
+
+    # Layer 1:
+    # Token 0: [1, 2] vs [0, 2] -> Top1 mismatch (0), Top-K partial match (1/2 = 0.5)
+    # Token 1: [3, 0] vs [1, 2] -> Top1 mismatch (0), Top-K mismatch (0/2 = 0)
+    # Token 2 is pad
+    l1_top1_expected = 0.0 / 2.0
+    l1_topk_expected = 0.5 / 2.0
+
+    np.testing.assert_allclose(_mean(m["distill/layer_1_router_similarity_top1"]), l1_top1_expected)
+    np.testing.assert_allclose(_mean(m["distill/layer_1_router_similarity_top2"]), l1_topk_expected)
 
   def test_compute_eval_loss_returns_sum_count_pair(self):
     vocab_size = 4

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -671,6 +671,7 @@ class TrainDistillTest(unittest.TestCase):
     model_bundle = mock.Mock()
     student_model = mock.Mock()
     model_bundle.student_model = student_model
+    model_bundle.teacher_model = None
 
     # Setup return values for the strategy functions to track the data flow
     mock_student_output = mock.Mock()
@@ -707,7 +708,7 @@ class TrainDistillTest(unittest.TestCase):
 
     # Verify loss computation pipeline
     trainer.strategy.create_labels.assert_called_once_with(mock_batch["targets"], targets_segmentation=None)
-    trainer.strategy.compute_eval_loss.assert_called_once_with(mock_student_output, mock_labels)
+    trainer.strategy.compute_eval_loss.assert_called_once_with(mock_student_output, mock_labels, teacher_output=None)
 
     # Verify it returns the correct loss
     self.assertEqual(actual_loss, mock_loss)


### PR DESCRIPTION
# Description

This PR introduces new metrics for evaluating the quality of Mixture-of-Experts (MoE) distillation. When distilling an MoE teacher into an MoE student, it is critical to understand not just the KL divergence of the final logits, but whether the student's routing decisions align with the teacher's, and how evenly the tokens are distributed across experts.

Key Features:
   * Expert Fraction Distribution: Automatically computes and logs distill/student_expert_{i}_fraction and distill/teacher_expert_{i}_fraction whenever a model has num_experts > 1.
   * Router Similarity: Introduces a new configuration flag record_router_similarity_metrics. When enabled, it computes per-layer Top-1 and Top-K routing overlap between the student and teacher models (e.g.,
     distill/layer_0_router_similarity_top1).
   * Eval Logging: Updated the distillation evaluation loop to conditionally run a stop_gradient forward pass of the teacher model so these metrics are populated during eval steps.



# Tests

Added test_router_similarity_metrics to verify that Top-1 and Top-K similarity ratios correctly ignore padded tokens (pad_id=0) and broadcast properly.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
