### PR TITLE
Fix ragged gather reduce correctness

### DIFF
--- a/src/maxtext/kernels/ragged/ragged_gather_reduce.py
+++ b/src/maxtext/kernels/ragged/ragged_gather_reduce.py
@@ -385,7 +385,7 @@ def _preprocess(
     reduce_group_size: int,
     num_row_partitions: int,
     num_simd_lanes: int,
-) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
   """Preprocesses indices for ragged gather reduce."""
   assert indices.ndim == 1, "Ragged scatter only supports 1d indices."
 
@@ -416,12 +416,16 @@ def _preprocess(
       num_src_rows_per_row_partition.astype(jnp.int32),
       (0, num_simd_lanes - num_row_partitions),
   )
+  # If there is no valid source row in a reduce group, we set the mask to
+  # False, so that the output for that group is set to zero.
+  mask = jnp.any(valid_rows_mask.reshape(-1, reduce_group_size), axis=-1)
 
   return (
       src_indices,
       dst_indices,
       topk_weights,
       num_src_rows_per_row_partition,
+      mask,
   )
 
 
@@ -481,11 +485,6 @@ def ragged_gather_reduce(
   # Heuristic threshold on whether to fallback for small inputs.
   dtype = x.dtype
   dtype_bytes = jax.dtypes.itemsize_bits(dtype) // 8
-  if jnp.size(x) * dtype_bytes * 2 < pltpu.get_tpu_info().vmem_capacity_bytes * 0.6:
-    # For small {input + output}, it's likely that both can be put in TC VMEM,
-    # so it's likely faster to run TC-based implementation on it than going
-    # through SC, without data movement to/from HBM.
-    return _fallback_implementation(x, indices, topk_weights, valid_rows_mask, reduce_group_size)
 
   hidden_size = x.shape[-1]
   input_size = indices.size
@@ -533,6 +532,7 @@ def ragged_gather_reduce(
       dst_indices,
       topk_weights,
       num_src_rows_per_row_partition,
+      mask,
   ) = _preprocess(
       indices,
       topk_weights,
@@ -588,4 +588,10 @@ def ragged_gather_reduce(
       },
   )(num_src_rows_per_row_partition, x, src_indices, dst_indices, topk_weights)
 
-  return out.astype(x.dtype)
+  # If there is no valid source row in a reduce group, set that group's output
+  # to zero.
+  return jnp.where(
+      mask[:, None],
+      out.astype(x.dtype),
+      jnp.zeros_like(out, dtype=x.dtype),
+  )[: (input_size // reduce_group_size), :hidden_size]

--- a/src/maxtext/kernels/ragged/ragged_sort.py
+++ b/src/maxtext/kernels/ragged/ragged_sort.py
@@ -303,6 +303,8 @@ def ring_ragged_unsort(
           valid_rows_mask=valid_rows_mask,
           reduce_group_size=topk,
           enforce_fallback=enforce_gather_reduce_fallback,
+          flops_override=gather_reduce_flops_override,
+          bytes_accessed_override=gather_reduce_bytes_accessed_override,
       )
     else:
       # Shift indices so they map to the packed local buffer [0, local_num_tokens).
@@ -319,6 +321,8 @@ def ring_ragged_unsort(
           valid_rows_mask=valid_rows_mask,
           reduce_group_size=topk,
           enforce_fallback=enforce_gather_reduce_fallback,
+          flops_override=gather_reduce_flops_override,
+          bytes_accessed_override=gather_reduce_bytes_accessed_override,
       )
 
     res = (
@@ -375,6 +379,8 @@ def ring_ragged_unsort(
           weights=weight_for_sorted,
           has_weights=True,
           enforce_fallback=enforce_gather_fallback,
+          flops_override=gather_flops_override,
+          bytes_accessed_override=gather_bytes_accessed_override,
       )
     else:
       # Slice the inverse permutation to match the packed local buffer.
@@ -392,6 +398,8 @@ def ring_ragged_unsort(
           weights=sliced_weights,
           has_weights=True,
           enforce_fallback=enforce_gather_fallback,
+          flops_override=gather_flops_override,
+          bytes_accessed_override=gather_bytes_accessed_override,
       )
     return grad_sorted_tokens, None, None, None
 

--- a/src/maxtext/kernels/ragged/ragged_sort.py
+++ b/src/maxtext/kernels/ragged/ragged_sort.py
@@ -186,6 +186,8 @@ def ring_ragged_sort(
           valid_rows_mask=valid_rows_mask,
           reduce_group_size=topk,
           enforce_fallback=enforce_gather_reduce_fallback,
+          flops_override=gather_reduce_flops_override,
+          bytes_accessed_override=gather_reduce_bytes_accessed_override,
       )
     else:
       # Buffering: g_x has size `local_buffer_size` (packed).
@@ -209,6 +211,8 @@ def ring_ragged_sort(
           valid_rows_mask=valid_rows_mask,
           reduce_group_size=topk,
           enforce_fallback=enforce_gather_reduce_fallback,
+          flops_override=gather_reduce_flops_override,
+          bytes_accessed_override=gather_reduce_bytes_accessed_override,
       )
     return grad_hidden_states, None
 

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -918,7 +918,6 @@ class RoutedMoE(nnx.Module):
           repeats=group_size,
           total_repeat_length=math.prod(selected_experts.shape),
       )
-
     return (
         sorted_inputs,
         sorted_selected_experts,

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -918,6 +918,7 @@ class RoutedMoE(nnx.Module):
           repeats=group_size,
           total_repeat_length=math.prod(selected_experts.shape),
       )
+
     return (
         sorted_inputs,
         sorted_selected_experts,


### PR DESCRIPTION
# Description

This PR does three things:

* Add the mask in `ragged_gather_reduce` kernel solving correctness using ragged sort kernels;
* Remove fallback mechanism in `ragged_gather_reduce` kernel of small tensors. It breaks our ragged sort unit test;
* Add fallback/cost estimate flags, which are missing in the previous PRs.


# Tests

CI tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
