### PR TITLE
Fix attribute error in managed_mldiagnostics_test

### DIFF
--- a/tests/unit/managed_mldiagnostics_test.py
+++ b/tests/unit/managed_mldiagnostics_test.py
@@ -17,7 +17,7 @@
 import unittest
 from unittest import mock
 
-from maxtext.common.managed_mldiagnostics import ManagedMLDiagnostics
+from maxtext.common.managed_mldiagnostics import ManagedMLDiagnostics, mldiag
 import pytest
 
 
@@ -34,7 +34,7 @@ class ManagedMLDiagnosticsTest(unittest.TestCase):
     mock_config = mock.MagicMock()
     mock_config.managed_mldiagnostics = False
 
-    with mock.patch.object(ManagedMLDiagnostics.mldiag, "machinelearning_run") as mock_run:
+    with mock.patch.object(mldiag, "machinelearning_run") as mock_run:
       ManagedMLDiagnostics(mock_config)
       mock_run.assert_not_called()
 
@@ -45,15 +45,17 @@ class ManagedMLDiagnosticsTest(unittest.TestCase):
     mock_config.run_name = "test_run"
     mock_config.managed_mldiagnostics_run_group = "test_group"
     mock_config.managed_mldiagnostics_dir = "gs://test_dir"
+    mock_config.managed_mldiagnostics_on_demand_profiling = False
     mock_config.get_keys.return_value = {"key1": "val1"}
 
-    with mock.patch.object(ManagedMLDiagnostics.mldiag, "machinelearning_run") as mock_run:
+    with mock.patch.object(mldiag, "machinelearning_run") as mock_run:
       ManagedMLDiagnostics(mock_config)
       mock_run.assert_called_once_with(
           name="test_run",
           run_group="test_group",
           configs={"key1": "val1"},
           gcs_path="gs://test_dir",
+          on_demand_xprof=False,
           region=None,
       )
 
@@ -64,15 +66,17 @@ class ManagedMLDiagnosticsTest(unittest.TestCase):
     mock_config.run_name = "test_run"
     mock_config.managed_mldiagnostics_run_group = "test_group"
     mock_config.managed_mldiagnostics_dir = "gs://test_dir"
+    mock_config.managed_mldiagnostics_on_demand_profiling = False
     mock_config.get_keys.return_value = {"key1": "val1"}
 
-    with mock.patch.object(ManagedMLDiagnostics.mldiag, "machinelearning_run") as mock_run:
+    with mock.patch.object(mldiag, "machinelearning_run") as mock_run:
       ManagedMLDiagnostics(mock_config)
       mock_run.assert_called_once_with(
           name="test_run",
           run_group="test_group",
           configs={"key1": "val1"},
           gcs_path="gs://test_dir",
+          on_demand_xprof=False,
           region="us-east1",
       )
 


### PR DESCRIPTION
# Description

MaxText CPU tests were [failing](https://screenshot.googleplex.com/5kWETrZuqLTyyy3) possibly due to changes in [cl/932303562](https://critique.corp.google.com/cl/932303562). This PR fixes:

1. **`AttributeError`**: `mldiag` is a module-level variable, not a class attribute. Fixed by importing it directly (`from maxtext.common.managed_mldiagnostics import ManagedMLDiagnostics, mldiag`) and patching `mldiag` instead of `ManagedMLDiagnostics.mldiag`.

2. **Missing `on_demand_xprof` arg**: The actual `machinelearning_run` call in the implementation also passes `on_demand_xprof=config.managed_mldiagnostics_on_demand_profiling`, so the test assertions and mock config needed that argument added.
# Tests

```
# Local test
python -m pytest tests/unit/managed_mldiagnostics_test.py -vv -s

# Logs
collected 3 items                                          

tests/unit/managed_mldiagnostics_test.py::ManagedMLDiagnosticsTest::test_enabled_empty_region_passes_none PASSED
tests/unit/managed_mldiagnostics_test.py::ManagedMLDiagnosticsTest::test_enabled_populated_region_passes_region PASSED
tests/unit/managed_mldiagnostics_test.py::ManagedMLDiagnosticsTest::test_not_enabled_noop PASSED
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
