### PR TITLE
Add reward_functions_path + reward_functions CLI knobs for custom rewards

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -232,6 +232,13 @@ eval_dataset_name: 'openai/gsm8k'
 # tmvp_config, x) -> dict with keys {prompts, question, answer}. When empty
 # (default), the built-in utils_rl.process_data is used.
 dataset_processor_path: ''
+# Optional: path to a user-provided Python file with custom reward functions,
+# AND a comma-separated list of function names to import from that file.
+# Each function signature: fn(prompts, completions, tmvp_config, **kwargs) -> list[float].
+# When both are set, the built-in [match_format_exactly, match_format_approximately,
+# check_numbers] reward list is REPLACED entirely.
+reward_functions_path: ''
+reward_functions: ''
 train_split: 'train'
 eval_split: 'test'
 hf_name: 'main' # subset of Hugging Face dataset

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2018,6 +2018,20 @@ class RLDataset(BaseModel):
           "When set, replaces the built-in dataset processor for custom datasets."
       ),
   )
+  reward_functions_path: str = Field(
+      "",
+      description=(
+          "Optional path to a user Python file containing custom reward functions. "
+          "Used with `reward_functions` to fully replace the built-in reward stack."
+      ),
+  )
+  reward_functions: str = Field(
+      "",
+      description=(
+          "Comma-separated names of reward functions to import from `reward_functions_path`. "
+          "Each function signature: (prompts, completions, tmvp_config, **kwargs) -> list[float]."
+      ),
+  )
 
 
 class RLEvaluation(BaseModel):

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -536,11 +536,28 @@ def create_rl_components(
 
     return _reward_fn
 
-  reward_fns = [  # type: ignore
-      make_reward_fn(utils_rl.match_format_exactly),
-      make_reward_fn(utils_rl.match_format_approximately),
-      make_reward_fn(utils_rl.check_numbers),
-  ]
+  # Optional user-provided reward functions. `reward_functions_path` is a
+  # filesystem path to a Python file. `reward_functions` is a comma-separated
+  # list of function names to import from that file. Each function must accept
+  # `prompts`, `completions`, `tmvp_config`, and `**kwargs` and return a list
+  # of floats.
+  # When both are set, the built-in reward_fns list below is REPLACED entirely
+  # by the user-provided functions (so users have full control over their
+  # reward stack — match the GPU recipe by passing your own vtc reward fn).
+  _custom_rewards_path = getattr(trainer_config, "reward_functions_path", "") or ""
+  _custom_rewards_names = getattr(trainer_config, "reward_functions", "") or ""
+  if _custom_rewards_path and _custom_rewards_names:
+    _names = [n.strip() for n in _custom_rewards_names.split(",") if n.strip()]
+    reward_fns = [make_reward_fn(_load_custom_callable(_custom_rewards_path, n)) for n in _names]
+    max_logging.log(
+        f"reward_fns: using {len(reward_fns)} custom reward function(s) " f"{_names} from {_custom_rewards_path}"
+    )
+  else:
+    reward_fns = [  # type: ignore
+        make_reward_fn(utils_rl.match_format_exactly),
+        make_reward_fn(utils_rl.match_format_approximately),
+        make_reward_fn(utils_rl.check_numbers),
+    ]
 
   # Create RL trainer
   max_logging.log("Setting up RL trainer...")


### PR DESCRIPTION
> **Stacked on top of #4031** (`pr/dataset-processor-path`). This PR reuses the `_load_custom_callable` helper added there. Will rebase onto `main` after #4031 merges.

## Summary

The post-train RL reward stack in `create_rl_components` is hardcoded to a 3-function list:

```python
reward_fns = [
    make_reward_fn(utils_rl.match_format_exactly),
    make_reward_fn(utils_rl.match_format_approximately),
    make_reward_fn(utils_rl.check_numbers),
]
```

Replacing it requires editing `train_rl.py`. This is fine for the GSM8K out-of-the-box recipe but blocks any user-provided reward (VTC-style partial credit, `math_verify`-based scorer, etc.) without forking maxtext.

This PR adds two new config knobs:
- `reward_functions_path` (str, default `""`) — filesystem path to a user Python file
- `reward_functions` (str, default `""`) — comma-separated list of function names to import from that file

When **both** are set, the built-in reward list is REPLACED entirely by the user-provided functions. Each user function must accept `(prompts, completions, tmvp_config, **kwargs)` and return `list[float]`. Default behavior is unchanged.

Field declarations land in the same `RLDataset` mixin as `dataset_processor_path` (#4031), consistent with the file's other RL-only knobs.

## Checklist
- [x] Pyink-clean (`--pyink-indentation=2 --line-length=122`)
- [x] Pydantic schema updated in `src/maxtext/configs/types.py` (`RLDataset` mixin)
- [x] Backward compatible — default-off when either knob is empty
- [x] No effect on non-RL training paths
- [x] Reuses `_load_custom_callable` from #4031 (covered by `load_custom_callable_test.py` there)
