### PR TITLE
fix: raise RuntimeError when checkpoint step >= config.steps

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -639,6 +639,9 @@ def train_loop(config, recorder, state=None):
       state,
   ) = train_utils.setup_train_loop(config, recorder)
 
+  start_step = get_first_step(model, state)  # this is the start_step for training
+  train_utils.validate_completed_steps(start_step, config.steps)
+
   if isinstance(model, nn.Module):
     if config.use_dpo:
       if "reference_params" not in state.params:
@@ -682,8 +685,6 @@ def train_loop(config, recorder, state=None):
       compiled = p_train_step.lower(*lower_args).compile(compiler_options=compiler_options)
       compiled_stats = compiled.memory_analysis()
       max_utils.print_compiled_memory_stats(compiled_stats)
-
-  start_step = get_first_step(model, state)  # this is the start_step for training
   prof = profiler.Profiler(config, offset_step=start_step)
   metric_logger_instance = metric_logger.MetricLogger(config=config, learning_rate_schedule=learning_rate_schedule)
 

--- a/src/maxtext/utils/train_utils.py
+++ b/src/maxtext/utils/train_utils.py
@@ -240,6 +240,10 @@ def setup_train_loop(config, recorder, devices=None):
     else:
       init_state_fn = partial(maxtext_utils.init_initial_state, model, tx, config, is_training, init_rng)
     checkpoint_manager = create_checkpoint_manager(config, mesh, init_state_fn)
+    if checkpoint_manager is not None:
+      checkpoint_step = checkpoint_manager.latest_step()
+      if checkpoint_step is not None:
+        validate_completed_steps(checkpoint_step + 1, config.steps)
 
   with maybe_record_goodput(recorder, GoodputEvent.TRAINING_PREPARATION):
     data_iterator, eval_data_iterator = create_data_iterator(config, mesh)
@@ -404,4 +408,15 @@ def validate_train_config(config):
     max_logging.log(
         "WARNING: Sequence packing is essentially ignored for synthetic data. "
         "Please use a real dataset to use sequence packing."
+    )
+
+
+def validate_completed_steps(completed_steps: int, config_steps: int):
+  """Raises RuntimeError if training has already completed up to config_steps."""
+  if completed_steps >= config_steps:
+    raise RuntimeError(
+        f"Requested training up to step {config_steps}, but a checkpoint already exists at step {completed_steps - 1} "
+        f"(which means {completed_steps} steps have been completed). "
+        f"Did you mean to continue training past step {completed_steps} (you should set steps > {completed_steps}) "
+        f"or to not load the checkpoint (use enable_checkpointing=False?)"
     )

--- a/tests/unit/train_utils_test.py
+++ b/tests/unit/train_utils_test.py
@@ -18,7 +18,11 @@ import unittest
 from dataclasses import dataclass
 from unittest.mock import MagicMock
 
-from maxtext.utils.train_utils import validate_train_config, create_training_optimizer
+from maxtext.utils.train_utils import (
+    validate_train_config,
+    create_training_optimizer,
+    validate_completed_steps,
+)
 
 
 @dataclass
@@ -185,11 +189,32 @@ class TestCreateTrainingOptimizer(unittest.TestCase):
     config.learning_rate_schedule_steps = 100
     config.lr_schedule_type = "cosine"
     config.use_iota_embed = False
-
     _, tx = create_training_optimizer(config, model=None)
-
     self.assertIsNotNone(tx)
     self.assertTrue(hasattr(tx, "init"))
+
+
+class TestValidateCompletedSteps(unittest.TestCase):
+  """Tests for validate_completed_steps."""
+
+  def test_under_steps_passes(self):
+    """Verifies no exception raised when completed_steps < config_steps."""
+    # Should not raise
+    validate_completed_steps(completed_steps=50, config_steps=100)
+
+  def test_equal_steps_raises(self):
+    """Verifies RuntimeError raised when completed_steps == config_steps."""
+    with self.assertRaises(RuntimeError) as context:
+      validate_completed_steps(completed_steps=100, config_steps=100)
+    self.assertIn("Requested training up to step 100, but a checkpoint already exists at step 99", str(context.exception))
+
+  def test_over_steps_raises(self):
+    """Verifies RuntimeError raised when completed_steps > config_steps."""
+    with self.assertRaises(RuntimeError) as context:
+      validate_completed_steps(completed_steps=105, config_steps=100)
+    self.assertIn(
+        "Requested training up to step 100, but a checkpoint already exists at step 104", str(context.exception)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
## Updated from the last PR https://github.com/AI-Hypercomputer/maxtext/pull/4022:
1. Enhance code reuse: use a function to validate the steps, being used in both `train_utils.py` and `trainer.py` 
2. Move `get_first_step` before the model JIT compilatoin, so it fail fast before the model compiling.

  
When a user sets steps=x and there is already a checkpoint saved at step x, the job should fail with a clear error message instead of performing no computation or failing with a confusing profiling error.

We add an early check in setup_train_loop (train_utils.py) to fail fast before loading the checkpoint or initializing TPU. We also add a fallback check in train_loop (train.py) to catch cases where the early check might have been bypassed (e.g. loading from a full state path with checkpointing disabled).

The error message guides the user on how to proceed (either increase steps or disable checkpoint loading).

Both checks are standardized to use a shared validation helper `validate_completed_steps` in `train_utils.py`.

FIXES: b/474108002

# Tests

## E2E Test Runs
https://paste.googleplex.com/6347641943359488
Phase 1: train 5 steps. Succeed.
Phase 2: train for the same 5 steps with the same config. Failed with a runtime error.

## Unit Tests
Added unit tests in `tests/unit/train_utils_test.py` to verify the validation logic:
- `TestValidateCompletedSteps.test_under_steps_passes`: Verifies no exception raised when completed_steps < config_steps.
- `TestValidateCompletedSteps.test_equal_steps_raises`: Verifies RuntimeError raised when completed_steps == config_steps.
- `TestValidateCompletedSteps.test_over_steps_raises`: Verifies RuntimeError raised when completed_steps > config_steps.

To run these tests:
```bash
python3 tests/unit/train_utils_test.py
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
