### PR TITLE
[DECOUPLED-MODE] grpo_trainer: route goodput/vertex imports through gcloud_stub for decoupled

### DIFF
--- a/src/maxtext/experimental/rl/grpo_trainer.py
+++ b/src/maxtext/experimental/rl/grpo_trainer.py
@@ -67,7 +67,9 @@ from maxtext.common import train_state_nnx
 
 import transformers
 
-from ml_goodput_measurement.src.goodput import GoodputRecorder
+from maxtext.common.goodput import goodput as _goodput_module
+
+GoodputRecorder = _goodput_module.GoodputRecorder
 
 import maxtext as mt
 from maxtext.configs import pyconfig
@@ -87,7 +89,7 @@ from maxtext.common.goodput import (
 from maxtext.experimental.rl import grpo_input_pipeline
 from maxtext.experimental.rl import grpo_utils
 from maxtext.common.metric_logger import MetricLogger
-from maxtext.common.vertex_tensorboard import VertexTensorboardManager
+from maxtext.common.gcloud_stub import vertex_tensorboard_modules
 from maxtext.utils import exceptions
 from maxtext.utils import gcs_utils
 from maxtext.utils import max_logging
@@ -97,6 +99,8 @@ from maxtext.utils import model_creation_utils
 from maxtext.utils import maxtext_utils
 from maxtext.utils import sharding
 from maxtext.utils import train_utils
+
+VertexTensorboardManager, _vertex_tb_is_stub = vertex_tensorboard_modules()
 
 # pylint: disable=too-many-positional-arguments
 


### PR DESCRIPTION
# Description

The top-level `from ml_goodput_measurement.src.goodput import GoodputRecorder` and `from maxtext.common.vertex_tensorboard import VertexTensorboardManager` (which pulls in `cloud_accelerator_diagnostics`) hard-require cloud-only packages that are intentionally absent in decoupled environments (DECOUPLE_GCLOUD=TRUE). A single ModuleNotFoundError at import time aborted pytest collection for the whole suite (exit 2).

Resolve both through the existing decoupled-aware paths, mirroring pre_train/train.py:
- GoodputRecorder (used only as a type annotation) now comes from the stub-aware `maxtext.common.goodput.goodput` namespace.
- VertexTensorboardManager now comes from `gcloud_stub.vertex_tensorboard_modules()`.
No behavior change when the real libraries are installed; decoupled runs fall back to the existing no-op stubs. Fixes rocm-decoupled collection (786/1157 collected, 371 deselected, exit 0).

# Tests

Downstream CI decoupled ROCm run.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
