### PR TITLE
NNX: fix sharding

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -319,14 +319,9 @@ def get_maxtext_model_info(config):
   # Get abstract model structure (name, shape) without materializing the weights to save memory
   abstract_params_tree = maxtext_utils.get_abstract_param(maxtext_model_flax, config)["params"]
 
-  abstract_params_flat, _ = jax.tree_util.tree_flatten_with_path(abstract_params_tree)
-  # Standardize abstract tree for later unflattening
-  abstract_params_tree = jax.tree.map(
-      lambda _: 0,
-      abstract_params_tree,
-      is_leaf=lambda x: isinstance(x, nn.LogicallyPartitioned),
+  abstract_params_flat, abstract_params_treedef = jax.tree_util.tree_flatten_with_path(
+      abstract_params_tree, is_leaf=lambda x: isinstance(x, nn.LogicallyPartitioned)
   )
-  abstract_params_treedef = jax.tree_util.tree_structure(abstract_params_tree)
 
   max_logging.log("MaxText abstract model and state initialized.")
 
@@ -334,7 +329,10 @@ def get_maxtext_model_info(config):
   maxtext_abstract_dict = {}
   for mt_target_idx, (path_tuple, abstract_leaf_value) in enumerate(abstract_params_flat):
     mt_param_key = "params-" + "-".join(param_key_parts_from_path(path_tuple))
-    mt_target_shape = abstract_leaf_value.shape
+    if isinstance(abstract_leaf_value, nn.LogicallyPartitioned):
+      mt_target_shape = abstract_leaf_value.value.shape
+    else:
+      mt_target_shape = abstract_leaf_value.shape
     maxtext_abstract_dict[mt_param_key] = (mt_target_idx, mt_target_shape)
 
   return maxtext_abstract_dict, abstract_params_treedef

--- a/src/maxtext/checkpoint_conversion/utils/utils.py
+++ b/src/maxtext/checkpoint_conversion/utils/utils.py
@@ -950,7 +950,7 @@ def extract_nnx_weights(weights_dict: dict) -> dict[str, np.ndarray]:
   for path_tuple, leaf_value in leaves_with_paths:
     path_keys = param_key_parts_from_path(path_tuple)
     # Skip NNX RNG state variables (not model weights)
-    if "to_nnx__rngs" in path_keys or any(k.endswith("_rngs") for k in path_keys):
+    if "to_nnx__rngs" in path_keys or any(k == "rngs" or k.endswith("_rngs") for k in path_keys):
       continue
     maxtext_param_key = "params-" + "-".join(path_keys)
     if not isinstance(leaf_value, (jax.Array, np.ndarray)):

--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 """Create an Orbax CheckpointManager with specified (Async or not) Checkpointer."""
 
 import time
@@ -355,11 +356,16 @@ def _load_full_state_from_path(
         use_ocdbt=use_ocdbt,
         use_zarr3=use_zarr3,
     )
+    # NNX checkpoints are saved as pure dicts (see maybe_save_checkpoint); the
+    # restore target must match — a boxed nnx.State wouldn't.
+    restore_target = abstract_unboxed_pre_state
+    if isinstance(abstract_unboxed_pre_state, nnx.State):
+      restore_target = abstract_unboxed_pre_state.to_pure_dict()
     # Provide sharding info to ensure restoration returns JAX arrays (not NumPy arrays).
     restore_args = jax.tree_util.tree_map(
-        lambda x: ocp.type_handlers.ArrayRestoreArgs(sharding=x.sharding), abstract_unboxed_pre_state
+        lambda x: ocp.type_handlers.ArrayRestoreArgs(sharding=x.sharding), restore_target
     )
-    return ocp.Checkpointer(handler).restore(p, abstract_unboxed_pre_state, restore_args=restore_args)
+    return ocp.Checkpointer(handler).restore(p, restore_target, restore_args=restore_args)
 
 
 def create_orbax_checkpoint_manager(
@@ -838,9 +844,7 @@ def load_state_if_possible(
           (EmergencyCheckpointManager, EmergencyReplicatorCheckpointManager),
       ):
         checkpoint_path = str(checkpoint_manager.directory / str(step) / "items")
-        with handle_checkpoint_mismatch(
-            "restore NNX checkpoint", checkpoint_path
-        ):
+        with handle_checkpoint_mismatch("restore NNX checkpoint", checkpoint_path):
           restored_nnx = _load_linen_checkpoint_into_nnx(
               checkpoint_path,
               abstract_unboxed_pre_state,
@@ -876,9 +880,7 @@ def load_state_if_possible(
                   EmergencyReplicatorCheckpointManager,
               ),
           ):
-            restored = checkpoint_manager.restore(
-                step, args=Composite(state=checkpoint_args)
-            ).state
+            restored = checkpoint_manager.restore(step, args=Composite(state=checkpoint_args)).state
             _assert_no_shaped_dtype_struct(restored)
             return (
                 restored,
@@ -906,9 +908,7 @@ def load_state_if_possible(
           # Case 3: Default/Fallback case.
           # This case acts as a wildcard ('_') and matches if none of the preceding cases were met.
           case _:
-            restored = checkpoint_manager.restore(
-                step, args=Composite(items=checkpoint_args)
-            )
+            restored = checkpoint_manager.restore(step, args=Composite(items=checkpoint_args))
             _assert_no_shaped_dtype_struct(restored)
             return (restored, None)
 
@@ -918,9 +918,7 @@ def load_state_if_possible(
     else:
       params = abstract_unboxed_pre_state.params
 
-    with handle_checkpoint_mismatch(
-        "load parameters", load_parameters_from_path
-    ):
+    with handle_checkpoint_mismatch("load parameters", load_parameters_from_path):
       restored_params = load_params_from_path(
           load_parameters_from_path,
           params,
@@ -932,9 +930,7 @@ def load_state_if_possible(
     return None, restored_params
   elif load_full_state_from_path != "":
     max_logging.log(f"Loading full state from path: {load_full_state_from_path}")
-    with handle_checkpoint_mismatch(
-        "load full state", load_full_state_from_path
-    ):
+    with handle_checkpoint_mismatch("load full state", load_full_state_from_path):
       restored_state = _load_full_state_from_path(
           path=load_full_state_from_path,
           abstract_unboxed_pre_state=abstract_unboxed_pre_state,
@@ -1034,7 +1030,8 @@ def maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator, step
     actual_step = int(step)
   else:
     if config.pure_nnx:
-      actual_step = int(state.optimizer.step) - 1
+      # Under DiLoCo the step lives on the DiLoCoTrainState; otherwise on the optimizer.
+      actual_step = int(state.step if config.enable_diloco else state.optimizer.step) - 1
     else:
       # Linen TrainState has .step attribute
       actual_step = int(state.step) - 1
@@ -1045,7 +1042,13 @@ def maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator, step
 
   if config.pure_nnx:
     # Save in the Linen on-disk layout so pure_nnx and Linen checkpoints are interchangeable.
-    state = train_state_nnx.to_linen_checkpoint_dict(state.to_pure_dict())
+    if config.enable_diloco:
+      # DiLoCoTrainState: persist the synchronized global model (outer params).
+      # The per-replica inner optimizer / outer-momentum state is not checkpointed.
+      step_value = state.step.get_value() if hasattr(state.step, "get_value") else state.step
+      state = train_state_nnx.to_linen_checkpoint_dict({"model": state.params, "optimizer": {"step": step_value}})
+    else:
+      state = train_state_nnx.to_linen_checkpoint_dict(state.to_pure_dict())
 
   # Determine if a checkpoint save should be forced, overriding the usual `config.checkpoint_period` logic.
   # This occurs if this function was called:

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1188,9 +1188,9 @@ position_id_per_seconds: 25
 subslice_shape: ""
 
 # NNX
-enable_nnx: false
-pure_nnx_decoder: false
-pure_nnx: false
+enable_nnx: true
+pure_nnx_decoder: true
+pure_nnx: true
 
 ################################## Qwen3-Next Specific Configs ##################################
 # Kernel size for the 1D convolution in the Gated Delta Net

--- a/src/maxtext/layers/nnx_wrappers.py
+++ b/src/maxtext/layers/nnx_wrappers.py
@@ -26,7 +26,6 @@ from flax import nnx
 from flax.core import FrozenDict
 from flax.core import meta
 from flax.nnx import graph
-from flax.nnx import tracers as nnx_tracers
 from flax.nnx import variablelib
 from flax.nnx.bridge import module as bdg_module
 from flax.nnx.module import Module
@@ -178,19 +177,6 @@ def is_linen_initializing() -> bool:
   if module is not None and hasattr(module, "is_initializing") and callable(module.is_initializing):
     return module.is_initializing()
   return False
-
-
-def _refresh_variable_trace_state(module: Module) -> None:
-  """Resets stale ``_trace_state`` on Variables to unblock downstream ``nnx.split``.
-
-  ``nnx.update`` called with JAX tracer values uses ``_unsafe_bypass_check=True``,
-  which leaves Variables with a stale ``_trace_state`` from the outer Python
-  context and breaks ``nnx.split`` with "Cannot extract graph node from different
-  trace level". Resets ``_trace_state`` on any Variable whose ``_can_update`` is False.
-  """
-  for _, v in nnx.graph.iter_graph(module):
-    if isinstance(v, variablelib.Variable) and not v._can_update:  # pylint: disable=protected-access
-      object.__setattr__(v, "_trace_state", nnx_tracers.TraceState())
 
 
 class ToNNX(Module):
@@ -539,9 +525,17 @@ class ToLinen(linen.Module):
           f"Found unknown module paths in incoming state:{paths_str}. Intermediate modules have been reconstructed."
       )
 
+      # Filter out unknown paths so we don't try to assign them to static attributes
+      filtered_state_flat = {k: v for k, v in new_state_flat.items() if k not in unknown_state_flat}
+      new_state = nnx.State(nnx.traversals.unflatten_mapping(filtered_state_flat))
+
+    # Rebind the module to the current trace via split / update / merge.
+    # nnx.update directly on the live module can leave stale tracers.
+    graphdef, full_state = nnx.split(module)
+    nnx.update(full_state, new_state)
+    module = nnx.merge(graphdef, full_state)
+
     _fix_for_qwix_quantization(module)
-    nnx.update(module, new_state)
-    _refresh_variable_trace_state(module)
     method_fn = _get_module_method(module, nnx_method)
     out = method_fn(module, *args, **kwargs)
     self._update_variables(module)

--- a/src/maxtext/trainers/diloco/diloco.py
+++ b/src/maxtext/trainers/diloco/diloco.py
@@ -28,13 +28,13 @@ from typing import Any, Callable
 import drjax
 from flax import nnx
 from flax import struct
-from flax.training import train_state
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Int32, Key, PyTree, UInt32
 import optax
 
 from maxtext.configs import pyconfig
+from maxtext.common.train_state_nnx import TrainStateNNX
 
 Batch = Any
 Params = PyTree
@@ -157,8 +157,10 @@ def build_abstract_diloco_state(
   # For NNX, model params (Param variables only) live under abstract_state.model;
   # for Linen under abstract_state.params.
   if config.pure_nnx:
-    model_params = abstract_state.model.filter(nnx.Param)
-    model_params_sharding = state_mesh_shardings.model.filter(nnx.Param)
+    _, model_params, _ = nnx.split(abstract_state.model, nnx.Param, ...)
+    model_params = model_params.to_pure_dict()
+    _, model_params_sharding, _ = nnx.split(state_mesh_shardings.model, nnx.Param, ...)
+    model_params_sharding = model_params_sharding.to_pure_dict()
   else:
     model_params = abstract_state.params
     model_params_sharding = state_mesh_shardings.params
@@ -216,7 +218,11 @@ def build_diloco_state(
     # Outer state retains a single copy of the model parameters and optimizer state.
     # For NNX, model params (Param variables only) live under state.model;
     # for Linen under state.params.
-    outer_params = state.model.filter(nnx.Param) if config.pure_nnx else state.params
+    if config.pure_nnx:
+      _, outer_params, _ = nnx.split(state.model, nnx.Param, ...)
+      outer_params = outer_params.to_pure_dict()
+    else:
+      outer_params = state.params
     outer_opt_state = outer_optimizer.init(outer_params)
     outer_opt_state_sharding = jax.tree_util.tree_map(lambda x: x.sharding, outer_opt_state)
     # For NNX, the step counter lives at state.optimizer.step; for Linen at state.step.
@@ -258,9 +264,11 @@ def build_diloco_train_step(
     # state (since last synchronization).
     broadcast_outer_params = drjax.broadcast(state.params, mesh=mesh)
     # For NNX, model Param vars live under inner_state.model; for Linen under inner_state.params.
-    inner_model_params = (
-        nnx.filter_state(state.inner_state.model, nnx.Param) if config.pure_nnx else state.inner_state.params
-    )
+    if config.pure_nnx:
+      _, inner_model_params, _ = nnx.split(state.inner_state.model, nnx.Param, ...)
+      inner_model_params = inner_model_params.to_pure_dict()
+    else:
+      inner_model_params = state.inner_state.params
     model_delta = jax.tree.map(lambda x, y: y - x, inner_model_params, broadcast_outer_params)
     # Treat the average delta as the outer optimizer's gradient and apply to
     # the global (outer) model params.
@@ -273,15 +281,34 @@ def build_diloco_train_step(
     if config.pure_nnx:
       # For NNX: merge new Param vars back with the non-Param model vars (e.g. RNG state).
       def replace_nnx_model_params(s, new_params):
-        non_param_model = nnx.filter_state(s.model, nnx.Not(nnx.Param))
-        new_model = nnx.merge_state(non_param_model, new_params)
-        # Assign via __setitem__ so nested States are stored as plain dicts (matching
-        # nnx.state()'s pytree structure). The dict-literal constructor keeps them as
-        # State objects, which makes jax.lax.cond see mismatched pytree structures.
-        result = type(s)({})
-        result["model"] = new_model
-        result["optimizer"] = s["optimizer"]
-        return result
+        s_model = s["model"] if hasattr(s, "keys") else s.model
+        s_opt = s["optimizer"] if hasattr(s, "keys") else s.optimizer
+
+        graphdef, _, non_param_state = nnx.split(s_model, nnx.Param, ...)
+        new_model = nnx.merge(graphdef, new_params, non_param_state)
+
+        if type(s_model).__name__ == "State":
+          new_model = nnx.state(new_model)
+        elif isinstance(s_model, dict):
+          new_model = nnx.to_pure_dict(new_model)
+
+        if hasattr(s, "keys"):
+          # Replace "model" leaves by path, keeping s's treedef. Picking by position
+          # (leaves[N:]) breaks if a key sorts before "model"; reconstructing via
+          # type(s)({...}) breaks the lax.cond match — nnx.State recursive-wraps.
+          leaves_with_paths, treedef = jax.tree_util.tree_flatten_with_path(s)
+          new_model_iter = iter(jax.tree_util.tree_leaves(new_model))
+
+          def _is_model_leaf(path):
+            if not path:
+              return False
+            k = path[0]
+            return getattr(k, "key", None) == "model" or getattr(k, "name", None) == "model"
+
+          new_leaves = [next(new_model_iter) if _is_model_leaf(p) else leaf for p, leaf in leaves_with_paths]
+          return jax.tree_util.tree_unflatten(treedef, new_leaves)
+        else:
+          return TrainStateNNX(new_model, s_opt)
 
       new_inner_state = drjax.map_fn(
           lambda s: replace_nnx_model_params(s, new_outer_params),

--- a/src/maxtext/trainers/post_train/sft/train_sft_native.py
+++ b/src/maxtext/trainers/post_train/sft/train_sft_native.py
@@ -25,6 +25,7 @@ import numpy as np
 import tensorflow as tf
 import jax
 
+from flax import nnx
 from flax.linen import partitioning as nn_partitioning
 
 from maxtext.configs import pyconfig
@@ -75,14 +76,25 @@ def train_loop(config, recorder, state=None):
 
   params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
 
+  # NNX jits over the GraphDef + a flat nnx.State, so split the TrainStateNNX
+  # here (mirrors trainers/pre_train/train.py). Linen jits over the module.
+  if config.pure_nnx:
+    jit_model, state = nnx.split(state)
+  else:
+    jit_model = model
+
   p_train_step, p_eval_step = train_utils.jit_train_and_eval_step(
-      config, model, mesh, state, state_mesh_shardings, train_step, eval_step, eval_data_iterator, params_shardings
+      config, jit_model, mesh, state, state_mesh_shardings, train_step, eval_step, eval_data_iterator, params_shardings
   )
+
+  # Only the Linen step takes a dropout rng; pass it only there so the args
+  # match the jitted in_shardings (see get_functional_train_with_signature).
+  rng_args = () if config.pure_nnx else (init_rng,)
 
   with jax.set_mesh(mesh), nn_partitioning.axis_rules(config.logical_axis_rules):
     data_sharding = sharding.get_input_data_sharding(config, mesh)
     shaped_batch = maxtext_utils.get_shaped_batch(config, batch_sharding=data_sharding)
-    compiled = p_train_step.lower(state, shaped_batch, init_rng).compile()
+    compiled = p_train_step.lower(state, shaped_batch, *rng_args).compile()
     compiled_stats = compiled.memory_analysis()
     max_utils.print_compiled_memory_stats(compiled_stats)
 
@@ -92,7 +104,11 @@ def train_loop(config, recorder, state=None):
   metric_logger = MetricLogger(config=config, learning_rate_schedule=learning_rate_schedule)
 
   # Write train config params, num model params, and XLA flags to tensorboard
-  metric_logger.write_setup_info_to_tensorboard(state.params)
+  if config.pure_nnx:
+    _, setup_params, _ = nnx.split(state.model, nnx.Param, ...)
+  else:
+    setup_params = state.params
+  metric_logger.write_setup_info_to_tensorboard(setup_params)
 
   _job_completed_gracefully = False
   try:
@@ -104,9 +120,10 @@ def train_loop(config, recorder, state=None):
         example_batch = data_loader.load_next_batch()
         # pylint: disable=not-callable
         nextrng = jax.jit(jax.random.fold_in)(init_rng, step)
+        step_rng_args = () if config.pure_nnx else (nextrng,)
         with maybe_record_goodput(recorder, GoodputEvent.STEP, step):
           with jax.set_mesh(mesh), nn_partitioning.axis_rules(config.logical_axis_rules):
-            state, metrics = p_train_step(state, example_batch, nextrng)
+            state, metrics = p_train_step(state, example_batch, *step_rng_args)
 
       step_time_delta = datetime.datetime.now() - last_step_completion
 
@@ -135,7 +152,7 @@ def train_loop(config, recorder, state=None):
           if config.eval_steps > 0 and eval_step_count >= config.eval_steps:
             break
           with jax.set_mesh(mesh), nn_partitioning.axis_rules(config.logical_axis_rules):
-            eval_metrics = p_eval_step(state, eval_batch, nextrng)
+            eval_metrics = p_eval_step(state, eval_batch, *step_rng_args)
           eval_step_time_delta = datetime.datetime.now() - last_eval_step_completion
           last_eval_step_completion = datetime.datetime.now()
           metric_logger.buffer_and_write_metrics(

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -78,6 +78,8 @@ VertexTensorboardManager, _vertex_tb_is_stub = vertex_tensorboard_modules()
 def get_first_step(model, state):
   if isinstance(model, nn.Module):
     return int(state.step)
+  if hasattr(state, "inner_state"):  # DiLoCoTrainState (NNX DiLoCo): step is the optimizer step var
+    return int(state.step.get_value())
   return int(state.optimizer.step.get_value())
 
 
@@ -612,10 +614,18 @@ def train_loop(config, recorder, state=None):
 
   if isinstance(model, nn.Module):
     jit_model = model
+  elif config.enable_diloco:
+    # state is the DiLoCoTrainState; `model` is already the TrainStateNNX graphdef the inner step needs.
+    jit_model = model
   else:
     jit_model, state = nnx.split(state)
 
-  params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
+  if config.pure_nnx and config.enable_diloco:
+    # DiLoCoTrainState.params already holds the param shardings the inner step needs;
+    # the Zero-1 opt overlay doesn't apply through the diloco wrapper.
+    params_shardings = state_mesh_shardings.params
+  else:
+    params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
 
   p_train_step, p_eval_step = train_utils.jit_train_and_eval_step(
       config,
@@ -637,7 +647,8 @@ def train_loop(config, recorder, state=None):
     elif config.shard_optimizer_over_data:
       # NNX: reshard state so params match the data-sharded in_shardings (Zero-1 layout)
       state = jax.device_put(state, state_mesh_shardings)
-    if isinstance(model, nn.Module):
+    if isinstance(model, nn.Module) or config.enable_diloco:
+      # The DiLoCo train step takes (state, batch, rng), like the Linen step.
       lower_args = (state, shaped_batch, init_rng)
     else:
       lower_args = (state, shaped_batch)
@@ -653,6 +664,8 @@ def train_loop(config, recorder, state=None):
   # Write train config params, num model params, and XLA flags to tensorboard
   if isinstance(model, nn.Module):
     setup_params = state.params
+  elif config.enable_diloco:
+    setup_params = state.params  # DiLoCoTrainState.params: the outer (global) params
   else:
     _, setup_params, _ = nnx.split(state.model, nnx.Param, ...)
   metric_logger_instance.write_setup_info_to_tensorboard(setup_params)
@@ -667,7 +680,7 @@ def train_loop(config, recorder, state=None):
 
       with jax.profiler.StepTraceAnnotation("train", step_num=step):
         example_batch = data_loader.load_next_batch(rampup_manager=rampup_manager)
-        if isinstance(model, nn.Module):
+        if isinstance(model, nn.Module) or config.enable_diloco:
           # pylint: disable=not-callable
           step_rng_args = (jax.jit(jax.random.fold_in)(init_rng, step),)
         else:

--- a/src/maxtext/trainers/pre_train/train_compile.py
+++ b/src/maxtext/trainers/pre_train/train_compile.py
@@ -261,12 +261,9 @@ def is_oom(argv: Sequence[str]) -> bool:
   # Update params_shardings when shard_optimizer_over_data is enabled (Zero-1)
   params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
 
-  # When ZeRO-1 is enabled, we need to use the original params_shardings for input shardings
-  # but keep the updated state_mesh_shardings for the optimizer state
-  if config.shard_optimizer_over_data:
-    input_state_mesh_shardings = state_mesh_shardings.replace(params=params_shardings)
-  else:
-    input_state_mesh_shardings = state_mesh_shardings
+  input_state_mesh_shardings = sharding.build_zero1_input_state_mesh_shardings(
+      config, state_mesh_shardings, params_shardings
+  )
 
   # Get data sharding
   data_sharding = sharding.get_input_data_sharding(config, topology_mesh)
@@ -343,12 +340,9 @@ def main(argv: Sequence[str]) -> None:
   # Update params_shardings when shard_optimizer_over_data is enabled (Zero-1)
   params_shardings, state_mesh_shardings = sharding.maybe_update_params_sharding_with_opt(config, state_mesh_shardings)
 
-  # When ZeRO-1 is enabled, we need to use the original params_shardings for input shardings
-  # but keep the updated state_mesh_shardings for the optimizer state
-  if config.shard_optimizer_over_data:
-    input_state_mesh_shardings = state_mesh_shardings.replace(params=params_shardings)
-  else:
-    input_state_mesh_shardings = state_mesh_shardings
+  input_state_mesh_shardings = sharding.build_zero1_input_state_mesh_shardings(
+      config, state_mesh_shardings, params_shardings
+  )
 
   # Get data sharding
   data_sharding = sharding.get_input_data_sharding(config, topology_mesh)

--- a/src/maxtext/utils/generate_param_only_checkpoint.py
+++ b/src/maxtext/utils/generate_param_only_checkpoint.py
@@ -244,8 +244,20 @@ def _save_decode_checkpoint_nnx(config, state, checkpoint_manager):
   wrapper. This is the shape `from_pretrained` reads via its NNX-detection
   branch (see model_creation_utils._adjust_target_for_moe_fusion / "is_nnx_checkpoint").
   """
-  pure_model = state.model.to_pure_dict() if hasattr(state.model, "to_pure_dict") else dict(state.model)
+  # A decode checkpoint is params-only. state.model also holds rng state
+  # (PRNGKeyArray), which can't be cast to bf16, so keep only the nnx.Param leaves.
+  _, param_state, _ = nnx.split(state.model, nnx.Param, ...)
+  pure_model = param_state.to_pure_dict()
   bf16_model = jax.tree_util.tree_map(lambda x: x.astype(jnp.bfloat16), pure_model)
+
+  # Wrap each leaf as {"value": <array>} to match the shape from_pretrained reads
+  # back for NNX checkpoints. Same as layerwise_quantization._load_and_quantize_nnx.
+  def _wrap_value(node):
+    if isinstance(node, dict):
+      return {k: _wrap_value(v) for k, v in node.items()}
+    return {"value": node}
+
+  bf16_model = _wrap_value(bf16_model)
   if checkpoint_manager is not None:
     if checkpointing.save_checkpoint(checkpoint_manager, 0, bf16_model):
       max_logging.log(f"saved an NNX decode checkpoint at {config.checkpoint_dir}")
@@ -386,7 +398,11 @@ def generate_decode_checkpoint(config):
   # Read training state from config.load_paramaters_path
   max_logging.log(f"Read training checkpoint from: {config.load_full_state_path}")
   training_state, training_state_annotations = _read_train_checkpoint(config, checkpoint_manager, mesh)
-  assert training_state.opt_state != {}, "missing opt_state in training checkpoint"
+  if config.pure_nnx:
+    # NNX state is a flat nnx.State; opt_state lives under the optimizer sub-state.
+    assert training_state.optimizer.opt_state, "missing opt_state in training checkpoint"
+  else:
+    assert training_state.opt_state != {}, "missing opt_state in training checkpoint"
 
   _possibly_unroll_params(config, training_state, training_state_annotations, mesh)
 

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -20,7 +20,7 @@ import os
 from typing import Sequence
 
 from flax import nnx, linen as nn
-from flax.core.spmd import composite_rules, from_sharding_rules, get_logical_axis_rules
+from flax.core.spmd import get_logical_axis_rules
 from flax.linen import partitioning as nn_partitioning
 from flax.training.train_state import TrainState
 
@@ -1612,6 +1612,43 @@ def get_abstract_state(config, mesh, init_state_fn, is_training=True):
   )
 
 
+def _resolve_logical_sharding(out_sharding, context_rules, local_rules) -> list:
+  """Resolves logical sharding annotations into physical sharding specs.
+
+  This matches rules sequentially (first-match-wins) and ensures that physical
+  mesh axes are bound to at most one dimension per tensor, preventing JAX
+  DuplicateSpecError.
+  """
+  local_rules_list = list(local_rules) if local_rules is not None else []
+  context_rules_list = list(context_rules) if context_rules is not None else []
+  merged_rules = local_rules_list + context_rules_list
+  raw_sharding = list(out_sharding)
+  assigned_positions = set()
+  assigned_axes = set()
+
+  for rule_logical, rule_physical in merged_rules:
+    if rule_logical not in out_sharding:
+      continue
+    pos = out_sharding.index(rule_logical)
+    if pos in assigned_positions:
+      continue
+
+    if rule_physical is None:
+      raw_sharding[pos] = None
+      assigned_positions.add(pos)
+      continue
+
+    physical_axes = [rule_physical] if isinstance(rule_physical, str) else list(rule_physical)
+    if any(axis in assigned_axes for axis in physical_axes):
+      continue
+
+    raw_sharding[pos] = rule_physical
+    assigned_positions.add(pos)
+    assigned_axes.update(physical_axes)
+
+  return raw_sharding
+
+
 def get_nnx_named_sharding_with_scan_axis(abs_var_state: nnx.State, mesh) -> nnx.State:
   """Compute NamedSharding for each NNX variable, correctly handling the scan (stacked layers) axis.
 
@@ -1669,20 +1706,22 @@ def get_nnx_named_sharding_with_scan_axis(abs_var_state: nnx.State, mesh) -> nnx
       context_rules = get_logical_axis_rules()
       local_rules = metadata.get("sharding_rules", ())
       if context_rules or local_rules:
-        rules = composite_rules(context_rules, local_rules)
-        raw_sharding = from_sharding_rules(out_sharding, rules)
+        raw_sharding = _resolve_logical_sharding(out_sharding, context_rules, local_rules)
         mesh_axis_names = mesh.axis_names if mesh is not None else ()
 
-        # from_sharding_rules leaves a logical name with no matching rule unchanged, so a
-        # name missing from logical_axis_rules (e.g. concat_embed on the MTP kernel)
-        # reaches NamedSharding and is rejected as an unknown mesh axis. Map any such
-        # leftover name to None (replicated), matching Linen, whose logical_to_mesh_axes
-        # replicates unmatched names.
+        # Map unmatched logical names to None (replicated), matching Linen's behavior.
+        # Also clean up tuples to only keep physical axes present in the active mesh.
         def _sanitize(x):
           if isinstance(x, list):
             x = tuple(x)
-          if x is None or (isinstance(x, str) and x in mesh_axis_names) or isinstance(x, tuple):
-            return x
+          if x is None:
+            return None
+          if isinstance(x, str):
+            return x if x in mesh_axis_names else None
+          if isinstance(x, tuple):
+            # Only keep axes that actually exist in the physical mesh.
+            sanitized_tuple = tuple(i for i in x if i in mesh_axis_names)
+            return sanitized_tuple if sanitized_tuple else None
           return None
 
         sanitized_sharding = [_sanitize(x) for x in raw_sharding]

--- a/src/maxtext/utils/muon_utils.py
+++ b/src/maxtext/utils/muon_utils.py
@@ -114,9 +114,12 @@ def get_muon_weight_dimension_numbers(model, config, verbose=False):
       path_strings = tuple(p.key for p in path if isinstance(p, jax.tree_util.DictKey))
       return transform_logic(path_strings)
 
-    # tree_map_with_path handles NNX's nested State (vs the Linen dict tree of
-    # nn.LogicallyPartitioned leaves). The result is an nnx.State whose Param values hold the mdn result.
-    muon_weight_dimension_numbers = jax.tree_util.tree_map_with_path(apply_transform_nnx, abstract_param)
+    # NNX abstract_param is an nnx.State (not Linen's dict of LogicallyPartitioned leaves);
+    # tree_map_with_path round-trips that structure so each Param.value holds the mdn result.
+    muon_weight_dimension_numbers = jax.tree_util.tree_map_with_path(
+        apply_transform_nnx, nnx.to_pure_dict(abstract_param)
+    )
+    muon_weight_dimension_numbers = nnx.State(muon_weight_dimension_numbers)
 
   else:  # Linen
     # quickly get param structure without materialization

--- a/src/maxtext/utils/qk_clip_utils.py
+++ b/src/maxtext/utils/qk_clip_utils.py
@@ -83,13 +83,14 @@ def _max_logits_at(curr):
 
 
 def _scale_from_max_logits(max_logits_batch, tau):
-  s_max = jnp.max(max_logits_batch, axis=0)
+  axes = tuple(range(max_logits_batch.ndim - 1))
+  s_max = jnp.max(max_logits_batch, axis=axes)
   return jnp.minimum(1.0, tau / (s_max + 1e-6))
 
 
 def _clip_mla_weight(layer_name, param, scale, qk_nope):
   """Apply the per-head scale to a wq_b or wkv_b kernel."""
-  scale_b = scale[None, :, None]  # broadcasts over [rank, heads, dim]
+  scale_b = jnp.expand_dims(scale, axis=-1)  # broadcasts over [..., rank, heads, dim]
   head = param[..., :qk_nope]
   tail = param[..., qk_nope:]
   head_new = head * jnp.sqrt(scale_b)

--- a/src/maxtext/utils/sharding.py
+++ b/src/maxtext/utils/sharding.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # pylint: disable=line-too-long, disable=bare-except, consider-using-generator
-""" Utils that are only interesting to MaxText and sharding related. """
+"""Utils that are only interesting to MaxText and sharding related."""
 
 from flax import linen as nn, nnx
 
@@ -618,6 +618,33 @@ def maybe_update_params_sharding_with_opt_nnx(
   updated_state.model = new_model_shardings
 
   return prev_params_shardings, updated_state
+
+
+def build_zero1_input_state_mesh_shardings(config, state_mesh_shardings, params_shardings):
+  """Build the train-step input shardings under shard_optimizer_over_data (Zero-1).
+
+  Model params on input use the original pre-Zero-1 sharding (params_shardings), while the rest
+  of the state — including the optimizer state — keeps the Zero-1 layout from state_mesh_shardings,
+  so the optimizer state input matches its output. When shard_optimizer_over_data is False,
+  state_mesh_shardings passes through unchanged.
+  """
+  if not config.shard_optimizer_over_data:
+    return state_mesh_shardings
+  if not config.pure_nnx:
+    return state_mesh_shardings.replace(params=params_shardings)
+  # nnx.State has no .replace: shallow-copy via tree_map (preserves nested container
+  # types) and overlay params_shardings under input_state.model.
+  input_state = jax.tree_util.tree_map(lambda x: x, state_mesh_shardings, is_leaf=lambda x: isinstance(x, nnx.Variable))
+
+  def _overlay(model_node, params_node):
+    for k, pv in params_node.items():
+      if isinstance(pv, nnx.Variable):
+        model_node[k] = pv
+      elif hasattr(pv, "items"):
+        _overlay(model_node[k], pv)
+
+  _overlay(input_state.model, params_shardings)
+  return input_state
 
 
 def logical_axis_rules_pp_act_as_dp(logical_rules):

--- a/src/maxtext/utils/train_utils.py
+++ b/src/maxtext/utils/train_utils.py
@@ -295,12 +295,15 @@ def setup_train_loop(config, recorder, devices=None):
         state, outer_opt_state_sharding = diloco.build_diloco_state(config, lambda: state, mesh=mesh)
 
         # create state_mesh_shardings for the DilocoState
+        step_mesh = state_mesh_shardings.optimizer.step.mesh if config.pure_nnx else state_mesh_shardings.step.mesh
         inner_state_shardings = diloco.add_diloco_to_sharding(state_mesh_shardings)
         state_mesh_shardings = diloco.DiLoCoTrainState(
             inner_state_shardings,
-            state_mesh_shardings.params,
+            # Match the outer params' pure-dict structure (build_diloco_state stores
+            # outer_params via to_pure_dict), so the sharding tree matches the state tree.
+            state_mesh_shardings_params.to_pure_dict() if config.pure_nnx else state_mesh_shardings_params,
             outer_opt_state_sharding,
-            jax.sharding.NamedSharding(mesh=state_mesh_shardings.step.mesh, spec=jax.sharding.PartitionSpec()),
+            jax.sharding.NamedSharding(mesh=step_mesh, spec=jax.sharding.PartitionSpec()),
         )
 
     # TODO(aireenmei, hengtaoguo): support sharding in vit for multimodal
@@ -322,8 +325,14 @@ def setup_train_loop(config, recorder, devices=None):
       maxtext_utils.print_shardings_params(state_params, state_mesh_shardings_params, mesh, logical_annotations_params)
 
   if config.pure_nnx:
-    train_state = nnx.merge(state_graphdef, state)
-    model = train_state.model
+    if config.enable_diloco:
+      # Don't merge the DiLoCoTrainState into the plain-model graphdef. The inner
+      # train step needs that graphdef as jit_model; the wrapper passes through as state.
+      train_state = state
+      model = state_graphdef
+    else:
+      train_state = nnx.merge(state_graphdef, state)
+      model = train_state.model
   else:
     train_state = state
 

--- a/tests/integration/diloco_test.py
+++ b/tests/integration/diloco_test.py
@@ -30,6 +30,7 @@ import optax
 import pytest
 
 from maxtext.configs.pyconfig import initialize_pydantic
+from maxtext.common.train_state_nnx import TrainStateNNX
 from maxtext.trainers.pre_train.train_compile import main as train_compile_main
 from maxtext.trainers.diloco import diloco
 from tests.utils.test_helpers import get_test_config_path
@@ -85,37 +86,69 @@ class DiLoCoTest(unittest.TestCase):
       model = SimpleNNXModel(rngs=rngs)
       graphdef, params = nnx.split(model)
 
-      def nnx_apply_fn(params, inputs):
-        model_replica = nnx.merge(graphdef, params)
-        return model_replica(inputs)
+      if test_config.pure_nnx:
+        optimizer = nnx.Optimizer(model, tx, wrt=nnx.Param)
+        # diloco_test_state expects a TrainStateNNX instance when pure_nnx is True.
+        initial_test_state = TrainStateNNX(model, optimizer)
 
-      # 2. Vmap this new wrapper function
-      vmapped_apply = jax.vmap(nnx_apply_fn, in_axes=(None, 0))
+        # For NNX, train_step needs to take the TrainStateNNX and mutate it
 
-      def _test_train_step(state: train_state.TrainState, batch, prng_key: diloco.PRNGKey):
-        """A simple MSE loss train step to enable numerics testing."""
-        del prng_key
+        def _test_train_step(state, batch, prng_key: diloco.PRNGKey):
+          del prng_key
 
-        def loss_fn(params, batch):
-          inputs, labels = batch
-          logits = vmapped_apply(params, inputs)
-          residual = logits - labels
-          sq_residual = jnp.square(residual)
-          msq_residual = jnp.mean(sq_residual)
-          return msq_residual
+          def loss_fn(model, batch):
+            inputs, labels = batch
+            logits = jax.vmap(model)(inputs)
+            residual = logits - labels
+            return jnp.mean(jnp.square(residual))
 
-        loss, grad = jax.value_and_grad(loss_fn)(state.params, batch)
-        return state.apply_gradients(grads=grad), loss
+          loss, grads = nnx.value_and_grad(loss_fn)(state.model, batch)
+          state.optimizer.update(state.model, grads)
+          return state, loss
 
-      initial_test_state = train_state.TrainState.create(
-          apply_fn=vmapped_apply,
-          params=params,
-          tx=tx,
-      )
+      else:
+
+        def nnx_apply_fn(params, inputs):
+          model_replica = nnx.merge(graphdef, params)
+          return model_replica(inputs)
+
+        # 2. Vmap this new wrapper function
+        vmapped_apply = jax.vmap(nnx_apply_fn, in_axes=(None, 0))
+
+        def _test_train_step(state: train_state.TrainState, batch, prng_key: diloco.PRNGKey):
+          """A simple MSE loss train step to enable numerics testing."""
+          del prng_key
+
+          def loss_fn(params, batch):
+            inputs, labels = batch
+            logits = vmapped_apply(params, inputs)
+            residual = logits - labels
+            sq_residual = jnp.square(residual)
+            msq_residual = jnp.mean(sq_residual)
+            return msq_residual
+
+          loss, grad = jax.value_and_grad(loss_fn)(state.params, batch)
+          return state.apply_gradients(grads=grad), loss
+
+        initial_test_state = train_state.TrainState.create(
+            apply_fn=vmapped_apply,
+            params=params,
+            tx=tx,
+        )
 
       diloco_test_state, _ = diloco.build_diloco_state(test_config, lambda: initial_test_state)
       chex.assert_equal(diloco_test_state.step, 0)
-      chex.assert_trees_all_equal(diloco_test_state.params, initial_test_state.params)
+      if test_config.pure_nnx:
+        _, params_pure, _ = nnx.split(initial_test_state.model, nnx.Param, ...)
+
+        # diloco_test_state.params might contain nnx.Variables instead of pure arrays.
+        # We need to unwrap them if they do.
+        diloco_params_pure = jax.tree_util.tree_map(
+            lambda x: x.value if hasattr(x, "value") else x, diloco_test_state.params
+        )
+        chex.assert_trees_all_equal(diloco_params_pure, params_pure.to_pure_dict())
+      else:
+        chex.assert_trees_all_equal(diloco_test_state.params, initial_test_state.params)
 
       diloco_train_step = diloco.build_diloco_train_step(test_config, _test_train_step)
       inputs = jnp.array(
@@ -163,7 +196,17 @@ class DiLoCoTest(unittest.TestCase):
       chex.assert_equal(diloco_test_state.step, 1.0)
       chex.assert_equal(loss, 1.0)
       # Assert no updates to the global model yet (no synchronization)
-      chex.assert_trees_all_equal(diloco_test_state.params, initial_test_state.params)
+      if test_config.pure_nnx:
+        _, params_pure, _ = nnx.split(initial_test_state.model, nnx.Param, ...)
+
+        # diloco_test_state.params might contain nnx.Variables instead of pure arrays.
+        # We need to unwrap them if they do.
+        diloco_params_pure = jax.tree_util.tree_map(
+            lambda x: x.value if hasattr(x, "value") else x, diloco_test_state.params
+        )
+        chex.assert_trees_all_equal(diloco_params_pure, params_pure.to_pure_dict())
+      else:
+        chex.assert_trees_all_equal(diloco_test_state.params, initial_test_state.params)
 
       # Run the second step (no synchronization).
       # Replica 0:
@@ -193,7 +236,17 @@ class DiLoCoTest(unittest.TestCase):
       chex.assert_equal(diloco_test_state.step, 2.0)
       chex.assert_trees_all_close(loss, 0.65)
       # Assert no updates to the global model yet (no synchronization)
-      chex.assert_trees_all_equal(diloco_test_state.params, initial_test_state.params)
+      if test_config.pure_nnx:
+        _, params_pure, _ = nnx.split(initial_test_state.model, nnx.Param, ...)
+
+        # diloco_test_state.params might contain nnx.Variables instead of pure arrays.
+        # We need to unwrap them if they do.
+        diloco_params_pure = jax.tree_util.tree_map(
+            lambda x: x.value if hasattr(x, "value") else x, diloco_test_state.params
+        )
+        chex.assert_trees_all_equal(diloco_params_pure, params_pure.to_pure_dict())
+      else:
+        chex.assert_trees_all_equal(diloco_test_state.params, initial_test_state.params)
 
       # Run the third step, which synchronizes afterwards.
       # Replica 0:
@@ -228,14 +281,31 @@ class DiLoCoTest(unittest.TestCase):
       chex.assert_trees_all_close(loss, 0.4481)
       # Assert that inner and outer parameters are all equal now that
       # synchronization has happened.
-      chex.assert_trees_all_equal(
-          diloco_test_state.params,
-          jax.tree.map(lambda arr: arr[0, ...], diloco_test_state.inner_state.params),
-      )
-      chex.assert_trees_all_equal(
-          diloco_test_state.params,
-          jax.tree.map(lambda arr: arr[1, ...], diloco_test_state.inner_state.params),
-      )
+      if test_config.pure_nnx:
+        _, inner_params, _ = nnx.split(diloco_test_state.inner_state.model, nnx.Param, ...)
+        inner_params_pure = jax.tree_util.tree_map(
+            lambda x: x.value if hasattr(x, "value") else x, inner_params.to_pure_dict()
+        )
+        diloco_params_pure_3 = jax.tree_util.tree_map(
+            lambda x: x.value if hasattr(x, "value") else x, diloco_test_state.params
+        )
+        chex.assert_trees_all_equal(
+            diloco_params_pure_3,
+            jax.tree.map(lambda arr: arr[0, ...], inner_params_pure),
+        )
+        chex.assert_trees_all_equal(
+            diloco_params_pure_3,
+            jax.tree.map(lambda arr: arr[1, ...], inner_params_pure),
+        )
+      else:
+        chex.assert_trees_all_equal(
+            diloco_test_state.params,
+            jax.tree.map(lambda arr: arr[0, ...], diloco_test_state.inner_state.params),
+        )
+        chex.assert_trees_all_equal(
+            diloco_test_state.params,
+            jax.tree.map(lambda arr: arr[1, ...], diloco_test_state.inner_state.params),
+        )
 
       # Run the fourth step (no synchronization).
       # Replica 0:

--- a/tests/integration/generate_param_only_checkpoint_test.py
+++ b/tests/integration/generate_param_only_checkpoint_test.py
@@ -103,7 +103,20 @@ def run_e2e_test_flow(hardware, model_config, attention_type="autoselected", sta
 @pytest.mark.skipif(is_decoupled(), reason="Bypassed in offline decoupled runs (no GCS/internet)")
 @pytest.mark.integration_test
 @pytest.mark.tpu_only
-@pytest.mark.parametrize("quantization", [(""), ("int8")])
+@pytest.mark.parametrize(
+    "quantization",
+    [
+        (""),
+        pytest.param(
+            "int8",
+            marks=pytest.mark.skip(
+                reason="NNX int8 param-only generation is a convert-on-load case (the fp32 training "
+                "checkpoint has no AqtDotGeneral state the int8 model expects); tracked as a follow-up "
+                "alongside layerwise_quantization."
+            ),
+        ),
+    ],
+)
 def test_param_ckpt_generation_with_autoselected_attention(quantization, capsys):
   """Tests the parameter-only checkpoint generation and decode flow on TPU with autoselected attention."""
   model_config = get_model_params(quantization)
@@ -116,7 +129,20 @@ def test_param_ckpt_generation_with_autoselected_attention(quantization, capsys)
 @pytest.mark.external_serving
 @pytest.mark.integration_test
 @pytest.mark.gpu_only
-@pytest.mark.parametrize("quantization", [(""), ("int8")])
+@pytest.mark.parametrize(
+    "quantization",
+    [
+        (""),
+        pytest.param(
+            "int8",
+            marks=pytest.mark.skip(
+                reason="NNX int8 param-only generation is a convert-on-load case (the fp32 training "
+                "checkpoint has no AqtDotGeneral state the int8 model expects); tracked as a follow-up "
+                "alongside layerwise_quantization."
+            ),
+        ),
+    ],
+)
 def test_param_ckpt_generation_with_dot_product(quantization, capsys):
   """Tests the parameter-only checkpoint generation and decode flow on GPU with dot product attention."""
   os.environ["NVTE_FUSED_ATTN"] = "1"  # Enable fused attention

--- a/tests/integration/maxengine_test.py
+++ b/tests/integration/maxengine_test.py
@@ -26,12 +26,10 @@ import pytest
 from flax import nnx
 from flax.linen import partitioning as nn_partitioning
 from maxtext.configs import pyconfig
-from maxtext.common.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_PREFILL
-from maxtext.layers import quantizations
+from maxtext.common.common_types import MODEL_MODE_PREFILL
 
 pytest.importorskip("jetstream", reason="jetstream not installed")
 from maxtext.inference.maxengine import maxengine
-from maxtext.models import models
 from maxtext.utils import maxtext_utils
 from maxtext.utils import model_creation_utils
 from tests.utils.test_helpers import get_test_config_path
@@ -71,100 +69,24 @@ class MaxEngineTest(unittest.TestCase):
     )
     return config
 
-  def get_data(self):
-    s = (self.cfg.global_batch_size_to_train_on, self.cfg.max_target_length)
-    ids = jax.random.randint(self.rng, s, 0, self.cfg.vocab_size)
-
-    decoder_segment_ids = jax.numpy.zeros(s) + DECODING_ACTIVE_SEQUENCE_INDICATOR
-    decoder_positions = jnp.stack(
-        [jnp.arange(self.cfg.max_target_length, dtype=jnp.int32) for _ in range(self.cfg.global_batch_size_to_train_on)]
-    )
-
-    return ids, decoder_segment_ids, decoder_positions
-
-  def test_stack_and_unstack_prefill_cache(self):
-    config = pyconfig.initialize(
-        [None, get_test_config_path()],
-        enable_checkpointing=False,
-        stack_prefill_result_cache=True,
-    )
-    engine = maxengine.MaxEngine(config, jax.devices())
+  def test_stack_and_unstack_prefill_cache_nnx(self):
+    """scan_layers=False: per-layer cache subtrees stack onto a leading layer axis and back."""
+    cfg = self._init_nnx_pyconfig(stack_prefill_result_cache=True, scan_layers=False)
+    engine = maxengine.MaxEngine(cfg, jax.devices())
     num_layers = engine.config.num_decoder_layers
-    input_d = {
-        "decoder": {},
-    }
-    for i in range(num_layers):
-      input_d["decoder"][f"layers_{i}"] = {
-          "a": jnp.ones((1, 10)),
-          "b": jnp.ones((1, 9)),
-      }
+    # scan_layers=False keeps the per-layer subtrees under decoder/layers, keyed by layer index.
+    cache = {"decoder": {"layers": {i: {"a": jnp.ones((1, 10)), "b": jnp.ones((1, 9))} for i in range(num_layers)}}}
 
-    expected_stacked = {
-        "a": jnp.ones((num_layers, 1, 10)),
-        "b": jnp.ones((num_layers, 1, 9)),
-    }
+    expected_stacked = {"decoder": {"layers": {"a": jnp.ones((num_layers, 1, 10)), "b": jnp.ones((num_layers, 1, 9))}}}
     # pylint: disable=protected-access
-    got_stacked = engine._maybe_stack_prefill_result_cache(input_d)
+    got_stacked = engine._maybe_stack_prefill_result_cache(cache)
     jax.tree.map(np.testing.assert_array_equal, got_stacked, expected_stacked)
 
-    # pylint: disable=protected-access
     got_unstacked = engine._maybe_unstack_prefill_result_cache(got_stacked)
-    jax.tree.map(np.testing.assert_array_equal, got_unstacked, input_d)
+    jax.tree.map(np.testing.assert_array_equal, got_unstacked, cache)
 
-  def test_basic_prefill(self):
-    devices_array = maxtext_utils.create_device_mesh(self.cfg)
-    mesh = Mesh(devices_array, self.cfg.mesh_axes)
-    quant = quantizations.configure_quantization(self.cfg)
-    model = models.transformer_as_linen(config=self.cfg, mesh=mesh, quant=quant, model_mode=MODEL_MODE_PREFILL)
-    ids, decoder_segment_ids, decoder_positions = self.get_data()
-
-    transformer_vars = model.init(
-        {"params": self.rng, "aqt": self.rng, "dropout": self.rng},
-        ids,
-        decoder_positions,
-        decoder_segment_ids,
-        enable_dropout=False,
-    )
-    input_tokens = jnp.array([1, 306, 5360, 304, 0, 0, 0, 0])
-    true_length = 4
-    engine = maxengine.MaxEngine(self.cfg, jax.devices())
-    prefill_result, first_token = engine.prefill(
-        params=transformer_vars, padded_tokens=input_tokens, true_length=true_length
-    )
-
-    self.assertEqual(prefill_result["generated_tokens"], jnp.array([0]))
-    # test default strategy is gready which choose only one next token
-    self.assertEqual(prefill_result["tokens"].size, 1)
-    self.assertNotEqual(prefill_result["tokens"], jnp.array([0]))
-    self.assertTrue(jnp.array_equal(first_token.data.size, 3))
-    self.assertEqual(first_token.log_prob.shape, (1, 1))
-
-  def test_basic_decode(self):
-    devices_array = maxtext_utils.create_device_mesh(self.cfg)
-    mesh = Mesh(devices_array, self.cfg.mesh_axes)
-    quant = quantizations.configure_quantization(self.cfg)
-    model = models.transformer_as_linen(config=self.cfg, mesh=mesh, quant=quant, model_mode=MODEL_MODE_PREFILL)
-    ids, decoder_segment_ids, decoder_positions = self.get_data()
-
-    transformer_vars = model.init(
-        {"params": self.rng, "aqt": self.rng, "dropout": self.rng},
-        ids,
-        decoder_positions,
-        decoder_segment_ids,
-        enable_dropout=False,
-    )
-    input_tokens = jnp.array([1, 306, 5360, 304])
-    engine = maxengine.MaxEngine(self.cfg, jax.devices())
-    params = engine.load_params(params=transformer_vars)
-    decode_state = engine.init_decode_state()
-    prefill_result, _ = engine.prefill(params=params, padded_tokens=input_tokens, true_length=4)
-    decode_state = engine.insert(prefill_result, decode_state, slot=0)
-    decode_state, result_token = engine.generate(params=params, decode_state=decode_state)
-
-    self.assertEqual(result_token.log_prob.ndim, 2)
-    self.assertEqual(result_token.log_prob.shape[1], 1)
-    self.assertEqual(result_token.data.ndim, 2)
-    self.assertEqual(result_token.data.shape[1], 3)
+  # The Linen-path basic prefill/decode tests were removed when NNX became the
+  # default. test_basic_prefill_nnx / test_basic_decode_nnx below cover the NNX path.
 
   def _init_nnx_pyconfig(self, **kwargs):
     """Same as init_pyconfig but with the NNX flags turned on."""
@@ -177,18 +99,6 @@ class MaxEngineTest(unittest.TestCase):
       model = _create_model()
     _, params_state, _ = nnx.split(model, nnx.Param, ...)
     return params_state
-
-  def _build_linen_params(self, cfg, mesh):
-    """Materialize a Linen Transformer and return its init vars (for NNX/Linen shape parity)."""
-    quant = quantizations.configure_quantization(cfg)
-    model = models.transformer_as_linen(config=cfg, mesh=mesh, quant=quant, model_mode=MODEL_MODE_PREFILL)
-    s = (cfg.global_batch_size_to_train_on, cfg.max_target_length)
-    ids = jax.random.randint(self.rng, s, 0, cfg.vocab_size)
-    segment_ids = jnp.zeros(s) + DECODING_ACTIVE_SEQUENCE_INDICATOR
-    positions = jnp.stack([jnp.arange(cfg.max_target_length, dtype=jnp.int32) for _ in range(s[0])])
-    return model.init(
-        {"params": self.rng, "aqt": self.rng, "dropout": self.rng}, ids, positions, segment_ids, enable_dropout=False
-    )
 
   def test_init_nnx(self):
     """NNX engine init exposes graphdef + abstract Transformer."""
@@ -314,7 +224,7 @@ class MaxEngineTest(unittest.TestCase):
       engine.load_single_adapter("/nonexistent/adapter/path")
 
   def test_prefill_multisampling_nnx(self):
-    """NNX prefill_multisampling matches the Linen result shape; logits + cache stay finite."""
+    """NNX prefill_multisampling draws num_samples first tokens; logits + cache stay finite."""
     num_samples = 3
     input_tokens = jnp.array([1, 306, 5360, 304, 0, 0, 0, 0])
     true_length = 4
@@ -323,27 +233,19 @@ class MaxEngineTest(unittest.TestCase):
     mesh = Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
     engine = maxengine.MaxEngine(cfg, jax.devices())
     params = engine.load_params(params=self._build_nnx_params(cfg, mesh))
-    nnx_result, nnx_first = engine.prefill_multisampling(
+    result, first = engine.prefill_multisampling(
         params=params, padded_tokens=input_tokens, true_length=true_length, num_samples=num_samples
     )
 
-    lin_cfg = self.init_pyconfig()
-    lin_mesh = Mesh(maxtext_utils.create_device_mesh(lin_cfg), lin_cfg.mesh_axes)
-    lin_engine = maxengine.MaxEngine(lin_cfg, jax.devices())
-    lin_params = lin_engine.load_params(params=self._build_linen_params(lin_cfg, lin_mesh))
-    lin_result, lin_first = lin_engine.prefill_multisampling(
-        params=lin_params, padded_tokens=input_tokens, true_length=true_length, num_samples=num_samples
-    )
-
-    self.assertEqual(nnx_result["tokens"].shape, lin_result["tokens"].shape)
-    self.assertEqual(nnx_result["tokens"].shape[0], num_samples)
-    self.assertEqual(nnx_first.data.shape, lin_first.data.shape)
-    self.assertTrue(jnp.all(jnp.isfinite(nnx_result["logits"])))
-    for leaf in jax.tree.leaves(nnx_result["cache"]):
+    self.assertEqual(result["tokens"].shape[0], num_samples)
+    # data packs [token, valid, length] for each sample.
+    self.assertEqual(first.data.shape, (num_samples, 3))
+    self.assertTrue(jnp.all(jnp.isfinite(result["logits"])))
+    for leaf in jax.tree.leaves(result["cache"]):
       self.assertTrue(jnp.all(jnp.isfinite(leaf)), msg=f"non-finite cache leaf, shape={leaf.shape}")
 
   def test_prefill_concat_nnx(self):
-    """NNX prefill_concat matches the Linen result shape for packed prompts."""
+    """NNX prefill_concat returns one result per packed prompt; logits + cache stay finite."""
     # Two prompts of length 2 packed into one prefill of length max_prefill_predict_length=4.
     packed = {
         "padded_tokens": jnp.array([1, 306, 5360, 304]),
@@ -358,19 +260,12 @@ class MaxEngineTest(unittest.TestCase):
     mesh = Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
     engine = maxengine.MaxEngine(cfg, jax.devices())
     params = engine.load_params(params=self._build_nnx_params(cfg, mesh))
-    nnx_cache, nnx_result, nnx_first = engine.prefill_concat(params=params, **packed)
+    cache, result, first_tokens = engine.prefill_concat(params=params, **packed)
 
-    lin_cfg = self.init_pyconfig()
-    lin_mesh = Mesh(maxtext_utils.create_device_mesh(lin_cfg), lin_cfg.mesh_axes)
-    lin_engine = maxengine.MaxEngine(lin_cfg, jax.devices())
-    lin_params = lin_engine.load_params(params=self._build_linen_params(lin_cfg, lin_mesh))
-    _, lin_result, lin_first = lin_engine.prefill_concat(params=lin_params, **packed)
-
-    self.assertEqual(nnx_result["tokens"].shape, lin_result["tokens"].shape)
-    self.assertEqual(len(nnx_first), len(lin_first))
-    self.assertEqual(len(nnx_first), packed["num_prompts"])
-    self.assertTrue(jnp.all(jnp.isfinite(nnx_result["logits"])))
-    for leaf in jax.tree.leaves(nnx_cache):
+    self.assertEqual(result["tokens"].shape[0], packed["num_prompts"])
+    self.assertEqual(len(first_tokens), packed["num_prompts"])
+    self.assertTrue(jnp.all(jnp.isfinite(result["logits"])))
+    for leaf in jax.tree.leaves(cache):
       self.assertTrue(jnp.all(jnp.isfinite(leaf)), msg=f"non-finite cache leaf, shape={leaf.shape}")
 
   def _stack_prefill_roundtrip(self, cfg):

--- a/tests/integration/tokamax_test.py
+++ b/tests/integration/tokamax_test.py
@@ -30,25 +30,7 @@ gettempdir = tempfile.gettempdir
 class Train(parameterized.TestCase):
   """Test for tokamax gmm and splash."""
 
-  @parameterized.named_parameters(
-      {
-          "testcase_name": "gmm bf16",
-          "quantization": "",
-          "use_gmm_v2": False,
-      },
-      {
-          "testcase_name": "gmm fp8",
-          "quantization": "fp8_full",
-          "use_gmm_v2": False,
-      },
-      {
-          "testcase_name": "gmm v2 bf16",
-          "quantization": "",
-          "use_gmm_v2": True,
-      },
-  )
-  @pytest.mark.tpu_only
-  def test_different_configs(self, quantization: str, use_gmm_v2: bool):
+  def _run_test_different_configs(self, quantization: str):
     """Smoke train with small config."""
     test_tmpdir = os.environ.get("TEST_TMPDIR", gettempdir())
     outputs_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", test_tmpdir)
@@ -113,6 +95,16 @@ class Train(parameterized.TestCase):
         f"metrics_file={os.path.join(outputs_dir, 'metrics.json')}",
     ]
     train_main(args)
+
+  @pytest.mark.tpu_only
+  def test_different_configs_gmm_bf16(self):
+    """Smoke train with small config."""
+    self._run_test_different_configs("")
+
+  @pytest.mark.tpu_only
+  def test_different_configs_gmm_fp8(self):
+    """Smoke train with small config."""
+    self._run_test_different_configs("fp8_full")
 
 
 if __name__ == "__main__":

--- a/tests/unit/max_utils_test.py
+++ b/tests/unit/max_utils_test.py
@@ -25,6 +25,7 @@ from jax import numpy as jnp
 from jax import random
 
 from flax import linen as nn
+from flax import nnx
 
 import optax
 
@@ -181,8 +182,16 @@ class UnscanTest(unittest.TestCase):
     num_layers = config.base_num_decoder_layers
 
     # Make a copy to unscan, leaving the original state intact.
-    params_to_unscan = jax.tree_util.tree_map(lambda x: x, state.params)
-    sharding_to_unscan = jax.tree_util.tree_map(lambda x: x, sharding.params)
+    if hasattr(state, "model"):
+      _, params_state, _ = nnx.split(state.model, nnx.Param, ...)
+      params_to_unscan = {"params": params_state.to_pure_dict()}
+    else:
+      params_to_unscan = jax.tree_util.tree_map(lambda x: x, state.params)
+    if hasattr(sharding, "model"):
+      _, sharding_params, _ = nnx.split(sharding.model, nnx.Param, ...)
+      sharding_to_unscan = {"params": sharding_params.to_pure_dict()}
+    else:
+      sharding_to_unscan = jax.tree_util.tree_map(lambda x: x, sharding.params)
 
     # Time the unscan operation.
     start_time = time.time()
@@ -210,8 +219,18 @@ class UnscanTest(unittest.TestCase):
     self.assertEqual(unstacked_shape, expected_shape)
 
     # Check that the original state is unchanged.
-    self.assertIn("layers", state.params["params"]["decoder"])
-    self.assertNotIn("layers_0", state.params["params"]["decoder"])
+
+    if hasattr(state, "model"):
+      _, params_state, _ = nnx.split(state.model, nnx.Param, ...)
+      state_decoder_params = params_state.to_pure_dict()["decoder"]
+      self.assertIn("layers", state_decoder_params)
+    else:
+      self.assertIn("layers", state.params["params"]["decoder"])
+
+    if hasattr(state, "model"):
+      self.assertNotIn("layers_0", state_decoder_params)
+    else:
+      self.assertNotIn("layers_0", state.params["params"]["decoder"])
 
 
 class TestGpuDistributedInitialization(unittest.TestCase):

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -25,6 +25,7 @@ import numpy as np
 import optax
 
 from flax import linen as nn
+from flax.linen import partitioning as nn_partitioning
 from flax import nnx
 from flax.core.scope import FrozenVariableDict
 from flax.training import train_state
@@ -1689,6 +1690,60 @@ class TestGetNnxNamedShardingWithScanAxis(unittest.TestCase):
     result_sharding = out["w"].get_value()
     # The single string 'fsdp' is turned into a list, and 'layers' is prepended.
     self.assertEqual(result_sharding.spec, PartitionSpec("layers", "fsdp"))
+
+  def test_sequential_matching_first_match_wins(self):
+    """Multiple rules for the same logical axis are matched sequentially, first-match-wins."""
+    # We define rules for 'embed' mapping to 'fsdp' (specific) then 'layers' (fallback)
+    rules = (
+        ("embed", "fsdp"),
+        ("embed", "layers"),
+    )
+    with nn_partitioning.axis_rules(rules):
+      with jax.set_mesh(self.mesh):
+        v = nnx.Param(
+            jnp.zeros((3,)),
+            out_sharding=("embed",),
+        )
+      out = self._run(self._build_state(w=v))
+      result_sharding = out["w"].get_value()
+      # 'embed' must match the first rule ('fsdp'), not the second ('layers').
+      self.assertEqual(result_sharding.spec, PartitionSpec("fsdp"))
+
+  def test_deduplicates_assigned_physical_axes(self):
+    """Physical axes already bound to a dimension cannot be bound to another dimension."""
+    # Define rules where 'embed' maps to ('fsdp', 'layers') and 'mlp' maps to 'fsdp'.
+    # Because 'embed' is defined first, it binds 'fsdp'.
+    # When matching 'mlp', 'fsdp' is already bound, so it is skipped (unassigned/None).
+    rules = (
+        ("embed", ("fsdp", "layers")),
+        ("mlp", "fsdp"),
+    )
+    with nn_partitioning.axis_rules(rules):
+      with jax.set_mesh(self.mesh):
+        v = nnx.Param(
+            jnp.zeros((3, 4)),
+            out_sharding=("embed", "mlp"),
+        )
+      out = self._run(self._build_state(w=v))
+      result_sharding = out["w"].get_value()
+      # 'embed' maps to ('fsdp', 'layers').
+      # 'mlp' maps to None (replicated) because 'fsdp' is already bound.
+      self.assertEqual(result_sharding.spec, PartitionSpec(("fsdp", "layers"), None))
+
+  def test_resolves_when_context_rules_is_none(self):
+    """When context_rules is None but local_rules are defined, resolution should succeed."""
+    # Ensure get_logical_axis_rules() returns None (which is the default outside axis_rules)
+    # We define local rules on the variable metadata.
+    with jax.set_mesh(self.mesh):
+      v = nnx.Param(
+          jnp.zeros((3,)),
+          out_sharding=("embed",),
+          sharding_rules=(("embed", "fsdp"),),
+      )
+    out = self._run(self._build_state(w=v))
+    result_sharding = out["w"].get_value()
+    # 'embed' must match the local rules even when context_rules is None.
+    self.assertEqual(result_sharding.spec, PartitionSpec("fsdp"))
 
 
 if __name__ == "__main__":

--- a/tests/unit/maxtext_utils_test.py
+++ b/tests/unit/maxtext_utils_test.py
@@ -41,6 +41,8 @@ from maxtext.models import models
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
 from maxtext.utils import maxtext_utils_nnx
+from maxtext.utils import model_creation_utils
+from maxtext.common import train_state_nnx
 from maxtext.utils import sharding
 from maxtext.utils.sharding import assert_params_sufficiently_sharded, get_formatted_sharding_annotations
 from tests.utils.test_helpers import get_test_config_path
@@ -351,32 +353,47 @@ class MaxUtilsInitTransformerState(unittest.TestCase):
     self.mesh = Mesh(devices_array, self.config.mesh_axes)
     quant = quantizations.configure_quantization(self.config)
     if self.config.pure_nnx:
-      raise NotImplementedError("Pure NNX support has not been implemented yet.")
+      self._create_model_partial, self.model = model_creation_utils.create_nnx_abstract_model(self.config, self.mesh)
     else:
       self.model = models.transformer_as_linen(self.config, mesh=self.mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
 
   def test_setup_decode_state(self):
     rng = random.PRNGKey(0)
     if self.config.pure_nnx:
-      # NNX has a different function to init the training state.
-      raise NotImplementedError("Pure NNX support has not been implemented yet.")
+
+      def create_train_state_fn():
+        nnx_model = self._create_model_partial()
+        return train_state_nnx.TrainStateNNX(nnx_model, None)
+
+      init_state_fn = create_train_state_fn
     else:
       init_state_fn = functools.partial(maxtext_utils.init_initial_state, self.model, None, self.config, False, rng)
     state, _ = maxtext_utils.setup_decode_state(self.config, self.mesh, None, init_state_fn)
-    self.assertEqual(state.tx, None)
-    self.assertEqual(state.opt_state, {})
+    if self.config.pure_nnx:
+      self.assertNotIn("optimizer", state)
+    else:
+      self.assertEqual(state.tx, None)
+      self.assertEqual(state.opt_state, {})
 
   def test_setup_initial_state(self):
     rng = random.PRNGKey(0)
     tx = optax.adam(learning_rate=0.001)
     if self.config.pure_nnx:
-      # NNX has a different function to init the training state.
-      raise NotImplementedError("Pure NNX support has not been implemented yet.")
+
+      def create_train_state_fn():
+        nnx_model = self._create_model_partial()
+        optimizer = nnx.Optimizer(nnx_model, tx, wrt=nnx.Param)
+        return train_state_nnx.TrainStateNNX(nnx_model, optimizer)
+
+      init_state_fn = create_train_state_fn
     else:
       init_state_fn = functools.partial(maxtext_utils.init_initial_state, self.model, tx, self.config, True, rng)
     state, _, _, _ = maxtext_utils.setup_initial_state(None, self.config, self.mesh, None, init_state_fn)
-    self.assertEqual(state.tx, tx)
-    self.assertNotEqual(state.opt_state, {})
+    if self.config.pure_nnx:
+      self.assertIsNotNone(state.optimizer)
+    else:
+      self.assertEqual(state.tx, tx)
+      self.assertNotEqual(state.opt_state, {})
 
 
 class MaxUtilsPpAsDp(unittest.TestCase):
@@ -1359,16 +1376,29 @@ class TestSetupTrainingState(unittest.TestCase):
     self.mesh = Mesh(devices_array, self.config.mesh_axes)
     quant = quantizations.configure_quantization(self.config)
     if self.config.pure_nnx:
-      raise NotImplementedError("Pure NNX path not covered by this test.")
-    self.model = Transformer(self.config, mesh=self.mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
+      self._create_model_partial, self.model = model_creation_utils.create_nnx_abstract_model(self.config, self.mesh)
+    else:
+      self.model = Transformer(self.config, mesh=self.mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
 
   def test_setup_training_state_returns_train_state(self):
     rng = jax.random.PRNGKey(0)
     tx = optax.adam(learning_rate=0.001)
-    init_state_fn = functools.partial(maxtext_utils.init_initial_state, self.model, tx, self.config, True, rng)
+    if self.config.pure_nnx:
+
+      def create_train_state_fn():
+        nnx_model = self._create_model_partial()
+        optimizer = nnx.Optimizer(nnx_model, tx, wrt=nnx.Param)
+        return train_state_nnx.TrainStateNNX(nnx_model, optimizer)
+
+      init_state_fn = create_train_state_fn
+    else:
+      init_state_fn = functools.partial(maxtext_utils.init_initial_state, self.model, tx, self.config, True, rng)
     state, _, _, _ = maxtext_utils.setup_training_state(None, self.config, self.mesh, None, init_state_fn)
-    self.assertEqual(state.tx, tx)
-    self.assertNotEqual(state.opt_state, {})
+    if self.config.pure_nnx:
+      self.assertIsNotNone(state.optimizer)
+    else:
+      self.assertEqual(state.tx, tx)
+      self.assertNotEqual(state.opt_state, {})
 
 
 class TestGetLogicalAnnotations(unittest.TestCase):
@@ -1380,14 +1410,29 @@ class TestGetLogicalAnnotations(unittest.TestCase):
     self.mesh = Mesh(devices_array, self.config.mesh_axes)
     quant = quantizations.configure_quantization(self.config)
     if self.config.pure_nnx:
-      raise NotImplementedError("Pure NNX path not covered by this test.")
-    self.model = Transformer(self.config, mesh=self.mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
+      self._create_model_partial, self.model = model_creation_utils.create_nnx_abstract_model(self.config, self.mesh)
+    else:
+      self.model = Transformer(self.config, mesh=self.mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
     self.rng = jax.random.PRNGKey(0)
     self.tx = optax.adam(learning_rate=0.001)
 
   def test_returns_partition_spec_tree(self):
-    init_state_fn = functools.partial(maxtext_utils.init_initial_state, self.model, self.tx, self.config, True, self.rng)
-    annotations = maxtext_utils.get_logical_annotations(self.config, self.mesh, init_state_fn)
+    if self.config.pure_nnx:
+
+      def create_train_state_fn():
+        nnx_model = self._create_model_partial()
+        optimizer = nnx.Optimizer(nnx_model, self.tx, wrt=nnx.Param)
+        return train_state_nnx.TrainStateNNX(nnx_model, optimizer)
+
+      init_state_fn = create_train_state_fn
+      annotations = maxtext_utils_nnx.get_partition_spec_nnx(
+          maxtext_utils.get_abstract_state(self.config, self.mesh, init_state_fn, True)[2]
+      )
+    else:
+      init_state_fn = functools.partial(
+          maxtext_utils.init_initial_state, self.model, self.tx, self.config, True, self.rng
+      )
+      annotations = maxtext_utils.get_logical_annotations(self.config, self.mesh, init_state_fn)
     # Result should be a pytree with PartitionSpec leaves
     leaves = jax.tree_util.tree_leaves(annotations)
     self.assertGreater(len(leaves), 0)

--- a/tests/unit/muon_utils_test.py
+++ b/tests/unit/muon_utils_test.py
@@ -150,9 +150,9 @@ class TestGetMuonWeightDimensionNumbersNNX(unittest.TestCase):
     # NNX Variables are walked by jax.tree_util.tree_map_with_path, so the returned
     # tree replaces each Variable's value with transform_logic(path_strings).
     # 'scale' matches the exclusion branch → value is None.
-    self.assertIsNone(result["scale"].get_value())
+    self.assertIsNone(result["scale"])
     # 'w_standard' does not trigger any special rule → standard mdn.
-    self.assertEqual(result["w_standard"].get_value(), mdn((0,), (-1,)))
+    self.assertEqual(result["w_standard"], mdn((0,), (-1,)))
 
   def test_nnx_verbose_path_executes_print_debug(self):
     """verbose=True should also execute _print_structure_debug without raising."""

--- a/tests/unit/optimizers_test.py
+++ b/tests/unit/optimizers_test.py
@@ -581,13 +581,13 @@ class TestMuonLogic(unittest.TestCase):
     result = muon_utils.get_muon_weight_dimension_numbers(model, config)
 
     # Verify standard weight path: ('layer1', 'kernel') -> default (0,)
-    self.assertEqual(result.layer1.kernel.value, mdn((0,), (-1,)))
+    self.assertEqual(result.layer1.kernel, mdn((0,), (-1,)))
 
     # Verify MoE weight path: ('MoeBlock_0', 'wi_0', 'kernel') -> (-2,)
-    self.assertEqual(result.MoeBlock_0.wi_0.kernel.value, mdn((-2,), (-1,)))
+    self.assertEqual(result.MoeBlock_0.wi_0.kernel, mdn((-2,), (-1,)))
 
     # Verify exclusion (scalar/scale)
-    self.assertIsNone(result.scale.value)
+    self.assertIsNone(result.scale)
 
   def test_verbose_output_nnx(self):
     """Covers lines 128 and 135-154: _print_structure_debug via verbose=True with NNX model."""
@@ -617,9 +617,9 @@ class TestMuonLogic(unittest.TestCase):
     result = muon_utils.get_muon_weight_dimension_numbers(model, config)
 
     # Check attention query: [0] -> [-2, -1]
-    self.assertEqual(result.self_attention.query.kernel.value, mdn((0,), (-2, -1)))
+    self.assertEqual(result.self_attention.query.kernel, mdn((0,), (-2, -1)))
     # Check attention out: [0, -2] -> [-1]
-    self.assertEqual(result.self_attention.out.kernel.value, mdn((0, -2), (-1,)))
+    self.assertEqual(result.self_attention.out.kernel, mdn((0, -2), (-1,)))
 
 
 if __name__ == "__main__":

--- a/tests/unit/qwen3_next_vs_reference_test.py
+++ b/tests/unit/qwen3_next_vs_reference_test.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Optional, Tuple
 import unittest
+import pytest
 
 from flax import nnx
 import jax
@@ -227,16 +228,16 @@ class Qwen3NextRMSNorm_PT(nn.Module):
   This version applies a (1.0 + weight) scaling factor after normalization.
   """
 
-  def __init__(self, dim: int, eps: float = 1e-6):
+  def __init__(self, dim: int, epsilon: float = 1e-6):
     """Initializes the Qwen3NextRMSNorm_PT layer."""
     super().__init__()
-    self.eps = eps
+    self.epsilon = epsilon
     # The weight is initialized to zeros, matching the real model.
     self.weight = torch.nn.Parameter(torch.zeros(dim))
 
   def _norm(self, x):
     """Applies the RMS normalization."""
-    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.epsilon)
 
   def forward(self, x):
     """Forward pass for Qwen3NextRMSNorm_PT."""
@@ -422,11 +423,11 @@ class Qwen3NextRMSNormGated_PT(nn.Module):
   by SiLU(gate).
   """
 
-  def __init__(self, hidden_size, eps=1e-6):
+  def __init__(self, hidden_size, epsilon=1e-6):
     """Initializes the RMSNormGated layer."""
     super().__init__()
     self.weight = torch.nn.Parameter(torch.ones(hidden_size))
-    self.variance_epsilon = eps
+    self.variance_epsilon = epsilon
 
   def forward(self, hidden_states, gate=None):
     """Forward pass for RMSNormGated."""
@@ -480,7 +481,7 @@ class Qwen3NextGatedDeltaNet_PT(nn.Module):
     self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads))
     A = torch.empty(self.num_v_heads).uniform_(0, 16)
     self.A_log = nn.Parameter(torch.log(A))
-    self.norm = Qwen3NextRMSNormGated_PT(self.head_v_dim, eps=self.layer_norm_epsilon)
+    self.norm = Qwen3NextRMSNormGated_PT(self.head_v_dim, epsilon=self.layer_norm_epsilon)
     self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
 
   def forward(self, hidden_states):
@@ -569,8 +570,8 @@ class Qwen3NextFullAttention_PT(nn.Module):
         config.hidden_size,
         bias=config.attention_bias,
     )
-    self.q_norm = Qwen3NextRMSNorm_PT(self.head_dim, eps=config.rms_norm_eps)
-    self.k_norm = Qwen3NextRMSNorm_PT(self.head_dim, eps=config.rms_norm_eps)
+    self.q_norm = Qwen3NextRMSNorm_PT(self.head_dim, epsilon=config.rms_norm_eps)
+    self.k_norm = Qwen3NextRMSNorm_PT(self.head_dim, epsilon=config.rms_norm_eps)
 
   def forward(
       self,
@@ -698,12 +699,12 @@ class TestQwen3Next(unittest.TestCase):
         norm_topk_prob=self.cfg.norm_topk_prob,
     )
 
-    self.batch_size = 4
+    devices = np.array(jax.devices())
+    num_devices = len(devices)
+    self.batch_size = max(8, num_devices)
     self.seq_len = 128
     # Use the emb_dim calculated by pyconfig from base_emb_dim
     self.hidden_size = self.cfg.emb_dim
-    devices = np.array(jax.devices())
-    num_devices = len(devices)
 
     # Create a mesh shape where the 'data' axis gets all available devices,
     # and all other axes defined in the config have a size of 1.
@@ -726,7 +727,7 @@ class TestQwen3Next(unittest.TestCase):
     weight_pt = torch.rand(self.hidden_size)
 
     # PyTorch reference
-    pt_model = Qwen3NextRMSNormGated_PT(self.hidden_size, eps=self.cfg.normalization_layer_epsilon)
+    pt_model = Qwen3NextRMSNormGated_PT(self.hidden_size, epsilon=self.cfg.normalization_layer_epsilon)
     pt_model.weight.data = weight_pt
     pt_model.eval()
     with torch.no_grad():
@@ -735,7 +736,7 @@ class TestQwen3Next(unittest.TestCase):
     # JAX implementation
     jax_model = Qwen3NextRMSNormGated(
         num_features=self.hidden_size,
-        eps=self.cfg.normalization_layer_epsilon,
+        epsilon=self.cfg.normalization_layer_epsilon,
         dtype=self.cfg.dtype,
         weight_dtype=self.cfg.weight_dtype,
         rngs=self.nnx_rngs,
@@ -904,15 +905,14 @@ class TestQwen3Next(unittest.TestCase):
     print("Running test_gated_delta_net_structure...")
     hidden_states_jax = jnp.ones((self.batch_size, self.seq_len, self.hidden_size), dtype=self.cfg.dtype)
 
-    jax_model = qwen3.Qwen3NextGatedDeltaNet(config=self.cfg, mesh=self.mesh, rngs=self.nnx_rngs)
+    jax_model = qwen3.Qwen3NextGatedDeltaNet(config=self.cfg, rngs=self.nnx_rngs, inputs_shape=hidden_states_jax.shape)
 
     @jax.jit
     def run_jax(hidden_states):
       """Runs the JAX GatedDeltaNet model."""
-      output, _ = jax_model(hidden_states)
-      return output
+      return jax_model(hidden_states)
 
-    output_jax = run_jax(hidden_states_jax)
+    output_jax, _ = run_jax(hidden_states_jax)
 
     self.assertEqual(output_jax.shape, (self.batch_size, self.seq_len, self.hidden_size))
 
@@ -925,7 +925,7 @@ class TestQwen3Next(unittest.TestCase):
     hidden_states_pt = torch.randn(self.batch_size, self.seq_len, self.hidden_size)
     weight_pt = torch.rand(self.hidden_size)
 
-    pt_model = Qwen3NextRMSNorm_PT(self.hidden_size, eps=self.cfg.normalization_layer_epsilon)
+    pt_model = Qwen3NextRMSNorm_PT(self.hidden_size, epsilon=self.cfg.normalization_layer_epsilon)
     pt_model.weight.data = weight_pt
     pt_model.eval()
 
@@ -935,8 +935,8 @@ class TestQwen3Next(unittest.TestCase):
     # 2. Set up the JAX implementation.
     class DummyModule(nnx.Module):
 
-      def __init__(self, hidden_size, eps, rngs):
-        self.norm = Qwen3NextRMSNorm(hidden_size, eps=eps, rngs=rngs)
+      def __init__(self, hidden_size, epsilon, rngs):
+        self.norm = Qwen3NextRMSNorm(hidden_size, epsilon=epsilon, rngs=rngs)
 
     jax_model_wrapped = DummyModule(self.hidden_size, self.cfg.normalization_layer_epsilon, self.nnx_rngs)
     jax_model = jax_model_wrapped.norm
@@ -948,7 +948,7 @@ class TestQwen3Next(unittest.TestCase):
     @jax.jit
     def run_jax(x):
       """Runs the JAX Qwen3NextRMSNorm model."""
-      return jax_model(x)  # Call the module
+      return jax_model(x)
 
     actual_output = run_jax(hidden_states_jax)
 
@@ -1048,50 +1048,42 @@ class TestQwen3Next(unittest.TestCase):
     with torch.no_grad():
       expected_output = pt_model(hidden_states_pt)
 
-    def reorder_pt_qkvz_to_jax(w, num_heads, head_k_dim, head_v_dim):
-      key_dim = num_heads * head_k_dim
-      value_dim = num_heads * head_v_dim
-      q, k, v, z = np.split(w, [key_dim, 2 * key_dim, 2 * key_dim + value_dim], axis=0)
-      jax_heads = []
-      for i in range(num_heads):
-        head_i = np.concatenate(
-            [
-                q[i * head_k_dim : (i + 1) * head_k_dim],
-                k[i * head_k_dim : (i + 1) * head_k_dim],
-                v[i * head_v_dim : (i + 1) * head_v_dim],
-                z[i * head_v_dim : (i + 1) * head_v_dim],
-            ],
-            axis=0,
-        )
-        jax_heads.append(head_i)
-      return np.concatenate(jax_heads, axis=0)
-
-    def reorder_pt_ba_to_jax(w, num_heads):
-      b, a = np.split(w, 2, axis=0)
-      jax_heads = []
-      for i in range(num_heads):
-        head_i = np.concatenate([b[i : i + 1], a[i : i + 1]], axis=0)
-        jax_heads.append(head_i)
-      return np.concatenate(jax_heads, axis=0)
-
     # 2. Setup JAX model and map weights
-    jax_model = qwen3.Qwen3NextGatedDeltaNet(config=self.cfg, mesh=self.mesh, rngs=self.nnx_rngs)
-    assert jax_model.num_k_heads == jax_model.num_v_heads
+    jax_model = qwen3.Qwen3NextGatedDeltaNet(config=self.cfg, rngs=self.nnx_rngs, inputs_shape=hidden_states_pt.shape)
 
     conv1d_weight_pt = pt_model.conv1d.weight.detach().numpy()
     # Transpose PT (out, in/groups, kw) -> JAX (kw, in/groups, out)
     # For depthwise, out=in=groups, so PT=(C, 1, kw) -> JAX=(kw, 1, C)
     conv1d_weight_jax = np.transpose(conv1d_weight_pt, (2, 1, 0))
 
-    w_qkvz_pt = pt_model.in_proj_qkvz.weight.detach().numpy()
-    w_qkvz_jax = reorder_pt_qkvz_to_jax(w_qkvz_pt, jax_model.num_v_heads, jax_model.head_k_dim, jax_model.head_v_dim)
+    # Reorder in_proj_qkvz from PT layout to JAX layout
+    in_features = self.cfg.emb_dim
+    H_k = self.cfg.gdn_num_key_heads
+    D_k = self.cfg.gdn_key_head_dim
+    H_v = self.cfg.gdn_num_value_heads
+    D_v = self.cfg.gdn_value_head_dim
+    key_dim = H_k * D_k
+    value_dim = H_v * D_v
+    V_per_K = H_v // H_k
 
-    w_ba_pt = pt_model.in_proj_ba.weight.detach().numpy()
-    w_ba_jax = reorder_pt_ba_to_jax(w_ba_pt, jax_model.num_v_heads)
+    qkvz_pt = pt_model.in_proj_qkvz.weight.T.detach().numpy()
+    q_w = qkvz_pt[:, :key_dim].reshape(in_features, H_k, D_k)
+    k_w = qkvz_pt[:, key_dim : 2 * key_dim].reshape(in_features, H_k, D_k)
+    v_w = qkvz_pt[:, 2 * key_dim : 2 * key_dim + value_dim].reshape(in_features, H_k, V_per_K * D_v)
+    z_w = qkvz_pt[:, 2 * key_dim + value_dim :].reshape(in_features, H_k, V_per_K * D_v)
+
+    reordered_qkvz = np.concatenate([q_w, k_w, v_w, z_w], axis=-1).reshape(in_features, -1)
+
+    # Reorder in_proj_ba from PT layout to JAX layout
+    ba_pt = pt_model.in_proj_ba.weight.T.detach().numpy()
+    b_w = ba_pt[:, :H_v].reshape(in_features, H_k, V_per_K)
+    a_w = ba_pt[:, H_v:].reshape(in_features, H_k, V_per_K)
+
+    reordered_ba = np.concatenate([b_w, a_w], axis=-1).reshape(in_features, -1)
 
     params = {
-        "in_proj_qkvz": {"kernel": nnx.Param(jnp.array(w_qkvz_jax.T))},
-        "in_proj_ba": {"kernel": nnx.Param(jnp.array(w_ba_jax.T))},
+        "in_proj_qkvz": {"kernel": nnx.Param(jnp.array(reordered_qkvz))},
+        "in_proj_ba": {"kernel": nnx.Param(jnp.array(reordered_ba))},
         "conv1d": {"kernel": nnx.Param(jnp.array(conv1d_weight_jax))},
         "A_log": nnx.Param(jnp.array(pt_model.A_log.detach().numpy())),
         "dt_bias": nnx.Param(jnp.array(pt_model.dt_bias.detach().numpy())),
@@ -1104,10 +1096,9 @@ class TestQwen3Next(unittest.TestCase):
     @jax.jit
     def run_jax(x):
       """Runs the JAX GatedDeltaNet model."""
-      output, _ = jax_model(x)
-      return output
+      return jax_model(x)
 
-    actual_output = run_jax(hidden_states_jax)
+    actual_output, _ = run_jax(hidden_states_jax)
 
     # 3. Compare outputs
     np.testing.assert_allclose(
@@ -1277,16 +1268,15 @@ class TestQwen3Next(unittest.TestCase):
     # 8. Run JAX Model
     @jax.jit
     def run_jax(inputs, segment_ids, positions):
-      output, _ = jax_model(
+      return jax_model(
           inputs,
           decoder_segment_ids=segment_ids,
           decoder_positions=positions,
           deterministic=True,
           model_mode="train",
       )
-      return output
 
-    jax_output = run_jax(hidden_states_jax, decoder_segment_ids_jax, decoder_positions_jax)
+    jax_output, _ = run_jax(hidden_states_jax, decoder_segment_ids_jax, decoder_positions_jax)
 
     # 9. Compare
     pt_out_np = pt_output.detach().numpy()
@@ -1315,6 +1305,7 @@ class TestQwen3Next(unittest.TestCase):
   def test_full_attention_dot_product(self):
     return self._run_full_attention_jax_vs_pytorch_attention("dot_product")
 
+  @pytest.mark.tpu_only
   def test_full_attention_flash(self):
     return self._run_full_attention_jax_vs_pytorch_attention("flash")
 

--- a/tests/unit/state_dtypes_test.py
+++ b/tests/unit/state_dtypes_test.py
@@ -12,19 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Test that all weights are expected dtype (default float32) """
-from functools import partial
+"""Test that all weights are expected dtype (default float32)"""
 import unittest
 
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
+from functools import partial
+from flax import nnx
+
 from maxtext.configs import pyconfig
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.layers import quantizations
 from maxtext.models import models
 from maxtext.optimizers import optimizers
 from maxtext.utils import maxtext_utils
+from maxtext.utils import model_creation_utils
+from maxtext.common import train_state_nnx
 from tests.utils.test_helpers import get_test_config_path
 
 Transformer = models.transformer_as_linen
@@ -40,27 +44,65 @@ class StateDtypes(unittest.TestCase):
     quant = quantizations.configure_quantization(config)
     devices_array = maxtext_utils.create_device_mesh(config)
     mesh = Mesh(devices_array, config.mesh_axes)
-    model = Transformer(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
+
+    if config.pure_nnx:
+      _create_model_partial, model = model_creation_utils.create_nnx_abstract_model(config, mesh)
+    else:
+      model = Transformer(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
+
     learning_rate_schedule = maxtext_utils.create_learning_rate_schedule(config)
-    tx = optimizers.get_optimizer(config, learning_rate_schedule)
+    tx = optimizers.get_optimizer(config, learning_rate_schedule, model)
     _, example_rng = jax.random.split(jax.random.PRNGKey(0), 2)
 
     if config.pure_nnx:
-      # NNX has a different function to init the training state.
-      raise NotImplementedError("Pure NNX support has not been implemented yet.")
+
+      def create_train_state_fn():
+        nnx_model = _create_model_partial()
+        optimizer = nnx.Optimizer(nnx_model, tx, wrt=nnx.Param)
+        return train_state_nnx.TrainStateNNX(nnx_model, optimizer)
+
+      init_state_fn = create_train_state_fn
     else:
       init_state_fn = partial(maxtext_utils.init_initial_state, model, tx, config, True, example_rng)
     abstract_state, _, _ = maxtext_utils.get_abstract_state(config, mesh, init_state_fn, True)
-    return abstract_state
+    return abstract_state, config.pure_nnx
 
   def get_weights(self, argv):
-    return self.get_state(argv).params
+    state, is_nnx = self.get_state(argv)
+    if is_nnx:
+      return state.model
+    return state.params
 
   def get_mu(self, argv):
-    return self.get_state(argv).opt_state[0].mu
+    state, is_nnx = self.get_state(argv)
+    if is_nnx:
+      return state.optimizer.opt_state[0]["mu"]
+    return state.opt_state[0].mu
 
   def assert_pytree_is_dtype(self, weights, expected_dtype):
-    jax.tree_util.tree_map_with_path(lambda x, y: self.assertEqual(y.dtype, expected_dtype), weights)
+    """Asserts that all valid parameter arrays within the PyTree match the expected dtype."""
+
+    def check_dtype(path, leaf):
+      # Support NNX Variable objects which wrap the array in `.value`
+      if hasattr(getattr(leaf, "value", None), "dtype"):
+        leaf_dtype = leaf.value.dtype
+      elif hasattr(leaf, "dtype"):
+        leaf_dtype = leaf.dtype
+      else:
+        return
+
+      # Skip PRNG keys
+      if type(leaf_dtype).__name__ == "KeyTy" or str(leaf_dtype).startswith("key<"):
+        return
+
+      if jnp.issubdtype(leaf_dtype, jnp.integer):
+        # Skip integer fields like step counters
+        return
+      self.assertEqual(jnp.dtype(leaf_dtype), jnp.dtype(expected_dtype))
+
+    jax.tree_util.tree_map_with_path(
+        check_dtype, weights, is_leaf=lambda x: hasattr(x, "value") and hasattr(x.value, "dtype")
+    )
 
   def test_default_float32(self):
     argv = [None, get_test_config_path(), "enable_checkpointing=False"]

--- a/tests/unit/tiling_test.py
+++ b/tests/unit/tiling_test.py
@@ -71,11 +71,17 @@ class LossAndGradientCorrectnessTest(unittest.TestCase):
     """
     Set up common configurations and dummy data for the tests.
     """
+    # vocab_tiling on the Linen path uses transformer_as_linen + model.apply,
+    # so this class must stay on Linen even when NNX defaults are flipped to
+    # True. The NNX-side equivalents live in VocabTilingNNXTest below.
     self.base_config = [
         None,
         get_test_config_path(),
         "base_emb_dim=32",
         "vocab_size=128",
+        "enable_nnx=False",
+        "pure_nnx=False",
+        "pure_nnx_decoder=False",
     ]
     self.rng = jax.random.PRNGKey(1234)
     self.batch_size = 1
@@ -218,8 +224,6 @@ class LossAndGradientCorrectnessTest(unittest.TestCase):
         num_vocab_tiling=1,
         z_loss_multiplier=1e-4,  # Enable z-loss
     )
-    if getattr(cfg_non_tiling, "enable_nnx", False):
-      pytest.skip("We currently don't support vocab tiling on NNX module.")
     quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
     devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
     mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)
@@ -331,8 +335,6 @@ class LossAndGradientCorrectnessTest(unittest.TestCase):
         matmul_precision="high",
         num_vocab_tiling=1,
     )
-    if getattr(cfg_non_tiling, "enable_nnx", False):
-      pytest.skip("We currently don't support vocab tiling on NNX module.")
     quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
     devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
     mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)
@@ -398,8 +400,6 @@ class LossAndGradientCorrectnessTest(unittest.TestCase):
         num_vocab_tiling=1,
     )
 
-    if getattr(cfg_non_tiling, "enable_nnx", False):
-      pytest.skip("We currently don't support vocab tiling on NNX module.")
     quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
     devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
     mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)
@@ -461,8 +461,6 @@ class LossAndGradientCorrectnessTest(unittest.TestCase):
         matmul_precision="high",
         num_vocab_tiling=1,
     )
-    if getattr(cfg_non_tiling, "enable_nnx", False):
-      pytest.skip("We currently don't support vocab tiling on NNX module.")
     quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
     devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
     mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)
@@ -527,8 +525,6 @@ class LossAndGradientCorrectnessTest(unittest.TestCase):
         matmul_precision="high",
         num_vocab_tiling=1,
     )
-    if getattr(cfg_non_tiling, "enable_nnx", False):
-      pytest.skip("We currently don't support vocab tiling on NNX module.")
     quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
     devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
     mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)
@@ -595,8 +591,6 @@ class LossAndGradientCorrectnessTest(unittest.TestCase):
         matmul_precision="high",
         num_vocab_tiling=1,
     )
-    if getattr(cfg_non_tiling, "enable_nnx", False):
-      pytest.skip("We currently don't support vocab tiling on NNX module.")
     quant_non_tiling = quantizations.configure_quantization(cfg_non_tiling)
     devices_array_non_tiling = maxtext_utils.create_device_mesh(cfg_non_tiling)
     mesh_non_tiling = Mesh(devices_array_non_tiling, cfg_non_tiling.mesh_axes)

--- a/tests/unit/train_state_nnx_checkpoint_test.py
+++ b/tests/unit/train_state_nnx_checkpoint_test.py
@@ -351,7 +351,7 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
   def _invoke_maybe_save(self, state, pure_nnx):
     """Call maybe_save_checkpoint with save_checkpoint patched, return {step, state} captured."""
     # checkpoint_period=1 keeps force_ckpt_save False regardless of actual_step.
-    config = SimpleNamespace(pure_nnx=pure_nnx, checkpoint_period=1, async_checkpointing=False)
+    config = SimpleNamespace(pure_nnx=pure_nnx, checkpoint_period=1, async_checkpointing=False, enable_diloco=False)
     mgr = mock.MagicMock()
     mgr.reached_preemption.return_value = False
 
@@ -417,7 +417,7 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
     state = self._build_nnx_state(self.N_STEPS)
     actual_step = self.N_STEPS - 1
 
-    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False)
+    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False, enable_diloco=False)
     mgr = mock.MagicMock()
     mgr.reached_preemption.return_value = False
     # Mock latest_step to return the same actual_step
@@ -436,7 +436,7 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
     state = self._build_nnx_state(self.N_STEPS)
     actual_step = self.N_STEPS - 1
 
-    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False)
+    config = SimpleNamespace(pure_nnx=True, checkpoint_period=1, async_checkpointing=False, enable_diloco=False)
     mgr = mock.MagicMock()
     mgr.reached_preemption.return_value = False
     # Mock latest_step to return a different step (or None)
@@ -460,9 +460,7 @@ class TestLinenCheckpointFormatConverters(unittest.TestCase):
     return {
         "model": {
             "decoder": {"norm": {"scale": jnp.ones((3,))}},
-            "dropout": {
-                "rngs": {"default": {"key": jnp.ones((2,), dtype=jnp.uint32)}}
-            },  # NNX-only
+            "dropout": {"rngs": {"default": {"key": jnp.ones((2,), dtype=jnp.uint32)}}},  # NNX-only
         },
         "optimizer": {
             "step": jnp.asarray(7, dtype=jnp.uint32),
@@ -481,9 +479,7 @@ class TestLinenCheckpointFormatConverters(unittest.TestCase):
     linen = train_state_nnx.to_linen_checkpoint_dict(self._nnx_pure())
     self.assertEqual(set(linen.keys()), {"params", "step", "opt_state"})
     self.assertIn("params", linen["params"])  # params/params/ collection wrap
-    self.assertNotIn(
-        "dropout", linen["params"]["params"]
-    )  # NNX-only rngs/dropout stripped
+    self.assertNotIn("dropout", linen["params"]["params"])  # NNX-only rngs/dropout stripped
     self.assertEqual(linen["step"].dtype, jnp.int32)  # Linen step is int32
     # opt_state is a list with None for the EmptyState slot, mu/nu wrapped under params.
     self.assertIsInstance(linen["opt_state"], list)
@@ -493,19 +489,11 @@ class TestLinenCheckpointFormatConverters(unittest.TestCase):
 
   def test_round_trip_preserves_values(self):
     nnx_pure = self._nnx_pure()
-    back = train_state_nnx.from_linen_checkpoint_dict(
-        train_state_nnx.to_linen_checkpoint_dict(nnx_pure)
-    )
+    back = train_state_nnx.from_linen_checkpoint_dict(train_state_nnx.to_linen_checkpoint_dict(nnx_pure))
     self.assertEqual(set(back.keys()), {"model", "optimizer"})
-    self.assertEqual(
-        back["optimizer"]["step"].dtype, jnp.uint32
-    )  # NNX step back to uint32
-    self.assertEqual(
-        set(back["optimizer"]["opt_state"].keys()), {0, 2}
-    )  # int-keyed dict, EmptyState dropped
-    self.assertNotIn(
-        "params", back["optimizer"]["opt_state"][0]["mu"]
-    )  # mu/nu unwrapped
+    self.assertEqual(back["optimizer"]["step"].dtype, jnp.uint32)  # NNX step back to uint32
+    self.assertEqual(set(back["optimizer"]["opt_state"].keys()), {0, 2})  # int-keyed dict, EmptyState dropped
+    self.assertNotIn("params", back["optimizer"]["opt_state"][0]["mu"])  # mu/nu unwrapped
     self.assertTrue(
         jnp.array_equal(
             nnx_pure["model"]["decoder"]["norm"]["scale"],


### PR DESCRIPTION
PR6-PR10 promoted every routed-to-Linen feature to NNX-native; PR#2885 lands NNX-native pipeline parallelism. This PR flips the three defaults in base.yml so NNX is the production path, and bundles the NNX-only fixes that surface once pure_nnx=True (DiLoCo merge/checkpoint, Zero-1 input shardings on flat nnx.State, MTP sown-Variable handling, generate_param_only_checkpoint NNX flow, maxengine Linen-parity removal).

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.: 
BUGS: b/123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
