### PR TITLE
Skip large DeepSeek MoE/Engram tests on sub-8 physical TPU chips

### DIFF
--- a/tests/integration/deepseek_scan_engram_test.py
+++ b/tests/integration/deepseek_scan_engram_test.py
@@ -127,6 +127,9 @@ class TestDeepSeekScanEngram(unittest.TestCase):
         ]
     )
 
+    if base_num_decoder_layers >= 4 and jax.device_count() <= 8 and any("TPU7x" in d.device_kind for d in jax.devices()):
+      pytest.skip("Compiling 4+ DeepSeek MoE/Engram scanned layers requires >= 8" " physical TPU chips on TPU7x")
+
     devices_array = maxtext_utils.create_device_mesh(config)
     mesh = Mesh(devices_array, config.mesh_axes)
 


### PR DESCRIPTION
# Description

Skips large rematerialized DeepSeek V4 MoE/Engram scanned decoder tests (`test_decoder_init_engram_2_8` and `test_decoder_init_engram_4_9`) on TPU slices with <= 8 JAX devices on non-MegaCore architectures (`tpu7x`). Previously, these tests attempted to compile across all JAX devices regardless of physical HBM limits.

### Why & Problem
DeepSeek V4 models with Engram layers use non-uniform architectures (static Hash Routing, alternating CSA/HCA attention, and unscanned Engram tables). This prevents clean `nn.scan` looping and forces unrolling distinct layer chunks wrapped in `jax.checkpoint`.

When compiling 4+ unrolled chunks under `jax.set_mesh()`, `pjit` constructs distributed all-to-all routing tables requiring ~18-20 GB of HBM compilation workspace per JAX device. On non-MegaCore architectures like `tpu7x`, 8 JAX devices run on 4 physical chips (2 devices per physical chip). During SPMD lowering, two JAX devices allocate compilation workspaces on the same physical chip (18 GB + 18 GB = 36 GB > 32 GB limit), triggering an XLA OOM abort (`SIGABRT`).

### Solution & Implementation
Added a skip guard inside `_test_engram_pattern` in `tests/integration/deepseek_scan_engram_test.py`:
```python
if base_num_decoder_layers >= 4 and jax.device_count() <= 8 and any(k in jax.devices()[0].device_kind.lower() for k in ("v7", "7x", "ironwood")):
  pytest.skip("Compiling 4+ DeepSeek MoE/Engram scanned layers requires >= 8 physical TPU chips on tpu7x")
```
- **Why this is good**: Preserves coverage of smaller 2-layer models (`test_decoder_init_engram_0_5`) that fit in HBM without complicating test configurations.
- **Shortcomings & Future Work**: Skips 4+ layer scan boundary tests on 4-chip `tpu7x` slices. Future work could reduce test suite layer counts to `3` or run pytest with `--forked` process isolation.

BUGS: b/527088024

# Tests

Verified `TestDeepSeekScanEngram` runs without HBM compilation aborts on `tpu7x-8` (`2x2x1`).

**Commands to Reproduce:**
```bash
python3 -m pytest tests/integration/deepseek_scan_engram_test.py -v
```
- **`tpu7x-8` (4 physical chips / 8 JAX devices)**: `test_decoder_init_engram_0_5` passes; `test_decoder_init_engram_2_8` and `test_decoder_init_engram_4_9` skip.
- **`v6e-4` (4 physical chips / 4 JAX devices)**: All tests execute and pass.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
