### PR TITLE
Clarify and improve scan_layers mismatch error handling

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -7,4 +7,5 @@ hidden:
 ---
 development/update_dependencies.md
 development/contribute_docs.md
+development/hlo_diff_testing.md
 ```

--- a/docs/guides/checkpointing_solutions/convert_checkpoint.md
+++ b/docs/guides/checkpointing_solutions/convert_checkpoint.md
@@ -70,7 +70,7 @@ You can find your converted checkpoint files under `${BASE_OUTPUT_DIRECTORY}/0/i
 ### Key Parameters
 
 - `model_name`: The specific model identifier. It must match a supported entry in the MaxText [globals.py](https://github.com/AI-Hypercomputer/maxtext/blob/16b684840db9b96b19e24e84ac49f06af7204ae3/src/maxtext/utils/globals.py#L46C1-L46C7).
-- `scan_layers`: Controls whether the output uses a scanned (`scan_layers=true`) or unscanned (`scan_layers=false`) checkpoint format. Refer [here](../../reference/core_concepts/checkpoints.md) for more information.
+- `scan_layers`: Controls whether the output uses a scanned (`scan_layers=true`) or unscanned (`scan_layers=false`) checkpoint format. Refer [here](../../reference/core_concepts/checkpoints.md) for more information. **IMPORTANT:** This setting *must* match the `scan_layers` value used during model training or loading. A mismatch will cause PyTree loading errors (though MaxText will intercept these and raise a descriptive `ValueError` explaining the mismatch).
 - `use_multimodal`: Indicates if multimodality is used, important for Gemma3.
 - `base_output_directory`: The path where the converted Orbax checkpoint will be stored; it can be Google Cloud Storage (GCS) or local.
 - `hardware=cpu`: The conversion script runs on a CPU machine.
@@ -239,7 +239,10 @@ Here is an example [PR to add support for gemma3 multi-modal model](https://gith
 
 ### Common Errors
 
-- "Type ShapeDtypeStruct is not a valid JAX type": Usually caused by a mismatch in the `scan_layers` flag.
+- "Type ShapeDtypeStruct is not a valid JAX type" or generic **PyTree structure/shape mismatches** (e.g., Orbax reporting `"X/Y paths matched"`, such as `143/145 paths`):
+  This is almost always caused by a mismatch in the `scan_layers` configuration between the checkpoint conversion script (e.g., `to_maxtext.py` or `to_huggingface.py`) and the trainer/inference runner (e.g., `train.py`).
+
+  - **Solution:** Ensure the `scan_layers` flag is set to the exact same value (`True` or `False`) in both the conversion command and your training/execution command.
 
 - If the converted checkpoint loads without errors but produces nonsensical output, likely an error in the Q/K/V weight reshaping logic during conversion.
 

--- a/docs/guides/data_input_pipeline.md
+++ b/docs/guides/data_input_pipeline.md
@@ -64,5 +64,6 @@ hidden:
 data_input_pipeline/data_input_grain
 data_input_pipeline/data_input_hf
 data_input_pipeline/data_input_tfds
+data_input_pipeline/olmo_grain
 data_input_pipeline/data_pipeline_perf.md
 ```

--- a/docs/guides/optimization.md
+++ b/docs/guides/optimization.md
@@ -18,37 +18,38 @@
 
 Explore techniques for maximizing performance, including model customization, sharding strategies, Pallas kernels, and benchmarking.
 
-::::{grid} 1 2 2 2
-:gutter: 2
-
-:::{grid-item-card} 🛠️ Customizing Model Configs
+````{grid} 1 2 2 2
+---
+gutter: 2
+---
+```{grid-item-card} 🛠️ Customizing Model Configs
 :link: optimization/custom_model
 :link-type: doc
 
 Optimize and customize your LLM model configurations for higher performance (MFU) on TPUs.
-:::
+```
 
-:::{grid-item-card} 🥞 Sharding Strategies
+```{grid-item-card} 🥞 Sharding Strategies
 :link: optimization/sharding
 :link-type: doc
 
 Choose efficient sharding strategies (FSDP, TP, EP, PP) using Roofline Analysis and understand arithmetic intensity.
-:::
+```
 
-:::{grid-item-card} ⚡ Pallas Kernels
+```{grid-item-card} ⚡ Pallas Kernels
 :link: optimization/pallas_kernels_performance
 :link-type: doc
 
 Optimize with Pallas kernels for fine-grained control.
-:::
+```
 
-:::{grid-item-card} 📈 Benchmarking & Tuning
+```{grid-item-card} 📈 Benchmarking & Tuning
 :link: optimization/benchmark_and_performance
 :link-type: doc
 
 Guide to setting up benchmarks, performing performance tuning, and analyzing metrics.
-:::
-::::
+```
+````
 
 ```{toctree}
 ---
@@ -57,6 +58,7 @@ maxdepth: 1
 ---
 optimization/custom_model.md
 optimization/sharding.md
+optimization/custom_mesh_and_rule.md
 optimization/pallas_kernels_performance.md
 optimization/benchmark_and_performance.md
 ```

--- a/docs/reference/core_concepts/checkpoints.md
+++ b/docs/reference/core_concepts/checkpoints.md
@@ -66,6 +66,14 @@ Their difference can also be represented in the following pytree structure:
 
 The stacked format is highly efficient but has one key requirement: all layers within the `scan` operation must have identical configurations. For models with heterogeneous layers (where layer configurations differ), stacking is not possible, and only unstacked checkpoints can be used.
 
+In MaxText, the **`scan_layers`** configuration parameter is used to control this setting:
+
+- `scan_layers=true` tells MaxText to stack layer parameters (recommended for training).
+- `scan_layers=false` tells MaxText to keep layer parameters unstacked (often required for inference and certain model architectures).
+
+> [!IMPORTANT]
+> **PyTree Structure Compatibility:** Because JAX expects the loaded PyTree structure to exactly match the model's instantiated structure, the value of the `scan_layers` flag during execution (training, SFT, RL, DPO, or decoding) **must** match the format of the checkpoint being loaded. A mismatch will cause PyTree loading or shape/path mismatch errors (which MaxText will intercept to raise a descriptive `ValueError` pointing to the scan_layers setting).
+
 ### Takeaways
 
 To summarize the four checkpoint types:

--- a/docs/run_maxtext/run_maxtext_localhost.md
+++ b/docs/run_maxtext/run_maxtext_localhost.md
@@ -65,6 +65,9 @@ python3 -m maxtext.inference.decode \
 
 **Note:** Because the model hasn't been properly trained, the output text will be random. To generate meaningful output, you need to load a trained checkpoint using the `load_parameters_path` argument.
 
+> [!NOTE]
+> **Checkpoints & `scan_layers` compatibility:** When loading an external or converted checkpoint via `load_parameters_path`, the `scan_layers` setting in your command **must** match the setting used to save the checkpoint. If the checkpoint was saved/converted with `scan_layers=False` (common for Hugging Face conversions and inference runs), you must specify `scan_layers=False` in your command. Otherwise, JAX/Orbax will raise PyTree structure mismatch errors.
+
 ### Running models using provided configs
 
 MaxText provides many OSS model configs that you can use directly to run training jobs on those model-specific architectures. These model-specific YAML files are located in `src/maxtext/configs/models` for TPU-oriented defaults, and `src/maxtext/configs/models/gpu` for GPU-oriented defaults.

--- a/docs/tutorials/posttraining/dpo.md
+++ b/docs/tutorials/posttraining/dpo.md
@@ -103,6 +103,14 @@ Refer to the steps in [Hugging Face to MaxText](../../guides/checkpointing_solut
 export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
+> [!IMPORTANT]
+> **Matching the `scan_layers` Parameter:**
+> The `scan_layers` setting during your fine-tuning run **must match** the setting used when creating the checkpoint at `MAXTEXT_CKPT_PATH`.
+>
+> - If the checkpoint was converted or saved with `scan_layers=False` (which is common for Hugging Face conversions and inference-ready models), you **must also provide `scan_layers=False` in the MaxText command.**
+> - If `scan_layers` does not match, MaxText will raise a `ValueError`.
+>   See the [Checkpoints concept guide](../../reference/core_concepts/checkpoints.md) for more details.
+
 ## Running DPO Training
 
 You can run the DPO training using the specialized post-training script:

--- a/docs/tutorials/posttraining/rl_on_multi_host.md
+++ b/docs/tutorials/posttraining/rl_on_multi_host.md
@@ -148,6 +148,14 @@ Refer to the steps in [Hugging Face to MaxText](../../guides/checkpointing_solut
 export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
+> [!IMPORTANT]
+> **Matching the `scan_layers` Parameter:**
+> The `scan_layers` setting during your RL training run **must match** the setting used when creating the checkpoint at `MAXTEXT_CKPT_PATH`.
+>
+> - If the checkpoint was converted or saved with `scan_layers=False` (which is common for Hugging Face conversions and inference-ready models), you **must also provide `scan_layers=False` in the MaxText command.**
+> - If `scan_layers` does not match, MaxText will raise a `ValueError`.
+>   See the [Checkpoints concept guide](../../reference/core_concepts/checkpoints.md) for more details.
+
 ## Submit your RL workload via Pathways
 
 See the **Troubleshooting** section for concise instructions on how to retry or

--- a/docs/tutorials/posttraining/sft.md
+++ b/docs/tutorials/posttraining/sft.md
@@ -88,6 +88,14 @@ Refer the steps in [Hugging Face to MaxText](../../guides/checkpointing_solution
 export MAXTEXT_CKPT_PATH=<CKPT_PATH> # e.g., gs://my-bucket/my-model-checkpoint/0/items
 ```
 
+> [!IMPORTANT]
+> **Matching the `scan_layers` Parameter:**
+> The `scan_layers` setting during your fine-tuning run **must match** the setting used when creating the checkpoint at `MAXTEXT_CKPT_PATH`.
+>
+> - If the checkpoint was converted or saved with `scan_layers=False` (which is common for Hugging Face conversions and inference-ready models), you **must also provide `scan_layers=False` in the MaxText command.**
+> - If `scan_layers` does not match, MaxText will raise a `ValueError`.
+>   See the [Checkpoints concept guide](../../reference/core_concepts/checkpoints.md) for more details.
+
 ## Run SFT on Hugging Face Dataset
 
 Now you are ready to run SFT using the following command:

--- a/docs/tutorials/posttraining/sft_on_multi_host.md
+++ b/docs/tutorials/posttraining/sft_on_multi_host.md
@@ -139,6 +139,14 @@ Refer the steps in [Hugging Face to MaxText](../../guides/checkpointing_solution
 export MAXTEXT_CKPT_PATH=<CKPT_PATH> # gs://my-bucket/my-checkpoint-directory/0/items
 ```
 
+> [!IMPORTANT]
+> **Matching the `scan_layers` Parameter:**
+> The `scan_layers` setting during your fine-tuning run **must match** the setting used when creating the checkpoint at `MAXTEXT_CKPT_PATH`.
+>
+> - If the checkpoint was converted or saved with `scan_layers=False` (which is common for Hugging Face conversions and inference-ready models), you **must also provide `scan_layers=False` in the MaxText command.**
+> - If `scan_layers` does not match, MaxText will raise a `ValueError`.
+>   See the [Checkpoints concept guide](../../reference/core_concepts/checkpoints.md) for more details.
+
 ## Submit workload on GKE cluster
 
 This section provides the command to run SFT on a GKE cluster.

--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -18,6 +18,7 @@ import time
 from typing import Any, Optional
 
 from absl import flags
+import contextlib
 import datetime
 from etils import epath
 from flax import nnx
@@ -639,12 +640,14 @@ def _restore_grain_iterator(
   if isinstance(data_iterator, RemoteIteratorWrapper):
     grain_restore_args = GrainCheckpointRestore(item=data_iterator)
     restored_state = checkpoint_manager.restore(step, args=Composite(items=checkpoint_args, iter=grain_restore_args))
+    _assert_no_shaped_dtype_struct(restored_state)
     return (restored_state, None)
 
   # ElasticIterator: one shared `process_0.json` regardless of shard count.
   if not isinstance(data_iterator, list) and isinstance(data_iterator.local_iterator, ElasticIterator):
     grain_restore_args = GrainCheckpointRestore(item=data_iterator.local_iterator)
     restored_state = checkpoint_manager.restore(step, args=Composite(items=checkpoint_args, iter=grain_restore_args))
+    _assert_no_shaped_dtype_struct(restored_state)
     return (restored_state, None)
 
   directory = checkpoint_manager.directory / str(step) / "iter"
@@ -693,7 +696,64 @@ def _restore_grain_iterator(
 
   # Call restore once with the composed arguments
   restored_state = checkpoint_manager.restore(step, args=Composite(items=checkpoint_args, iter=grain_restore_args))
+  _assert_no_shaped_dtype_struct(restored_state)
   return (restored_state, None)
+
+
+def is_structural_or_shape_mismatch(e: Exception) -> bool:
+  """Helper to check if an exception is likely a PyTree structure or shape mismatch."""
+  if not isinstance(e, (ValueError, TypeError)):
+    return False
+  msg = str(e).lower()
+  mismatch_keywords = [
+      "mismatch",
+      "structure",
+      "shape",
+      "tree",
+      "leaf",
+      "leaves",
+      "paths matched",
+      "shapedtypestruct",
+      "invalid type",
+  ]
+  return any(kw in msg for kw in mismatch_keywords)
+
+
+def _assert_no_shaped_dtype_struct(pytree):
+  """Asserts that there are no jax.ShapeDtypeStruct leaves in the restored pytree."""
+  if isinstance(pytree, jax.ShapeDtypeStruct):
+    raise ValueError(
+        f"Some parameters in the restored state remained as ShapeDtypeStruct (indicating structure mismatch): {pytree}."
+    )
+
+  if hasattr(pytree, "keys") and hasattr(pytree, "__getitem__"):
+    for k in pytree.keys():
+      _assert_no_shaped_dtype_struct(pytree[k])
+  elif isinstance(pytree, (list, tuple)):
+    for v in pytree:
+      _assert_no_shaped_dtype_struct(v)
+  else:
+    leaves = jax.tree_util.tree_leaves(pytree)
+    if len(leaves) == 1 and leaves[0] is pytree:
+      return
+    for leaf in leaves:
+      _assert_no_shaped_dtype_struct(leaf)
+
+
+@contextlib.contextmanager
+def handle_checkpoint_mismatch(context_name: str, path: str):
+  """Context manager to intercept PyTree/shape mismatches and raise descriptive errors."""
+  try:
+    yield
+  except Exception as e:
+    if is_structural_or_shape_mismatch(e):
+      raise ValueError(
+          f"Failed to {context_name} from {path}. "
+          "This is often caused by a mismatch in the 'scan_layers' configuration "
+          "(stacked vs unstacked) between your current execution command and "
+          f"the saved checkpoint. Original error: {e}"
+      ) from e
+    raise
 
 
 def load_state_if_possible(
@@ -777,13 +837,15 @@ def load_state_if_possible(
           (EmergencyCheckpointManager, EmergencyReplicatorCheckpointManager),
       ):
         checkpoint_path = str(checkpoint_manager.directory / str(step) / "items")
-        restored_nnx = _load_linen_checkpoint_into_nnx(
-            checkpoint_path,
-            abstract_unboxed_pre_state,
-            checkpoint_storage_concurrent_gb,
-            use_ocdbt,
-            use_zarr3,
-        )
+        with handle_checkpoint_mismatch("restore NNX checkpoint", checkpoint_path):
+          restored_nnx = _load_linen_checkpoint_into_nnx(
+              checkpoint_path,
+              abstract_unboxed_pre_state,
+              checkpoint_storage_concurrent_gb,
+              use_ocdbt,
+              use_zarr3,
+          )
+          _assert_no_shaped_dtype_struct(restored_nnx)
         return ({"items": restored_nnx}, None)
 
       # Convert nnx.State to pure dict to match how checkpoints are saved for NNX
@@ -798,37 +860,43 @@ def load_state_if_possible(
           partial_restore=True,
       )
 
-      match (checkpoint_manager, dataset_type, data_iterator):
-        # Case 1: Matches if 'checkpoint_manager' is an instance of either EmergencyCheckpointManager
-        # or EmergencyReplicatorCheckpointManager. The '_' indicates that 'dataset_type' and
-        # 'data_iterator' can be any value and aren't used in this pattern.
-        case (checkpoint_manager, _, _) if isinstance(
-            checkpoint_manager,
-            (EmergencyCheckpointManager, EmergencyReplicatorCheckpointManager),
-        ):
-          return (
-              checkpoint_manager.restore(step, args=Composite(state=checkpoint_args)).state,
-              None,
-          )
-        # Case 2: Matches if dataset type is "grain" and the data iterator is not a
-        # PlaceHolderDataIterator and a specific checkpoint file exists for the iterator
-        case (
-            checkpoint_manager,
-            dataset_type,
-            data_iterator,
-        ) if (
-            dataset_type == "grain"
-            and data_iterator
-            and not isinstance(data_iterator, PlaceHolderDataIterator)
-            and (checkpoint_manager.directory / str(step) / "iter").exists()
-        ):
-          return _restore_grain_iterator(
-              checkpoint_manager, step, data_iterator, checkpoint_args, expansion_factor_real_data
-          )
-        # Case 3: Default/Fallback case.
-        # This case acts as a wildcard ('_') and matches if none of the preceding cases were met.
-        case _:
-          return (checkpoint_manager.restore(step, args=Composite(items=checkpoint_args)), None)
+      checkpoint_path = str(checkpoint_manager.directory / str(step))
+      with handle_checkpoint_mismatch("restore checkpoint", checkpoint_path):
+        match (checkpoint_manager, dataset_type, data_iterator):
+          # Case 1: Matches if 'checkpoint_manager' is an instance of either EmergencyCheckpointManager
+          # or EmergencyReplicatorCheckpointManager. The '_' indicates that 'dataset_type' and
+          # 'data_iterator' can be any value and aren't used in this pattern.
+          case (checkpoint_manager, _, _) if isinstance(
+              checkpoint_manager,
+              (EmergencyCheckpointManager, EmergencyReplicatorCheckpointManager),
+          ):
+            restored = checkpoint_manager.restore(step, args=Composite(state=checkpoint_args)).state
+            _assert_no_shaped_dtype_struct(restored)
+            return (
+                restored,
+                None,
+            )
+          # Case 2: Matches if dataset type is "grain" and the data iterator is not a
+          # PlaceHolderDataIterator and a specific checkpoint file exists for the iterator
+          case (
+              checkpoint_manager,
+              dataset_type,
+              data_iterator,
+          ) if (
+              dataset_type == "grain"
+              and data_iterator
+              and not isinstance(data_iterator, PlaceHolderDataIterator)
+              and (checkpoint_manager.directory / str(step) / "iter").exists()
+          ):
+            return _restore_grain_iterator(
+                checkpoint_manager, step, data_iterator, checkpoint_args, expansion_factor_real_data
+            )
+          # Case 3: Default/Fallback case.
+          # This case acts as a wildcard ('_') and matches if none of the preceding cases were met.
+          case _:
+            restored = checkpoint_manager.restore(step, args=Composite(items=checkpoint_args))
+            _assert_no_shaped_dtype_struct(restored)
+            return (restored, None)
 
   if load_parameters_from_path != "":
     if isinstance(abstract_unboxed_pre_state, nnx.State):
@@ -836,26 +904,30 @@ def load_state_if_possible(
     else:
       params = abstract_unboxed_pre_state.params
 
-    restored_params = load_params_from_path(
-        load_parameters_from_path,
-        params,
-        checkpoint_storage_concurrent_gb,
-        use_ocdbt=use_ocdbt,
-        use_zarr3=use_zarr3,
-    )
+    with handle_checkpoint_mismatch("load parameters", load_parameters_from_path):
+      restored_params = load_params_from_path(
+          load_parameters_from_path,
+          params,
+          checkpoint_storage_concurrent_gb,
+          use_ocdbt=use_ocdbt,
+          use_zarr3=use_zarr3,
+      )
+      _assert_no_shaped_dtype_struct(restored_params)
     return None, restored_params
   elif load_full_state_from_path != "":
     max_logging.log(f"Loading full state from path: {load_full_state_from_path}")
-    restored_state = _load_full_state_from_path(
-        path=load_full_state_from_path,
-        abstract_unboxed_pre_state=abstract_unboxed_pre_state,
-        enable_orbax_v1=enable_orbax_v1,
-        checkpoint_conversion_fn=checkpoint_conversion_fn,
-        source_checkpoint_layout=source_checkpoint_layout,
-        checkpoint_storage_concurrent_gb=checkpoint_storage_concurrent_gb,
-        use_ocdbt=use_ocdbt,
-        use_zarr3=use_zarr3,
-    )
+    with handle_checkpoint_mismatch("load full state", load_full_state_from_path):
+      restored_state = _load_full_state_from_path(
+          path=load_full_state_from_path,
+          abstract_unboxed_pre_state=abstract_unboxed_pre_state,
+          enable_orbax_v1=enable_orbax_v1,
+          checkpoint_conversion_fn=checkpoint_conversion_fn,
+          source_checkpoint_layout=source_checkpoint_layout,
+          checkpoint_storage_concurrent_gb=checkpoint_storage_concurrent_gb,
+          use_ocdbt=use_ocdbt,
+          use_zarr3=use_zarr3,
+      )
+      _assert_no_shaped_dtype_struct(restored_state)
     return {"items": restored_state}, None
   else:
     max_logging.log("No existing checkpoints found, not restoring checkpoint.")

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -50,6 +50,7 @@ from maxtext.models import models
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils, maxtext_utils, maxtext_utils_nnx
 from maxtext.integration.tunix.tunix_adapter import TunixMaxTextAdapter
+from maxtext.common.checkpointing import handle_checkpoint_mismatch
 from orbax import checkpoint as ocp
 
 try:
@@ -421,12 +422,7 @@ def _fix_restore_args_for_shape_mismatch(restore_args, stored_metadata_tree, mes
   if rank_mismatched_paths:
     sample = "\n".join(rank_mismatched_paths[:5])
     more = f"\n  ... and {len(rank_mismatched_paths) - 5} more" if len(rank_mismatched_paths) > 5 else ""
-    raise ValueError(
-        f"Checkpoint rank mismatches detected ({len(rank_mismatched_paths)} arrays). "
-        "This usually means a scanned (scan_layers=True) checkpoint was loaded with "
-        "scan_layers=False, or vice versa. Please ensure the checkpoint format matches "
-        f"the scan_layers setting.\n{sample}{more}"
-    )
+    raise ValueError(f"Checkpoint rank mismatches detected ({len(rank_mismatched_paths)} arrays):\n{sample}{more}")
 
   # Detect structural mismatch (e.g. scanned checkpoint loaded into unscanned model).
   # In that case the checkpoint tree has "layers" (all layers stacked) but the model
@@ -438,10 +434,7 @@ def _fix_restore_args_for_shape_mismatch(restore_args, stored_metadata_tree, mes
     more = f"\n  ... and {len(missing_paths) - 5} more" if len(missing_paths) > 5 else ""
     raise ValueError(
         f"Checkpoint structure mismatch: {len(missing_paths)} of {total_arrays} model parameter "
-        "paths were not found in the checkpoint. "
-        "This usually means a scanned (scan_layers=True) checkpoint is being loaded with "
-        "scan_layers=False, or vice versa. Please ensure the checkpoint format matches the "
-        f"scan_layers setting.\nExample missing paths:\n{sample}{more}"
+        f"paths were not found in the checkpoint.\nExample missing paths:\n{sample}{more}"
     )
 
   if mismatched_paths_sharded:
@@ -859,7 +852,7 @@ def from_pretrained(
 
   with mesh:
     if config.load_parameters_path:
-      try:
+      with handle_checkpoint_mismatch("load parameters", config.load_parameters_path):
         ckptr = ocp.Checkpointer(
             ocp.PyTreeCheckpointHandler(
                 restore_concurrent_gb=config.checkpoint_storage_concurrent_gb,
@@ -1058,9 +1051,6 @@ def from_pretrained(
               "(e.g. a scanned checkpoint loaded with scan_layers=False, or vice versa). "
               "Please ensure the checkpoint format matches the scan_layers setting."
           )
-
-      except Exception as e:
-        raise ValueError(f"Checkpoint loading failed: {e}") from e
 
     if wrap_with_tunix_adapter:
       with mesh:

--- a/tests/integration/checkpointing_test.py
+++ b/tests/integration/checkpointing_test.py
@@ -195,3 +195,38 @@ def test_autoselected_attention():
 def test_with_dot_product():
   """Tests checkpointing with dot_product attention on GPU."""
   run_checkpointing("gpu", "dot_product")
+
+
+@pytest.mark.integration_test
+@pytest.mark.tpu_only
+@pytest.mark.scheduled_only
+def test_scan_layers_mismatch_tpu():
+  """Tests scan_layers mismatch checkpoint loading raises ValueError on TPU."""
+  hardware = "tpu"
+  attention_type = "autoselected"
+  run_date = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+  local_ckpt_dir = "/tmp/maxtext_local_output"
+
+  def get_cmd(steps, metrics_file):
+    return get_checkpointing_command(
+        run_date,
+        hardware=hardware,
+        steps=steps,
+        metrics_file=metrics_file,
+        attention_type=attention_type,
+        dataset_type="synthetic",
+        dataset_path="/tmp/gcsfuse",
+        base_output_directory=local_ckpt_dir,
+    )
+
+  # 1. Save checkpoint with scan_layers=True (default) and steps=1
+  train_main(get_cmd(steps=1, metrics_file="saved_metrics_mismatch.txt"))
+
+  # 2. Attempt to restore with scan_layers=False and assert ValueError
+  mismatch_command = get_cmd(steps=2, metrics_file="restored_metrics_mismatch.txt") + ["scan_layers=False"]
+
+  with pytest.raises(ValueError) as excinfo:
+    train_main(mismatch_command)
+
+  assert "Failed to restore checkpoint" in str(excinfo.value)
+  assert "scan_layers" in str(excinfo.value)

--- a/tests/unit/checkpointing_nnx_load_test.py
+++ b/tests/unit/checkpointing_nnx_load_test.py
@@ -104,6 +104,69 @@ class TestLoadStateIfPossibleNNX(unittest.TestCase):
     self.assertIsNone(full)
     self.assertIsNone(params)
 
+  def test_load_state_if_possible_wraps_load_params_mismatch_exception(self):
+    """Verifies that load_state_if_possible intercepts and wraps PyTree mismatches in load_params_from_path."""
+    abstract = _abstract_nnx_state()
+    with mock.patch.object(checkpointing, "load_params_from_path", side_effect=ValueError("PyTree structure mismatch")):
+      with self.assertRaises(ValueError) as ctx:
+        checkpointing.load_state_if_possible(
+            checkpoint_manager=None,
+            data_iterator=None,
+            load_parameters_from_path="gs://does-not-exist/params",
+            load_full_state_from_path="",
+            checkpoint_storage_concurrent_gb=8,
+            abstract_unboxed_pre_state=abstract,
+        )
+      self.assertIn("Failed to load parameters from gs://does-not-exist/params.", str(ctx.exception))
+      self.assertIn("This is often caused by a mismatch in the 'scan_layers' configuration", str(ctx.exception))
+
+  def test_load_state_if_possible_re_raises_other_load_params_exceptions(self):
+    """Verifies that load_state_if_possible does not intercept other errors from load_params_from_path."""
+    abstract = _abstract_nnx_state()
+    with mock.patch.object(checkpointing, "load_params_from_path", side_effect=FileNotFoundError("no such file")):
+      with self.assertRaises(FileNotFoundError):
+        checkpointing.load_state_if_possible(
+            checkpoint_manager=None,
+            data_iterator=None,
+            load_parameters_from_path="gs://does-not-exist/params",
+            load_full_state_from_path="",
+            checkpoint_storage_concurrent_gb=8,
+            abstract_unboxed_pre_state=abstract,
+        )
+
+
+class TestCheckpointMismatchHandling(unittest.TestCase):
+  """Unit tests for the checkpoint mismatch detection and wrapper context manager."""
+
+  def test_is_structural_or_shape_mismatch(self):
+    """Verifies that is_structural_or_shape_mismatch matches only shape/tree mismatches in ValueError/TypeError."""
+    # Matches
+    self.assertTrue(checkpointing.is_structural_or_shape_mismatch(ValueError("PyTree structure mismatch")))
+    self.assertTrue(checkpointing.is_structural_or_shape_mismatch(TypeError("shape mismatch in leaf")))
+    self.assertTrue(checkpointing.is_structural_or_shape_mismatch(ValueError("tree paths matched 143/145")))
+    self.assertTrue(checkpointing.is_structural_or_shape_mismatch(ValueError("invalid type shapedtypestruct")))
+
+    # Does not match
+    self.assertFalse(checkpointing.is_structural_or_shape_mismatch(ValueError("checkpoint directory does not exist")))
+    self.assertFalse(checkpointing.is_structural_or_shape_mismatch(FileNotFoundError("file not found: checkpoint")))
+    self.assertFalse(checkpointing.is_structural_or_shape_mismatch(RuntimeError("something went wrong")))
+
+  def test_handle_checkpoint_mismatch_intercepts_matching_exceptions(self):
+    """Verifies that handle_checkpoint_mismatch intercepts and wraps structural errors."""
+    with self.assertRaises(ValueError) as ctx:
+      with checkpointing.handle_checkpoint_mismatch("load parameters", "gs://bucket/params"):
+        raise ValueError("PyTree structure mismatch")
+
+    self.assertIn("Failed to load parameters from gs://bucket/params.", str(ctx.exception))
+    self.assertIn("This is often caused by a mismatch in the 'scan_layers' configuration", str(ctx.exception))
+    self.assertIn("Original error: PyTree structure mismatch", str(ctx.exception))
+
+  def test_handle_checkpoint_mismatch_re_raises_non_matching_exceptions(self):
+    """Verifies that handle_checkpoint_mismatch does not intercept non-structural errors."""
+    with self.assertRaises(FileNotFoundError):
+      with checkpointing.handle_checkpoint_mismatch("load parameters", "gs://bucket/params"):
+        raise FileNotFoundError("file not found: checkpoint")
+
 
 class TestLoadParamsIntoNNX(unittest.TestCase):
   """Weight-only load (load_parameters_path) of a Linen-layout checkpoint into NNX."""
@@ -131,12 +194,8 @@ class TestLoadParamsIntoNNX(unittest.TestCase):
 
     self.assertIsInstance(restored, nnx.State)
     pure = restored.to_pure_dict()
-    self.assertTrue(
-        jnp.array_equal(pure["linear"]["kernel"], weights["linear"]["kernel"])
-    )
-    self.assertTrue(
-        jnp.array_equal(pure["linear"]["bias"], weights["linear"]["bias"])
-    )
+    self.assertTrue(jnp.array_equal(pure["linear"]["kernel"], weights["linear"]["kernel"]))
+    self.assertTrue(jnp.array_equal(pure["linear"]["bias"], weights["linear"]["bias"]))
 
 
 if __name__ == "__main__":

--- a/tests/unit/model_creation_utils_test.py
+++ b/tests/unit/model_creation_utils_test.py
@@ -712,15 +712,15 @@ class TestCreateNnxModel(unittest.TestCase):
     self.assertIsInstance(model, models.Transformer)
 
   @patch("maxtext.utils.model_creation_utils.ocp")
-  def test_checkpoint_load_error_raises_value_error(self, mock_ocp):
-    """Any exception during checkpoint loading should be re-raised as ValueError."""
+  def test_checkpoint_load_error_propagates(self, mock_ocp):
+    """Non-mismatch exceptions during checkpoint loading should propagate directly."""
     mock_ckptr = MagicMock()
     mock_ckptr.metadata.side_effect = RuntimeError("disk on fire")
     mock_ocp.Checkpointer.return_value = mock_ckptr
     mock_ocp.PyTreeCheckpointHandler.return_value = MagicMock()
 
     cfg = _make_config(enable_checkpointing=True, load_parameters_path="gs://fake/bad_ckpt")
-    with self.assertRaises(ValueError):
+    with self.assertRaises(RuntimeError):
       model_creation_utils.from_pretrained(cfg, self.mesh)
 
 


### PR DESCRIPTION
When scan_layers is inconsistent between checkpoint creation and training, Orbax throws an error. 
This PR documents this and improves error handling across all possible restore paths.

FIXES: b/520780284

# Tests

Unit and integration tests were added to verify error handling.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
