### PR TITLE
stabilize GHA test workflows and use local checkpoints

### DIFF
--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -162,13 +162,15 @@ jobs:
             # Dynamically discover the 'nvidia' folder and prepend all its sub-library
             # directories (including nccl, cublas, cudnn) to LD_LIBRARY_PATH to prevent
             # JAX from partially loading incompatible system-level CUDA libraries.
-            NVIDIA_DIR=$(find .venv/lib/ -maxdepth 3 -name "nvidia" -type d 2>/dev/null | head -n 1)
-            if [ -n "${NVIDIA_DIR}" ]; then
-              for dir in "${NVIDIA_DIR}"/*; do
-                if [ -d "$dir/lib" ]; then
-                  export LD_LIBRARY_PATH=$(pwd)/$dir/lib:${LD_LIBRARY_PATH}
-                fi
-              done
+            if [ -d ".venv/lib" ]; then
+              NVIDIA_DIR=$(find .venv/lib/ -maxdepth 3 -name "nvidia" -type d 2>/dev/null | head -n 1)
+              if [ -n "${NVIDIA_DIR}" ]; then
+                for dir in "${NVIDIA_DIR}"/*; do
+                  if [ -d "$dir/lib" ]; then
+                    export LD_LIBRARY_PATH=$(pwd)/$dir/lib:${LD_LIBRARY_PATH}
+                  fi
+                done
+              fi
             fi
           fi
           if [ "${INPUTS_TOTAL_WORKERS}" -gt 1 ]; then

--- a/tests/integration/checkpoint_compatibility_test.py
+++ b/tests/integration/checkpoint_compatibility_test.py
@@ -49,6 +49,7 @@ def run_checkpoint_compatibility(hardware, attention_type):
       "grain_worker_count=0",
       "grain_train_files=/tmp/gcsfuse/array-record/c4/en/3.0.1/c4-train.array_record*",
   ]
+  local_ckpt_dir = "/tmp/maxtext_local_output"
 
   # Run training using grain input pipeline
   train_main(
@@ -60,6 +61,7 @@ def run_checkpoint_compatibility(hardware, attention_type):
           attention_type=attention_type,
           dataset_type="grain",
           dataset_path="/tmp/gcsfuse",
+          base_output_directory=local_ckpt_dir,
       )
       + grain_command
   )
@@ -74,6 +76,7 @@ def run_checkpoint_compatibility(hardware, attention_type):
           attention_type=attention_type,
           dataset_type="tfds",
           dataset_path="/tmp/gcsfuse",
+          base_output_directory=local_ckpt_dir,
       )
   )
 

--- a/tests/integration/checkpointing_test.py
+++ b/tests/integration/checkpointing_test.py
@@ -41,7 +41,9 @@ from tests.utils.test_helpers import (
 )
 
 
-def get_checkpointing_command(run_date, hardware, steps, metrics_file, attention_type, dataset_type, dataset_path):
+def get_checkpointing_command(
+    run_date, hardware, steps, metrics_file, attention_type, dataset_type, dataset_path, base_output_directory=None
+):
   """Generates a command list for a checkpointing test run.
 
   Args:
@@ -56,7 +58,8 @@ def get_checkpointing_command(run_date, hardware, steps, metrics_file, attention
   Returns:
     A list of strings representing the command line arguments.
   """
-  base_output_directory = get_test_base_output_directory()
+  if base_output_directory is None:
+    base_output_directory = get_test_base_output_directory()
   model_params = [
       "base_emb_dim=128",
       "base_num_query_heads=2",
@@ -148,6 +151,7 @@ def run_checkpointing(hardware, attention_type):
       "grain_worker_count=0",
       f"grain_train_files={selected_pattern}",
   ]
+  local_ckpt_dir = "/tmp/maxtext_local_output"
   train_main(
       get_checkpointing_command(
           run_date,
@@ -157,6 +161,7 @@ def run_checkpointing(hardware, attention_type):
           attention_type=attention_type,
           dataset_type="grain",
           dataset_path=dataset_path,
+          base_output_directory=local_ckpt_dir,
       )
       + grain_command
   )
@@ -170,6 +175,7 @@ def run_checkpointing(hardware, attention_type):
           attention_type=attention_type,
           dataset_type="grain",
           dataset_path=dataset_path,
+          base_output_directory=local_ckpt_dir,
       )
       + grain_command
   )


### PR DESCRIPTION
# Description

This PR stabilizes the GitHub Actions (GHA) test workflow by fixing two critical failures in the CI/CD pipeline:
1. **Workflow Crash on GPU Image Testing:** Prevents the test runner from crashing when the local virtual environment (`.venv`) is missing (e.g., when testing pre-installed packages in the Docker image).
2. **GCS Checkpoint Write Failures:** Fixes a `FileNotFoundError` on `run_2_metrics.txt` in checkpoint integration tests by forcing checkpoints to be written to a local temporary directory instead of Google Cloud Storage (GCS).

### Why these changes are being made & The problems solved:

#### 1. GPU Library Discovery Crash
* **Context:** To avoid conflicts with system-level CUDA libraries on GHA GPU runners, the workflow dynamically discovers pip-installed `nvidia` sub-libraries inside `.venv/lib/` and prepends them to `LD_LIBRARY_PATH` using `find .venv/lib/`.
* **The Problem:** When running tests in "pre-installed image mode" (`maxtext_installed=true`), the `.venv` directory is never created. Because GHA executes bash steps with `set -e`, running `find` on the non-existent `.venv/lib/` directory returned exit code `1`, immediately crashing the entire "Run Tests" step before tests could begin.
* **The Solution:** Wrap the discovery block in a directory check (`if [ -d ".venv/lib" ]`). This safely skips the path override in image-testing mode where system/image-level libraries are already correctly configured, while preserving it for local virtual environment runs.

#### 2. GCS Checkpoint Write Failure
* **Context:** Checkpoint integration tests (`checkpointing_test.py` and `checkpoint_compatibility_test.py`) verify that saving and restoring checkpoints works across different steps and input pipelines.
* **The Problem:** By default, these tests were configured to write checkpoints to the cloud bucket `gs://runner-maxtext-logs`. GHA runners do not have write access to this bucket. When the training run attempted to save a checkpoint, it failed and raised a `StopTraining` exception. Because this exception is caught and swallowed by the training loop's graceful exit logic, the run terminated early (at step 0) before writing step metrics to `run_2_metrics.txt`, causing the test to fail with a `FileNotFoundError`.
* **The Solution:** We updated `get_checkpointing_command` to accept an optional `base_output_directory` parameter, and modified both checkpointing integration tests to write their checkpoints locally to `/tmp/maxtext_local_output`. This makes the tests hermetic, faster, and completely independent of external cloud write permissions.

# Tests

Maxtext Package Test workflow is passing: https://github.com/AI-Hypercomputer/maxtext/actions/runs/26788575971

Build Images workflow is passing: https://github.com/AI-Hypercomputer/maxtext/actions/runs/26837419916

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
