### PR TITLE
Fix ragged gather reduce to offload two sparse cores

### DIFF
--- a/src/maxtext/kernels/ragged/ragged_sort.py
+++ b/src/maxtext/kernels/ragged/ragged_sort.py
@@ -125,8 +125,9 @@ def ring_ragged_sort(hidden_states_local, topk_indices_local, num_experts, topk,
     # only iterates over the populated prefix, so we hand it the mask directly
     # rather than materializing a (mostly-zero) dense buffer ourselves.
     n = topk_argsort_revert_indices.shape[0]
-    pos = jnp.arange(n)
-    valid_rows_mask = (pos >= shard_output_start) & (pos < shard_output_end)
+    valid_rows_mask = (topk_argsort_revert_indices >= shard_output_start) & (
+        topk_argsort_revert_indices < shard_output_end
+    )
     # The forward scatter-add over `token_indices_sorted` is equivalent to a
     # gather-reduce: each input token has exactly `topk` contributions located
     # at sorted positions `topk_argsort_revert_indices[t*topk:(t+1)*topk]`.


### PR DESCRIPTION
# Description

To fix b/518953536: we observe long ragged gather reduce operation in bwd pass, and this change reduce it from 28ms to 3.4ms per layer.

`topk_argsort_revert_indices` is a scrambled permutation with values are scattered randomly across the entire mask, ensuring that both SC0 and SC1 are actively processing data concurrently.


# Tests

* Before [profile](https://screenshot.googleplex.com/AekAPrBy7zTzUDG)
* After [profile](https://screenshot.googleplex.com/BqPSv2i6LKnbtSi)
* Expect unit tests green

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
