### PR TITLE
Add E2E test scripts for qwen3-30b model

### DIFF
--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Validates the Qwen3-30B pre-training pipeline using a pre-converted MaxText checkpoint.
+
+# The flow of this script is as follows:
+# 1. Run inference on the pre-converted checkpoint.
+# 2. Run pre-training starting from the pre-converted checkpoint.
+# 3. Run inference on the checkpoint produced by the pre-training run.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID
+# bash test_qwen3.sh $RUN_ID
+
+
+set -ex
+
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+MODEL_NAME='qwen3-30b-a3b-base'
+
+
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
+UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${run_id}/0/items
+SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+
+DATASET_PATH=gs://maxtext-dataset
+
+# Step 1: Run inference on the pre-converted checkpoint
+python3 -m maxtext.inference.decode \
+    model_name=${MODEL_NAME} tokenizer_type="huggingface" \
+    load_parameters_path=${UNSCANNED_CKPT_PATH} \
+    per_device_batch_size=1 run_name=${run_id} \
+    max_prefill_predict_length=8 max_target_length=16 steps=1 async_checkpointing=false \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    scan_layers=false prompt='I love to' attention=\'dot_product\'
+
+# Step 2: Run pre-training starting from the pre-converted checkpoint
+python3 -m maxtext.trainers.pre_train.train \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/train \
+    dataset_path=${DATASET_PATH} tokenizer_type="huggingface" \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    per_device_batch_size=0.125 run_name=${run_id} \
+    max_target_length=64 steps=5 async_checkpointing=false \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    model_name=${MODEL_NAME} scan_layers=true \
+    remat_policy=full \
+    ici_tensor_parallelism=4 ici_fsdp_parallelism=2 weight_dtype=bfloat16 dtype=bfloat16 opt_type=sgd optimizer_memory_host_offload=true
+
+# Step 3: Run inference on the checkpoint produced by the pre-training run
+python3 -m maxtext.inference.decode \
+    model_name=${MODEL_NAME} tokenizer_type="huggingface" \
+    load_parameters_path=${BASE_OUTPUT_DIRECTORY}/train/${run_id}/checkpoints/4/items \
+    per_device_batch_size=1 run_name=${run_id} \
+    max_prefill_predict_length=8 max_target_length=16 steps=4 async_checkpointing=false \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    scan_layers=true prompt='I love to' attention=\'dot_product\'

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_rl.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_rl.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Validates the Qwen3 RL pipeline using a pre-converted MaxText checkpoint.
+
+# The flow of this script is as follows:
+# 1. Run inference on the pre-converted checkpoint.
+# 2. Run RL starting from the pre-converted checkpoint.
+# 3. Run inference on the checkpoint produced by the RL run.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID
+# bash test_qwen3_rl.sh $RUN_ID
+
+set -ex
+
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb
+export VLLM_RAY_EXTRA_ENV_VARS_TO_COPY="PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"
+export VLLM_ENABLE_V1_MULTIPROCESSING=0
+export JAX_RANDOM_WEIGHTS=1
+export SKIP_JAX_PRECOMPILE=1
+export NEW_MODEL_DESIGN=1
+export TPU_MIN_LOG_LEVEL=0
+export TF_CPP_MIN_LOG_LEVEL=0
+export TPU_STDERR_LOG_LEVEL=0
+
+# Force Python to use "spawn" instead of "fork" for multiprocessing to prevent gRPC socket corruption
+cat << 'EOF' > usercustomize.py
+import multiprocessing
+try:
+    multiprocessing.set_start_method("spawn", force=True)
+except Exception:
+    pass
+EOF
+export PYTHONPATH=${PYTHONPATH:-.}:$(pwd)
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+MODEL_NAME='qwen3-30b-a3b-base'
+
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
+UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${run_id}/0/items
+SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items
+
+# Step 1: Run inference on the pre-converted checkpoint
+python3 -m maxtext.inference.vllm_decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    hbm_utilization_vllm=0.85 \
+    prompt='Suggest some famous landmarks in London.' \
+    max_target_length=256 max_num_batched_tokens=256 \
+    ici_tensor_parallelism=8  \
+    allow_split_physical_axes=True prefuse_moe_weights=True \
+    use_chat_template=True scan_layers=True enable_single_controller=True
+
+# Step 2: Run RL starting from the pre-converted checkpoint
+python3 -m maxtext.trainers.post_train.rl.train_rl \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/rl \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    run_name=${run_id} rl.loss_algo='grpo' scan_layers=True \
+    num_batches=5 batch_size=4 train_micro_batch_size=1 num_test_batches=5 \
+    model_name=${MODEL_NAME} enable_single_controller=True \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    rollout_tensor_parallelism=8 \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    vllm_additional_config='{"maxtext_config": {"model_name": "'${MODEL_NAME}'", "allow_split_physical_axes": true, "scan_layers": false, "prefuse_moe_weights": True}}' \
+    remat_policy=full hbm_utilization_vllm=0.55 use_pathways=True \
+    chips_per_vm=8 ici_tensor_parallelism=4\
+    max_target_length=512 weight_dtype=bfloat16 dtype=bfloat16 opt_type=sgd \
+    enable_tunix_perf_metrics=True rl.num_generations=16 \
+    debug.rl=False rl.reshard_chunk_size=1 
+
+# Step 3: Run inference on the checkpoint produced by the RL run
+python3 -m maxtext.inference.vllm_decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${BASE_OUTPUT_DIRECTORY}/rl/${run_id}/checkpoints/actor/4/items \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    hbm_utilization_vllm=0.85 \
+    prompt='Suggest some famous landmarks in London.' \
+    max_target_length=256 max_num_batched_tokens=256 \
+    ici_tensor_parallelism=8  \
+    allow_split_physical_axes=True prefuse_moe_weights=True \
+    use_chat_template=True scan_layers=True enable_single_controller=True

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_sft.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_sft.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Validates the Qwen3 SFT pipeline using a pre-converted MaxText checkpoint.
+
+
+# The flow of this script is as follows:
+# 1. Run inference on the pre-converted checkpoint.
+# 2. Run SFT starting from the pre-converted checkpoint.
+# 3. Run inference on the checkpoint produced by the SFT run.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID
+# bash test_qwen3_sft.sh $RUN_ID
+
+
+set -ex
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+export NEW_MODEL_DESIGN=1
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+MODEL_NAME='qwen3-30b-a3b-base'
+
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
+UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${run_id}/0/items
+SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items
+
+# Step 1: Run inference on the pre-converted checkpoint
+python3 -m maxtext.inference.vllm_decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    hbm_utilization_vllm=0.85 \
+    use_chat_template=True scan_layers=true enable_single_controller=True \
+    ici_tensor_parallelism=4 prompt="Suggest some famous landmarks in London."
+
+# Step 2: Run SFT starting from the pre-converted checkpoint
+python3 -m maxtext.trainers.post_train.sft.train_sft \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/sft \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    per_device_batch_size=0.125 run_name=${run_id} \
+    steps=5 scan_layers=true \
+    model_name=${MODEL_NAME} \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    remat_policy=full \
+    ici_tensor_parallelism=1 ici_fsdp_parallelism=1 ici_expert_parallelism=8 \
+    enable_single_controller=True max_target_length=16 weight_dtype=bfloat16 dtype=bfloat16 opt_type=sgd
+
+# Step 3: Run inference on the checkpoint produced by the SFT run
+python3 -m maxtext.inference.vllm_decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${BASE_OUTPUT_DIRECTORY}/sft/${run_id}/checkpoints/5/model_params \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    hbm_utilization_vllm=0.85 \
+    use_chat_template=True scan_layers=true enable_single_controller=True \
+    ici_tensor_parallelism=4 prompt="Suggest some famous landmarks in London."

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Converts a MaxText checkpoint to a Hugging Face model checkpoint.
+
+# Usage:
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_hf.sh $RUN_ID $CHECKPOINT_PATH $SCAN_LAYERS
+
+
+set -ex
+
+run_id=$1
+CKPT_PATH=$2
+SCAN_LAYERS=${3:-false}
+
+MODEL_NAME='qwen3-30b-a3b-base'
+BASE_OUTPUT_DIRECTORY="gs://runner-maxtext-logs/${MODEL_NAME}"
+
+if [ "${SCAN_LAYERS,,}" = "true" ]; then
+    scan_status="scanned"
+else
+    scan_status="unscanned"
+fi
+
+# Convert the checkpoint to Hugging Face format
+python3 -m maxtext.checkpoint_conversion.to_huggingface \
+    model_name=${MODEL_NAME} \
+    tokenizer_type="huggingface" \
+    load_parameters_path=${CKPT_PATH} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/to_huggingface/${scan_status}/${run_id} \
+    scan_layers=$SCAN_LAYERS

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Converts Qwen3-30B HuggingFace checkpoint to MaxText format and validates logit correctness.
+
+# The flow of this script is as follows:
+# 1. Install PyTorch (CPU) required for checkpoint conversion.
+# 2. Convert the HuggingFace checkpoint to MaxText format in both unscanned and scanned formats.
+# 3. Run a forward pass logits check to verify the converted checkpoint matches the original HF model.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID
+
+set -ex
+
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+MODEL_NAME='qwen3-30b-a3b-base'
+HF_GOLDEN_MODEL='Qwen/Qwen3-30B-A3B-Base'
+
+
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}/to_maxtext
+
+# Step 1: Install torch
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# Step 2: Convert the checkpoint from Hugging Face
+python3 -m maxtext.checkpoint_conversion.to_maxtext \
+    model_name=${MODEL_NAME} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/unscanned/${run_id} \
+    scan_layers=false \
+    hardware=cpu skip_jax_distributed_system=True \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    --lazy_load_tensors=False \
+    --eager_load_method='safetensors'
+
+UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/unscanned/${run_id}/0/items
+echo "Unscanned checkpoint path: ${UNSCANNED_CKPT_PATH}"
+
+# Convert to scanned format
+python3 -m maxtext.checkpoint_conversion.to_maxtext \
+    model_name=${MODEL_NAME} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/scanned/${run_id} \
+    scan_layers=true \
+    hardware=cpu skip_jax_distributed_system=True \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    --lazy_load_tensors=False \
+    --eager_load_method='safetensors'
+
+SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/scanned/${run_id}/0/items
+echo "Scanned checkpoint path: ${SCANNED_CKPT_PATH}"
+
+# Step 3: Run forward pass logits check
+python3 -m tests.utils.forward_pass_logit_checker \
+    load_parameters_path=${UNSCANNED_CKPT_PATH} \
+    model_name=${MODEL_NAME} \
+    scan_layers=false \
+    --hf_model_path=${HF_GOLDEN_MODEL} \
+    --max_kl_div=0.03 \
+    --run_hf_model=true \
+    hardware=cpu skip_jax_distributed_system=True


### PR DESCRIPTION
# Description

End-to-End test scripts for Qwen3-30b model. 


# Tests
Test with `RUN_ID=2026-06-15-22-21-28`

to_mt.sh, to_hf.sh, pre-training and sft training are tested on single host TPU v6e-8 vm. 


```
# Export your Hugging Face token (if not already set)
export HF_TOKEN=<your Hugging Face access token>

# Create a unique run ID for this batch of tests
export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)

# Convert the HF checkpoint to MaxText format
bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh $RUN_ID

# Run the pre-train test
bash tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh $RUN_ID

# Run the SFT test
bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_sft.sh $RUN_ID


# convert MaxText checkpoint back to HF format
bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh $RUN_ID $CHECKPOINT_PATH
```

The RL test ran on the v5p-128 cluster and completed 5 training steps. However, the full script did not finish because GKE terminated the jobset due to high cluster demand. The xpk command is:

```
#!/bin/bash

# This script launches a Reinforcement Learning (RL) training workload for the
# Qwen3-30B-A3B model on a GKE cluster using XPK.

set -ex

# --- Environment Setup ---
if ! pip show xpk &> /dev/null; then
    echo "xpk not found in the environment. Please install it by running:"
    echo "uv pip install -e .[runner] --resolution=lowest"
    exit 1
fi

export RUN_ID=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
export PROJECT_ID="${PROJECT_ID:-cloud-tpu-multipod-dev}" # GCP project ID where the cluster is deployed
export CLUSTER_NAME="${CLUSTER_NAME:-v5p-64-bodaborg-europe-west4-b}" # Name of your cluster
export ZONE="${ZONE:-europe-west4}" # Zone where your cluster is deployed
export BASE_OUTPUT_DIRECTORY="${BASE_OUTPUT_DIRECTORY:-gs://runner-maxtext-logs/qwen3-30b-a3b-base}"
export BASE_DOCKER_IMAGE="${BASE_DOCKER_IMAGE:-gcr.io/tpu-prod-env-multipod/maxtext_post_training_nightly:latest}" 
export MAXTEXT_CKPT_PATH="${MAXTEXT_CKPT_PATH:-${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${RUN_ID}/0/items}"
export TPU_TYPE="v5p-64"
export WORKLOAD_NAME="rl-${RUN_ID}"
export MODEL_NAME="${MODEL_NAME:-qwen3-30b-a3b-base}"
export use_pathways="${use_pathways:-True}"
export run_id="${RUN_ID}"

# XLA Flags
XLA_FLAGS="--xla_tpu_dvfs_p_state=7 \
--xla_tpu_scoped_vmem_limit_kib=65536 \
--xla_tpu_num_sparse_cores_for_gather_offloading=1 \
--xla_tpu_bf16_emission_mode=NATIVE_EMISSION \
--xla_tpu_enable_sparse_core_reduce_scatter_v2=true \
--xla_tpu_enable_sparse_core_collective_offload_all_gather=true \
--xla_tpu_enable_sparse_core_collective_offload_2d_all_gather=true \
--xla_tpu_use_tc_device_shape_on_sc=True \
--xla_sc_disable_megacore_partitioning=True \
--xla_tpu_enable_async_collective_fusion_fuse_all_gather=false \
--xla_enable_async_all_gather=true \
--xla_tpu_prefer_async_allgather_to_allreduce=true \
--xla_tpu_enable_sparse_core_collective_offload_all_reduce=true \
--xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true \
--xla_tpu_enable_sparse_core_collective_offload_3d_all_gather=true \
--xla_tpu_use_single_sparse_core_for_all_gather_offload=true \
--xla_tpu_enable_concurrent_sparse_core_offloading=true \
--xla_tpu_enable_offloading_gather_to_sparsecore=true \
--xla_tpu_sparse_core_all_gather_latency_multiplier=1 \
--xla_tpu_sparse_core_reduce_scatter_latency_multiplier=3 \
--xla_tpu_enable_sparse_core_collective_aggregator=true \
--xla_tpu_enable_latency_hiding_layer_scheduler=true \
--xla_tpu_scheduler_percent_shared_memory_limit=150 \
--xla_tpu_enable_layer_scheduler_for_dependent_collectives=true \
--xla_tpu_enable_sparse_core_collective_offload_nd_reduce_scatter=true \
--xla_tpu_pcie_bandwidth_multiplier=0.03 \
--xla_tpu_enable_sparse_core_offload_queuing_in_lhs=true \
--xla_tpu_enable_multi_compute_overlap_in_layer_scheduler=false \
--xla_tpu_enable_3d_reduce_scatter_decomposer=false"

# Use base64 encoding to prevent any YAML formatting errors with xpk
MAXTEXT_COMMAND_B64=$(cat "$(dirname "$0")/test_qwen3_rl.sh" | base64 -w 0)

# Workload Creation
xpk workload create-pathways \
  --cluster=$CLUSTER_NAME \
  --project=$PROJECT_ID \
  --zone=$ZONE \
  --priority=medium \
  --max-restarts=0 \
  --tpu-type=$TPU_TYPE \
  --num-slices=1 \
  --base-docker-image="${BASE_DOCKER_IMAGE}" \
  --workload="${WORKLOAD_NAME}" \
  --custom-pathways-proxy-server-args='${XLA_FLAGS}' \
  --command="echo ${MAXTEXT_COMMAND_B64} | base64 -d | bash -s -- ${RUN_ID} ${use_pathways}"

```


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
