### PR TITLE
Add elastic training (MaxText + Pathways on GKE) example

### DIFF
--- a/src/maxtext/examples/elastic_training/.env.example
+++ b/src/maxtext/examples/elastic_training/.env.example
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Required
+PROJECT_ID=your-project-id
+HF_TOKEN=hf_...
+
+# Optional (defaults work for most users)
+# REGION=us-central1
+# ZONE=us-central1-a
+# CLUSTER_NAME=maxtext-elastic-training
+# BUCKET_NAME=maxtext-elastic-training-your-project-id
+# DATASET=glaive
+# DEBUGGING=false
+# RUN_NAME=elastic-qwen3-0.6b
+# TPU_RESERVATION=
+# Spot (preemptible) TPUs: cheaper, reclaimable. Mutually exclusive with TPU_RESERVATION.
+# TPU_SPOT=false

--- a/src/maxtext/examples/elastic_training/.gcloudignore
+++ b/src/maxtext/examples/elastic_training/.gcloudignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+.terraform
+terraform/
+*.md
+*.tfstate
+*.tfstate.*
+.env
+.env.example
+.DS_Store

--- a/src/maxtext/examples/elastic_training/.gitignore
+++ b/src/maxtext/examples/elastic_training/.gitignore
@@ -1,0 +1,15 @@
+# Secrets / local config
+.env
+terraform.tfvars
+
+# Terraform state (the .terraform.lock.hcl IS committed for reproducible installs)
+.terraform/
+*.tfstate
+*.tfstate.*
+
+# Python
+__pycache__/
+*.pyc
+
+# OS
+.DS_Store

--- a/src/maxtext/examples/elastic_training/Makefile
+++ b/src/maxtext/examples/elastic_training/Makefile
@@ -1,0 +1,393 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHELL := /bin/bash
+.ONESHELL:
+.SHELLFLAGS := -e -c
+
+-include .env
+export
+
+# Defaults
+REGION          ?= us-central1
+ZONE            ?= us-central1-a
+CLUSTER_NAME    ?= maxtext-elastic-training
+# Empty => let the RAPID release channel pick the current GKE version (recommended).
+# Set a specific version (e.g. 1.35.3-gke.1993000) only if you need to pin one.
+CLUSTER_VERSION ?=
+BUCKET_NAME     ?= maxtext-elastic-training-$(PROJECT_ID)
+DATASET         ?= glaive
+DEBUGGING       ?= false
+RUN_NAME        ?= elastic-qwen3-0.6b
+TPU_RESERVATION ?=
+# Use Spot (preemptible) TPUs (cheaper, reclaimable). Leave empty for on-demand.
+TPU_SPOT        ?= false
+# Set CONFIRM=yes to skip the interactive cost prompt before `make infra` (for CI).
+CONFIRM         ?=
+
+# TPU config (fixed for this demo)
+TPU_MACHINE_TYPE := ct5lp-hightpu-4t
+TPU_TOPOLOGY     := 4x4
+NUM_TPU_SLICES   := 3
+NODES_PER_SLICE  := 4
+CPU_MACHINE_TYPE := n2-standard-64
+NUM_CPU_NODES    := 1
+
+# Derived
+AR_REGION ?= $(REGION)
+AR_REPO   ?= maxtext-elastic
+IMAGE     := $(AR_REGION)-docker.pkg.dev/$(PROJECT_ID)/$(AR_REPO)/maxtext-runner:latest
+
+# Formatting
+B := \033[1m
+D := \033[2m
+C := \033[36m
+G := \033[32m
+Y := \033[33m
+R := \033[31m
+Z := \033[0m
+LINE := $(D)──────────────────────────────────────────────────────────────────$(Z)
+
+# Targets
+.PHONY: help setup infra deploy demo status logs fail destroy
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  $(C)%-15s$(Z) %s\n", $$1, $$2}'
+
+# Setup
+setup: ## Generate terraform.tfvars from .env
+	@test -n "$(PROJECT_ID)" || { echo -e "  $(R)✗$(Z) PROJECT_ID not set. Run: cp .env.example .env"; exit 1; }
+	test -n "$(HF_TOKEN)" || { echo -e "  $(R)✗$(Z) HF_TOKEN not set in .env"; exit 1; }
+	printf '%s\n' \
+		'project_id       = "$(PROJECT_ID)"' \
+		'region           = "$(REGION)"' \
+		'zone             = "$(ZONE)"' \
+		'cluster_name     = "$(CLUSTER_NAME)"' \
+		'cluster_version  = "$(CLUSTER_VERSION)"' \
+		'network          = "default"' \
+		'subnetwork       = "default"' \
+		'tpu_machine_type = "$(TPU_MACHINE_TYPE)"' \
+		'tpu_topology     = "$(TPU_TOPOLOGY)"' \
+		'num_tpu_slices   = $(NUM_TPU_SLICES)' \
+		'nodes_per_slice  = $(NODES_PER_SLICE)' \
+		'cpu_machine_type = "$(CPU_MACHINE_TYPE)"' \
+		'num_cpu_nodes    = $(NUM_CPU_NODES)' \
+		'gcs_bucket_name  = "$(BUCKET_NAME)"' \
+		'hf_token         = "$(HF_TOKEN)"' \
+		'tpu_reservation  = "$(TPU_RESERVATION)"' \
+		'tpu_spot         = $(TPU_SPOT)' \
+		> terraform/terraform.tfvars
+	echo -e "  $(G)✓$(Z) Generated terraform/terraform.tfvars"
+
+# Infrastructure
+infra: setup ## Provision GKE cluster, TPU nodes, GCS bucket
+	@echo -e "\n$(LINE)"
+	echo -e "  $(B)$(C)Provisioning infrastructure$(Z)"
+	echo -e "$(LINE)\n"
+	# Cost guard: $(NUM_TPU_SLICES) x v5litepod-16 + $(CPU_MACHINE_TYPE) bill ~\$$61/hr while up
+	# (on-demand list price; verify current TPU pricing). Skip the prompt with: make infra CONFIRM=yes
+	if [ "$(CONFIRM)" != "yes" ]; then
+		echo -e "  $(Y)!$(Z) This provisions $(NUM_TPU_SLICES) TPU slices + 1 CPU node, about $(B)\$$61/hr$(Z) until you run $(B)make destroy$(Z)."
+		read -p "    Continue? [y/N] " ans
+		case "$$ans" in [yY]*) ;; *) echo -e "  $(D)Aborted.$(Z)"; exit 1;; esac
+		echo ""
+	fi
+	cd terraform && terraform init -input=false && terraform apply -auto-approve
+	echo ""
+	echo -e "  $(G)✓$(Z) Infrastructure ready"
+	echo -e "  $(D)Cluster: $(CLUSTER_NAME) | Zone: $(ZONE) | TPU slices: $(NUM_TPU_SLICES)$(Z)"
+
+# Deploy
+deploy: ## Run Cloud Build pipeline (build, install APIs, deploy training)
+	@echo -e "\n$(LINE)"
+	echo -e "  $(B)$(C)Running Cloud Build pipeline$(Z)"
+	echo -e "$(LINE)\n"
+	# Use the dedicated build SA from Terraform, not the legacy default compute SA
+	# (which new GCP projects disable). Falls back gracefully if outputs are absent.
+	BUILD_SA=$$(cd terraform && terraform output -raw cloudbuild_service_account 2>/dev/null || true)
+	SA_FLAG=""
+	if [ -n "$$BUILD_SA" ]; then SA_FLAG="--service-account=projects/$(PROJECT_ID)/serviceAccounts/$$BUILD_SA"; fi
+	gcloud builds submit --config=deploy/deploy.yaml $$SA_FLAG \
+		--substitutions=_CLUSTER_NAME=$(CLUSTER_NAME),_CLUSTER_ZONE=$(ZONE),_BUCKET_NAME=$(BUCKET_NAME),_DATASET=$(DATASET),_DEBUGGING=$(DEBUGGING),_RUN_NAME=$(RUN_NAME) \
+		--project=$(PROJECT_ID)
+	echo ""
+	echo -e "  $(G)✓$(Z) Cloud Build complete"
+
+# Status & Logs
+status: ## Show pod status
+	@gcloud container clusters get-credentials "$(CLUSTER_NAME)" \
+		--zone="$(ZONE)" --project="$(PROJECT_ID)" --quiet 2>/dev/null
+	kubectl get pods
+
+logs: ## Tail training logs
+	@gcloud container clusters get-credentials "$(CLUSTER_NAME)" \
+		--zone="$(ZONE)" --project="$(PROJECT_ID)" --quiet 2>/dev/null
+	POD=$$(kubectl get pods -l job-name=pw-elastic-pathways-head-0 \
+		-o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+	kubectl logs "$$POD" -c main --follow
+
+# Simulate failure
+SLICE ?= 2
+fail: ## Simulate slice failure (SLICE=2 by default)
+	@gcloud container clusters get-credentials "$(CLUSTER_NAME)" \
+		--zone="$(ZONE)" --project="$(PROJECT_ID)" --quiet 2>/dev/null
+	# Wait for a safe window between checkpoint writes.
+	# Checkpoint writes take ~10s. Elastic retry resumes cleanly between writes,
+	# so we time the termination for that window.
+	echo -e "  $(D)Waiting for safe checkpoint window (step 140-395)...$(Z)"
+	for i in $$(seq 1 600); do
+		POD=$$(kubectl get pods -l job-name=pw-elastic-pathways-head-0 \
+			-o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+		if [ -n "$$POD" ]; then
+			LAST=$$(kubectl logs "$$POD" -c main --tail=1 2>/dev/null || true)
+			if echo "$$LAST" | grep -q "completed step:"; then
+				STEP=$$(echo "$$LAST" | grep -o 'step: [0-9]*' | grep -o '[0-9]*')
+				MOD=$$((STEP % 100))
+				if [ "$$STEP" -ge 140 ] && [ $$MOD -ge 40 ] && [ $$MOD -le 95 ]; then
+					echo -e "\n  $(G)✓$(Z) Step $$STEP, safe window"
+					break
+				fi
+				echo -ne "\r  $(D)Step $$STEP, waiting...$(Z)  "
+			fi
+		fi
+		sleep 2
+	done
+	VICTIM=$$(kubectl get pods -l "job-name=pw-elastic-worker-$(SLICE)" \
+		-o jsonpath='{.items[0].metadata.name}')
+	echo -e "  $(R)Terminating$(Z) $(B)$$VICTIM$(Z) $(D)(slice $(SLICE))$(Z)"
+	# --grace-period=0 --force: SIGKILL immediately. Default 30s grace lets the
+	# worker keep serving while "Terminating"; at ~0.2s/step that is ~150 steps
+	# before Pathways even notices. A real hardware failure does not drain.
+	kubectl delete pod "$$VICTIM" --grace-period=0 --force
+	echo -e "  $(G)✓$(Z) Pod deleted, watch recovery with: make logs"
+
+# Destroy
+destroy: ## Tear down everything
+	@echo -e "\n$(LINE)"
+	echo -e "  $(B)$(C)Destroying infrastructure$(Z)"
+	echo -e "$(LINE)\n"
+	gcloud container clusters get-credentials "$(CLUSTER_NAME)" \
+		--zone="$(ZONE)" --project="$(PROJECT_ID)" --quiet 2>/dev/null || true
+	kubectl delete jobset pw-elastic --ignore-not-found=true 2>/dev/null || true
+	cd terraform && terraform destroy -auto-approve
+	echo ""
+	echo -e "  $(G)✓$(Z) All resources destroyed"
+
+# Demo (full interactive flow)
+demo: ## Run full elastic training demo (deploy → train → fail → recover)
+	@case "$(MAKE_VERSION)" in 3.8[01]*) printf '  $(R)✗$(Z) GNU Make $(MAKE_VERSION) is too old (need ≥ 3.82 for .ONESHELL)\n  $(D)On macOS: brew install make, then run: gmake demo$(Z)\n'; exit 1;; esac; set -uo pipefail
+	# Formatting helpers
+	step_header() {
+		echo ""
+		echo -e "$(LINE)"
+		echo -e "  $(B)$(C)[$$1/5]$(Z) $(B)$$2$(Z)"
+		echo -e "$(LINE)"
+		echo ""
+	}
+	ok()     { echo -e "  $(G)✓$(Z) $$*"; }
+	info()   { echo -e "  $(D)$$*$(Z)"; }
+	detail() { echo -e "    $(D)$$*$(Z)"; }
+	warn()   { echo -e "  $(Y)!$(Z) $$*"; }
+	head_pod() {
+		kubectl get pods -l job-name=pw-elastic-pathways-head-0 \
+			-o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+	}
+	pods_ready() {
+		local count
+		count=$$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=pw-elastic \
+			--no-headers 2>/dev/null | grep -c "Running" || true)
+		[ "$$count" -ge 13 ]
+	}
+	training_started() {
+		local pod
+		pod=$$(head_pod)
+		[ -n "$$pod" ] && kubectl logs "$$pod" -c main --tail=5 2>/dev/null | grep -q "completed step:"
+	}
+	spin() {
+		local msg="$$1" check_fn="$$2" timeout="$${3:-300}" elapsed=0
+		local chars='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
+		while [ $$elapsed -lt $$timeout ]; do
+			for (( i=0; i<$${#chars}; i++ )); do
+				echo -ne "\r  $(D)$${chars:$$i:1} $$msg ($${elapsed}s)$(Z)  "
+				sleep 0.5
+				elapsed=$$((elapsed + 1))
+				if [ $$((elapsed % 5)) -eq 0 ] && eval "$$check_fn"; then
+					echo -ne "\r\033[K"
+					return 0
+				fi
+			done
+		done
+		echo -ne "\r\033[K"
+		return 1
+	}
+	# Intro
+	echo ""
+	echo -e "  $(B)Elastic Training Demo$(Z)"
+	echo -e "  $(D)Fault-tolerant training on Cloud TPUs with Pathways$(Z)"
+	echo ""
+	echo -e "  Dataset     $(B)$(DATASET)$(Z)"
+	echo -e "  Debugging   $(B)$(DEBUGGING)$(Z)"
+	echo -e "  TPU slices  $(B)3 x v5litepod-16$(Z) (48 chips)"
+	echo -e "  Run name    $(D)$(RUN_NAME)$(Z)"
+	echo -e "  Bucket      $(D)gs://$(BUCKET_NAME)$(Z)"
+	# Step 1: Deploy
+	step_header 1 "Deploy JobSet"
+	if [ "$(DATASET)" = "glaive" ]; then
+		if ! gcloud storage ls "gs://$(BUCKET_NAME)/data/glaive-fc-v2/" --project="$(PROJECT_ID)" >/dev/null 2>&1; then
+			echo -e "  $(R)✗$(Z) Glaive data not found. Run 'make deploy' first."
+			exit 1
+		fi
+	fi
+	gcloud container clusters get-credentials "$(CLUSTER_NAME)" \
+		--zone="$(ZONE)" --project="$(PROJECT_ID)" --quiet 2>/dev/null
+	kubectl delete jobset pw-elastic --ignore-not-found --wait=true 2>/dev/null || true
+	bash deploy/jobs/training/submit.sh
+	ok "JobSet created"
+	info "elastic_enabled=true  elastic_timeout=300s  elastic_max_retries=10"
+	# Step 2: Wait for pods
+	step_header 2 "Wait for pods"
+	info "Expecting 13 pods: 1 head + 4 workers x 3 slices"
+	echo ""
+	if spin "Waiting for all pods to schedule and start" "pods_ready" 300; then
+		ok "All pods running"
+	else
+		echo -e "  $(R)✗$(Z) Timed out waiting for pods"
+		kubectl get pods
+		exit 1
+	fi
+	echo ""
+	kubectl get pods -l jobset.sigs.k8s.io/jobset-name=pw-elastic --no-headers 2>/dev/null \
+		| awk '{printf "    %-45s %s\n", $$1, $$3}'
+	echo ""
+	# Step 3: Wait for training
+	step_header 3 "Wait for training"
+	info "XLA compilation + first step takes ~3 minutes"
+	echo ""
+	if spin "Compiling and starting training" "training_started" 420; then
+		ok "Training is running"
+	else
+		warn "Timed out, training may still be compiling"
+	fi
+	echo ""
+	POD=$$(head_pod)
+	if [ -n "$$POD" ]; then
+		kubectl logs "$$POD" -c main --tail=10 2>/dev/null \
+			| grep "completed step:" \
+			| tail -3 \
+			| while read -r line; do
+				step=$$(echo "$$line" | grep -o 'step: [0-9]*' | grep -o '[0-9]*')
+				loss=$$(echo "$$line" | grep -o 'loss: [0-9.]*' | grep -o '[0-9.]*')
+				tflops=$$(echo "$$line" | grep -o 'TFLOP/s/device: [0-9.]*' | grep -o '[0-9.]*')
+				echo -e "    step $(B)$$step$(Z)  loss $(B)$$loss$(Z)  $(D)$$tflops TFLOP/s/device$(Z)"
+			done
+	fi
+	echo ""
+	# Step 4: Simulate failure
+	step_header 4 "Simulate slice failure"
+	# Wait for a safe window: at least one non-zero checkpoint committed and no
+	# write in flight. checkpoint_period=100, write takes ~10s with qwen3-0.6b.
+	info "Waiting for checkpoint 100 to commit (safe termination window)"
+	echo ""
+	STEP_BEFORE="?"
+	for i in $$(seq 1 200); do
+		POD=$$(head_pod)
+		L=$$(kubectl logs "$$POD" -c main --tail=5 2>/dev/null | grep "completed step:" | tail -1 || true)
+		if [ -n "$$L" ]; then
+			S=$$(echo "$$L" | grep -o 'step: [0-9]*' | grep -o '[0-9]*')
+			M=$$((S % 100))
+			echo -ne "\r  $(D)step $$S$(Z)  "
+			if [ "$$S" -ge 140 ] && [ $$M -ge 40 ] && [ $$M -le 95 ]; then
+				STEP_BEFORE=$$S
+				echo -ne "\r\033[K"
+				break
+			fi
+		fi
+		sleep 1
+	done
+	ok "Training at step $(B)$$STEP_BEFORE$(Z), checkpoint 100 committed, safe to terminate"
+	echo ""
+	VICTIM=$$(kubectl get pods -l "job-name=pw-elastic-worker-2" \
+		-o jsonpath='{.items[0].metadata.name}')
+	echo -e "  $(R)Terminating$(Z) $(B)$$VICTIM$(Z) $(D)(slice 2, --grace-period=0)$(Z)"
+	kubectl delete pod "$$VICTIM" --grace-period=0 --force > /dev/null 2>&1
+	echo ""
+	info "What happens now:"
+	detail "1. Pathways heartbeat times out (~10s) → connection lost"
+	detail "2. elastic_retry catches the error in-process"
+	detail "3. Incomplete checkpoints cleaned up on GCS"
+	detail "4. Replacement worker pod schedules on slice 2"
+	detail "5. Checkpoint restored, training rewinds and resumes"
+	echo ""
+	# Step 5: Verify recovery
+	step_header 5 "Verify recovery"
+	wait_log() {
+		kubectl logs "$$(head_pod)" -c main 2>/dev/null | grep -qE "$$1"
+	}
+	if spin "Waiting for Pathways to detect slice down" "wait_log 'Slice down event detected'" 90; then
+		ok "Slice down event detected"
+	else
+		warn "No slice-down event, check: make logs"
+	fi
+	if spin "Waiting for checkpoint restore" "wait_log 'Restoring checkpoint from'" 90; then
+		ok "Checkpoint restored"
+	else
+		warn "Restore not seen, check: make logs"
+	fi
+	# Training resumed = step regression observed (rewind) and tail shows steps
+	step_regression() {
+		kubectl logs "$$(head_pod)" -c main 2>/dev/null \
+			| grep -o 'completed step: [0-9]*' | grep -o '[0-9]*' \
+			| awk 'NR>1 && $$1<prev {found=1} {prev=$$1} END{exit !found}'
+	}
+	if spin "Waiting for training to resume" "step_regression" 120; then
+		ok "Training resumed"
+	else
+		warn "Still recovering, check: make logs"
+	fi
+	echo ""
+	POD=$$(head_pod)
+	kubectl logs "$$POD" -c main 2>/dev/null \
+		| grep -E "Slice down event|Elastic attempt [2-9]|Keeping gs://|Restoring checkpoint from|Sufficient slices" \
+		| sed 's/^.*] //' \
+		| while read -r line; do detail "$$line"; done
+	echo ""
+	REWIND=$$(kubectl logs "$$POD" -c main 2>/dev/null \
+		| grep -o 'completed step: [0-9]*' | grep -o '[0-9]*' \
+		| awk 'NR>1 && $$1<prev {print prev " → " $$1; exit} {prev=$$1}')
+	STEP_AFTER=$$(kubectl logs "$$POD" -c main --tail=20 2>/dev/null \
+		| grep "completed step:" | tail -1 | grep -o 'step: [0-9]*' | grep -o '[0-9]*' || echo "?")
+	ok "Step rewind: $(B)$$REWIND$(Z) $(D)(restored from last good checkpoint)$(Z)"
+	ok "Now training at step $(B)$$STEP_AFTER$(Z), same head pod, no job restart"
+	echo ""
+	PRX=$$(kubectl get pod "$$POD" -o jsonpath='{.status.initContainerStatuses[?(@.name=="pathways-proxy")].restartCount}' 2>/dev/null)
+	JSR=$$(kubectl get jobset pw-elastic -o jsonpath='{.status.restarts}' 2>/dev/null)
+	detail "pathways-proxy restartCount = $${PRX:-0}"
+	detail "jobset restarts            = $${JSR:-0}"
+	echo ""
+	ok "GCS checkpoints:"
+	{ gcloud storage ls "gs://$(BUCKET_NAME)/output/$(RUN_NAME)/checkpoints/" 2>/dev/null || true; } \
+		| grep -E '/[0-9]+/$$' \
+		| while read -r dir; do
+			detail "$$(basename "$${dir%/}")"
+		done || true
+	echo ""
+	echo -e "$(LINE)"
+	echo -e "  $(G)$(B)Demo complete$(Z)"
+	echo -e "$(LINE)"
+	echo ""
+	info "Training is still running. Next:"
+	detail "make logs       , tail training output"
+	detail "make fail SLICE=1, simulate another failure"
+	detail "make destroy    , tear down everything"

--- a/src/maxtext/examples/elastic_training/README.md
+++ b/src/maxtext/examples/elastic_training/README.md
@@ -1,0 +1,191 @@
+<!--
+ # Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ -->
+
+# Elastic Training on Cloud TPUs with MaxText and Pathways
+
+Train Qwen3 0.6B across 3 TPU v5e slices on GKE, terminate a slice mid-run, and watch training recover **in-process** from the last checkpoint: same head pod, no job restart, about 40 seconds end to end.
+
+You can run this lab two ways, and they do exactly the same thing. The steps below use the `make` targets from your terminal. If you'd rather step through each command interactively, open [`elastic_qwen3_demo.ipynb`](./elastic_qwen3_demo.ipynb) in this folder instead.
+
+## What is elastic training?
+
+Large model training runs across many TPU slices. When one slice fails, a hardware fault, a preemption, a network blip, the result is that the whole job crashes and you restart from scratch, losing minutes of XLA compilation plus everything since the last checkpoint.
+
+Elastic training keeps the training process alive instead. Pathways detects the dead slice, MaxText's `elastic_retry` catches the error inside the same Python process, Orbax cleans up any half-written checkpoint on GCS, and training rewinds to the last good step. The head pod never restarts, so you skip the cold-start recompile.
+
+Three components make that possible:
+
+- **Pathways** orchestrates training across the slices. A Resource Manager on a CPU node coordinates all slices and detects when one goes down.
+- **MaxText** wraps the training loop with `elastic_retry`. When Pathways reports a failure, it catches the exception, cleans up, and restarts training in-process.
+- **Orbax** handles checkpointing. Each checkpoint writes to GCS and creates a `commit_success` marker only after all data is flushed, so a checkpoint interrupted mid-write has no marker and is safely discarded on recovery.
+
+```mermaid
+sequenceDiagram
+    participant T as Training Loop
+    participant E as elastic_retry
+    participant C as Checkpointing
+    participant GCS as GCS Bucket
+
+    T->>T: Training step N
+    Note over T: Slice fails
+    T-->>E: Exception caught
+    E->>C: clean_up_checkpoints()
+    C->>GCS: Check for commit_success marker
+    C->>GCS: No marker found, delete incomplete checkpoint
+    E->>T: Re-initialize training
+    T->>GCS: Load last good checkpoint
+    T->>T: Resume training from checkpoint
+```
+
+## What you'll need
+
+This notebook drives Google Cloud infrastructure, so it expects to run from a machine that already has the CLIs and credentials, Cloud Shell, or a local shell with the Cloud SDK. It does not install them. You'll need:
+
+- A Google Cloud project with billing enabled.
+- TPU v5e on-demand quota: at least 48 chips in `us-central1` (request `Tpu-v5-litepod-device` quota in [IAM & Admin > Quotas](https://console.cloud.google.com/iam-admin/quotas)).
+- A [HuggingFace token](https://huggingface.co/settings/tokens) with the `read` role. Qwen3 is ungated, but the pipeline wires the token through so you can swap in a gated model later.
+- CLI tools: `terraform` (>= 1.5.0), `gcloud`, `kubectl`, and GNU `make` (>= 3.82).
+
+The TPU slices are the expensive part, so keep an eye on cost and check [TPU pricing](https://cloud.google.com/tpu/pricing) before you start. A full run takes about 30 minutes, so budget roughly $30, and always clean up when you're done.
+
+## 1. Set up your environment
+
+Authenticate, then create your config file. You only need to set `PROJECT_ID` and `HF_TOKEN`; everything else has a sensible default.
+
+```bash
+gcloud auth application-default login
+gcloud config set project <YOUR_PROJECT_ID>
+
+cp .env.example .env
+# Edit .env with your project ID and HuggingFace token
+```
+
+Run `make help` at any time to see every available target.
+
+## 2. Provision the infrastructure
+
+`make infra` reads your `.env`, generates `terraform.tfvars`, and runs Terraform. It creates the GKE cluster, the TPU and CPU node pools, a GCS bucket, Artifact Registry, a dedicated Cloud Build service account, the IAM bindings, and pushes your HF token to both Secret Manager and a Kubernetes secret.
+
+```bash
+make infra
+```
+
+This takes about 10 minutes. You should see:
+
+```
+  Infrastructure ready
+  Cluster: maxtext-elastic-training | Zone: us-central1-a | TPU slices: 3
+```
+
+If Terraform fails with quota errors, check your `Tpu-v5-litepod-device` quota in [IAM & Admin > Quotas](https://console.cloud.google.com/iam-admin/quotas).
+
+## 3. Deploy training
+
+`make deploy` runs a Cloud Build pipeline that builds the MaxText image, installs the JobSet API, downloads the tokenizer to GCS, prepares the training data, and deploys the training JobSet.
+
+```bash
+make deploy
+```
+
+This takes about 6 minutes and ends with `Cloud Build complete`. Check the pods:
+
+```bash
+make status
+```
+
+You should see 13 pods: 1 head pod (running the training script, with the Pathways Resource Manager and IFRT proxy as sidecars) and 12 worker pods across 3 slices.
+
+## 4. Watch training start
+
+```bash
+make logs
+```
+
+After XLA compilation (about 2-3 minutes) you should see elastic training enabled and a steady stream of steps:
+
+```
+Elastic utils: Elastic training enabled.
+Elastic Retry Enabled
+completed step: 8, seconds: 0.159, TFLOP/s/device: 43.430, loss: 220.774
+completed step: 9, seconds: 0.166, TFLOP/s/device: 41.524, loss: 217.296
+completed step: 10, seconds: 0.160, TFLOP/s/device: 43.230, loss: 216.126
+```
+
+From then on expect ~43 TFLOP/s/device at ~0.16s/step. Once the step counter passes ~130 (so checkpoint 100 has committed), interrupt the log stream and move on.
+
+## 5. Break it, and watch it recover
+
+The simplest path is the narrated demo, which deploys the JobSet, waits for training, terminates a worker on slice 2, and verifies recovery:
+
+```bash
+make demo
+```
+
+You should see something close to:
+
+```
+[4/5] Simulate slice failure
+  Training at step 137, checkpoint 100 committed, safe to terminate
+  Terminating pw-elastic-worker-2-0-j55zd (slice 2, --grace-period=0)
+
+[5/5] Verify recovery
+  Slice down event detected
+  Checkpoint restored
+  Training resumed
+  Step rewind: 150 -> 101 (restored from last good checkpoint)
+  Now training at step 115, same head pod, no job restart
+    pathways-proxy restartCount = 0
+    jobset restarts            = 0
+```
+
+Those two zeros are the whole point: the head pod's proxy sidecar never restarted, and the JobSet never restarted. Recovery happened inside the live process.
+
+If you'd rather drive each step yourself:
+
+```bash
+make logs              # wait for steps to pass ~130 (checkpoint 100 committed)
+make fail              # waits for a safe window, then terminates a worker on slice 2 (SIGKILL)
+make logs              # watch recovery
+```
+
+Within ~15 seconds of the termination, the same head pod log stream shows the recovery sequence:
+
+```
+Slice down event detected. Retrying.
+Found commit_success file. Keeping gs://.../checkpoints/100/.
+Elastic attempt 2 out of 10
+Restoring checkpoint from gs://.../checkpoints/100.
+completed step: 101, ...
+```
+
+The step counter dropping (e.g. 150 -> 101) is the rewind to the last committed checkpoint. You can trigger another failure on a different slice with `make fail SLICE=1`.
+
+## 6. Clean up
+
+```bash
+make destroy
+```
+
+This deletes the JobSet and runs `terraform destroy` to tear down everything. The TPU slices cost ~$58/hr, so don't skip it.
+
+## Going further
+
+- **Cheaper capacity**: the slices are on-demand by default, which guarantees replacement capacity is available when one goes down. For cost-sensitive experimentation, set `TPU_SPOT=true` to use Spot (preemptible) TPUs, or `TPU_RESERVATION=<name>` to consume a reservation (the two are mutually exclusive).
+- **A larger model**: during recovery the checkpoint streams through the `pathways-proxy` sidecar, capped at `memory: 100G` in `deploy/jobs/training/jobset.yaml`. Qwen3 0.6B keeps the checkpoint around 7 GiB; to run something bigger (Qwen3 4B is ~135 GiB), raise that memory limit to whatever the CPU node can spare.
+- **The elastic training flags** live in `deploy/jobs/training/train.sh`: `elastic_enabled`, `elastic_timeout_seconds`, `elastic_max_retries`, `enable_single_controller` (runs training through Pathways), and `checkpoint_period=100` (frequent enough that recovery rewinds only a little).
+- **Debugging**: set `DEBUGGING=true` in `.env` to add XProf profiling and goodput monitoring.
+
+One thing this demo does not show is true elastic _degradation_, where training continues on 2 of 3 slices at reduced throughput while the third is down. That needs dynamic mesh resize, which MaxText does not support yet; today the mesh is fixed at startup, so recovery always means restoring the checkpoint and waiting for all slices.

--- a/src/maxtext/examples/elastic_training/deploy/deploy.yaml
+++ b/src/maxtext/examples/elastic_training/deploy/deploy.yaml
@@ -1,0 +1,227 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cloud Build pipeline: build the MaxText image, prepare data, deploy training.
+# Run after `terraform apply`. The Makefile `deploy` target and the notebook both
+# invoke this; `terraform output -raw cloudbuild_command` prints the full command.
+
+substitutions:
+  _CLUSTER_NAME: ""
+  _CLUSTER_ZONE: ""
+  _BUCKET_NAME: ""
+  _IMAGE_NAME: maxtext-runner
+  _RUN_NAME: elastic-qwen3-0.6b
+  _DATASET: glaive          # "synthetic" or "glaive"
+  _HF_DATASET: hiyouga/glaive-function-calling-v2-sharegpt
+  _NUM_SHARDS: "64"
+  _MAXTEXT_REPO: https://github.com/AI-Hypercomputer/maxtext.git
+  _MAXTEXT_BRANCH: main
+  _JOBSET_VERSION: v0.8.0
+  _AR_REGION: us-central1
+  _AR_REPO: maxtext-elastic
+  _DEBUGGING: "false"
+
+steps:
+  # =========================================================================
+  # Phase 1: Build and push MaxText Docker image
+  # =========================================================================
+
+  - id: clone-maxtext
+    name: gcr.io/cloud-builders/git
+    args: ['clone', '--depth=1', '--branch=${_MAXTEXT_BRANCH}', '${_MAXTEXT_REPO}', 'maxtext']
+
+  - id: build-base-image
+    name: gcr.io/cloud-builders/docker
+    dir: maxtext
+    waitFor: ['clone-maxtext']
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        bash src/dependencies/scripts/docker_build_dependency_image.sh MODE=stable DEVICE=tpu
+
+  - id: upgrade-deps
+    name: gcr.io/cloud-builders/docker
+    waitFor: ['build-base-image']
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        docker run --name deps-upgrade maxtext_base_image \
+          uv pip install --system \
+            "pathwaysutils>=0.1.7" \
+            "datasets" \
+            "array-record"
+        docker commit deps-upgrade maxtext_base_image
+        docker rm deps-upgrade
+
+  - id: push-image
+    name: gcr.io/cloud-builders/docker
+    waitFor: ['upgrade-deps']
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        docker tag maxtext_base_image ${_AR_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_IMAGE_NAME}:latest
+        docker push ${_AR_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_IMAGE_NAME}:latest
+
+  # =========================================================================
+  # Phase 2: Configure cluster and install K8s APIs
+  # =========================================================================
+
+  - id: get-credentials
+    name: gcr.io/cloud-builders/gcloud
+    waitFor: ['-']
+    args:
+      - container
+      - clusters
+      - get-credentials
+      - ${_CLUSTER_NAME}
+      - --zone=${_CLUSTER_ZONE}
+      - --project=$PROJECT_ID
+
+  - id: install-jobset
+    name: gcr.io/cloud-builders/kubectl
+    waitFor: ['get-credentials']
+    args: ['apply', '--server-side', '-f', 'https://github.com/kubernetes-sigs/jobset/releases/download/${_JOBSET_VERSION}/manifests.yaml']
+    env:
+      - CLOUDSDK_COMPUTE_ZONE=${_CLUSTER_ZONE}
+      - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+
+  - id: verify-apis
+    name: gcr.io/cloud-builders/kubectl
+    waitFor: ['install-jobset']
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        echo "=== Waiting for CRDs to be established ==="
+        sleep 10
+        kubectl get crd | grep jobset
+    env:
+      - CLOUDSDK_COMPUTE_ZONE=${_CLUSTER_ZONE}
+      - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+
+  # =========================================================================
+  # Phase 3: Download tokenizer to GCS
+  # =========================================================================
+
+  - id: download-tokenizer
+    name: ${_AR_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_IMAGE_NAME}:latest
+    waitFor: ['push-image']
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        # Qwen3 family shares one tokenizer; the 4B repo is ungated and works
+        # for qwen3-0.6b too. Keep the path stable across model swaps.
+        TOKENIZER_PATH="Qwen/Qwen3-4B"
+        GCS_PATH="gs://${_BUCKET_NAME}/tokenizer/qwen3-4b"
+
+        # Skip if already downloaded
+        if gcloud storage ls "$${GCS_PATH}/tokenizer.json" >/dev/null 2>&1; then
+          echo "=== Tokenizer already exists in GCS, skipping ==="
+          exit 0
+        fi
+
+        echo "=== Downloading tokenizer: $${TOKENIZER_PATH} ==="
+        python3 -c "
+        from huggingface_hub import snapshot_download
+        snapshot_download(
+            '$${TOKENIZER_PATH}',
+            local_dir='/tmp/tokenizer',
+            allow_patterns=['tokenizer*', 'special_tokens_map*', '*.model'],
+        )
+        "
+
+        echo "=== Uploading tokenizer to $${GCS_PATH}/ ==="
+        gcloud storage cp -r /tmp/tokenizer/* "$${GCS_PATH}/"
+        echo "=== Tokenizer uploaded ==="
+        gcloud storage ls "$${GCS_PATH}/"
+
+  # =========================================================================
+  # Phase 4: Data preparation (runs on cluster CPU pool, skipped for synthetic)
+  # =========================================================================
+
+  - id: submit-data-prep
+    name: gcr.io/cloud-builders/kubectl
+    waitFor: ['download-tokenizer', 'verify-apis']
+    entrypoint: bash
+    args: ['deploy/jobs/data-prep/submit.sh']
+    env:
+      - CLOUDSDK_COMPUTE_ZONE=${_CLUSTER_ZONE}
+      - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+      - DATASET=${_DATASET}
+      - BUCKET_NAME=${_BUCKET_NAME}
+      - PROJECT_ID=$PROJECT_ID
+      - NUM_SHARDS=${_NUM_SHARDS}
+      - HF_DATASET=${_HF_DATASET}
+      - IMAGE=${_AR_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_IMAGE_NAME}:latest
+
+  - id: wait-data-prep
+    name: gcr.io/cloud-builders/kubectl
+    waitFor: ['submit-data-prep']
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        if [ "${_DATASET}" = "synthetic" ]; then exit 0; fi
+
+        # Skip if data prep was not submitted (data already existed)
+        if ! kubectl get job data-prep-glaive >/dev/null 2>&1; then
+          echo "=== Data prep skipped (data already exists) ==="
+          exit 0
+        fi
+
+        echo "=== Waiting for data prep to complete (timeout: 15m) ==="
+        kubectl wait --for=condition=complete job/data-prep-glaive --timeout=900s
+
+        echo ""
+        echo "=== Data prep logs ==="
+        kubectl logs job/data-prep-glaive --tail=20
+
+        echo ""
+        echo "=== Data files ==="
+        gcloud storage ls "gs://${_BUCKET_NAME}/data/glaive-fc-v2/" --project=$PROJECT_ID
+    env:
+      - CLOUDSDK_COMPUTE_ZONE=${_CLUSTER_ZONE}
+      - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+
+  # =========================================================================
+  # Phase 5: Deploy JobSet with elastic training
+  # =========================================================================
+
+  - id: deploy-training
+    name: gcr.io/cloud-builders/kubectl
+    waitFor: ['wait-data-prep']
+    entrypoint: bash
+    args: ['deploy/jobs/training/submit.sh']
+    env:
+      - CLOUDSDK_COMPUTE_ZONE=${_CLUSTER_ZONE}
+      - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+      - DATASET=${_DATASET}
+      - BUCKET_NAME=${_BUCKET_NAME}
+      - IMAGE=${_AR_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_IMAGE_NAME}:latest
+      - RUN_NAME=${_RUN_NAME}
+      - DEBUGGING=${_DEBUGGING}
+
+options:
+  machineType: E2_HIGHCPU_32
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 5400s

--- a/src/maxtext/examples/elastic_training/deploy/jobs/data-prep/manifest.yaml
+++ b/src/maxtext/examples/elastic_training/deploy/jobs/data-prep/manifest.yaml
@@ -1,0 +1,48 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: data-prep-glaive
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: cpu-pathways-np
+      restartPolicy: Never
+      containers:
+      - name: data-prep
+        image: IMAGE_PLACEHOLDER
+        resources:
+          requests:
+            cpu: "16"
+            memory: "64Gi"
+          limits:
+            cpu: "32"
+            memory: "96Gi"
+        command:
+        - python3
+        - /scripts/prepare_data.py
+        - --dataset=HF_DATASET_PLACEHOLDER
+        - --output=gs://BUCKET_PLACEHOLDER/data/glaive-fc-v2
+        - --num-shards=NUM_SHARDS_PLACEHOLDER
+        volumeMounts:
+        - name: script
+          mountPath: /scripts
+      volumes:
+      - name: script
+        configMap:
+          name: data-prep-script

--- a/src/maxtext/examples/elastic_training/deploy/jobs/data-prep/prepare_data.py
+++ b/src/maxtext/examples/elastic_training/deploy/jobs/data-prep/prepare_data.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert a HuggingFace dataset to MaxText Grain ArrayRecord format.
+
+Flattens ShareGPT conversations into plain text with role markers,
+serializes as tf.train.Example protos (using raw protobuf, no TF dependency),
+and writes sharded ArrayRecord files.
+
+Dependencies: datasets, array-record, protobuf (no tensorflow required).
+
+Usage:
+    python prepare_data.py \
+        --dataset hiyouga/glaive-function-calling-v2-sharegpt \
+        --output gs://my-bucket/data/glaive-fc-v2 \
+        --num-shards 64
+
+    # Local output (then upload manually):
+    python prepare_data.py --output /tmp/glaive-data --num-shards 8
+"""
+
+import argparse
+import os
+import subprocess
+import tempfile
+
+from datasets import load_dataset, concatenate_datasets
+from array_record.python.array_record_module import ArrayRecordWriter
+
+
+# Protobuf serialization (wire-compatible with tf.train.Example)
+# MaxText's ParseFeatures calls example_pb2.Example().ParseFromString(element),
+# which expects the standard tf.train.Example proto wire format. We encode it
+# directly with raw protobuf, no TensorFlow or compiled proto files needed.
+
+def _varint_bytes(value):
+    """Encode an integer as a protobuf varint."""
+    pieces = []
+    while value > 0x7F:
+        pieces.append((value & 0x7F) | 0x80)
+        value >>= 7
+    pieces.append(value & 0x7F)
+    return bytes(pieces)
+
+
+def _length_delimited(field_number, data):
+    """Encode a length-delimited protobuf field."""
+    tag = _varint_bytes((field_number << 3) | 2)
+    return tag + _varint_bytes(len(data)) + data
+
+
+def make_example(text: str) -> bytes:
+    """Serialize text as a tf.train.Example proto.
+
+    Wire format:
+        Example { features { feature { key: "text", value { bytes_list { value: [text] } } } } }
+    """
+    text_bytes = text.encode("utf-8")
+    # BytesList: field 1 = bytes value
+    bytes_list = _length_delimited(1, text_bytes)
+    # Feature: field 1 = bytes_list (oneof)
+    feature_value = _length_delimited(1, bytes_list)
+    # Features.FeatureEntry (map): field 1 = key (string), field 2 = value (Feature)
+    key_field = _length_delimited(1, b"text")
+    value_field = _length_delimited(2, feature_value)
+    feature_entry = key_field + value_field
+    # Features: field 1 = feature (map entries)
+    features = _length_delimited(1, feature_entry)
+    # Example: field 1 = features
+    example = _length_delimited(1, features)
+    return example
+
+
+# ShareGPT role -> role marker
+ROLE_MAP = {
+    "system": "<|system|>",
+    "human": "<|user|>",
+    "user": "<|user|>",
+    "gpt": "<|assistant|>",
+    "assistant": "<|assistant|>",
+    "tool": "<|tool|>",
+    "function": "<|tool|>",
+    "function_call": "<|tool_call|>",
+    "observation": "<|observation|>",
+}
+
+
+def flatten_conversation(conversations: list[dict]) -> str:
+    """Flatten a ShareGPT conversation into a single text string with role markers.
+
+    Args:
+        conversations: List of {"from": role, "value": text} dicts.
+
+    Returns:
+        Flattened text with role markers.
+    """
+    parts = []
+    for turn in conversations:
+        role = turn.get("from", "")
+        value = turn.get("value", "")
+        marker = ROLE_MAP.get(role, f"<|{role}|>")
+        parts.append(f"{marker}\n{value}")
+    return "\n".join(parts)
+
+
+def write_arrayrecord_shard(records: list[bytes], output_path: str):
+    """Write serialized records to a single ArrayRecord file."""
+    writer = ArrayRecordWriter(output_path, "group_size:1")
+    for record in records:
+        writer.write(record)
+    writer.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert HuggingFace dataset to MaxText Grain ArrayRecord format"
+    )
+    parser.add_argument(
+        "--dataset",
+        default="hiyouga/glaive-function-calling-v2-sharegpt",
+        help="HuggingFace dataset path",
+    )
+    parser.add_argument(
+        "--configs",
+        nargs="*",
+        default=None,
+        help="Dataset config names to load (default: all configs)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output path (local dir or gs:// URI)",
+    )
+    parser.add_argument(
+        "--num-shards",
+        type=int,
+        default=8,
+        help="Number of ArrayRecord shards to create",
+    )
+    parser.add_argument(
+        "--max-examples",
+        type=int,
+        default=None,
+        help="Max examples to process (for testing)",
+    )
+    args = parser.parse_args()
+
+    # Determine output location
+    is_gcs = args.output.startswith("gs://")
+    if is_gcs:
+        local_dir = tempfile.mkdtemp(prefix="maxtext-data-")
+        gcs_dir = args.output.rstrip("/")
+    else:
+        local_dir = args.output
+        os.makedirs(local_dir, exist_ok=True)
+
+    # Load dataset
+    print(f"Loading dataset: {args.dataset}")
+    if args.configs:
+        datasets_list = []
+        for config in args.configs:
+            print(f"  Loading config: {config}")
+            ds = load_dataset(args.dataset, config, split="train")
+            datasets_list.append(ds)
+        dataset = concatenate_datasets(datasets_list)
+    else:
+        dataset = load_dataset(args.dataset, split="train")
+
+    if args.max_examples:
+        dataset = dataset.select(range(min(args.max_examples, len(dataset))))
+
+    print(f"  Total examples: {len(dataset)}")
+    print(f"  Columns: {dataset.column_names}")
+
+    # Determine the conversation column
+    conv_column = None
+    for candidate in ("conversations", "messages", "text"):
+        if candidate in dataset.column_names:
+            conv_column = candidate
+            break
+
+    if conv_column is None:
+        raise ValueError(
+            f"No conversation column found. Available: {dataset.column_names}"
+        )
+    print(f"  Using column: {conv_column}")
+
+    # Preview first example
+    first = dataset[0]
+    if conv_column in ("conversations", "messages"):
+        sample_text = flatten_conversation(first[conv_column])
+    else:
+        sample_text = first[conv_column]
+    print(f"\n  Preview (first 500 chars):\n  {'─' * 60}")
+    for line in sample_text[:500].split("\n"):
+        print(f"  {line}")
+    print(f"  {'─' * 60}\n")
+
+    # Convert and shard
+    examples_per_shard = len(dataset) // args.num_shards
+    remainder = len(dataset) % args.num_shards
+
+    total_written = 0
+    shard_paths = []
+
+    for shard_idx in range(args.num_shards):
+        start = shard_idx * examples_per_shard + min(shard_idx, remainder)
+        end = start + examples_per_shard + (1 if shard_idx < remainder else 0)
+
+        shard_name = f"train.array_record-{shard_idx:05d}-of-{args.num_shards:05d}"
+        shard_path = os.path.join(local_dir, shard_name)
+        shard_paths.append(shard_path)
+
+        records = []
+        for i in range(start, end):
+            example = dataset[i]
+            if conv_column in ("conversations", "messages"):
+                text = flatten_conversation(example[conv_column])
+            else:
+                text = example[conv_column]
+
+            if text.strip():
+                records.append(make_example(text))
+
+        write_arrayrecord_shard(records, shard_path)
+        total_written += len(records)
+        print(
+            f"  Shard {shard_idx + 1}/{args.num_shards}: "
+            f"{len(records)} records -> {shard_name}"
+        )
+
+    print(f"\nTotal records written: {total_written}")
+
+    # Upload to GCS if needed
+    if is_gcs:
+        print(f"\nUploading to {gcs_dir}/")
+        for shard_path in shard_paths:
+            shard_name = os.path.basename(shard_path)
+            gcs_path = f"{gcs_dir}/{shard_name}"
+            subprocess.run(
+                ["gcloud", "storage", "cp", shard_path, gcs_path],
+                check=True,
+            )
+            print(f"  Uploaded {shard_name}")
+
+        # Clean up temp dir
+        import shutil
+        shutil.rmtree(local_dir)
+        print(f"\nDone. Use in MaxText config:")
+        print(f"  grain_train_files={gcs_dir}/train.array_record*")
+    else:
+        print(f"\nDone. Files in: {local_dir}")
+        print(f"  grain_train_files={local_dir}/train.array_record*")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/maxtext/examples/elastic_training/deploy/jobs/data-prep/submit.sh
+++ b/src/maxtext/examples/elastic_training/deploy/jobs/data-prep/submit.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Submit a data preparation K8s Job on the cluster.
+#
+# Converts a HuggingFace dataset to MaxText Grain ArrayRecord format
+# and uploads shards to GCS. Skips if data already exists.
+#
+# Required env vars (set by Cloud Build or manually):
+#   DATASET       - "synthetic" or "glaive"
+#   BUCKET_NAME   - GCS bucket name
+#   PROJECT_ID    - GCP project ID
+#   NUM_SHARDS    - number of ArrayRecord shards
+#   HF_DATASET    - HuggingFace dataset path
+#   IMAGE         - container image for the data prep job
+#
+# Usage:
+#   # Via Cloud Build (env vars set automatically):
+#   bash deploy/jobs/data-prep/submit.sh
+#
+#   # Standalone:
+#   DATASET=glaive BUCKET_NAME=my-bucket PROJECT_ID=my-project \
+#   NUM_SHARDS=8 HF_DATASET=hiyouga/glaive-function-calling-v2-sharegpt \
+#   IMAGE=us-central1-docker.pkg.dev/my-project/maxtext/maxtext-runner:latest \
+#   bash deploy/jobs/data-prep/submit.sh
+
+set -euo pipefail
+
+# Skip if synthetic
+if [ "${DATASET}" != "glaive" ]; then
+  echo "=== Using synthetic data, skipping data prep ==="
+  exit 0
+fi
+
+# Skip if data already exists
+MARKER=$(printf "gs://${BUCKET_NAME}/data/glaive-fc-v2/train.array_record-00000-of-%05d" "${NUM_SHARDS}")
+if gcloud storage ls "${MARKER}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+  echo "=== Data already prepared, skipping ==="
+  gcloud storage ls "gs://${BUCKET_NAME}/data/glaive-fc-v2/" --project="${PROJECT_ID}"
+  exit 0
+fi
+
+# Create ConfigMap from prepare_data.py
+echo "=== Creating ConfigMap with prepare_data.py ==="
+kubectl delete configmap data-prep-script --ignore-not-found=true 2>/dev/null
+kubectl create configmap data-prep-script --from-file=prepare_data.py=deploy/jobs/data-prep/prepare_data.py
+
+# Render the Job manifest
+echo "=== Rendering data prep Job manifest ==="
+sed \
+  -e "s|IMAGE_PLACEHOLDER|${IMAGE}|g" \
+  -e "s|HF_DATASET_PLACEHOLDER|${HF_DATASET}|g" \
+  -e "s|BUCKET_PLACEHOLDER|${BUCKET_NAME}|g" \
+  -e "s|NUM_SHARDS_PLACEHOLDER|${NUM_SHARDS}|g" \
+  deploy/jobs/data-prep/manifest.yaml > /tmp/data-prep-job.yaml
+
+# Submit the Job
+echo "=== Submitting data prep job ==="
+kubectl delete job data-prep-glaive --ignore-not-found=true 2>/dev/null
+kubectl apply -f /tmp/data-prep-job.yaml
+echo "=== Data prep job submitted ==="
+kubectl get job data-prep-glaive

--- a/src/maxtext/examples/elastic_training/deploy/jobs/training/jobset.yaml
+++ b/src/maxtext/examples/elastic_training/deploy/jobs/training/jobset.yaml
@@ -1,0 +1,255 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: pw-elastic
+  labels:
+    app: pw-elastic
+spec:
+  coordinator:
+    replicatedJob: pathways-head
+  failurePolicy:
+    maxRestarts: 20
+    restartStrategy: Recreate
+  network:
+    enableDNSHostnames: true
+    publishNotReadyAddresses: true
+  startupPolicy:
+    startupPolicyOrder: InOrder
+  successPolicy:
+    operator: All
+    targetReplicatedJobs:
+      - pathways-head
+  replicatedJobs:
+    - name: pathways-head
+      replicas: 1
+      template:
+        metadata:
+          annotations:
+            alpha.jobset.sigs.k8s.io/exclusive-topology: kubernetes.io/hostname
+        spec:
+          backoffLimit: 0
+          completionMode: Indexed
+          completions: 1
+          parallelism: 1
+          template:
+            metadata:
+              labels:
+                app: pw-elastic
+              annotations:
+                alpha.jobset.sigs.k8s.io/exclusive-topology: kubernetes.io/hostname
+            spec:
+              hostNetwork: true
+              dnsPolicy: ClusterFirstWithHostNet
+              restartPolicy: OnFailure
+              nodeSelector:
+                cloud.google.com/gke-nodepool: cpu-pathways-np
+              tolerations:
+                - key: node.kubernetes.io/memory-pressure
+                  operator: Exists
+                  effect: NoSchedule
+                - key: node.kubernetes.io/disk-pressure
+                  operator: Exists
+                  effect: NoSchedule
+              initContainers:
+                - name: fetch-tokenizer
+                  image: gcr.io/google.com/cloudsdktool/google-cloud-cli:slim
+                  command:
+                    - bash
+                    - -c
+                    - |
+                      set -e
+                      echo "=== Downloading tokenizer from GCS ==="
+                      gcloud storage cp -r "gs://BUCKET_PLACEHOLDER/tokenizer/qwen3-4b/*" /tokenizer/
+                      echo "=== Tokenizer ready ==="
+                      ls -la /tokenizer/
+                  volumeMounts:
+                    - name: tokenizer
+                      mountPath: /tokenizer
+                - name: pathways-rm
+                  image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest
+                  imagePullPolicy: Always
+                  restartPolicy: Always
+                  args:
+                    - --server_port=29001
+                    - --gcs_scratch_location=gs://BUCKET_PLACEHOLDER/pathways
+                    - --node_type=resource_manager
+                    # Slice count (3): keep in sync with --num_elastic_slices and worker replicas.
+                    - --instance_count=3
+                    - --instance_type=tpuv5e:4x4
+                  env:
+                    - name: REPLICATED_JOB_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.annotations['jobset.sigs.k8s.io/replicatedjob-name']
+                    - name: JOBSET_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.annotations['jobset.sigs.k8s.io/jobset-name']
+                    - name: HOST_ADDRESS
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
+                    - name: TPU_SKIP_MDS_QUERY
+                      value: "true"
+                  ports:
+                    - containerPort: 29001
+                    - containerPort: 29002
+                  resources:
+                    limits:
+                      cpu: "8"
+                      memory: 32G
+                - name: pathways-proxy
+                  image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest
+                  imagePullPolicy: Always
+                  restartPolicy: Always
+                  args:
+                    - --server_port=29000
+                    - --resource_manager_address=$(PATHWAYS_HEAD):29001
+                    - --gcs_scratch_location=gs://BUCKET_PLACEHOLDER/pathways
+                    # Slice count (3): set = slice count so Pathways tolerates any missing slice.
+                    - --num_elastic_slices=3
+                  env:
+                    - name: PATHWAYS_HEAD
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
+                  ports:
+                    - containerPort: 29000
+                  resources:
+                    limits:
+                      cpu: "16"
+                      memory: 100G
+              containers:
+                - name: main
+                  image: IMAGE_PLACEHOLDER
+                  command: ["/bin/bash", "/scripts/train.sh"]
+                  env:
+                    - name: BUCKET_NAME
+                      value: BUCKET_PLACEHOLDER
+                    - name: RUN_NAME
+                      value: RUN_NAME_PLACEHOLDER
+                    - name: DATASET
+                      value: DATASET_PLACEHOLDER
+                    - name: DEBUGGING
+                      value: "DEBUGGING_PLACEHOLDER"
+                    - name: HF_TOKEN
+                      valueFrom:
+                        secretKeyRef:
+                          name: hf-token
+                          key: token
+                    - name: PATHWAYS_HEAD
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
+                    - name: JAX_PLATFORMS
+                      value: proxy
+                    - name: XCLOUD_ENVIRONMENT
+                      value: GCP
+                    - name: JAX_BACKEND_TARGET
+                      value: grpc://$(PATHWAYS_HEAD):29000
+                  volumeMounts:
+                    - name: train-script
+                      mountPath: /scripts
+                    - name: tokenizer
+                      mountPath: /tokenizer
+                      readOnly: true
+              volumes:
+                - name: train-script
+                  configMap:
+                    name: train-script
+                    defaultMode: 0755
+                - name: tokenizer
+                  emptyDir: {}
+    - name: worker
+      # Slice count (3): one worker Job per TPU slice; matches the head pod flags above.
+      replicas: 3
+      template:
+        spec:
+          backoffLimit: 20
+          completionMode: Indexed
+          completions: 4
+          parallelism: 4
+          template:
+            metadata:
+              labels:
+                app: pw-elastic
+              annotations:
+                alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool
+            spec:
+              hostNetwork: true
+              dnsPolicy: ClusterFirstWithHostNet
+              restartPolicy: OnFailure
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+                cloud.google.com/gke-tpu-topology: 4x4
+              containers:
+                - name: pathways-worker
+                  image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest
+                  imagePullPolicy: Always
+                  args:
+                    - --server_port=29005
+                    - --resource_manager_address=$(PATHWAYS_HEAD):29001
+                    - --gcs_scratch_location=gs://BUCKET_PLACEHOLDER/pathways
+                  env:
+                    - name: TPU_MIN_LOG_LEVEL
+                      value: "0"
+                    - name: TF_CPP_MIN_LOG_LEVEL
+                      value: "0"
+                    - name: XCLOUD_ENVIRONMENT
+                      value: GCP
+                    - name: MEGASCALE_GRPC_ENABLE_XOR_TRACER
+                      value: "false"
+                    - name: MEGASCALE_NUM_SLICES
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['jobset.sigs.k8s.io/replicatedjob-replicas']
+                    - name: JOBSET_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.annotations['jobset.sigs.k8s.io/jobset-name']
+                    - name: REPLICATED_JOB_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.annotations['jobset.sigs.k8s.io/replicatedjob-name']
+                    - name: MEGASCALE_SLICE_ID
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['jobset.sigs.k8s.io/job-index']
+                    - name: PATHWAYS_HEAD
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
+                    - name: MEGASCALE_COORDINATOR_ADDRESS
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
+                  ports:
+                    - containerPort: 29005
+                    - containerPort: 29006
+                    - containerPort: 8471
+                    - containerPort: 8080
+                  resources:
+                    limits:
+                      google.com/tpu: "4"
+                  volumeMounts:
+                    - name: shared-tmp
+                      mountPath: /tmp
+              volumes:
+                - name: shared-tmp
+                  hostPath:
+                    path: /tmp
+                    type: DirectoryOrCreate

--- a/src/maxtext/examples/elastic_training/deploy/jobs/training/submit.sh
+++ b/src/maxtext/examples/elastic_training/deploy/jobs/training/submit.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploy the elastic training JobSet on the cluster.
+#
+# Renders the training manifest with dataset-specific flags
+# and applies it to the cluster.
+#
+# Required env vars (set by Cloud Build or manually):
+#   DATASET       - "synthetic" or "glaive"
+#   BUCKET_NAME   - GCS bucket name
+#   IMAGE         - container image for training
+#   RUN_NAME      - training run name
+#
+# Prerequisites:
+#   K8s secret "hf-token" must exist (created by Terraform)
+#
+# Usage:
+#   # Via Cloud Build (env vars set automatically):
+#   bash deploy/jobs/training/submit.sh
+#
+#   # Standalone:
+#   DATASET=glaive BUCKET_NAME=my-bucket RUN_NAME=elastic-qwen3-0.6b \
+#   IMAGE=us-central1-docker.pkg.dev/my-project/maxtext/maxtext-runner:latest \
+#   bash deploy/jobs/training/submit.sh
+
+set -euo pipefail
+
+# Clean up previous run output
+echo "=== Cleaning GCS output for run: ${RUN_NAME} ==="
+gcloud storage rm -r "gs://${BUCKET_NAME}/output/${RUN_NAME}/" 2>/dev/null || true
+gcloud storage rm -r "gs://${BUCKET_NAME}/pathways/" 2>/dev/null || true
+
+# Delete existing job if present
+echo "=== Deploying training job (dataset=${DATASET}) ==="
+kubectl delete jobset pw-elastic --ignore-not-found=true --wait=true 2>/dev/null || true
+sleep 3
+
+# Create ConfigMap from train.sh
+echo "=== Creating ConfigMap with train.sh ==="
+kubectl delete configmap train-script --ignore-not-found=true 2>/dev/null
+kubectl create configmap train-script --from-file=train.sh=deploy/jobs/training/train.sh
+
+# Render the manifest
+sed \
+  -e "s|IMAGE_PLACEHOLDER|${IMAGE}|g" \
+  -e "s|BUCKET_PLACEHOLDER|${BUCKET_NAME}|g" \
+  -e "s|RUN_NAME_PLACEHOLDER|${RUN_NAME}|g" \
+  -e "s|DATASET_PLACEHOLDER|${DATASET}|g" \
+  -e "s|DEBUGGING_PLACEHOLDER|${DEBUGGING:-false}|g" \
+  deploy/jobs/training/jobset.yaml > /tmp/training-job.yaml
+
+# Apply
+kubectl apply -f /tmp/training-job.yaml
+
+echo ""
+echo "=== JobSet deployed ==="
+echo "Monitor with:"
+echo "  kubectl logs -f \$(kubectl get pods -l job-name=pw-elastic-pathways-head-0 -o name | head -1) -c main"

--- a/src/maxtext/examples/elastic_training/deploy/jobs/training/train.sh
+++ b/src/maxtext/examples/elastic_training/deploy/jobs/training/train.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run MaxText elastic training with Qwen3 0.6B.
+#
+# Called inside the training container by the JobSet manifest.
+# All flags are passed via environment variables so the manifest
+# stays clean and the command is easy to modify.
+#
+# Required env vars:
+#   BUCKET_NAME   - GCS bucket for output and scratch
+#   RUN_NAME      - training run name (used in checkpoint path)
+#   DATASET       - "synthetic" or "glaive"
+#
+# Optional env vars (debugging):
+#   DEBUGGING     - "true" to enable all debugging features (default: "false")
+
+set -euo pipefail
+
+# Dataset-specific flags
+if [ "${DATASET}" = "glaive" ]; then
+  DATASET_FLAGS=(
+    dataset_type=grain
+    grain_file_type=arrayrecord
+    "grain_train_files=gs://${BUCKET_NAME}/data/glaive-fc-v2/train.array_record*"
+    grain_worker_count=2
+    tokenize_train_data=true
+    tokenizer_path=/tokenizer
+    num_epoch=50
+  )
+else
+  DATASET_FLAGS=(
+    dataset_type=synthetic
+    reuse_example_batch=1
+  )
+fi
+
+# Debugging flags: DEBUGGING=true adds XProf profiling + goodput monitoring.
+DEBUG_FLAGS=()
+if [ "${DEBUGGING:-false}" = "true" ]; then
+  DEBUG_FLAGS=(
+    profiler=xplane
+    profiler_steps=5
+    skip_first_n_steps_for_profiler=1
+    enable_goodput_recording=True
+    monitor_goodput=True
+    goodput_upload_interval_seconds=30
+    enable_checkpoint_cloud_logger=True
+  )
+  echo "Debugging enabled: xplane profiler + goodput monitoring"
+fi
+
+# Training. checkpoint_period=100 keeps a recent checkpoint for fast recovery;
+# qwen3-0.6b keeps the checkpoint (~7 GiB) under the proxy memory limit. See the
+# README appendix for the rationale and how to run a larger model.
+python3 -m maxtext.trainers.pre_train.train \
+  src/maxtext/configs/base.yml \
+  base_output_directory=gs://${BUCKET_NAME}/output \
+  run_name=${RUN_NAME} \
+  model_name=qwen3-0.6b \
+  per_device_batch_size=1 \
+  enable_checkpointing=true \
+  enable_single_controller=True \
+  remat_policy=full \
+  steps=5000 \
+  checkpoint_period=100 \
+  max_target_length=2048 \
+  attention=flash \
+  gcs_metrics=True \
+  elastic_enabled=true \
+  elastic_timeout_seconds=300 \
+  elastic_max_retries=10 \
+  "${DATASET_FLAGS[@]}" \
+  "${DEBUG_FLAGS[@]}"

--- a/src/maxtext/examples/elastic_training/elastic_qwen3_demo.ipynb
+++ b/src/maxtext/examples/elastic_training/elastic_qwen3_demo.ipynb
@@ -1,0 +1,696 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2026 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Elastic Training on Cloud TPUs with MaxText and Pathways\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://colab.research.google.com/github/AI-Hypercomputer/maxtext/blob/main/src/maxtext/examples/elastic_training/elastic_qwen3_demo.ipynb\">\n",
+    "      <img width=\"32px\" src=\"https://www.gstatic.com/pantheon/images/bigquery/welcome_page/colab-logo.svg\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/examples/elastic_training/elastic_qwen3_demo.ipynb\">\n",
+    "      <img width=\"32px\" src=\"https://raw.githubusercontent.com/primer/octicons/refs/heads/main/icons/mark-github-24.svg\" alt=\"GitHub logo\"><br> View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>\n",
+    "\n",
+    "<div style=\"clear: both;\"></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "| Author(s) |\n",
+    "| --- |\n",
+    "| [Ivan Nardini](https://github.com/inardini) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "\n",
+    "This tutorial demonstrates **elastic training** on Cloud TPUs: training that survives a slice failure in-process, without restarting the job. You will provision 3 TPU v5e slices on GKE, launch a Qwen3 0.6B pre-training run orchestrated by Pathways, terminate a worker mid-run to simulate a hardware failure, and confirm that training recovers from the last checkpoint on the same head pod, in about 40 seconds, with no job restart.\n",
+    "\n",
+    "**What you'll do:**\n",
+    "1. Provision a GKE cluster with 3 TPU v5e slices and a CPU node (`terraform apply`)\n",
+    "2. Deploy the MaxText image and the elastic training JobSet via Cloud Build (`gcloud builds submit`)\n",
+    "3. Watch training compile and reach a steady step rate (`kubectl logs`)\n",
+    "4. Terminate a worker and verify in-process recovery (`kubectl delete pod`)\n",
+    "5. Tear down all infrastructure (`terraform destroy`)\n",
+    "\n",
+    "Each step runs a single `terraform`, `gcloud`, or `kubectl` command. The same steps are available as `make` targets for terminal use; this notebook calls the underlying commands directly. The Terraform config, the Cloud Build pipeline, and the training JobSet live next to this notebook in `terraform/` and `deploy/`.\n",
+    "\n",
+    "### Why elastic training\n",
+    "\n",
+    "Large model training runs across many TPU slices, and at that scale individual slices fail routinely, from hardware faults, preemption, or network blips. By default a single slice failure crashes the whole job: you restart from scratch and lose both the XLA compilation time (JAX compiling the model graph for the TPU) and all progress since the last checkpoint.\n",
+    "\n",
+    "Elastic training avoids the full restart. **Pathways** (the runtime that orchestrates training across slices) detects the dead slice and reports it to the training process. **MaxText**'s `elastic_retry` wraps the training step and catches that error *inside the same Python process*, rather than letting it propagate and kill the job. **Orbax** (the checkpoint library) discards any checkpoint that was interrupted mid-write, and training rewinds to the last fully committed checkpoint. Because the head process never exits, the expensive XLA recompile is skipped and recovery completes in roughly 40 seconds.\n",
+    "\n",
+    "This is a multi-host workload: it requires 3 live TPU v5e slices (48 chips) plus a Pathways control plane on GKE, so it runs on a real Google Cloud project with TPU quota rather than in single-runner notebook CI."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The recovery sequence\n",
+    "\n",
+    "The diagram below traces what happens the moment a slice fails. The `commit_success` marker is the key detail: Orbax writes it only after a checkpoint is fully flushed to GCS, so a checkpoint interrupted mid-write has no marker and is safely discarded, and recovery always resumes from a complete checkpoint. You will see each of these log lines appear in Step 4.\n",
+    "\n",
+    "```mermaid\n",
+    "sequenceDiagram\n",
+    "    participant T as Training Loop\n",
+    "    participant E as elastic_retry\n",
+    "    participant C as Checkpointing\n",
+    "    participant GCS as GCS Bucket\n",
+    "\n",
+    "    T->>T: Training step N\n",
+    "    Note over T: Slice fails\n",
+    "    T-->>E: Exception caught\n",
+    "    E->>C: clean_up_checkpoints()\n",
+    "    C->>GCS: Check for commit_success marker\n",
+    "    C->>GCS: No marker found, delete incomplete checkpoint\n",
+    "    E->>T: Re-initialize training\n",
+    "    T->>GCS: Load last good checkpoint\n",
+    "    T->>T: Resume training from checkpoint\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Notice.** This notebook provisions real infrastructure (3 TPU v5e slices + a CPU node) at on-demand list price, so a full ~30-minute run costs roughly **$30**. (TPU v5e is ~$1.20/chip-hr. See [TPU pricing](https://cloud.google.com/tpu/pricing).) **Always run the final `terraform destroy` cell when you are done**, even if you stop halfway."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get started"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prerequisites\n",
+    "\n",
+    "This notebook drives Google Cloud infrastructure, so it expects to run from a machine that already has the CLIs and credentials, Cloud Shell, or a local shell with the Cloud SDK. It does not install them. You'll need:\n",
+    "\n",
+    "- A Google Cloud project with billing enabled.\n",
+    "- **TPU v5e on-demand quota**: at least 48 chips in `us-central1`. Request the `Tpu-v5-litepod-device` quota in [IAM & Admin > Quotas](https://console.cloud.google.com/iam-admin/quotas); without it, provisioning fails.\n",
+    "- A [Hugging Face token](https://huggingface.co/settings/tokens) with the `read` role. Qwen3 is ungated, but the pipeline wires the token through so the same setup works for a gated model.\n",
+    "- CLI tools on your PATH: `terraform` (>= 1.5.0), `gcloud`, and `kubectl`.\n",
+    "\n",
+    "For the supported ways to run MaxText notebooks (Colab, VS Code, local Jupyter), see the [Run MaxText Python Notebooks](https://github.com/AI-Hypercomputer/maxtext/blob/main/docs/guides/run_python_notebook.md) guide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set your configuration\n",
+    "\n",
+    "Edit the two **required** values below, `PROJECT_ID` and `HF_TOKEN`. The remaining variables have defaults that match `terraform/variables.tf` and rarely need changing. This is the notebook's **parameters** cell, so an automated runner can override any of these values without editing the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Required: edit these two (or override them when testing).\n",
+    "PROJECT_ID = \"your-project-id\"  # your GCP project ID\n",
+    "HF_TOKEN = \"hf_...\"             # your HuggingFace read token\n",
+    "\n",
+    "# Optional: defaults match terraform/variables.tf.\n",
+    "REGION = \"us-central1\"\n",
+    "ZONE = \"us-central1-a\"\n",
+    "CLUSTER_NAME = \"maxtext-elastic-training\"\n",
+    "BUCKET_NAME = \"\"  # leave empty to derive maxtext-elastic-training-PROJECT_ID below\n",
+    "DATASET = \"glaive\"  # \"glaive\" or \"synthetic\"\n",
+    "RUN_NAME = \"elastic-qwen3-0.6b\"\n",
+    "DEBUGGING = \"false\"\n",
+    "TPU_SPOT = False       # True = cheaper Spot (preemptible) TPUs; False = on-demand\n",
+    "SLICE = \"2\"            # which slice to terminate in the failure step\n",
+    "RUN_SECOND_FAILURE = False  # set True to terminate a second slice at the end\n",
+    "HEADLESS = \"\"          # set non-empty by automated test runs to skip interactive prompts\n",
+    "\n",
+    "# Total seconds to wait for long-running stages before giving up (headless safety).\n",
+    "POLL_TIMEOUT = 1800"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Apply the configuration\n",
+    "\n",
+    "This cell derives computed values (such as the bucket name), exports everything to the environment so the `terraform`, `gcloud`, and `kubectl` cells can read it, and changes into the example directory so the relative `terraform/` and `deploy/` paths resolve. It is kept separate from the parameters cell so it re-runs after an automated runner injects overrides."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not BUCKET_NAME:\n",
+    "    BUCKET_NAME = f\"maxtext-elastic-training-{PROJECT_ID}\"\n",
+    "\n",
+    "os.environ.update(\n",
+    "    PROJECT_ID=PROJECT_ID, HF_TOKEN=HF_TOKEN, REGION=REGION, ZONE=ZONE,\n",
+    "    CLUSTER_NAME=CLUSTER_NAME, BUCKET_NAME=BUCKET_NAME, DATASET=DATASET,\n",
+    "    RUN_NAME=RUN_NAME, DEBUGGING=DEBUGGING, SLICE=str(SLICE),\n",
+    ")\n",
+    "\n",
+    "# Move into the example folder so terraform/ and deploy/ resolve. Idempotent: if we are\n",
+    "# already inside elastic_training/ we stay put; otherwise we look for it relative to the\n",
+    "# cloned MaxText repo, and stop with a clear message if it is not there.\n",
+    "EXAMPLE_DIR = \"src/maxtext/examples/elastic_training\"\n",
+    "if os.path.basename(os.getcwd()) != \"elastic_training\":\n",
+    "    if os.path.isdir(EXAMPLE_DIR):\n",
+    "        os.chdir(EXAMPLE_DIR)\n",
+    "    elif not os.path.isdir(\"terraform\"):\n",
+    "        raise RuntimeError(\n",
+    "            \"Run this notebook from a cloned MaxText repo: \"\n",
+    "            \"`git clone https://github.com/AI-Hypercomputer/maxtext`, then open \"\n",
+    "            \"src/maxtext/examples/elastic_training/elastic_qwen3_demo.ipynb from there.\"\n",
+    "        )\n",
+    "assert os.path.isdir(\"terraform\") and os.path.isdir(\"deploy\"), (\n",
+    "    f\"Expected terraform/ and deploy/ in {os.getcwd()}; are you in the elastic_training folder?\"\n",
+    ")\n",
+    "print(f\"Configured project {PROJECT_ID}, bucket {BUCKET_NAME}\")\n",
+    "print(f\"Working directory: {os.getcwd()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Authenticate\n",
+    "\n",
+    "Terraform, `gcloud`, and `kubectl` all act through Application Default Credentials (ADC). In Colab this cell authenticates you interactively. On a kernel that already has ADC, a TPU VM, Cloud Shell, or a service-account runner, it detects the existing credentials and does nothing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    from google.colab import auth\n",
+    "\n",
+    "    auth.authenticate_user()\n",
+    "elif not HEADLESS:\n",
+    "    # Interactive run: open the login flow only if ADC is not already present.\n",
+    "    # Headless runs (HEADLESS set, e.g. automated notebook testing) skip this and\n",
+    "    # rely on the runner's service account / ADC.\n",
+    "    has_adc = os.system(\"gcloud auth application-default print-access-token >/dev/null 2>&1\") == 0\n",
+    "    if not has_adc:\n",
+    "        !gcloud auth application-default login\n",
+    "    else:\n",
+    "        print(\"ADC already present; skipping login.\")\n",
+    "else:\n",
+    "    print(\"HEADLESS set; relying on the runner service account / ADC.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate `terraform.tfvars`\n",
+    "\n",
+    "Terraform reads its inputs from `terraform/terraform.tfvars`. This cell writes that file from the configuration above. (The `Makefile` generates the same file from a `.env` for terminal use; the notebook writes it directly.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tfvars = f'''project_id       = \"{PROJECT_ID}\"\n",
+    "region           = \"{REGION}\"\n",
+    "zone             = \"{ZONE}\"\n",
+    "cluster_name     = \"{CLUSTER_NAME}\"\n",
+    "cluster_version  = \"\"\n",
+    "network          = \"default\"\n",
+    "subnetwork       = \"default\"\n",
+    "tpu_machine_type = \"ct5lp-hightpu-4t\"\n",
+    "tpu_topology     = \"4x4\"\n",
+    "num_tpu_slices   = 3\n",
+    "nodes_per_slice  = 4\n",
+    "cpu_machine_type = \"n2-standard-64\"\n",
+    "num_cpu_nodes    = 1\n",
+    "gcs_bucket_name  = \"{BUCKET_NAME}\"\n",
+    "hf_token         = \"{HF_TOKEN}\"\n",
+    "tpu_reservation  = \"\"\n",
+    "tpu_spot         = {str(TPU_SPOT).lower()}\n",
+    "'''\n",
+    "\n",
+    "with open(\"terraform/terraform.tfvars\", \"w\") as f:\n",
+    "    f.write(tfvars)\n",
+    "print(\"Wrote terraform/terraform.tfvars\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Provision the infrastructure\n",
+    "\n",
+    "`terraform apply` creates everything the run needs: the GKE cluster, the TPU and CPU node pools, a GCS bucket for checkpoints, an Artifact Registry repository, a dedicated Cloud Build service account (new projects disable the legacy default compute SA), the IAM bindings, and the Hugging Face token wired into both Secret Manager and a Kubernetes secret. The `-chdir=terraform` flag runs Terraform against the `terraform/` subfolder.\n",
+    "\n",
+    "This takes about **10 minutes** and starts the ~$61/hr meter (Step 6 tears it down).\n",
+    "\n",
+    "### What you should see\n",
+    "\n",
+    "Terraform prints a plan, applies it, and ends with:\n",
+    "\n",
+    "```\n",
+    "Apply complete! Resources: NN added, 0 changed, 0 destroyed.\n",
+    "```\n",
+    "\n",
+    "> **Troubleshooting**: if Terraform fails with quota errors, check your `Tpu-v5-litepod-device` quota in IAM & Admin > Quotas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!terraform -chdir=terraform init -input=false\n",
+    "!terraform -chdir=terraform apply -auto-approve"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Deploy the training job\n",
+    "\n",
+    "A single Cloud Build pipeline runs five phases: build the MaxText image, install the JobSet API on the cluster, download the tokenizer to GCS, prepare the training data, and apply the training JobSet. The image builds in Cloud Build, so no local Docker is needed. The build runs as the dedicated service account Terraform created in Step 1, retrieved here from the Terraform output.\n",
+    "\n",
+    "This takes about **6 minutes**.\n",
+    "\n",
+    "### What you should see\n",
+    "\n",
+    "A stream of Cloud Build step logs ending with:\n",
+    "\n",
+    "```\n",
+    "DONE\n",
+    "...\n",
+    "STATUS: SUCCESS\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "# Dedicated Cloud Build SA created by Terraform (new projects disable the default compute SA).\n",
+    "BUILD_SA=$(terraform -chdir=terraform output -raw cloudbuild_service_account)\n",
+    "gcloud builds submit --config=deploy/deploy.yaml \\\n",
+    "  --service-account=\"projects/$PROJECT_ID/serviceAccounts/$BUILD_SA\" \\\n",
+    "  --substitutions=_CLUSTER_NAME=$CLUSTER_NAME,_CLUSTER_ZONE=$ZONE,_BUCKET_NAME=$BUCKET_NAME,_DATASET=$DATASET,_DEBUGGING=$DEBUGGING,_RUN_NAME=$RUN_NAME \\\n",
+    "  --project=\"$PROJECT_ID\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Check the pods\n",
+    "\n",
+    "Fetch cluster credentials and list the pods to confirm the JobSet scheduled correctly.\n",
+    "\n",
+    "### What you should see\n",
+    "\n",
+    "**13 pods**: 1 head pod (running the training script `main`, with the Pathways Resource Manager and the IFRT proxy as sidecars) and **12 worker pods across 3 slices** (4 workers per slice). It can take a couple of minutes for all of them to reach `Running`:\n",
+    "\n",
+    "```\n",
+    "NAME                                 READY   STATUS    RESTARTS   AGE\n",
+    "pw-elastic-pathways-head-0-0-xxxxx   1/1     Running   0          2m\n",
+    "pw-elastic-worker-0-0-xxxxx          1/1     Running   0          2m\n",
+    "...\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "gcloud container clusters get-credentials \"$CLUSTER_NAME\" \\\n",
+    "  --zone=\"$ZONE\" --project=\"$PROJECT_ID\" --quiet\n",
+    "kubectl get pods"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Log helpers\n",
+    "\n",
+    "The next steps wait for specific markers in the head pod's log, a steady step rate, then the recovery sequence. `kubectl logs --follow` streams indefinitely and never returns, which is fine to watch by hand but hangs an automated run. These helpers poll the log until the marker appears (or `POLL_TIMEOUT` elapses) and then return, so the notebook runs cleanly both interactively and headlessly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "import subprocess\n",
+    "import time\n",
+    "\n",
+    "\n",
+    "def head_pod():\n",
+    "    \"\"\"Return the head pod name, or \"\" if it is not scheduled yet.\"\"\"\n",
+    "    out = subprocess.run(\n",
+    "        [\"kubectl\", \"get\", \"pods\", \"-l\", \"job-name=pw-elastic-pathways-head-0\",\n",
+    "         \"-o\", \"jsonpath={.items[0].metadata.name}\"],\n",
+    "        capture_output=True, text=True,\n",
+    "    )\n",
+    "    return out.stdout.strip()\n",
+    "\n",
+    "\n",
+    "def head_log(tail=200):\n",
+    "    \"\"\"Return the last `tail` lines of the head pod main container log.\"\"\"\n",
+    "    pod = head_pod()\n",
+    "    if not pod:\n",
+    "        return \"\"\n",
+    "    out = subprocess.run(\n",
+    "        [\"kubectl\", \"logs\", pod, \"-c\", \"main\", f\"--tail={tail}\"],\n",
+    "        capture_output=True, text=True,\n",
+    "    )\n",
+    "    return out.stdout\n",
+    "\n",
+    "\n",
+    "def latest_step(log_text):\n",
+    "    \"\"\"Highest \"completed step: N\" seen in the log text, or -1.\"\"\"\n",
+    "    steps = [int(m) for m in re.findall(r'completed step: (\\d+)', log_text)]\n",
+    "    return max(steps) if steps else -1\n",
+    "\n",
+    "\n",
+    "def wait_for(predicate, what, timeout=None, interval=5):\n",
+    "    \"\"\"Poll until predicate(log_text) is true. Returns the final log text.\"\"\"\n",
+    "    timeout = timeout or POLL_TIMEOUT\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        log = head_log()\n",
+    "        if predicate(log):\n",
+    "            print(f\"OK: {what}\")\n",
+    "            return log\n",
+    "        time.sleep(interval)\n",
+    "    raise TimeoutError(f\"Timed out after {timeout}s waiting for: {what}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Watch training start\n",
+    "\n",
+    "Wait for training to compile and reach a steady step rate. The cell polls the head pod log until the step counter passes ~130, which guarantees checkpoint 100 has committed, the checkpoint recovery will restore from in the next step, then prints the latest step lines. It returns on its own, so it is safe to re-run and safe for an automated run.\n",
+    "\n",
+    "### What you should see\n",
+    "\n",
+    "After XLA compilation (about **2-3 minutes**), the log shows that elastic training is enabled and then a steady stream of steps:\n",
+    "\n",
+    "```\n",
+    "Elastic utils: Elastic training enabled.\n",
+    "Elastic Retry Enabled\n",
+    "completed step: 8, seconds: 0.159, TFLOP/s/device: 43.430, loss: 220.774\n",
+    "completed step: 9, seconds: 0.166, TFLOP/s/device: 41.524, loss: 217.296\n",
+    "completed step: 10, seconds: 0.160, TFLOP/s/device: 43.230, loss: 216.126\n",
+    "```\n",
+    "\n",
+    "From then on expect **~43 TFLOP/s/device at ~0.16s/step**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "log = wait_for(lambda t: latest_step(t) >= 130,\n",
+    "               \"training reached step 130 (checkpoint 100 committed)\")\n",
+    "for line in [l for l in log.splitlines() if \"completed step:\" in l][-3:]:\n",
+    "    print(line)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Simulate a slice failure\n",
+    "\n",
+    "This step injects the failure. The cell first waits for a **safe checkpoint window**: elastic retry can only recover from a fully committed checkpoint, so it waits until the step is past 140 and off the write boundary, ensuring a clean checkpoint exists and none is in flight. It then terminates a worker on the chosen slice (`SLICE`, default 2) with `kubectl delete pod --grace-period=0 --force`, an immediate SIGKILL. The hard termination is deliberate: it mimics a real hardware failure, which does not drain gracefully the way an ordinary pod deletion does. Set `SLICE` in the parameters cell to target a different slice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def in_safe_window(log_text):\n",
+    "    step = latest_step(log_text)\n",
+    "    mod = step % 100\n",
+    "    return step >= 140 and 40 <= mod <= 95\n",
+    "\n",
+    "\n",
+    "wait_for(in_safe_window, \"safe checkpoint window (step >= 140, off the write boundary)\")\n",
+    "step_before = latest_step(head_log())\n",
+    "print(f\"Training at step {step_before}; terminating a worker on slice {SLICE}\")\n",
+    "\n",
+    "victim = subprocess.run(\n",
+    "    [\"kubectl\", \"get\", \"pods\", \"-l\", f\"job-name=pw-elastic-worker-{SLICE}\",\n",
+    "     \"-o\", \"jsonpath={.items[0].metadata.name}\"],\n",
+    "    capture_output=True, text=True,\n",
+    ").stdout.strip()\n",
+    "if not victim:\n",
+    "    print(f\"No running worker found on slice {SLICE} yet. If you just triggered a failure, \"\n",
+    "          \"wait for recovery to finish, then re-run this cell.\")\n",
+    "else:\n",
+    "    print(f\"Terminating {victim} (slice {SLICE}, --grace-period=0)\")\n",
+    "    subprocess.run([\"kubectl\", \"delete\", \"pod\", victim, \"--grace-period=0\", \"--force\"], check=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Verify recovery\n",
+    "\n",
+    "Recovery shows up in the *same head pod log* tailed earlier, which is the point: the head process never exited. Within ~15 seconds of the termination, Pathways reports the slice down and elastic retry restores the last committed checkpoint, with no new pod and no job restart. The cell waits for the restore marker and the resumed step counter, then prints the recovery lines.\n",
+    "\n",
+    "### What you should see\n",
+    "\n",
+    "```\n",
+    "Slice down event detected. Retrying.\n",
+    "Found commit_success file. Keeping gs://.../checkpoints/100/.\n",
+    "Elastic attempt 2 out of 10\n",
+    "Restoring checkpoint from gs://.../checkpoints/100.\n",
+    "completed step: 101, ...\n",
+    "```\n",
+    "\n",
+    "The step counter dropping (e.g. 150 -> 101) is the rewind to the last committed checkpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "log = wait_for(\n",
+    "    lambda t: \"Restoring checkpoint from\" in t or \"Slice down event detected\" in t,\n",
+    "    \"recovery started (slice down detected / checkpoint restoring)\",\n",
+    ")\n",
+    "markers = (\"Slice down event\", \"Elastic attempt\", \"Keeping gs://\",\n",
+    "           \"Restoring checkpoint from\")\n",
+    "for line in log.splitlines():\n",
+    "    if any(m in line for m in markers):\n",
+    "        print(line)\n",
+    "print(f\"Latest step after recovery: {latest_step(head_log())}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 7: Confirm nothing restarted\n",
+    "\n",
+    "Two `kubectl` queries confirm the recovery was in-process rather than a restart: the `pathways-proxy` init-container's `restartCount` and the JobSet's `restarts`. Both read `0`, the container and the JobSet are the same ones from before the failure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "kubectl get pod -l job-name=pw-elastic-pathways-head-0 \\\n",
+    "  -o jsonpath='{.items[0].status.initContainerStatuses[?(@.name==\"pathways-proxy\")].restartCount}'\n",
+    "echo \"  <- pathways-proxy restartCount (expect 0)\"\n",
+    "kubectl get jobset pw-elastic -o jsonpath='{.status.restarts}'\n",
+    "echo \"  <- jobset restarts (expect 0)\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Trigger a second failure (optional)\n",
+    "\n",
+    "The job is still running, so you can repeat the failure on a different slice to confirm recovery is repeatable. This cell runs only when `RUN_SECOND_FAILURE = True` in the parameters cell (off by default). It terminates a worker on slice 1 and waits for the second recovery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if RUN_SECOND_FAILURE:\n",
+    "    second_slice = \"1\"\n",
+    "    wait_for(in_safe_window,\n",
+    "             \"safe window before second failure\")\n",
+    "    victim = subprocess.run(\n",
+    "        [\"kubectl\", \"get\", \"pods\", \"-l\", f\"job-name=pw-elastic-worker-{second_slice}\",\n",
+    "         \"-o\", \"jsonpath={.items[0].metadata.name}\"],\n",
+    "        capture_output=True, text=True,\n",
+    "    ).stdout.strip()\n",
+    "    if not victim:\n",
+    "        print(f\"No running worker found on slice {second_slice}; skipping.\")\n",
+    "    else:\n",
+    "        print(f\"Terminating {victim} (slice {second_slice})\")\n",
+    "        subprocess.run([\"kubectl\", \"delete\", \"pod\", victim, \"--grace-period=0\", \"--force\"], check=True)\n",
+    "        wait_for(lambda t: \"Restoring checkpoint from\" in t,\n",
+    "                 \"second recovery started\")\n",
+    "else:\n",
+    "    print(\"RUN_SECOND_FAILURE is False; skipping the optional second failure.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**What this demo does *not* show**: true elastic *degradation*, where training continues on 2 of 3 slices at reduced throughput while the third is down. That requires dynamic mesh resize in MaxText, which is not yet implemented: today the mesh is fixed at startup, so recovery always means \"restore the checkpoint and wait for all slices\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clean up\n",
+    "\n",
+    "Tear everything down to stop the meter. This deletes the JobSet and runs `terraform destroy` to remove all the infrastructure created in Step 1. The TPU slices cost ~$58/hr, so do not skip this. To remove everything completely, you can also [delete the Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects).\n",
+    "\n",
+    "### What you should see\n",
+    "\n",
+    "```\n",
+    "Destroy complete! Resources: NN destroyed.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "gcloud container clusters get-credentials \"$CLUSTER_NAME\" \\\n",
+    "  --zone=\"$ZONE\" --project=\"$PROJECT_ID\" --quiet || true\n",
+    "kubectl delete jobset pw-elastic --ignore-not-found=true || true\n",
+    "terraform -chdir=terraform destroy -auto-approve"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Learn more\n",
+    "\n",
+    "- **Elastic training flags**: the run is configured in `deploy/jobs/training/train.sh`, `elastic_enabled`, `elastic_timeout_seconds`, `elastic_max_retries`, `enable_single_controller` (runs training through Pathways), and `checkpoint_period=100` (frequent enough that recovery rewinds only a little).\n",
+    "- **Running a larger model**: during recovery the checkpoint streams through the `pathways-proxy` sidecar, capped at `memory: 100G` in `deploy/jobs/training/jobset.yaml`. Qwen3 0.6B keeps the checkpoint around 7 GiB; for a bigger model, raise that limit. See the README for details.\n",
+    "- **Terminal workflow**: the `Makefile` wraps every command here as `make infra`, `make deploy`, `make demo`, `make fail`, and `make destroy`.\n",
+    "- **Check out [MaxText documentation](https://maxtext.readthedocs.io/)**. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "elastic_qwen3_demo.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/src/maxtext/examples/elastic_training/terraform/.terraform.lock.hcl
+++ b/src/maxtext/examples/elastic_training/terraform/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.27.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:6AJy+nvWVF6i+f2HS5AXloSTlSA0y5kjDCFOWYr6HZY=",
+    "zh:240605f01c575a32378b96634a7bbe17462051320fa7df064dae8d81e9c9c471",
+    "zh:41ffa473e08379de494c7beb4bc1ee98631c2657355dacd15fe75f52eb2ffd99",
+    "zh:4b813338a275c7d5bbd69f8a9d4fbd97b7672064ee42e98f1f01699f7b8ced77",
+    "zh:7f582320ea0578e3eaf4ec54fc370b1eac684972afe0728a94a961a52a037053",
+    "zh:84f53702ba1c8d912236d1911b90db2b1dbc011127831ae67dfcd280710334d8",
+    "zh:85d775e3c42f3b88914d059bd11c46e25a1cb9cce912c9fbc35428114b099d47",
+    "zh:93a2a30bc254706525eaa5e0a35d2122377b735fe1f3dccd887c35b3755b32d3",
+    "zh:a921d2ab38464bce393e8fd2aa11a140ed56632f94895d93bb272e204931c8c6",
+    "zh:c221992557de048b40a4fae102dfa5200c32715b21c0a251c1e931eafbc6a698",
+    "zh:cef310150cdf62a6a49e45f049f21077c58971c6197b70528a69b572dbf218fd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f630cf936bbbadc67a374329cc80fbe9d706fa2fb1556e130bc7a3f0386697fb",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "3.0.1"
+  constraints = ">= 2.30.0"
+  hashes = [
+    "h1:P0c8knzZnouTNFIRij8IS7+pqd0OKaFDYX0j4GRsiqo=",
+    "zh:02d55b0b2238fd17ffa12d5464593864e80f402b90b31f6e1bd02249b9727281",
+    "zh:20b93a51bfeed82682b3c12f09bac3031f5bdb4977c47c97a042e4df4fb2f9ba",
+    "zh:6e14486ecfaee38c09ccf33d4fdaf791409f90795c1b66e026c226fad8bc03c7",
+    "zh:8d0656ff422df94575668e32c310980193fccb1c28117e5c78dd2d4050a760a6",
+    "zh:9795119b30ec0c1baa99a79abace56ac850b6e6fbce60e7f6067792f6eb4b5f4",
+    "zh:b388c87acc40f6bd9620f4e23f01f3c7b41d9b88a68d5255dec0a72f0bdec249",
+    "zh:b59abd0a980649c2f97f172392f080eaeb18e486b603f83bf95f5d93aeccc090",
+    "zh:ba6e3060fddf4a022087d8f09e38aa0001c705f21170c2ded3d1c26c12f70d97",
+    "zh:c12626d044b1d5501cf95ca78cbe507c13ad1dd9f12d4736df66eb8e5f336eb8",
+    "zh:c55203240d50f4cdeb3df1e1760630d677679f5b1a6ffd9eba23662a4ad05119",
+    "zh:ea206a5a32d6e0d6e32f1849ad703da9a28355d9c516282a8458b5cf1502b2a1",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/src/maxtext/examples/elastic_training/terraform/main.tf
+++ b/src/maxtext/examples/elastic_training/terraform/main.tf
@@ -1,0 +1,294 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "kubernetes" {
+  host                   = "https://${google_container_cluster.pathways.endpoint}"
+  cluster_ca_certificate = base64decode(google_container_cluster.pathways.master_auth[0].cluster_ca_certificate)
+  token                  = data.google_client_config.default.access_token
+}
+
+data "google_client_config" "default" {}
+
+# Enable required APIs
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "container.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "tpu.googleapis.com",
+    "storage.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "secretmanager.googleapis.com",
+  ])
+
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# GCS bucket for checkpoints and Pathways scratch
+resource "google_storage_bucket" "training" {
+  name          = var.gcs_bucket_name
+  location      = var.region
+  force_destroy = true
+
+  uniform_bucket_level_access = true
+
+  depends_on = [google_project_service.apis]
+}
+
+# Artifact Registry for Docker images
+resource "google_artifact_registry_repository" "maxtext" {
+  location      = var.region
+  repository_id = "maxtext-elastic"
+  format        = "DOCKER"
+
+  depends_on = [google_project_service.apis]
+}
+
+# Service account for GKE workloads (Pathways + MaxText)
+resource "google_service_account" "gke_workload" {
+  account_id   = "maxtext-elastic-workload"
+  display_name = "GKE workload SA for ${var.cluster_name}"
+
+  depends_on = [google_project_service.apis]
+}
+
+# Workload SA needs full GCS access for checkpoints and Pathways scratch
+resource "google_storage_bucket_iam_member" "workload_gcs" {
+  bucket = google_storage_bucket.training.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.gke_workload.email}"
+}
+
+# Workload SA needs AR read access to pull training images.
+# Granted at the project level so it works consistently across organization IAM setups.
+resource "google_project_iam_member" "workload_ar" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.gke_workload.email}"
+}
+
+# Workload SA needs logging access
+resource "google_project_iam_member" "workload_logging" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gke_workload.email}"
+}
+
+# Workload SA needs monitoring access
+resource "google_project_iam_member" "workload_monitoring" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gke_workload.email}"
+}
+
+# Cloud Build service account. Dedicated SA (new projects disable the legacy
+# default compute SA), passed to `gcloud builds submit --service-account`.
+resource "google_service_account" "cloudbuild" {
+  account_id   = "maxtext-elastic-build"
+  display_name = "Cloud Build SA for ${var.cluster_name}"
+
+  depends_on = [google_project_service.apis]
+}
+
+locals {
+  cloudbuild_sa = "serviceAccount:${google_service_account.cloudbuild.email}"
+}
+
+# Build logs (required when submitting with a user-specified SA + CLOUD_LOGGING_ONLY)
+resource "google_project_iam_member" "cloudbuild_logging" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = local.cloudbuild_sa
+}
+
+# Cloud Build SA needs GKE access to get credentials, install APIs, and deploy manifests
+resource "google_project_iam_member" "cloudbuild_gke" {
+  project = var.project_id
+  role    = "roles/container.admin"
+  member  = local.cloudbuild_sa
+}
+
+# Cloud Build SA needs storage access to read source and check GCS during data prep
+resource "google_project_iam_member" "cloudbuild_storage" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = local.cloudbuild_sa
+}
+
+# Cloud Build SA needs AR access to push images.
+# Granted at the project level (same rationale as workload_ar above).
+resource "google_project_iam_member" "cloudbuild_ar" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = local.cloudbuild_sa
+}
+
+# Cloud Build SA needs Secret Manager access to read HF token
+resource "google_project_iam_member" "cloudbuild_secrets" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = local.cloudbuild_sa
+}
+
+# GKE cluster
+resource "google_container_cluster" "pathways" {
+  name     = var.cluster_name
+  location = var.zone
+
+  # Empty cluster_version => omit the pin and let the RAPID channel choose.
+  min_master_version = var.cluster_version != "" ? var.cluster_version : null
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  initial_node_count       = 1
+  remove_default_node_pool = true
+  deletion_protection      = false
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  release_channel {
+    channel = "RAPID"
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# CPU node pool for Pathways controller (resource manager + proxy server)
+resource "google_container_node_pool" "cpu_pathways" {
+  name     = "cpu-pathways-np"
+  location = var.zone
+  cluster  = google_container_cluster.pathways.name
+
+  node_count = var.num_cpu_nodes
+
+  node_config {
+    machine_type    = var.cpu_machine_type
+    service_account = google_service_account.gke_workload.email
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+
+    workload_metadata_config {
+      mode = "GCE_METADATA"
+    }
+  }
+}
+
+# TPU node pools, one per slice
+resource "google_container_node_pool" "tpu_slices" {
+  count = var.num_tpu_slices
+
+  name     = "tpu-np-${count.index + 1}"
+  location = var.zone
+  cluster  = google_container_cluster.pathways.name
+
+  node_count = var.nodes_per_slice
+
+  node_config {
+    machine_type    = var.tpu_machine_type
+    service_account = google_service_account.gke_workload.email
+
+    # Spot TPUs: cheaper, reclaimable. Off by default; opt in with tpu_spot=true.
+    spot = var.tpu_spot
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+
+    workload_metadata_config {
+      mode = "GCE_METADATA"
+    }
+
+    dynamic "reservation_affinity" {
+      for_each = var.tpu_reservation != "" ? [1] : []
+      content {
+        consume_reservation_type = "SPECIFIC_RESERVATION"
+        key                      = "compute.googleapis.com/reservation-name"
+        values                   = [var.tpu_reservation]
+      }
+    }
+  }
+
+  placement_policy {
+    type         = "COMPACT"
+    tpu_topology = var.tpu_topology
+  }
+
+  # Spot and a specific reservation are mutually exclusive on GCP; catch the
+  # conflict at plan time with a clear message instead of an opaque apply error.
+  lifecycle {
+    precondition {
+      condition     = !(var.tpu_spot && var.tpu_reservation != "")
+      error_message = "tpu_spot and tpu_reservation are mutually exclusive: Spot TPUs cannot consume a specific reservation."
+    }
+  }
+}
+
+# HuggingFace token, stored in Secret Manager (Cloud Build) and K8s (pods)
+resource "google_secret_manager_secret" "hf_token" {
+  secret_id = "maxtext-elastic-hf-token"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "hf_token" {
+  secret      = google_secret_manager_secret.hf_token.id
+  secret_data = var.hf_token
+}
+
+resource "kubernetes_secret_v1" "hf_token" {
+  metadata {
+    name      = "hf-token"
+    namespace = "default"
+  }
+
+  data = {
+    token = var.hf_token
+  }
+
+  depends_on = [
+    google_container_cluster.pathways,
+    google_container_node_pool.cpu_pathways,
+  ]
+}

--- a/src/maxtext/examples/elastic_training/terraform/outputs.tf
+++ b/src/maxtext/examples/elastic_training/terraform/outputs.tf
@@ -1,0 +1,59 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster_name" {
+  description = "GKE cluster name"
+  value       = google_container_cluster.pathways.name
+}
+
+output "cluster_endpoint" {
+  description = "GKE cluster endpoint"
+  value       = google_container_cluster.pathways.endpoint
+  sensitive   = true
+}
+
+output "cluster_zone" {
+  description = "GKE cluster zone"
+  value       = google_container_cluster.pathways.location
+}
+
+output "gcs_bucket" {
+  description = "GCS bucket for checkpoints and Pathways scratch"
+  value       = google_storage_bucket.training.name
+}
+
+output "tpu_node_pools" {
+  description = "TPU node pool names"
+  value       = [for np in google_container_node_pool.tpu_slices : np.name]
+}
+
+output "workload_service_account" {
+  description = "GKE workload service account email"
+  value       = google_service_account.gke_workload.email
+}
+
+output "project_id" {
+  description = "GCP project ID"
+  value       = var.project_id
+}
+
+output "cloudbuild_service_account" {
+  description = "Dedicated Cloud Build service account email"
+  value       = google_service_account.cloudbuild.email
+}
+
+output "cloudbuild_command" {
+  description = "Command to run the Cloud Build pipeline"
+  value       = "gcloud builds submit --config=deploy/deploy.yaml --service-account=projects/${var.project_id}/serviceAccounts/${google_service_account.cloudbuild.email} --substitutions=_CLUSTER_NAME=${google_container_cluster.pathways.name},_CLUSTER_ZONE=${google_container_cluster.pathways.location},_BUCKET_NAME=${google_storage_bucket.training.name} --project=${var.project_id}"
+}

--- a/src/maxtext/examples/elastic_training/terraform/terraform.tfvars.example
+++ b/src/maxtext/examples/elastic_training/terraform/terraform.tfvars.example
@@ -1,0 +1,48 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id      = "your-project-id"
+region          = "us-central1"
+zone            = "us-central1-a"
+cluster_name    = "maxtext-elastic-training"
+# Leave empty to let the RAPID channel pick the current GKE version (recommended).
+# Pin a specific version only if you must, e.g. "1.35.3-gke.1993000".
+cluster_version = ""
+network         = "default"
+subnetwork      = "default"
+
+# TPU config: 3 slices of v5litepod-16 (48 chips total)
+tpu_machine_type = "ct5lp-hightpu-4t"
+tpu_topology     = "4x4"
+num_tpu_slices   = 3
+nodes_per_slice  = 4
+
+# Pathways controller
+cpu_machine_type = "n2-standard-64"
+num_cpu_nodes    = 1
+
+# GCS
+gcs_bucket_name = "maxtext-elastic-training-your-project-id"
+
+# HuggingFace token (Qwen3 is ungated, but wired through for swapping to gated models)
+# Get yours at https://huggingface.co/settings/tokens
+# Terraform pushes this to Secret Manager (for Cloud Build) and K8s (for training pods)
+hf_token = "hf_..."
+
+# TPU reservation (optional, leave empty for on-demand)
+# tpu_reservation = "my-reservation-name"
+
+# Spot (preemptible) TPUs: cheaper, reclaimable. Off by default (on-demand).
+# Mutually exclusive with a reservation.
+# tpu_spot = true

--- a/src/maxtext/examples/elastic_training/terraform/variables.tf
+++ b/src/maxtext/examples/elastic_training/terraform/variables.tf
@@ -1,0 +1,121 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the GKE cluster"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "GCP zone for the GKE cluster and TPU node pools"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster"
+  type        = string
+  default     = "maxtext-elastic-training"
+}
+
+variable "cluster_version" {
+  description = "Pin a GKE master version (e.g. 1.35.3-gke.1993000). Leave empty to let the RAPID release channel pick the current version, recommended, since a pinned patch eventually ages out of the channel and breaks 'terraform apply'."
+  type        = string
+  default     = ""
+}
+
+variable "network" {
+  description = "VPC network name"
+  type        = string
+  default     = "default"
+}
+
+variable "subnetwork" {
+  description = "VPC subnetwork name"
+  type        = string
+  default     = "default"
+}
+
+# TPU configuration
+variable "tpu_machine_type" {
+  description = "TPU machine type for worker node pools"
+  type        = string
+  default     = "ct5lp-hightpu-4t"
+}
+
+variable "tpu_topology" {
+  description = "TPU topology per slice"
+  type        = string
+  default     = "4x4"
+}
+
+variable "num_tpu_slices" {
+  description = "Number of TPU slices (node pools)"
+  type        = number
+  default     = 3
+}
+
+variable "nodes_per_slice" {
+  description = "Number of nodes per TPU node pool"
+  type        = number
+  default     = 4
+}
+
+# CPU node pool for Pathways controller
+variable "cpu_machine_type" {
+  description = "Machine type for the Pathways CPU node pool"
+  type        = string
+  default     = "n2-standard-64"
+}
+
+variable "num_cpu_nodes" {
+  description = "Number of CPU nodes for Pathways controller"
+  type        = number
+  default     = 1
+}
+
+# HuggingFace token (Qwen3 is ungated, but wired through for swapping to gated models)
+variable "hf_token" {
+  description = "HuggingFace API token for accessing gated models"
+  type        = string
+  sensitive   = true
+}
+
+# TPU reservation (optional, use if you have a reserved capacity)
+variable "tpu_reservation" {
+  description = "TPU reservation name. Leave empty to use on-demand."
+  type        = string
+  default     = ""
+}
+
+# Spot (preemptible) TPUs, cheaper, but can be reclaimed at any time. Handy for
+# this demo since elastic recovery already tolerates a slice disappearing. Leave
+# false for on-demand or when using a reservation (the two are mutually exclusive).
+variable "tpu_spot" {
+  description = "Use Spot (preemptible) TPU VMs instead of on-demand."
+  type        = bool
+  default     = false
+}
+
+# GCS bucket for checkpoints and Pathways scratch
+variable "gcs_bucket_name" {
+  description = "GCS bucket name for checkpoints and Pathways artifacts"
+  type        = string
+}


### PR DESCRIPTION
This PR adds a runnable elastic training example: train Qwen3 0.6B across 3 TPU v5e slices on GKE with Pathways, kill a slice mid-run, and watch training recover in-process from the last checkpoint without restarting the job.

## Motivation

When a TPU slice fails mid-run (hardware fault, preemption, network blip), the default outcome is the whole job crashes and restarts from scratch, losing XLA compilation time plus everything since the last checkpoint. **Elastic training** keeps the process alive: Pathways detects the dead slice, MaxText's `elastic_retry` catches the error in-process, Orbax discards any half-written checkpoint, and training rewinds to the last good step. The head pod never restarts; recovery takes ~40s end to end. There is no runnable example in `examples/` that shows this end to end — this PR adds one.

## What's added

A self-contained example under `src/maxtext/examples/elastic_training/`:

- **`terraform/`** — GKE cluster, TPU + CPU node pools, GCS bucket, Artifact Registry, a dedicated Cloud Build SA, IAM, and HF-token wiring.
- **`deploy/`** — Cloud Build pipeline, the training JobSet + `train.sh`, and a data-prep job.
- **`Makefile`** — terminal driver (`make infra` / `deploy` / `logs` / `fail` / `demo` / `destroy`).
- **`elastic_qwen3_demo.ipynb`** — equivalent cell-by-cell run with narration and "what you should see" checkpoints; runs raw `terraform` / `gcloud` / `kubectl`, cleared outputs, no emojis.
- **`README.md`** — narrative, mermaid recovery diagram, flags appendix.
