### PR TITLE
Fix misleading preemption logs in checkpointing

### DIFF
--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -1071,15 +1071,11 @@ def maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator, step
   except elastic_utils.manager.ScaleUpSignalError as e:
     if config.elastic_enabled:
       max_logging.log(f"Elastic event detected, letting exception bubble up: {e}")
-      raise
-    else:
-      raise exceptions.StopTraining("Job is preempted.") from e
+    raise
   except jax.errors.JaxRuntimeError as e:
     if config.elastic_enabled:
       max_logging.log(f"Elastic event detected, letting exception bubble up: {e}")
-      raise
-    else:
-      raise exceptions.StopTraining("Job is preempted.") from e
+    raise
   except Exception as e:
     raise exceptions.StopTraining(f"Checkpointing failed. {str(e)}") from e
 
@@ -1089,7 +1085,7 @@ def maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator, step
 
   # Raise exception upon preemption
   if checkpoint_manager.reached_preemption(actual_step):
-    raise exceptions.StopTraining("Job is preempted.")
+    raise exceptions.StopTraining("Job received termination signal (SIGTERM).")
 
 
 def save_checkpoint(checkpoint_manager, step, state, config=None, data_iterator=None, force=False):

--- a/tests/unit/train_state_nnx_checkpoint_test.py
+++ b/tests/unit/train_state_nnx_checkpoint_test.py
@@ -495,6 +495,53 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
     # Assert that save_checkpoint WAS called!
     save_checkpoint_mock.assert_called_once()
 
+  def test_maybe_save_checkpoint_raises_on_preemption(self):
+    """Verify maybe_save_checkpoint raises StopTraining on preemption."""
+    state = self._build_nnx_state(self.N_STEPS)
+    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False)
+    mgr = mock.MagicMock()
+    mgr.reached_preemption.return_value = True
+    mgr.latest_step.return_value = None
+
+    save_checkpoint_mock = mock.MagicMock()
+    save_checkpoint_mock.return_value = False
+
+    with mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock):
+      with self.assertRaises(checkpointing.exceptions.StopTraining) as context:
+        checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=None)
+      
+      self.assertEqual(str(context.exception), "Job received termination signal (SIGTERM).")
+
+  def test_maybe_save_checkpoint_propagates_jax_runtime_error_elastic_disabled(self):
+    """Verify maybe_save_checkpoint propagates JaxRuntimeError when elastic is disabled."""
+    state = self._build_nnx_state(self.N_STEPS)
+    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False, elastic_enabled=False)
+    mgr = mock.MagicMock()
+    mgr.reached_preemption.return_value = False
+    mgr.latest_step.return_value = None
+
+    save_checkpoint_mock = mock.MagicMock()
+    save_checkpoint_mock.side_effect = jax.errors.JaxRuntimeError("mock JAX error")
+
+    with mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock):
+      with self.assertRaises(jax.errors.JaxRuntimeError):
+        checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=None)
+
+  def test_maybe_save_checkpoint_propagates_jax_runtime_error_elastic_enabled(self):
+    """Verify maybe_save_checkpoint propagates JaxRuntimeError when elastic is enabled."""
+    state = self._build_nnx_state(self.N_STEPS)
+    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False, elastic_enabled=True)
+    mgr = mock.MagicMock()
+    mgr.reached_preemption.return_value = False
+    mgr.latest_step.return_value = None
+
+    save_checkpoint_mock = mock.MagicMock()
+    save_checkpoint_mock.side_effect = jax.errors.JaxRuntimeError("mock JAX error")
+
+    with mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock):
+      with self.assertRaises(jax.errors.JaxRuntimeError):
+        checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=None)
+
 
 class TestLinenCheckpointFormatConverters(unittest.TestCase):
   """to_linen_checkpoint_dict / from_linen_checkpoint_dict (NNX <-> Linen on-disk layout)."""

--- a/tests/unit/train_state_nnx_checkpoint_test.py
+++ b/tests/unit/train_state_nnx_checkpoint_test.py
@@ -498,7 +498,12 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
   def test_maybe_save_checkpoint_raises_on_preemption(self):
     """Verify maybe_save_checkpoint raises StopTraining on preemption."""
     state = self._build_nnx_state(self.N_STEPS)
-    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False)
+    config = SimpleNamespace(
+        pure_nnx=True,
+        checkpoint_period=1,
+        async_checkpointing=False,
+        enable_diloco=False,
+    )
     mgr = mock.MagicMock()
     mgr.reached_preemption.return_value = True
     mgr.latest_step.return_value = None
@@ -515,7 +520,13 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
   def test_maybe_save_checkpoint_propagates_jax_runtime_error_elastic_disabled(self):
     """Verify maybe_save_checkpoint propagates JaxRuntimeError when elastic is disabled."""
     state = self._build_nnx_state(self.N_STEPS)
-    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False, elastic_enabled=False)
+    config = SimpleNamespace(
+        pure_nnx=True,
+        checkpoint_period=1,
+        async_checkpointing=False,
+        elastic_enabled=False,
+        enable_diloco=False,
+    )
     mgr = mock.MagicMock()
     mgr.reached_preemption.return_value = False
     mgr.latest_step.return_value = None
@@ -530,7 +541,13 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
   def test_maybe_save_checkpoint_propagates_jax_runtime_error_elastic_enabled(self):
     """Verify maybe_save_checkpoint propagates JaxRuntimeError when elastic is enabled."""
     state = self._build_nnx_state(self.N_STEPS)
-    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False, elastic_enabled=True)
+    config = SimpleNamespace(
+        pure_nnx=True,
+        checkpoint_period=1,
+        async_checkpointing=False,
+        elastic_enabled=True,
+        enable_diloco=False,
+    )
     mgr = mock.MagicMock()
     mgr.reached_preemption.return_value = False
     mgr.latest_step.return_value = None

--- a/tests/unit/train_state_nnx_checkpoint_test.py
+++ b/tests/unit/train_state_nnx_checkpoint_test.py
@@ -509,7 +509,7 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
     with mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock):
       with self.assertRaises(checkpointing.exceptions.StopTraining) as context:
         checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=None)
-      
+
       self.assertEqual(str(context.exception), "Job received termination signal (SIGTERM).")
 
   def test_maybe_save_checkpoint_propagates_jax_runtime_error_elastic_disabled(self):


### PR DESCRIPTION
Resolve misleading "Job is preempted" error logs in MaxText checkpointing.

### Changes
1. **Raise JaxRuntimeError directly**: Instead of catching `JaxRuntimeError` and raising `StopTraining("Job is preempted.")` when elasticity is disabled, we now let the exception bubble up. This allows the process to crash normally, preventing silent failures and ensuring the logs show the actual cause of the crash (e.g. OOM).
2. **Reword SIGTERM preemption message**: Updated the `StopTraining` message when `reached_preemption` is true to `"Job received termination signal (SIGTERM)."` since SIGTERM is sent by GKE/Kueue for various non-preemption events (e.g., updates, scaling down).

Fixes: b/516962538

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
