### PR TITLE
Fix JAX Mesh IndexError in TrainDistillTest unit tests by mocking create_device_mesh to return a real 1-device array

### DIFF
--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -1064,6 +1064,8 @@ class TrainDistillTest(unittest.TestCase):
   ):
     """Verifies offline mode (offline_data_dir is set) skips teacher model loading."""
     # 1. Configs
+    devices = jax.devices()[:1]
+    mock_create_mesh.return_value = np.array(devices)
     mock_global = mock.Mock()
     mock_global.student_overrides = {}
     mock_global.teacher_overrides = {}  # No checkpoint needed
@@ -1172,6 +1174,8 @@ class TrainDistillTest(unittest.TestCase):
       mock_trainer_cls,
   ):
     """Verifies online mode (offline_data_dir is None) loads both student and teacher models."""
+    devices = jax.devices()[:1]
+    mock_create_mesh.return_value = np.array(devices)
     mock_global = mock.Mock()
     mock_global.student_overrides = {}
     mock_global.teacher_overrides = {"load_parameters_path": "gs://ckpt"}


### PR DESCRIPTION
# Description

This PR fixes a `ValueError` (due to mismatched dimensions `0 != 1`) and `TypeError` in JAX's C++ compilation cache during distillation unit tests. 

The issue was introduced by a previous PR replacing `with mesh:` with `with jax.set_mesh(mesh)`. The new JAX context manager evaluates `mesh.abstract_mesh`, which accesses the first device in the mesh (`mesh.devices.flat[0]`), causing an `IndexError` on the empty mesh that was previously mocked in `TrainDistillTest`. 

Furthermore, JAX's C++ compilation cache expects concrete JAX device objects, which makes mocking devices with `unittest.mock.Mock()` trigger a `TypeError` during trace compilation inside a `set_mesh` block.

We resolved this by mocking `create_device_mesh` in `tests/post_training/unit/train_distill_test.py` to return a 1D numpy array containing the first real device on the host (`np.array(jax.devices()[:1])`). JAX always has at least one real device (e.g., CPU) available in the active JAX runtime environment, ensuring the tests are fully portable and pass cleanly on both TPU VMs and CPU/GPU dev hosts.

# Tests

Tested on the remote TPU VM (`bvandermoon-dev-v6e`):
```bash
source /home/bvandermoon_google_com/workspace/maxtext/maxtext/maxtext_venv/bin/activate
cd /home/bvandermoon_google_com/workspace/maxtext/maxtext
PYTHONPATH=src pytest tests/post_training/unit/
```
All 91 post-training unit tests (including all 24 `train_distill_test.py` tests) passed successfully.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
