### PR TITLE
Fix cuDNN SDPA autoregressive inference when KV cache batch differs from decode batch

### DIFF
--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -884,6 +884,14 @@ class AttentionOp(nnx.Module):
       wv_product_einsum: Callable[..., Array],
   ):
     """Apply attention"""
+    if self.attention_kernel == "cudnn_flash_jax":
+      validate_gpu_flash_attention(sinks, record_max_logits)
+      if isinstance(key, KVTensor):
+        key = key.dequant()
+      if isinstance(value, KVTensor):
+        value = value.dequant()
+      query, key, value = self._align_qkv_for_cudnn_flash(query, key, value)
+
     self.check_attention_inputs(query, key, value)
     length = query.shape[-3]
     target_hardware = self.mesh.devices[(0,) * self.mesh.devices.ndim].platform
@@ -1008,11 +1016,6 @@ class AttentionOp(nnx.Module):
           None,
       )
     elif self.attention_kernel == "cudnn_flash_jax":
-      validate_gpu_flash_attention(sinks, record_max_logits)
-      if isinstance(key, KVTensor):
-        key = key.dequant()
-      if isinstance(value, KVTensor):
-        value = value.dequant()
       return (
           *self.cudnn_jax_flash_attention(query, key, value, decoder_segment_ids, model_mode),
           None,
@@ -1638,6 +1641,36 @@ class AttentionOp(nnx.Module):
     )
     return dpa_layer(query, key, value, sequence_descriptor=attn_mask)
 
+  def _align_qkv_for_cudnn_flash(
+      self,
+      query: Array,
+      key: Array,
+      value: Array,
+  ) -> tuple[Array, Array, Array]:
+    if query.shape[0] != key.shape[0]:
+      if key.shape[0] == 1 and query.shape[0] > 1:
+        key = jnp.broadcast_to(key, (query.shape[0], *key.shape[1:]))
+        value = jnp.broadcast_to(value, (query.shape[0], *value.shape[1:]))
+      else:
+        raise ValueError(
+            "Query and key/value batch sizes must match for cuDNN flash attention: "
+            f"{query.shape=}, {key.shape=}, {value.shape=}"
+        )
+
+    query_sharding = jax.typeof(query).sharding
+    if query_sharding is not None and not (
+        isinstance(query_sharding, jax.sharding.NamedSharding) and query_sharding.mesh.empty
+    ):
+      query = jax.lax.with_sharding_constraint(query, query_sharding)
+      key = jax.lax.with_sharding_constraint(key, query_sharding)
+      value = jax.lax.with_sharding_constraint(value, query_sharding)
+    elif self.is_partition_in_decode(query.shape[1]):
+      decode_qkv_sharding = (DECODE_BATCH, DECODE_LENGTH, HEAD, D_KV)
+      query = partitioning.with_sharding_constraint(query, decode_qkv_sharding)
+      key = partitioning.with_sharding_constraint(key, decode_qkv_sharding)
+      value = partitioning.with_sharding_constraint(value, decode_qkv_sharding)
+    return query, key, value
+
   def cudnn_jax_flash_attention(
       self,
       query: Array,
@@ -1658,6 +1691,8 @@ class AttentionOp(nnx.Module):
 
     if model_mode == MODEL_MODE_AUTOREGRESSIVE:
       lengths = jnp.sum(decoder_segment_ids, axis=-1)
+      if lengths.shape[0] == 1 and query.shape[0] > 1:
+        lengths = jnp.broadcast_to(lengths, (query.shape[0],))
 
       output, lse = dot_product_attention(
           query,

--- a/tests/integration/generate_param_only_checkpoint_test.py
+++ b/tests/integration/generate_param_only_checkpoint_test.py
@@ -41,19 +41,27 @@ def get_model_params(quantization):
   ]
 
 
-def run_e2e_test_flow(hardware, model_config, attention_type="autoselected", state_path=None):
+def run_e2e_test_flow(
+    hardware,
+    model_config,
+    attention_type="autoselected",
+    state_path=None,
+    train_attention_type=None,
+    decode_config_extra=None,
+):
   """Helper function to run training, generate parameter-only checkpoint, and decode."""
   base_output_directory = get_test_base_output_directory()
   dataset_path = get_test_dataset_path()
   run_date = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-  test_config = [
+  train_attention = train_attention_type if train_attention_type is not None else attention_type
+  decode_extra = decode_config_extra or []
+  shared_config = [
       None,
       get_test_config_path(),
       f"base_output_directory={base_output_directory}",
       "async_checkpointing=False",
       "enable_checkpointing=True",
       f"hardware={hardware}",
-      f"attention={attention_type}",
       "max_target_length=128",
       "per_device_batch_size=1",
   ] + model_config
@@ -70,7 +78,7 @@ def run_e2e_test_flow(hardware, model_config, attention_type="autoselected", sta
             hardware=hardware,
             steps=1,
             metrics_file="run_metrics.txt",
-            attention_type=attention_type,
+            attention_type=train_attention,
             dataset_type="synthetic",
             dataset_path=dataset_path,
         )
@@ -79,8 +87,9 @@ def run_e2e_test_flow(hardware, model_config, attention_type="autoselected", sta
 
   # Generate parameter-only checkpoint
   generate_param_only_ckpt_config = (
-      test_config
+      shared_config
       + [
+          f"attention={train_attention}",
           f"run_name=generate_param_{run_date}",
           f"load_full_state_path={state_path}",
       ]
@@ -90,11 +99,13 @@ def run_e2e_test_flow(hardware, model_config, attention_type="autoselected", sta
 
   # Run inference on parameter-only checkpoint
   decode_config = (
-      test_config
+      shared_config
       + [
+          f"attention={attention_type}",
           f"run_name=decode_{run_date}",
           f"load_parameters_path={base_output_directory}/generate_param_{run_date}/checkpoints/0/items",
       ]
+      + decode_extra
       + pathways_command
   )
   decode_main(decode_config)
@@ -122,6 +133,32 @@ def test_param_ckpt_generation_with_dot_product(quantization, capsys):
   os.environ["NVTE_FUSED_ATTN"] = "1"  # Enable fused attention
   model_config = get_model_params(quantization)
   run_e2e_test_flow(hardware="gpu", attention_type="dot_product", model_config=model_config)
+  captured = capsys.readouterr()
+  expected_output = "Input `I love to`"
+  assert expected_output in captured.out
+
+
+AR_SDPA_DECODE_OVERRIDES = [
+    "ici_fsdp_parallelism=1",
+    "ici_autoregressive_parallelism=-1",
+    "skip_jax_distributed_system=True",
+    "max_prefill_predict_length=8",
+    "max_target_length=16",
+]
+
+
+@pytest.mark.external_serving
+@pytest.mark.integration_test
+@pytest.mark.gpu_only
+def test_param_ckpt_generation_with_cudnn_flash_jax_ar_decode(capsys):
+  model_config = get_model_params("")
+  run_e2e_test_flow(
+      hardware="gpu",
+      attention_type="cudnn_flash_jax",
+      train_attention_type="dot_product",
+      model_config=model_config,
+      decode_config_extra=AR_SDPA_DECODE_OVERRIDES,
+  )
   captured = capsys.readouterr()
   expected_output = "Input `I love to`"
   assert expected_output in captured.out

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -373,6 +373,67 @@ class CudnnTePackedSequenceDescriptorTest(unittest.TestCase):
     self.assertIs(output, descriptor_calls[1])
 
 
+class CudnnFlashJaxInferenceTest(unittest.TestCase):
+
+  def _make_attention_op(self):
+    config = types.SimpleNamespace(ici_context_autoregressive_parallelism=0)
+    mesh = types.SimpleNamespace()
+    return AttentionOp(
+        config=config,
+        mesh=mesh,
+        attention_kernel="cudnn_flash_jax",
+        max_target_length=128,
+        num_query_heads=2,
+        num_kv_heads=2,
+    )
+
+  def test_align_qkv_broadcasts_kv_batch(self):
+    attention = self._make_attention_op()
+    query = jnp.ones((8, 1, 2, 64))
+    key = jnp.ones((1, 4, 2, 64))
+    value = jnp.ones((1, 4, 2, 64))
+    with mock.patch("jax.lax.with_sharding_constraint", side_effect=lambda x, _: x):
+      _, aligned_key, aligned_value = attention._align_qkv_for_cudnn_flash(query, key, value)
+    self.assertEqual(aligned_key.shape[0], 8)
+    self.assertEqual(aligned_value.shape[0], 8)
+
+  def test_align_qkv_raises_on_invalid_batch(self):
+    attention = self._make_attention_op()
+    query = jnp.ones((8, 1, 2, 64))
+    key = jnp.ones((2, 4, 2, 64))
+    value = jnp.ones((2, 4, 2, 64))
+    with self.assertRaises(ValueError):
+      attention._align_qkv_for_cudnn_flash(query, key, value)
+
+  def test_cudnn_jax_flash_attention_broadcasts_ar_lengths(self):
+    attention = self._make_attention_op()
+    query = jnp.zeros((8, 1, 2, 64))
+    key = jnp.zeros((8, 4, 2, 64))
+    value = jnp.zeros((8, 4, 2, 64))
+    decoder_segment_ids = jnp.ones((1, 4))
+    mock_dot_product_attention = mock.Mock(
+        return_value=(jnp.zeros((8, 1, 2, 64)), jnp.zeros((8, 2)))
+    )
+    fused_attention_module = types.ModuleType("jax._src.cudnn.fused_attention_stablehlo")
+    fused_attention_module.dot_product_attention = mock_dot_product_attention
+    fused_attention_module.MaskType = types.SimpleNamespace(PADDING="padding", CAUSAL="causal")
+    with mock.patch.dict(
+        sys.modules,
+        {"jax._src.cudnn.fused_attention_stablehlo": fused_attention_module},
+    ):
+      attention.cudnn_jax_flash_attention(
+          query,
+          key,
+          value,
+          decoder_segment_ids,
+          model_mode=MODEL_MODE_AUTOREGRESSIVE,
+      )
+    q_seqlen = mock_dot_product_attention.call_args.kwargs["q_seqlen"]
+    kv_seqlen = mock_dot_product_attention.call_args.kwargs["kv_seqlen"]
+    self.assertEqual(q_seqlen.shape, (8,))
+    self.assertEqual(kv_seqlen.shape, (8,))
+
+
 class AttentionTest(parameterized.TestCase):
   """Test for the Attention"""
 


### PR DESCRIPTION
# Description

AR decode with `cudnn_flash_jax` and `ici_autoregressive_parallelism=-1` fails because the fused cuDNN SDPA kernel requires matching Q/K/V batch and sharding. Queries are sharded across the AR mesh while the KV cache often has batch 1.

Align Q/K/V and broadcast lengths when needed, before the fused call. Scoped to cudnn_flash_jax only.

# Tests

`pytest tests/unit/attention_test.py::CudnnFlashJaxInferenceTest`

 `pytest tests/integration/generate_param_only_checkpoint_test.py::test_param_ckpt_generation_with_cudnn_flash_jax_ar_decode`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
