### PR TITLE
[DRAFT] Workaround TPU SparseCore compilation failure in ring_ragged_unsort b…

### DIFF
--- a/src/maxtext/kernels/ragged/ragged_sort.py
+++ b/src/maxtext/kernels/ragged/ragged_sort.py
@@ -343,16 +343,16 @@ def ring_ragged_unsort(
     if buffer_size >= n:
       # ragged_gather fans out g_hidden_states_local by reading the same row
       # multiple times when idx_inv // topk maps multiple positions to it.
-      # Per-slot routing weights are applied inside the kernel.
+      # Apply weights outside the kernel to avoid a compilation issue with
+      # tpu.bitcast in the has_weights=True path on SparseCore.
       weight_for_sorted = topk_weights_flat[idx_inv]
       grad_sorted_tokens = ragged_gather(
           g_hidden_states_local,
           idx_inv // topk,
           shard_output_start[None],
           shard_output_end[None],
-          weights=weight_for_sorted,
-          has_weights=True,
       )
+      grad_sorted_tokens = grad_sorted_tokens * weight_for_sorted[:, None]
     else:
       # Slice the inverse permutation to match the packed local buffer.
       padded_idx_inv = jnp.pad(idx_inv, (0, buffer_size))
@@ -361,14 +361,15 @@ def ring_ragged_unsort(
       # Slice the per-slot routing weights to match the packed local buffer.
       padded_weights = jnp.pad(topk_weights_flat[idx_inv], (0, buffer_size))
       sliced_weights = jax.lax.dynamic_slice_in_dim(padded_weights, shard_output_start, buffer_size, axis=0)
+      # Apply weights outside the kernel to avoid a compilation issue with
+      # tpu.bitcast in the has_weights=True path on SparseCore.
       grad_sorted_tokens = ragged_gather(
           g_hidden_states_local,
           sliced_idx_inv // topk,
           jnp.int32(0)[None],
           gather_end[None],
-          weights=sliced_weights,
-          has_weights=True,
       )
+      grad_sorted_tokens = grad_sorted_tokens * sliced_weights[:, None]
     return grad_sorted_tokens, None, None, None
 
   _ring_ragged_unsort.defvjp(_ring_ragged_unsort_fwd, _ring_ragged_unsort_bwd)


### PR DESCRIPTION
…ackward.

Previously, _ring_ragged_unsort_bwd called ragged_gather with has_weights=True to apply routing weights inside the Pallas kernel. However, this triggers an unsupported tpu.bitcast operation (vector<8xi32> -> vector<8xf32>) on TPU SparseCore during compilation, leading to "INTERNAL: Operation not supported" errors in nightly tests.

This fix works around the issue by calling ragged_gather without weights (has_weights=False) and applying the routing weights outside the kernel using JAX element-wise multiplication. This avoids the buggy compilation path while maintaining correctness.

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.: 
BUGS: b/123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
