### PR TITLE
Remove stale Tunix degenerate group masking config

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -66,8 +66,6 @@ rl:
   off_policy_steps: 0
   # System prompt injected into the agent at rollout time.
   system_prompt: ''
-  # If true, mask degenerate groups (all-zero advantages) from contributing to the loss.
-  degenerate_group_masking: true
   # Upper-bound clipping epsilon for GRPO loss; defaults to grpo_epsilon when null.
   epsilon_high: null
   # Number of model keys to chunk for resharding tensors between trainer and rollout devices.

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2156,10 +2156,6 @@ class RL(BaseModel):
       "",
       description="System prompt injected into the agent at rollout time (agentic only).",
   )
-  degenerate_group_masking: bool = Field(
-      True,
-      description="Mask degenerate groups (all-zero advantages) from contributing to loss (agentic only).",
-  )
   epsilon_high: Optional[float] = Field(
       None,
       description="Upper-bound clipping epsilon for GRPO loss. Defaults to epsilon when None (agentic only).",

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -555,7 +555,6 @@ def create_rl_components(
         max_concurrency=trainer_config.rl.max_concurrency,
         off_policy_steps=trainer_config.rl.off_policy_steps,
         system_prompt=trainer_config.rl.system_prompt,
-        degenerate_group_masking=trainer_config.rl.degenerate_group_masking,
         epsilon_high=trainer_config.rl.epsilon_high,
     )
     # Instantiate the custom MaxText chat parser


### PR DESCRIPTION
# Description

Removed degenerated group masking related configs as this feature is remove in Tunix (https://github.com/google/tunix/pull/1637)

FIXES: #4323 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
