### PR TITLE
Add Github run id as suffix to verified tag in nightly docker images

### DIFF
--- a/.github/workflows/promote_docker_image.yml
+++ b/.github/workflows/promote_docker_image.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   handle_result:
-    name: Handle Airflow DAG Result - ${{ github.event.client_payload.dag_id }}
+    name: Handle Airflow DAG Result
     runs-on: ubuntu-latest
     steps:
       - name: Report DAG result
@@ -37,12 +37,14 @@ jobs:
           DAG_ID="${{ github.event.client_payload.dag_id }}"
           DAG_RUN_ID="${{ github.event.client_payload.dag_run_id }}"
           SHA="${{ github.event.client_payload.sha }}"
+          GITHUB_RUN_ID="${{ github.event.client_payload.github_run_id }}"
 
           echo "================================"
-          echo "DAG ID:      ${DAG_ID}"
-          echo "DAG Run ID:  ${DAG_RUN_ID}"
-          echo "Commit SHA:  ${SHA}"
-          echo "State:       ${STATE}"
+          echo "Github Run ID: ${GITHUB_RUN_ID}"
+          echo "DAG ID:        ${DAG_ID}"
+          echo "DAG Run ID:    ${DAG_RUN_ID}"
+          echo "Commit SHA:    ${SHA}"
+          echo "State:         ${STATE}"
           echo "================================"
 
           case "$STATE" in
@@ -74,9 +76,8 @@ jobs:
           GITHUB_RUN_ID="${{ github.event.client_payload.github_run_id }}"
 
           # Add the traceability tag to confirm it passed validation suite
-          SHORT_DAG_RUN_ID=$(echo "${{ github.event.client_payload.dag_run_id }}" | cut -c1-7)
           gcloud container images add-tag "${SOURCE_IMAGE}:${GITHUB_RUN_ID}" \
-            "${SOURCE_IMAGE}:verified-${SHORT_DAG_RUN_ID}" --quiet
+            "${SOURCE_IMAGE}:verified-${GITHUB_RUN_ID}" --quiet
 
           # Add "latest" tag
           gcloud container images add-tag "${SOURCE_IMAGE}:${GITHUB_RUN_ID}" "${SOURCE_IMAGE}:latest" --quiet


### PR DESCRIPTION
# Description

This PR updates the MaxText nightly Docker image promotion workflow to append the original GitHub run ID as a suffix to the `verified` Docker image tag. 

Previously, when the image promotion workflow was triggered, it added a traceability tag of the form `verified-${SHORT_DAG_RUN_ID}` (where `SHORT_DAG_RUN_ID` is a 7-character prefix of the Airflow `dag_run_id`), which is always `verified-manual_`: https://github.com/AI-Hypercomputer/maxtext/actions/runs/28075831893/job/83119782137. This leads to potential tag collision. While DAG run IDs are generally unique, appending the `GITHUB_RUN_ID` guarantees a highly unique namespace per image build run, reducing the risk of overlap.

# Tests

The image promotion step can be monitored and verified on the next successful nightly E2E test suite execution to confirm that images are pushed with the new suffix tag format.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
