### PR TITLE
Use regular checkout instead of github action checkout v5.

### DIFF
--- a/.github/workflows/run_pathways_tests.yml
+++ b/.github/workflows/run_pathways_tests.yml
@@ -72,9 +72,11 @@ jobs:
       options: ${{ inputs.container_resource_option }}
     steps:
       - name: Checkout MaxText
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.maxtext_sha }}
+        run: |
+          git config --global --add safe.directory /__w/maxtext/maxtext
+          git clone https://github.com/google/maxtext.git .
+          git fetch origin ${{ inputs.maxtext_sha }}
+          git checkout FETCH_HEAD
       - name: Download the maxtext wheel
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:


### PR DESCRIPTION
# Description

Use regular checkout for pathways test workflows instead of github action checkout v5.

Sometimes the github runner pod can crash before the post checkout action. This change will skip the post checkout step (the post checkout step is not needed anyway since we are getting a new environment every run).

FIXES: b/521475816

# Tests

The post checkout step is gone: https://github.com/AI-Hypercomputer/maxtext/actions/runs/27307583883/job/80669551875

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
