### PR TITLE
fix: remove accidental debug logging from decoder pipeline

### DIFF
--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -1026,9 +1026,6 @@ class Decoder(nn.Module):
             current_broadcast_args.extend([None, None, None, attention_metadata])
             current_in_axes_tuple.extend([nn.broadcast] * 4)
 
-            max_logging.info(f"DEBUG: len(current_broadcast_args)={len(current_broadcast_args)}")
-            max_logging.info(f"DEBUG: current_broadcast_args={[type(a) for a in current_broadcast_args]}")
-
             final_carry, _ = self.scan_decoder_layers(
                 cfg,
                 RemattedBlockLayer,


### PR DESCRIPTION
## Summary

- Removes two `max_logging.info(f"DEBUG: ...")` statements that were accidentally committed to the pipeline scan path inside `Decoder.__call__` (`layers/decoders.py`, previously lines 1029–1030).
- These lines emitted on **every decode step**, polluting production inference logs with internal debug output.
- No logic change — surrounding `current_broadcast_args` construction and `scan_decoder_layers` call are untouched.

## Test plan

- [ ] Python syntax verified locally (`ast.parse` passes).
- [ ] Existing unit and integration tests for the decoder path cover the surrounding logic (no new test needed — this is a pure log-line deletion with no behavioral change).