### PR TITLE
[RL] Fix GPT-OSS 20B dimension mismatch error in vLLM adapter by resolving intermediate_size fallback

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -112,7 +112,10 @@ def generate_maxtext_config(vllm_config: VllmConfig) -> pyconfig.HyperParameters
       if hasattr(vllm_config.model_config.hf_config, "text_config")
       else vllm_config.model_config.hf_config
   )
-  hidden_size = getattr(hf_config, "moe_intermediate_size", None)
+  hidden_size = (
+      getattr(hf_config, "moe_intermediate_size", None)
+      or getattr(hf_config, "intermediate_size", None)
+  )
   num_lanes = pltpu.get_tpu_info().num_lanes
   num_kv_heads = hf_config.num_key_value_heads
 

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -2448,6 +2448,8 @@ class RoutedMoE(nnx.Module):
 
     # Map MaxText config fields to fused_moe_func args
     activation = self.config.mlp_activations[0]  # e.g. "silu"
+    if activation == "sigmoid":
+      activation = "swigluoai"
     scoring_fn = self.config.routed_score_func if self.config.routed_score_func else "softmax"
 
     # Check if the model architecture intrinsically renormalizes weights


### PR DESCRIPTION
# Description

This PR fixes a dimension mismatch error for GPT-OSS 20B in the vLLM adapter. Previously, the adapter looked up `moe_intermediate_size` in the Hugging Face configuration, which resulted in `None` for dense models like GPT-OSS 20B. This change resolves the fallback by checking `intermediate_size` if `moe_intermediate_size` is not present.

FIXES: b/475304467

# Tests

Tested manually by verifying the config generation logic with GPT-OSS 20B Hugging Face configuration.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
