### PR TITLE
Disable JAX compilation cache when `dump_hlo` is True

### DIFF
--- a/src/maxtext/configs/pyconfig.py
+++ b/src/maxtext/configs/pyconfig.py
@@ -541,9 +541,14 @@ def _initialize_pydantic(argv: list[str] | None = None, **kwargs) -> MaxTextConf
   if "pytest" not in sys.modules:
     max_utils.maybe_initialize_jax_distributed_system(pydantic_kwargs)
   if pydantic_kwargs.get("jax_cache_dir"):
-    from jax.experimental.compilation_cache import compilation_cache  # pylint: disable=import-outside-toplevel
+    if pydantic_kwargs.get("dump_hlo"):
+      max_logging.warning(
+          "JAX compilation cache is disabled because dump_hlo is True. HLO dumping requires recompilation."
+      )
+    else:
+      from jax.experimental.compilation_cache import compilation_cache  # pylint: disable=import-outside-toplevel
 
-    compilation_cache.set_cache_dir(os.path.expanduser(pydantic_kwargs["jax_cache_dir"]))
+      compilation_cache.set_cache_dir(os.path.expanduser(pydantic_kwargs["jax_cache_dir"]))
 
   pydantic_config = types.MaxTextConfig(**pydantic_kwargs)
   config = HyperParameters(pydantic_config)


### PR DESCRIPTION
# Description

When `dump_hlo=true` is set, MaxText relies on XLA compiler flags to dump HLO files during compilation. However, if `jax_cache_dir` is configured, subsequent runs reuse the JAX compilation cache on disk. Since compilation is bypassed, XLA does not run, and no HLO files are dumped. This silently fails to produce HLOs if the user clears the dump directory between runs.

**Solution:** Automatically bypass the JAX compilation cache initialization in pyconfig.py if `dump_hlo` is True. This forces recompilation and ensures that HLOs are always generated as requested. A warning is logged to inform the user:
```
JAX compilation cache is disabled because dump_hlo is True. HLO dumping requires recompilation.
```

**Alternative considered:** We explored programmatically extracting the final HLO text from the cached executable using compiled.as_text(). While this successfully retrieves the post-optimization HLO even on cache hits, it is unable to recover the full suite of XLA compiler intermediate output files (like before_optimizations.txt, tpu_comp_env.txt, memory usage reports, etc.) which are never generated when compilation is skipped. Forcing recompilation remains the only way to guarantee the complete dump.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/440500124

# Tests

Tested on my TPU VM using a tiny model before and after the fix to confirm that when `dump_hlo==True` XLA compilation gets triggered and HLO is dumped.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
