### PR TITLE
Fix compile_cache_test by filtering cache files for jit_train_step

### DIFF
--- a/tests/unit/compile_cache_test.py
+++ b/tests/unit/compile_cache_test.py
@@ -106,8 +106,11 @@ def test_train_step_cache_hit():
         "cache was not writeable or the JAX cache configuration was ignored."
     )
 
-    assert len(cache_files) == 1, (
-        f"Expected exactly 1 JAX compilation cache file, but found {len(cache_files)}: {cache_files}. "
+    train_step_cache_files = [f for f in cache_files if f.startswith("jit_train_step")]
+    assert len(train_step_cache_files) == 1, (
+        f"Expected exactly 1 JAX compilation cache file for 'jit_train_step', "
+        f"but found {len(train_step_cache_files)}: {train_step_cache_files} "
+        f"(all cache files: {cache_files}). "
         "This indicates a cache miss where AOT compilation and runtime execution generated different keys, "
         "causing train_step to be compiled twice (double-compilation regression)."
     )


### PR DESCRIPTION
# Description

Previously, test_train_step_cache_hit asserted that the compilation cache contained exactly 1 file, assuming only the `jit_train_step`  would be cached. However, in nightly workflow JAX also caches other compiled functions, causing the test to fail.

This fix changes the assertion to filter the cache files for the  prefix before verifying that only one compilation occurred, making the test robust against other functions being cached.

BUGS: b/517327969

# Tests

Manual of the affected test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
