### PR TITLE
Remove hardcoded vision hyperparams from Qwen mm preprocessor

### DIFF
--- a/benchmarks/multimodal/multimodal_eval.py
+++ b/benchmarks/multimodal/multimodal_eval.py
@@ -202,7 +202,7 @@ def main(config, local_args):
     prefill_length = config.max_prefill_predict_length
     parsed_dataset_example = parse_dataset_example(example, hf_path, local_args)
     prompt = construct_prompt(parsed_dataset_example, config, local_args)
-    processor_output = mm_processor.preprocess_image_for_training(parsed_dataset_example.image_np, config.model_name)
+    processor_output = mm_processor.preprocess_image_for_training(parsed_dataset_example.image_np, config)
     prefill_length -= mm_processor.get_image_offsets(config=config, processor_output=processor_output)
     print("\n" + "*" * 50)
 

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1821,7 +1821,7 @@ class MultimodalGeneral(BaseModel):
   freeze_vision_encoder_params: bool = Field(True, description="Freeze the parameters of the vision encoder.")
   freeze_audio_encoder_params: bool = Field(True, description="Freeze the parameters of the audio encoder.")
   use_audio: bool = Field(False, description="Enable audio encoder for multimodal models.")
-  image_size_for_vit: int | list[int] = Field(896, description="Input image size for the Vision Transformer.")
+  image_size_for_vit: int | list[int] | None = Field(896, description="Input image size for the Vision Transformer.")
   image_path: PathStr = Field("", description="Path to an image for decoding.")
   image_placeholder: str = Field("<|image|>", description="Placeholder string for images in text prompts.")
   posemb_type_for_vit: str = Field("learn", description="Positional embedding type for the vision encoder.")

--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -108,7 +108,7 @@ def vision_sft_preprocessing_pipeline(
 
   dataset = dataset.map(
       input_pipeline_utils.pre_process_image_sft,
-      fn_kwargs={"image_column": "images", "model_name": config.model_name},
+      fn_kwargs={"image_column": "images", "config": config},
   )
 
   tokenizer = transformers.AutoTokenizer.from_pretrained(

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -119,7 +119,7 @@ def merge_image_columns(example, image_columns, max_num_images_per_example):
   return example
 
 
-def pre_process_image_sft(example, image_column, model_name):
+def pre_process_image_sft(example, image_column, config):
   """pre-process image for multimodal SFT"""
 
   def _process_image_fn(image):
@@ -128,7 +128,7 @@ def pre_process_image_sft(example, image_column, model_name):
     else:
       image = np.array(mm_utils.convert_to_RGB(image))
 
-    image = mm_processor.preprocess_image_for_training(image, model_name)
+    image = mm_processor.preprocess_image_for_training(image, config)
     return image
 
   example[image_column] = _process_image_fn(example[image_column])

--- a/src/maxtext/multimodal/processor.py
+++ b/src/maxtext/multimodal/processor.py
@@ -54,26 +54,26 @@ def preprocess_mm_data(config):
   return processor_outputs
 
 
-def preprocess_image_for_training(image, model_name):
+def preprocess_image_for_training(image, config):
   """Preprocesses a single image for training based on the model name."""
-  if model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
+  if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
     from maxtext.multimodal.processor_gemma3 import preprocess_mm_data_gemma3  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_gemma3(image)
-  elif model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
+  elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
     from maxtext.multimodal.processor_gemma4 import preprocess_mm_data_gemma4  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_gemma4(image)
-  elif model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
+  elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
     from maxtext.multimodal.processor_llama4 import preprocess_mm_data_llama4  # pylint: disable=import-outside-toplevel
 
     return preprocess_mm_data_llama4(image)
-  elif model_name in ["qwen3-omni-30b-a3b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
+  elif config.model_name in ["qwen3-omni-30b-a3b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"]:
     from maxtext.multimodal.processor_qwen3_omni import preprocess_mm_data_qwen3_omni_for_training  # pylint: disable=import-outside-toplevel
 
-    return preprocess_mm_data_qwen3_omni_for_training(image)
+    return preprocess_mm_data_qwen3_omni_for_training(image, config)
   else:
-    raise ValueError(f"Model {model_name} not supported for image preprocessing.")
+    raise ValueError(f"Model {config.model_name} not supported for image preprocessing.")
 
 
 def get_image_offsets(config, processor_output: mm_utils.PreprocessorOutput | None):

--- a/src/maxtext/multimodal/processor_qwen3_omni.py
+++ b/src/maxtext/multimodal/processor_qwen3_omni.py
@@ -527,26 +527,24 @@ def pre_process_audio_qwen3_omni(audio_array):
   return audio_features, audio_features_mask
 
 
-def preprocess_mm_data_qwen3_omni_for_training(images):
-  """Preprocesses image(s) for Qwen3-Omni SFT training using default model constants."""
-
-  class _DefaultConfig:
-    patch_size_for_vit = 16
-    spatial_merge_size_for_vit = 2
-    temporal_patch_size_for_vit = QWEN3_TEMPORAL_PATCH_SIZE
-
+def preprocess_mm_data_qwen3_omni_for_training(images, config):
+  """Preprocesses image(s) for Qwen3-Omni SFT training using model config constants."""
   images_in = [images] if isinstance(images, np.ndarray) else images
-  pixel_values, pixel_grid_thw = pre_process_qwen3_image(
-      images_in, _DefaultConfig(), force_resize=(QWEN3_OMNI_IMAGE_SIZE, QWEN3_OMNI_IMAGE_SIZE)
-  )
+  if config.image_size_for_vit is None:
+    force_resize = None
+  elif isinstance(config.image_size_for_vit, (list, tuple)):
+    force_resize = tuple(config.image_size_for_vit)
+  else:
+    force_resize = (config.image_size_for_vit, config.image_size_for_vit)
+  pixel_values, pixel_grid_thw = pre_process_qwen3_image(images_in, config, force_resize=force_resize)
   pixel_values = np.reshape(
       pixel_values,
       (
           len(images_in),
-          3,  # num_channels_for_vit
-          _DefaultConfig.temporal_patch_size_for_vit * pixel_grid_thw[0, 0],
-          _DefaultConfig.patch_size_for_vit * pixel_grid_thw[0, 1],
-          _DefaultConfig.patch_size_for_vit * pixel_grid_thw[0, 2],
+          config.num_channels_for_vit,
+          config.temporal_patch_size_for_vit * pixel_grid_thw[0, 0],
+          config.patch_size_for_vit * pixel_grid_thw[0, 1],
+          config.patch_size_for_vit * pixel_grid_thw[0, 2],
       ),
   )
   return Qwen3OmniPreprocessorOutput(


### PR DESCRIPTION
# Description

This PR plumbs the `config` object through the call chain so the preprocessor can read those values from the config directly during training, instead of the hardcoded hyperparams within the code:
- Function `preprocess_image_for_training()` is used by both `train_sft_native` and `multimodal_eval`. This PR replaces the input field `model_name` with `config`, so that all the hyperparams are accessible for model-specific preprocessing.
- `temporal_patch_size_for_vit` and `patch_size_for_vit` are now configurable from the call. If we set them larger, we could shrink the multimodal token length for experiments.

# Tests
Both SFT and multimodal_eval are using this chain, unimpacted:
```
I0603 22:12:06.924745 140537598176384 metric_logger.py:207] completed step: 0, seconds: 104.988, TFLOP/s/device: 0.044, Tokens/s/device: 19.507, total_weights: 36, loss: 12.508, lm_loss: 12.508, perplexity: 270415.000, moe_lb_loss: 0.000
I0603 22:12:06.926819 140537598176384 metric_logger.py:314] To see full metrics 'tensorboard --logdir=gs://hengtaoguo-maxtext-logs/sft/qwen3-omni-30b-a3b/qwen3-omni-30b-a3b_2026-06-03-22-07/tensorboard/'
I0603 22:12:07.418258 140537598176384 metric_logger.py:207] completed step: 1, seconds: 0.475, TFLOP/s/device: 9.640, Tokens/s/device: 4313.086, total_weights: 43, loss: 12.423, lm_loss: 12.423, perplexity: 248505.000, moe_lb_loss: 0.000
I0603 22:12:07.497086 140537598176384 metric_logger.py:207] completed step: 2, seconds: 0.494, TFLOP/s/device: 9.274, Tokens/s/device: 4149.403, total_weights: 39, loss: 10.753, lm_loss: 10.753, perplexity: 46787.500, moe_lb_loss: 0.000
I0603 22:12:07.605809 140537598176384 metric_logger.py:207] completed step: 3, seconds: 0.055, TFLOP/s/device: 83.565, Tokens/s/device: 37388.637, total_weights: 37, loss: 9.743, lm_loss: 9.743, perplexity: 17027.156, moe_lb_loss: 0.000
I0603 22:12:07.714559 140537598176384 metric_logger.py:207] completed step: 4, seconds: 0.074, TFLOP/s/device: 61.663, Tokens/s/device: 27589.180, total_weights: 40, loss: 8.717, lm_loss: 8.717, perplexity: 6107.000, moe_lb_loss: 0.000
I0603 22:12:07.823418 140537598176384 metric_logger.py:207] completed step: 5, seconds: 0.107, TFLOP/s/device: 42.646, Tokens/s/device: 19080.449, total_weights: 40, loss: 8.500, lm_loss: 8.500, perplexity: 4913.910, moe_lb_loss: 0.000
I0603 22:12:07.931622 140537598176384 metric_logger.py:207] completed step: 6, seconds: 0.108, TFLOP/s/device: 42.425, Tokens/s/device: 18981.593, total_weights: 44, loss: 7.644, lm_loss: 7.644, perplexity: 2088.221, moe_lb_loss: 0.000
I0603 22:12:08.039936 140537598176384 metric_logger.py:207] completed step: 7, seconds: 0.108, TFLOP/s/device: 42.464, Tokens/s/device: 18999.026, total_weights: 41, loss: 7.799, lm_loss: 7.799, perplexity: 2438.695, moe_lb_loss: 0.000
I0603 22:12:08.147849 140537598176384 metric_logger.py:207] completed step: 8, seconds: 0.099, TFLOP/s/device: 46.465, Tokens/s/device: 20789.556, total_weights: 42, loss: 7.081, lm_loss: 7.081, perplexity: 1189.438, moe_lb_loss: 0.000
I0603 22:12:08.255663 140537598176384 metric_logger.py:207] completed step: 9, seconds: 0.108, TFLOP/s/device: 42.435, Tokens/s/device: 18986.344, total_weights: 40, loss: 7.798, lm_loss: 7.798, perplexity: 2436.887, moe_lb_loss: 0.000
```

```
python -m benchmarks.multimodal.multimodal_eval maxtext/configs/base.yml model_name=qwen3-omni-30b-a3b tokenizer_path=Qwen/Qwen3-Omni-30B-A3B-Instruct tokenizer_type=huggingface load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-omni-30b-a3b/unscanned/001/0/items base_output_directory=gs://hengtaoguo-maxtext-logs/eval per_device_batch_size=1 run_name=mmeval_test steps=1 async_checkpointing=false scan_layers=false use_multimodal=true attention=\'dot_product\' max_prefill_predict_length=1024 max_target_length=1044 hf_path=HuggingFaceM4/ChartQA hf_eval_split=test hf_access_token=<xxx> add_bos=False image_size_for_vit=null override_model_config=True --num_examples=5
```

Now the image can also be fed to the model at the original size (without resize): [logs](https://paste.googleplex.com/6735427225649152)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
