### PR TITLE
Add fused partial accumulation support to Tokamax v2 GMM kernel      

### DIFF
--- a/src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_gmm_kernel.py
+++ b/src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_gmm_kernel.py
@@ -204,6 +204,7 @@ class GmmConfigs:
   rhs_cfgs: InputConfigs
   out_dtype: jnp.dtype
   acc_dtype: jnp.dtype
+  has_partial_sum: bool
   zero_init: bool
   fuse_act: str | None
 
@@ -219,7 +220,7 @@ class GmmConfigs:
       return self.dims.size_n // 2
 
 
-TileFn = Callable[[Dimensions, InputConfigs, InputConfigs, int, str | None], TileSizes]
+TileFn = Callable[[Dimensions, InputConfigs, InputConfigs, int | None, str | None, bool], TileSizes]
 
 
 class IndexMaps:
@@ -270,10 +271,20 @@ class IndexMaps:
 
     return (pl.ds(row_start, row_size), 0, n_id)
 
+  def ps_index_map(self, n_id: jax.Array, gm_id: jax.Array, _: jax.Array):
+    m_start = self.metadata_ref.gm_id_to_m_offset[gm_id]
+    m_end = self.metadata_ref.gm_id_to_m_offset[gm_id + 1]
+
+    row_start = m_start // self.cfgs.dims.size_lhs_sublane
+    row_end = pl.cdiv(m_end, self.cfgs.dims.size_lhs_sublane)
+    row_size = row_end - row_start
+
+    return (pl.ds(row_start, row_size), 0, n_id)
+
 
 def generate_block_specs(
     metadata_ref: MetadataRef, cfgs: GmmConfigs
-) -> Tuple[Tuple[pl.BlockSpec, WeightsRef], pl.BlockSpec]:
+) -> Tuple[Tuple[pl.BlockSpec, WeightsRef, pl.BlockSpec | None], pl.BlockSpec]:
   """Generates block specs for the given lhs, rhs, and out refs."""
 
   index_map = IndexMaps(metadata_ref, cfgs)
@@ -294,7 +305,7 @@ def generate_block_specs(
       index_map.rhs_weight_index_map,
       pipeline_mode=pl.Buffered(buffer_count=3),
   )
-  rhs_scale_block_spec = rhs_bias_block_spec = None
+  rhs_scale_block_spec = rhs_bias_block_spec = ps_block_spec = None
   if cfgs.rhs_cfgs.has_bias:
     rhs_bias_block_spec = pl.BlockSpec(
         (None, 1, cfgs.tiles.tile_n),
@@ -304,6 +315,12 @@ def generate_block_specs(
     rhs_scale_block_spec = pl.BlockSpec(
         (None, cfgs.num_quant_blocks_per_tile_k, 1, cfgs.tiles.tile_n),
         index_map.rhs_scale_index_map,
+    )
+
+  if cfgs.has_partial_sum:
+    ps_block_spec = pl.BlockSpec(
+        (bounded_slice_gm, cfgs.dims.size_lhs_sublane, cfgs.tiles.tile_n),
+        index_map.ps_index_map,
     )
 
   rhs_block_spec = WeightsRef(
@@ -317,7 +334,7 @@ def generate_block_specs(
       index_map.out_index_map,
   )
 
-  return (lhs_block_spec, rhs_block_spec), out_block_spec
+  return (lhs_block_spec, rhs_block_spec, ps_block_spec), out_block_spec
 
 
 # Define kernels.
@@ -328,6 +345,9 @@ def inner_kernel(
     tiled_lhs_ref: jax.Array,
     # [tile_m // size_lhs_sublane, size_lhs_sublane, tile_k]
     tiled_rhs_ref: RhsRef,  # [tile_k, tile_n]
+    # Partial Sum
+    tiled_ps_ref: jax.Array | None,
+    # [tile_m // size_lhs_sublane, size_lhs_sublane, tile_n]
     # Out
     tiled_out_ref: jax.Array,
     # [tile_m // size_lhs_sublane, size_lhs_sublane, tile_n]
@@ -489,6 +509,9 @@ def inner_kernel(
       if cfgs.rhs_cfgs.has_bias:
         tiled_rhs_bias = tiled_rhs_ref.get_bias()
         acc += tiled_rhs_bias.astype(acc.dtype)
+      if cfgs.has_partial_sum:
+        ps_tile = tiled_ps_ref[...].reshape(acc.shape)
+        acc += ps_tile.astype(acc.dtype)
 
       acc = apply_act_fn(acc, cfgs.fuse_act)
 
@@ -746,6 +769,7 @@ def kernel_main(
     # In
     lhs_ref: jax.Array,  # [size_m, size_k]
     rhs_ref: WeightsRef,  # [size_group, size_k, size_n]
+    partial_sum_ref: jax.Array,  # [size_m, size_n]
     # Out
     out_ref: jax.Array,  # [size_m, size_n]
     # Scratch memory
@@ -812,7 +836,7 @@ def kernel_main(
         dims=cfgs.dims,
     )
 
-  (lhs_spec, rhs_spec), out_spec = generate_block_specs(metadata_ref, cfgs)
+  (lhs_spec, rhs_spec, ps_spec), out_spec = generate_block_specs(metadata_ref, cfgs)
 
   if cfgs.fuse_act is not None:
     rhs_up_ref = jax.tree.map(lambda x: x.at[..., cfgs.out_size_n :], rhs_ref)
@@ -827,16 +851,19 @@ def kernel_main(
   pipeline_fn = pltpu.emit_pipeline(
       functools.partial(inner_kernel, cfgs=cfgs),
       grid=(num_n, num_gm, num_k),
-      in_specs=(lhs_spec, rhs_spec),
+      in_specs=(lhs_spec, rhs_spec, ps_spec),
       out_specs=out_spec,
   )
 
   # Bounded slice requires second last dim to be aligned to the sublane size.
   # rhs_ref uses static tiling thus reshape is not needed.
   lhs_in = lhs_ref.reshape(-1, cfgs.dims.size_lhs_sublane, lhs_ref.shape[-1])
+  ps_in = None
+  if cfgs.has_partial_sum:
+    ps_in = partial_sum_ref.reshape(-1, cfgs.dims.size_lhs_sublane, partial_sum_ref.shape[-1])
   out_in = out_ref.reshape(-1, cfgs.dims.size_lhs_sublane, out_ref.shape[-1])
   scratches = [partial_out_ref, acc_ref, metadata_ref]
-  pipeline_fn(lhs_in, rhs_ref, out_in, scratches=scratches)
+  pipeline_fn(lhs_in, rhs_ref, ps_in, out_in, scratches=scratches)
 
   if cfgs.zero_init:
     zero_out_end(out_ref, semaphore_ref, zero_size, dims=cfgs.dims)
@@ -848,6 +875,7 @@ def calculate_tiling(
     rhs_cfgs: InputConfigs,
     vmem_limit_bytes: int,
     fuse_act: str | None = None,
+    has_partial_sum: bool = False,
 ) -> TileSizes:
   """Calculate optimal tile sizes for GMM kernel."""
 
@@ -914,11 +942,13 @@ def calculate_tiling(
     acc_dtype_bytes = 2 if lhs_cfgs.quant_dtype is not None else 4
     acc_vmem = tile_m * acc_cols * acc_dtype_bytes
 
-    # 4. Output tile (double-buffered)
+    # 4. Output tile (double-buffered) and partial sum buffer
     out_dtype_bytes = jax.dtypes.itemsize_bits(lhs_cfgs.dtype) // 8
     out_vmem = 2 * tile_m * tn * out_dtype_bytes
+    ps_vmem = 2 * tile_m * tn * out_dtype_bytes if has_partial_sum else 0
+    partial_out_vmem = dims.size_lhs_sublane * tn * out_dtype_bytes
 
-    return lhs_vmem + rhs_vmem + acc_vmem + out_vmem
+    return lhs_vmem + rhs_vmem + acc_vmem + out_vmem + ps_vmem + partial_out_vmem
 
   # Multiple k tiles will introduce accumulation overhead. Thus, we first try
   # to fit the tensors into vmem by only adjusting tile_n.
@@ -952,6 +982,7 @@ def validate_inputs(
     rhs: jax.Array,
     rhs_scale: jax.Array | None,
     rhs_bias: jax.Array | None,
+    partial_sum: jax.Array | None,
     group_sizes: jax.Array,
     group_offset: jax.Array,
     fuse_act: str | None = None,
@@ -967,6 +998,8 @@ def validate_inputs(
   assert rhs.shape == (size_group, size_k, size_n)
   if rhs_bias is not None:
     assert rhs_bias.shape == (size_group, 1, size_n)
+  if partial_sum is not None:
+    assert partial_sum.shape == (size_m, size_n)
   if rhs_scale is not None:
     num_quant_blocks = rhs_scale.shape[1]
     assert rhs_scale.shape == (size_group, num_quant_blocks, 1, size_n)
@@ -1043,6 +1076,7 @@ def make_gmm_configs(
     rhs: jax.Array,
     rhs_scale: jax.Array | None,
     rhs_bias: jax.Array | None,
+    partial_sum: jax.Array | None,
     group_sizes: jax.Array,
     group_offset: jax.Array,
     *,
@@ -1056,7 +1090,7 @@ def make_gmm_configs(
 ):
   """Fills the GMM config for the GMM kernel."""
 
-  dims = validate_inputs(lhs, rhs, rhs_scale, rhs_bias, group_sizes, group_offset, fuse_act)
+  dims = validate_inputs(lhs, rhs, rhs_scale, rhs_bias, partial_sum, group_sizes, group_offset, fuse_act)
 
   if rhs_scale is not None:
     has_scale = True
@@ -1118,7 +1152,7 @@ def make_gmm_configs(
   if isinstance(tile_info, TileSizes):
     tiles = tile_info
   else:
-    tiles = tile_info(dims, lhs_cfgs, rhs_cfgs, vmem_limit_bytes, fuse_act)
+    tiles = tile_info(dims, lhs_cfgs, rhs_cfgs, vmem_limit_bytes, fuse_act, partial_sum is not None)
 
   return GmmConfigs(
       dims=dims,
@@ -1127,6 +1161,7 @@ def make_gmm_configs(
       rhs_cfgs=rhs_cfgs,
       out_dtype=jnp.dtype(out_dtype),
       acc_dtype=jnp.dtype(acc_dtype),
+      has_partial_sum=partial_sum is not None,
       zero_init=zero_initialize,
       fuse_act=fuse_act,
   )
@@ -1161,6 +1196,7 @@ def gmm_v2(
     group_sizes: jax.Array,  # int32[size_lhs_group]
     rhs_scale: jax.Array | None = None,  # [size_group, num_blocks, 1, out_size]
     rhs_bias: jax.Array | None = None,  # [size_group, 1, out_size]
+    partial_sum: jax.Array | None = None,  # [size_m, size_n]
     group_offset: jax.Array | None = None,  # int32[1]
     *,
     tile_info: TileSizes | TileFn = calculate_tiling,
@@ -1184,6 +1220,7 @@ def gmm_v2(
     group_sizes: The group sizes of lhs rows of shape [size_lhs_group,].
     rhs_scale: The rhs scale of shape [size_group, num_blocks, 1, out_size].
     rhs_bias: The rhs bias of shape [size_group, 1, out_size].
+    partial_sum: Optional. Per-token partial sums of shape [size_m, size_n].
     group_offset: Optional. The group offset of shape [1,].
     tile_info: The tile sizes or tile function to use.
     vmem_limit_bytes: Optional vmem limit in bytes.
@@ -1214,6 +1251,7 @@ def gmm_v2(
       rhs,
       rhs_scale,
       rhs_bias,
+      partial_sum,
       group_sizes,
       group_offset,
       tile_info=tile_info,
@@ -1280,20 +1318,35 @@ def gmm_v2(
   aligned_n = align_to(cfgs.out_size_n, num_lanes)
   out_init = jax.ShapeDtypeStruct((dims.size_m, aligned_n), cfgs.out_dtype)
   rhs_weights = WeightsRef(weight=rhs, scale=rhs_scale, bias=rhs_bias)
+  in_specs = [
+      pl.BlockSpec(memory_space=pltpu.HBM),
+      WeightsRef(
+          weight=pl.BlockSpec(memory_space=pltpu.HBM),
+          scale=rhs_scale_spec,
+          bias=rhs_bias_spec,
+      ),
+  ]
+
+  partial_sum_spec = None
+  if partial_sum is not None:
+    in_specs.append(pl.BlockSpec(memory_space=pltpu.HBM))
+    partial_sum_spec = pl.BlockSpec(memory_space=pltpu.HBM)
+  in_specs = [
+      pl.BlockSpec(memory_space=pltpu.HBM),  # lhs
+      WeightsRef(
+          weight=pl.BlockSpec(memory_space=pltpu.HBM),
+          scale=rhs_scale_spec,
+          bias=rhs_bias_spec,
+      ),  # rhs_weights
+      partial_sum_spec,  # partial_sum
+  ]
 
   return pl.pallas_call(
       functools.partial(kernel_main, cfgs=cfgs),
       out_shape=out_init,
       grid_spec=pltpu.PrefetchScalarGridSpec(
           num_scalar_prefetch=2,
-          in_specs=[
-              pl.BlockSpec(memory_space=pltpu.HBM),
-              WeightsRef(
-                  weight=pl.BlockSpec(memory_space=pltpu.HBM),
-                  scale=rhs_scale_spec,
-                  bias=rhs_bias_spec,
-              ),
-          ],
+          in_specs=in_specs,
           out_specs=pl.BlockSpec(memory_space=pltpu.HBM),
           scratch_shapes=scratch_shapes,
       ),
@@ -1304,4 +1357,4 @@ def gmm_v2(
       name=get_scope_name(cfgs),
       cost_estimate=get_cost_estimate(cfgs),
       metadata=get_metadata(cfgs),
-  )(group_sizes, group_offset, lhs, rhs_weights)[:, : cfgs.out_size_n]
+  )(group_sizes, group_offset, lhs, rhs_weights, partial_sum)[:, : cfgs.out_size_n]

--- a/src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_tgmm_kernel.py
+++ b/src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_tgmm_kernel.py
@@ -263,6 +263,7 @@ def make_tgmm_configs(
       tiles=tiles,
       lhs_cfgs=lhs_cfgs,
       rhs_cfgs=rhs_cfgs,
+      has_partial_sum=False,  # This should always be False until partial sum support is added in bwd pass.
       out_dtype=jnp.dtype(out_dtype),
       acc_dtype=jnp.dtype(acc_dtype),
       # GMM's 'zero_init' zeros unvisited m-rows via DMA, which doesn't apply to

--- a/tests/unit/pallas_mosaic_tpu_v2_kernel_test.py
+++ b/tests/unit/pallas_mosaic_tpu_v2_kernel_test.py
@@ -1,0 +1,971 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for Pallas Mosaic TPU v2 kernels."""
+
+import collections
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import chex
+import jax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+import jax.numpy as jnp
+from maxtext.kernels.megablox import common
+from maxtext.kernels.megablox import pallas_mosaic_tpu_v2_gmm_kernel as gmm_backend
+from maxtext.kernels.megablox import pallas_mosaic_tpu_v2_tgmm_kernel as tgmm_backend
+
+
+def poison_tpu_memory():
+  """Fills TPU scratchpad memory with NaNs to simulate garbage state."""
+  tpu_info = pltpu.get_tpu_info()
+  # Security: Use a large but safe portion of VMEM/SMEM to avoid OOM.
+  vmem_size = (4 * 1024 * 1024) // 4  # 4MB
+  smem_size = (tpu_info.smem_capacity_bytes // 4) - 8192
+
+  def poison_kernel(in_ref, out_ref, v_scratch, s_scratch):
+    del in_ref, out_ref
+    v_scratch[...] = jnp.full_like(v_scratch, jnp.nan)
+    for i in range(s_scratch.shape[0]):
+      s_scratch[i] = 0x7FC00000  # IEEE 754 NaN bit pattern
+
+  pl.pallas_call(
+      poison_kernel,
+      out_shape=jax.ShapeDtypeStruct((1,), jnp.float32),
+      grid=(1,),
+      scratch_shapes=[
+          pltpu.VMEM((vmem_size // 128, 128), jnp.float32),
+          pltpu.SMEM((smem_size,), jnp.int32),
+      ],
+      compiler_params=pltpu.CompilerParams(disable_bounds_checks=True),
+  )(jnp.zeros((1,), dtype=jnp.float32))
+
+
+_GroupConfig = collections.namedtuple("_GroupConfig", ["num_groups", "group_offset", "num_local_groups"])
+
+
+def get_group_sizes(batch_size: int, num_groups: int) -> jax.Array:
+  distribution = jax.random.uniform(jax.random.key(0), (num_groups - 1,), dtype=jnp.float32)
+  distribution = distribution / jnp.sum(distribution)
+  group_sizes = jnp.floor(distribution * batch_size).astype(jnp.int32)
+  return jnp.append(group_sizes, batch_size - jnp.sum(group_sizes))
+
+
+def quantize_tensor(x: jax.Array, dtype: jnp.dtype, axis: int = -1, block_size: int = 256):
+  """Quantizes a tensor along a specified axis in blocks."""
+  if jnp.issubdtype(dtype, jnp.integer):
+    dtype_info = jnp.iinfo(dtype)
+    max_val = int(dtype_info.max)
+    min_val = int(dtype_info.min)
+  else:
+    dtype_info = jnp.finfo(dtype)
+    max_val = float(dtype_info.max)
+    min_val = float(dtype_info.min)
+
+  orig_shape = x.shape
+  blocked_shape = orig_shape[:axis] + (-1, block_size) + orig_shape[axis + 1 :]
+  x_blocked = x.reshape(blocked_shape)
+
+  x_blocked_abs_max = jnp.max(jnp.abs(x_blocked), axis=axis + 1, keepdims=True)
+  scale = x_blocked_abs_max / max_val
+  x_blocked_q = jnp.clip(x_blocked / scale, min_val, max_val).astype(dtype)
+
+  x_q = x_blocked_q.reshape(orig_shape)
+  x_q = jnp.nan_to_num(x_q)
+  scale = scale.squeeze(axis=axis + 1).astype(jnp.float32)
+  return x_q, scale
+
+
+def reference_gmm(
+    lhs: jax.Array,  # [m, k]
+    rhs: jax.Array,  # [num_groups, k, n]
+    group_sizes: jax.Array,  # [num_groups]
+    partial_sum: jax.Array | None = None,  # [m, n]
+    rhs_scale: jax.Array | None = None,
+    rhs_bias: jax.Array | None = None,
+    group_offset: jax.Array | None = None,  # int32[1]
+):
+  """Computes reference grouped matrix multiplication."""
+  num_tokens = lhs.shape[0]
+  num_groups, in_size, out_size = rhs.shape
+  assert num_groups > 0, f"rhs must have at least 1 group, got {num_groups}"
+  assert lhs.shape[1] == in_size
+
+  if group_offset is None:
+    group_offset = jnp.array([0], dtype=jnp.int32)
+  elif jnp.isscalar(group_offset):
+    assert group_offset.size == 1
+    if jnp.isscalar(group_offset):
+      group_offset = group_offset[None]
+
+  if rhs_scale is not None:
+    num_blocks = rhs_scale.shape[1]
+  else:
+    num_blocks = 1
+  block_size = in_size // num_blocks
+
+  start = 0
+  gmm_out = []
+  for global_group in range(group_sizes.size):
+    group_size = group_sizes[global_group]
+
+    group = global_group - group_offset[0]
+    end = min(start + group_size, num_tokens)
+    group_size = end - start
+    if 0 <= group < num_groups:
+      lhs_slice = lhs[start:end]
+      rhs_slice = rhs[group]
+
+      out = jnp.array(0.0, dtype=jnp.float32)
+      for block in range(num_blocks):
+        block_start = block * block_size
+        block_end = block_start + block_size
+        lhs_block = lhs_slice[:, block_start:block_end].astype(jnp.float32)
+        rhs_block = rhs_slice[block_start:block_end, :].astype(jnp.float32)
+
+        acc = jnp.einsum("bd,dh->bh", lhs_block, rhs_block)
+        if rhs_scale is not None:
+          acc *= rhs_scale[group][block]
+        out += acc
+      if rhs_bias is not None:
+        out = out + rhs_bias[group]
+      if partial_sum is not None:
+        out = out + partial_sum[start:end]
+    else:
+      out = jnp.zeros((group_size, out_size), dtype=lhs.dtype)
+
+    gmm_out.append(out.astype(lhs.dtype))
+    start = end
+
+  return jnp.concat(gmm_out, axis=0)
+
+
+def reference_tgmm(
+    lhs,  # [k, m]
+    rhs,  # [m, n]
+    group_sizes,  # [num_groups]
+    # num_actual_groups comes from weights.shape[0]
+    num_actual_groups,  # int32
+    # group_offset is obtained from
+    # jnp.arange(0, num_experts, num_experts_per_shard)
+    group_offset=None,
+):  # [num_groups, k, n]
+  """Computes reference transposed grouped matrix multiplication."""
+  # Compute lhs[:, sizes[i-1]:sizes[i]] @ rhs[sizes[i-1]:sizes[i], :]
+  if group_offset is None:
+    group_offset = jnp.array([0], dtype=jnp.int32)
+  elif jnp.isscalar(group_offset):
+    assert group_offset.size == 1
+    if jnp.isscalar(group_offset):
+      group_offset = group_offset[None]
+
+  start = 0
+  out = []
+  for global_group in range(group_sizes.size):
+    group_size = group_sizes[global_group]
+    group = global_group - group_offset[0]
+    end = start + group_size
+    if 0 <= group < num_actual_groups:
+      out.append(lhs[:, start:end] @ rhs[start:end, :])
+    start = end
+  return jnp.stack(out)
+
+
+# Default per-dtype tolerances, mirroring
+# jax._src.public_test_util._default_tolerance. Extend this map if a new output
+# dtype is introduced into a default-tolerance assertion.
+_DTYPE_TOL = {
+    jnp.dtype(jnp.bfloat16): 1e-1,
+}
+
+
+def _lookup_tol(dtype):
+  key = jnp.dtype(dtype)
+  if key not in _DTYPE_TOL:
+    raise KeyError(f"No default tolerance for dtype {key!r}. " f"Add it to _DTYPE_TOL or pass explicit atol/rtol.")
+  return _DTYPE_TOL[key]
+
+
+def assert_arrays_all_close(actual, desired, *, atol=None, rtol=None):
+  if atol is None:
+    atol = max(_lookup_tol(actual.dtype), _lookup_tol(desired.dtype))
+  if rtol is None:
+    rtol = max(_lookup_tol(actual.dtype), _lookup_tol(desired.dtype))
+  chex.assert_trees_all_close(actual, desired, atol=atol, rtol=rtol)
+
+
+class GmmTest(parameterized.TestCase):
+
+  def setUp(self):
+    if jax.default_backend() != "tpu":
+      self.skipTest("Only supported on TPUs.")
+    super().setUp()
+
+  @parameterized.product(
+      batch_size=[128, 512],
+      in_size=[512, 1024],
+      out_size=[512, 1024],
+      num_groups=[16, 32],
+      has_bias=[True, False],
+      has_partial_sum=[True, False],
+      group_offset=[0, 2, 3],
+  )
+  def test_gmm_basic(self, batch_size, in_size, out_size, num_groups, has_bias, has_partial_sum, group_offset):
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+    k0, k1, k2, k3 = jax.random.split(key, 4)
+
+    lhs = jax.random.normal(k0, (batch_size, in_size), dtype=jnp.bfloat16)
+    rhs = jax.random.normal(k1, (num_local_groups, in_size, out_size), dtype=jnp.bfloat16)
+    rhs_bias = None
+    if has_bias:
+      rhs_bias = jax.random.normal(k2, (num_local_groups, 1, out_size), dtype=jnp.bfloat16)
+
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+    ps = None
+    if has_partial_sum:
+      ps = jax.random.normal(k3, (batch_size, out_size), dtype=jnp.bfloat16)
+
+    expected = reference_gmm(lhs, rhs, group_sizes, partial_sum=ps, rhs_bias=rhs_bias, group_offset=group_offset)
+
+    actual = gmm_backend.gmm_v2(
+        lhs,
+        rhs,
+        group_sizes,
+        partial_sum=ps,
+        rhs_bias=rhs_bias,
+        group_offset=group_offset,
+    )
+
+    assert_arrays_all_close(actual, expected)
+
+  @parameterized.product(
+      batch_size=[128, 1024],
+      in_size=[512, 1024],
+      out_size=[512, 1024],
+      num_groups=[5, 16, 32],
+      group_offset=[0, 2, 3],
+  )
+  def test_tgmm_basic(self, batch_size, in_size, out_size, num_groups, group_offset):
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+    key1, key2 = jax.random.split(key, 2)
+    lhs = jax.random.normal(key1, (batch_size, in_size), dtype=jnp.bfloat16)  # [m, k]
+    grad = jax.random.normal(key2, (batch_size, out_size), dtype=jnp.bfloat16)  # [m, n]
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    # if batch_size=128, num_groups=3, an example group_size is
+    # group_sizes=Array([14, 14, ..., 7]).
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    lhs_t = lhs.swapaxes(0, 1)  # [k, m]
+    expected = reference_tgmm(lhs_t, grad, group_sizes, num_local_groups, group_offset=group_offset)
+    actual = tgmm_backend.tgmm_v2(
+        lhs,
+        grad,
+        group_sizes,
+        num_local_groups,
+        group_offset=group_offset,
+        preferred_element_type=jnp.bfloat16,
+    )
+    self.assertEqual(actual.shape, (num_local_groups, in_size, out_size))
+    # diff = jnp.abs(expected - actual)
+    # max_diff_idx = jnp.unravel_index(jnp.argmax(diff), diff.shape)
+    # print(f"Output max diff: {jnp.max(diff)} at index {max_diff_idx}")
+    # print(f"Output mean diff: {jnp.mean(jnp.abs(expected - actual))}")
+    assert_arrays_all_close(actual, expected)
+
+  @parameterized.product(
+      batch_size=[128, 256],
+      in_size=[255, 500],
+      out_size=[255, 500],
+      num_groups=[16],
+      group_offset=[0],
+  )
+  def test_tgmm_implicit_padding(self, batch_size, in_size, out_size, num_groups, group_offset):
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+    key1, key2 = jax.random.split(key, 2)
+    lhs = jax.random.normal(key1, (batch_size, in_size), dtype=jnp.bfloat16)
+    grad = jax.random.normal(key2, (batch_size, out_size), dtype=jnp.bfloat16)
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    lhs_t = lhs.swapaxes(0, 1)
+    expected = reference_tgmm(lhs_t, grad, group_sizes, num_local_groups, group_offset=group_offset)
+    actual = tgmm_backend.tgmm_v2(
+        lhs,
+        grad,
+        group_sizes,
+        num_local_groups,
+        group_offset=group_offset,
+        preferred_element_type=jnp.bfloat16,
+    )
+    self.assertEqual(actual.shape, (num_local_groups, in_size, out_size))
+    assert_arrays_all_close(actual, expected)
+
+  @parameterized.product(
+      batch_size=[256, 1024],
+      in_size=[1024],
+      out_size=[1024],
+      num_groups=[16],
+      group_offset=[0, 2],
+      tile_k=[256, 512],
+      tile_n=[256, 512],
+  )
+  def test_tgmm_with_tile_info(
+      self,
+      batch_size,
+      in_size,
+      out_size,
+      num_groups,
+      group_offset,
+      tile_k,
+      tile_n,
+  ):
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+    key1, key2 = jax.random.split(key, 2)
+    lhs = jax.random.normal(key1, (batch_size, in_size), dtype=jnp.bfloat16)
+    grad = jax.random.normal(key2, (batch_size, out_size), dtype=jnp.bfloat16)
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    lhs_t = lhs.swapaxes(0, 1)
+    expected = reference_tgmm(lhs_t, grad, group_sizes, num_local_groups, group_offset=group_offset)
+
+    tile_info = gmm_backend.TileSizes(tile_m=256, tile_k=tile_k, tile_n=tile_n)
+    actual = tgmm_backend.tgmm_v2(
+        lhs,
+        grad,
+        group_sizes,
+        num_local_groups,
+        group_offset=group_offset,
+        preferred_element_type=jnp.bfloat16,
+        tile_info=tile_info,
+    )
+    self.assertEqual(actual.shape, (num_local_groups, in_size, out_size))
+    assert_arrays_all_close(actual, expected)
+
+  @parameterized.product(
+      batch_size=[128],
+      in_size=[512],
+      out_size=[512],
+      num_groups=[4],
+      group_offset=[0],
+      empty_group_index=[0, 1, 2, 3],
+  )
+  def test_tgmm_empty_group(
+      self,
+      batch_size,
+      in_size,
+      out_size,
+      num_groups,
+      group_offset,
+      empty_group_index,
+  ):
+    """Test that TGMM correctly zeros output for empty groups."""
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+    key1, key2 = jax.random.split(key, 2)
+    lhs = jax.random.normal(key1, (batch_size, in_size), dtype=jnp.bfloat16)
+    grad = jax.random.normal(key2, (batch_size, out_size), dtype=jnp.bfloat16)
+
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    # Redistribute the empty group's tokens to the last group.
+    group_sizes = group_sizes.at[-1].add(group_sizes[empty_group_index])
+    group_sizes = group_sizes.at[empty_group_index].set(0)
+
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    lhs_t = lhs.swapaxes(0, 1)
+    expected = reference_tgmm(lhs_t, grad, group_sizes, num_local_groups, group_offset=group_offset)
+    actual = tgmm_backend.tgmm_v2(
+        lhs,
+        grad,
+        group_sizes,
+        num_local_groups,
+        group_offset=group_offset,
+        preferred_element_type=jnp.bfloat16,
+    )
+    self.assertEqual(actual.shape, (num_local_groups, in_size, out_size))
+    assert_arrays_all_close(actual, expected)
+
+  def test_tgmm_explicitly_exercises_all_branches(self):
+    # Group 0 (size 4*tile_m, 4 gm tiles): matmul_new_group, matmul, matmul,
+    # matmul_group_changing.
+    # Group 1 (size 64, 1 gm tile): matmul_new_group_and_changing.
+
+    tile_m = tile_k = tile_n = 256
+    in_size = out_size = 256
+    num_local_groups = 2
+    g0, g1 = 4 * tile_m, 64
+    batch_size = g0 + g1
+
+    key = jax.random.key(0)
+    key1, key2 = jax.random.split(key, 2)
+    lhs = jax.random.normal(key1, (batch_size, in_size), dtype=jnp.bfloat16)
+    grad = jax.random.normal(key2, (batch_size, out_size), dtype=jnp.bfloat16)
+    group_sizes = jnp.array([g0, g1], dtype=jnp.int32)
+    group_offset = jnp.array(0, dtype=jnp.int32)
+
+    lhs_t = lhs.swapaxes(0, 1)
+    expected = reference_tgmm(lhs_t, grad, group_sizes, num_local_groups, group_offset=group_offset)
+    tile_info = gmm_backend.TileSizes(tile_m=tile_m, tile_k=tile_k, tile_n=tile_n)
+    actual = tgmm_backend.tgmm_v2(
+        lhs,
+        grad,
+        group_sizes,
+        num_local_groups,
+        group_offset=group_offset,
+        preferred_element_type=jnp.bfloat16,
+        tile_info=tile_info,
+    )
+    self.assertEqual(actual.shape, (num_local_groups, in_size, out_size))
+    assert_arrays_all_close(actual, expected)
+
+  @parameterized.product(
+      batch_size=[128],
+      in_size=[512, 1024],
+      out_size=[512, 1024],
+      num_groups=[16, 32],
+      has_bias=[True, False],
+      weight_dtype=[jnp.int8, jnp.float8_e4m3fn, jnp.float4_e2m1fn],
+      block_size=[64, 128, 256, 512],
+      group_offset=[0, 2, 3],
+  )
+  def test_gmm_weight_quantized(
+      self,
+      batch_size,
+      in_size,
+      out_size,
+      num_groups,
+      has_bias,
+      weight_dtype,
+      block_size,
+      group_offset,
+  ):
+    if weight_dtype == jnp.float4_e2m1fn and common.tpu_generation() < 7:
+      self.skipTest("Expect TPUv7+")
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+
+    lhs = jax.random.uniform(key, (batch_size, in_size), jnp.bfloat16, -1, 1)
+    rhs = jax.random.uniform(key, (num_local_groups, in_size, out_size), jnp.bfloat16, -1, 1)
+    rhs_q, rhs_scale = quantize_tensor(rhs, weight_dtype, axis=1, block_size=block_size)
+    rhs_scale = jnp.expand_dims(rhs_scale, axis=2)
+
+    rhs_bias = None
+    if has_bias:
+      rhs_bias = jax.random.normal(key, (num_local_groups, 1, out_size), dtype=jnp.bfloat16)
+
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    expected = reference_gmm(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        rhs_bias=rhs_bias,
+        group_offset=group_offset,
+    )
+
+    actual = gmm_backend.gmm_v2(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        group_offset=group_offset,
+        rhs_bias=rhs_bias,
+        maybe_quantize_lhs=False,
+    ).astype(lhs.dtype)
+
+    chex.assert_trees_all_close(actual, expected, atol=3e-1, rtol=3e-1)
+
+  def test_gmm_security_isolation(self):
+    """Verifies that sequences (experts) are isolated from each other.
+
+    This test checks that NaNs or extreme values in one expert group do not
+    pollute the output of other expert groups, even if they share the same
+    sublane tile.
+    """
+    batch_size = 128
+    in_size = 512
+    out_size = 512
+    num_groups = 4
+    key = jax.random.key(42)
+
+    lhs = jax.random.normal(key, (batch_size, in_size), dtype=jnp.bfloat16)
+    rhs = jax.random.normal(key, (num_groups, in_size, out_size), dtype=jnp.bfloat16)
+
+    # We use very small group sizes to force expert groups to share tiles.
+    # sublane_size is typically 8 or 16.
+    group_sizes = jnp.array([4, 4, 4, batch_size - 12], dtype=jnp.int32)
+
+    # 1. Run baseline
+    actual_clean = gmm_backend.gmm_v2(lhs, rhs, group_sizes)
+
+    # 2. Inject NaNs into all experts except the first one.
+    # If isolation fails, the NaNs will leak into the first expert's output.
+    rhs_malicious = rhs.at[1:].set(jnp.nan)
+    actual_malicious = gmm_backend.gmm_v2(lhs, rhs_malicious, group_sizes)
+
+    # Verify that the first expert's output is identical and NaN-free.
+    first_expert_size = group_sizes[0]
+    chex.assert_trees_all_close(
+        actual_malicious[:first_expert_size],
+        actual_clean[:first_expert_size],
+        atol=0.0,
+        rtol=0.0,
+    )
+    self.assertFalse(jnp.any(jnp.isnan(actual_malicious[:first_expert_size])))
+
+  def test_gmm_uninitialized_memory_robustness(self):
+    """Verifies that the kernel is robust against uninitialized scratchpads.
+
+    This test intentionally poisons TPU VMEM/SMEM with NaNs before running the
+    GMM kernel. This ensures that  no stale data from previous sessions can leak
+    into the output.
+    """
+    # 1. Poison TPU memory with NaNs
+    poison_tpu_memory()
+
+    # 2. Run GMM kernel
+    batch_size = 128
+    in_size = 512
+    out_size = 512
+    num_groups = 4
+    key = jax.random.key(0)
+    lhs = jax.random.normal(key, (batch_size, in_size), dtype=jnp.bfloat16)
+    rhs = jax.random.normal(key, (num_groups, in_size, out_size), dtype=jnp.bfloat16)
+    group_sizes = jnp.array([batch_size // 4] * 4, dtype=jnp.int32)
+
+    actual = gmm_backend.gmm_v2(lhs, rhs, group_sizes)
+
+    # 3. Verify that the output is NaN-free
+    self.assertFalse(jnp.any(jnp.isnan(actual)))
+
+  @parameterized.product(
+      batch_size=[128],
+      in_size=[1024],
+      out_size=[512],
+      num_groups=[16],
+      weight_dtype=[jnp.int8, jnp.float8_e4m3fn, jnp.float4_e2m1fn],
+      block_size=[1024],
+      tile_k=[128, 256, 512],
+      group_offset=[0],
+  )
+  def test_gmm_weight_quantized_block_larger_than_tile_k(
+      self,
+      batch_size,
+      in_size,
+      out_size,
+      num_groups,
+      weight_dtype,
+      block_size,
+      tile_k,
+      group_offset,
+  ):
+    """Test that quant_block_size > tile_k is handled correctly."""
+    if weight_dtype == jnp.float4_e2m1fn and common.tpu_generation() < 7:
+      self.skipTest("Expect TPUv7+")
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+
+    lhs = jax.random.uniform(key, (batch_size, in_size), jnp.bfloat16, -1, 1)
+    rhs = jax.random.uniform(key, (num_local_groups, in_size, out_size), jnp.bfloat16, -1, 1)
+    rhs_q, rhs_scale = quantize_tensor(rhs, weight_dtype, axis=1, block_size=block_size)
+    rhs_scale = jnp.expand_dims(rhs_scale, axis=2)
+
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    expected = reference_gmm(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        group_offset=group_offset,
+    )
+
+    tile_info = gmm_backend.TileSizes(tile_m=128, tile_k=tile_k, tile_n=out_size)
+    actual = gmm_backend.gmm_v2(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        group_offset=group_offset,
+        tile_info=tile_info,
+        maybe_quantize_lhs=False,
+    ).astype(lhs.dtype)
+
+    chex.assert_trees_all_close(actual, expected, atol=3e-1, rtol=3e-1)
+
+  @parameterized.product(
+      batch_size=[128],
+      in_size=[1024],
+      out_size=[512],
+      num_groups=[16],
+      weight_dtype=[jnp.int4, jnp.int8, jnp.float8_e4m3fn],
+      block_size=[1024],
+      tile_k=[128, 256, 512],
+      group_offset=[0],
+  )
+  def test_gmm_activation_weight_quantized_block_larger_than_tile_k(
+      self,
+      batch_size,
+      in_size,
+      out_size,
+      num_groups,
+      weight_dtype,
+      block_size,
+      tile_k,
+      group_offset,
+  ):
+    """Test activation+weight quantized path with quant_block_size > tile_k."""
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+
+    lhs = jax.random.uniform(key, (batch_size, in_size), jnp.bfloat16, -1, 1)
+    rhs = jax.random.uniform(key, (num_local_groups, in_size, out_size), jnp.bfloat16, -1, 1)
+    rhs_q, rhs_scale = quantize_tensor(rhs, weight_dtype, axis=1, block_size=block_size)
+    rhs_scale = jnp.expand_dims(rhs_scale, axis=2)
+
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    expected = reference_gmm(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        group_offset=group_offset,
+    )
+
+    tile_info = gmm_backend.TileSizes(tile_m=128, tile_k=tile_k, tile_n=out_size)
+    actual = gmm_backend.gmm_v2(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        group_offset=group_offset,
+        tile_info=tile_info,
+        maybe_quantize_lhs=True,
+    ).astype(lhs.dtype)
+
+    chex.assert_trees_all_close(actual, expected, atol=1.2, rtol=1.2)
+
+  @parameterized.product(
+      batch_size=[128],
+      in_size=[512, 1024],
+      out_size=[512, 1024],
+      num_groups=[16, 32],
+      weight_dtype=[jnp.int4, jnp.uint4, jnp.int8, jnp.float8_e4m3fn],
+      block_size=[512, 1024],
+      group_offset=[0, 2, 3],
+  )
+  def test_gmm_activation_weight_quantized(
+      self,
+      batch_size,
+      in_size,
+      out_size,
+      num_groups,
+      weight_dtype,
+      block_size,
+      group_offset,
+  ):
+    if weight_dtype == jnp.float4_e2m1fn and common.tpu_generation() < 7:
+      self.skipTest("Expect TPUv7+")
+    if block_size > in_size:
+      self.skipTest("block_size must be <= in_size")
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+
+    lhs = jax.random.uniform(key, (batch_size, in_size), jnp.bfloat16, -1, 1)
+    rhs = jax.random.uniform(key, (num_local_groups, in_size, out_size), jnp.bfloat16, -1, 1)
+    rhs_q, rhs_scale = quantize_tensor(rhs, weight_dtype, axis=1, block_size=block_size)
+    rhs_scale = jnp.expand_dims(rhs_scale, axis=2)
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    expected = reference_gmm(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        group_offset=group_offset,
+    )
+
+    actual = gmm_backend.gmm_v2(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        group_offset=group_offset,
+        maybe_quantize_lhs=True,
+    ).astype(lhs.dtype)
+
+    chex.assert_trees_all_close(actual, expected, atol=1.1, rtol=1.1)
+
+  @parameterized.product(
+      batch_size=[128, 256],
+      in_size=[255, 500],
+      out_size=[255, 500],
+      num_groups=[16],
+      has_bias=[True, False],
+      group_offset=[0],
+  )
+  def test_gmm_implicit_padding(self, batch_size, in_size, out_size, num_groups, has_bias, group_offset):
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+
+    lhs = jax.random.normal(key, (batch_size, in_size), dtype=jnp.bfloat16)
+    rhs = jax.random.normal(key, (num_local_groups, in_size, out_size), dtype=jnp.bfloat16)
+    rhs_bias = None
+    if has_bias:
+      rhs_bias = jax.random.normal(key, (num_local_groups, 1, out_size), dtype=jnp.bfloat16)
+
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    expected = reference_gmm(
+        lhs,
+        rhs,
+        group_sizes,
+        rhs_bias=rhs_bias,
+        group_offset=group_offset,
+    )
+
+    actual = gmm_backend.gmm_v2(
+        lhs,
+        rhs,
+        group_sizes,
+        rhs_bias=rhs_bias,
+        group_offset=group_offset,
+    )
+
+    self.assertEqual(actual.shape, (batch_size, out_size))
+    assert_arrays_all_close(actual, expected)
+
+  @parameterized.product(
+      batch_size=[128],
+      in_size=[512],
+      out_size=[500],
+      num_groups=[16],
+      has_bias=[True, False],
+      weight_dtype=[jnp.int8, jnp.float8_e4m3fn],
+      block_size=[512],
+      group_offset=[0],
+  )
+  def test_gmm_weight_quantized_padding(
+      self,
+      batch_size,
+      in_size,
+      out_size,
+      num_groups,
+      has_bias,
+      weight_dtype,
+      block_size,
+      group_offset,
+  ):
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+
+    lhs = jax.random.normal(key, (batch_size, in_size), dtype=jnp.bfloat16)
+    rhs = jax.random.normal(key, (num_local_groups, in_size, out_size), dtype=jnp.bfloat16)
+    rhs_q, rhs_scale = quantize_tensor(rhs, weight_dtype, axis=1, block_size=block_size)
+    rhs_scale = jnp.expand_dims(rhs_scale, axis=2)
+
+    rhs_bias = None
+    if has_bias:
+      rhs_bias = jax.random.normal(key, (num_local_groups, 1, out_size), dtype=jnp.bfloat16)
+
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    expected = reference_gmm(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        rhs_bias=rhs_bias,
+        group_offset=group_offset,
+    )
+
+    actual = gmm_backend.gmm_v2(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        group_offset=group_offset,
+        rhs_bias=rhs_bias,
+        maybe_quantize_lhs=False,
+    ).astype(lhs.dtype)
+
+    self.assertEqual(actual.shape, (batch_size, out_size))
+    chex.assert_trees_all_close(actual, expected, atol=3e-1, rtol=3e-1)
+
+  @parameterized.product(
+      batch_size=[128],
+      in_size=[512],
+      out_size=[512],
+      # group_config: (num_groups, group_offset, num_local_groups)
+      group_config=[
+          # groups 0-1: group<0, groups 2-5: local and active,
+          # groups 6-15: group>=num_local_groups
+          _GroupConfig(num_groups=16, group_offset=2, num_local_groups=4),
+          # no negative groups, groups 0-7: local and active,
+          # groups 8-15: group>=num_local_groups
+          _GroupConfig(num_groups=16, group_offset=0, num_local_groups=8),
+          # groups 0-3: group<0, groups 4-7: local and active,
+          # groups 8-31: group>=num_local_groups
+          _GroupConfig(num_groups=32, group_offset=4, num_local_groups=4),
+      ],
+  )
+  def test_gmm_nonlocal_groups_produce_zeros(self, batch_size, in_size, out_size, group_config):
+    num_groups, group_offset, num_local_groups = group_config
+    key = jax.random.key(0)
+
+    lhs = jax.random.normal(key, (batch_size, in_size), dtype=jnp.bfloat16)
+    rhs = jax.random.normal(key, (num_local_groups, in_size, out_size), dtype=jnp.bfloat16)
+    rhs_bias = jax.random.normal(key, (num_local_groups, 1, out_size), dtype=jnp.bfloat16)
+
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    expected = reference_gmm(
+        lhs,
+        rhs,
+        group_sizes,
+        rhs_bias=rhs_bias,
+        group_offset=group_offset,
+    )
+
+    actual = gmm_backend.gmm_v2(
+        lhs,
+        rhs,
+        group_sizes,
+        rhs_bias=rhs_bias,
+        group_offset=group_offset,
+    )
+
+    self.assertEqual(actual.shape, (batch_size, out_size))
+    assert_arrays_all_close(actual, expected)
+
+  @parameterized.product(
+      batch_size=[128],
+      in_size=[512],
+      out_size=[512],
+      num_groups=[16],
+      has_bias=[True, False],
+      use_weight_scale=[True, False],
+      maybe_quantize_lhs=[True, False],
+      fuse_act=["silu", "swigluoai", "gelu"],
+      group_offset=[0, 2],
+      block_size=[256, 512],
+  )
+  def test_gmm_fused_activation(
+      self,
+      batch_size,
+      in_size,
+      out_size,
+      num_groups,
+      has_bias,
+      use_weight_scale,
+      maybe_quantize_lhs,
+      fuse_act,
+      group_offset,
+      block_size,
+  ):
+    if maybe_quantize_lhs and not use_weight_scale:
+      self.skipTest("LHS quantization requires RHS quantization/scale in this config.")
+    if block_size > in_size:
+      self.skipTest("block_size must be <= in_size")
+    key = jax.random.key(0)
+    final_out_size = out_size // 2
+    num_local_groups = num_groups - group_offset
+
+    # 1. Generate Inputs
+    lhs = jax.random.uniform(key, (batch_size, in_size), jnp.bfloat16, -1, 1)
+    rhs = jax.random.uniform(key, (num_local_groups, in_size, out_size), jnp.bfloat16, -1, 1)
+
+    rhs_q = rhs
+    rhs_scale = None
+    if use_weight_scale:
+      rhs_q, rhs_scale = quantize_tensor(rhs, jnp.int8, axis=1, block_size=block_size)
+      rhs_scale = jnp.expand_dims(rhs_scale, axis=2)
+
+    rhs_bias = None
+    if has_bias:
+      rhs_bias = jax.random.normal(key, (num_local_groups, 1, out_size), dtype=jnp.bfloat16)
+
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array([group_offset], dtype=jnp.int32)
+
+    # 2. Simulate LHS Quantization Noise
+    lhs_simulated = lhs
+    # because the kernel quantizes LHS in blocks, while reference does it at the
+    # whole tensor level, and output is casted down we need to simulate that
+    # quantization noise in the reference as well for a fair comparison
+    if maybe_quantize_lhs:
+      lhs_block_size = min(512, in_size)
+      lhs_q, lhs_scale_factor = quantize_tensor(lhs, jnp.int8, axis=1, block_size=lhs_block_size)
+      lhs_q_blocked = lhs_q.reshape(batch_size, -1, lhs_block_size).astype(jnp.float32)
+      lhs_scale_expanded = jnp.expand_dims(lhs_scale_factor, axis=2)
+      lhs_simulated = (lhs_q_blocked * lhs_scale_expanded).reshape(lhs.shape).astype(lhs.dtype)
+
+    # 3. Compute Reference Output
+    raw_expected = reference_gmm(
+        lhs_simulated,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        rhs_bias=rhs_bias,
+        group_offset=group_offset,
+    )
+
+    # Slice the reference and apply the activation function
+    expected = gmm_backend.apply_act_fn(raw_expected.astype(jnp.float32), fuse_act).astype(lhs.dtype)
+
+    # 4. Compute Actual Kernel Output
+    actual = gmm_backend.gmm_v2(
+        lhs,
+        rhs_q,
+        group_sizes,
+        rhs_scale=rhs_scale,
+        rhs_bias=rhs_bias,
+        group_offset=group_offset,
+        maybe_quantize_lhs=maybe_quantize_lhs,
+        fuse_act=fuse_act,
+    ).astype(lhs.dtype)
+
+    # 5. Compare Results
+    self.assertEqual(actual.shape, (batch_size, final_out_size))
+
+    # tolerances based quantization noise difference between reference and
+    # gmm_v2
+    if maybe_quantize_lhs:
+      atol, rtol = 4.0, 2.0  # Act + Weight Quantization
+    elif use_weight_scale:
+      atol, rtol = 3e-1, 3e-1  # Weight Quantization Only
+    else:
+      atol, rtol = 5e-2, 5e-2  # Unquantized Path (bfloat16 precision diffs)
+
+    chex.assert_trees_all_close(actual, expected, atol=atol, rtol=rtol)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
# Description                                                                                        
In current MoE architectures with Expert Parallelism (EP) and Ring of Experts enabled, input activations must be sequentially All-Gathered across EP shards before computing GMMs. This sequential bottleneck can account for ~24.9% of forward pass step time using ds3 as an example.
                                                                                        
To overlap EP All-Gather communication with computation, we chunk input activations along the embedding dimension (E). While computing the i-th GMM chunk, we concurrently gather and sort activations for the (i + 1)-th chunk. However, naive chunking introduces a significant memory bandwidth overhead due to partial sum accumulation across chunks:

To eliminate this memory bandwidth overhead, this PR adds fused partial accumulation directly into the V2 GMM kernel. Because the GMM kernel is heavily compute-bound (high arithmetic intensity on TPU v6e / v7x), fusing element-wise partial sum loading and addition into the inner GMM pipeline reduces accumulation memory movement and hides it behind matrix multiplication compute.

  ## Proposed Changes

  1. Kernel Fused Accumulation (pallas_mosaic_tpu_v2_gmm_kernel.py):
      • Added an optional  partial_sum  input tensor (shape  [size_m, size_n] ) to      
      gmm_v2() .
      • Updated block specifications ( generate_block_specs ) and VMEM tiling           
      calculations ( calculate_tiling ) to allocate double-buffered VMEM space for      
      incoming partial sums when  has_partial_sum=True .
      • Threaded  partial_sum_ref  into the inner kernel pipeline so prior chunk        
      accumulations are loaded directly into accumulator registers ( acc += ps_tile )   
      before final activation / output write-back.
  2. Test Migration (pallas_mosaic_tpu_v2_gmm_kernel_test.py):
      • Migrated the comprehensive V2 GMM test suite from Tokamax into MaxText.
      • Refactored test dependencies to use MaxText's internal common.tpu_generation() 
      and Megablox ops.

FIXES: b/522351030
FIXES: b/512156666

# Tests
Ran `pytest src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_gmm_kernel_test.py`
Result:  933 passed, 267 skipped  (skipped tests gated on TPUv7+ / specific dtypes).

Performance:
Benchmarked performance with ds3 specs (Chunks = 4). Script used with exact configs is attached at the bottom. 
[Wall-Clock Latency] WITH Partial Sum: 0.3271 ms
[Wall-Clock Latency] WITHOUT Partial Sum: 0.3130 ms
[Wall-Clock Latency] Overhead with partial sum: 0.0141 ms, ~ 4.5%

Results with experts = 64:
[Wall-Clock Latency] WITH Partial Sum: 0.4676 ms
[Wall-Clock Latency] WITHOUT Partial Sum: 0.4605 ms
[Wall-Clock Latency] Overhead with partial sum: 0.0071 ms, ~ 1.5%

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

# Script:
```
import time
import jax
import jax.numpy as jnp
from tokamax._src.ops.ragged_dot import pallas_mosaic_tpu_v2_gmm_kernel as gmm_backend
from tokamax._src.ops.ragged_dot.pallas_mosaic_tpu_v2_kernel_test import get_group_sizes

# 1. Initialize DeepSeek-V3 Tensors (M=2048, G=32, K=7168, N=2048)
M, G, K, N = 2048, 32, 7168 // 4, 2048
key = jax.random.key(42)
k0, k1, k2 = jax.random.split(key, 3)

print(f"Initializing DeepSeek-V3 MoE Tensors (M={M}, G={G}, K={K}, N={N})...")
lhs = jax.random.normal(k0, (M, K), dtype=jnp.bfloat16)
rhs = jax.random.normal(k1, (G, K, N), dtype=jnp.bfloat16)
ps  = jax.random.normal(k2, (M, N), dtype=jnp.bfloat16)
sizes = get_group_sizes(M, G)
offset = jnp.array([0], dtype=jnp.int32)

# 2. Compile & Warmup
print("Compiling XLA kernels & warming up...")
gmm_backend.gmm_v2(lhs, rhs, sizes, partial_sum=ps, group_offset=offset).block_until_ready()
gmm_backend.gmm_v2(lhs, rhs, sizes, partial_sum=None, group_offset=offset).block_until_ready()

# 3. Wall-Clock Benchmarks
print("Running wall-clock microbenchmarks ...")
iterations = 10
start = time.perf_counter()
for _ in range(iterations):
  gmm_backend.gmm_v2(lhs, rhs, sizes, partial_sum=ps, group_offset=offset).block_until_ready()
t_ps = (time.perf_counter() - start) / iterations

start = time.perf_counter()
for _ in range(iterations):
  gmm_backend.gmm_v2(lhs, rhs, sizes, partial_sum=None, group_offset=offset).block_until_ready()
t_no_ps = (time.perf_counter() - start) / iterations

print("-" * 70)
print(f"[Wall-Clock Latency] WITH Partial Sum:    {t_ps*1e3:.4f} ms")
print(f"[Wall-Clock Latency] WITHOUT Partial Sum: {t_no_ps*1e3:.4f} ms")
print(f"[Wall-Clock Latency] Overhead Delta:      {(t_ps - t_no_ps)*1e3:.4f} ms")
print("-" * 70)

# 4. Capture jax.profiler Timeline Traces
print("Capturing TensorBoard hardware trace...")
jax.profiler.start_trace("/tmp/deepseek_profile_logs")
with jax.profiler.TraceAnnotation("DeepSeek_GMM_With_PartialSum"):
  for _ in range(10):
    gmm_backend.gmm_v2(lhs, rhs, sizes, partial_sum=ps, group_offset=offset).block_until_ready()
with jax.profiler.TraceAnnotation("DeepSeek_GMM_Without_PartialSum"):
  for _ in range(10):
    gmm_backend.gmm_v2(lhs, rhs, sizes, partial_sum=None, group_offset=offset).block_until_ready()
jax.profiler.stop_trace()
print("Hardware trace successfully saved to /tmp/deepseek_profile_logs")
```