### PR TITLE
docs: fix broken links and cross-references

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
                 <span><h1>MaxText</h1></span>
                 <h3>High performance, highly scalable, open-source LLM library and reference implementation written in pure Python/JAX and targeting Google Cloud TPUs and GPUs for training.</h3>
                 <div class="hero-cta">
-                <a class="button button-primary" href="./tutorials.html">Get started</a>
+                <a class="button button-primary" href="./getting_started.html">Get started</a>
                 </div>
             </div>
         </section>

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,6 @@ file: index.html
 ---
 ```
 
-:link: reference/api
-
 <div class="doc-body">
 <section class="latest-news">
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -53,7 +53,7 @@ MaxText is [available in PyPI](https://pypi.org/project/maxtext/) and can be ins
 
 #### Changes
 
-- Use the new `maxtext[runner]` installation option to build Docker images without cloning the repository. This can be used for scheduling jobs through XPK. See the [MaxText installation instructions](build_maxtext.md) for more info.
+- Use the new `maxtext[runner]` installation option to build Docker images without cloning the repository. This can be used for scheduling jobs through XPK. See the [MaxText installation instructions](tutorials/build_maxtext.md) for more info.
 - Config can now be inferred for most MaxText commands. If you choose not to provide a config, MaxText will now [select an appropriate one](https://github.com/AI-Hypercomputer/maxtext/blob/9e786c888cc7acdfc00a8f73064e285017e80b86/src/maxtext/configs/pyconfig.py#L51-L67).
 - Configs in MaxText PyPI will now be picked up without storing them locally.
 - New features from DeepSeek-AI are now supported: Conditional Memory via Scalable Lookup ([Engram](https://arxiv.org/abs/2601.07372)) and Manifold-Constrained Hyper-Connections ([mHC](https://arxiv.org/abs/2512.24880)). Try them out with our [deepseek-custom](https://github.com/AI-Hypercomputer/maxtext/blob/9e786c888cc7acdfc00a8f73064e285017e80b86/src/maxtext/configs/models/deepseek-custom.yml) starter config.

--- a/docs/run_maxtext/run_maxtext_single_host_gpu.md
+++ b/docs/run_maxtext/run_maxtext_single_host_gpu.md
@@ -62,7 +62,7 @@ https://stackoverflow.com/questions/72932940/failed-to-initialize-nvml-unknown-e
 
 ## Build MaxText Docker image
 
-For instructions on building the MaxText Docker image, please refer to the [official documentation](../build_maxtext.md).
+For instructions on building the MaxText Docker image, please refer to the [official documentation](../tutorials/build_maxtext.md).
 
 ## Test
 

--- a/docs/run_maxtext/run_maxtext_via_pathways.md
+++ b/docs/run_maxtext/run_maxtext_via_pathways.md
@@ -35,7 +35,7 @@ Before you can run a MaxText workload, you must complete the following setup ste
 
 2. **Create a GKE cluster** configured for Pathways.
 
-3. **Build and upload a MaxText Docker image** to your project's Artifact Registry. For instructions on building and uploading the MaxText Docker image, please refer to the [official documentation](../build_maxtext.md).
+3. **Build and upload a MaxText Docker image** to your project's Artifact Registry. For instructions on building and uploading the MaxText Docker image, please refer to the [official documentation](../tutorials/build_maxtext.md).
 
 ## 2. Environment configuration
 

--- a/docs/run_maxtext/run_maxtext_via_xpk.md
+++ b/docs/run_maxtext/run_maxtext_via_xpk.md
@@ -101,7 +101,7 @@ ______________________________________________________________________
 
 ## 3. Build the MaxText Docker image
 
-For instructions on building the MaxText Docker image, please refer to the [official documentation](../build_maxtext.md).
+For instructions on building the MaxText Docker image, please refer to the [official documentation](../tutorials/build_maxtext.md).
 
 ______________________________________________________________________
 

--- a/docs/tutorials/posttraining/rl_on_multi_host.md
+++ b/docs/tutorials/posttraining/rl_on_multi_host.md
@@ -68,7 +68,7 @@ Before starting, ensure you have:
 
 ## Build and upload MaxText Docker image
 
-For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../../build_maxtext.md).
+For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../build_maxtext.md).
 
 ## Setup Environment Variables
 

--- a/docs/tutorials/posttraining/sft.md
+++ b/docs/tutorials/posttraining/sft.md
@@ -186,4 +186,4 @@ python3 -m maxtext.trainers.post_train.sft.train_sft \
 
 ### Runnable Example in the Codebase
 
-For a complete, runnable SFT workflow that demonstrates how to configure the training loop and use a custom dataset formatter (`formatting_func_path` and `formatting_func_kwargs`), check out the [sft_qwen3_demo.ipynb](../../../src/maxtext/examples/sft_qwen3_demo.ipynb) Jupyter notebook.
+For a complete, runnable SFT workflow that demonstrates how to configure the training loop and use a custom dataset formatter (`formatting_func_path` and `formatting_func_kwargs`), check out the [sft_qwen3_demo.ipynb](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/maxtext/examples/sft_qwen3_demo.ipynb) Jupyter notebook.

--- a/docs/tutorials/posttraining/sft_on_multi_host.md
+++ b/docs/tutorials/posttraining/sft_on_multi_host.md
@@ -41,7 +41,7 @@ Before starting, ensure you have:
 
 ## Build and upload MaxText Docker image
 
-For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../../build_maxtext.md).
+For instructions on building and uploading the MaxText Docker image with post-training dependencies, please refer to the [official documentation](../build_maxtext.md).
 
 ## Create GKE cluster
 


### PR DESCRIPTION
# Description

- Removed broken standalone link in index.md.

- Updated 'Get started' link in index.html.

- Fixed relative paths to build_maxtext.md.

- Replaced relative link to sft_qwen3_demo.ipynb with GitHub link.

# Tests

Build locally

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
