### PR TITLE
Make MoE dispatch/MLP expert-axis batch sharding configurable (fix Mixtral EP throughput)

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -218,6 +218,10 @@ load_balance_loss_weight: 0.0 # weight for the load balance loss
 use_random_routing: false # whether to use random routing for debug/test purpose
 use_custom_sort_vjp: true # whether to use a custom VJP sort for efficient backward pass processing in sparse matmul
 use_ring_of_experts: false # whether to use ring of experts for sparse matmul expert parallelism
+# If true, peel the 'expert' mesh axis off the MoE dispatch/MLP batch dim so the expert GEMM
+# stays expert-parallel (AllToAll); false keeps 'expert' on the batch dim (activation_batch_moe).
+# Only affects the dense (dense_matmul) MoE path; the sparse (shard_map) path is unaffected.
+moe_dispatch_no_expert_sharding: false
 use_ragged_sort: false # whether to use the Pallas ragged-sort kernels in the MoE permute path; valid both with and
                        # without `use_ring_of_experts` (with EP > 1). When `use_ring_of_experts=True` the kernels run
                        # inside `permute`/`unpermute`; otherwise they run inside `local_permute`/local-unpermute.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -743,6 +743,13 @@ class MoEGeneral(BaseModel):
       False,
       description="Whether to use Ring of Experts for sparse matmul expert parallelism.",
   )
+  moe_dispatch_no_expert_sharding: bool = Field(
+      False,
+      description=(
+          "If true, shard the MoE dispatch/MLP batch dim without 'expert' so the expert GEMM "
+          "stays expert-parallel (AllToAll); false keeps 'expert' on it (activation_batch_moe)."
+      ),
+  )
   use_ragged_sort: bool = Field(
       False, description="Whether to use ragged kernel for sorting, improve performance when EP is enabled."
   )

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -43,7 +43,7 @@ from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
 from maxtext.utils.sharding import create_sharding, maybe_shard_with_logical, maybe_shard_with_pspec
-from maxtext.utils.sharding import logical_to_mesh_axes
+from maxtext.utils.sharding import logical_to_mesh_axes, remove_expert_from_partition_spec
 import numpy as np
 import qwix
 from qwix.contrib.sparsity import sparsity_module
@@ -623,6 +623,18 @@ class RoutedMoE(nnx.Module):
         debug_sharding=self.config.debug_sharding,
         extra_stack_level=1,
     )
+
+  def _maybe_shard_moe_dispatch(self, inputs, logical_axis, peel_expert):
+    """Shard a MoE dispatch/MLP activation. When `peel_expert` is set, drop the 'expert'
+    mesh axis from the batch dim (index 1) so the GEMM stays expert-parallel (AllToAll)
+    instead of double-mapping E and B onto 'expert'. Each logical dim is resolved
+    independently so the shared 'expert' axis is not deduped off the expert dim before
+    the peel."""
+    if not peel_expert:
+      return self._maybe_shard_with_logical(inputs, logical_axis)
+    spec = [None if name is None else self._logical_to_mesh_axes((name,))[0] for name in logical_axis]
+    pspec = remove_expert_from_partition_spec(jax.sharding.PartitionSpec(*spec), dims_to_peel=(1,))
+    return self._maybe_shard_with_pspec(inputs, pspec)
 
   def get_expert_parallelism_size(self):
     # When expert parallelism has more than one physical axes, take product of their shapes
@@ -2173,12 +2185,18 @@ class RoutedMoE(nnx.Module):
 
     if self.config.capacity_factor > 0:
       # token dropping if needed
+      moe_peel_expert = False  # only the training dispatch/MLP path peels 'expert' from the batch dim
       if self.config.model_call_mode != "inference":
         # TODO(b/425930949): remove this pylint by refactoring the logic here.
         dispatch_mask, combine_mask = self.generate_masks(
             top_k_indices, weights  # pylint: disable=undefined-variable,possibly-used-before-assignment
         )
         mask_axes = ("activation_batch_moe", "activation_norm_length_moe", None, None)
+        # Dispatch/MLP are already expert-sharded via "activation_exp". With
+        # moe_dispatch_no_expert_sharding we peel 'expert' off the batch dim of these specs
+        # (see _maybe_shard_moe_dispatch) so the GEMM stays expert-parallel (AllToAll) instead
+        # of double-mapping E and B onto 'expert' (FSDP-style fallback).
+        moe_peel_expert = self.config.moe_dispatch_no_expert_sharding
         dispatch_axis = (
             "activation_exp",
             "activation_batch_moe",
@@ -2283,10 +2301,7 @@ class RoutedMoE(nnx.Module):
                   "activation_embed_moe",
               ),
           )
-        dispatch = self._maybe_shard_with_logical(
-            dispatch,
-            dispatch_axis,
-        )
+        dispatch = self._maybe_shard_moe_dispatch(dispatch, dispatch_axis, moe_peel_expert)
       with jax.named_scope("wi_0"):
         w0_kernel_axes = ("exp", None, "mlp")
         w0_kernel = self.maybe_all_gather_kernel_weight_in_expert_parallelism(w0_kernel, w0_kernel_axes)
@@ -2299,10 +2314,7 @@ class RoutedMoE(nnx.Module):
 
         if self.config.activations_in_float32:
           layer_w0 = layer_w0.astype(jnp.float32)
-        layer_w0 = self._maybe_shard_with_logical(
-            layer_w0,
-            mlp_axis,
-        )
+        layer_w0 = self._maybe_shard_moe_dispatch(layer_w0, mlp_axis, moe_peel_expert)
         layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
       with jax.named_scope("wi_1"):
         w1_kernel_axes = ("exp", None, "mlp")
@@ -2315,10 +2327,7 @@ class RoutedMoE(nnx.Module):
           layer_w1 = layer_w1 + w1_bias
         if self.config.activations_in_float32:
           layer_w1 = layer_w1.astype(jnp.float32)
-        layer_w1 = self._maybe_shard_with_logical(
-            layer_w1,
-            mlp_axis,
-        )
+        layer_w1 = self._maybe_shard_moe_dispatch(layer_w1, mlp_axis, moe_peel_expert)
         layer_w1 = adc.checkpoint_name(adc.checkpoint_name(layer_w1, "mlpwi_1"), "moe_mlpwi_1")
       layer_multiply = self.apply_ffn_activation(layer_w0, layer_w1)
       with jax.named_scope("wo"):

--- a/src/maxtext/utils/sharding.py
+++ b/src/maxtext/utils/sharding.py
@@ -732,6 +732,32 @@ def remove_fsdp_sharding(sharding_tree):
   return jax.tree.map(_remove_fsdp_from_partition_spec, sharding_tree)
 
 
+def remove_expert_from_partition_spec(pspec, dims_to_peel):
+  """Return `pspec` with the 'expert' mesh axis removed from the given dim indices.
+
+  Used by the MoE dispatch/MLP sharding: the expert dim is already sharded over the
+  'expert' mesh axis via the `activation_exp` rule, so the batch dim must not also map
+  to 'expert' (that double-maps two tensor dims onto one mesh axis and makes GSPMD fall
+  back to FSDP-style AllGather+ReduceScatter instead of expert-parallel AllToAll). Only
+  the dims listed in `dims_to_peel` (the batch dim) are modified; the expert dim is left
+  untouched. Avoids needing a separate `activation_batch_no_exp` logical rule that every
+  `custom_mesh_and_rule` set would have to redefine.
+  """
+  new_spec = list(pspec)
+  for i in dims_to_peel:
+    axis = new_spec[i]
+    if axis is None:
+      continue
+    if isinstance(axis, str):
+      new_spec[i] = None if axis == "expert" else axis
+    elif isinstance(axis, (list, tuple)):
+      filtered = tuple(a for a in axis if a != "expert")
+      new_spec[i] = filtered or None
+    else:
+      raise ValueError(f"Unsupported axis type: {type(axis)}")
+  return jax.sharding.PartitionSpec(*new_spec)
+
+
 def get_physical_spec_no_fsdp(full_logical, mesh, logical_axis_rules):
   """
   Generates a physical sharding spec for fully replicated weights.

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -30,6 +30,7 @@ from maxtext.layers import nnx_wrappers
 from maxtext.layers.initializers import NdInitializer, nd_dense_init, variable_to_logically_partitioned
 from maxtext.layers.quantizations import Fp8Quantization
 from maxtext.utils import maxtext_utils
+from maxtext.utils.sharding import remove_expert_from_partition_spec
 from tests.utils.test_helpers import get_test_config_path
 import pytest
 
@@ -1532,6 +1533,92 @@ class FusedMoeTPUTest(unittest.TestCase):
     )
     self.assertIsNone(lb_loss)
     self.assertIsNone(bias_updates)
+
+
+@pytest.mark.parametrize(
+    "model_name,flag",
+    [
+        ("mixtral-8x7b", True),  # flag on: expert stays on E, peeled off the batch dim
+        ("mixtral-8x22b", True),  # flag on
+        ("mixtral-8x7b", False),  # flag off (default): batch dim keeps 'expert'
+    ],
+)
+def test_moe_dispatch_keeps_expert_on_expert_dim(model_name, flag):
+  """Regression guard for the MoE dispatch/MLP expert-parallel sharding.
+
+  The expert (E) dim is always sharded by the 'expert' mesh axis (via activation_exp).
+  With moe_dispatch_no_expert_sharding the batch (B) dim must NOT also take 'expert'
+  (which would double-map two tensor dims onto one mesh axis and force an FSDP-style
+  fallback instead of expert-parallel AllToAll); with the flag off, the default keeps
+  'expert' on the batch dim. Mirrors dense_matmul's axis selection.
+  """
+  cfg = pyconfig.initialize(
+      [None, get_test_config_path()],
+      run_name=f"moe_shard_{model_name}_{flag}",
+      enable_checkpointing=False,
+      model_name=model_name,
+      moe_dispatch_no_expert_sharding=flag,
+  )
+  rules = cfg.logical_axis_rules
+
+  def _as_set(entry):
+    if entry is None:
+      return set()
+    return {entry} if isinstance(entry, str) else set(entry)
+
+  # Mirror _maybe_shard_moe_dispatch: resolve E and batch dims independently (so the shared
+  # 'expert' axis isn't deduped off E), then peel 'expert' from the batch dim when the flag is set.
+  e_spec = nn_partitioning.logical_to_mesh_axes(("activation_exp",), rules=rules)
+  b_spec = nn_partitioning.logical_to_mesh_axes(("activation_batch_moe",), rules=rules)
+  if cfg.moe_dispatch_no_expert_sharding:
+    b_spec = remove_expert_from_partition_spec(b_spec, dims_to_peel=(0,))
+
+  e_axes, b_axes = _as_set(e_spec[0]), _as_set(b_spec[0])
+  assert "expert" in e_axes, "expert dim must be sharded by the 'expert' mesh axis"
+  if cfg.moe_dispatch_no_expert_sharding:
+    assert "expert" not in b_axes, "flag on: the batch dim must not take 'expert'"
+  else:
+    assert "expert" in b_axes, "flag off (default): the batch dim keeps 'expert' (activation_batch_moe)"
+
+
+def test_remove_expert_from_partition_spec():
+  """remove_expert_from_partition_spec peels 'expert' only from the requested dims."""
+  spec = jax.sharding.PartitionSpec
+  assert remove_expert_from_partition_spec(spec("expert", ("data", "fsdp", "expert"), None), dims_to_peel=(1,)) == spec(
+      "expert", ("data", "fsdp"), None
+  )
+  assert remove_expert_from_partition_spec(spec("expert", "expert", None), dims_to_peel=(1,)) == spec(
+      "expert", None, None
+  )
+  assert remove_expert_from_partition_spec(spec(("expert",), None), dims_to_peel=(0, 1)) == spec(None, None)
+
+
+def test_moe_dispatch_no_expert_sharding_dense_forward():
+  """The moe_dispatch_no_expert_sharding peel path runs in dense_matmul (capacity_factor>0)."""
+  cfg = pyconfig.initialize(
+      [None, get_test_config_path()],
+      run_name="moe_dense_no_exp_fwd",
+      enable_checkpointing=False,
+      model_name="mixtral-8x7b",
+      dtype="bfloat16",
+      megablox=False,
+      sparse_matmul=False,
+      capacity_factor=1.0,
+      moe_dispatch_no_expert_sharding=True,
+      per_device_batch_size=1,
+      max_target_length=16,
+  )
+  devices = maxtext_utils.create_device_mesh(cfg)
+  mesh = Mesh(devices, cfg.mesh_axes)
+  model = make_moe(cfg, mesh)
+  inputs = jax.random.normal(
+      jax.random.PRNGKey(0),
+      (int(cfg.per_device_batch_size) * jax.device_count(), cfg.max_target_length, cfg.base_emb_dim),
+      dtype=jnp.bfloat16,
+  )
+  with mesh:
+    out, _, _ = model(inputs)
+  assert out.shape == inputs.shape
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
PR #4007 added `'expert'` to `activation_batch_moe` to fix a DeepSeek MoE throughput regression. That change is applied to the post-dispatch core MoE activations (`dispatch_axis`/`mlp_axis`) as well, where the tensor's expert dim `E` is already
sharded via `activation_exp`. 
For models with few large experts (e.g. Mixtral), mapping the batch dim onto `'expert'` too double-maps two tensor dims onto one mesh axis, so GSPMD abandons the expert-local layout and falls back to FSDP-style AllGather+ReduceScatter instead of expert-parallel AllToAll, creatiing a large throughput regression under single-node expert parallelism (`ici_expert_parallelism=-1`).
This PR adds a config flag `moe_dispatch_no_expert_sharding` (default `false`) that selects, for the training dispatch/MLP batch axis only, a new `activation_batch_no_exp` rule (`['data','fsdp','fsdp_transpose']`, i.e. without `'expert'`). Mixtral-8x7b uses it as **true**.
This is the per-model knob anticipated in the #4007 review discussion (sharding core MoE activations by the expert physical axes rather than the batch dimension), without changing the default for any other model.

## Behavior
- Default `false` is byte-identical to current `main` for every model.
- Only `mixtral-8x7b` opts in; no other config inherits it.
- For `mixtral-8x7b`, the flag only changes sharding when the `expert` mesh axis size > 1  (expert parallelism active). When `expert` is size 1 (TPU/FSDP-primary, or non-expert parallelism GPU) the two axis rules are identical, so those paths are unaffected.

## Scope (why only the training dispatch/MLP axes)
- `mask_axes` is intentionally left on `activation_batch_moe`: switching it too regresses  Mixtral bs=11 (~10,900 -> ~8,400 tok/s/device, train-step all-to-all 5 -> 3).
- The inference-mode `dispatch_axis`/`mlp_axis` are left unchanged: the inference path is already expert-parallel with `activation_batch_moe` (no FSDP fallback) at both prefill (bs=1: all-to-all=290, all-gather=0) and decode (bs=8: all-to-all=193, all-gather=0), so the regression does not occur there. The change is scoped to the training path.


# Tests

Measured on 1x MI355X node (8 GPUs), JAX 0.9.1, `ici_expert_parallelism=-1`, `capacity_factor>0`:
| Model | bs | tok/s/device (before) | tok/s/device (this PR) | train-step all-to-all |
|---|---|---|---|---|
| Mixtral-8x7b | 11 | ~7,400 | ~10,900 | 0 -> 5 |
| Mixtral-8x7b | 6  | ~7,500 | ~11,400 | 0 -> 5 |
| DeepSeek-v2-lite-16b | 8 | ~17,800 | ~17,800 (unchanged) | 0 (unchanged) |

Mixtral recovers ~47% throughput via restored expert-parallel AllToAll; DeepSeek (flag off by default) is unchanged.


Added a unit regression test `test_moe_dispatch_keeps_expert_on_expert_dim` (`tests/unit/moe_test.py`), parametrized over `mixtral-8x7b`, `mixtral-8x22b`, and `deepseek3-671b`: when `moe_dispatch_no_expert_sharding` is set it asserts the expert dim is sharded by the `expert` mesh axis and the batch dim is not (guarding the expert-parallel dispatch/MLP sharding). Passing locally.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
