### PR TITLE
Add optional Approximate Top-K configuration for MLA Indexer

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -397,6 +397,8 @@ use_indexer: false
 indexer_head_dim: 128
 indexer_n_heads: 64
 indexer_topk: 2048
+use_approx_top_k: false
+approx_top_k_recall: 0.95
 # Determines the training strategy for the indexer:
 # - false (Dense Warm-up): Computes indexer loss over all tokens. Used with `trainable_parameters_mask` to freeze other model parameters.
 # - true (Sparse Training): Computes indexer loss over top-k tokens only and detaches the indexer input for independent optimization.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -668,6 +668,8 @@ class AttentionIndexer(BaseModel):
       description="Determines the training strategy for the indexer: Dense Warm-up or Sparse Training stage.",
   )
   indexer_loss_scaling_factor: float = Field(0.0, description="Multiplier for the indexer KL divergence loss.")
+  use_approx_top_k: bool = Field(False, description="Whether to use approximate top-k selection for the indexer on TPU.")
+  approx_top_k_recall: float = Field(0.95, description="Recall target for approximate top-k selection.")
 
 
 class Llama4Attention(BaseModel):

--- a/src/maxtext/layers/attention_mla.py
+++ b/src/maxtext/layers/attention_mla.py
@@ -366,7 +366,14 @@ class Indexer(nnx.Module):
       indexer_score += attention_mask
 
     # TopK selection based on index score
-    _, topk_indices = jax.lax.top_k(indexer_score, k=self.indexer_topk)  # topk_indices [b, t, k]
+    if self.config.use_approx_top_k:
+      _, topk_indices = jax.lax.approx_max_k(
+          indexer_score,
+          k=self.indexer_topk,
+          recall_target=self.config.approx_top_k_recall,
+      )
+    else:
+      _, topk_indices = jax.lax.top_k(indexer_score, k=self.indexer_topk)  # topk_indices [b, t, k]
 
     # Create Sparse Index Mask: 0 and large negatives
     indexer_mask = self.generate_mask(topk_indices, k.shape[1])  # [b, t, s]

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -1802,6 +1802,61 @@ class MLATest(attention_test_util.MLATestBase):
 
     np.testing.assert_allclose(loss, 0.0, atol=1e-5)
 
+  def test_indexer_with_approx_top_k(self):
+    """Verify indexer runs with approx_max_k enabled."""
+    mla_config_args = self.config_arguments.copy()
+    mla_config_args["use_indexer"] = True
+    mla_config_args["use_approx_top_k"] = True
+    mla_config_args["attention"] = "dot_product"
+
+    cfg, mla = self.init_mla(mla_config_args, rope_type="default")
+
+    bsz, seqlen = 2, 8
+    lnx, decoder_segment_ids, decoder_positions = self.get_structured_data(cfg, cfg.dtype)
+
+    # Run forward pass which triggers indexer
+    out, _ = mla(
+        lnx,
+        lnx,
+        decoder_segment_ids=decoder_segment_ids,
+        inputs_positions=decoder_positions,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    self.assertIsNotNone(out)
+
+  def test_approx_top_k_recall(self):
+    """Verify that approx_max_k meets the specified recall target compared to exact top_k."""
+    jax_rng = jax.random.PRNGKey(0)
+
+    # We need a large enough N to make the approximation meaningful.
+    # Use shape [batch=4, queries=16, N=1024]
+    batch, queries, N = 4, 16, 1024
+    K = 64
+    recall_target = 0.95
+
+    # Generate random scores
+    scores = jax.random.normal(jax_rng, (batch, queries, N))
+
+    # 1. Run exact Top-K
+    _, true_indices = jax.lax.top_k(scores, k=K)  # [batch, queries, K]
+
+    # 2. Run approx Top-K
+    _, approx_indices = jax.lax.approx_max_k(scores, k=K, recall_target=recall_target)  # [batch, queries, K]
+
+    # 3. Calculate Recall
+    # Broadcast compare true_indices [B, Q, K, 1] and approx_indices [B, Q, 1, K]
+    matches = (true_indices[..., None] == approx_indices[..., None, :]).any(axis=-1)  # [B, Q, K]
+    num_matches = matches.sum(axis=-1)  # [B, Q]
+    actual_recalls = num_matches / K  # [B, Q]
+    mean_recall = jnp.mean(actual_recalls)
+
+    print(f"\nApprox Top-K Recall Target: {recall_target}, Actual Mean Recall: {mean_recall:.4f}")
+
+    # Assert that the actual recall is close to or exceeds the target.
+    # We allow a small margin (e.g., 0.05) due to the approximate nature and sample size.
+    self.assertGreaterEqual(mean_recall, recall_target - 0.05)
+
   def test_indexer_gradients(self):
     # Test that gradients do NOT flow back to inputs
     bsz, seqlen = 2, 8


### PR DESCRIPTION
# Description
This PR adds an optional configuration parameter `use_approx_top_k` to the Multi-head Latent Attention (MLA) Indexer, allowing users to enable JAX's TPU-optimized `approx_max_k` primitive instead of the default exact `top_k` selection. 

### Why is this change being made?
During performance investigations of DeepSeek-V3.2 in long-context mode (128K sequence length) with 128-way Context Parallelism (CP=128), the `top-k` was identified a major bottleneck in the MLA Indexer forward pass:
*   The indexer computes a local score matrix of shape `[1, 1024, 131072]` on each device.
*   The default exact `top_k` selection is implemented on TPU via an expensive **Bitonic Sort** along the 131K sequence dimension.
*   Sorting 131K elements per layer across 61 layers introduces massive step-time overhead.

Benchmarks show a 4x speedup on f32[1,1024,65536] tensors when tested with the approximate path enabled using a recall target of 0.95.


### Why this is a good solution
JAX's `approx_max_k` employs block-based reduction optimized for TPU Matrix Units (MXU). It avoids full bitonic sorting, reducing complexity from $\mathcal{O}(N \log^2 N)$ to $\approx \mathcal{O}(N + K \log K)$ with a significantly smaller constant factor. 

**Micro-benchmarks show a ~4x speedup on `f32[1, 1024, 65536]` tensors when tested on TPU with the approximate path enabled using a recall target of 0.95.**

### Specific Implementation Details
1.  **Configuration Schema (types.py):** Added `use_approx_top_k` and `approx_top_k_recall` to the `AttentionIndexer` Pydantic class to pass configuration validation.
2.  **Default Config (base.yml):** Exposed the parameters with safe defaults (`use_approx_top_k: false`, `approx_top_k_recall: 0.95`).
3.  **Model Architecture (attention_mla.py):** Updated `Indexer.__call__` to conditionally route the selection to `jax.lax.approx_max_k` when enabled.

### Shortcomings & Future Improvements
*   There is not systematic study on how the accuracy lost of using `use_approx_top_k` instead of `top_k` might affect downstream model performance, while it is expected to be minimal when a high recall rate is used.

# Tests

### 1. Regression Guard (Default Path)
We ran the attention unit test suite with the default configuration (`use_approx_top_k=false`) to ensure no regressions:
*   **Command:** `pytest tests/unit/attention_test.py`
*   **Result:** **PASSED** (20 passed, 32 skipped).

### 2. Compilation & Tracing Safety
We added a new unit test, `test_indexer_with_approx_top_k`, to verify that the new path compiles and traces successfully in JAX:
*   **Command:** `pytest tests/unit/attention_test.py -k test_indexer_with_approx_top_k`
*   **Result:** **PASSED**.

### 3. Mathematical Correctness & Recall Tracking
We added a correctness test, `test_approx_top_k_recall`, which generates random scores of shape `[4, 16, 1024]`, runs both exact and approximate top-K ($K=64$), and calculates the actual recall:
*   **Command:** `pytest tests/unit/attention_test.py -k test_approx_top_k_recall -s`
*   **Result:** **PASSED** (Achieved **100% recall** on CPU).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests and provided workload links above if applicable. *https://xprof.corp.google.com/trace_viewer/zjiahao-9369408277271509466?view_start=23269.070&view_end=23384.958*
- [] I have made or will make corresponding changes to the doc if needed.

