### PR TITLE
Double-buffer inner scans during gradient accumulation

### DIFF
--- a/src/maxtext/utils/gradient_accumulation.py
+++ b/src/maxtext/utils/gradient_accumulation.py
@@ -16,6 +16,7 @@
 
 import jax
 import jax.numpy as jnp
+from jax.experimental.xla_metadata import set_xla_metadata
 from jax.sharding import NamedSharding
 from flax import nnx
 
@@ -108,11 +109,16 @@ def gradient_accumulation_loss_and_grad(
 
   def accumulate_gradient(acc_grad_and_loss, data):
     ga_params = acc_grad_and_loss["ga_params"]
+    # Scope double-buffering to model scans, not the enclosing gradient accumulation scan.
+    # This metadata only affects XLA:GPU; see https://github.com/openxla/xla/pull/43468.
+    # Enable it with JAX_OPTIMIZATION_LEVEL=O1 and
+    # XLA_FLAGS="--xla_gpu_enable_while_loop_unrolling=WHILE_LOOP_UNROLLING_MANUAL_UNROLL".
     if is_nnx:
       # Reconstruct the model using the fixed parameters (ga_params)
       # and the advancing non-parameter state (RNGs) from the carry.
       local_model = nnx.merge(graphdef, ga_params, acc_grad_and_loss["rest_state"], copy=True)
-      (_, aux), cur_batch_gradient = grad_func(local_model, config, data, None, None, is_train=True)
+      with set_xla_metadata(_xla_loop_unroll_strategy="double-buffer"):
+        (_, aux), cur_batch_gradient = grad_func(local_model, config, data, None, None, is_train=True)
       _, _, next_rest_state = nnx.split(local_model, nnx.Param, ...)
       acc_grad_and_loss["rest_state"] = next_rest_state
     else:
@@ -121,7 +127,8 @@ def gradient_accumulation_loss_and_grad(
           if dropout_rng is not None
           else None
       )
-      (_, aux), cur_batch_gradient = grad_func(model, config, data, rng, ga_params, is_train=True)
+      with set_xla_metadata(_xla_loop_unroll_strategy="double-buffer"):
+        (_, aux), cur_batch_gradient = grad_func(model, config, data, rng, ga_params, is_train=True)
     acc_grad_and_loss["loss"] += aux["xent_sum"] + aux.get("dpo_loss", 0.0)
     acc_grad_and_loss["moe_lb_loss"] += aux["moe_lb_loss"]
     acc_grad_and_loss["indexer_loss"] += aux["indexer_loss"]


### PR DESCRIPTION
# Description

This change enables double-buffered manual loop unrolling for model scans inside gradient accumulation. Previously, neither the outer gradient-accumulation scan nor its nested model scans specified a manual unrolling strategy. This change tags only the inner model computation while leaving the outer accumulation scan untagged.

Manual loop-unrolling control was added in [OpenXLA/XLA#43468](https://github.com/openxla/xla/pull/43468). When gradient accumulation is enabled, MaxText has an outer scan over microbatches that may contain inner scans over model layers. Applying the metadata to the outer scan would double-buffer both loops (which introduces significant compile-time and memory overheads).

The implementation scopes:

```python
set_xla_metadata(_xla_loop_unroll_strategy="double-buffer")
```

around the per-microbatch `grad_func(...)` call in both the Linen and NNX paths. Because the enclosing gradient-accumulation `jax.lax.scan` is created outside this metadata scope, it remains untagged.

The manual XLA pass can be enabled with:

```bash
export JAX_OPTIMIZATION_LEVEL=O1
export XLA_FLAGS="--xla_gpu_enable_while_loop_unrolling=WHILE_LOOP_UNROLLING_MANUAL_UNROLL"
```

## Default behavior

This change is not hidden behind an additional MaxText configuration flag because the XLA manual-unrolling option already acts as the opt-in gate.

The metadata alone does not enable double-buffering. XLA's default GPU strategy remains `WHILE_LOOP_UNROLLING_AUTO_UNROLL`. The `_xla_loop_unroll_strategy="double-buffer"` attribute is acted upon only when the user explicitly selects `WHILE_LOOP_UNROLLING_MANUAL_UNROLL`.

Therefore:

- Default GPU behavior remains unchanged.
- CPU and TPU compilation are unaffected because this is an XLA GPU pass.
- With manual mode enabled, tagged inner scans are double-buffered while the untagged gradient-accumulation scan is not.
- XLA versions without manual-unrolling support should ignore the frontend attribute.

One limitation is that the metadata context surrounds `grad_func(...)`, so it may tag multiple nested scans traced inside the loss and gradient computation, including forward and backward scans. If future workloads require targeting only a specific decoder-layer scan, the metadata scope can be narrowed to that scan or exposed through a more granular MaxText configuration option.

The change does not affect the Tunix gradient-accumulation implementation.


# Tests

For manual verification, run a gradient-accumulation workload with the environment variables above and inspect the generated HLO. Confirm that `_xla_loop_unroll_strategy="double-buffer"` is attached to the inner model scan and not the outer accumulation scan.

## Performance

DeepSeek-v3 on 128 GB300 GPUs.
Gradient Accumulation: 1
Memory consumption / GPU =  240 GB
Compile time: 3 mins

Gradient Accumulation: 2 (before this PR)
Memory consumption / GPU = 410 GB (OOM)
Compile time: 6 mins

Gradient Accumulation: 2 (with this PR)
Memory consumption / GPU = 250 GB
Compile time: 3 mins

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).