### PR TITLE
Fix MRoPE dimension expansion in vLLM adapter for hybrid Qwen models

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -252,7 +252,7 @@ class MaxTextForCausalLM(nnx.Module):
 
     # Ensure inputs are at least 2D with a batch dimension
     input_ids = jnp.expand_dims(input_ids, axis=1)
-    input_positions = jnp.expand_dims(attention_metadata.input_positions, axis=1)
+    input_positions = jnp.expand_dims(attention_metadata.input_positions, axis=-1)
 
     with self.mesh, nn.logical_axis_rules(self.maxtext_config.logical_axis_rules):
       aux_hidden_states = []


### PR DESCRIPTION
# Description

When serving models that use MRoPE — such as Qwen3.5 and Qwen3-Omni (`use_mrope=True`) — vLLM passes 3D position indices of shape `(3, num_tokens)`.

The vLLM adapter was expanding this at `axis=1`, producing a shape of `(3, 1, num_tokens)`. When broadcasted against key projections during RoPE application, it incorrectly inflated the key sequence dimension (resulting in `(batch, max_num_tokens, heads, head_dim)`), ultimately leading to a shape validation failure in the RPA kernel: `ValueError: Expected k.shape=(33554432, 1, 256) to be equal to v.shape=(2048, 1, 256)`.

The solution expand at `axis=-1` to obtain the correct shape for both MRoPE and non-MRoPE cases.

# Tests

Manual tests in E2E runs.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
