### PR TITLE
Fix elastic manager initialization bug when elastic is disabled

### DIFF
--- a/src/maxtext/utils/elastic_utils.py
+++ b/src/maxtext/utils/elastic_utils.py
@@ -31,7 +31,7 @@ pending_elastic_event_type = None
 def record_elastic_event_start(recorder, config) -> None:
   """Records start of an elastic scale up event."""
   global pending_elastic_event_type
-  event_type = 'elastic_scale_up' if is_scale_up_event(config) else 'elastic_slice_down'
+  event_type = "elastic_scale_up" if is_scale_up_event(config) else "elastic_slice_down"
   pending_elastic_event_type = event_type
   if recorder:
     recorder.record_custom_badput_event_start_time(custom_badput_event_type=event_type)
@@ -46,7 +46,7 @@ def record_elastic_wait_end_and_reinit_start(recorder) -> None:
   pending_elastic_event_type = None
   if recorder:
     recorder.record_custom_badput_event_end_time(custom_badput_event_type=event_type)
-    recorder.record_custom_badput_event_start_time(custom_badput_event_type='elastic_reinitialization')
+    recorder.record_custom_badput_event_start_time(custom_badput_event_type="elastic_reinitialization")
   pending_reinit_recorder = recorder
 
 
@@ -54,15 +54,18 @@ def record_elastic_reinit_end() -> None:
   """Records end of elastic reinitialization event."""
   global pending_reinit_recorder
   if pending_reinit_recorder is not None:
-    pending_reinit_recorder.record_custom_badput_event_end_time(
-        custom_badput_event_type='elastic_reinitialization'
-    )
+    pending_reinit_recorder.record_custom_badput_event_end_time(custom_badput_event_type="elastic_reinitialization")
     pending_reinit_recorder = None
 
 
 def elastic_enabled(config) -> bool:
   """Returns whether elastic mode is enabled."""
   return pathwaysutils.is_pathways_backend_used() and config.elastic_enabled
+
+
+def should_use_elastic(config) -> bool:
+  """Returns whether elastic training should be used."""
+  return config is not None and elastic_enabled(config)
 
 
 def clean_up_checkpoints(checkpoint_dir: str):
@@ -102,7 +105,7 @@ def clean_up_checkpoints(checkpoint_dir: str):
 def ensure_elastic_manager_initialized(config):
   """Initializes elastic manager if it's not initialized and pathways is used."""
   global elastic_manager
-  if pathwaysutils.is_pathways_backend_used() and config.elastic_enabled and elastic_manager is None:
+  if should_use_elastic(config) and elastic_manager is None:
     elastic_manager = manager.Manager()
 
 
@@ -114,7 +117,7 @@ def get_local_batch_size(config) -> int:
 def live_devices(config=None):
   """Returns the list of live devices."""
   # If pathways is not used or elastic_manager is not initialized, return all devices
-  if pathwaysutils.is_pathways_backend_used() and config is not None:
+  if should_use_elastic(config):
     ensure_elastic_manager_initialized(config)
     assert elastic_manager is not None
     # Filter devices that are in active slices

--- a/tests/unit/elastic_utils_test.py
+++ b/tests/unit/elastic_utils_test.py
@@ -153,6 +153,18 @@ class ElasticUtilsTest(unittest.TestCase):
     devices = elastic_utils.live_devices(config)
     self.assertEqual(devices, [device0])
 
+  def test_live_devices_disabled(self):
+    """Tests live_devices when pathways is used but elastic is disabled."""
+    self.fake_pathwaysutils.is_pathways_backend_used.return_value = True
+    device0 = FakeDevice(slice_index=0)
+    self.fake_jax.devices.return_value = [device0]
+
+    config = FakeConfig()
+    config.elastic_enabled = False
+    devices = elastic_utils.live_devices(config)
+    self.assertEqual(devices, [device0])
+    self.assertIsNone(elastic_utils.elastic_manager)
+
   def test_elastic_retry_disabled(self):
     """Tests elastic_retry when disabled but pathways is used."""
     self.fake_pathwaysutils.is_pathways_backend_used.return_value = True
@@ -313,9 +325,9 @@ class ElasticUtilsTest(unittest.TestCase):
     elastic_utils.record_elastic_event_start(fake_recorder, config)
 
     fake_recorder.record_custom_badput_event_start_time.assert_called_once_with(
-        custom_badput_event_type='elastic_slice_down'
+        custom_badput_event_type="elastic_slice_down"
     )
-    self.assertEqual(elastic_utils.pending_elastic_event_type, 'elastic_slice_down')
+    self.assertEqual(elastic_utils.pending_elastic_event_type, "elastic_slice_down")
 
   def test_record_elastic_event_start_scale_up(self):
     """Tests recording an elastic slice scale up start."""
@@ -327,7 +339,7 @@ class ElasticUtilsTest(unittest.TestCase):
     elastic_utils.record_elastic_event_start(fake_recorder, config)
 
     fake_recorder.record_custom_badput_event_start_time.assert_called_once_with(
-        custom_badput_event_type='elastic_scale_up'
+        custom_badput_event_type="elastic_scale_up"
     )
 
   def test_record_elastic_wait_end_and_reinit_start_noop_on_first_attempt(self):
@@ -343,16 +355,16 @@ class ElasticUtilsTest(unittest.TestCase):
 
   def test_record_elastic_wait_end_and_reinit_start(self):
     """Test recording end of slice down and start of reinit."""
-    elastic_utils.pending_elastic_event_type = 'elastic_slice_down'
+    elastic_utils.pending_elastic_event_type = "elastic_slice_down"
     fake_recorder = Mock()
 
     elastic_utils.record_elastic_wait_end_and_reinit_start(fake_recorder)
 
     fake_recorder.record_custom_badput_event_end_time.assert_called_once_with(
-        custom_badput_event_type='elastic_slice_down'
+        custom_badput_event_type="elastic_slice_down"
     )
     fake_recorder.record_custom_badput_event_start_time.assert_called_once_with(
-        custom_badput_event_type='elastic_reinitialization'
+        custom_badput_event_type="elastic_reinitialization"
     )
     self.assertIs(elastic_utils.pending_reinit_recorder, fake_recorder)
     self.assertIsNone(elastic_utils.pending_elastic_event_type)
@@ -365,7 +377,7 @@ class ElasticUtilsTest(unittest.TestCase):
     elastic_utils.record_elastic_reinit_end()
 
     fake_recorder.record_custom_badput_event_end_time.assert_called_once_with(
-        custom_badput_event_type='elastic_reinitialization'
+        custom_badput_event_type="elastic_reinitialization"
     )
     self.assertIsNone(elastic_utils.pending_reinit_recorder)
 


### PR DESCRIPTION
# Description
This PR fixes a bug where the workload fails with AssertionError: assertion elastic_manager is not None when elastic training is disabled but the Pathways backend is used.

# Root Cause
In elastic_utils.py, `live_devices()` checked if the Pathways backend was used, but did not verify if `elastic_enabled` was True before calling `ensure_elastic_manager_initialized()` and asserting that `elastic_manager is not None`. Since `elastic_enabled` was False, `elastic_manager` was never initialized, leading to the assertion failure.

# Solution
Introduced a helper function `should_use_elastic(config)` which safely checks if the configuration is present and if elastic training is enabled (using `elastic_enabled(config)`).
Refactored `ensure_elastic_manager_initialized` and `live_devices` to use `should_use_elastic(config)` instead of partial checks.

Wrap elastic check condition into should_use_elastic and use it in ensure_elastic_manager_initialized and live_devices to avoid crash when elastic_enabled is False but pathways is used.

# Tests
Added a unit test `test_live_devices_disabled` to cover the case where pathways is used but elastic is disabled.

FIXES: b/521670882
Verified: b/521670882#comment4

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
