### PR TITLE
Add local_sa_* flags for local attention tuning

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1098,11 +1098,26 @@ sa_use_fused_bwd_kernel: false
 sa_q_layout: "HEAD_DIM_MINOR"
 sa_k_layout: "HEAD_DIM_MINOR"
 sa_v_layout: "HEAD_DIM_MINOR"
+use_splash_scheduler: false # to use tokamax splash attention scheduler.
+# local_sa_* variants apply to local (sliding window) attention layers;
+# if None, each inherits from the corresponding global sa_* flag.
+local_sa_block_q: None  # inherits from sa_block_q if None
+local_sa_block_kv: None  # inherits from sa_block_kv if None
+local_sa_block_kv_compute: None  # inherits from sa_block_kv_compute if None
+local_sa_block_q_dkv: None  # inherits from sa_block_q_dkv if None
+local_sa_block_kv_dkv: None  # inherits from sa_block_kv_dkv if None
+local_sa_block_kv_dkv_compute: None  # inherits from sa_block_kv_dkv_compute if None
+local_sa_block_q_dq: None  # inherits from sa_block_q_dq if None
+local_sa_block_kv_dq: None  # inherits from sa_block_kv_dq if None
+local_sa_use_fused_bwd_kernel: None  # inherits from sa_use_fused_bwd_kernel if None
+local_sa_q_layout: None  # inherits from sa_q_layout if None
+local_sa_k_layout: None  # inherits from sa_k_layout if None
+local_sa_v_layout: None  # inherits from sa_v_layout if None
+local_use_splash_scheduler: None  # inherits from use_splash_scheduler if None
 use_max_logit_estimate: -1 # -1 means no estimate, any > 0 value will be used as max logit estimate
 cost_estimate_flops_fwd: -1 # -1 means using splash default cost estmiation, any >= 0 value will be used as cost estmiation for splash to overlap for communication (forward)
 cost_estimate_flops_bwd: -1 # -1 means using splash default cost estmiation, any >= 0 value will be used as cost estmiation for splash to overlap for communication (backward)
 dq_reduction_steps: 0 #the number of reduction steps. For now, only 3 or all the kv steps are supported.
-use_splash_scheduler: false # to use tokamax splash attention scheduler.
 ### Determine if we want to use load balance for context parallelism
 context_parallel_load_balance: true
 context_parallel_strategy: "all_gather" # "all_gather" or "ring"

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -698,6 +698,25 @@ class SplashAttention(BaseModel):
   sa_q_layout: str = Field("HEAD_DIM_MINOR", description="Layout for Q in splash attention.")
   sa_k_layout: str = Field("HEAD_DIM_MINOR", description="Layout for K in splash attention.")
   sa_v_layout: str = Field("HEAD_DIM_MINOR", description="Layout for V in splash attention.")
+  use_splash_scheduler: bool = Field(False, description="Use experimental splash attention scheduler.")
+  # If None, each local_sa_* flag inherits from the corresponding sa_* flag.
+  local_sa_block_q: int | None = Field(None, description="Block size for Q in local splash attention.")
+  local_sa_block_kv: int | None = Field(None, description="Block size for KV in local splash attention.")
+  local_sa_block_kv_compute: int | None = Field(None, description="Block size for KV compute in local splash attention.")
+  local_sa_block_q_dkv: int | None = Field(None, description="Block size for Q_dkv in local splash attention.")
+  local_sa_block_kv_dkv: int | None = Field(None, description="Block size for KV_dkv in local splash attention.")
+  local_sa_block_kv_dkv_compute: int | None = Field(
+      None, description="Block size for KV_dkv compute in local splash attention."
+  )
+  local_sa_block_q_dq: int | None = Field(None, description="Block size for Q_dq in local splash attention.")
+  local_sa_block_kv_dq: int | None = Field(None, description="Block size for KV_dq in local splash attention.")
+  local_sa_use_fused_bwd_kernel: bool | None = Field(
+      None, description="Use fused backward kernel in local splash attention."
+  )
+  local_sa_q_layout: str | None = Field(None, description="Layout for Q in local splash attention.")
+  local_sa_k_layout: str | None = Field(None, description="Layout for K in local splash attention.")
+  local_sa_v_layout: str | None = Field(None, description="Layout for V in local splash attention.")
+  local_use_splash_scheduler: bool | None = Field(None, description="Use experimental local splash attention scheduler.")
   use_max_logit_estimate: int = Field(
       -1,
       description="-1 means no estimate, any > 0 value will be used as max logit estimate",
@@ -716,7 +735,6 @@ class SplashAttention(BaseModel):
       0,
       description="the number of reduction steps. For now, only 3 or all the kv steps are supported.",
   )
-  use_splash_scheduler: bool = Field(False, description="Use experimental splash attention scheduler.")
 
 
 class MoEGeneral(BaseModel):
@@ -2934,7 +2952,35 @@ class MaxTextConfig(
       ):
         self.logical_axis_rules.append(["aqt_amax_history", ("stage",)])
 
-    # H. RUN ALL CROSS-FIELD VALIDATIONS
+    # H. RESOLVE local_sa_* FLAGS: inherit from global sa_* if not explicitly set.
+    if self.local_sa_block_q is None:
+      self.local_sa_block_q = self.sa_block_q
+    if self.local_sa_block_kv is None:
+      self.local_sa_block_kv = self.sa_block_kv
+    if self.local_sa_block_kv_compute is None:
+      self.local_sa_block_kv_compute = self.sa_block_kv_compute
+    if self.local_sa_block_q_dkv is None:
+      self.local_sa_block_q_dkv = self.sa_block_q_dkv
+    if self.local_sa_block_kv_dkv is None:
+      self.local_sa_block_kv_dkv = self.sa_block_kv_dkv
+    if self.local_sa_block_kv_dkv_compute is None:
+      self.local_sa_block_kv_dkv_compute = self.sa_block_kv_dkv_compute
+    if self.local_sa_block_q_dq is None:
+      self.local_sa_block_q_dq = self.sa_block_q_dq
+    if self.local_sa_block_kv_dq is None:
+      self.local_sa_block_kv_dq = self.sa_block_kv_dq
+    if self.local_sa_use_fused_bwd_kernel is None:
+      self.local_sa_use_fused_bwd_kernel = self.sa_use_fused_bwd_kernel
+    if self.local_sa_q_layout is None:
+      self.local_sa_q_layout = self.sa_q_layout
+    if self.local_sa_k_layout is None:
+      self.local_sa_k_layout = self.sa_k_layout
+    if self.local_sa_v_layout is None:
+      self.local_sa_v_layout = self.sa_v_layout
+    if self.local_use_splash_scheduler is None:
+      self.local_use_splash_scheduler = self.use_splash_scheduler
+
+    # I. RUN ALL CROSS-FIELD VALIDATIONS
     if self.load_parameters_path and self.load_full_state_path:
       raise ValueError("At most one of `load_parameters_path` or `load_full_state_path` should be set.")
     if self.elastic_enabled and not self.enable_single_controller:

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -79,19 +79,6 @@ from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_
 # pylint: disable=line-too-long, g-doc-args, g-doc-return-or-yield, bad-continuation, g-inconsistent-quotes
 # pytype: disable=attribute-error
 
-# Used to pass in splash attention block sizes from config.
-global_block_q = 0
-global_block_kv = 0
-global_block_kv_compute = 0
-global_block_q_dkv = 0
-global_block_kv_dkv = 0
-global_block_kv_dkv_compute = 0
-global_block_q_dq = 0
-global_block_kv_dq = 0
-global_use_fused_bwd_kernel = False
-global_q_layout = ""
-global_k_layout = ""
-global_v_layout = ""
 
 dynamic_vector_slice_in_dim = jax.vmap(lax.dynamic_slice_in_dim, in_axes=(None, 0, None, None))
 
@@ -492,6 +479,36 @@ class AttentionOp(nnx.Module):
     self.quant = quant
     self.kv_quant = kv_quant
     self.attention_type = attention_type
+    # Block sizes are only used by TPU splash attention kernels. Exclude non-splash kernels
+    if self.attention_kernel not in ("dot_product", "paged", "vllm_rpa", "cudnn_flash_te", "cudnn_flash_jax"):
+      if self.attention_type == AttentionType.LOCAL_SLIDING:
+        self.block_q = self.config.local_sa_block_q
+        self.block_kv = self.config.local_sa_block_kv
+        self.block_kv_compute = self.config.local_sa_block_kv_compute
+        self.block_q_dkv = self.config.local_sa_block_q_dkv
+        self.block_kv_dkv = self.config.local_sa_block_kv_dkv
+        self.block_kv_dkv_compute = self.config.local_sa_block_kv_dkv_compute
+        self.block_q_dq = self.config.local_sa_block_q_dq
+        self.block_kv_dq = self.config.local_sa_block_kv_dq
+        self.use_fused_bwd_kernel = self.config.local_sa_use_fused_bwd_kernel
+        self.q_layout = self.config.local_sa_q_layout
+        self.k_layout = self.config.local_sa_k_layout
+        self.v_layout = self.config.local_sa_v_layout
+        self.use_splash_scheduler = self.config.local_use_splash_scheduler
+      else:
+        self.block_q = self.config.sa_block_q
+        self.block_kv = self.config.sa_block_kv
+        self.block_kv_compute = self.config.sa_block_kv_compute
+        self.block_q_dkv = self.config.sa_block_q_dkv
+        self.block_kv_dkv = self.config.sa_block_kv_dkv
+        self.block_kv_dkv_compute = self.config.sa_block_kv_dkv_compute
+        self.block_q_dq = self.config.sa_block_q_dq
+        self.block_kv_dq = self.config.sa_block_kv_dq
+        self.use_fused_bwd_kernel = self.config.sa_use_fused_bwd_kernel
+        self.q_layout = self.config.sa_q_layout
+        self.k_layout = self.config.sa_k_layout
+        self.v_layout = self.config.sa_v_layout
+        self.use_splash_scheduler = self.config.use_splash_scheduler
     self.attn_logits_soft_cap = attn_logits_soft_cap
     self.sliding_window_size = sliding_window_size
     self.chunk_attn_window_size = chunk_attn_window_size
@@ -1187,22 +1204,6 @@ class AttentionOp(nnx.Module):
     axis_names_kv = self._logical_to_mesh_axes(self.flash_axis_names_kv)
     indexer_mask_axis_names = self._logical_to_mesh_axes((BATCH_ATTN, Q_LENGTH, KV_LENGTH))
 
-    global global_block_q, global_block_kv, global_block_kv_compute, global_block_q_dkv, global_block_kv_dkv
-    global global_block_kv_dkv_compute, global_block_q_dq, global_block_kv_dq, global_use_fused_bwd_kernel
-    global global_q_layout, global_k_layout, global_v_layout
-    global_block_q = self.config.sa_block_q
-    global_block_kv = self.config.sa_block_kv
-    global_block_kv_compute = self.config.sa_block_kv_compute
-    global_block_q_dkv = self.config.sa_block_q_dkv
-    global_block_kv_dkv = self.config.sa_block_kv_dkv
-    global_block_kv_dkv_compute = self.config.sa_block_kv_dkv_compute
-    global_block_q_dq = self.config.sa_block_q_dq
-    global_block_kv_dq = self.config.sa_block_kv_dq
-    global_use_fused_bwd_kernel = self.config.sa_use_fused_bwd_kernel
-    global_q_layout = self.config.sa_q_layout
-    global_k_layout = self.config.sa_k_layout
-    global_v_layout = self.config.sa_v_layout
-
     devices_in_data_fsdp = self.mesh.shape.get("data", 1) * self.mesh.shape.get("fsdp", 1)
     assert (query.shape[0] / devices_in_data_fsdp).is_integer(), (
         "Batch dimension should be shardable among the devices in data and fsdp"
@@ -1214,16 +1215,16 @@ class AttentionOp(nnx.Module):
     def create_sa_config(config, query, key, attn_logits_soft_cap):
       if config.use_tokamax_splash:
         sa_config = tokamax_splash_kernel.SplashConfig(
-            block_q=min(global_block_q, query.shape[2]),
-            block_kv=min(global_block_kv, key.shape[2]),
-            block_kv_compute=min(global_block_kv_compute, key.shape[2]),
-            block_q_dkv=min(global_block_q_dkv, query.shape[2]),
-            block_kv_dkv=min(global_block_kv_dkv, key.shape[2]),
-            block_kv_dkv_compute=min(global_block_kv_dkv_compute, query.shape[2]),
+            block_q=min(self.block_q, query.shape[2]),
+            block_kv=min(self.block_kv, key.shape[2]),
+            block_kv_compute=min(self.block_kv_compute, key.shape[2]),
+            block_q_dkv=min(self.block_q_dkv, query.shape[2]),
+            block_kv_dkv=min(self.block_kv_dkv, key.shape[2]),
+            block_kv_dkv_compute=min(self.block_kv_dkv_compute, key.shape[2]),
             use_fused_bwd_kernel=True,  # tokamax only supports fused bwd kernel
-            q_layout=tokamax_splash_kernel.QKVLayout[global_q_layout],
-            k_layout=tokamax_splash_kernel.QKVLayout[global_k_layout],
-            v_layout=tokamax_splash_kernel.QKVLayout[global_v_layout],
+            q_layout=tokamax_splash_kernel.QKVLayout[self.q_layout],
+            k_layout=tokamax_splash_kernel.QKVLayout[self.k_layout],
+            v_layout=tokamax_splash_kernel.QKVLayout[self.v_layout],
             attn_logits_soft_cap=attn_logits_soft_cap,
             residual_checkpoint_name="context",
             fwd_cost_estimate=pl.CostEstimate(
@@ -1241,22 +1242,22 @@ class AttentionOp(nnx.Module):
             if config.cost_estimate_flops_bwd >= 0
             else None,
             dq_reduction_steps=config.dq_reduction_steps if config.dq_reduction_steps > 0 else None,
-            use_experimental_scheduler=config.use_splash_scheduler,
+            use_experimental_scheduler=self.use_splash_scheduler,
         )
       else:
         sa_config = splash_attention_kernel.BlockSizes(
-            block_q=min(global_block_q, query.shape[2]),
-            block_kv=min(global_block_kv, key.shape[2]),
-            block_kv_compute=min(global_block_kv_compute, key.shape[2]),
-            block_q_dkv=min(global_block_q_dkv, query.shape[2]),
-            block_kv_dkv=min(global_block_kv_dkv, key.shape[2]),
-            block_kv_dkv_compute=min(global_block_kv_dkv_compute, query.shape[2]),
-            block_q_dq=None if global_use_fused_bwd_kernel else min(global_block_q_dq, query.shape[2]),
-            block_kv_dq=None if global_use_fused_bwd_kernel else min(global_block_kv_dq, query.shape[2]),
-            use_fused_bwd_kernel=global_use_fused_bwd_kernel,
-            q_layout=splash_attention_kernel.QKVLayout[global_q_layout],
-            k_layout=splash_attention_kernel.QKVLayout[global_k_layout],
-            v_layout=splash_attention_kernel.QKVLayout[global_v_layout],
+            block_q=min(self.block_q, query.shape[2]),
+            block_kv=min(self.block_kv, key.shape[2]),
+            block_kv_compute=min(self.block_kv_compute, key.shape[2]),
+            block_q_dkv=min(self.block_q_dkv, query.shape[2]),
+            block_kv_dkv=min(self.block_kv_dkv, key.shape[2]),
+            block_kv_dkv_compute=min(self.block_kv_dkv_compute, key.shape[2]),
+            block_q_dq=None if self.use_fused_bwd_kernel else min(self.block_q_dq, query.shape[2]),
+            block_kv_dq=None if self.use_fused_bwd_kernel else min(self.block_kv_dq, query.shape[2]),
+            use_fused_bwd_kernel=self.use_fused_bwd_kernel,
+            q_layout=splash_attention_kernel.QKVLayout[self.q_layout],
+            k_layout=splash_attention_kernel.QKVLayout[self.k_layout],
+            v_layout=splash_attention_kernel.QKVLayout[self.v_layout],
         )
       return sa_config
 
@@ -1489,8 +1490,8 @@ class AttentionOp(nnx.Module):
             key,
             value,
             decoder_segment_ids_tuple,
-            block_kv=self.config.sa_block_kv,
-            block_q=self.config.sa_block_q,
+            block_kv=self.block_kv,
+            block_q=self.block_q,
             mask=materialized_mask,
             mask_value=DEFAULT_MASK_VALUE,
         )

--- a/tests/unit/pyconfig_test.py
+++ b/tests/unit/pyconfig_test.py
@@ -238,6 +238,85 @@ class PyconfigTest(unittest.TestCase):
     # Verify that passing this coerced list to the SFT column validator passes without error (Scenario A)
     data_processing_utils.validate_and_configure_sft_columns(config.train_data_columns, None)
 
+  def test_local_sa_flags_inherit_from_global_when_unset(self):
+    """local_sa_* flags default to None and should inherit the corresponding sa_* value."""
+    config = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        sa_block_q=64,
+        sa_block_kv=128,
+        sa_block_kv_compute=192,
+        sa_block_q_dkv=64,
+        sa_block_kv_dkv=128,
+        sa_block_kv_dkv_compute=192,
+        sa_block_q_dq=64,
+        sa_block_kv_dq=128,
+        sa_use_fused_bwd_kernel=True,
+        sa_q_layout="HEAD_DIM_MINOR",
+        sa_k_layout="HEAD_DIM_MINOR",
+        sa_v_layout="HEAD_DIM_MINOR",
+        use_splash_scheduler=True,
+    )
+    self.assertEqual(config.local_sa_block_q, 64)
+    self.assertEqual(config.local_sa_block_kv, 128)
+    self.assertEqual(config.local_sa_block_kv_compute, 192)
+    self.assertEqual(config.local_sa_block_q_dkv, 64)
+    self.assertEqual(config.local_sa_block_kv_dkv, 128)
+    self.assertEqual(config.local_sa_block_kv_dkv_compute, 192)
+    self.assertEqual(config.local_sa_block_q_dq, 64)
+    self.assertEqual(config.local_sa_block_kv_dq, 128)
+    self.assertTrue(config.local_sa_use_fused_bwd_kernel)
+    self.assertEqual(config.local_sa_q_layout, "HEAD_DIM_MINOR")
+    self.assertEqual(config.local_sa_k_layout, "HEAD_DIM_MINOR")
+    self.assertEqual(config.local_sa_v_layout, "HEAD_DIM_MINOR")
+    self.assertTrue(config.local_use_splash_scheduler)
+
+  def test_local_sa_flags_explicit_override(self):
+    """Explicitly set local_sa_* flags should not be overridden by the global sa_* value."""
+    config = pyconfig.initialize(
+        [os.path.join(MAXTEXT_PKG_DIR, "train.py"), get_test_config_path()],
+        skip_jax_distributed_system=True,
+        sa_block_q=512,
+        local_sa_block_q=64,
+        sa_block_kv=512,
+        local_sa_block_kv=128,
+        sa_block_kv_compute=512,
+        local_sa_block_kv_compute=192,
+        sa_block_q_dkv=512,
+        local_sa_block_q_dkv=64,
+        sa_block_kv_dkv=512,
+        local_sa_block_kv_dkv=128,
+        sa_block_kv_dkv_compute=512,
+        local_sa_block_kv_dkv_compute=192,
+        sa_block_q_dq=512,
+        local_sa_block_q_dq=64,
+        sa_block_kv_dq=512,
+        local_sa_block_kv_dq=128,
+        sa_use_fused_bwd_kernel=False,
+        local_sa_use_fused_bwd_kernel=True,
+        sa_q_layout="HEAD_DIM_MINOR",
+        local_sa_q_layout="SEQ_MINOR",
+        sa_k_layout="HEAD_DIM_MINOR",
+        local_sa_k_layout="SEQ_MINOR",
+        sa_v_layout="HEAD_DIM_MINOR",
+        local_sa_v_layout="SEQ_MINOR",
+        use_splash_scheduler=True,
+        local_use_splash_scheduler=False,
+    )
+    self.assertEqual(config.local_sa_block_q, 64)
+    self.assertEqual(config.local_sa_block_kv, 128)
+    self.assertEqual(config.local_sa_block_kv_compute, 192)
+    self.assertEqual(config.local_sa_block_q_dkv, 64)
+    self.assertEqual(config.local_sa_block_kv_dkv, 128)
+    self.assertEqual(config.local_sa_block_kv_dkv_compute, 192)
+    self.assertEqual(config.local_sa_block_q_dq, 64)
+    self.assertEqual(config.local_sa_block_kv_dq, 128)
+    self.assertTrue(config.local_sa_use_fused_bwd_kernel)
+    self.assertEqual(config.local_sa_q_layout, "SEQ_MINOR")
+    self.assertEqual(config.local_sa_k_layout, "SEQ_MINOR")
+    self.assertEqual(config.local_sa_v_layout, "SEQ_MINOR")
+    self.assertFalse(config.local_use_splash_scheduler)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description
* Gemma4 uses local-sliding attention and global attention with different head_count, head_dim, and requires different block size for the best perf. 
* Also fix a bug `block_kv_dkv_compute=min(global_block_kv_dkv_compute, query.shape[2])` should use `key.shape`

# Tests
Tested in tuning experiments

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
