### PR TITLE
Optimize distillation perf for qwen3-30b (20%→26% MFU) and gpt-oss-20b (17%→19%)

### DIFF
--- a/scripts/distillation/distill_gpt_oss_20b.sh
+++ b/scripts/distillation/distill_gpt_oss_20b.sh
@@ -46,8 +46,9 @@ export DISTILL_TEMPERATURE="${DISTILL_TEMPERATURE:-1.0}"
 export DISTILL_BETA="${DISTILL_BETA:-0}"
 export DISTILL_LAYER_INDICES="${DISTILL_LAYER_INDICES:-[]}"
 
-# XLA flags tuned for ~17% MFU. sparse_core_collective_aggregator is required
-# by latency_hiding_layer_scheduler.
+# XLA flags tuned for ~17% MFU (~19% with context=device, the splash/megablox
+# tile sizes, and the dp2 x fsdp64 mesh, all set in the config).
+# sparse_core_collective_aggregator is required by latency_hiding_layer_scheduler.
 export XPK_LIBTPU_INIT_ARGS="${XPK_LIBTPU_INIT_ARGS:---xla_tpu_scoped_vmem_limit_kib=65536 \
 --xla_tpu_impure_enable_packed_bf16_math_ops=true \
 --xla_tpu_aggressive_opt_barrier_removal=true \

--- a/scripts/distillation/distill_qwen3_30b_base.sh
+++ b/scripts/distillation/distill_qwen3_30b_base.sh
@@ -41,7 +41,9 @@ export DISTILL_TEMPERATURE="${DISTILL_TEMPERATURE:-1.0}"
 export DISTILL_BETA="${DISTILL_BETA:-1.0}"
 export DISTILL_LAYER_INDICES="${DISTILL_LAYER_INDICES:-[0,1,2,3,4,5,6,7]}"
 
-# XLA flags tuned for ~20% MFU.
+# XLA flags tuned for ~20% MFU. With the megablox tiles, SEQ_MINOR q-layout,
+# and context=device now set in the configs: ~26% MFU (default config) /
+# ~24% (pdbs=8 + activation offload variant).
 export XPK_LIBTPU_INIT_ARGS="${XPK_LIBTPU_INIT_ARGS:---xla_tpu_scoped_vmem_limit_kib=61440 \
 --xla_tpu_enable_all_experimental_scheduler_features=true \
 --xla_tpu_enable_scheduler_memory_pressure_tracking=true \

--- a/src/maxtext/configs/post_train/distillation_gpt_oss_20b.yml
+++ b/src/maxtext/configs/post_train/distillation_gpt_oss_20b.yml
@@ -1,4 +1,4 @@
-# gpt-oss-20b distillation. ~17% MFU on v7x.
+# gpt-oss-20b distillation. ~19% MFU on v7x.
 base_config: "base.yml"
 
 # NOTE: load_parameters_path values are placeholders. Replace them with paths
@@ -22,8 +22,18 @@ distill_layer_indices: []
 enable_nnx: True
 load_balance_loss_weight: 0.001
 
-ici_fsdp_parallelism: 32
-ici_data_parallelism: 4
+# Megablox grouped-matmul m-tile (batch_seq). The k/n dims already default to
+# the full 2880 for gpt-oss; raising the m-tile from the 512 default is worth
+# ~+3% MFU on v7x.
+wi_tile_fwd_batch_seq: 1024
+wi_tile_dlhs_batch_seq: 1024
+wi_tile_drhs_batch_seq: 1024
+wo_tile_fwd_batch_seq: 1024
+wo_tile_dlhs_batch_seq: 1024
+wo_tile_drhs_batch_seq: 1024
+
+ici_fsdp_parallelism: 64
+ici_data_parallelism: 2
 
 dataset_type: "grain"
 grain_file_type: "arrayrecord"
@@ -41,6 +51,12 @@ tokenizer_type: "huggingface"
 max_target_length: 32768
 per_device_batch_size: 1
 gradient_accumulation_steps: 1
+
+# Keep attention outputs on device instead of rematerializing them: the
+# backward pass skips the splash-forward re-runs (~+8% MFU). pdbs=1 is the
+# HBM frontier at this sequence length (pdbs=2 OOMs with or without this).
+remat_policy: 'custom'
+context: 'device'
 
 steps: 100000
 learning_rate_schedule_steps: 100000
@@ -63,15 +79,17 @@ z_loss_multiplier: 1.0e-5
 float32_logits: True
 
 # Tokamax splash attention. Layouts: HEAD_DIM_MINOR | SEQ_MINOR.
+# kv-compute sub-blocks of 1024 inside the 2048 fetch blocks are ~+2% MFU on
+# v7x (uniformly smaller blocks regress).
 attention: "flash"
 use_tokamax_splash: True
 sa_use_fused_bwd_kernel: True
 sa_block_q: 2048
 sa_block_kv: 2048
-sa_block_kv_compute: 2048
+sa_block_kv_compute: 1024
 sa_block_q_dkv: 2048
 sa_block_kv_dkv: 2048
-sa_block_kv_dkv_compute: 2048
+sa_block_kv_dkv_compute: 1024
 sa_block_q_dq: 2048
 sa_block_kv_dq: 2048
 sa_q_layout: "SEQ_MINOR"

--- a/src/maxtext/configs/post_train/distillation_qwen3_30b_base.yml
+++ b/src/maxtext/configs/post_train/distillation_qwen3_30b_base.yml
@@ -1,4 +1,4 @@
-# Qwen3-30b-a3b-base distillation. ~20% MFU on v7x.
+# Qwen3-30b-a3b-base distillation. ~26% MFU on v7x.
 base_config: "base.yml"
 
 # NOTE: load_parameters_path values are placeholders. Replace them with paths
@@ -41,8 +41,15 @@ tokenizer_path: "src/maxtext/assets/tokenizers/qwen3-tokenizer"
 tokenizer_type: "huggingface"
 
 max_target_length: 8192
-per_device_batch_size: 4
+per_device_batch_size: 6
 gradient_accumulation_steps: 1
+
+# Keep attention outputs on device instead of rematerializing them: the
+# backward pass skips the splash-forward re-runs. Fits with the teacher
+# resident up to pdbs=6 (does NOT fit at pdbs=8, with or without host
+# offload).
+remat_policy: 'custom'
+context: 'device'
 
 steps: 100000
 learning_rate_schedule_steps: 100000
@@ -76,6 +83,21 @@ sa_block_kv_dkv: 2048
 sa_block_kv_dkv_compute: 1024
 sa_block_q_dq: 1024
 sa_block_kv_dq: 1024
-sa_q_layout: "HEAD_DIM_MINOR"
+sa_q_layout: "SEQ_MINOR"
 sa_k_layout: "SEQ_MINOR"
 sa_v_layout: "HEAD_DIM_MINOR"
+
+# Megablox grouped-matmul tile sizes at the full dims (emb 2048 / moe-mlp 768).
+# Worth ~+10% MFU together with sa_q_layout=SEQ_MINOR on v7x.
+wi_tile_fwd_embed_dim: 2048
+wi_tile_dlhs_embed_dim: 2048
+wi_tile_drhs_embed_dim: 2048
+wo_tile_fwd_embed_dim: 2048
+wo_tile_dlhs_embed_dim: 2048
+wo_tile_drhs_embed_dim: 2048
+wi_tile_fwd_mlp_dim: 768
+wi_tile_dlhs_mlp_dim: 768
+wi_tile_drhs_mlp_dim: 768
+wo_tile_fwd_mlp_dim: 768
+wo_tile_dlhs_mlp_dim: 768
+wo_tile_drhs_mlp_dim: 768

--- a/src/maxtext/configs/post_train/distillation_qwen3_30b_base_pdbs8.yml
+++ b/src/maxtext/configs/post_train/distillation_qwen3_30b_base_pdbs8.yml
@@ -1,4 +1,4 @@
-# Qwen3-30b-a3b-base distillation, pdbs=8 + activation offload. ~22% MFU on v7x.
+# Qwen3-30b-a3b-base distillation, pdbs=8 + activation offload. ~24% MFU on v7x.
 base_config: "base.yml"
 
 # NOTE: load_parameters_path values are placeholders. Replace them with paths
@@ -80,6 +80,21 @@ sa_block_kv_dkv: 2048
 sa_block_kv_dkv_compute: 1024
 sa_block_q_dq: 1024
 sa_block_kv_dq: 1024
-sa_q_layout: "HEAD_DIM_MINOR"
+sa_q_layout: "SEQ_MINOR"
 sa_k_layout: "SEQ_MINOR"
 sa_v_layout: "HEAD_DIM_MINOR"
+
+# Megablox grouped-matmul tile sizes at the full dims (emb 2048 / moe-mlp 768).
+# Worth ~+10% MFU together with sa_q_layout=SEQ_MINOR on v7x.
+wi_tile_fwd_embed_dim: 2048
+wi_tile_dlhs_embed_dim: 2048
+wi_tile_drhs_embed_dim: 2048
+wo_tile_fwd_embed_dim: 2048
+wo_tile_dlhs_embed_dim: 2048
+wo_tile_drhs_embed_dim: 2048
+wi_tile_fwd_mlp_dim: 768
+wi_tile_dlhs_mlp_dim: 768
+wi_tile_drhs_mlp_dim: 768
+wo_tile_fwd_mlp_dim: 768
+wo_tile_dlhs_mlp_dim: 768
+wo_tile_drhs_mlp_dim: 768


### PR DESCRIPTION
# Description

Performance optimization of the qwen3-30b-a3b and gpt-oss-20b distillation configs on
TPU v7x (`tpu7x-4x4x4`).

MFU on v7x:

- **qwen3-30b-a3b**: ~20% → **~26%** for pdbs=6 and the pdbs=8 + activation-offload
  variant: ~22% → ~24%
- **gpt-oss-20b**: ~17% → **~19%**

All knobs are profile-derived (xplane) and documented inline:

- **`context=device` + `custom` remat** — keep attention outputs on device so the
  backward pass skips the splash-forward re-runs (per-layer forward call count
  halves in the profile). The dominant win; the configs note the HBM frontiers
  (qwen fits to pdbs=6 with the teacher resident, gpt-oss is pdbs=1 at seq 32k).
- **Megablox grouped-matmul tiles** — qwen at the full dims (emb 2048 /
  moe-mlp 768), ~+10% together with the layout change; gpt-oss raises the
  batch-seq m-tile 512 → 1024 (its k/n dims are already full), ~+3%.
- **Splash-attention** — `sa_q_layout: SEQ_MINOR` on qwen; kv-compute sub-blocks
  2048 → 1024 on gpt-oss (~+2%; uniformly smaller blocks regress).
- **Batch / mesh** — qwen default moves pdbs 4 → 6 in the headroom freed by
  dropping host offload; gpt-oss mesh moves to dp2 × fsdp64.

# Tests

30-step runs on `tpu7x-4x4x4` (xpk), steady-state step times, each
delta measured against the baselines. Loss and perplexity unchanged from
baseline.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
