### PR TITLE
Fix deprecated setup.sh and setup_post_training_requirements.sh documentation references

### DIFF
--- a/docs/guides/monitoring_and_debugging/features_and_diagnostics.md
+++ b/docs/guides/monitoring_and_debugging/features_and_diagnostics.md
@@ -30,7 +30,7 @@ You may use only a CPU or a single VM from a different family to pre-compile for
 
 - The ahead of time compilation can be saved and then loaded for fast startup and restart times on the target hardware.
 
-The tool `train_compile.py` is tightly linked to `train.py` and uses the same configuration file `src/maxtext/configs/base.yml`. Although you don't need to run on a TPU, you do need to install `jax[tpu]` in addition to other dependencies, so we recommend running `setup.sh` to install these if you have not already done so.
+The tool `train_compile.py` is tightly linked to `train.py` and uses the same configuration file `src/maxtext/configs/base.yml`. Although you don't need to run on a TPU, you do need to install `jax[tpu]` in addition to other dependencies, so we recommend following the [MaxText installation instructions](../../install_maxtext.md) to install these if you have not already done so.
 
 #### Example AOT 1: Compile ahead of time basics
 

--- a/docs/run_maxtext/run_maxtext_via_multihost_job.md
+++ b/docs/run_maxtext/run_maxtext_via_multihost_job.md
@@ -68,7 +68,7 @@ The `multihost_job.py` script:
 
    ```sh
    RUN_NAME=${YOUR_JOB_NAME?} # You may set this to any unique name for a fresh run.
-   python3 multihost_job.py --NUM_SLICES=${NODE_COUNT?} --RUN_NAME=${RUN_NAME?} --BUCKET_NAME=${BUCKET_NAME?} --CQR_EXTRA_ARGS="--reserved" --COMMAND="bash tools/setup/setup.sh && python3 -m maxtext.trainers.pre_train.train run_name=${RUN_NAME?}"
+   python3 tools/orchestration/multihost_job.py --NUM_SLICES=${NODE_COUNT?} --RUN_NAME=${RUN_NAME?} --BUCKET_NAME=${BUCKET_NAME?} --CQR_EXTRA_ARGS="--reserved" --COMMAND="pip install uv && uv pip install -e .[tpu] --resolution=lowest && install_tpu_pre_train_extra_deps && python3 -m maxtext.trainers.pre_train.train run_name=${RUN_NAME?}"
    ```
 
    We tell `multihost_job` to target the `reserved` pool by by including `--reserved` as extra arguments to the CQR request, but you may instead target the `on-demand` pool by removing the `--CQR_EXTRA_ARGS` flag (on-demand is default), or the pre-emptible pool with `--CQR_EXTRA_ARGS="--best-effort"`, which may be necessary if your reservation is full.

--- a/docs/run_maxtext/run_maxtext_via_multihost_runner.md
+++ b/docs/run_maxtext/run_maxtext_via_multihost_runner.md
@@ -87,10 +87,10 @@ Although there are several steps below, most are for the initial setup. Once set
    ```
 
 4. **Install dependencies.**
-   Install the dependencies of `train.py` on each worker using `multihost_runner.py`:
+   Install the dependencies of `train.py` on each worker using `multihost_runner.py` inside a virtual environment:
 
    ```
-   python3 multihost_runner.py --TPU_PREFIX=${TPU_PREFIX?} --COMMAND="bash tools/setup/setup.sh"
+   python3 tools/orchestration/multihost_runner.py --TPU_PREFIX=${TPU_PREFIX?} --COMMAND="pip install uv && uv venv --python 3.12 --seed venv-maxtext && source venv-maxtext/bin/activate && uv pip install -e .[tpu] --resolution=lowest && install_tpu_pre_train_extra_deps"
    ```
 
    If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_IP=true`.
@@ -106,7 +106,7 @@ Although there are several steps below, most are for the initial setup. Once set
    Set config values for `base_output_directory` and `dataset_path` in `configs/base.yml` if not set already.
 
    ```
-   python3 multihost_runner.py --TPU_PREFIX=${TPU_PREFIX?} --COMMAND="python3 -m maxtext.trainers.pre_train.train run_name=${RUN_NAME?}"
+   python3 tools/orchestration/multihost_runner.py --TPU_PREFIX=${TPU_PREFIX?} --COMMAND="source venv-maxtext/bin/activate && python3 -m maxtext.trainers.pre_train.train run_name=${RUN_NAME?}"
    ```
 
    If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_IP=true`.

--- a/docs/tutorials/posttraining/knowledge_distillation.md
+++ b/docs/tutorials/posttraining/knowledge_distillation.md
@@ -47,15 +47,7 @@ export RUN_NAME=<your-run-name> # e.g., distill-20260115
 
 #### b. Install dependencies
 
-To install MaxText and its dependencies for post-training (including vLLM for the teacher), run the following:
-
-1. Follow the [MaxText installation instructions](../../install_maxtext.md).
-
-2. Install the additional dependencies for post-training:
-
-```bash
-bash tools/setup/setup_post_training_requirements.sh
-```
+To install MaxText and its dependencies for post-training (including vLLM for the teacher), follow the [MaxText installation instructions](../../install_maxtext.md) and select the `tpu-post-train` installation target (e.g., `maxtext[tpu-post-train]` or `.[tpu-post-train]`).
 
 #### c. Setup storage with Hyperdisk
 

--- a/src/dependencies/scripts/setup.sh
+++ b/src/dependencies/scripts/setup.sh
@@ -19,44 +19,44 @@
 # ==================================
 
 # Install dependencies in dependencies/generated_requirements/tpu-requirements.txt
-## bash tools/setup/setup.sh MODE=stable
+## bash src/dependencies/scripts/setup.sh MODE=stable
 
 # Install dependencies in dependencies/generated_requirements/tpu-requirements.txt + specified jax, jaxlib, libtpu
-## bash tools/setup/setup.sh MODE=stable JAX_VERSION=0.8.0
+## bash src/dependencies/scripts/setup.sh MODE=stable JAX_VERSION=0.8.0
 
 # Install dependencies in dependencies/generated_requirements/tpu-requirements.txt + custom libtpu
-## bash tools/setup/setup.sh MODE=stable LIBTPU_GCS_PATH=gs://my_custom_libtpu/libtpu.so
+## bash src/dependencies/scripts/setup.sh MODE=stable LIBTPU_GCS_PATH=gs://my_custom_libtpu/libtpu.so
 
 # Install dependencies in dependencies/generated_requirements/tpu-requirements.txt + jax-nightly, jaxlib-nightly, libtpu-nightly
-## bash tools/setup/setup.sh MODE=nightly
+## bash src/dependencies/scripts/setup.sh MODE=nightly
 
 # Install dependencies in dependencies/generated_requirements/tpu-requirements.txt + specified jax-nightly, jaxlib-nightly + latest libtpu-nightly
-## bash tools/setup/setup.sh MODE=nightly JAX_VERSION=0.8.2.dev20251211
+## bash src/dependencies/scripts/setup.sh MODE=nightly JAX_VERSION=0.8.2.dev20251211
 
 # Install dependencies in dependencies/generated_requirements/tpu-requirements.txt + specified jax-nightly, jaxlib-nightly + specific libtpu-nightly
-## bash tools/setup/setup.sh MODE=nightly JAX_VERSION=0.8.1 LIBTPU_VERSION=0.0.31.dev20251119+nightly
+## bash src/dependencies/scripts/setup.sh MODE=nightly JAX_VERSION=0.8.1 LIBTPU_VERSION=0.0.31.dev20251119+nightly
 
 # Install dependencies in dependencies/generated_requirements/tpu-requirements.txt + jax-nightly, jaxlib-nightly + custom libtpu
-## bash tools/setup/setup.sh MODE=nightly LIBTPU_GCS_PATH=gs://my_custom_libtpu/libtpu.so
+## bash src/dependencies/scripts/setup.sh MODE=nightly LIBTPU_GCS_PATH=gs://my_custom_libtpu/libtpu.so
 
 # Install custom libtpu only
-## bash tools/setup/setup.sh MODE=libtpu-only LIBTPU_GCS_PATH=gs://my_custom_libtpu/libtpu.so
+## bash src/dependencies/scripts/setup.sh MODE=libtpu-only LIBTPU_GCS_PATH=gs://my_custom_libtpu/libtpu.so
 
 # ==================================
 # GPU EXAMPLES
 # ==================================
 
 # Install dependencies in dependencies/generated_requirements/cuda12-requirements.txt
-## bash tools/setup/setup.sh MODE=stable DEVICE=gpu
+## bash src/dependencies/scripts/setup.sh MODE=stable DEVICE=gpu
 
 # Install dependencies in dependencies/generated_requirements/cuda12-requirements.txt + specified jax, jaxlib, jax-cuda12-plugin, jax-cuda12-pjrt
-## bash tools/setup/setup.sh MODE=stable DEVICE=gpu JAX_VERSION=0.4.13
+## bash src/dependencies/scripts/setup.sh MODE=stable DEVICE=gpu JAX_VERSION=0.4.13
 
 # Install dependencies in dependencies/generated_requirements/cuda12-requirements.txt + jax-nightly, jaxlib-nightly
-## bash tools/setup/setup.sh MODE=nightly DEVICE=gpu
+## bash src/dependencies/scripts/setup.sh MODE=nightly DEVICE=gpu
 
 # Install dependencies in dependencies/generated_requirements/cuda12-requirements.txt + specified jax, jaxlib, jax-cuda12-plugin, jax-cuda12-pjrt
-## bash tools/setup/setup.sh MODE=nightly DEVICE=gpu JAX_VERSION=0.4.36.dev20241109
+## bash src/dependencies/scripts/setup.sh MODE=nightly DEVICE=gpu JAX_VERSION=0.4.36.dev20241109
 
 
 # Enable "exit immediately if any command fails" option


### PR DESCRIPTION
# Description

This PR fixes references to deprecated/removed setup scripts (`setup.sh` and `setup_post_training_requirements.sh`) and replaces them with standard pip/uv target installations.

Specifically:
- In [docs/tutorials/posttraining/knowledge_distillation.md](file:///usr/local/google/home/bvandermoon/workspace/maxtext_security/maxtext/docs/tutorials/posttraining/knowledge_distillation.md), replaced the reference to the deprecated `tools/setup/setup_post_training_requirements.sh` script with the `tpu-post-train` pip installation instructions.
- In [docs/run_maxtext/run_maxtext_via_multihost_job.md](file:///usr/local/google/home/bvandermoon/workspace/maxtext_security/maxtext/docs/run_maxtext/run_maxtext_via_multihost_job.md) and [docs/run_maxtext/run_maxtext_via_multihost_runner.md](file:///usr/local/google/home/bvandermoon/workspace/maxtext_security/maxtext/docs/run_maxtext/run_maxtext_via_multihost_runner.md), replaced references to `tools/setup/setup.sh` with the pip/uv virtual environment setup commands.
- In [src/dependencies/scripts/setup.sh](file:///usr/local/google/home/bvandermoon/workspace/maxtext_security/maxtext/src/dependencies/scripts/setup.sh), updated the comment examples to point to its current location instead of the deprecated `tools/setup/setup.sh` path.
- In [docs/guides/monitoring_and_debugging/features_and_diagnostics.md](file:///usr/local/google/home/bvandermoon/workspace/maxtext_security/maxtext/docs/guides/monitoring_and_debugging/features_and_diagnostics.md), replaced the `setup.sh` suggestion with a link to the MaxText installation guide.

FIXES: b/518880720

# Tests

Verified the documentation changes by:
1. **Link Verification**: Confirmed that the relative path resolved correctly from `docs/tutorials/posttraining/knowledge_distillation.md` to `docs/install_maxtext.md`.
2. **Commands Verification**: Verified that the modified python paths (`tools/orchestration/multihost_runner.py` and `tools/orchestration/multihost_job.py`) exist and run correctly when invoked from the root directory.
3. **Comments Verification**: Updated comments in `src/dependencies/scripts/setup.sh` to match its restructured path.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
