### PR TITLE
Add dynamic loss balancing for distillation feature and logit losses

### DIFF
--- a/src/maxtext/trainers/post_train/distillation/distillation_utils.py
+++ b/src/maxtext/trainers/post_train/distillation/distillation_utils.py
@@ -543,11 +543,10 @@ class CombinedDistillationStrategy(DistillationStrategy):
 
     ce_teacher_sum = jnp.sum(ce_teacher_per_pos * mask)
 
-    base_logit_loss = (alpha * soft_loss_mean) + ((1.0 - alpha) * hard_loss_mean)
-
+    # Feature Loss Scaling (match Logit Loss magnitude)
     feature_loss = jnp.array(0.0, dtype=jnp.float32)
+
     if self.beta_feature > 0.0:
-      assert s_features is not None and t_features is not None
       if self.layer_indices is not None:
         s_features_sliced = jnp.take(s_features, self.layer_indices, axis=0)
         t_features_sliced = jnp.take(t_features, self.layer_indices, axis=0)
@@ -558,9 +557,23 @@ class CombinedDistillationStrategy(DistillationStrategy):
       s_features_sliced = s_features_sliced.astype(jnp.float32)
       t_features_sliced = t_features_sliced.astype(jnp.float32)
 
-      feature_loss = beta_feature * self.feature_loss_fn(s_features_sliced, t_features_sliced, mask)
+      # Calculate raw feature loss
+      raw_feature_loss = self.feature_loss_fn(s_features_sliced, t_features_sliced, mask)
 
-    total_loss = base_logit_loss + feature_loss
+      # Match magnitude: Scale raw feature loss to match soft loss mean
+      feature_mag_scale = jax.lax.stop_gradient(soft_loss_mean) / jnp.maximum(
+          jax.lax.stop_gradient(raw_feature_loss), 1e-8
+      )
+      feature_loss = raw_feature_loss * feature_mag_scale
+
+    # Combined Distillation Loss (Logits + Balanced Features)
+    kd_loss = soft_loss_mean + feature_loss
+
+    # KD Scaling (match Hard/Task Loss magnitude)
+    kd_mag_scale = jax.lax.stop_gradient(hard_loss_mean) / jnp.maximum(jax.lax.stop_gradient(kd_loss), 1e-8)
+    balanced_kd_loss = kd_loss * kd_mag_scale
+
+    total_loss = hard_loss_mean + (alpha * balanced_kd_loss)
 
     moe_lb_loss = jnp.array(0.0)
     if student_output.moe_lb_loss is not None:


### PR DESCRIPTION
# Description

This PR updates the distillation loss computation in MaxText by introducing dynamic weighting for the feature loss and knowledge distillation terms. 

In `src/maxtext/trainers/post_train/distillation/distillation_utils.py`, we implemented a dynamic scale to match the raw feature loss magnitude to the softened logit loss (`soft_loss_mean`), and then scale the combined `kd_loss` to match the target task loss (`hard_loss_mean`). 

This dynamic loss balancing strategy is the approach used by the PIE team, and it helps stabilize multi-task objectives by making sure that different loss components maintain proportional gradient updates throughout training.

### Specific Implementation Details:
- **Feature Loss Scaling:** Raw feature loss is multiplied by `feature_mag_scale`, which is computed as the ratio of `soft_loss_mean` to `raw_feature_loss` (both with stop-gradients applied to match `detach()`).
- **Combined Distillation (KD) Scaling:** The combined distillation loss `kd_loss` is scaled using `kd_mag_scale`, computed as the ratio of `hard_loss_mean` to `kd_loss`.
- **Total Loss:** Calculated as: `total_loss = hard_loss_mean + (alpha * balanced_kd_loss)`.

# Tests

Ran training job with this new dynamic loss weighting strategy. 

- Config: https://paste.googleplex.com/4870625280786432
- Training Logs: [Logs](https://pantheon.corp.google.com/kubernetes/service/us-central1/bodaborg-super-xpk-x8p/default/kd-q30b-rep/logs?e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)
- Output Directory: [gs://ajkv-distillation/online-distillation-runs/qwen3-30b/reproduce-mmlu/kd-q30b-rep/kd_q30b_rep](https://pantheon.corp.google.com/storage/browser/ajkv-distillation/online-distillation-runs/qwen3-30b/reproduce-mmlu/kd-q30b-rep/kd_q30b_rep/checkpoints;tab=objects?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&e=13802955&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).