### PR TITLE
fix gemma3 to_maxtext flag

### DIFF
--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh
@@ -39,6 +39,7 @@ python3 -m maxtext.checkpoint_conversion.to_maxtext \
     scan_layers=false \
     hardware=cpu skip_jax_distributed_system=True \
     checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    --lazy_load_tensors=False \
     --eager_load_method='transformers'
 
 UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/unscanned/${run_id}/0/items
@@ -52,6 +53,7 @@ python3 -m maxtext.checkpoint_conversion.to_maxtext \
     scan_layers=true \
     hardware=cpu skip_jax_distributed_system=True \
     checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    --lazy_load_tensors=False \
     --eager_load_method='transformers'
 
 SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/scanned/${run_id}/0/items


### PR DESCRIPTION
# Description

Fix the E2E test shell scripts for to maxtext checkpoint conversion for gemma3 model. 

# Tests

Command tested on Tpu v6e. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
