### PR TITLE
Fix MaxText 52b.sh AOT compilation OOM on v4-384

### DIFF
--- a/src/maxtext/configs/tpu/v4/52b.sh
+++ b/src/maxtext/configs/tpu/v4/52b.sh
@@ -57,6 +57,6 @@ fi
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
 python3 -m maxtext.trainers.pre_train.$EXECUTABLE "${MAXTEXT_CONFIGS_DIR:-${MAXTEXT_REPO_ROOT:-$PWD}/src/maxtext/configs}"//base.yml\
     profiler=xplane enable_checkpointing=false steps=10\
-    ici_fsdp_parallelism=192 ici_tensor_parallelism=1 per_device_batch_size=7 remat_policy=full\
+    ici_fsdp_parallelism=192 ici_tensor_parallelism=1 per_device_batch_size=7 remat_policy=full attention=flash num_vocab_tiling=8\
     base_num_decoder_layers=32 base_emb_dim=12288 base_mlp_dim=49152 base_num_query_heads=32 base_num_kv_heads=32 learning_rate=1e-8\
     base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH


### PR DESCRIPTION
# Description

This PR resolves the TPU HBM Out-of-Memory (OOM) error during Ahead-of-Time (AOT) compilation for the `v4-384` topology with `per_device_batch_size=7` by enabling Vocabulary Tiling and forcing Flash Attention in the `52b.sh` configuration.

### Details
*   The default configuration of `52b.sh` fails with an HBM OOM during compilation (Used 33.27G of 30.75G).
*   Enabling vocabulary tiling (`num_vocab_tiling=8`) and forcing flash attention (`attention=flash`) reduces peak memory usage and compiler fragmentation, allowing the compilation to succeed.
*   This solution keeps `TP=1` and `remat_policy=full` (no activation offloading), preserving the original performance profile.

FIXED: b/517329766
BUGS: b/517329766

# Tests

The fix was verified by running the AOT compilation script directly on a TPU VM targeting the 2-slice `v4-384` topology.
```bash
bash src/maxtext/configs/tpu/v4/52b.sh \
  EXECUTABLE=train_compile \
  M_COMPILE_TOPOLOGY=v4-384 \
  M_COMPILE_TOPOLOGY_NUM_SLICES=2 \
  DATASET_PATH=dummy-dataset \
  OUTPUT_PATH=dummy-output-dir \
  RUN_PREFLIGHT=false
```

Compilation completed successfully:
```
Jitting and compilation complete!
Finished train_compile.py successfully!
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
