### PR TITLE
Clarify GCS bucket permission requirements in SFT and RL tutorials

### DIFF
--- a/docs/tutorials/posttraining/rl_on_multi_host.md
+++ b/docs/tutorials/posttraining/rl_on_multi_host.md
@@ -59,7 +59,7 @@ Before starting, ensure you have:
 - **IAM Roles** required:
   - **Kubernetes Engine Developer** (`roles/container.developer`) to submit and manage workloads on GKE.
   - **Artifact Registry Writer** (`roles/artifactregistry.writer`) to upload Docker images.
-  - **Storage Object Admin** (`roles/storage.objectAdmin`) on your GCS bucket to read/write checkpoints and logs.
+  - **Storage Admin** (`roles/storage.admin`) or **Storage Object Admin** (`roles/storage.objectAdmin`) combined with **Storage Legacy Bucket Reader** (`roles/storage.legacyBucketReader`) on your GCS bucket to read/write checkpoints and logs. (Note: A bucket-level read permission like `storage.buckets.get` is required by JAX/TensorStore to verify bucket existence and metadata; using `roles/storage.objectAdmin` alone will cause a misleading "bucket not found" error).
 - A Hugging Face account with an access token for downloading models.
 - Prerequisites for XPK installed (follow [official documentation](https://github.com/AI-Hypercomputer/xpk/blob/main/docs/installation.md#1-prerequisites)).
   - **Important:** Modern GKE clusters require the GKE auth plugin. If you encounter `gke-gcloud-auth-plugin not found` when running `kubectl` commands, you must install it locally (e.g., `sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin` for `apt` installations, or `gcloud components install gke-gcloud-auth-plugin` for standalone archive installations).

--- a/docs/tutorials/posttraining/sft_on_multi_host.md
+++ b/docs/tutorials/posttraining/sft_on_multi_host.md
@@ -32,7 +32,7 @@ Before starting, ensure you have:
 - **IAM Roles** required:
   - **Kubernetes Engine Developer** (`roles/container.developer`) to submit and manage workloads on GKE.
   - **Artifact Registry Writer** (`roles/artifactregistry.writer`) to upload Docker images.
-  - **Storage Object Admin** (`roles/storage.objectAdmin`) on your GCS bucket to read/write checkpoints and logs.
+  - **Storage Admin** (`roles/storage.admin`) or **Storage Object Admin** (`roles/storage.objectAdmin`) combined with **Storage Legacy Bucket Reader** (`roles/storage.legacyBucketReader`) on your GCS bucket to read/write checkpoints and logs. (Note: A bucket-level read permission like `storage.buckets.get` is required by JAX/TensorStore to verify bucket existence and metadata; using `roles/storage.objectAdmin` alone will cause a misleading "bucket not found" error).
 - A Hugging Face account with an access token for downloading models.
 - Prerequisites for XPK installed (follow [official documentation](https://github.com/AI-Hypercomputer/xpk/blob/main/docs/installation.md#1-prerequisites)).
   - **Important:** Modern GKE clusters require the GKE auth plugin. If you encounter `gke-gcloud-auth-plugin not found` when running `kubectl` commands, you must install it locally (e.g., `sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin` for `apt` installations, or `gcloud components install gke-gcloud-auth-plugin` for standalone archive installations).


### PR DESCRIPTION
Updates the SFT and RL multi-host tutorials to recommend either the broader Storage Admin role, or combining the restrictive Storage Object Admin role with Storage Legacy Bucket Reader. This ensures JAX/TensorStore can perform bucket-level operations (like storage.buckets.get) and prevents misleading 'bucket not found' errors.

FIXES: b/520780283

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
