### PR TITLE
Remove obsolete Tokamax gmm pipeline FSDP workaround

### DIFF
--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -1247,10 +1247,7 @@ class RoutedMoE(nnx.Module):
       return output
 
     def get_tokamax_group_sizes(group_sizes, inputs, kernel):
-      # TODO (b/491979205) pipeline fsdp ag per repeat fails tokamax gmm
-      if self.config.use_qwix_quantization or (
-          self.config.using_pipeline_parallelism and self.config.pipeline_fsdp_ag_per_repeat
-      ):
+      if self.config.use_qwix_quantization:
         return group_sizes
       elif self.config.attention == "vllm_rpa":
         return group_sizes


### PR DESCRIPTION
# Description

Removes the workaround that skipped Tokamax representative group sizes for pipeline parallelism with `pipeline_fsdp_ag_per_repeat=true`.

b/491979205

# Tests

Ran successfully

```bash
python3 -m maxtext.trainers.pre_train.train_compile \
  src/maxtext/configs/base.yml \
  compiled_trainstep_file=/tmp/test_tokamax_gmm_pipeline_ag_per_repeat.pickle \
  compile_topology=v5p-8 \
  compile_topology_num_slices=1 \
  per_device_batch_size=2 \
  ici_pipeline_parallelism=2 \
  ici_expert_parallelism=2 \
  pipeline_parallel_layers=4 \
  num_pipeline_microbatches=4 \
  model_name=deepseek3-test \
  override_model_config=true \
  base_num_decoder_layers=7 \
  sparse_matmul=true \
  megablox=false \
  use_tokamax_gmm=true \
  max_target_length=128 \
  pipeline_fsdp_ag_per_repeat=true \
  pure_nnx_decoder=false
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).