### PR TITLE
Move data_processing_test to cpu

### DIFF
--- a/tests/unit/grain_data_processing_test.py
+++ b/tests/unit/grain_data_processing_test.py
@@ -181,6 +181,7 @@ class _GrainArrayRecordSetup:
     return pyconfig.initialize([sys.argv[0], get_test_config_path()], **kwargs)
 
 
+@pytest.mark.cpu_only
 class GrainArrayRecordProcessingTest(
     _GrainArrayRecordSetup, GrainDeterminismMixin, GrainBaseProcessingTest, unittest.TestCase
 ):
@@ -201,6 +202,7 @@ class GrainArrayRecordProcessingTest(
     super().test_batch_determinism()
 
 
+@pytest.mark.cpu_only
 class GrainArrayRecordProcessingWithMultiSourceBlendingTest(
     _GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase
 ):
@@ -211,6 +213,7 @@ class GrainArrayRecordProcessingWithMultiSourceBlendingTest(
     self.config = self._make_config(grain_train_files=train_files_weighted)
 
 
+@pytest.mark.cpu_only
 class GrainArrayRecordProcessingWithMixtureConfigTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
 
   def setUp(self):
@@ -270,6 +273,7 @@ class GrainArrayRecordAutoTuneTest(_GrainArrayRecordSetup, GrainBaseProcessingTe
     self.config = self._make_config(grain_ram_budget_mb=512, grain_worker_count=-1)  # Enable auto-tuning
 
 
+@pytest.mark.cpu_only
 class GrainArrayRecordTiktokenTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with tiktoken tokenizer."""
 
@@ -281,6 +285,7 @@ class GrainArrayRecordTiktokenTest(_GrainArrayRecordSetup, GrainBaseProcessingTe
     )
 
 
+@pytest.mark.cpu_only
 class GrainArrayRecordHFTokenizerTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with HuggingFace tokenizer."""
 
@@ -292,6 +297,7 @@ class GrainArrayRecordHFTokenizerTest(_GrainArrayRecordSetup, GrainBaseProcessin
     )
 
 
+@pytest.mark.cpu_only
 class GrainArrayRecordBestFitPackingTest(_GrainArrayRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with best_fit packing strategy."""
 
@@ -381,6 +387,7 @@ class _GrainParquetSetup:
     return pyconfig.initialize([sys.argv[0], get_test_config_path()], **kwargs)
 
 
+@pytest.mark.cpu_only
 class GrainParquetProcessingTest(_GrainParquetSetup, GrainDeterminismMixin, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with Parquet format.
 
@@ -519,6 +526,7 @@ class _GrainTFRecordSetup:
     return pyconfig.initialize([sys.argv[0], get_test_config_path()], **kwargs)
 
 
+@pytest.mark.cpu_only
 class GrainTFRecordProcessingTest(_GrainTFRecordSetup, GrainDeterminismMixin, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with TFRecord format.
 
@@ -533,6 +541,7 @@ class GrainTFRecordProcessingTest(_GrainTFRecordSetup, GrainDeterminismMixin, Gr
     super().setUpClass()
 
 
+@pytest.mark.cpu_only
 class GrainTFRecordPreTokenizedProcessingTest(_GrainTFRecordSetup, GrainBaseProcessingTest, unittest.TestCase):
   """Test grain data processing with a pre-tokenized TFRecord dataset (tokenize_train_data=False).
 

--- a/tests/unit/hf_data_processing_test.py
+++ b/tests/unit/hf_data_processing_test.py
@@ -19,6 +19,7 @@ import unittest
 import os.path
 
 import jax
+import pytest
 from jax.sharding import Mesh
 from jax.experimental import mesh_utils
 
@@ -30,6 +31,7 @@ from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from tests.utils.test_helpers import get_test_config_path, get_test_base_output_directory
 
 
+@pytest.mark.cpu_only
 class HfDataProcessingTest(unittest.TestCase):
 
   def setUp(self):

--- a/tests/unit/tfds_data_processing_test.py
+++ b/tests/unit/tfds_data_processing_test.py
@@ -33,6 +33,7 @@ from maxtext.input_pipeline import input_pipeline_interface
 from tests.utils.test_helpers import get_test_config_path, get_test_base_output_directory
 
 
+@pytest.mark.cpu_only
 class TfdsDataProcessingTest(unittest.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
# Description

data_processing tests are the top time consuming tests on TPU runner. But it data loading only requires CPU. This PR moves the tests to cpu_only to save TPU runner resources. 

# Tests

NA

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
