### PR TITLE
Add ragged buffer to ring of experts

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2416,9 +2416,14 @@ class MaxTextConfig(
 
   def validate_ragged_buffer_factor(self):
     if self.ragged_buffer_factor <= 0:
-      return  # Nothing to validate if not using ragged buffer factor
-    if self.use_ring_of_experts:
-      raise ValueError("Currently we only support ragged buffer factor with ragged a2a approach.")
+      return  # Not using a ragged buffer factor
+
+    if self.use_ring_of_experts and not self.use_ragged_sort:
+      raise ValueError(
+          "Ragged buffer factor is currently only supported with:\n"
+          "  1. Ragged A2A approach (use_ring_of_experts=False)\n"
+          "  2. Ragged sort with ring of experts (use_ring_of_experts=True AND use_ragged_sort=True)"
+      )
 
   @model_validator(mode="after")
   def set_derived_and_validate_values(self) -> "MaxTextConfig":

--- a/src/maxtext/kernels/ragged/ragged_gather.py
+++ b/src/maxtext/kernels/ragged/ragged_gather.py
@@ -69,9 +69,9 @@ def main_kernel(
 
   # Read start and end tensor values.
   dma_list = []
-  dma = pltpu.make_async_copy(start_ref, start_vmem_ref.at[:1], recv_sem)
+  dma = pltpu.make_async_copy(start_ref.at[:1], start_vmem_ref.at[:1], recv_sem)
   dma_list.append(dma)
-  dma = pltpu.make_async_copy(end_ref, end_vmem_ref.at[:1], recv_sem)
+  dma = pltpu.make_async_copy(end_ref.at[:1], end_vmem_ref.at[:1], recv_sem)
   dma_list.append(dma)
 
   jax.tree.map(lambda x: x.start(), dma_list)
@@ -241,10 +241,16 @@ def ragged_gather(x: jax.Array, indices: jax.Array, start: jax.Array, end: jax.A
   assert x.ndim == 2, "Ragged gather only supports 2d inputs."
   assert indices.ndim == 1, "Ragged gather only supports 1d indices."
 
-  if jnp.isscalar(start):
-    start = start[None]
-  if jnp.isscalar(end):
-    end = end[None]
+  # TODO(b/522341181): this is a workaround to avoid unexpected type mismatch
+  if jnp.ndim(start) == 0:
+    start = jnp.repeat(start, 2)
+  elif start.shape == (1,):
+    start = jnp.pad(start, (0, 1))
+
+  if jnp.ndim(end) == 0:
+    end = jnp.repeat(end, 2)
+  elif end.shape == (1,):
+    end = jnp.pad(end, (0, 1))
 
   dtype = x.dtype
 

--- a/src/maxtext/kernels/ragged/ragged_sort.py
+++ b/src/maxtext/kernels/ragged/ragged_sort.py
@@ -20,7 +20,15 @@ from maxtext.kernels.ragged.ragged_gather import ragged_gather
 from maxtext.kernels.ragged.ragged_gather_reduce import ragged_gather_reduce
 
 
-def ring_ragged_sort(hidden_states_local, topk_indices_local, num_experts, topk, ep_name, ep_size):
+def ring_ragged_sort(
+    hidden_states_local,
+    topk_indices_local,
+    num_experts,
+    topk,
+    ep_name,
+    ep_size,
+    buffer_size=None,
+):
   """Ragged-gather variant for AG-RS Expert Parallelism token routing.
 
   Unlike :func:`a2a_ragged_sort`, which operates on a valid prefix within a single shard,
@@ -47,10 +55,12 @@ def ring_ragged_sort(hidden_states_local, topk_indices_local, num_experts, topk,
     topk: scalar ``int`` representing the routing top-k factor.
     ep_name: ``str`` identifying the expert parallel axis name.
     ep_size: scalar ``int`` representing the expert parallel mesh size.
+    buffer_size: optional scalar ``int`` representing the size of the local buffer.
 
   Returns:
     A tuple containing:
-      - Processed activations tensor of shape ``[num_tokens_local * topk, hidden]`` containing
+      - Processed activations tensor of shape ``[buffer_size, hidden]``
+      containing
         only the tokens destined for local experts, padded with zeros elsewhere.
       - 1D tensor ``group_sizes_local`` tracking expert token counts.
       - 1D tensor ``topk_argsort_revert_indices`` for inverse routing.
@@ -85,12 +95,34 @@ def ring_ragged_sort(hidden_states_local, topk_indices_local, num_experts, topk,
     shard_output_start = group_offsets[experts_start]
     shard_output_end = group_offsets[experts_end]
 
-    x = ragged_gather(
-        hidden_states_local,
-        token_indices_sorted,
-        shard_output_start,
-        shard_output_end,
-    )
+    if buffer_size is None or buffer_size >= num_tokens_local * topk:
+      local_buffer_size = num_tokens_local * topk
+      x = ragged_gather(
+          hidden_states_local,
+          token_indices_sorted,
+          shard_output_start[None],
+          shard_output_end[None],
+      )
+    else:
+      local_buffer_size = buffer_size
+      # We only gather up to the available buffer size or the actual number of
+      # tokens destined for this shard's experts, whichever is smaller.
+      gather_end = jnp.minimum(shard_output_end - shard_output_start, local_buffer_size)
+      # Pad the indices to ensure we can safely slice a block of size `local_buffer_size`
+      # starting at `shard_output_start` without going out-of-bounds during compilation.
+      padded_token_indices_sorted = jnp.pad(token_indices_sorted, (0, local_buffer_size))
+      sliced_indices = jax.lax.dynamic_slice_in_dim(
+          padded_token_indices_sorted,
+          shard_output_start,
+          local_buffer_size,
+          axis=0,
+      )
+      x = ragged_gather(
+          hidden_states_local,
+          sliced_indices,
+          jnp.int32(0)[None],
+          gather_end[None],
+      )
 
     out = (x, group_sizes_local, topk_argsort_revert_indices)
 
@@ -98,6 +130,7 @@ def ring_ragged_sort(hidden_states_local, topk_indices_local, num_experts, topk,
         topk_argsort_revert_indices,
         shard_output_start,
         shard_output_end,
+        local_buffer_size,
         hidden_states_local.shape,
     )
 
@@ -106,36 +139,63 @@ def ring_ragged_sort(hidden_states_local, topk_indices_local, num_experts, topk,
   @jax.named_scope("ragged-gather-bwd")
   def _ring_ragged_sort_bwd(res, g_out):
     """Backward pass for the gather: a Pallas SC ragged gather reduce.
-
     The forward gathers ``hidden_states_local[token_indices_sorted[i]]`` into
     ``x[i]`` for ``i`` in ``[shard_output_start, shard_output_end)``.  The
     gradient w.r.t. ``hidden_states_local`` is therefore::
-
         g_hidden_states[token_indices_sorted[i]] += g_x[i]    (i in valid range)
-
     which is exactly a ragged gather reduce.
     """
-    topk_argsort_revert_indices, shard_output_start, shard_output_end, _ = res
+    (
+        topk_argsort_revert_indices,
+        shard_output_start,
+        shard_output_end,
+        local_buffer_size,
+        _,
+    ) = res
     g_x, _, _ = g_out
     # Restrict to the [start, end) source range via a validity bitmask. The
     # ragged kernel packs valid rows to the front of each row-partition and
     # only iterates over the populated prefix, so we hand it the mask directly
     # rather than materializing a (mostly-zero) dense buffer ourselves.
     n = topk_argsort_revert_indices.shape[0]
-    valid_rows_mask = (topk_argsort_revert_indices >= shard_output_start) & (
-        topk_argsort_revert_indices < shard_output_end
-    )
-    # The forward scatter-add over `token_indices_sorted` is equivalent to a
-    # gather-reduce: each input token has exactly `topk` contributions located
-    # at sorted positions `topk_argsort_revert_indices[t*topk:(t+1)*topk]`.
-    # `topk_weights` is set to ones because this op has no per-row weighting.
-    grad_hidden_states = ragged_gather_reduce(
-        g_x,
-        topk_argsort_revert_indices,
-        topk_weights=jnp.ones((n,), dtype=jnp.float32),
-        valid_rows_mask=valid_rows_mask,
-        reduce_group_size=topk,
-    )
+
+    if local_buffer_size >= n:
+      valid_rows_mask = (topk_argsort_revert_indices >= shard_output_start) & (
+          topk_argsort_revert_indices < shard_output_end
+      )
+      # The forward scatter-add over `token_indices_sorted` is equivalent to a
+      # gather-reduce: each input token has exactly `topk` contributions located
+      # at sorted positions `topk_argsort_revert_indices[t*topk:(t+1)*topk]`.
+      # `topk_weights` is set to ones because this op has no per-row weighting.
+      grad_hidden_states = ragged_gather_reduce(
+          g_x,
+          topk_argsort_revert_indices,
+          topk_weights=jnp.ones((n,), dtype=jnp.float32),
+          valid_rows_mask=valid_rows_mask,
+          reduce_group_size=topk,
+      )
+    else:
+      # Buffering: g_x has size `local_buffer_size` (packed).
+      # The revert indices are global [0, n), but they must map to the local
+      # packed g_x buffer.
+      shifted_indices = topk_argsort_revert_indices - shard_output_start
+      local_num_tokens = shard_output_end - shard_output_start
+      # We only reduce gradients from the valid portion of the local buffer.
+      limit = jnp.minimum(local_num_tokens, local_buffer_size)
+      # Mask out tokens that were not gathered (either because they belong to
+      # other shards, or they exceeded the local buffer size).
+      valid_rows_mask = (shifted_indices >= 0) & (shifted_indices < limit)
+      # Clamp invalid indices to 0 to prevent compile-time/run-time out-of-bounds
+      # in JAX. These clamped values will be ignored due to `valid_rows_mask`.
+      safe_indices = jnp.where(valid_rows_mask, shifted_indices, 0)
+
+      grad_hidden_states = ragged_gather_reduce(
+          g_x,
+          safe_indices,
+          topk_weights=jnp.ones((n,), dtype=jnp.float32),
+          valid_rows_mask=valid_rows_mask,
+          reduce_group_size=topk,
+      )
     return grad_hidden_states, None
 
   _ring_ragged_sort.defvjp(_ring_ragged_sort_fwd, _ring_ragged_sort_bwd)
@@ -168,7 +228,7 @@ def ring_ragged_unsort(
     ``[shard_output_start, shard_output_end)``.
 
   Args:
-    sorted_tokens_local: 2D ``[num_tokens_local * topk, hidden]`` output tensor from local experts.
+    sorted_tokens_local: 2D ``[buffer_size, hidden]`` output tensor from local experts.
     group_sizes_local: 1D tensor tracking the token loads per expert.
     topk_argsort_revert_indices: 1D permutation restoring flat token positions.
     topk: scalar ``int`` representing the routing top-k factor.
@@ -200,26 +260,51 @@ def ring_ragged_unsort(
     shard_output_start = group_offsets[experts_start]
     shard_output_end = group_offsets[experts_end]
 
-    # Express the scatter as a gather-reduce: each output row pulls
-    # from sorted_tokens_local at position `topk_argsort_revert_indices[i]` if
-    # that position is within this shard's [start, end) range, else zero.
-    # The routing weights are applied per-row before the topk reduction.
-    valid_rows_mask = (topk_argsort_revert_indices >= shard_output_start) & (
-        topk_argsort_revert_indices < shard_output_end
-    )
-    out = ragged_gather_reduce(
-        sorted_tokens_local,
-        topk_argsort_revert_indices,
-        topk_weights=topk_weights_flat,
-        valid_rows_mask=valid_rows_mask,
-        reduce_group_size=topk,
-    )
+    buffer_size = sorted_tokens_local.shape[0]
+    num_tokens = topk_argsort_revert_indices.shape[0]
+
+    # We support two buffering modes:
+    # 1. buffer_size >= num_tokens: sorted_tokens_local has size >= num_tokens,
+    #    and local tokens are at their global positions [start, end).
+    # 2. buffer_size < num_tokens: sorted_tokens_local has size < num_tokens,
+    #    and local tokens are packed at [0, local_num_tokens).
+    if buffer_size >= num_tokens:
+      # Express the scatter as a gather-reduce: each output row pulls
+      # from sorted_tokens_local at position `topk_argsort_revert_indices[i]` if
+      # that position is within this shard's [start, end) range, else zero.
+      # The routing weights are applied per-row before the topk reduction.
+      valid_rows_mask = (topk_argsort_revert_indices >= shard_output_start) & (
+          topk_argsort_revert_indices < shard_output_end
+      )
+      out = ragged_gather_reduce(
+          sorted_tokens_local,
+          topk_argsort_revert_indices,
+          topk_weights=topk_weights_flat,
+          valid_rows_mask=valid_rows_mask,
+          reduce_group_size=topk,
+      )
+    else:
+      # Shift indices so they map to the packed local buffer [0, local_num_tokens).
+      shifted_indices = topk_argsort_revert_indices - shard_output_start
+      local_num_tokens = shard_output_end - shard_output_start
+      limit = jnp.minimum(local_num_tokens, buffer_size)
+      valid_rows_mask = (shifted_indices >= 0) & (shifted_indices < limit)
+      safe_indices = jnp.where(valid_rows_mask, shifted_indices, 0)
+
+      out = ragged_gather_reduce(
+          sorted_tokens_local,
+          safe_indices,
+          topk_weights=topk_weights_flat,
+          valid_rows_mask=valid_rows_mask,
+          reduce_group_size=topk,
+      )
 
     res = (
         topk_argsort_revert_indices,
         topk_weights_flat,
         shard_output_start,
         shard_output_end,
+        buffer_size,
     )
 
     return out, res
@@ -236,7 +321,13 @@ def ring_ragged_unsort(
       g_sorted_tokens[j] = w[i] * g_out[i // topk]
     where j = revert[i] and j in [start, end).
     """
-    topk_argsort_revert_indices, topk_weights_flat, shard_output_start, shard_output_end = res
+    (
+        topk_argsort_revert_indices,
+        topk_weights_flat,
+        shard_output_start,
+        shard_output_end,
+        buffer_size,
+    ) = res
     g_hidden_states_local = g_out
 
     # Expand g_out from [num_tokens] to [num_tokens * topk] by repeating each
@@ -246,16 +337,32 @@ def ring_ragged_unsort(
     # Apply per-slot routing weights: g_weighted[i] = w[i] * g_out[i // topk]
     g_weighted = g_expanded * topk_weights_flat[:, None]
 
-    # We want: g_sorted_tokens[j] = g_weighted[i] where revert[i]=j.
-    # Build the inverse permutation idx_inv such that idx_inv[j] = i.
-    idx_inv = jnp.argsort(topk_argsort_revert_indices)
-    # Because revert is a permutation, gathering with idx_inv reorders correctly.
-    grad_sorted_tokens = ragged_gather(
-        g_weighted,
-        idx_inv,
-        shard_output_start,
-        shard_output_end,
-    )
+    n = topk_argsort_revert_indices.shape[0]
+
+    # Handle the same two buffering modes for backward pass.
+    if buffer_size >= n:
+      # We want: g_sorted_tokens[j] = g_weighted[i] where revert[i]=j.
+      # Build the inverse permutation idx_inv such that idx_inv[j] = i.
+      idx_inv = jnp.argsort(topk_argsort_revert_indices)
+      # Because revert is a permutation, gathering with idx_inv reorders correctly.
+      grad_sorted_tokens = ragged_gather(
+          g_weighted,
+          idx_inv,
+          shard_output_start[None],
+          shard_output_end[None],
+      )
+    else:
+      # Slice the inverse permutation to match the packed local buffer.
+      idx_inv = jnp.argsort(topk_argsort_revert_indices)
+      padded_idx_inv = jnp.pad(idx_inv, (0, buffer_size))
+      sliced_idx_inv = jax.lax.dynamic_slice_in_dim(padded_idx_inv, shard_output_start, buffer_size, axis=0)
+      gather_end = jnp.minimum(shard_output_end - shard_output_start, buffer_size)
+      grad_sorted_tokens = ragged_gather(
+          g_weighted,
+          sliced_idx_inv,
+          jnp.int32(0)[None],
+          gather_end[None],
+      )
     return grad_sorted_tokens, None, None, None
 
   _ring_ragged_unsort.defvjp(_ring_ragged_unsort_fwd, _ring_ragged_unsort_bwd)
@@ -306,7 +413,7 @@ def a2a_ragged_sort(inputs, sort_indices, valid_end):
   def _a2a_ragged_sort_fwd(inputs, sort_indices, valid_end):
     start = jnp.int32(0)
     end = valid_end.astype(jnp.int32) if hasattr(valid_end, "astype") else jnp.int32(valid_end)
-    out = ragged_gather(inputs, sort_indices, start, end)
+    out = ragged_gather(inputs, sort_indices, start[None], end[None])
     n = sort_indices.shape[0]
     valid_mask = jnp.arange(n) < end
     out = jnp.where(valid_mask[:, None], out, 0.0)
@@ -390,7 +497,7 @@ def a2a_ragged_unsort(sorted_tokens, revert_indices, valid_end):
     # Because revert_indices is a permutation, build the inverse and use
     # ragged_gather to pull the per-row gradients to the right positions.
     idx_inv = jnp.argsort(revert_indices)
-    grad_sorted = ragged_gather(g_out, idx_inv, start, end)
+    grad_sorted = ragged_gather(g_out, idx_inv, start[None], end[None])
     num_rows = sorted_tokens_shape[0]
     pos = jnp.arange(num_rows)
     valid = pos < end

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -88,6 +88,8 @@ class RouteOutput:
   lb_loss: Optional[jax.Array]
   # Dynamic bias updates for loss-free load balancing, used only for Deepseek models
   bias_updates: Optional[jax.Array]
+  # Shape [local experts], tracks number of local tokens routed to every local expert.
+  local_group_sizes: Optional[jax.Array] = None
 
 
 def _sort_activations(
@@ -823,9 +825,22 @@ class RoutedMoE(nnx.Module):
     # let local_permute()/local_unpermute apply the ragged kernels on the
     # local prefix of valid rows.
     use_ragged_in_permute = self.config.use_ragged_sort and self.config.use_ring_of_experts
+    buffer_size = None
     if use_ragged_in_permute:
       topk_indices_2d = jnp.reshape(selected_experts, (bsz_times_seq_len, selected_experts.shape[2]))
       # roll_to_expert_id is not directly used in the kernel, ep axis id is directly called
+      if self.config.ragged_buffer_factor > 0.0:
+        balanced_size = (bsz_times_seq_len // num_expert_parallelism) * self.num_experts_per_tok
+        buffer_size = self.get_ragged_buffer_size(
+            balanced_size,
+            num_expert_parallelism,
+            self.config.num_experts,
+            self.num_experts_per_tok,
+            self.config.ragged_buffer_factor,
+        )
+      else:
+        buffer_size = None
+
       sorted_inputs, group_size, sorted_selected_experts = ring_ragged_sort(
           inputs_2d,
           topk_indices_2d,
@@ -833,6 +848,7 @@ class RoutedMoE(nnx.Module):
           self.num_experts_per_tok,
           self._expert_parallelism_name,
           num_expert_parallelism,
+          buffer_size=buffer_size,
       )
     else:
       flatten_selected_experts = jnp.ravel(selected_experts)
@@ -846,13 +862,35 @@ class RoutedMoE(nnx.Module):
           self.dtype
       )
       group_size = jnp.bincount(flatten_selected_experts, length=self.num_experts)
-      # Return the experts for each sorted input.
-    expert_indices = jnp.arange(self.num_experts)
-    sorted_experts = jnp.repeat(
-        expert_indices,
-        repeats=group_size,
-        total_repeat_length=math.prod(selected_experts.shape),
-    )
+
+    num_tokens = bsz_times_seq_len * self.num_experts_per_tok
+    use_truncated_buffer = use_ragged_in_permute and buffer_size is not None and buffer_size < num_tokens
+
+    if use_truncated_buffer:
+      local_num_experts = self.config.num_experts // num_expert_parallelism
+      shard_idx = jax.lax.axis_index(self._expert_parallelism_name) if num_expert_parallelism > 1 else 0
+      experts_start = shard_idx * local_num_experts
+      local_group_size = jax.lax.dynamic_slice_in_dim(
+          group_size,
+          experts_start,
+          local_num_experts,
+          axis=0,
+      )
+      expert_indices = jnp.arange(local_num_experts)
+      sorted_experts = jnp.repeat(
+          expert_indices,
+          repeats=local_group_size,
+          total_repeat_length=buffer_size,
+      )
+    else:
+      local_group_size = None
+      expert_indices = jnp.arange(self.num_experts)
+      sorted_experts = jnp.repeat(
+          expert_indices,
+          repeats=group_size,
+          total_repeat_length=math.prod(selected_experts.shape),
+      )
+
     return (
         sorted_inputs,
         sorted_selected_experts,
@@ -861,6 +899,7 @@ class RoutedMoE(nnx.Module):
         sorted_experts,
         lb_loss,
         bias_updates,
+        local_group_size,
     )
 
   def unpermute(
@@ -1430,7 +1469,16 @@ class RoutedMoE(nnx.Module):
 
         # "Route" tokens within each shard.
         num_experts_per_shard = self.config.num_experts // num_ep
-        x, sorted_selected_experts, weights, group_sizes, selected_experts, lb_loss, bias_updates = self.permute(
+        (
+            x,
+            sorted_selected_experts,
+            weights,
+            group_sizes,
+            selected_experts,
+            lb_loss,
+            bias_updates,
+            local_group_sizes,
+        ) = self.permute(
             x,
             logits,
             pre_bias_logits,
@@ -1441,9 +1489,16 @@ class RoutedMoE(nnx.Module):
         )
 
       else:
-        x, sorted_selected_experts, weights, group_sizes, selected_experts, lb_loss, bias_updates = self.permute(
-            x, logits, pre_bias_logits, self.config.use_custom_sort_vjp, rngs=rngs, input_ids=input_ids
-        )
+        (
+            x,
+            sorted_selected_experts,
+            weights,
+            group_sizes,
+            selected_experts,
+            lb_loss,
+            bias_updates,
+            local_group_sizes,
+        ) = self.permute(x, logits, pre_bias_logits, self.config.use_custom_sort_vjp, rngs, input_ids=input_ids)
 
         if num_ep > 1:
           batch_axis = self._expert_parallelism_name if is_batch_sharded_by_expert else "data"
@@ -1508,6 +1563,7 @@ class RoutedMoE(nnx.Module):
               weights=weights,
               lb_loss=lb_loss,
               bias_updates=bias_updates,
+              local_group_sizes=local_group_sizes,
           ),
           RouteMetadata(
               expert_shard_id=expert_shard_id,
@@ -1615,14 +1671,27 @@ class RoutedMoE(nnx.Module):
 
       num_ep = self.get_expert_parallelism_size()
       num_experts_per_shard = self.config.num_experts // num_ep
-      if self.config.use_ragged_sort and self.config.use_ring_of_experts:
-        experts_start = route_metadata.expert_shard_id * num_experts_per_shard
-      else:
-        experts_start = 0
 
-      gmm_fn = functools.partial(
-          gmm, group_sizes=routing.group_sizes, expert_assignments=routing.selected_experts, group_offset=experts_start
-      )
+      use_truncated_buffer = self.config.use_ring_of_experts and x.shape[0] < routing.sorted_selected_experts.shape[0]
+      if use_truncated_buffer:
+        local_group_sizes = routing.local_group_sizes
+        gmm_fn = functools.partial(
+            gmm,
+            group_sizes=local_group_sizes,
+            expert_assignments=routing.selected_experts,
+            group_offset=0,
+        )
+      else:
+        if self.config.use_ragged_sort and self.config.use_ring_of_experts:
+          experts_start = route_metadata.expert_shard_id * num_experts_per_shard
+        else:
+          experts_start = 0
+        gmm_fn = functools.partial(
+            gmm,
+            group_sizes=routing.group_sizes,
+            expert_assignments=routing.selected_experts,
+            group_offset=experts_start,
+        )
       intermediate_layer = gmm_up(x, w0, w1, w0_bias, w1_bias, gmm_fn, weight_gather)
 
       wo_gather_axes, wo_tile_size = get_wo_gmm_params()

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -600,7 +600,7 @@ class RoutedMoeTest(unittest.TestCase):
       actual_output, _, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
       self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
 
-  def _run_ragged_sort_loss_and_grad(self, use_ring_of_experts: bool):
+  def _run_ragged_sort_loss_and_grad(self, use_ring_of_experts: bool, ragged_buffer_factor: float = -1.0):
     """Loss and gradient correctness for the use_ragged_sort flag.
 
     Compares an EP run with use_ragged_sort=True against the same
@@ -610,6 +610,8 @@ class RoutedMoeTest(unittest.TestCase):
     """
 
     def _build_cfg(use_ragged_sort: bool):
+      # Disable the buffer factor (-1.0) for the non-ragged sort baseline
+      effective_buffer_factor = ragged_buffer_factor if use_ragged_sort else -1.0
       return pyconfig.initialize(
           [None, get_test_config_path()],
           run_name=(f"moe_block_use_ragged_sort_{use_ragged_sort}" f"_ring_{use_ring_of_experts}_test"),
@@ -627,6 +629,7 @@ class RoutedMoeTest(unittest.TestCase):
           use_ring_of_experts=use_ring_of_experts,
           max_target_length=128,
           use_ragged_sort=use_ragged_sort,
+          ragged_buffer_factor=effective_buffer_factor,
       )
 
     def _build_model(cfg, mesh):
@@ -717,8 +720,18 @@ class RoutedMoeTest(unittest.TestCase):
 
   @pytest.mark.tpu_only
   @pytest.mark.skip_on_tpu7x
+  def test_ragged_sort_loss_and_grad_ring_of_experts_ragged_buffer(self):
+    self._run_ragged_sort_loss_and_grad(use_ring_of_experts=True, ragged_buffer_factor=1.5)
+
+  @pytest.mark.tpu_only
+  @pytest.mark.skip_on_tpu7x
   def test_ragged_sort_loss_and_grad_no_ring_of_experts(self):
     self._run_ragged_sort_loss_and_grad(use_ring_of_experts=False)
+
+  @pytest.mark.tpu_only
+  @pytest.mark.skip_on_tpu7x
+  def test_ragged_sort_loss_and_grad_no_ring_of_experts_ragged_buffer(self):
+    self._run_ragged_sort_loss_and_grad(use_ring_of_experts=False, ragged_buffer_factor=1.5)
 
   @pytest.mark.tpu_only
   def test_moe_fsdp_two_stage_parallelism_tpu_only(self):


### PR DESCRIPTION
# Description

Add ragged buffer to ring of experts, b/510333475.

# Tests

* Expect the tests are green with added ones
* Before this change - baseline, step time: 17.814s, 1840 TPS, [logs](https://screenshot.googleplex.com/7cQB7tYoHEwxA3r)
* After this change - ragged_buffer = 1.5, step time: 17.528s, 1870 TPS, [logs](https://screenshot.googleplex.com/AGqx9a8GQrtuBPj)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
