### PR TITLE
Support ragged gather reduce kernel fan-in in forward pass

### DIFF
--- a/src/maxtext/kernels/ragged/ragged_sort.py
+++ b/src/maxtext/kernels/ragged/ragged_sort.py
@@ -143,39 +143,53 @@ def ring_ragged_sort(hidden_states_local, topk_indices_local, num_experts, topk,
   return _ring_ragged_sort(hidden_states_local, topk_indices_local)
 
 
-def ring_ragged_unsort(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices, local_num_experts, ep_name):
+def ring_ragged_unsort(
+    sorted_tokens_local,
+    group_sizes_local,
+    topk_argsort_revert_indices,
+    topk,
+    local_num_experts,
+    ep_name,
+    topk_weights,
+):
   """Dual of :func:`ring_ragged_sort`.
 
   Forward:
-    ``out[i] = sorted_tokens_local[topk_argsort_revert_indices[i]]`` for
-    ``topk_argsort_revert_indices[i]`` in ``[shard_output_start, shard_output_end)``;
-    other rows are zeroed. This scatters the processed outputs from the experts hosted
-    on this shard back to their flat arrival buffer positions.
+    ``out[i] = sum_k( w[i*topk+k] * sorted_tokens_local[topk_argsort_revert_indices[i*topk+k]] )``
+    for positions where ``topk_argsort_revert_indices`` is in
+    ``[shard_output_start, shard_output_end)``; other rows are zeroed.
+    This scatters the processed outputs from the experts hosted on this shard
+    back to their flat arrival buffer positions, applying routing weights
+    during the reduction.
 
   Backward:
-    ``g_sorted_tokens[j] = g_out[i]`` where ``j = topk_argsort_revert_indices[i]``
-    and ``j`` is in ``[shard_output_start, shard_output_end)``. Since the source indices
-    represent a permutation, this is a masked ragged gather over the inverse permutation.
+    ``g_sorted_tokens[j] = w[i] * g_out[i // topk]`` where
+    ``j = topk_argsort_revert_indices[i]`` and ``j`` is in
+    ``[shard_output_start, shard_output_end)``.
 
   Args:
     sorted_tokens_local: 2D ``[num_tokens_local * topk, hidden]`` output tensor from local experts.
     group_sizes_local: 1D tensor tracking the token loads per expert.
     topk_argsort_revert_indices: 1D permutation restoring flat token positions.
+    topk: scalar ``int`` representing the routing top-k factor.
     local_num_experts: scalar ``int`` representing the count of experts hosted on this shard.
     ep_name: ``str`` identifying the expert parallel axis name.
+    topk_weights: ``[num_tokens_local * topk]`` tensor of per-slot routing weights.
 
   Returns:
-    A 2D ``[num_tokens_local * topk, hidden]`` tensor with expert outputs scattered back
+    A 2D ``[num_tokens_local, hidden]`` tensor with expert outputs scattered back
     to their original global sequence locations, with unpopulated positions zeroed out.
   """
 
   @jax.custom_vjp
-  def _ring_ragged_unsort(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices):
+  def _ring_ragged_unsort(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices, topk_weights_flat):
     """Unsort and scatter activations."""
-    return _ring_ragged_unsort_fwd(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices)[0]
+    return _ring_ragged_unsort_fwd(
+        sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices, topk_weights_flat
+    )[0]
 
   @jax.named_scope("ragged-scatter-fwd")
-  def _ring_ragged_unsort_fwd(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices):
+  def _ring_ragged_unsort_fwd(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices, topk_weights_flat):
     """Executes unsorting sending tokens back."""
     group_offsets = jnp.cumulative_sum(group_sizes_local, include_initial=True)
 
@@ -186,25 +200,24 @@ def ring_ragged_unsort(sorted_tokens_local, group_sizes_local, topk_argsort_reve
     shard_output_start = group_offsets[experts_start]
     shard_output_end = group_offsets[experts_end]
 
-    # Express the scatter as a degenerate gather-reduce: each output row pulls
+    # Express the scatter as a gather-reduce: each output row pulls
     # from sorted_tokens_local at position `topk_argsort_revert_indices[i]` if
     # that position is within this shard's [start, end) range, else zero.
-    # `reduce_group_size=1` and all-ones weights make this a pure gather; the
-    # kernel itself zeros rows whose `valid_rows_mask` entry is False.
-    n = topk_argsort_revert_indices.shape[0]
+    # The routing weights are applied per-row before the topk reduction.
     valid_rows_mask = (topk_argsort_revert_indices >= shard_output_start) & (
         topk_argsort_revert_indices < shard_output_end
     )
     out = ragged_gather_reduce(
         sorted_tokens_local,
         topk_argsort_revert_indices,
-        topk_weights=jnp.ones((n,), dtype=jnp.float32),
+        topk_weights=topk_weights_flat,
         valid_rows_mask=valid_rows_mask,
-        reduce_group_size=1,
+        reduce_group_size=topk,
     )
 
     res = (
         topk_argsort_revert_indices,
+        topk_weights_flat,
         shard_output_start,
         shard_output_end,
     )
@@ -213,44 +226,44 @@ def ring_ragged_unsort(sorted_tokens_local, group_sizes_local, topk_argsort_reve
 
   @jax.named_scope("ragged-scatter-bwd")
   def _ring_ragged_unsort_bwd(res, g_out):
-    """Backward pass for the scatter: a Pallas SC ragged gather.
+    """Backward pass for the scatter with routing weights.
 
-    The forward scatter computes
-    ``out[i] = sorted_tokens[topk_argsort_revert_indices[i]]`` masked by
-    ``valid_mask[i] = (topk_argsort_revert_indices[i] >= start) and (< end)``.
+    The forward computes (per output token t, with topk slots k=0..topk-1):
+      out[t] = sum_k  w[t*topk+k] * sorted_tokens[revert[t*topk+k]]
+    masked by validity.
 
-    Equivalently, defining ``j = topk_argsort_revert_indices[i]``, the forward is
-    ``out[i] = sorted_tokens[j]`` whenever ``j in [start, end)``.
-
-    ``topk_argsort_revert_indices`` is a permutation of
-    ``[0, sorted_tokens_local_shape[0])``, so the gradient pulls back per-row::
-
-        g_sorted_tokens[j] = g_hidden_states_local[i]   where j = revert[i]
-                                                        and j in [start, end).
-
-    This is exactly a ragged gather of ``g_hidden_states_local`` along the
-    inverse permutation ``argsort(revert)``, but restricted to the [start,end)
-    range of ``j``.  The simpler equivalent: gather of g_hidden_states_local
-    using the inverse permutation, masked.
+    Gradient w.r.t. sorted_tokens:
+      g_sorted_tokens[j] = w[i] * g_out[i // topk]
+    where j = revert[i] and j in [start, end).
     """
-    topk_argsort_revert_indices, shard_output_start, shard_output_end = res
+    topk_argsort_revert_indices, topk_weights_flat, shard_output_start, shard_output_end = res
     g_hidden_states_local = g_out
 
-    # We want: g_sorted_tokens[j] = g_hidden_states_local[i] where revert[i]=j.
+    # Expand g_out from [num_tokens] to [num_tokens * topk] by repeating each
+    # row topk times, so that g_expanded[i] = g_out[i // topk].
+    g_expanded = jnp.repeat(g_hidden_states_local, topk, axis=0)
+
+    # Apply per-slot routing weights: g_weighted[i] = w[i] * g_out[i // topk]
+    g_weighted = g_expanded * topk_weights_flat[:, None]
+
+    # We want: g_sorted_tokens[j] = g_weighted[i] where revert[i]=j.
     # Build the inverse permutation idx_inv such that idx_inv[j] = i.
     idx_inv = jnp.argsort(topk_argsort_revert_indices)
     # Because revert is a permutation, gathering with idx_inv reorders correctly.
     grad_sorted_tokens = ragged_gather(
-        g_hidden_states_local,
+        g_weighted,
         idx_inv,
         shard_output_start,
         shard_output_end,
     )
-    return grad_sorted_tokens, None, None
+    return grad_sorted_tokens, None, None, None
 
   _ring_ragged_unsort.defvjp(_ring_ragged_unsort_fwd, _ring_ragged_unsort_bwd)
 
-  return _ring_ragged_unsort(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices)
+  # Build the flat weights array from the routing weights.
+  topk_weights_flat = topk_weights.astype(jnp.float32)
+
+  return _ring_ragged_unsort(sorted_tokens_local, group_sizes_local, topk_argsort_revert_indices, topk_weights_flat)
 
 
 def a2a_ragged_sort(inputs, sort_indices, valid_end):

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -839,12 +839,18 @@ class RoutedMoE(nnx.Module):
 
     if self.config.use_ragged_sort and self.config.use_ring_of_experts:
       local_num_experts = self.config.num_experts // self.get_expert_parallelism_size()
-      unsort_intermediate = ring_ragged_unsort(
+      # Build the flat routing weights in the same layout as
+      # topk_argsort_revert_indices (i.e. the flat token×topk order before
+      # sorting by expert). `weights` has shape (batch, seq, topk); flatten it.
+      flat_weights = jnp.ravel(weights).astype(jnp.float32)
+      output = ring_ragged_unsort(
           intermediate,
           group_sizes,
           sorted_selected_experts,
+          self.num_experts_per_tok,
           local_num_experts,
           self._expert_parallelism_name,
+          topk_weights=flat_weights,
       )
     else:
       unsort_intermediate = _sort_activations(
@@ -852,25 +858,25 @@ class RoutedMoE(nnx.Module):
           jnp.argsort(sorted_selected_experts),
           use_custom_sort_vjp,
       )
-    reshaped_weights = jnp.reshape(weights, (-1, self.num_experts_per_tok))
-    reshaped_intermediate = jnp.reshape(
-        unsort_intermediate,
-        (reshaped_weights.shape[0], self.num_experts_per_tok, -1),
-    )
-    with jax.named_scope("weight_sum"):
-      matmul_precision = jax.lax.Precision(self.config.matmul_precision)
-      if self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4:
-        # For Llama4, combine using weights of 1 for selected experts
-        reshaped_weights = jnp.ones_like(reshaped_weights)
-      if self.config.float32_weight_sum:
-        reshaped_intermediate = reshaped_intermediate.astype(jnp.float32)
-        reshaped_weights = reshaped_weights.astype(jnp.float32)
-      output = jnp.einsum(
-          "BKE,BK -> BE",
-          reshaped_intermediate,
-          reshaped_weights,
-          precision=matmul_precision,
+      reshaped_weights = jnp.reshape(weights, (-1, self.num_experts_per_tok))
+      reshaped_intermediate = jnp.reshape(
+          unsort_intermediate,
+          (reshaped_weights.shape[0], self.num_experts_per_tok, -1),
       )
+      with jax.named_scope("weight_sum"):
+        matmul_precision = jax.lax.Precision(self.config.matmul_precision)
+        if self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4:
+          # For Llama4, combine using weights of 1 for selected experts
+          reshaped_weights = jnp.ones_like(reshaped_weights)
+        if self.config.float32_weight_sum:
+          reshaped_intermediate = reshaped_intermediate.astype(jnp.float32)
+          reshaped_weights = reshaped_weights.astype(jnp.float32)
+        output = jnp.einsum(
+            "BKE,BK -> BE",
+            reshaped_intermediate,
+            reshaped_weights,
+            precision=matmul_precision,
+        )
     return output.reshape(batch_size, sequence_length, -1).astype(self.dtype)
 
   @staticmethod


### PR DESCRIPTION
# Description

Before this PR, the fan-in feature of `ragged_gather_reduce` kernel is not properly used in the forward pass. We still have weight sum after gather reduce kernel and no fan in is used. This PR corrects this mistake and further improve performance.

# Tests

* Step time before change: [19.05 s](http://xprof.corp.google.com/trace_viewer/chengnuojin-1068214515790825753)
* Step time after change: [17.8 s](http://xprof.corp.google.com/trace_viewer/chengnuojin-9288426616673894265)

Performance gets improved 7%.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
