### PR TITLE
Fix KeyError('question') in evaluate-time reward path

### DIFF
--- a/src/maxtext/trainers/post_train/rl/evaluate_rl.py
+++ b/src/maxtext/trainers/post_train/rl/evaluate_rl.py
@@ -183,7 +183,7 @@ def score_responses(tmvp_config, question, responses, answers):
   raise ValueError(f"Unknown eval_mode: {eval_mode!r}")
 
 
-def _compute_row_reward(reward_fns, prompt, responses, answer, row_idx):
+def _compute_row_reward(reward_fns, prompt, question, responses, answer, row_idx):
   """Sum the per-function reward scores across all sampled responses for one prompt.
 
   Honors the sampling strategy `evaluate()` ran with: when `num_passes > 1`
@@ -192,6 +192,12 @@ def _compute_row_reward(reward_fns, prompt, responses, answer, row_idx):
   helper sums the reward across all of them. The caller divides the
   total by the number of (prompt, response) pairs to get the per-sample
   mean reward, mirroring tunix's GRPO per-rollout reward aggregation.
+
+  `question` is forwarded as a reward-fn kwarg because the built-in
+  `check_numbers` reward (and any user reward that wants to inspect the
+  raw question) reads it from `kwargs`. Training-time tunix passes the
+  whole dataset row to each reward fn; we mirror the kwargs the trainer
+  passes so eval-time and train-time reward calls are interchangeable.
 
   Returns a tuple `(score_sum, n_responses)`. On any exception the
   failure is logged and `(0.0, 0)` is returned so the caller's running
@@ -203,7 +209,7 @@ def _compute_row_reward(reward_fns, prompt, responses, answer, row_idx):
     score_sum = 0.0
     for resp in responses:
       for fn in reward_fns:
-        scores = fn(prompts=[prompt], completions=[resp], answer=[answer])
+        scores = fn(prompts=[prompt], completions=[resp], answer=[answer], question=question)
         if scores:
           score_sum += float(scores[0])
     return score_sum, len(responses)
@@ -283,7 +289,7 @@ def evaluate(
       # the actual per-(prompt, response) count at the end. See
       # `_compute_row_reward` for details.
       if use_reward:
-        row_sum, row_count = _compute_row_reward(reward_fns, prompt, responses, answer, total)
+        row_sum, row_count = _compute_row_reward(reward_fns, prompt, question, responses, answer, total)
         reward_sum += row_sum
         reward_count += row_count
 

--- a/tests/post_training/unit/evaluate_rl_test.py
+++ b/tests/post_training/unit/evaluate_rl_test.py
@@ -216,25 +216,27 @@ class TestComputeRowReward(unittest.TestCase):
   def _two_fns(self):
     """Return two reward functions whose per-response scores can be summed."""
 
-    # Each fn must accept prompts, completions, answer as keyword args and
-    # return a list of per-completion scores. The helper calls fn once per
-    # response with single-element lists, so the returned list has length 1.
-    def fn1(prompts, completions, answer):  # pylint: disable=unused-argument
+    # Each fn must accept prompts, completions, answer, question as keyword
+    # args and return a list of per-completion scores. The helper calls fn
+    # once per response with single-element lists, so the returned list has
+    # length 1.
+    def fn1(prompts, completions, answer, question):  # pylint: disable=unused-argument
       return [1.0 for _ in completions]
 
-    def fn2(prompts, completions, answer):  # pylint: disable=unused-argument
+    def fn2(prompts, completions, answer, question):  # pylint: disable=unused-argument
       return [float(len(c)) for c in completions]
 
     return [fn1, fn2]
 
   @pytest.mark.cpu_only
   def test_single_response_single_fn(self):
-    def fn(prompts, completions, answer):  # pylint: disable=unused-argument
+    def fn(prompts, completions, answer, question):  # pylint: disable=unused-argument
       return [2.5 for _ in completions]
 
     score_sum, count = evaluate_rl._compute_row_reward(
         reward_fns=[fn],
         prompt="p",
+        question="q",
         responses=["abc"],
         answer="gold",
         row_idx=0,
@@ -247,6 +249,7 @@ class TestComputeRowReward(unittest.TestCase):
     score_sum, count = evaluate_rl._compute_row_reward(
         reward_fns=self._two_fns(),
         prompt="p",
+        question="q",
         responses=["abcd"],
         answer="gold",
         row_idx=0,
@@ -261,6 +264,7 @@ class TestComputeRowReward(unittest.TestCase):
     score_sum, count = evaluate_rl._compute_row_reward(
         reward_fns=self._two_fns(),
         prompt="p",
+        question="q",
         responses=["a", "bcd", "ef"],
         answer="gold",
         row_idx=0,
@@ -276,6 +280,7 @@ class TestComputeRowReward(unittest.TestCase):
     score_sum, count = evaluate_rl._compute_row_reward(
         reward_fns=self._two_fns(),
         prompt="p",
+        question="q",
         responses=[],
         answer="gold",
         row_idx=0,
@@ -293,12 +298,64 @@ class TestComputeRowReward(unittest.TestCase):
     score_sum, count = evaluate_rl._compute_row_reward(
         reward_fns=[_boom],
         prompt="p",
+        question="q",
         responses=["abc"],
         answer="gold",
         row_idx=0,
     )
     self.assertEqual(score_sum, 0.0)
     self.assertEqual(count, 0)  # zero count so the caller's mean isn't biased
+
+  @pytest.mark.cpu_only
+  def test_question_is_forwarded_to_reward_fn(self):
+    """Regression: helper must pass `question` through to reward fns.
+
+    The built-in `check_numbers` reward reads `kwargs["question"]`; if the
+    helper omits it, every eval row produces `KeyError('question')` and
+    `mean_reward` collapses to 0.0.
+    """
+    received = {}
+
+    def fn(prompts, completions, answer, question):  # pylint: disable=unused-argument
+      received["question"] = question
+      return [1.0 for _ in completions]
+
+    evaluate_rl._compute_row_reward(
+        reward_fns=[fn],
+        prompt="p",
+        question="What is 2+2?",
+        responses=["abc"],
+        answer="gold",
+        row_idx=0,
+    )
+    self.assertEqual(received["question"], "What is 2+2?")
+
+  @pytest.mark.cpu_only
+  def test_integrates_with_real_check_numbers_reward(self):
+    """End-to-end: real `check_numbers` from utils_rl must not raise on the
+    eval-time kwargs the helper passes (regression for the original
+    `KeyError('question')` failure mode in production)."""
+    from maxtext.trainers.post_train.rl import utils_rl  # pylint: disable=import-outside-toplevel
+
+    config = _make_config(eval_mode="pass")
+
+    # `check_numbers` takes tmvp_config positionally via partial; mirror what
+    # train_rl.py's make_reward_fn does.
+    def wrapped_check_numbers(**kwargs):
+      return utils_rl.check_numbers(tmvp_config=config, **kwargs)
+
+    # A correct-answer response should yield a non-zero score (proves the
+    # kwargs all reached the inside of check_numbers).
+    score_sum, count = evaluate_rl._compute_row_reward(
+        reward_fns=[wrapped_check_numbers],
+        prompt="solve: 2+2",
+        question="What is 2+2?",
+        responses=["<reasoning>2+2=4</reasoning><answer>4</answer>"],
+        answer='["4"]',  # json-encoded list of acceptable answers
+        row_idx=0,
+    )
+    self.assertEqual(count, 1)
+    self.assertGreater(score_sum, 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
## Summary

`_compute_row_reward` in `evaluate_rl.py` (added in #4083) calls each reward function with only `(prompts=, completions=, answer=)`. The default `check_numbers` reward fn reads `kargs["question"]` at `utils_rl.py:430`, so it raises `KeyError('question')` on every eval row — suppressed by the helper's broad `except`, silently zeroing the reward contribution and producing `mean_reward=0.0`.

Symptom in production logs:

```
[eval-reward] reward_fn failed on row 127: KeyError('question')
```

## Fix

Thread `question` (already in scope at the caller as the per-row `zip` variable) through `_compute_row_reward` to each reward fn call. The training-time reward path always provides `question` because tunix passes the full dataset row dict; eval-time was the only caller that dropped it.

```python
# before
def _compute_row_reward(reward_fns, prompt, responses, answer, row_idx):
  ...
  scores = fn(prompts=[prompt], completions=[resp], answer=[answer])

# after
def _compute_row_reward(reward_fns, prompt, question, responses, answer, row_idx):
  ...
  scores = fn(prompts=[prompt], completions=[resp], answer=[answer], question=question)
```

# Tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

