### PR TITLE
Disable group offset for tokamax gmm

### DIFF
--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -1275,6 +1275,7 @@ class RoutedMoE(nnx.Module):
               rhs_vma_axes=rhs_vma_axes,
           )
         else:  # tokamax (unquantized)
+          group_offset = None
           output = tokamax.ragged_dot(
               lhs=inputs,
               rhs=kernel,

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -986,6 +986,32 @@ class TrainCompile(parameterized.TestCase):
         )
     )
 
+  @pytest.mark.cpu_only
+  @pytest.mark.skip(reason="b/489205940 Tokamax GMM not supported by AOT on CPU backend.")
+  def test_tokamax_gmm(self):
+    """AOT test for Tokamax GMM for DeepSeek3 Tiny model"""
+    compiled_trainstep_file = "/tmp/test_tokamax_gmm.pickle"
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "compile_topology_num_slices=1",
+            "model_name=deepseek3-tiny",
+            "ici_expert_parallelism=2",
+            "scan_layers=True",
+            "sparse_matmul=True",
+            "megablox=True",
+            "use_tokamax_gmm=True",
+            "max_target_length=128",
+            "per_device_batch_size=1",
+            "dtype=bfloat16",
+            "weight_dtype=float32",
+            "use_tokamax_splash=True",
+        )
+    )
+
   @parameterized.named_parameters(
       {"testcase_name": "consistent_rms_scaling", "muon_consistent_rms": 0.2},
       {"testcase_name": "width_scaling", "muon_consistent_rms": None},


### PR DESCRIPTION
# Description

This PR fixes `use_tokamax_gmm=true` code path when `use_ring_of_expert=false`. It also adds an tokamax gmm AOT test.

# Tests

CI tests and tokamax gmm AOT test (but skipped due to b/489205940)

Local test: https://paste.googleplex.com/6403591735738368. The compilation was successful.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
