### PR TITLE
Fix tokenizer path when using colocated_python

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2448,7 +2448,12 @@ class MaxTextConfig(
     # If the tokenizer path is a relative name without a directory, resolve it against the assets root.
     # This maintains backward compatibility for configs that just specify e.g., "tokenizer.llama2".
     tokenizer_path = getattr(self, "tokenizer_path", "")
-    if tokenizer_path and not os.path.exists(tokenizer_path) and not tokenizer_path.startswith("gs://"):
+    if (
+        tokenizer_path
+        and not os.path.exists(tokenizer_path)
+        and not tokenizer_path.startswith("gs://")
+        and not self.colocated_python_data_input
+    ):
       tokenizer_path = next(
           filter(
               os.path.exists,

--- a/src/maxtext/input_pipeline/tokenizer.py
+++ b/src/maxtext/input_pipeline/tokenizer.py
@@ -42,7 +42,10 @@ class TikTokenTokenizer:
         model_path (str): The path to the Tiktoken model file.
     """
 
-    mergeable_ranks = load_tiktoken_bpe(model_path)
+    try:
+      mergeable_ranks = load_tiktoken_bpe(model_path)
+    except Exception as e:
+      raise ValueError(f"Failed to load tiktoken tokenizer from {model_path}: {e}") from e
     num_base_tokens = len(mergeable_ranks)
     special_tokens = [
         "<|begin_of_text|>",
@@ -222,12 +225,15 @@ class HFTokenizer:
 
   def __init__(self, model_path: str, add_bos: bool, add_eos: bool, hf_access_token: str):
     max_logging.log(f"Loading HF tokenizer: {model_path}")
-    self.tokenizer = transformers.AutoTokenizer.from_pretrained(
-        model_path,
-        add_bos_token=add_bos,
-        add_eos_token=add_eos,
-        token=hf_access_token,
-    )
+    try:
+      self.tokenizer = transformers.AutoTokenizer.from_pretrained(
+          model_path,
+          add_bos_token=add_bos,
+          add_eos_token=add_eos,
+          token=hf_access_token,
+      )
+    except Exception as e:
+      raise ValueError(f"Failed to load Hugging Face tokenizer from {model_path}: {e}") from e
     self.pad_id = self.tokenizer.pad_token_id
     self.unk_id = self.tokenizer.unk_token_id
     self.bos_id = self.tokenizer.bos_token_id


### PR DESCRIPTION
# Description

b/521502791

* In `types.py`, we convert user provided relative tokenizer_path to absolute path based on local environment. But in colocated python, tokenizer loading is run remotely and requires keeping tokenizer_path a relative path.
* Add additional try-except blocks for tokenizer loading errors.

# Tests

Tested in the bug. Future item: add CI for colocated dataloading

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
