### PR TITLE
Fix explicit-mesh loss sharding assert on the NNX path

### DIFF
--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -221,8 +221,20 @@ def loss_fn(model, config, data, dropout_rng, params, sparsity_state=None, is_tr
       one_hot_targets = jax.nn.one_hot(data["targets"], config.vocab_size)
       xent, z_loss = max_utils.cross_entropy_with_logits(logits, one_hot_targets, z_loss=config.z_loss_multiplier)
 
-      xent = nn.with_logical_constraint(xent, ("activation_embed_and_logits_batch", "activation_length"))
-      z_loss = nn.with_logical_constraint(z_loss, ("activation_embed_and_logits_batch", "activation_length"))
+      xent = sharding.maybe_shard_with_logical(
+          xent,
+          ("activation_embed_and_logits_batch", "activation_length"),
+          model.mesh,
+          config.shard_mode,
+          debug_sharding=config.debug_sharding,
+      )
+      z_loss = sharding.maybe_shard_with_logical(
+          z_loss,
+          ("activation_embed_and_logits_batch", "activation_length"),
+          model.mesh,
+          config.shard_mode,
+          debug_sharding=config.debug_sharding,
+      )
 
       # Mask out paddings at the end of each example.
       xent = xent * (data["targets_segmentation"] != 0)

--- a/tests/unit/train_nnx_test.py
+++ b/tests/unit/train_nnx_test.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 import unittest
 
 from flax import nnx
+import jax
 import jax.numpy as jnp
 from maxtext.common import train_state_nnx
 from maxtext.trainers.pre_train import train as pre_train
@@ -59,6 +60,7 @@ class _Cfg:
   record_internal_nn_metrics: bool = False
   skip_step_on_spikes: bool = False
   shard_mode: int = 0  # ShardMode.AUTO
+  debug_sharding: bool = False
   weight_sparsity_n: int = 0
   weight_sparsity_m: int = 0
 
@@ -73,6 +75,8 @@ class _TinyDecoder(nnx.Module):
   def __init__(self, vocab_size: int, hidden: int, rngs: nnx.Rngs):
     self.embed = nnx.Embed(vocab_size, hidden, rngs=rngs)
     self.proj = nnx.Linear(hidden, vocab_size, rngs=rngs)
+    # loss_fn shards activations against model.mesh, so the stub needs one.
+    self.mesh = jax.make_mesh((1, 1, 1, 1), ("data", "fsdp", "expert", "context"))
 
   def __call__(
       self,


### PR DESCRIPTION
## Problem

Training `deepseek3-671b-batchsplit` (which sets `shard_mode=explicit`) with `pure_nnx=True` crashes at the first `train_step` compile:

```
AssertionError: `with_sharding_constraint` acts as an assert when all axes of
mesh are of type Explicit. The array sharding: P(('data', 'fsdp', 'expert'), None)
did not match the sharding provided: P(('data', 'fsdp', 'expert', 'context'), None).
```

## Root cause

`loss_fn` has two branches. The Linen branch already constrains `xent`/`z_loss` through MaxText's `sharding.maybe_shard_with_logical`, but the NNX branch (taken when `pure_nnx=True`) was still using raw Flax `nn.with_logical_constraint`.

The two resolve the logical axes differently:

- `nn.with_logical_constraint` maps `activation_embed_and_logits_batch` to `('data','fsdp','expert','context')` — it keeps the size-1 `context` axis.
- The rest of the model shards activations via `create_sharding`, which calls `remove_size_one_mesh_axis` and drops `context` (size 1 here), so logits — and therefore `xent` — arrive sharded `('data','fsdp','expert')`.

Under `auto` axes the constraint is just a hint, so the mismatch was harmless. Under `explicit` axes `with_sharding_constraint` becomes a hard assert that the spec matches exactly, so the extra `context` axis trips it.

## Fix

Convert the NNX branch to `sharding.maybe_shard_with_logical`, mirroring the already-fixed Linen branch. That helper builds the sharding via `create_sharding` (so size-1 `context` is dropped, matching the array) and, under an explicit mesh, calls `jax.sharding.reshard` instead of the asserting constraint. With `context` of size 1 the reshard is a no-op — same physical layout, just a matching spec.

Also updates `tests/unit/train_nnx_test.py`: the NNX branch now reads `model.mesh` and `config.debug_sharding`, so the tiny test stub gets a single-device mesh and the config stub gets `debug_sharding`.

## Tests
Before Fix (NNX, failed): https://cloudlogging.app.goo.gl/XF3eVFANEPx43XBG7
After Fix (NNX, passed): https://cloudlogging.app.goo.gl/DRsc4TkhtNm5nV929

Unit: `tests/unit/train_nnx_test.py` passes (7 passed).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
