### PR TITLE
Fix the param names for Gemma3 model

### DIFF
--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -86,17 +86,17 @@ def GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False
   # pylint: disable=line-too-long
   mapping = {
       # Embedding & final norm
-      "params-token_embedder-embedding": "model.language_model.embed_tokens.weight",
-      "params-decoder-decoder_norm-scale": "model.language_model.norm.weight",
+      "params-token_embedder-embedding": "language_model.model.embed_tokens.weight",
+      "params-decoder-decoder_norm-scale": "language_model.model.norm.weight",
       # Vision embed & pos
-      "params-vision_encoder-Gemma3VisionEncoderLayer_0-embedding-kernel": "model.vision_tower.vision_model.embeddings.patch_embedding.weight",
-      "params-vision_encoder-Gemma3VisionEncoderLayer_0-embedding-bias": "model.vision_tower.vision_model.embeddings.patch_embedding.bias",
-      "params-vision_encoder-Gemma3VisionEncoderLayer_0-pos_embedding": "model.vision_tower.vision_model.embeddings.position_embedding.weight",
-      "params-vision_encoder-Gemma3VisionEncoderLayer_0-Transformer-encoder_norm-scale": "model.vision_tower.vision_model.post_layernorm.weight",
-      "params-vision_encoder-Gemma3VisionEncoderLayer_0-Transformer-encoder_norm-bias": "model.vision_tower.vision_model.post_layernorm.bias",
+      "params-vision_encoder-Gemma3VisionEncoderLayer_0-embedding-kernel": "vision_tower.vision_model.embeddings.patch_embedding.weight",
+      "params-vision_encoder-Gemma3VisionEncoderLayer_0-embedding-bias": "vision_tower.vision_model.embeddings.patch_embedding.bias",
+      "params-vision_encoder-Gemma3VisionEncoderLayer_0-pos_embedding": "vision_tower.vision_model.embeddings.position_embedding.weight",
+      "params-vision_encoder-Gemma3VisionEncoderLayer_0-Transformer-encoder_norm-scale": "vision_tower.vision_model.post_layernorm.weight",
+      "params-vision_encoder-Gemma3VisionEncoderLayer_0-Transformer-encoder_norm-bias": "vision_tower.vision_model.post_layernorm.bias",
       # Multi-modal projector
-      "params-vision_encoder-VisionEmbedder_0-mm_input_projection-w": "model.multi_modal_projector.mm_input_projection_weight",
-      "params-vision_encoder-VisionEmbedder_0-mm_soft_embedding_norm-scale": "model.multi_modal_projector.mm_soft_emb_norm.weight",
+      "params-vision_encoder-VisionEmbedder_0-mm_input_projection-w": "multi_modal_projector.mm_input_projection_weight",
+      "params-vision_encoder-VisionEmbedder_0-mm_soft_embedding_norm-scale": "multi_modal_projector.mm_soft_emb_norm.weight",
   }
 
   vision_params = [
@@ -122,7 +122,7 @@ def GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False
   for i in range(Nvis):
     for mx, hf in vision_params:
       key = f"params-vision_encoder-Gemma3VisionEncoderLayer_0-Transformer-encoderblock_{i}-{mx}"
-      mapping[key] = f"model.vision_tower.vision_model.encoder.layers.{i}.{hf}"
+      mapping[key] = f"vision_tower.vision_model.encoder.layers.{i}.{hf}"
 
   # Text decoder mapping
   text_params = [
@@ -153,7 +153,7 @@ def GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False
       hf_indices = list(range(block_idx, num_scanned, attention_pattern_length))
       for mx, hf in text_params:
         key = f"params-decoder-layers-layers_{block_idx}-{mx}"
-        mapping[key] = [f"model.language_model.layers.{i}.{hf}" for i in hf_indices]
+        mapping[key] = [f"language_model.model.layers.{i}.{hf}" for i in hf_indices]
 
     # Remainder layers (unscanned): params-decoder-layers_remainder-layers_{rem_idx}-{param}
     if num_remaining > 0:
@@ -161,12 +161,12 @@ def GEMMA3_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False
         hf_layer_idx = num_scanned + rem_idx
         for mx, hf in text_params:
           key = f"params-decoder-layers_remainder-layers_{rem_idx}-{mx}"
-          mapping[key] = f"model.language_model.layers.{hf_layer_idx}.{hf}"
+          mapping[key] = f"language_model.model.layers.{hf_layer_idx}.{hf}"
   else:
     for i in range(Ndec):
       for mx, hf in text_params:
         key = f"params-decoder-layers_{i}-{mx}"
-        mapping[key] = f"model.language_model.layers.{i}.{hf}"
+        mapping[key] = f"language_model.model.layers.{i}.{hf}"
 
   return mapping
 


### PR DESCRIPTION
# Description

A quick fix for the param names mapping for Gemma3 model given the HF names are changed. 


# Tests

Successful conversion can be found: gs://yixuannwang-maxtext-dataset/gemma3-4b-mt/0/items
Tested on TPU v4, using this command:

`python3 -m tests.utils.forward_pass_logit_checker src/maxtext/configs/base.yml \
    load_parameters_path=gs://yixuannwang-maxtext-dataset/gemma3-4b-mt/0/items \
    model_name='gemma3-4b' \
    skip_jax_distributed_system=true \
    scan_layers=false \
    max_prefill_predict_length=4 \
    max_target_length=8 \
    use_multimodal=False \
    --run_hf_model=True \
    --hf_model_path='/home/yixuannwang_google_com/.cache/huggingface/hub/models--google--gemma-3-4b-it/snapshots/093f9f388b31de276ce2de164bdc2081324b9767' \
    --max_kl_div=0.015`

Output:
<img width="532" height="633" alt="Screenshot 2026-06-04 at 5 10 25 PM" src="https://github.com/user-attachments/assets/7e4414b4-5726-4779-8b4c-bd80eb26f408" />
<img width="518" height="632" alt="Screenshot 2026-06-04 at 5 10 42 PM" src="https://github.com/user-attachments/assets/af512f5f-dd4f-4de1-a922-df102f7d614e" />
<img width="538" height="635" alt="Screenshot 2026-06-04 at 5 10 50 PM" src="https://github.com/user-attachments/assets/ffd3b353-bc0f-419f-88e5-df8093999f13" />


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
