### PR TITLE
Fix the qwix._src.utils error

### DIFF
--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -38,7 +38,7 @@ from maxtext.layers import nnx_wrappers
 import qwix
 from qwix._src.core import dot_general_qt
 from qwix._src.core import sparsity
-from qwix._src.utils import flax_util
+from qwix._src import flax_util
 import qwix.pallas as qpl
 
 # Params used to define mixed precision quantization configs


### PR DESCRIPTION

# Description
Looks like Qwix moved some source files without bumping up the package version number. So, the flax_util is no longer under _src.utils.


# Tests
Unit test passed.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
