### PR TITLE
Overlap moe comms with collective matmul

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -220,6 +220,7 @@ load_balance_loss_weight: 0.0 # weight for the load balance loss
 use_random_routing: false # whether to use random routing for debug/test purpose
 use_custom_sort_vjp: true # whether to use a custom VJP sort for efficient backward pass processing in sparse matmul
 use_ring_of_experts: false # whether to use ring of experts for sparse matmul expert parallelism
+num_moe_emb_chunks: 0 # number of chunks for overlapping token all-gather and GMM computation along embedding dimension
 # If true, peel the 'expert' mesh axis off the MoE dispatch/MLP batch dim so the expert GEMM
 # stays expert-parallel (AllToAll); false keeps 'expert' on the batch dim (activation_batch_moe).
 # Only affects the dense (dense_matmul) MoE path; the sparse (shard_map) path is unaffected.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -623,6 +623,9 @@ class Attention(BaseModel):
           " Requires use_tokamax_gmm: true. Currently incompatible with quantization."
       ),
   )
+  num_moe_emb_chunks: int = Field(
+      0, description="Number of chunks for overlapping token all-gather and GMM computation along embedding dimension."
+  )
   ragged_block_size: int = Field(256, description="Block size for ragged attention.")
   enable_padding_causal_mask: bool = Field(True, description="Temporary flag for TE padding.")
   use_tokamax_splash: bool = Field(False, description="Whether to use tokamax splash attention.")
@@ -2591,6 +2594,17 @@ class MaxTextConfig(
           "TE Collective GEMM operations are only supported for TE quantization recipes (i.e. starting with 'te_')."
       )
 
+  def validate_num_moe_emb_chunks(self):
+    """
+    Validates that num_moe_emb_chunks is used with supported settings.
+    """
+    if self.num_moe_emb_chunks > 0:
+      if not self.use_gmm_v2 or not self.use_ring_of_experts:
+        raise ValueError(
+            f"num_moe_emb_chunks > 0 requires use_gmm_v2=True and use_ring_of_experts=True. "
+            f"Got use_gmm_v2={self.use_gmm_v2}, use_ring_of_experts={self.use_ring_of_experts}."
+        )
+
   @model_validator(mode="after")
   def set_derived_and_validate_values(self) -> "MaxTextConfig":
     """
@@ -3200,6 +3214,7 @@ class MaxTextConfig(
       if self.model_name.startswith("deepseek4") and self.first_num_hash_layers > 0 and self.use_ring_of_experts:
         raise ValueError("DeepSeek V4 hash routing is currently not supported with ring of experts.")
       self.validate_ragged_buffer_factor()
+    self.validate_num_moe_emb_chunks()
 
     # Gemma 4 small (E2B / E4B) uses per-layer KV sharing, which is incompatible with nn.scan.
     if self.model_name in ("gemma4-e2b", "gemma4-e4b") and self.scan_layers:

--- a/src/maxtext/kernels/megablox/ops.py
+++ b/src/maxtext/kernels/megablox/ops.py
@@ -74,6 +74,7 @@ def gmm(
     qwix_rule: qwix.QtRule | None = None,
     use_manual_quantization: bool = False,  # used in batchsplit
     use_gmm_v2: bool = False,
+    partial_sum: jnp.ndarray | None = None,
 ):
   """Grouped matrix multiplication operation."""
   quantization_rule = None
@@ -112,6 +113,7 @@ def gmm(
       lhs_vma_axes,
       rhs_vma_axes,
       use_gmm_v2,
+      partial_sum,
   )
 
 
@@ -142,6 +144,7 @@ def _gmm_fwd(
     lhs_vma_axes: tuple = tuple(),
     rhs_vma_axes: tuple = tuple(),
     use_gmm_v2: bool = False,
+    partial_sum: jnp.ndarray | None = None,
 ) -> tuple[
     jnp.ndarray,
     tuple[
@@ -200,6 +203,7 @@ def _gmm_fwd(
             tile_n=tiling[2],
         ),
         preferred_element_type=preferred_element_type,
+        partial_sum=partial_sum,
     )
   elif use_tokamax_backend:
     # manual_axis_type is for gmm with shard_map check_vma=True, needs tokamax > 0.0.12
@@ -234,7 +238,7 @@ def _gmm_fwd(
     for axis in lhs_vma_axes:
       out = jax.lax.pcast(out, axis_name=axis, to="varying")
 
-  return out, (lhs, rhs, group_sizes, group_offset)
+  return out, (lhs, rhs, group_sizes, group_offset, partial_sum)
 
 
 def _gmm_bwd(
@@ -256,12 +260,13 @@ def _gmm_bwd(
         jnp.ndarray | qpl.QArray,
         jnp.ndarray,
         jnp.ndarray | None,
+        jnp.ndarray | None,
     ],
     grad: jnp.ndarray,
-) -> tuple[jnp.ndarray, jnp.ndarray, None, None, jnp.ndarray]:
+) -> tuple[jnp.ndarray, jnp.ndarray, None, None, jnp.ndarray, jnp.ndarray | None]:
   """Backward function for throughput GMM VJP."""
   del preferred_element_type
-  lhs, rhs, group_sizes, group_offset = residual
+  lhs, rhs, group_sizes, group_offset, partial_sum_fwd = residual
   num_actual_groups = rhs.shape[0]
 
   # Jargon used here:
@@ -406,4 +411,5 @@ def _gmm_bwd(
   #
   # TODO(tgale, enriqueps, apaske): Fuse this transposition into the tgmm.
   drhs = drhs.swapaxes(1, 2) if transpose_rhs else drhs
-  return dlhs, drhs, None, None, grad
+  dpartial_sum = grad if partial_sum_fwd is not None else None
+  return dlhs, drhs, None, None, grad, dpartial_sum

--- a/src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_gmm_kernel.py
+++ b/src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_gmm_kernel.py
@@ -909,7 +909,9 @@ def calculate_tiling(
     tile_n_limit //= fuse_act_factor
 
   def _is_tile_k_quant_block_compatible(tk: int) -> bool:
-    if tk % rhs_cfgs.quant_block_size != 0 and rhs_cfgs.quant_block_size % tk != 0:  # pyrefly: ignore[unsupported-operation]
+    if (
+        tk % rhs_cfgs.quant_block_size != 0 and rhs_cfgs.quant_block_size % tk != 0
+    ):  # pyrefly: ignore[unsupported-operation]
       return False
     return True
 
@@ -999,7 +1001,9 @@ def validate_inputs(
   if rhs_bias is not None:
     assert rhs_bias.shape == (size_group, 1, size_n)
   if partial_sum is not None:
-    assert partial_sum.shape == (size_m, size_n)
+    assert partial_sum.shape[-1] == size_n
+    # lhs's m dimension can sometimes be padded to wi_tile_fwd_batch_seq
+    assert partial_sum.shape[0] <= size_m
   if rhs_scale is not None:
     num_quant_blocks = rhs_scale.shape[1]
     assert rhs_scale.shape == (size_group, num_quant_blocks, 1, size_n)
@@ -1341,6 +1345,13 @@ def gmm_v2(
       partial_sum_spec,  # partial_sum
   ]
 
+  input_output_aliases = {}
+  if partial_sum is not None:
+    flat_args_preceding = (group_sizes, group_offset, lhs, rhs_weights)
+    leaves = jax.tree_util.tree_leaves(flat_args_preceding)
+    partial_sum_idx = sum(1 for x in leaves if x is not None)
+    input_output_aliases = {partial_sum_idx: 0}
+
   return pl.pallas_call(
       functools.partial(kernel_main, cfgs=cfgs),
       out_shape=out_init,
@@ -1357,4 +1368,5 @@ def gmm_v2(
       name=get_scope_name(cfgs),
       cost_estimate=get_cost_estimate(cfgs),
       metadata=get_metadata(cfgs),
+      input_output_aliases=input_output_aliases,
   )(group_sizes, group_offset, lhs, rhs_weights, partial_sum)[:, : cfgs.out_size_n]

--- a/src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_tgmm_kernel.py
+++ b/src/maxtext/kernels/megablox/pallas_mosaic_tpu_v2_tgmm_kernel.py
@@ -763,6 +763,13 @@ def tgmm_v2(
       partial_sum_spec,
   ]
 
+  input_output_aliases = {}
+  if partial_sum is not None:
+    flat_args_preceding = (group_sizes, group_offset, lhs, rhs)
+    leaves = jax.tree_util.tree_leaves(flat_args_preceding)
+    partial_sum_idx = sum(1 for x in leaves if x is not None)
+    input_output_aliases = {partial_sum_idx: 0}
+
   raw_out = pl.pallas_call(
       functools.partial(tgmm_kernel_main, cfgs=cfgs),
       out_shape=out_init,
@@ -781,6 +788,7 @@ def tgmm_v2(
       # the metadata here is for profiling, debugging, and cost modeling.
       # It does not affect the kernel's computation.
       metadata=gmm_v2.get_metadata(cfgs),
+      input_output_aliases=input_output_aliases,
   )(group_sizes, group_offset, lhs, rhs, partial_sum)[:, : dims.size_k, : dims.size_n]
 
   if partial_sum is not None:

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -1295,7 +1295,7 @@ class RoutedMoE(nnx.Module):
         rhs_quantize_dtype = quant_dg.fwd.dg_quantizer.rhs.numerics.get_dtype()
       return lhs_quantize_dtype, rhs_quantize_dtype
 
-    def gmm(inputs, kernel, tiling, group_sizes, expert_assignments, weight_gather_axes, group_offset):
+    def gmm(inputs, kernel, tiling, group_sizes, expert_assignments, weight_gather_axes, group_offset, partial_sum=None):
       def extract_vma(tensor):
         # Parses the varying mesh axes from JAX's type string for a tensor inside shard_map.
         # jax.typeof(t) renders as e.g. 'f32[128,256]{V:(expert, fsdp)}'; this extracts
@@ -1316,6 +1316,8 @@ class RoutedMoE(nnx.Module):
       tokamax_group_sizes = get_tokamax_group_sizes(group_sizes, inputs, kernel)
       orig_inputs_shape = inputs.shape  # save shape of inputs before potentially padding.
       inputs, padding_amount = max_utils.maybe_pad(inputs, self.config.wi_tile_fwd_batch_seq)
+      if padding_amount > 0 and partial_sum is not None:
+        partial_sum = jnp.pad(partial_sum, ((0, padding_amount), (0, 0)))
       inputs = inputs.astype(self.dtype)
       kernel = kernel.astype(self.dtype)
       lhs_quantize_dtype, rhs_quantize_dtype = get_quantization_dtypes()
@@ -1341,6 +1343,7 @@ class RoutedMoE(nnx.Module):
               lhs_vma_axes=lhs_vma_axes,
               rhs_vma_axes=rhs_vma_axes,
               use_gmm_v2=self.config.use_gmm_v2,
+              partial_sum=partial_sum,
           )
         else:  # tokamax (unquantized)
           output = tokamax.ragged_dot(
@@ -1474,111 +1477,122 @@ class RoutedMoE(nnx.Module):
     ) = get_routed_moe_shardings(is_batch_sharded_by_expert, input_ids is not None)
     w0_pspec, w1_pspec, wo_pspec = maybe_aqt_partition(w0_kernel, w0_pspec, w1_kernel, w1_pspec, wo_kernel, wo_pspec)
 
-    def route(x, logits, pre_bias_logits, rngs, input_ids=None):
-      """Performs both across device and within device token routing/sorting"""
-      num_ep = self.get_expert_parallelism_size()
-      expert_shard_id = jax.lax.axis_index(self._expert_parallelism_name) if num_ep > 1 else 0
+    def roe_ag_and_route(x, logits, pre_bias_logits, num_ep, expert_shard_id, rngs, input_ids=None):
+      # The ring-of-experts strategy first duplicates the inputs to all
+      # expert shards, and then routes within each shard.
 
+      # Duplicate inputs to all expert shards.
+      x, logits, pre_bias_logits = tuple(
+          jax.lax.all_gather(z, axis_name=self._expert_parallelism_name, tiled=True) for z in (x, logits, pre_bias_logits)
+      )
+
+      # "Route" tokens within each shard.
+      num_experts_per_shard = self.config.num_experts // num_ep
+      (
+          x,
+          sorted_selected_experts,
+          weights,
+          group_sizes,
+          selected_experts,
+          lb_loss,
+          bias_updates,
+          local_group_sizes,
+      ) = self.permute(
+          x,
+          logits,
+          pre_bias_logits,
+          self.config.use_custom_sort_vjp,
+          roll_to_expert_id=num_experts_per_shard * expert_shard_id,
+          rngs=rngs,
+          input_ids=input_ids,
+      )
+      return (
+          x,
+          RouteOutput(
+              group_sizes=group_sizes,
+              selected_experts=selected_experts,
+              sorted_selected_experts=sorted_selected_experts,
+              weights=weights,
+              lb_loss=lb_loss,
+              bias_updates=bias_updates,
+              local_group_sizes=local_group_sizes,
+          ),
+          RouteMetadata(
+              expert_shard_id=expert_shard_id,
+              local_sorted_indices=None,
+              all_shards_group_sizes=None,
+              reshaped_group_sizes=None,
+          ),
+      )
+
+    def ra2a_and_route(x, logits, pre_bias_logits, num_ep, expert_shard_id, rngs, input_ids=None):
       local_sorted_indices = None
       all_shards_group_sizes = None
       reshaped_group_sizes = None
+      (
+          x,
+          sorted_selected_experts,
+          weights,
+          group_sizes,
+          selected_experts,
+          lb_loss,
+          bias_updates,
+          local_group_sizes,
+      ) = self.permute(x, logits, pre_bias_logits, self.config.use_custom_sort_vjp, rngs, input_ids=input_ids)
 
-      if self.config.use_ring_of_experts:
-        # The ring-of-experts strategy first duplicates the inputs to all
-        # expert shards, and then routes within each shard.
+      if num_ep > 1:
+        batch_axis = self._expert_parallelism_name if is_batch_sharded_by_expert else "data"
+        # get group sizes for all shards
+        local_expert_size = self.config.num_experts // num_ep
+        reshaped_group_sizes = jnp.sum(group_sizes.reshape(-1, local_expert_size), axis=1)
+        global_group_sizes = group_sizes
 
-        # Duplicate inputs to all expert shards.
-        x, logits, pre_bias_logits = tuple(
-            jax.lax.all_gather(z, axis_name=self._expert_parallelism_name, tiled=True)
-            for z in (x, logits, pre_bias_logits)
-        )
+        if is_batch_sharded_by_expert:
+          all_shards_group_sizes = jax.lax.all_gather(reshaped_group_sizes, axis_name=batch_axis)
+          input_offsets, send_sizes, output_offsets, recv_sizes = RoutedMoE.get_all_to_all_params(
+              all_shards_group_sizes,
+              expert_shard_id,
+              num_ep,
+          )
 
-        # "Route" tokens within each shard.
-        num_experts_per_shard = self.config.num_experts // num_ep
-        (
-            x,
-            sorted_selected_experts,
-            weights,
-            group_sizes,
-            selected_experts,
-            lb_loss,
-            bias_updates,
-            local_group_sizes,
-        ) = self.permute(
-            x,
-            logits,
-            pre_bias_logits,
-            self.config.use_custom_sort_vjp,
-            roll_to_expert_id=num_experts_per_shard * expert_shard_id,
-            rngs=rngs,
-            input_ids=input_ids,
-        )
+          buffer_size = self.get_ragged_buffer_size(
+              jnp.shape(x)[0],
+              num_ep,
+              self.config.num_experts,
+              self.config.num_experts_per_tok,
+              self.config.ragged_buffer_factor,
+          )
+          output_shape = jax.lax.empty((buffer_size, self.moe_expert_input_dim), dtype=x.dtype)
 
-      else:
-        (
-            x,
-            sorted_selected_experts,
-            weights,
-            group_sizes,
-            selected_experts,
-            lb_loss,
-            bias_updates,
-            local_group_sizes,
-        ) = self.permute(x, logits, pre_bias_logits, self.config.use_custom_sort_vjp, rngs, input_ids=input_ids)
-
-        if num_ep > 1:
-          batch_axis = self._expert_parallelism_name if is_batch_sharded_by_expert else "data"
-          # get group sizes for all shards
-          local_expert_size = self.config.num_experts // num_ep
-          reshaped_group_sizes = jnp.sum(group_sizes.reshape(-1, local_expert_size), axis=1)
-          global_group_sizes = group_sizes
-
-          if is_batch_sharded_by_expert:
-            all_shards_group_sizes = jax.lax.all_gather(reshaped_group_sizes, axis_name=batch_axis)
-            input_offsets, send_sizes, output_offsets, recv_sizes = RoutedMoE.get_all_to_all_params(
-                all_shards_group_sizes,
-                expert_shard_id,
-                num_ep,
-            )
-
-            buffer_size = self.get_ragged_buffer_size(
-                jnp.shape(x)[0],
-                num_ep,
-                self.config.num_experts,
-                self.config.num_experts_per_tok,
-                self.config.ragged_buffer_factor,
-            )
-            output_shape = jax.lax.empty((buffer_size, self.moe_expert_input_dim), dtype=x.dtype)
-
-            x = jax.lax.ragged_all_to_all(
-                x,
-                output_shape,
-                input_offsets,
-                send_sizes,
-                output_offsets,
-                recv_sizes,
-                axis_name=self._expert_parallelism_name,
-            )
-            global_group_sizes = jax.lax.all_gather(group_sizes, axis_name=self._expert_parallelism_name)
-            x, local_sorted_indices, group_sizes, selected_experts = RoutedMoE.local_permute(
-                x,
-                global_group_sizes,
-                local_expert_size,
-                shard_index=expert_shard_id,
-                use_custom_sort_vjp=self.config.use_custom_sort_vjp,
-                use_ragged_sort=self.config.use_ragged_sort,
-            )
-          else:
-            x, local_sorted_indices, group_sizes, selected_experts = RoutedMoE.local_permute(
-                x,
-                global_group_sizes[None, :],
-                local_expert_size,
-                shard_index=expert_shard_id,
-                is_offset=True,
-                global_sorted_experts=selected_experts,
-                use_custom_sort_vjp=self.config.use_custom_sort_vjp,
-                use_ragged_sort=self.config.use_ragged_sort,
-            )
+          x = jax.lax.ragged_all_to_all(
+              x,
+              output_shape,
+              input_offsets,
+              send_sizes,
+              output_offsets,
+              recv_sizes,
+              axis_name=self._expert_parallelism_name,
+          )
+          global_group_sizes = jax.lax.all_gather(group_sizes, axis_name=self._expert_parallelism_name)
+          x, local_sorted_indices, group_sizes, selected_experts = RoutedMoE.local_permute(
+              x,
+              global_group_sizes,
+              local_expert_size,
+              shard_index=expert_shard_id,
+              use_custom_sort_vjp=self.config.use_custom_sort_vjp,
+              use_ragged_sort=self.config.use_ragged_sort,
+          )
+        else:
+          x, local_sorted_indices, group_sizes, selected_experts = RoutedMoE.local_permute(
+              x,
+              global_group_sizes[None, :],
+              local_expert_size,
+              shard_index=expert_shard_id,
+              is_offset=True,
+              global_sorted_experts=selected_experts,
+              use_custom_sort_vjp=self.config.use_custom_sort_vjp,
+              use_ragged_sort=self.config.use_ragged_sort,
+          )
 
       return (
           x,
@@ -1598,6 +1612,32 @@ class RoutedMoE(nnx.Module):
               reshaped_group_sizes=reshaped_group_sizes,
           ),
       )
+
+    def route(x, logits, pre_bias_logits, rngs, input_ids=None):
+      """Performs both across device and within device token routing/sorting"""
+      num_ep = self.get_expert_parallelism_size()
+      expert_shard_id = jax.lax.axis_index(self._expert_parallelism_name) if num_ep > 1 else 0
+
+      if self.config.use_ring_of_experts:
+        return roe_ag_and_route(
+            x,
+            logits,
+            pre_bias_logits,
+            num_ep,
+            expert_shard_id,
+            rngs,
+            input_ids=input_ids,
+        )
+      else:
+        return ra2a_and_route(
+            x,
+            logits,
+            pre_bias_logits,
+            num_ep,
+            expert_shard_id,
+            rngs,
+            input_ids=input_ids,
+        )
 
     def get_active_sharding_axes(pspec_dim_axes, tensor_dim_index):
       if pspec_dim_axes is None:
@@ -1647,7 +1687,17 @@ class RoutedMoE(nnx.Module):
       )
       return wo_gather_axes, wo_tile_size
 
-    def gmm_up(x, w0, w1, w0_bias, w1_bias, gmm_fn, weight_gather):
+    def gmm_up(
+        x,
+        w0,
+        w1,
+        w0_bias,
+        w1_bias,
+        gmm_fn,
+        weight_gather,
+        partial_accum0=None,
+        partial_accum1=None,
+    ):
       """Run the two up-projections (gate + up) and apply the FFN activation."""
       wi_gather_axes, wi_tile_size = get_wi_gmm_params()
       if self.config.prefuse_moe_weights:
@@ -1656,7 +1706,7 @@ class RoutedMoE(nnx.Module):
         out = gmm_fn(x, w_fused, tiling=wi_tile_size, weight_gather_axes=wi_gather_axes)
         n = out.shape[-1] // 2
         layer_w0, layer_w1 = out[:, :n], out[:, n:]
-        if self.config.mlp_bias:
+        if self.config.mlp_bias and w0_bias is not None and w1_bias is not None:
           layer_w0 = layer_w0 + w0_bias
           layer_w1 = layer_w1 + w1_bias
         layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
@@ -1667,8 +1717,9 @@ class RoutedMoE(nnx.Module):
             w0,
             tiling=wi_tile_size,
             weight_gather_axes=wi_gather_axes,
+            partial_sum=partial_accum0,
         )
-        if self.config.mlp_bias:
+        if self.config.mlp_bias and w0_bias is not None:
           layer_w0 = layer_w0 + w0_bias
         layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
 
@@ -1677,11 +1728,12 @@ class RoutedMoE(nnx.Module):
             w1,
             tiling=wi_tile_size,
             weight_gather_axes=wi_gather_axes,
+            partial_sum=partial_accum1,
         )
-        if self.config.mlp_bias:
+        if self.config.mlp_bias and w1_bias is not None:
           layer_w1 = layer_w1 + w1_bias
         layer_w1 = adc.checkpoint_name(layer_w1, "moe_mlpwi_1")
-      return self.apply_ffn_activation(layer_w0, layer_w1)
+      return layer_w0, layer_w1
 
     def get_gmm_for_local_experts(x, routing, route_metadata):
       """Return a partial GMM function with preconfigured routing params."""
@@ -1761,6 +1813,94 @@ class RoutedMoE(nnx.Module):
           axis_name=self._expert_parallelism_name,
       )
 
+    def moe_emb_chunking(
+        x, logits, pre_bias_logits, w0, w1, w0_bias, w1_bias, wo_bias, sharded_input_ids, rngs, embed_dim
+    ):
+      """Overlap token all-gather and GMM computation along embedding dimension."""
+      num_ep = self.get_expert_parallelism_size()
+      expert_shard_id = jax.lax.axis_index(self._expert_parallelism_name) if num_ep > 1 else 0
+
+      chunk_dim = embed_dim // self.config.num_moe_emb_chunks
+      chunk_rngs = (
+          jax.random.split(rngs.params(), self.config.num_moe_emb_chunks)
+          if self.config.use_random_routing
+          and rngs is not None
+          and hasattr(rngs, "params")
+          and callable(getattr(rngs, "params"))
+          else [rngs] * self.config.num_moe_emb_chunks
+      )
+      if rngs is not None:
+        chunk_rngs = jax.random.split(rngs.params(), self.config.num_moe_emb_chunks)
+
+      first_x_unrouted = jax.lax.dynamic_slice_in_dim(x, 0, chunk_dim, axis=2)
+      cur_x_chunk, routing, route_metadata = roe_ag_and_route(
+          first_x_unrouted,
+          logits,
+          pre_bias_logits,
+          num_ep,
+          expert_shard_id,
+          nnx.Rngs(params=chunk_rngs[0]) if chunk_rngs is not None else None,
+          input_ids=sharded_input_ids,
+      )
+
+      if self.config.mlp_bias:
+        w0_bias, w1_bias, wo_bias = self.transform_bias(routing.selected_experts, w0_bias, w1_bias, wo_bias)
+
+      partial_sum0 = jnp.zeros((cur_x_chunk.shape[0], w0.shape[-1]), dtype=cur_x_chunk.dtype)
+      partial_sum1 = jnp.zeros((cur_x_chunk.shape[0], w1.shape[-1]), dtype=cur_x_chunk.dtype)
+
+      def scan_fn(carry, _):
+        cur_x, ps0, ps1, chunk_idx = carry
+
+        cur_w0 = jax.lax.dynamic_slice_in_dim(w0, chunk_idx * chunk_dim, chunk_dim, axis=1)
+        cur_w1 = jax.lax.dynamic_slice_in_dim(w1, chunk_idx * chunk_dim, chunk_dim, axis=1)
+        gmm_fn = get_gmm_for_local_experts(cur_x, routing, route_metadata)
+        next_ps0, next_ps1 = gmm_up(
+            cur_x,
+            cur_w0,
+            cur_w1,
+            None,  # Only add biases once at the end of the loop
+            None,  # Only add biases once at the end of the loop
+            gmm_fn,
+            weight_gather,
+            partial_accum0=ps0,
+            partial_accum1=ps1,
+        )
+        next_x_unrouted = jax.lax.dynamic_slice_in_dim(x, (chunk_idx + 1) * chunk_dim, chunk_dim, axis=2)
+        next_x, _, _ = roe_ag_and_route(
+            next_x_unrouted,
+            logits,
+            pre_bias_logits,
+            num_ep,
+            expert_shard_id,
+            nnx.Rngs(params=chunk_rngs[chunk_idx + 1]) if chunk_rngs is not None else None,
+            input_ids=sharded_input_ids,
+        )
+        return (next_x, next_ps0, next_ps1, chunk_idx + 1), None
+
+      (last_x_chunk, ps0, ps1, _), _ = jax.lax.scan(
+          scan_fn,
+          (cur_x_chunk, partial_sum0, partial_sum1, 0),
+          None,
+          length=self.config.num_moe_emb_chunks - 1,
+      )
+      # gmm the last chunk
+      last_w0 = jax.lax.dynamic_slice_in_dim(w0, (self.config.num_moe_emb_chunks - 1) * chunk_dim, chunk_dim, axis=1)
+      last_w1 = jax.lax.dynamic_slice_in_dim(w1, (self.config.num_moe_emb_chunks - 1) * chunk_dim, chunk_dim, axis=1)
+      gmm_fn = get_gmm_for_local_experts(last_x_chunk, routing, route_metadata)
+      output0, output1 = gmm_up(
+          last_x_chunk,
+          last_w0,
+          last_w1,
+          w0_bias,
+          w1_bias,
+          gmm_fn,
+          weight_gather,
+          partial_accum0=ps0,
+          partial_accum1=ps1,
+      )
+      return output0, output1, gmm_fn, routing, route_metadata, wo_bias
+
     @functools.partial(
         jax.shard_map,
         mesh=self.mesh,
@@ -1787,15 +1927,21 @@ class RoutedMoE(nnx.Module):
     def sparse_matmul_route_and_compute(
         x, logits, pre_bias_logits, w0, w1, wo, w0_bias, w1_bias, wo_bias, sharded_input_ids, rngs
     ):
-      batch_size, sequence_length, _ = x.shape
-      x, routing, route_metadata = route(x, logits, pre_bias_logits, rngs, input_ids=sharded_input_ids)
+      batch_size, sequence_length, embed_dim = x.shape
+      if self.config.num_moe_emb_chunks > 0:
+        output0, output1, gmm_fn, routing, route_metadata, wo_bias = moe_emb_chunking(
+            x, logits, pre_bias_logits, w0, w1, w0_bias, w1_bias, wo_bias, sharded_input_ids, rngs, embed_dim
+        )
+      else:
+        x, routing, route_metadata = route(x, logits, pre_bias_logits, rngs, input_ids=sharded_input_ids)
 
-      if self.config.mlp_bias:
-        w0_bias, w1_bias, wo_bias = self.transform_bias(routing.selected_experts, w0_bias, w1_bias, wo_bias)
+        if self.config.mlp_bias:
+          w0_bias, w1_bias, wo_bias = self.transform_bias(routing.selected_experts, w0_bias, w1_bias, wo_bias)
 
-      gmm_fn = get_gmm_for_local_experts(x, routing, route_metadata)
-      intermediate_layer = gmm_up(x, w0, w1, w0_bias, w1_bias, gmm_fn, weight_gather)
+        gmm_fn = get_gmm_for_local_experts(x, routing, route_metadata)
+        output0, output1 = gmm_up(x, w0, w1, w0_bias, w1_bias, gmm_fn, weight_gather)
 
+      intermediate_layer = self.apply_ffn_activation(output0, output1)
       wo_gather_axes, wo_tile_size = get_wo_gmm_params()
       intermediate_output = gmm_fn(
           intermediate_layer,

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -538,6 +538,41 @@ class RoutedMoeTest(unittest.TestCase):
     self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-03, atol=1e-03, equal_nan=False))
 
   @pytest.mark.tpu_only
+  def test_moe_emb_chunking_gmm_v2(self):
+    cfg = pyconfig.initialize(
+        [None, get_test_config_path()],
+        run_name="moe_block_chunking_gmm_v2_test",
+        enable_checkpointing=False,
+        model_name="mixtral-8x7b",
+        dtype="bfloat16",
+        weight_dtype="bfloat16",
+        megablox=False,
+        sparse_matmul=True,
+        use_tokamax_gmm=True,
+        use_gmm_v2=True,
+        num_moe_emb_chunks=4,
+        use_ring_of_experts=True,
+        mlp_bias=True,
+        per_device_batch_size=1,
+        max_target_length=128,
+    )
+
+    rng = jax.random.PRNGKey(1234)
+    rng_model, rng_hidden_states = jax.random.split(rng)
+    device_count = jax.device_count()
+    hidden_states = jax.random.uniform(
+        rng_hidden_states,
+        (int(cfg.per_device_batch_size) * device_count, cfg.max_target_length, cfg.base_emb_dim),
+        dtype=cfg.dtype,
+    )
+
+    devices_array = maxtext_utils.create_device_mesh(cfg)
+    mesh = Mesh(devices_array, cfg.mesh_axes)
+    variables, expected_output = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
+    actual_output, _, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
+    self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
+
+  @pytest.mark.tpu_only
   def test_megablox_expert_parallelism(self):
     cfg = pyconfig.initialize(
         [None, get_test_config_path()],

--- a/tests/unit/pallas_mosaic_tpu_v2_kernel_test.py
+++ b/tests/unit/pallas_mosaic_tpu_v2_kernel_test.py
@@ -260,6 +260,36 @@ class GmmTest(parameterized.TestCase):
 
   @pytest.mark.skip(reason="Test takes too long, can run locally to verify changes b/528087469")
   @parameterized.product(
+      batch_size=[128, 256],
+      in_size=[512],
+      out_size=[512],
+      num_groups=[4],
+      group_offset=[0],
+  )
+  def test_gmm_partial_sum(self, batch_size, in_size, out_size, num_groups, group_offset):
+    """Test GMM with partial sum accumulation and memory aliasing."""
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+    k0, k1, k2 = jax.random.split(key, 3)
+
+    lhs = jax.random.normal(k0, (batch_size, in_size), dtype=jnp.bfloat16)
+    rhs = jax.random.normal(k1, (num_local_groups, in_size, out_size), dtype=jnp.bfloat16)
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+    ps = jax.random.normal(k2, (batch_size, out_size), dtype=jnp.bfloat16)
+
+    expected = reference_gmm(lhs, rhs, group_sizes, partial_sum=ps, group_offset=group_offset)
+    actual = gmm_backend.gmm_v2(
+        lhs,
+        rhs,
+        group_sizes,
+        partial_sum=ps,
+        group_offset=group_offset,
+    )
+    assert_arrays_all_close(actual, expected)
+
+  @pytest.mark.skip(reason="Test takes too long, can run locally to verify changes b/528087469")
+  @parameterized.product(
       batch_size=[128, 1024],
       in_size=[512, 1024],
       out_size=[512, 1024],
@@ -413,6 +443,51 @@ class GmmTest(parameterized.TestCase):
         grad,
         group_sizes,
         num_local_groups,
+        group_offset=group_offset,
+        preferred_element_type=jnp.bfloat16,
+    )
+    self.assertEqual(actual.shape, (num_local_groups, in_size, out_size))
+    assert_arrays_all_close(actual, expected)
+
+  @pytest.mark.skip(reason="Test takes too long, can run locally to verify changes b/528087469")
+  @parameterized.product(
+      batch_size=[256],
+      in_size=[512],
+      out_size=[512],
+      num_groups=[4],
+      group_offset=[0],
+      empty_group_index=[0, 1, 2, 3],
+  )
+  def test_tgmm_empty_group_with_partial_sum(
+      self,
+      batch_size,
+      in_size,
+      out_size,
+      num_groups,
+      group_offset,
+      empty_group_index,
+  ):
+    """Test that TGMM correctly preserves partial sum for empty groups."""
+    num_local_groups = num_groups - group_offset
+    key = jax.random.key(0)
+    key1, key2, key3 = jax.random.split(key, 3)
+    lhs = jax.random.normal(key1, (batch_size, in_size), dtype=jnp.bfloat16)
+    grad = jax.random.normal(key2, (batch_size, out_size), dtype=jnp.bfloat16)
+    ps = jax.random.normal(key3, (num_local_groups, in_size, out_size), dtype=jnp.bfloat16)
+
+    group_sizes = get_group_sizes(batch_size, num_groups)
+    group_sizes = group_sizes.at[-1].add(group_sizes[empty_group_index])
+    group_sizes = group_sizes.at[empty_group_index].set(0)
+    group_offset = jnp.array(group_offset, dtype=jnp.int32)
+
+    lhs_t = lhs.swapaxes(0, 1)
+    expected = reference_tgmm(lhs_t, grad, group_sizes, num_local_groups, group_offset=group_offset, partial_sum=ps)
+    actual = tgmm_backend.tgmm_v2(
+        lhs,
+        grad,
+        group_sizes,
+        num_local_groups,
+        partial_sum=ps,
         group_offset=group_offset,
         preferred_element_type=jnp.bfloat16,
     )

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -566,6 +566,63 @@ class TrainCompile(parameterized.TestCase):
     )
 
   @pytest.mark.cpu_only
+  def test_moe_emb_chunking(self):
+    temp_dir = gettempdir()
+    compiled_trainstep_file = os.path.join(temp_dir, "test_moe_emb_chunking.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "use_iota_embed=true",
+            "compile_topology_num_slices=1",
+            "model_name=deepseek3-test",
+            "sparse_matmul=True",
+            "megablox=False",
+            "use_tokamax_gmm=True",
+            "use_gmm_v2=True",
+            "num_moe_emb_chunks=7",
+            "use_ring_of_experts=True",
+            "per_device_batch_size=2",
+            "max_target_length=1024",
+            "attention=flash",
+            "dtype=bfloat16",
+            "weight_dtype=bfloat16",
+            "scan_layers=True",
+        )
+    )
+
+  @pytest.mark.cpu_only
+  def test_moe_emb_chunking_with_mlp_bias(self):
+    temp_dir = gettempdir()
+    compiled_trainstep_file = os.path.join(temp_dir, "test_moe_emb_chunking_bias.pickle")
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-8",
+            "use_iota_embed=true",
+            "compile_topology_num_slices=1",
+            "model_name=deepseek3-test",
+            "sparse_matmul=True",
+            "megablox=False",
+            "use_tokamax_gmm=True",
+            "use_gmm_v2=True",
+            "num_moe_emb_chunks=7",
+            "use_ring_of_experts=True",
+            "mlp_bias=True",
+            "per_device_batch_size=2",
+            "max_target_length=1024",
+            "attention=flash",
+            "dtype=bfloat16",
+            "weight_dtype=bfloat16",
+            "scan_layers=True",
+        )
+    )
+
+  @pytest.mark.cpu_only
   def test_moe_deepseek_unscanned_bf16(self):
     temp_dir = gettempdir()
     compiled_trainstep_file = os.path.join(temp_dir, "test_moe_deepseek_unscanned_bf16.pickle")
@@ -809,24 +866,26 @@ class TrainCompile(parameterized.TestCase):
   def test_deepseek4(self, scan_layers):
     # test deepseek4 compile (Linen-only: DeepSeek NNX decoder rewrite is a follow-up PR).
     compiled_trainstep_file = f"/tmp/test_deepseek4_{scan_layers}.pickle"
-    train_compile_main((
-        "",
-        get_test_config_path(),
-        f"compiled_trainstep_file={compiled_trainstep_file}",
-        "compile_topology=v5p-256",
-        "use_iota_embed=true",
-        "compile_topology_num_slices=1",
-        "model_name=deepseek4-284b",
-        "per_device_batch_size=1",
-        "max_target_length=1024",
-        f"scan_layers={scan_layers}",
-        "attention=dot_product",
-        "dtype=bfloat16",
-        "weight_dtype=bfloat16",
-        "enable_nnx=False",
-        "pure_nnx=False",
-        "pure_nnx_decoder=False",
-    ))
+    train_compile_main(
+        (
+            "",
+            get_test_config_path(),
+            f"compiled_trainstep_file={compiled_trainstep_file}",
+            "compile_topology=v5p-256",
+            "use_iota_embed=true",
+            "compile_topology_num_slices=1",
+            "model_name=deepseek4-284b",
+            "per_device_batch_size=1",
+            "max_target_length=1024",
+            f"scan_layers={scan_layers}",
+            "attention=dot_product",
+            "dtype=bfloat16",
+            "weight_dtype=bfloat16",
+            "enable_nnx=False",
+            "pure_nnx=False",
+            "pure_nnx_decoder=False",
+        )
+    )
 
   @pytest.mark.cpu_only
   def test_indexer_dense_warmup(self):


### PR DESCRIPTION
### Description
Implements **Overlapped All-Gather and GMM Computation (Collective Matmul)** for Ring of Experts (RoE) in MoE layers to hide communication overhead and token sorting latency. The changes include:
- Chunks input activations along the contracting embedding dimension (`embed_dim // num_chunks`). While chunk `i` computes GMM up-projections, chunk `i+1` concurrently executes Ring of Experts All-Gather and routing across expert parallel shards.
  - Update kernel to use in-place Partial Sum Accumulation to avoid unnecessary copies using `input_output_aliases`

### Testing
- **Layer Tests (`tests/unit/moe_test.py`)**: Verified chunked GMM v2 routing, partial sum accumulation, and MLP bias addition (`test_chunking_gmm_v2` with `mlp_bias=True`).
- **AOT Compilation Tests (`tests/unit/train_compile_test.py`)**: Verified ahead-of-time HLO compilation and sharding on multi-slice topologies for chunked MoE (`test_moe_chunking` and `test_moe_chunking_with_mlp_bias`).
- **Low-Level Pallas Kernel Tests (`tests/unit/pallas_mosaic_tpu_v2_kernel_test.py`)**: Verified numerical correctness and in-place buffer aliasing for partial sum accumulation across GMM (`test_gmm_partial_sum0/1`) and TGMM with zero-initialized empty expert groups (`test_tgmm_empty_group_with_partial_sum0-3`).
- **End-to-End Execution & Profiling**: Verified E2E training execution on v6e-8 TPU VM (`deepseek3-tiny` with `chunk_ag_gmm=True`, `num_chunks=4`) and generated XPlane / XProf traces confirming communication-compute overlap.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
