### PR TITLE
Split heavy test jobs across more workers

### DIFF
--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -151,6 +151,13 @@ jobs:
       - name: Copy test assets files
         if: ${{ !inputs.maxtext_installed }}
         run : gcloud storage cp gs://maxtext-test-assets/* tests/assets
+      - name: Download Converted Test Durations
+        if: inputs.total_workers > 1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: test-durations-${{ github.run_id }}-${{ inputs.flavor }}
+          path: .
+        continue-on-error: true
       - name: Run Tests
         shell: bash
         run: |
@@ -221,11 +228,18 @@ jobs:
           fi
           if [ "${INPUTS_TOTAL_WORKERS}" -gt 1 ]; then
             $PYTHON_EXE -m pip install --quiet pytest-split
-            if [ "${INPUTS_DEVICE_TYPE}" = "tpu" ]; then
-              SPLIT_ARGS="--splits ${INPUTS_TOTAL_WORKERS} --group ${INPUTS_WORKER_GROUP}"
+            if [ -f .test_durations ]; then
+              echo "Using downloaded .test_durations with least_duration splitting algorithm."
+              SPLIT_ALGO="--splitting-algorithm least_duration"
             else
+              echo "Warning: .test_durations not found. Falling back to default split."
+              SPLIT_ALGO=""
+            fi
+            if [ "${INPUTS_DEVICE_TYPE}" = "cpu" ]; then
               $PYTHON_EXE -m pip install --quiet pytest-xdist
-              SPLIT_ARGS="--splits ${INPUTS_TOTAL_WORKERS} --group ${INPUTS_WORKER_GROUP} -n auto"
+              SPLIT_ARGS="--splits ${INPUTS_TOTAL_WORKERS} --group ${INPUTS_WORKER_GROUP} -n auto ${SPLIT_ALGO}"
+            else
+              SPLIT_ARGS="--splits ${INPUTS_TOTAL_WORKERS} --group ${INPUTS_WORKER_GROUP} ${SPLIT_ALGO}"
             fi
           else
             SPLIT_ARGS=""
@@ -245,7 +259,13 @@ jobs:
               $SPLIT_ARGS \
               ${INPUTS_PYTEST_EXTRA_ARGS} &
             PYTEST_PID=$!
-            wait "$PYTEST_PID"
+            PYTEST_EXIT_CODE=0
+            wait "$PYTEST_PID" || PYTEST_EXIT_CODE=$?
+            if [ "$PYTEST_EXIT_CODE" -eq 5 ]; then
+              echo "No tests collected for worker group ${INPUTS_WORKER_GROUP} (pytest exit code 5), treating as success."
+            elif [ "$PYTEST_EXIT_CODE" -ne 0 ]; then
+              exit "$PYTEST_EXIT_CODE"
+            fi
           fi
 
         env:

--- a/.github/workflows/run_tests_against_package.yml
+++ b/.github/workflows/run_tests_against_package.yml
@@ -217,11 +217,41 @@ jobs:
           fi
           if [ "${INPUTS_TOTAL_WORKERS}" -gt 1 ]; then
             $PYTHON_EXE -m pip install --quiet pytest-split
-            if [ "${INPUTS_DEVICE_TYPE}" = "tpu" ]; then
-              SPLIT_ARGS="--splits ${INPUTS_TOTAL_WORKERS} --group ${INPUTS_WORKER_GROUP}"
-            else
+            if [ "${INPUTS_DEVICE_TYPE}" = "cpu" ]; then
               $PYTHON_EXE -m pip install --quiet pytest-xdist
-              SPLIT_ARGS="--splits ${INPUTS_TOTAL_WORKERS} --group ${INPUTS_WORKER_GROUP} -n auto"
+              SPLIT_ARGS="--splits ${INPUTS_TOTAL_WORKERS} --group ${INPUTS_WORKER_GROUP} -n auto --splitting-algorithm least_duration"
+            else
+              SPLIT_ARGS="--splits ${INPUTS_TOTAL_WORKERS} --group ${INPUTS_WORKER_GROUP} --splitting-algorithm least_duration"
+            fi
+            # Remove any existing .test_durations to ensure we don't use stale data
+            rm -f .test_durations per_test_baseline.json
+
+            CANDIDATE_URLS=(
+              "https://raw.githubusercontent.com/${{ github.repository }}/gh-pages/dev/bench/per_test_baseline.json"
+            )
+            if [ "${{ github.repository }}" != "AI-Hypercomputer/maxtext" ]; then
+              CANDIDATE_URLS+=("https://raw.githubusercontent.com/AI-Hypercomputer/maxtext/gh-pages/dev/bench/per_test_baseline.json")
+            fi
+
+            DOWNLOADED=false
+            for URL in "${CANDIDATE_URLS[@]}"; do
+              echo "Attempting to download test durations from: ${URL}"
+              if curl -sSf "${URL}" -o per_test_baseline.json; then
+                echo "Successfully downloaded baseline durations from: ${URL}"
+                DOWNLOADED=true
+                break
+              fi
+            done
+
+            if [ "$DOWNLOADED" = true ]; then
+              if $PYTHON_EXE tools/dev/convert_durations.py per_test_baseline.json .test_durations --flavor "${{ inputs.flavor }}"; then
+                echo "Successfully converted durations to .test_durations"
+              else
+                echo "Warning: Failed to convert durations. Falling back to default split."
+              fi
+              rm -f per_test_baseline.json
+            else
+              echo "Warning: Historical test durations unavailable. Falling back to default split."
             fi
           else
             SPLIT_ARGS=""

--- a/.github/workflows/run_tests_coordinator.yml
+++ b/.github/workflows/run_tests_coordinator.yml
@@ -80,19 +80,26 @@ jobs:
           CPU_UNIT_WORKER_GROUPS='[1, 2, 3, 4]'
 
           # TPU worker constants
-          TPU_UNIT_TOTAL_WORKERS=2
-          TPU_UNIT_WORKER_GROUPS='[1, 2]'
+          TPU_UNIT_TOTAL_WORKERS=3
+          TPU_UNIT_WORKER_GROUPS='[1, 2, 3]'
+
+          # GPU worker constants
+          GPU_UNIT_TOTAL_WORKERS=3
+          GPU_UNIT_WORKER_GROUPS='[1, 2, 3]'
 
           # Default fallback constants
           DEFAULT_TOTAL_WORKERS=1
           DEFAULT_WORKER_GROUPS='[1]'
 
-          if [[ "$FLAVOR" == "cpu-unit" || "$FLAVOR" == "cpu-post-training-unit" ]]; then
+          if [[ "$FLAVOR" == cpu-* ]]; then
             echo "worker_groups=${CPU_UNIT_WORKER_GROUPS}" >> "$GITHUB_OUTPUT"
             echo "total_workers=${CPU_UNIT_TOTAL_WORKERS}" >> "$GITHUB_OUTPUT"
-          elif [[ "$FLAVOR" == "tpu-unit" ]]; then
+          elif [[ "$FLAVOR" == tpu-* || "$FLAVOR" == tpu7x-* ]]; then
             echo "worker_groups=${TPU_UNIT_WORKER_GROUPS}" >> "$GITHUB_OUTPUT"
             echo "total_workers=${TPU_UNIT_TOTAL_WORKERS}" >> "$GITHUB_OUTPUT"
+          elif [[ "$FLAVOR" == gpu-* ]]; then
+            echo "worker_groups=${GPU_UNIT_WORKER_GROUPS}" >> "$GITHUB_OUTPUT"
+            echo "total_workers=${GPU_UNIT_TOTAL_WORKERS}" >> "$GITHUB_OUTPUT"
           else
             echo "worker_groups=${DEFAULT_WORKER_GROUPS}" >> "$GITHUB_OUTPUT"
             echo "total_workers=${DEFAULT_TOTAL_WORKERS}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/run_tests_coordinator.yml
+++ b/.github/workflows/run_tests_coordinator.yml
@@ -29,7 +29,7 @@ on:
             tpu7x-post-training-unit, tpu7x-post-training-integration,
             gpu-unit, gpu-integration,
             cpu-unit, cpu-integration,
-            cpu-post-training-unit
+            cpu-post-training-unit, cpu-post-training-integration
           )
         required: true
         type: string
@@ -66,33 +66,59 @@ jobs:
       worker_groups: ${{ steps.set-params.outputs.worker_groups }}
       total_workers: ${{ steps.set-params.outputs.total_workers }}
     steps:
-      - id: set-params
-        name: Set Worker Parameters
+      - name: Checkout MaxText
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.maxtext_sha || github.sha }}
+
+      - name: Download per-test baseline
+        id: download-baseline
+        shell: bash
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          CANDIDATE_URLS=(
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/gh-pages/dev/bench/per_test_baseline.json"
+          )
+          if [ "${GITHUB_REPOSITORY}" != "AI-Hypercomputer/maxtext" ]; then
+            CANDIDATE_URLS+=("https://raw.githubusercontent.com/AI-Hypercomputer/maxtext/gh-pages/dev/bench/per_test_baseline.json")
+          fi
+
+          for URL in "${CANDIDATE_URLS[@]}"; do
+            echo "Attempting to download test durations from: ${URL}"
+            if curl -sSf -H "User-Agent: github-actions" "${URL}" -o per_test_baseline.json; then
+              echo "Successfully downloaded baseline durations from: ${URL}"
+              echo "downloaded=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "downloaded=false" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate Workers & Convert Durations
+        id: set-params
+        shell: bash
         env:
           FLAVOR: ${{ inputs.flavor }}
+          BASELINE_DOWNLOADED: ${{ steps.download-baseline.outputs.downloaded }}
         run: |
-          # CPU worker constants
-          CPU_UNIT_TOTAL_WORKERS=4
-          CPU_UNIT_WORKER_GROUPS='[1, 2, 3, 4]'
-
-          # TPU worker constants
-          TPU_UNIT_TOTAL_WORKERS=2
-          TPU_UNIT_WORKER_GROUPS='[1, 2]'
-
-          # Default fallback constants
-          DEFAULT_TOTAL_WORKERS=1
-          DEFAULT_WORKER_GROUPS='[1]'
-
-          if [[ "$FLAVOR" == "cpu-unit" || "$FLAVOR" == "cpu-post-training-unit" ]]; then
-            echo "worker_groups=${CPU_UNIT_WORKER_GROUPS}" >> "$GITHUB_OUTPUT"
-            echo "total_workers=${CPU_UNIT_TOTAL_WORKERS}" >> "$GITHUB_OUTPUT"
-          elif [[ "$FLAVOR" == "tpu-unit" ]]; then
-            echo "worker_groups=${TPU_UNIT_WORKER_GROUPS}" >> "$GITHUB_OUTPUT"
-            echo "total_workers=${TPU_UNIT_TOTAL_WORKERS}" >> "$GITHUB_OUTPUT"
+          if [ "${BASELINE_DOWNLOADED}" = "true" ]; then
+            CALC_OUTPUT=$(python3 tools/dev/calculate_workers.py --flavor "$FLAVOR" --baseline per_test_baseline.json)
+            python3 tools/dev/convert_durations.py per_test_baseline.json .test_durations --flavor "$FLAVOR"
           else
-            echo "worker_groups=${DEFAULT_WORKER_GROUPS}" >> "$GITHUB_OUTPUT"
-            echo "total_workers=${DEFAULT_TOTAL_WORKERS}" >> "$GITHUB_OUTPUT"
+            CALC_OUTPUT=$(python3 tools/dev/calculate_workers.py --flavor "$FLAVOR")
           fi
+
+          echo "${CALC_OUTPUT}"
+          echo "${CALC_OUTPUT}" | grep -E '^(total_workers|worker_groups)=' >> "$GITHUB_OUTPUT"
+
+      - name: Upload Converted Test Durations
+        if: steps.download-baseline.outputs.downloaded == 'true'
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: test-durations-${{ github.run_id }}-${{ inputs.flavor }}
+          path: .test_durations
+          if-no-files-found: ignore
+          retention-days: 1
 
   execute-test-package:
     name: Execute Tests

--- a/tests/dev/calculate_workers_test.py
+++ b/tests/dev/calculate_workers_test.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for tools/dev/calculate_workers.py."""
+
+import json
+import subprocess
+import sys
+from tools.dev.calculate_workers import DEFAULT_WORKERS
+from tools.dev.calculate_workers import LIGHTWEIGHT_SUITE_MINUTES_THRESHOLD
+from tools.dev.calculate_workers import MAX_CPU_WORKERS
+from tools.dev.calculate_workers import MAX_GPU_WORKERS
+from tools.dev.calculate_workers import MAX_TPU_WORKERS
+from tools.dev.calculate_workers import TARGET_MINUTES_PER_WORKER
+from tools.dev.calculate_workers import calculate_workers
+from tools.dev.calculate_workers import get_max_workers_for_flavor
+
+
+def test_constants():
+  """Tests that module constants have expected defaults."""
+  assert MAX_CPU_WORKERS == 4
+  assert MAX_TPU_WORKERS == 3
+  assert MAX_GPU_WORKERS == 3
+  assert DEFAULT_WORKERS == 1
+  assert LIGHTWEIGHT_SUITE_MINUTES_THRESHOLD == 8.0
+  assert TARGET_MINUTES_PER_WORKER == 4.0
+
+
+def test_get_max_workers_for_flavor():
+  """Tests device-specific maximum worker safety caps."""
+  assert get_max_workers_for_flavor("cpu-unit") == 4
+  assert get_max_workers_for_flavor("cpu-integration") == 4
+  assert get_max_workers_for_flavor("cpu-post-training-unit") == 4
+  assert get_max_workers_for_flavor("tpu-unit") == 3
+  assert get_max_workers_for_flavor("tpu-integration") == 3
+  assert get_max_workers_for_flavor("tpu7x-unit") == 3
+  assert get_max_workers_for_flavor("gpu-unit") == 3
+  assert get_max_workers_for_flavor("gpu-integration") == 3
+  assert get_max_workers_for_flavor("unknown-flavor") == 1
+
+
+def test_calculate_workers_no_baseline():
+  """Tests fallback behavior when baseline data is not provided."""
+  workers, groups = calculate_workers("cpu-unit", None)
+  assert workers == 4
+  assert groups == [1, 2, 3, 4]
+
+  workers, groups = calculate_workers("tpu-unit", None)
+  assert workers == 3
+  assert groups == [1, 2, 3]
+
+  workers, groups = calculate_workers("unknown-flavor", None)
+  assert workers == 1
+  assert groups == [1]
+
+
+def test_calculate_workers_zero_matching_tests():
+  """Tests behavior when baseline exists but has 0 matching tests for flavor."""
+  baseline = {
+      "tpu-unit::tests.unit.test_a": 10.0,
+  }
+  workers, groups = calculate_workers("cpu-unit", baseline)
+  assert workers == 1
+  assert groups == [1]
+
+
+def test_calculate_workers_heavy_suite():
+  """Tests worker allocation for heavy suites (> 8 mins total duration)."""
+  baseline = {f"cpu-unit::test_{i}": 60.0 for i in range(20)}  # 20 mins total
+  workers, groups = calculate_workers("cpu-unit", baseline)
+  assert workers == 4
+  assert groups == [1, 2, 3, 4]
+
+  baseline_tpu = {f"tpu-unit::test_{i}": 60.0 for i in range(15)}  # 15 mins total
+  workers, groups = calculate_workers("tpu-unit", baseline_tpu)
+  assert workers == 3
+  assert groups == [1, 2, 3]
+
+
+def test_calculate_workers_lightweight_suite():
+  """Tests worker right-sizing for lightweight test suites (< 8 mins total)."""
+  # 3 tests taking 40s each = 120s (2.0 mins total)
+  baseline = {
+      "cpu-post-training-integration::test_1": 40.0,
+      "cpu-post-training-integration::test_2": 40.0,
+      "cpu-post-training-integration::test_3": 40.0,
+  }
+  workers, groups = calculate_workers("cpu-post-training-integration", baseline)
+  assert workers == 1
+  assert groups == [1]
+
+  # 6 tests taking 50s each = 300s (5.0 mins total) -> ceil(5.0 / 4.0) = 2 workers
+  baseline_medium = {f"cpu-post-training-unit::test_{i}": 50.0 for i in range(6)}
+  workers, groups = calculate_workers("cpu-post-training-unit", baseline_medium)
+  assert workers == 2
+  assert groups == [1, 2]
+
+
+def test_calculate_workers_fewer_tests_than_max_workers():
+  """Tests that worker count never exceeds the number of tests."""
+  # 2 tests taking 500s each = 1000s (16.6 mins total) -> max_workers would be 4, but only 2 tests!
+  baseline = {
+      "cpu-unit::test_heavy_1": 500.0,
+      "cpu-unit::test_heavy_2": 500.0,
+  }
+  workers, groups = calculate_workers("cpu-unit", baseline)
+  assert workers == 2
+  assert groups == [1, 2]
+
+
+def test_main_cli(tmp_path):
+  """Tests the CLI entry point stdout output."""
+  baseline_file = tmp_path / "baseline.json"
+  baseline_data = {
+      "tpu-unit::test_1": 600.0,
+      "tpu-unit::test_2": 600.0,
+  }
+  baseline_file.write_text(json.dumps(baseline_data), encoding="utf-8")
+
+  cmd = [
+      sys.executable,
+      "-m",
+      "tools.dev.calculate_workers",
+      "--flavor",
+      "tpu-unit",
+      "--baseline",
+      str(baseline_file),
+  ]
+
+  res = subprocess.run(cmd, capture_output=True, text=True, check=True)
+  assert res.returncode == 0
+  lines = res.stdout.strip().splitlines()
+  assert "total_workers=2" in lines
+  assert "worker_groups=[1, 2]" in lines

--- a/tests/dev/convert_durations_test.py
+++ b/tests/dev/convert_durations_test.py
@@ -1,0 +1,66 @@
+"""Tests for convert_durations utility."""
+
+# pylint: disable=redefined-outer-name
+
+import pytest
+from tools.dev import convert_durations
+
+
+@pytest.fixture
+def mock_repo_root(tmp_path):
+  """Creates a temporary mock directory structure."""
+  (tmp_path / "tests" / "unit").mkdir(parents=True)
+  (tmp_path / "tests" / "gather_reduce_sc_test.py").touch()
+  (tmp_path / "tests" / "unit" / "attention_test.py").touch()
+  (tmp_path / "tests" / "unit" / "no_class_test.py").touch()
+  return str(tmp_path)
+
+
+def test_convert_entry_legacy_format(mock_repo_root):
+  res = convert_durations.convert_entry(
+      "tests.gather_reduce_sc_test.GatherReduceScTest.test_column0",
+      0.003,
+      repo_root=mock_repo_root,
+  )
+  assert res == (
+      "",
+      "tests/gather_reduce_sc_test.py::GatherReduceScTest::test_column0",
+      0.003,
+  )
+
+
+def test_convert_entry_flavor_prefixed(mock_repo_root):
+  res = convert_durations.convert_entry(
+      "cpu-unit::tests.unit.attention_test.AttentionTest.test_dot_product",
+      64.84,
+      repo_root=mock_repo_root,
+  )
+  assert res == (
+      "cpu-unit",
+      "tests/unit/attention_test.py::AttentionTest::test_dot_product",
+      64.84,
+  )
+
+
+def test_convert_entry_non_existent_file(mock_repo_root):
+  res = convert_durations.convert_entry(
+      "tests.unit.non_existent_test.FooTest.test_bar",
+      1.0,
+      repo_root=mock_repo_root,
+  )
+  assert res is None
+
+
+def test_convert_durations_flavor_priority(mock_repo_root):
+  raw_data = {
+      "cpu-unit::tests.unit.attention_test.AttentionTest.test_dot_product": 60.0,
+      "tpu-unit::tests.unit.attention_test.AttentionTest.test_dot_product": 1.5,
+      "tests.gather_reduce_sc_test.GatherReduceScTest.test_column0": 0.05,
+  }
+
+  cpu_durations = convert_durations.convert_durations(raw_data, target_flavor="cpu-unit", repo_root=mock_repo_root)
+  assert cpu_durations["tests/unit/attention_test.py::AttentionTest::test_dot_product"] == 60.0
+  assert cpu_durations["tests/gather_reduce_sc_test.py::GatherReduceScTest::test_column0"] == 0.05
+
+  tpu_durations = convert_durations.convert_durations(raw_data, target_flavor="tpu-unit", repo_root=mock_repo_root)
+  assert tpu_durations["tests/unit/attention_test.py::AttentionTest::test_dot_product"] == 1.5

--- a/tests/dev/convert_durations_test.py
+++ b/tests/dev/convert_durations_test.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for convert_durations utility."""
+
+# pylint: disable=redefined-outer-name
+
+import pytest
+from tools.dev import convert_durations
+
+
+@pytest.fixture
+def mock_repo_root(tmp_path):
+  """Creates a temporary mock directory structure."""
+  (tmp_path / "tests" / "unit").mkdir(parents=True)
+  (tmp_path / "tests" / "gather_reduce_sc_test.py").touch()
+  (tmp_path / "tests" / "unit" / "attention_test.py").touch()
+  (tmp_path / "tests" / "unit" / "no_class_test.py").touch()
+  return str(tmp_path)
+
+
+def test_convert_entry_legacy_format(mock_repo_root):
+  res = convert_durations.convert_entry(
+      "tests.gather_reduce_sc_test.GatherReduceScTest.test_column0",
+      0.003,
+      repo_root=mock_repo_root,
+  )
+  assert res == (
+      "",
+      "tests/gather_reduce_sc_test.py::GatherReduceScTest::test_column0",
+      0.003,
+  )
+
+
+def test_convert_entry_flavor_prefixed(mock_repo_root):
+  res = convert_durations.convert_entry(
+      "cpu-unit::tests.unit.attention_test.AttentionTest.test_dot_product",
+      64.84,
+      repo_root=mock_repo_root,
+  )
+  assert res == (
+      "cpu-unit",
+      "tests/unit/attention_test.py::AttentionTest::test_dot_product",
+      64.84,
+  )
+
+
+def test_convert_entry_non_existent_file(mock_repo_root):
+  res = convert_durations.convert_entry(
+      "tests.unit.non_existent_test.FooTest.test_bar",
+      1.0,
+      repo_root=mock_repo_root,
+  )
+  assert res is None
+
+
+def test_convert_durations_flavor_priority(mock_repo_root):
+  raw_data = {
+      "cpu-unit::tests.unit.attention_test.AttentionTest.test_dot_product": 60.0,
+      "tpu-unit::tests.unit.attention_test.AttentionTest.test_dot_product": 1.5,
+      "tests.gather_reduce_sc_test.GatherReduceScTest.test_column0": 0.05,
+  }
+
+  cpu_durations = convert_durations.convert_durations(raw_data, target_flavor="cpu-unit", repo_root=mock_repo_root)
+  assert cpu_durations["tests/unit/attention_test.py::AttentionTest::test_dot_product"] == 60.0
+  assert cpu_durations["tests/gather_reduce_sc_test.py::GatherReduceScTest::test_column0"] == 0.05
+
+  tpu_durations = convert_durations.convert_durations(raw_data, target_flavor="tpu-unit", repo_root=mock_repo_root)
+  assert tpu_durations["tests/unit/attention_test.py::AttentionTest::test_dot_product"] == 1.5
+
+
+def test_convert_entry_parameterized_with_dots(mock_repo_root):
+  """Tests that dots within parametrization brackets are preserved."""
+  res = convert_durations.convert_entry(
+      "cpu-integration::tests.unit.attention_test.AttentionTest.test_hlo_diff[qwen3_1.7b-qwen3-1.7b-overrides2]",
+      45.2,
+      repo_root=mock_repo_root,
+  )
+  assert res == (
+      "cpu-integration",
+      "tests/unit/attention_test.py::AttentionTest::test_hlo_diff[qwen3_1.7b-qwen3-1.7b-overrides2]",
+      45.2,
+  )

--- a/tools/dev/__init__.py
+++ b/tools/dev/__init__.py
@@ -1,0 +1,1 @@
+"""Development tools package."""

--- a/tools/dev/__init__.py
+++ b/tools/dev/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Development tools package."""

--- a/tools/dev/calculate_workers.py
+++ b/tools/dev/calculate_workers.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Calculates the optimal number of workers for a given test flavor."""
+
+import argparse
+import json
+import math
+import os
+import sys
+
+
+# Maximum worker limits by hardware flavor
+MAX_CPU_WORKERS = 4
+MAX_TPU_WORKERS = 3
+MAX_GPU_WORKERS = 3
+DEFAULT_WORKERS = 1
+
+# Right-sizing parameters for fast test suites
+LIGHTWEIGHT_SUITE_MINUTES_THRESHOLD = 8.0
+TARGET_MINUTES_PER_WORKER = 4.0
+
+
+def get_max_workers_for_flavor(flavor: str) -> int:
+  """Returns the maximum worker safety cap for a given test flavor."""
+  if flavor.startswith("cpu-"):
+    return MAX_CPU_WORKERS
+  if flavor.startswith("tpu-") or flavor.startswith("tpu7x-"):
+    return MAX_TPU_WORKERS
+  if flavor.startswith("gpu-"):
+    return MAX_GPU_WORKERS
+  return DEFAULT_WORKERS
+
+
+def calculate_workers(flavor: str, baseline_data: dict[str, float] | None = None) -> tuple[int, list[int]]:
+  """Calculates total workers and worker groups based on baseline data.
+
+  Args:
+    flavor: The test flavor name (e.g. 'cpu-unit', 'tpu-unit').
+    baseline_data: Optional dictionary mapping baseline keys to durations (sec).
+
+  Returns:
+    A tuple of (total_workers, worker_groups).
+  """
+  max_workers = get_max_workers_for_flavor(flavor)
+
+  if not baseline_data:
+    return max_workers, list(range(1, max_workers + 1))
+
+  prefix = f"{flavor}::"
+  matching = [float(dur) for k, dur in baseline_data.items() if k.startswith(prefix) and isinstance(dur, (int, float))]
+  test_count = len(matching)
+  total_seconds = sum(matching)
+  total_minutes = total_seconds / 60.0
+
+  if test_count == 0:
+    return DEFAULT_WORKERS, [DEFAULT_WORKERS]
+
+  # Never allocate more workers than available tests
+  workers = min(max_workers, test_count)
+
+  # For lightweight test suites, right-size worker count
+  if total_minutes < LIGHTWEIGHT_SUITE_MINUTES_THRESHOLD:
+    workers = min(workers, max(1, math.ceil(total_minutes / TARGET_MINUTES_PER_WORKER)))
+
+  workers = max(1, workers)
+  return workers, list(range(1, workers + 1))
+
+
+def main() -> int:
+  """CLI entry point for calculating worker parameters."""
+  parser = argparse.ArgumentParser(description="Calculate total workers and worker groups for a test flavor.")
+  parser.add_argument(
+      "--flavor",
+      type=str,
+      required=True,
+      help="Test flavor name (e.g. cpu-unit, tpu-unit)",
+  )
+  parser.add_argument(
+      "--baseline",
+      type=str,
+      default=None,
+      help="Path to per_test_baseline.json",
+  )
+
+  args = parser.parse_args()
+
+  baseline_data = None
+  if args.baseline and os.path.isfile(args.baseline):
+    try:
+      with open(args.baseline, "r", encoding="utf-8") as f:
+        baseline_data = json.load(f)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      print(
+          f"Warning: Failed to read baseline file '{args.baseline}': {e}",
+          file=sys.stderr,
+      )
+
+  total_workers, worker_groups = calculate_workers(args.flavor, baseline_data)
+  worker_groups_json = json.dumps(worker_groups)
+
+  print(f"total_workers={total_workers}")
+  print(f"worker_groups={worker_groups_json}")
+
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/tools/dev/convert_durations.py
+++ b/tools/dev/convert_durations.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility to convert test durations format for pytest-split."""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict, Optional, Tuple
+
+
+def get_repo_root() -> str:
+  """Returns the absolute path to the repository root directory."""
+  return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def convert_entry(
+    key: str,
+    duration: float,
+    repo_root: Optional[str] = None,
+) -> Optional[Tuple[str, str, float]]:
+  """Converts a test entry from dot notation to pytest-split format.
+
+  Args:
+    key: Raw baseline key (e.g. '<flavor>::tests.unit.test_file.Class.method'
+      or 'tests.unit.test_file.Class.method').
+    duration: Test execution duration in seconds.
+    repo_root: Path to repository root for resolving test files.
+
+  Returns:
+    Tuple of (flavor, pytest_node_id, duration) or None if not resolvable.
+  """
+  if repo_root is None:
+    repo_root = get_repo_root()
+
+  flavor = ""
+  if "::" in key:
+    flavor, key = key.split("::", 1)
+
+  # Extract pytest parametrization bracket (e.g. '[param1.ext-param2]') if present
+  # so dots within parameter values are preserved and not split into '::'.
+  params = ""
+  if "[" in key and key.endswith("]"):
+    bracket_idx = key.index("[")
+    params = key[bracket_idx:]
+    key = key[:bracket_idx]
+
+  parts = key.split(".")
+  if not parts or parts[0] != "tests":
+    return None
+
+  file_path = ""
+  remaining_parts = []
+  for i in range(1, len(parts)):
+    candidate_rel = os.path.join(*parts[:i]) + ".py"
+    candidate_abs = os.path.join(repo_root, candidate_rel)
+    if os.path.isfile(candidate_abs):
+      file_path = candidate_rel.replace(os.sep, "/")
+      remaining_parts = parts[i:]
+      break
+  else:
+    return None
+
+  new_key = f"{file_path}::" + "::".join(remaining_parts) + params
+  return flavor, new_key, duration
+
+
+def convert_durations(
+    raw_data: Dict[str, Any],
+    target_flavor: Optional[str] = None,
+    repo_root: Optional[str] = None,
+) -> Dict[str, float]:
+  """Converts raw baseline entries to pytest-split format with flavor priority.
+
+  Args:
+    raw_data: Mapping of test key to duration.
+    target_flavor: Optional target flavor to prioritize/filter.
+    repo_root: Path to repository root.
+
+  Returns:
+    Dictionary of {pytest_node_id: duration}.
+  """
+  exact_matches: Dict[str, float] = {}
+  fallback_matches: Dict[str, float] = {}
+
+  for key, duration in raw_data.items():
+    res = convert_entry(key, float(duration), repo_root=repo_root)
+    if not res:
+      continue
+    flavor, node_id, dur = res
+    if target_flavor and flavor == target_flavor:
+      exact_matches[node_id] = dur
+    elif not flavor:
+      fallback_matches[node_id] = dur
+    elif not target_flavor:
+      exact_matches[node_id] = dur
+
+  # Overlay exact matches on top of fallback matches
+  fallback_matches.update(exact_matches)
+  return fallback_matches
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Convert test durations format for pytest-split.")
+  parser.add_argument("input_file", help="Path to input per_test_baseline.json")
+  parser.add_argument("output_file", help="Path to output .test_durations JSON")
+  parser.add_argument(
+      "--flavor",
+      default=None,
+      help="Target test flavor to filter/prioritize durations for.",
+  )
+
+  args = parser.parse_args()
+
+  try:
+    with open(args.input_file, "r", encoding="utf-8") as f:
+      data = json.load(f)
+  except FileNotFoundError:
+    print(f"Error: Input file {args.input_file} not found.", file=sys.stderr)
+    sys.exit(1)
+  except json.JSONDecodeError as e:
+    print(f"Error: Failed to decode JSON from {args.input_file}: {e}", file=sys.stderr)
+    sys.exit(1)
+
+  converted_data = convert_durations(data, target_flavor=args.flavor)
+
+  with open(args.output_file, "w", encoding="utf-8") as f:
+    json.dump(converted_data, f, indent=2)
+
+  print(f"Successfully converted {len(converted_data)} test durations to" f" {args.output_file}")
+
+
+if __name__ == "__main__":
+  main()

--- a/tools/dev/convert_durations.py
+++ b/tools/dev/convert_durations.py
@@ -1,0 +1,124 @@
+"""Utility to convert test durations format for pytest-split."""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict, Optional, Tuple
+
+
+def get_repo_root() -> str:
+  """Returns the absolute path to the repository root directory."""
+  return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def convert_entry(
+    key: str,
+    duration: float,
+    repo_root: Optional[str] = None,
+) -> Optional[Tuple[str, str, float]]:
+  """Converts a test entry from dot notation to pytest-split format.
+
+  Args:
+    key: Raw baseline key (e.g. '<flavor>::tests.unit.test_file.Class.method'
+      or 'tests.unit.test_file.Class.method').
+    duration: Test execution duration in seconds.
+    repo_root: Path to repository root for resolving test files.
+
+  Returns:
+    Tuple of (flavor, pytest_node_id, duration) or None if not resolvable.
+  """
+  if repo_root is None:
+    repo_root = get_repo_root()
+
+  flavor = ""
+  if "::" in key:
+    flavor, key = key.split("::", 1)
+
+  parts = key.split(".")
+  if not parts or parts[0] != "tests":
+    return None
+
+  file_path = ""
+  remaining_parts = []
+  for i in range(1, len(parts)):
+    candidate_rel = os.path.join(*parts[:i]) + ".py"
+    candidate_abs = os.path.join(repo_root, candidate_rel)
+    if os.path.isfile(candidate_abs):
+      file_path = candidate_rel.replace(os.sep, "/")
+      remaining_parts = parts[i:]
+      break
+  else:
+    return None
+
+  new_key = f"{file_path}::" + "::".join(remaining_parts)
+  return flavor, new_key, duration
+
+
+def convert_durations(
+    raw_data: Dict[str, Any],
+    target_flavor: Optional[str] = None,
+    repo_root: Optional[str] = None,
+) -> Dict[str, float]:
+  """Converts raw baseline entries to pytest-split format with flavor priority.
+
+  Args:
+    raw_data: Mapping of test key to duration.
+    target_flavor: Optional target flavor to prioritize/filter.
+    repo_root: Path to repository root.
+
+  Returns:
+    Dictionary of {pytest_node_id: duration}.
+  """
+  exact_matches: Dict[str, float] = {}
+  fallback_matches: Dict[str, float] = {}
+
+  for key, duration in raw_data.items():
+    res = convert_entry(key, float(duration), repo_root=repo_root)
+    if not res:
+      continue
+    flavor, node_id, dur = res
+    if target_flavor and flavor == target_flavor:
+      exact_matches[node_id] = dur
+    elif not flavor:
+      fallback_matches[node_id] = dur
+    elif not target_flavor:
+      exact_matches[node_id] = dur
+
+  # Overlay exact matches on top of fallback matches
+  fallback_matches.update(exact_matches)
+  return fallback_matches
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Convert test durations format for pytest-split.")
+  parser.add_argument("input_file", help="Path to input per_test_baseline.json")
+  parser.add_argument("output_file", help="Path to output .test_durations JSON")
+  parser.add_argument(
+      "--flavor",
+      default=None,
+      help="Target test flavor to filter/prioritize durations for.",
+  )
+
+  args = parser.parse_args()
+
+  try:
+    with open(args.input_file, "r", encoding="utf-8") as f:
+      data = json.load(f)
+  except FileNotFoundError:
+    print(f"Error: Input file {args.input_file} not found.", file=sys.stderr)
+    sys.exit(1)
+  except json.JSONDecodeError as e:
+    print(f"Error: Failed to decode JSON from {args.input_file}: {e}", file=sys.stderr)
+    sys.exit(1)
+
+  converted_data = convert_durations(data, target_flavor=args.flavor)
+
+  with open(args.output_file, "w", encoding="utf-8") as f:
+    json.dump(converted_data, f, indent=2)
+
+  print(f"Successfully converted {len(converted_data)} test durations to" f" {args.output_file}")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
# Description

Implement b/529533388. Equally split unit and integration tests (CPU, TPU, and GPU) between runners using historical test durations.
We download historical test durations from `gh-pages` branch and use them to balance the shards.

- Enabled test splitting for all test flavors by pattern matching the device type in the coordinator workflow.
- Supported flavor-prefixed baseline keys (`<flavor>::tests.module.Class.test_func`) introduced by PR #4659.

### Execution Modes & Timing Dynamics
- **TPU / GPU Jobs (Sequential)**: Tests run sequentially on each runner. `pytest-split` balances the **sum of test durations**, so total job runtimes across TPU/GPU worker groups are **nearly identical** (e.g. `tpu-unit` finishes within 55 seconds across all 3 workers: 19.08m / 18.57m / 18.15m).
- **CPU Jobs (Parallel via `xdist`)**: Tests run concurrently across 16 worker cores per runner. Total job duration is bound by the **slowest single test** in each group. `pytest-split` distributes the top slowest tests across the 4 CPU workers to prevent runner overload, resulting in uneven UI job runtimes (16.68m / 9.65m / 7.70m / 6.30m) while achieving the **optimal overall wall-clock completion time (~16.7m)**.

FIXES: b/529533388

# Tests
- Verified optimal test partitioning in latest [PR test run 31156879079](https://github.com/AI-Hypercomputer/maxtext/actions/runs/31156879079) (commit `e59f8aa64`):
  - All test flavors (CPU, TPU, GPU) are successfully split across multiple workers.
  - Latest execution records showing balanced distribution:
    - **tpu-unit**: 19.08m / 18.57m / 18.15m (3 workers — remarkably balanced!)
    - **gpu-integration**: 11.23m / 11.02m / 10.55m (3 workers — remarkably balanced!)
    - **gpu-unit**: 10.55m / 7.95m / 7.87m (3 workers)
    - **tpu-integration**: 13.50m / 10.55m / 7.82m (3 workers)
    - **cpu-unit**: 16.68m / 9.65m / 7.70m / 6.30m (4 workers — parallel bound by slowest test)
    - **cpu-post-training-unit**: 5.63m / 5.45m / 4.72m / 4.58m (4 workers)
    - **tpu-post-training-unit**: 9.40m / 6.35m / 5.77m (3 workers)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).