### PR TITLE
checkpoint conversion support for deepseek v4

### DIFF
--- a/src/maxtext/checkpoint_conversion/to_maxtext.py
+++ b/src/maxtext/checkpoint_conversion/to_maxtext.py
@@ -317,7 +317,10 @@ def get_maxtext_model_info(config):
   quant = quantizations.configure_quantization(config)
   maxtext_model_flax = models.transformer_as_linen(config, mesh, quant=quant, model_mode=MODEL_MODE_TRAIN)
 
-  # Get abstract model structure (name, shape) without materializing the weights to save memory
+  # Get abstract model structure (name, shape) without materializing the weights to save memory.
+  # Extract the 'params' collection from the abstract model state. This focuses checkpoint
+  # conversion on trainable model parameters; variables outside the 'params' collection
+  # (such as non-trainable state or optimizer buffers) are not included.
   abstract_params_tree = maxtext_utils.get_abstract_param(maxtext_model_flax, config)["params"]
 
   abstract_params_flat, abstract_params_treedef = jax.tree_util.tree_flatten_with_path(
@@ -492,9 +495,12 @@ def _get_maxtext_indices_and_shapes(mt_param_key_or_keys, maxtext_abstract_dict)
 
   The index is the parameter's order in `maxtext_abstract_dict.keys()`.
   This function handles two forms of MaxText keys:
-  - `atomic_mt_key`: A single string representing one MaxText parameter that map to HF parameter(s).
+  - `atomic_mt_key`: A single string representing one MaxText parameter that maps to HF parameter(s).
+    Example: "params-decoder-layers_0-self_attention-query-kernel" -> returns a single index and shape tuple.
   - `composite_mt_key`: A tuple of strings representing multiple MaxText parameters derived from
     a single/bundled HF parameter source (e.g., HF gate_up_proj splitting into MT wi_0 and wi_1).
+    Example: ("params-decoder-layers_0-mlp-wi_0-kernel", "params-decoder-layers_0-mlp-wi_1-kernel") ->
+    returns lists of indices and shapes for each composite component.
   """
   is_composite_mt_key = isinstance(mt_param_key_or_keys, tuple)
   # atomic_mt_key
@@ -1013,9 +1019,9 @@ def main(
       if not lazy_load_tensors:
         max_logging.log(f"maxtext param: {mt_param_key_or_keys}")
 
-      hf_source_keys_or_key = param_map_mt_to_hf.get(mt_param_key_or_keys)
-      if hf_source_keys_or_key is None:
+      if mt_param_key_or_keys not in param_map_mt_to_hf:
         raise ValueError(f"MaxText parameter {mt_param_key_or_keys} not found in mapping.")
+      hf_source_keys_or_key = param_map_mt_to_hf.get(mt_param_key_or_keys)
       hook_fn = hook_fn_map_mt.get(mt_param_key_or_keys)
 
       # Step 1: Resolves MaxText key(s) to target indices and shapes

--- a/src/maxtext/checkpoint_conversion/utils/hf_model_configs.py
+++ b/src/maxtext/checkpoint_conversion/utils/hf_model_configs.py
@@ -1021,6 +1021,127 @@ class DeepseekV32Config(PTConfig):  # pyrefly: ignore[invalid-inheritance]
 
 deepseek32_671b_config = DeepseekV32Config(**deepseek32_671b_dict)
 
+
+deepseek4_284b_dict = {
+    "architectures": ["DeepseekV4ForCausalLM"],
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "bos_token_id": 0,
+    "eos_token_id": 1,
+    "expert_dtype": "fp4",
+    "hc_eps": 1e-06,
+    "hc_mult": 4,
+    "hc_sinkhorn_iters": 20,
+    "head_dim": 512,
+    "hidden_act": "silu",
+    "hidden_size": 4096,
+    "index_head_dim": 128,
+    "index_n_heads": 64,
+    "index_topk": 512,
+    "initializer_range": 0.02,
+    "max_position_embeddings": 1048576,
+    "model_type": "deepseek_v4",
+    "moe_intermediate_size": 2048,
+    "n_routed_experts": 256,
+    "n_shared_experts": 1,
+    "norm_topk_prob": True,
+    "num_attention_heads": 64,
+    "num_experts_per_tok": 6,
+    "num_hidden_layers": 43,
+    "num_hash_layers": 3,
+    "num_key_value_heads": 1,
+    "num_nextn_predict_layers": 1,
+    "o_groups": 8,
+    "o_lora_rank": 1024,
+    "q_lora_rank": 1024,
+    "qk_rope_head_dim": 64,
+    "quantization_config": {
+        "activation_scheme": "dynamic",
+        "fmt": "e4m3",
+        "quant_method": "fp8",
+        "scale_fmt": "ue8m0",
+        "weight_block_size": [128, 128],
+    },
+    "rms_norm_eps": 1e-06,
+    "rope_scaling": {
+        "beta_fast": 32,
+        "beta_slow": 1,
+        "factor": 16,
+        "original_max_position_embeddings": 65536,
+        "type": "yarn",
+    },
+    "rope_theta": 10000,
+    "routed_scaling_factor": 1.5,
+    "scoring_func": "sqrtsoftplus",
+    "sliding_window": 128,
+    "swiglu_limit": 10.0,
+    "tie_word_embeddings": False,
+    "topk_method": "noaux_tc",
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.57.1",
+    "use_cache": True,
+    "vocab_size": 129280,
+    "compress_rope_theta": 160000,
+    "compress_ratios": [
+        0,
+        0,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+        128,
+        4,
+    ],
+}
+
+
+# TODO(shuningjin): replace with DeepseekV4Config when available in transformers library
+class DeepseekV4Config(PTConfig):  # pyrefly: ignore[invalid-inheritance]
+  model_type = "deepseek_v4"
+
+  def __init__(self, **kwargs):
+    self.max_position_embeddings = kwargs.get("max_position_embeddings", 1048576)
+    super().__init__(**kwargs)
+
+
+deepseek4_284b_config = DeepseekV4Config(**deepseek4_284b_dict)
+
+
 # from https://huggingface.co/openai/gpt-oss-20b/blob/main/config.json
 # remove mxfp4 quantization_config, since we are using bf16
 gpt_oss_20b_dict = {
@@ -1738,6 +1859,7 @@ HF_MODEL_CONFIGS = {
     "deepseek2-16b": deepseek2_16b_config,
     "deepseek3-671b": deepseek3_671b_config,
     "deepseek3.2-671b": deepseek32_671b_config,
+    "deepseek4-284b": deepseek4_284b_config,
     "gpt-oss-20b": gpt_oss_20b_config,
     "gpt-oss-120b": gpt_oss_120b_config,
     "qwen3-omni-30b-a3b": qwen3_omni_30b_a3b_config,

--- a/src/maxtext/checkpoint_conversion/utils/hf_shape.py
+++ b/src/maxtext/checkpoint_conversion/utils/hf_shape.py
@@ -1162,6 +1162,112 @@ def QWEN3_VL_HF_WEIGHTS_TO_SHAPE(config):
 
 
 # {maxtext model name: {hf weight name: hf shape}}
+
+
+def DEEPSEEKV4_HF_WEIGHTS_TO_SHAPE(config):
+  """Returns a dictionary mapping HuggingFace weight names to shapes for DeepSeek V4."""
+  hidden_size = config["hidden_size"]
+  vocab_size = config["vocab_size"]
+  num_hidden_layers = config["num_hidden_layers"]
+  q_lora_rank = config.get("q_lora_rank", 1024)
+  kv_lora_rank = config.get("kv_lora_rank", 512)
+  # MaxText scales o_lora_rank by o_groups to get o_a_out_features (8192)
+  o_lora_rank = config.get("o_lora_rank", 1024) * config.get("o_groups", 8)
+  num_attention_heads = config["num_attention_heads"]
+  head_dim = config["head_dim"]
+
+  moe_intermediate_size = config["moe_intermediate_size"]
+  n_routed_experts = config["n_routed_experts"]
+
+  # Dynamic hyperparameters replacing hardcoded literals:
+  hc_mult = config.get("hc_mult", 4)
+  hc_dim = (2 * hc_mult) + (hc_mult**2)  # 2(4) + 16 = 24
+  num_hash_layers = config.get("num_hash_layers", 3)  # 3
+  index_n_heads = config.get("index_n_heads", 64)  # 64
+  index_head_dim = config.get("index_head_dim", 128)  # 128
+
+  mapping = {
+      "model.embed_tokens.weight": [vocab_size, hidden_size],
+      "model.norm.weight": [hidden_size],
+      "head.weight": [vocab_size, hidden_size],
+      "model.hc_head.hc_fn": [hc_mult, hidden_size * hc_mult],
+      "model.hc_head.hc_base": [hc_mult],
+      "model.hc_head.hc_scale": [1],
+  }
+
+  for layer_idx in range(num_hidden_layers):
+    layer_prefix = f"model.layers.{layer_idx}"
+    layer_mapping = {
+        f"{layer_prefix}.input_layernorm.weight": [hidden_size],
+        f"{layer_prefix}.post_attention_layernorm.weight": [hidden_size],
+        f"{layer_prefix}.self_attn.q_a_proj.weight": [q_lora_rank, hidden_size],
+        f"{layer_prefix}.self_attn.q_a_norm.weight": [q_lora_rank],
+        f"{layer_prefix}.self_attn.q_b_proj.weight": [num_attention_heads * head_dim, q_lora_rank],
+        f"{layer_prefix}.self_attn.kv_proj.weight": [kv_lora_rank, hidden_size],
+        f"{layer_prefix}.self_attn.kv_norm.weight": [kv_lora_rank],
+        f"{layer_prefix}.self_attn.sinks": [num_attention_heads],
+        f"{layer_prefix}.self_attn.o_a_proj.weight": [o_lora_rank, hidden_size],
+        f"{layer_prefix}.self_attn.o_b_proj.weight": [hidden_size, o_lora_rank],
+        # MHC
+        f"{layer_prefix}.attn_hc.fn": [hc_dim, hidden_size * hc_mult],
+        f"{layer_prefix}.attn_hc.base": [hc_dim],
+        f"{layer_prefix}.attn_hc.scale": [num_hash_layers],
+        f"{layer_prefix}.ffn_hc.fn": [hc_dim, hidden_size * hc_mult],
+        f"{layer_prefix}.ffn_hc.base": [hc_dim],
+        f"{layer_prefix}.ffn_hc.scale": [num_hash_layers],
+        # MLP / MoE Block
+        f"{layer_prefix}.mlp.gate.weight": [n_routed_experts, hidden_size],
+        f"{layer_prefix}.mlp.gate.e_score_correction_bias": [n_routed_experts],
+        f"{layer_prefix}.mlp.shared_experts.gate_proj.weight": [moe_intermediate_size, hidden_size],
+        f"{layer_prefix}.mlp.shared_experts.up_proj.weight": [moe_intermediate_size, hidden_size],
+        f"{layer_prefix}.mlp.shared_experts.down_proj.weight": [hidden_size, moe_intermediate_size],
+    }
+
+    # Experts
+    for e in range(n_routed_experts):
+      layer_mapping[f"{layer_prefix}.mlp.experts.{e}.w1.weight"] = [moe_intermediate_size, hidden_size]
+      layer_mapping[f"{layer_prefix}.mlp.experts.{e}.w3.weight"] = [moe_intermediate_size, hidden_size]
+      layer_mapping[f"{layer_prefix}.mlp.experts.{e}.w2.weight"] = [hidden_size, moe_intermediate_size]
+
+    # Compressors
+    if layer_idx >= 2:
+      c_type = "csa" if (layer_idx % 2 == 0) else "hca"
+      if c_type == "csa":
+        layer_mapping.update(
+            {
+                f"{layer_prefix}.self_attn.compressor.kv_proj.weight": [1024, hidden_size],
+                f"{layer_prefix}.self_attn.compressor.gate_proj.weight": [1024, hidden_size],
+                f"{layer_prefix}.self_attn.compressor.position_bias": [4, 1024],
+                f"{layer_prefix}.self_attn.compressor.kv_norm.weight": [512],
+            }
+        )
+        layer_mapping.update(
+            {
+                f"{layer_prefix}.self_attn.compressor.indexer.gate_proj.weight": [256, hidden_size],
+                f"{layer_prefix}.self_attn.compressor.indexer.kv_proj.weight": [256, hidden_size],
+                f"{layer_prefix}.self_attn.compressor.indexer.q_b_proj.weight": [
+                    index_n_heads * index_head_dim,
+                    q_lora_rank,
+                ],
+                f"{layer_prefix}.self_attn.compressor.indexer.scorer.weights_proj.weight": [index_n_heads, hidden_size],
+                f"{layer_prefix}.self_attn.compressor.indexer.position_bias": [4, 256],
+                f"{layer_prefix}.self_attn.compressor.indexer.kv_norm.weight": [128],
+            }
+        )
+      else:  # hca
+        layer_mapping.update(
+            {
+                f"{layer_prefix}.self_attn.compressor.kv_proj.weight": [512, hidden_size],
+                f"{layer_prefix}.self_attn.compressor.gate_proj.weight": [512, hidden_size],
+                f"{layer_prefix}.self_attn.compressor.position_bias": [128, 512],
+                f"{layer_prefix}.self_attn.compressor.kv_norm.weight": [512],
+            }
+        )
+
+    mapping.update(layer_mapping)
+  return mapping
+
+
 HF_SHAPE = {
     "gemma2-2b": GEMMA2_HF_WEIGHTS_TO_SHAPE,
     "gemma2-9b": GEMMA2_HF_WEIGHTS_TO_SHAPE,
@@ -1195,6 +1301,7 @@ HF_SHAPE = {
     "deepseek2-16b": DEEPSEEK_HF_WEIGHTS_TO_SHAPE,
     "deepseek3-671b": DEEPSEEK_HF_WEIGHTS_TO_SHAPE,
     "deepseek3.2-671b": DEEPSEEK_HF_WEIGHTS_TO_SHAPE,
+    "deepseek4-284b": DEEPSEEKV4_HF_WEIGHTS_TO_SHAPE,
     "gpt-oss-20b": GPT_OSS_HF_WEIGHTS_TO_SHAPE,
     "gpt-oss-120b": GPT_OSS_HF_WEIGHTS_TO_SHAPE,
     "mixtral-8x7b": MIXTRAL_HF_WEIGHTS_TO_SHAPE,

--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -3957,7 +3957,7 @@ def DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=F
 
     first_idx = hf_layer_indices[0] if is_list else hf_layer_indices
     if first_idx >= 2:
-      if first_idx % 2 == 0 or first_idx == 2:
+      if first_idx % 2 == 0:
         layer_map.update(
             {
                 f"{mt_layer_path}-self_attention-csa_compressor-kv_proj-kernel": get_hf_key(
@@ -4033,11 +4033,6 @@ def DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=F
   def transpose(input_tensor, target_shape=None):
     return np.transpose(input_tensor)
 
-  def transpose_stack(input_tensor, target_shape=None):
-    # input_tensor is a list of tensors
-    stacked = np.stack(input_tensor, axis=0)  # [E, out, in]
-    return np.transpose(stacked, (0, 2, 1))  # [E, in, out]
-
   def ones_norm(input_tensor, target_shape=None):
     return np.ones(target_shape, dtype=np.float32)
 
@@ -4048,12 +4043,18 @@ def DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=F
   def reshape_transpose_wq_b(input_tensor, target_shape=None):
     # HF: [n_heads * q_head_dim, kv_lora_rank]
     # MaxText: [kv_lora_rank, n_heads, q_head_dim]
+    if saving_to_hf:
+      tensor = input_tensor.reshape((input_tensor.shape[0], -1))
+      return np.transpose(tensor)
     tensor = np.transpose(input_tensor)  # [kv_lora_rank, n_heads * q_head_dim]
     return tensor.reshape(target_shape)
 
   def reshape_transpose_wkv(input_tensor, target_shape=None):
     # HF: [n_kv_heads * (q_head_dim + v_head_dim), kv_lora_rank]
     # MaxText: [kv_lora_rank, n_kv_heads, q_head_dim + v_head_dim]
+    if saving_to_hf:
+      tensor = input_tensor.reshape((input_tensor.shape[0], -1))
+      return np.transpose(tensor)
     tensor = np.transpose(input_tensor)
     return tensor.reshape(target_shape)
 
@@ -4061,6 +4062,9 @@ def DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=F
     # HF: [n_heads * v_head_dim, kv_lora_rank] (e.g. [8192, 4096])
     # MaxText: [n_heads, v_head_dim, kv_lora_rank] (e.g. [8, 4096, 1024])
     # We must reshape first and then permute (transpose) to get correct ordering.
+    if saving_to_hf:
+      tensor = np.transpose(input_tensor, (0, 2, 1))
+      return tensor.reshape(target_shape)
     num_heads = target_shape[0]
     embed_dim = target_shape[1]
     kv_lora_rank = target_shape[2]
@@ -4135,9 +4139,59 @@ def DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=F
     elif "hc_head-hc_base" in key or "hc_head-hc_scale" in key:
       mapping[key] = identity
     elif isinstance(hf_key, list):
-      mapping[key] = transpose if not saving_to_hf else transpose_stack
+      mapping[key] = transpose
     elif "-kernel" in key or "-embedding" in key or "-sinks" in key:
       mapping[key] = transpose
+
+  if saving_to_hf:
+
+    def mhc_concat_fn(input_tensors, target_shape=None):
+      if len(input_tensors) != 3:
+        raise ValueError(f"mhc_concat_fn expected 3 tensors (pre, post, res), got {len(input_tensors)}")
+      tensors = [np.asarray(t) for t in input_tensors]
+      res = np.transpose(np.concatenate(tensors, axis=1))
+      return res.reshape(target_shape) if target_shape is not None else res
+
+    def mhc_concat_base(input_tensors, target_shape=None):
+      if len(input_tensors) != 3:
+        raise ValueError(f"mhc_concat_base expected 3 tensors (pre, post, res), got {len(input_tensors)}")
+      tensors = [np.asarray(t).ravel() for t in input_tensors]
+      res = np.concatenate(tensors, axis=0)
+      return res.reshape(target_shape) if target_shape is not None else res
+
+    def mhc_concat_scale(input_tensors, target_shape=None):
+      if len(input_tensors) != 3:
+        raise ValueError(f"mhc_concat_scale expected 3 tensors (pre, post, res), got {len(input_tensors)}")
+      tensors = [np.asarray(t).ravel() for t in input_tensors]
+      res = np.concatenate(tensors, axis=0)
+      return res.reshape(target_shape) if target_shape is not None else res
+
+    # Process composite mappings
+    keys_to_delete = []
+    keys_to_add = {}
+    for key in list(mapping.keys()):
+      if "mhc" in key and "pre_alpha" in key and "scale" not in key:
+        post = key.replace("pre_alpha", "post_alpha")
+        res = key.replace("pre_alpha", "res_alpha")
+        keys_to_delete.extend([key, post, res])
+        keys_to_add[(key, post, res)] = mhc_concat_fn
+
+      if "mhc" in key and "pre_beta" in key:
+        post = key.replace("pre_beta", "post_beta")
+        res = key.replace("pre_beta", "res_beta")
+        keys_to_delete.extend([key, post, res])
+        keys_to_add[(key, post, res)] = mhc_concat_base
+
+      if "mhc" in key and "pre_alpha_scale" in key:
+        post = key.replace("pre_alpha_scale", "post_alpha_scale")
+        res = key.replace("pre_alpha_scale", "res_alpha_scale")
+        keys_to_delete.extend([key, post, res])
+        keys_to_add[(key, post, res)] = mhc_concat_scale
+
+    for k in set(keys_to_delete):
+      if k in mapping:
+        del mapping[k]
+    mapping.update(keys_to_add)
 
   return mapping
 

--- a/src/maxtext/checkpoint_conversion/utils/utils.py
+++ b/src/maxtext/checkpoint_conversion/utils/utils.py
@@ -163,22 +163,17 @@ def convert_jax_weight_to_numpy(weight: "jax.Array", dtype_str: None | str = Non
     A NumPy array containing the data from `weight`, cast to `dtype_str` if provided.
   """
   final_dtype_str = str(weight.dtype) if dtype_str is None else dtype_str
-  # JAX dtypes like 'bfloat16', 'float32' are understood by np.dtype()
-  target_np_dtype = np.dtype(final_dtype_str)
   expected_shape = weight.shape
 
-  # Gather the array across devices if it's sharded.
-  # process_allgather typically returns the array on the host.
+  if str(weight.dtype) != final_dtype_str:
+    # Cast in JAX before process_allgather to reduce interconnect data transfer and host RAM
+    # usage when downcasting dtypes.
+    weight = weight.astype(final_dtype_str)
+
   weight = multihost_utils.process_allgather(weight)
-
-  # Convert JAX array to NumPy array.
-  np_array = np.array(weight)
-
-  # Cast to the target NumPy dtype if it's different.
-  if np_array.dtype != target_np_dtype:
-    np_array = np_array.astype(target_np_dtype)
-
-  return np_array.reshape(expected_shape)  # Reshape for safety, though usually preserved.
+  # Use np.asarray to avoid redundant copies when the gathered buffer can be viewed directly.
+  np_array = np.asarray(weight)
+  return np_array.reshape(expected_shape)
 
 
 def _process(hf_path, processed_slice, output_weights, current_hook_fns, hf_shape_map, save_dtype):
@@ -254,6 +249,9 @@ def process_maxtext_param(
   if maxtext_param_key not in param_map:
     raise ValueError(f"MaxText param key '{maxtext_param_key}' not found in param_map.")
   hf_target_paths = param_map[maxtext_param_key]
+  if hf_target_paths is None:
+    max_logging.log(f"\tskipping parameter mapped to None: {maxtext_param_key}")
+    return []
   if not hf_target_paths:
     raise ValueError(f"No HF target paths found for MaxText key '{maxtext_param_key}'")
 


### PR DESCRIPTION
# Description

Adding support for DeepSeek V4-Flash checkpoint conversion through the conversion utility in maxtext. Supports scanned and unscanned conversion.

FIXES: b/509930555 (scanned conversion bug), b/509931406 (unscanned conversion bug)

# Tests

[509930698](https://b.corp.google.com/issues/509930698#comment18) This comment defines the relevant test scripts and test outputs we used to verify the checkpoint conversion. We verified parity between the output of the reference HuggingFace implementation provided by DeepSeek against our own MaxText implementation.

Tested the functionality of `to_huggingface.py` using this [roundtrip parity checking test](https://paste.googleplex.com/5295494044712960) with output log [linked here](https://paste.googleplex.com/4896796861136896).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
