### PR TITLE
fix: add missing all-gather for nnx vocabulary tiling

### DIFF
--- a/src/maxtext/utils/vocabulary_tiling.py
+++ b/src/maxtext/utils/vocabulary_tiling.py
@@ -349,6 +349,15 @@ def vocab_tiling_nnx_loss(model, hidden_states, data, config, is_train):
   # custom_vjp + lax.scan boundary, which fails for tied embeddings.
   graphdef, head_params, other_params, rest = nnx.split(model, _is_output_head_param_path, nnx.Param, ...)
 
+  # all gather only the embedding table
+  head_params = all_gather_over_fsdp(
+      head_params,
+      nnx.get_partition_spec(head_params),
+      model.mesh,
+      config.logical_axis_rules,
+      config.shard_mode,
+  )
+
   def _logits_for_chunk(chunk_head_params, chunk_other_params, chunk_rest, hidden_chunk):
     local_model = nnx.merge(graphdef, chunk_head_params, chunk_other_params, chunk_rest, copy=True)
     chunk_logits = local_model.logits_from_hidden_states_for_vocab_tiling(hidden_chunk, deterministic, model_mode)


### PR DESCRIPTION
# Description

Add missing all-gather of nnx embedding table. Allow the `NNX` memory and performance simiilar to `Linen` version.

# Tests
Script : [tpu-recipe](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/training/ironwood/gemma4-2b/8k-bf16-tpu7x-4x4x4/xpk/run_recipe.sh) for gemma4-2b

Machine : Cluster of ironwood v7x

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
