### PR TITLE
Skip test_train_save_and_resume distillation unit test.

### DIFF
--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -845,6 +845,7 @@ class TrainDistillTest(unittest.TestCase):
     with self.assertRaises(AssertionError, msg="Weights should have updated on the second pass."):
       np.testing.assert_allclose(student.linear.kernel.get_value(), initial_weights)
 
+  @pytest.mark.skip(reason="Hangs indefinitely on synthetic datasets")
   @mock.patch("clu.metric_writers.create_default_writer")
   @mock.patch("maxtext.trainers.post_train.distillation.train_distill.tokenizer.build_tokenizer")
   def test_train_save_and_resume(self, mock_build_tokenizer, mock_writer):


### PR DESCRIPTION
This test hangs indefinitely when running on synthetic datasets because the loop termination check inside `tunix` library is skipped when `is_managed_externally=True` is configured.




*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

CI 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
