### PR TITLE
docs(rl): update tutorial with AgenticGRPOLearner for async RL training

### DIFF
--- a/docs/tutorials/posttraining/rl.md
+++ b/docs/tutorials/posttraining/rl.md
@@ -126,6 +126,20 @@ The overview of what this run will do is as follows:
 4. Evaluate the policy model's performance on GSM8K math reasoning benchmark
    after the post-training with GRPO.
 
+By default, the above command will train the model using GRPOLearner from Tunix. To enable
+asynchronous RL training with AgenticGRPOLearner, we can set `rl.use_agentic_rollout` to
+true. An example command will be:
+
+```
+python3 -m maxtext.trainers.post_train.rl.train_rl \
+  model_name=${MODEL?} \
+  load_parameters_path=${MAXTEXT_CKPT_PATH?} \
+  run_name=${RUN_NAME?} \
+  base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
+  chips_per_vm=${CHIPS_PER_VM?} \
+  rl.use_agentic_rollout=True
+```
+
 ## Run GSPO
 
 Run the following command for GSPO:


### PR DESCRIPTION
# Description

Updates the `rl.md` tutorial documentation to include instructions and an example command for using `AgenticGRPOLearner` for asynchronous RL training.

# Tests

Command tested on Qwen3 4B using a v6e-8 machine.

```
# [Test Agentic Learner (default)]
export MODEL="qwen3-4b"
export BASE_OUTPUT_DIRECTORY="gs://yixuanm-maxtext-logs/AgenticGRPOTesting"
export RUN_NAME="agentic-0610-default"
export CHIPS_PER_VM=8
export MAXTEXT_CKPT_PATH="gs://yixuanm-maxtext-logs/AgenticGRPOTesting/qwen3-4b-ckpt/0/items/"

# GRPO command
python3 -m maxtext.trainers.post_train.rl.train_rl \
  model_name=${MODEL?} \
  load_parameters_path=${MAXTEXT_CKPT_PATH?} \
  run_name=${RUN_NAME?} \
  base_output_directory=${BASE_OUTPUT_DIRECTORY?} \
  chips_per_vm=${CHIPS_PER_VM?} \
  enable_tunix_perf_metrics=True \
  rl.use_agentic_rollout=True 
``` 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
