### PR TITLE
Make DeepSeek ragged A2A test scheduled-only

### DIFF
--- a/tests/integration/pipeline_parallelism_test.py
+++ b/tests/integration/pipeline_parallelism_test.py
@@ -345,6 +345,7 @@ class PipelineParallelismTest(unittest.TestCase):
         config, single_pipeline_stage_class=deepseek.DeepSeekMoELayerToLinen
     )
 
+  @pytest.mark.scheduled_only
   @pytest.mark.tpu_only
   def test_deepseek_ragged_a2a_ep_same_output_and_grad(self):
     config = pyconfig.initialize(


### PR DESCRIPTION
# Description

This test takes roughly 3 mins so we make it schedule only

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
