### PR TITLE
Fix job conditions and artifact handling in pypi_release workflow for workflow_dispatch

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -33,7 +33,7 @@ on:
       publish:
         description: 'Set to true to publish to PyPI.'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 permissions:
@@ -83,7 +83,8 @@ jobs:
     needs: handle_result
     if: |
       always() &&
-      (needs.handle_result.result == 'success' || needs.handle_result.result == 'skipped')
+      (needs.handle_result.result == 'success' || needs.handle_result.result == 'skipped') &&
+      (github.event_name == 'repository_dispatch' || inputs.publish)
     # "release" environment is configured in MaxText repository settings.
     # This environment requires manual approval before proceeding to the next job.
     environment: release
@@ -93,7 +94,9 @@ jobs:
 
   build_maxtext_package:
     needs: release_approval
-    if: needs.release_approval.result == 'success'
+    if: |
+      always() &&
+      (needs.release_approval.result == 'success' || needs.release_approval.result == 'skipped')
     uses: ./.github/workflows/build_package.yml
     with:
       device_type: tpu
@@ -104,14 +107,15 @@ jobs:
 
   publish_maxtext_to_pypi:
     name: Publish MaxText to PyPI
-    needs: release_approval
+    needs: [release_approval, build_maxtext_package]
     runs-on: ubuntu-latest
     environment: release
-    if: github.event_name == 'repository_dispatch' || github.event.inputs.publish == 'true'
+    if: needs.build_maxtext_package.result == 'success' && (github.event_name == 'repository_dispatch' || inputs.publish)
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce
         with:
           name: maxtext-wheel
+          path: dist/
       - name: Publish MaxText wheel to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -156,7 +160,7 @@ jobs:
         shell: bash
         run: |
           SOURCE_IMAGE="gcr.io/${{ vars.PROJECT_NAME }}/${{ matrix.image_name }}"
-          GITHUB_RUN_ID="${{ github.event.client_payload.github_run_id }}"
+          GITHUB_RUN_ID="${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.client_payload.github_run_id }}"
           gcloud container images add-tag \
             "${SOURCE_IMAGE}:${GITHUB_RUN_ID}" \
             "${SOURCE_IMAGE}:${{ needs.get_latest_maxtext_pypi_version.outputs.latest_pypi_version }}" \


### PR DESCRIPTION
# Description

This PR fixes several job conditions, input type mismatches, and artifact handling issues in the `pypi_release` GitHub Actions workflow to ensure it executes successfully when triggered manually via `workflow_dispatch`.

### Key Changes:

1. **Fix `workflow_dispatch` Run ID Handling:**
   - Configured `promote_docker_images` to fallback to `inputs.run_id` as the `GITHUB_RUN_ID` when the workflow is manually triggered. This is necessary because `client_payload` is unavailable in `workflow_dispatch` contexts.

2. **Refine `release_approval` Trigger Conditions:**
   - Restricted the `release_approval` job to only run under `repository_dispatch` or when `inputs.publish` is explicitly requested.

3. **Correct Input Type Definition:**
   - Changed the default value of the `publish` input parameter from the string `'false'` to the boolean `false`.

4. **Fix Artifact Download & Job Dependencies in PyPI Publishing:**
   - Updated the `publish_maxtext_to_pypi` job to download the built package artifact using `actions/download-artifact` instead of performing an unnecessary `actions/checkout`.
   - Added `build_maxtext_package` as an explicit dependency (`needs`) for the publishing job to guarantee the package is built before publishing is attempted.

5. **Simplify Boolean Conditionals:**
   - Streamlined various `if` conditions throughout the workflow to evaluate `inputs.publish` natively as a boolean value.

# Tests

- The changes have been validated and run successfully in the following workflow run:
  [Workflow Run #28195367927](https://github.com/AI-Hypercomputer/maxtext/actions/runs/28195367927)

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
