### PR TITLE
Fix Gemma-3 4B Multimodal SFT test script

### DIFF
--- a/tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh
+++ b/tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh
@@ -66,13 +66,14 @@ python3 -m maxtext.inference.decode \
     model_name=${MODEL_NAME} \
     load_parameters_path=${BASE_OUTPUT_DIRECTORY}/multimodal/sft/${run_id}/checkpoints/4/items \
     per_device_batch_size=1 \
-    run_name=${run_id}} \
+    run_name=${run_id} \
     max_prefill_predict_length=272 \
     max_target_length=300 \
     steps=1 \
     async_checkpointing=false \
     scan_layers=false \
     use_multimodal=true \
+    tokenizer_type=huggingface \
     prompt=\'Describe\ image\ \<start_of_image\>\' \
     image_path=\'tests/assets/test_image.jpg\' \
     attention=\'dot_product\'


### PR DESCRIPTION
# Description

This PR fixes multiple bugs and configuration issues in Step 4 of the Gemma-3 4B Multimodal SFT end-to-end test script:
1. **Fixes Syntax Typo**: Corrects the typo `run_name=${run_id}}` (with a trailing curly bracket) to `run_name=${run_id}`.
2. **Adds Missing Tokenizer Configuration**: Adds `tokenizer_type=huggingface` to Step 4. Without this, MaxText defaults to a SentencePiece tokenizer and attempts to load a local `.model` file at the Hugging Face repo path `google/gemma-3-4b-it`, resulting in the following error:
   ```text
   tensorflow.python.framework.errors_impl.NotFoundError: google/gemma-3-4b-it; No such file or directory
   ```

# Description of the issue we found
Without the `tokenizer_type=huggingface` flag, Step 4 of the end-to-end Gemma-3 SFT test crashes upon parameter loading when it tries to find a local SentencePiece model path under `google/gemma-3-4b-it` instead of fetching the proper Hugging Face config.

# Tests

We tested this change end-to-end on a v6e TPU VM:
1. Re-ran the end-to-end script `tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh` using a unique run ID.
2. Verified that Step 2 successfully executed inference.
3. Verified that Step 3 completed all 5 SFT training steps and successfully saved the checkpoints to GCS.
4. Verified that Step 4 successfully completed loading parameters from the newly trained SFT checkpoint on GCS, initialized the Hugging Face tokenizer, and correctly decoded/described the image:
   ```text
   Input `<start_of_turn>user
   Describe image <img><end_of_turn>
   <start_of_turn>model
   ` -> `Seattle skyline`
   ```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
