### PR TITLE
Added live slice count

### DIFF
--- a/src/maxtext/common/metric_logger.py
+++ b/src/maxtext/common/metric_logger.py
@@ -35,6 +35,7 @@ from maxtext.utils import gcs_utils
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
+from maxtext.utils import elastic_utils
 from collections import defaultdict
 
 mldiag, _ = mldiagnostics_modules()
@@ -169,6 +170,12 @@ class MetricLogger:
               f"seconds: {scalars['perf/step_time_seconds']:.3f}",
           ]
       )
+      if elastic_utils.elastic_enabled(self.config):
+        log_parts.extend(
+            [
+                f"live slice count: {len(elastic_utils.live_slice_indices(self.config))}",
+            ]
+        )
 
     # Add performance metrics only if strictly NOT in rampup phase
     # TODO(b/452468482): Enable performance metric (TFLOPs, Tokens/s) tracking during batch size rampup.

--- a/tests/unit/metric_logger_abort_test.py
+++ b/tests/unit/metric_logger_abort_test.py
@@ -117,3 +117,69 @@ class MetricLoggerMetadataTest(unittest.TestCase):
 
     self.assertEqual(logger.metadata[MetadataKey.PER_DEVICE_TFLOPS], 100.0)
     self.assertEqual(logger.metadata[MetadataKey.PER_DEVICE_TOKENS], 1000.0)
+
+
+class MetricLoggerLogMetricsTest(unittest.TestCase):
+  """Tests for metric_logger.log_metrics."""
+
+  def test_log_training_metrics_elastic_enabled(self):
+    logger = MetricLogger.__new__(MetricLogger)
+    logger.config = SimpleNamespace(
+        rampup_end_step=-1,
+        hide_profiler_step_metric=False,
+        num_experts=1,
+        mtp_num_layers=0,
+    )
+    metrics = {
+        "scalar": {
+            "learning/loss": 1.0,
+            "perf/step_time_seconds": 2.0,
+            "perf/per_device_tflops_per_sec": 100.0,
+            "perf/per_device_tokens_per_sec": 1000.0,
+            "learning/total_weights": 100,
+        }
+    }
+
+    with (
+        mock.patch.object(logger, "_is_profiler_boundary_step", return_value=False),
+        mock.patch("maxtext.common.metric_logger.max_logging.log") as mock_log,
+        mock.patch("maxtext.common.metric_logger.elastic_utils.elastic_enabled", return_value=True),
+        mock.patch("maxtext.common.metric_logger.elastic_utils.live_slice_indices", return_value=[0, 1, 2]),
+    ):
+      logger.log_metrics(metrics, step=1, metric_type="train")
+
+    mock_log.assert_called_once()
+    log_string = mock_log.call_args[0][0]
+    self.assertIn("live slice count: 3", log_string)
+
+  def test_log_training_metrics_elastic_disabled(self):
+    logger = MetricLogger.__new__(MetricLogger)
+    logger.config = SimpleNamespace(
+        rampup_end_step=-1,
+        hide_profiler_step_metric=False,
+        num_experts=1,
+        mtp_num_layers=0,
+    )
+
+    metrics = {
+        "scalar": {
+            "learning/loss": 1.0,
+            "perf/step_time_seconds": 2.0,
+            "perf/per_device_tflops_per_sec": 100.0,
+            "perf/per_device_tokens_per_sec": 1000.0,
+            "learning/total_weights": 100,
+        }
+    }
+
+    with (
+        mock.patch.object(logger, "_is_profiler_boundary_step", return_value=False),
+        mock.patch("maxtext.common.metric_logger.max_logging.log") as mock_log,
+        mock.patch("maxtext.common.metric_logger.elastic_utils.elastic_enabled", return_value=False),
+        mock.patch("maxtext.common.metric_logger.elastic_utils.live_slice_indices") as mock_live_slices,
+    ):
+      logger.log_metrics(metrics, step=1, metric_type="train")
+
+    mock_log.assert_called_once()
+    log_string = mock_log.call_args[0][0]
+    self.assertNotIn("live slice count", log_string)
+    mock_live_slices.assert_not_called()


### PR DESCRIPTION
# Description

Adding `active_slices` to the stepping log to help monitor elastic status

FIXES: b/520489064

# Tests

Tested with different TPU versions & topologies for McJax and Pathways
[McJax log](https://cloudlogging.app.goo.gl/oV3VSC6aEU7T4oNu5)
[Pathways without elastic](https://cloudlogging.app.goo.gl/4K8Zout8onjpdXLd7)
[Pathways with elastic](https://cloudlogging.app.goo.gl/LAJgaxMexfVxxQNC6)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
