### PR TITLE
Fix unspecified mesh-axis integer validation

### DIFF
--- a/src/maxtext/utils/max_utils.py
+++ b/src/maxtext/utils/max_utils.py
@@ -455,7 +455,7 @@ def fill_unspecified_mesh_axes(parallelism_vals, target_product, parallelism_typ
     determined_val = target_product / np.prod(parallelism_vals) * -1
 
     assert (
-        determined_val >= 1 and determined_val.is_integer
+        determined_val >= 1 and determined_val.is_integer()
     ), f"Unspecified value unable to be determined with the given\
       {parallelism_type} parallelism values"
 

--- a/tests/unit/max_utils_test.py
+++ b/tests/unit/max_utils_test.py
@@ -137,6 +137,20 @@ class MaxUtilsCustomMesh(unittest.TestCase):
       max_utils.is_valid_custom_mesh([1, 1, 1, 1, 1, 16, 16, 1], "invalid_strategy")
 
 
+class FillUnspecifiedMeshAxesTest(unittest.TestCase):
+  """Tests for fill_unspecified_mesh_axes."""
+
+  def test_rejects_non_integer_unspecified_value(self):
+    with self.assertRaises(AssertionError):
+      max_utils.fill_unspecified_mesh_axes([2, -1, 3], 10, "ICI")
+
+  def test_fills_integer_unspecified_value(self):
+    self.assertEqual(
+        max_utils.fill_unspecified_mesh_axes([2, -1, 5], 20, "ICI"),
+        [2, 2, 5],
+    )
+
+
 class UnscanTest(unittest.TestCase):
   """Test unscanning utility."""
 


### PR DESCRIPTION
# Description

Fixes `fill_unspecified_mesh_axes` by calling `float.is_integer()` when validating inferred mesh-axis parallelism.

Previously the assertion checked the bound method object instead of the boolean result, so non-integer inferred values could pass the intended validation.

# Tests

- `python3 -m py_compile src/maxtext/utils/max_utils.py tests/unit/max_utils_test.py`
- `git diff --check`
- `python3 -m pytest tests/unit/max_utils_test.py -k FillUnspecifiedMeshAxesTest`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).