### PR TITLE
Fix compute_row_reward() for match_format_exactly and match_format_approximately reward fns

### DIFF
--- a/src/maxtext/trainers/post_train/rl/evaluate_rl.py
+++ b/src/maxtext/trainers/post_train/rl/evaluate_rl.py
@@ -208,7 +208,7 @@ def _compute_row_reward(reward_fns, prompt, responses, answer, row_idx):
           score_sum += float(scores[0])
     return score_sum, len(responses)
   except Exception as e:  # pylint: disable=broad-exception-caught
-    max_logging.log(f"[eval-reward] reward_fn failed on row {row_idx}: {e!r}")
+    max_logging.log(f"[eval-reward] Reward function {fn.__name__} failed on row {row_idx}: {e!r}")
     return 0.0, 0
 
 

--- a/tests/post_training/unit/evaluate_rl_test.py
+++ b/tests/post_training/unit/evaluate_rl_test.py
@@ -18,9 +18,11 @@
 
 import unittest
 import pytest
+from functools import wraps
 from types import SimpleNamespace
 
 from maxtext.trainers.post_train.rl import evaluate_rl
+from maxtext.trainers.post_train.rl import utils_rl
 
 pytestmark = [pytest.mark.post_training]
 
@@ -213,7 +215,7 @@ class TestScoreResponses(unittest.TestCase):
 class TestComputeRowReward(unittest.TestCase):
   """Tests for _compute_row_reward (per-prompt eval-time reward aggregation)."""
 
-  def _two_fns(self):
+  def _reward_fns(self):
     """Return two reward functions whose per-response scores can be summed."""
 
     # Each fn must accept prompts, completions, answer as keyword args and
@@ -225,7 +227,7 @@ class TestComputeRowReward(unittest.TestCase):
     def fn2(prompts, completions, answer):  # pylint: disable=unused-argument
       return [float(len(c)) for c in completions]
 
-    return [fn1, fn2]
+    return [fn1, fn2, utils_rl.match_format_exactly]
 
   @pytest.mark.cpu_only
   def test_single_response_single_fn(self):
@@ -245,7 +247,7 @@ class TestComputeRowReward(unittest.TestCase):
   @pytest.mark.cpu_only
   def test_sums_across_reward_fns_for_single_response(self):
     score_sum, count = evaluate_rl._compute_row_reward(
-        reward_fns=self._two_fns(),
+        reward_fns=self._reward_fns(),
         prompt="p",
         responses=["abcd"],
         answer="gold",
@@ -259,7 +261,7 @@ class TestComputeRowReward(unittest.TestCase):
   def test_sums_across_passes_for_multiple_responses(self):
     """Multi-pass: helper must aggregate across ALL sampled responses, not just [0]."""
     score_sum, count = evaluate_rl._compute_row_reward(
-        reward_fns=self._two_fns(),
+        reward_fns=self._reward_fns(),
         prompt="p",
         responses=["a", "bcd", "ef"],
         answer="gold",
@@ -274,7 +276,7 @@ class TestComputeRowReward(unittest.TestCase):
   def test_empty_responses_returns_zero_and_zero_count(self):
     """An empty responses list must contribute nothing to the running mean."""
     score_sum, count = evaluate_rl._compute_row_reward(
-        reward_fns=self._two_fns(),
+        reward_fns=self._reward_fns(),
         prompt="p",
         responses=[],
         answer="gold",


### PR DESCRIPTION
# Description

This PR fixes the `compute_row_reward()` calculation for the `match_format_exactly` and `match_format_approximately` reward functions. 

**Why this change is being made:**
Previously, there was an issue with how the mean reward was being computed for format matching. 
https://screenshot.googleplex.com/Bka4uJJqgDMWjYb

This change ensures that the rewards assigned for exact and approximate formatting are correctly aggregated, producing accurate mean scores. 

# Tests

* CI tests
* Llama3.1-8b RL run on TPU VM

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
