### PR TITLE
Update outdated rollout parallelism comment

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -23,8 +23,7 @@ sampler_devices_fraction: 0.5
 chips_per_vm: 4  # depends on hardware, for v5p this is 4
 num_trainer_slices: -1
 num_samplers_slices: -1
-# Only specify rollout_data_parallelism when you would like to use more than one model
-# replicas in rollout. If not specified, rollout_tensor_parallelism will be auto-determined.
+# If rollout_data_parallelism is not specified, it will be auto-determined.
 rollout_data_parallelism: -1
 rollout_tensor_parallelism: 1
 rollout_expert_parallelism: 1


### PR DESCRIPTION
# Description

Update outdated code comment. `rollout_data_parallelism ` is the auto-determined field

# Tests

CI - code comment change only

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
