### PR TITLE
Optimize MLA generate_mask with scatter update

### DIFF
--- a/src/maxtext/layers/attention_mla.py
+++ b/src/maxtext/layers/attention_mla.py
@@ -232,15 +232,16 @@ class Indexer(nnx.Module):
     Returns:
         mask: [b, t, s] - `0.0` at topk_indices, `DEFAULT_MASK_VALUE` (large negative) elsewhere.
     """
-    # 1. Create a range [0, 1, ..., s-1]
-    # 2. Broadcast compare against [b, t, k] to get [b, t, k, s]
-    # 3. Use .any() to see if a s-index is present in any of the k slots
-    is_topk = (jnp.arange(s) == topk_indices[..., None]).any(axis=-2)
-    # 4. Use where to select between 0.0 and the mask value
-    # cast values to dtype
+    b, t, _ = topk_indices.shape
+    batch_indices = jnp.arange(b)[:, None, None]
+    time_indices = jnp.arange(t)[None, :, None]
+
     val_true = jnp.array(0.0, dtype=self.dtype)
     val_false = jnp.array(DEFAULT_MASK_VALUE, dtype=self.dtype)
-    return jnp.where(is_topk, val_true, val_false)
+
+    mask = jnp.full((b, t, s), val_false, dtype=self.dtype)
+    mask = mask.at[batch_indices, time_indices, topk_indices].set(val_true)
+    return mask
 
   def __call__(
       self,

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -1802,6 +1802,32 @@ class MLATest(attention_test_util.MLATestBase):
 
     np.testing.assert_allclose(loss, 0.0, atol=1e-5)
 
+  def test_generate_mask_equivalence(self):
+    """Test that the optimized scatter-based mask generation is equivalent to the old broadcast-based one."""
+    mla_config_args = self.config_arguments.copy()
+    mla_config_args["use_indexer"] = True
+    mla_config_args["attention"] = "dot_product"
+    _, mla = self.init_mla(mla_config_args, rope_type="default")
+
+    # Use a small shape that won't OOM the old method but is representative
+    b, t, k, s = 2, 128, 64, 1024
+
+    key = jax.random.PRNGKey(0)
+    topk_indices = jax.random.randint(key, (b, t, k), 0, s)
+
+    # Old implementation (broadcast-based) reconstructed for comparison
+    def generate_mask_old(topk_indices, s):
+      is_topk = (jnp.arange(s) == topk_indices[..., None]).any(axis=-2)
+      val_true = jnp.array(0.0, dtype=mla.indexer.dtype)
+      val_false = jnp.array(DEFAULT_MASK_VALUE, dtype=mla.indexer.dtype)
+      return jnp.where(is_topk, val_true, val_false)
+
+    mask_old = generate_mask_old(topk_indices, s)
+    mask_new = mla.indexer.generate_mask(topk_indices, s)
+
+    # Assert exact mathematical equivalence
+    np.testing.assert_allclose(mask_new, mask_old, atol=1e-5)
+
   def test_indexer_gradients(self):
     # Test that gradients do NOT flow back to inputs
     bsz, seqlen = 2, 8


### PR DESCRIPTION
# Description

This PR optimizes the `generate_mask` function in the Multi-head Latent Attention (MLA) sparse indexer by replacing a high-complexity broadcasted comparison with a JAX scatter-based update.

*   **The Problem:** The previous implementation `(jnp.arange(s) == topk_indices[..., None]).any(axis=-2)` had an algorithmic complexity of $O(b \cdot t \cdot k \cdot s)$. At a 128K context window, which theoretically creates a massive virtual intermediate tensor of ~274 Billion elements (~256 GB). On TPU, although the XLA compiler successfully fused the loop to avoid physical HBM allocation (reducing HBM traffic to ~142 MB), the hardware remained heavily bottlenecked by the sheer volume of element-wise ALU comparisons (274 Billion ops) executed in registers, taking ~153 ms per step.

*   **The Solution:** The optimized version initializes the mask to `DEFAULT_MASK_VALUE` $O(b \cdot t \cdot s)$ and then uses indexing to scatter-write `0.0` at the selected `topk_indices` $O(b \cdot t \cdot k)$, where $k \ll s$ (2,048 vs 131,072).

*   **Implementation Details:** Initializes the mask using `jnp.full` and performs the scatter update using broadcasted batch and time indices (`batch_indices = jnp.arange(b)[:, None, None]`, `time_indices = jnp.arange(t)[None, :, None]`) via `mask.at[batch_indices, time_indices, topk_indices].set(0.0)`.

# Tests

### 1. Mathematical Equivalence Test
Added `test_generate_mask_equivalence` to `tests/unit/attention_test.py` to verify that the new scatter-based implementation produces identical results to the old broadcast-based implementation.
*   **Result:** **Passed** (exact match within `atol=1e-5`).

### 2. Regression Testing
Ran the existing unit test suite to ensure no regressions in attention or model functionality:
*   `tests/unit/attention_test.py` (Passed)
*   `tests/unit/model_test.py` (Passed)


# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable. (Validation run `zj-scatter-mask-val` is currently running on the cluster).
- [ ] I have made or will make corresponding changes to the doc if needed.
