### PR TITLE
Fix pylint unused-variable error in quantizations.py

### DIFF
--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -1014,6 +1014,8 @@ class TransformerEngineQuantization(Quantization):
     import transformer_engine.jax  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
     from transformer_engine.common import recipe  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
 
+    default_recipe = self._recipe
+
     class TEWrapper(transformer_engine.jax.flax.module.TransformerEngineBase):
       """Wrapper module for TransformerEngine quantization."""
 
@@ -1022,7 +1024,7 @@ class TransformerEngineQuantization(Quantization):
           postfix: str = "",
           variable_collection: str | None = None,
           quantization_checkpoint_name: str | None = None,
-          fp8_recipe: recipe.Recipe | None = None,
+          fp8_recipe: recipe.Recipe | None = default_recipe,
           n_groups: int | None = None,
       ):
         """Generates a set of quantizers for TransformerEngine."""


### PR DESCRIPTION
# Description

As a result of https://github.com/AI-Hypercomputer/maxtext/commit/5ecfd7d824d409c91396bedb3b8fe81c0d82cf1c (which originated from cl/936695878) we are now seeing pylint errors.
Additionally, the code before the commit above always passed `fp8_recipe=fp8_recipe (==self.recipe)` to the `super().generate_quantizer_set()` function. After the commit it is passing `None`, which is potentially not the same.
This PR fixes the lint error and also restores the non-None behavior.  I will also ask the CL author to proof-read this PR.

# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
