### PR TITLE
Make ViT attention kernel configurable via attention_for_vit

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1867,6 +1867,7 @@ class MultimodalGeneral(BaseModel):
   """General configuration for Multimodal models."""
 
   use_multimodal: bool = Field(False, description="Enable multimodal capabilities.")
+  attention_for_vit: str = Field("dot_product", description="The attention algorithm to use for vision encoder.")
   freeze_vision_encoder_params: bool = Field(True, description="Freeze the parameters of the vision encoder.")
   freeze_audio_encoder_params: bool = Field(True, description="Freeze the parameters of the audio encoder.")
   use_audio: bool = Field(False, description="Enable audio encoder for multimodal models.")

--- a/src/maxtext/models/gemma3.py
+++ b/src/maxtext/models/gemma3.py
@@ -449,7 +449,7 @@ class Encoder1DBlock(nnx.Module):
         dtype=self.config.dtype_mm,
         weight_dtype=self.config.weight_dtype,
         mesh=self.mesh,
-        attention_kernel="dot_product",
+        attention_kernel=self.config.attention_for_vit,
         inputs_q_shape=(self.config.per_device_batch_size, self.seq_len, self.config.hidden_size_for_vit),
         inputs_kv_shape=(self.config.per_device_batch_size, self.seq_len, self.config.hidden_size_for_vit),
         dropout_rate=0,

--- a/src/maxtext/models/gemma4_vision.py
+++ b/src/maxtext/models/gemma4_vision.py
@@ -472,7 +472,7 @@ class Gemma4EncoderBlock(nnx.Module):
         head_dim=config.hidden_size_for_vit // config.num_attention_heads_for_vit,
         max_target_length=seq_len,
         mesh=mesh,
-        attention_kernel="dot_product",
+        attention_kernel=config.attention_for_vit,
         inputs_q_shape=dummy_shape,
         inputs_kv_shape=dummy_shape,
         dtype=config.dtype_mm,

--- a/src/maxtext/models/llama4.py
+++ b/src/maxtext/models/llama4.py
@@ -642,7 +642,7 @@ class Llama4VisionEncoderLayer(nnx.Module):
         num_kv_heads=self.config.num_attention_heads_for_vit,
         head_dim=self.config.hidden_size_for_vit // self.config.num_attention_heads_for_vit,
         max_target_length=(self.config.image_size_for_vit // self.config.patch_size_for_vit) ** 2 + 1,
-        attention_kernel="dot_product",
+        attention_kernel=self.config.attention_for_vit,
         inputs_q_shape=self.hidden_states_shape,
         inputs_kv_shape=self.hidden_states_shape,
         float32_qk_product=self.config.float32_qk_product,

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1906,7 +1906,7 @@ class Qwen3OmniMoeVisionAttention(nnx.Module):
         num_kv_heads=self.config.num_attention_heads_for_vit,
         head_dim=head_dim,
         max_target_length=self.config.num_position_embeddings_for_vit,
-        attention_kernel="dot_product",
+        attention_kernel=self.config.attention_for_vit,
         inputs_q_shape=(1, 1, self.config.hidden_size_for_vit),
         inputs_kv_shape=(1, 1, self.config.hidden_size_for_vit),
         float32_qk_product=self.config.float32_qk_product,


### PR DESCRIPTION
# Description

This PR replaces the hardcoded `attention_kernel="dot_product"` in multimodal vision encoders with a new configuration parameter `attention_for_vit`, default with `dot_product`.

### Motivation
During Qwen3-Omni multimodal training (especially with long videos, 32t x 32h x 32w=32768 sequence length), standard `dot_product` attention in the vision encoder can lead to out-of-memory (OOM) errors during compilation/training due to $O(N^2)$ scaling. Making the kernel configurable allows routing to memory-efficient attention kernels (e.g. Splash Attention via `"autoselected"`) on TPU, for video-SFT later.

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
