### PR TITLE
Add DeepSeek-V4 HyperHead, align Sinkhorn implementation, and add parity tests

### DIFF
--- a/src/maxtext/checkpoint_conversion/utils/param_mapping.py
+++ b/src/maxtext/checkpoint_conversion/utils/param_mapping.py
@@ -1269,7 +1269,9 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
     hooks[f"{mlp_prefix}-shared_expert-wo-kernel"] = transpose
     hooks[f"{mlp_prefix}-shared_expert_gate-kernel"] = transpose
 
-    hooks[(f"{mlp_prefix}-routed_experts-wi_0", f"{mlp_prefix}-routed_experts-wi_1")] = process_wi_0_wi_1  # pyrefly: ignore[unsupported-operation]
+    hooks[(f"{mlp_prefix}-routed_experts-wi_0", f"{mlp_prefix}-routed_experts-wi_1")] = (
+        process_wi_0_wi_1  # pyrefly: ignore[unsupported-operation]
+    )
     hooks[f"{mlp_prefix}-routed_experts-wo"] = transpose_expert
 
   # Vision hooks for Qwen3.5
@@ -1340,7 +1342,9 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
         return input_tensor.T.reshape(target_shape)
 
     # Apply vision hooks
-    hooks["params-vision_encoder-Qwen3_5MoeVisionEncoder_0-patch_embed-proj-kernel"] = reshape_conv3d_patch_embed  # pyrefly: ignore[bad-assignment]
+    hooks["params-vision_encoder-Qwen3_5MoeVisionEncoder_0-patch_embed-proj-kernel"] = (
+        reshape_conv3d_patch_embed  # pyrefly: ignore[bad-assignment]
+    )
 
     for i in range(n_vision_layers):
       prefix = f"params-vision_encoder-Qwen3_5MoeVisionEncoder_0-blocks_{i}"
@@ -1355,8 +1359,12 @@ def QWEN3_5_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fals
       hooks[f"{prefix}-mlp_out-kernel"] = reshape_kernel_vision  # pyrefly: ignore[bad-assignment]
 
     # Vision projector
-    hooks["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-mlp_0-kernel"] = reshape_kernel_vision  # pyrefly: ignore[bad-assignment]
-    hooks["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-mlp_2-kernel"] = reshape_kernel_vision  # pyrefly: ignore[bad-assignment]
+    hooks["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-mlp_0-kernel"] = (
+        reshape_kernel_vision  # pyrefly: ignore[bad-assignment]
+    )
+    hooks["params-vision_encoder-Qwen3_5MoeVisionProjector_0-merger-mlp_2-kernel"] = (
+        reshape_kernel_vision  # pyrefly: ignore[bad-assignment]
+    )
 
   return hooks
 
@@ -1384,7 +1392,9 @@ def QWEN3_NEXT_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=F
       prefix = f"params-decoder-layers-layer_{block_idx}"
 
       # Layer norms
-      mapping[f"{prefix}-input_layernorm-scale"] = [f"model.layers.{i}.input_layernorm.weight" for i in hf_indices]  # pyrefly: ignore[bad-assignment]
+      mapping[f"{prefix}-input_layernorm-scale"] = [
+          f"model.layers.{i}.input_layernorm.weight" for i in hf_indices
+      ]  # pyrefly: ignore[bad-assignment]
       mapping[f"{prefix}-post_attention_layernorm-scale"] = [  # pyrefly: ignore[bad-assignment]
           f"model.layers.{i}.post_attention_layernorm.weight" for i in hf_indices
       ]
@@ -1943,7 +1953,9 @@ def GPT_OSS_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, savin
     hooks[f"{prefix}-GptOssMlp-gate-kernel"] = transpose
     # `composite_mt_key`: A hook for combining multiple MaxText params.
     hooks[(f"{prefix}-GptOssMlp-wi_0", f"{prefix}-GptOssMlp-wi_1")] = interleave  # pyrefly: ignore[unsupported-operation]
-    hooks[(f"{prefix}-GptOssMlp-wi_0_bias", f"{prefix}-GptOssMlp-wi_1_bias")] = interleave  # pyrefly: ignore[unsupported-operation]
+    hooks[(f"{prefix}-GptOssMlp-wi_0_bias", f"{prefix}-GptOssMlp-wi_1_bias")] = (
+        interleave  # pyrefly: ignore[unsupported-operation]
+    )
 
   return hooks
 
@@ -3858,6 +3870,278 @@ def QWEN3_VL_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=Fal
 
 
 # {maxtext model name: {maxtext weight name: hf weight name}}
+
+
+def DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers=False):
+  """Maps MaxText parameter keys to HuggingFace parameter keys for DeepSeek V4."""
+  n_layers = config["num_hidden_layers"]
+  num_experts = config.get("n_routed_experts", 8)
+
+  mapping = {
+      "params-token_embedder-embedding": "model.embed_tokens.weight",
+      "params-decoder-decoder_norm-scale": "model.norm.weight",
+      "params-decoder-logits_dense-kernel": "head.weight",
+      "params-decoder-hc_head-hc_fn": "model.hc_head.hc_fn",
+      "params-decoder-hc_head-hc_base": "model.hc_head.hc_base",
+      "params-decoder-hc_head-hc_scale": "model.hc_head.hc_scale",
+  }
+
+  def add_layer_mapping(mt_layer_path, hf_layer_indices):
+    is_list = isinstance(hf_layer_indices, list)
+
+    def get_hf_key(subpath):
+      if subpath is None:
+        return None
+      if is_list:
+        return [f"model.layers.{idx}.{subpath}" for idx in hf_layer_indices]
+      else:
+        return f"model.layers.{hf_layer_indices}.{subpath}"
+
+    def get_hf_expert_keys(expert_subpath_template):
+      if is_list:
+        return [
+            [f"model.layers.{idx}.mlp.experts.{e}.{expert_subpath_template}" for idx in hf_layer_indices]
+            for e in range(num_experts)
+        ]
+      else:
+        return [f"model.layers.{hf_layer_indices}.mlp.experts.{e}.{expert_subpath_template}" for e in range(num_experts)]
+
+    layer_map = {
+        f"{mt_layer_path}-pre_self_attention_layer_norm-scale": get_hf_key("input_layernorm.weight"),
+        f"{mt_layer_path}-post_self_attention_layer_norm-scale": get_hf_key("post_attention_layernorm.weight"),
+        # Attention
+        f"{mt_layer_path}-self_attention-wq_a-kernel": get_hf_key("self_attn.q_a_proj.weight"),
+        f"{mt_layer_path}-self_attention-q_norm-scale": get_hf_key("self_attn.q_a_norm.weight"),
+        f"{mt_layer_path}-self_attention-wq_b-kernel": get_hf_key("self_attn.q_b_proj.weight"),
+        f"{mt_layer_path}-self_attention-wkv-kernel": get_hf_key("self_attn.kv_proj.weight"),
+        f"{mt_layer_path}-self_attention-kv_norm-scale": get_hf_key("self_attn.kv_norm.weight"),
+        f"{mt_layer_path}-self_attention-sinks": get_hf_key("self_attn.sinks"),
+        f"{mt_layer_path}-self_attention-o_a_proj-kernel": get_hf_key("self_attn.o_a_proj.weight"),
+        f"{mt_layer_path}-self_attention-o_b_proj-kernel": get_hf_key("self_attn.o_b_proj.weight"),
+        # mHC Attention
+        f"{mt_layer_path}-mhc_attention-mhc_norm-scale": None,
+        f"{mt_layer_path}-mhc_attention-pre_alpha": get_hf_key("attn_hc.fn"),
+        f"{mt_layer_path}-mhc_attention-post_alpha": get_hf_key("attn_hc.fn"),
+        f"{mt_layer_path}-mhc_attention-res_alpha": get_hf_key("attn_hc.fn"),
+        f"{mt_layer_path}-mhc_attention-pre_beta": get_hf_key("attn_hc.base"),
+        f"{mt_layer_path}-mhc_attention-post_beta": get_hf_key("attn_hc.base"),
+        f"{mt_layer_path}-mhc_attention-res_beta": get_hf_key("attn_hc.base"),
+        f"{mt_layer_path}-mhc_attention-pre_alpha_scale": get_hf_key("attn_hc.scale"),
+        f"{mt_layer_path}-mhc_attention-post_alpha_scale": get_hf_key("attn_hc.scale"),
+        f"{mt_layer_path}-mhc_attention-res_alpha_scale": get_hf_key("attn_hc.scale"),
+        # mHC MLP
+        f"{mt_layer_path}-mhc_mlp-mhc_norm-scale": None,
+        f"{mt_layer_path}-mhc_mlp-pre_alpha": get_hf_key("ffn_hc.fn"),
+        f"{mt_layer_path}-mhc_mlp-post_alpha": get_hf_key("ffn_hc.fn"),
+        f"{mt_layer_path}-mhc_mlp-res_alpha": get_hf_key("ffn_hc.fn"),
+        f"{mt_layer_path}-mhc_mlp-pre_beta": get_hf_key("ffn_hc.base"),
+        f"{mt_layer_path}-mhc_mlp-post_beta": get_hf_key("ffn_hc.base"),
+        f"{mt_layer_path}-mhc_mlp-res_beta": get_hf_key("ffn_hc.base"),
+        f"{mt_layer_path}-mhc_mlp-pre_alpha_scale": get_hf_key("ffn_hc.scale"),
+        f"{mt_layer_path}-mhc_mlp-post_alpha_scale": get_hf_key("ffn_hc.scale"),
+        f"{mt_layer_path}-mhc_mlp-res_alpha_scale": get_hf_key("ffn_hc.scale"),
+        # MoE Block
+        f"{mt_layer_path}-mlp-MoeBlock_0-gate-kernel": get_hf_key("mlp.gate.weight"),
+        # Shared Experts
+        f"{mt_layer_path}-mlp-shared_experts-wi_0-kernel": get_hf_key("mlp.shared_experts.gate_proj.weight"),
+        f"{mt_layer_path}-mlp-shared_experts-wi_1-kernel": get_hf_key("mlp.shared_experts.up_proj.weight"),
+        f"{mt_layer_path}-mlp-shared_experts-wo-kernel": get_hf_key("mlp.shared_experts.down_proj.weight"),
+        # Stacked Experts
+        f"{mt_layer_path}-mlp-MoeBlock_0-wi_0": get_hf_expert_keys("w1.weight"),
+        f"{mt_layer_path}-mlp-MoeBlock_0-wi_1": get_hf_expert_keys("w3.weight"),
+        f"{mt_layer_path}-mlp-MoeBlock_0-wo": get_hf_expert_keys("w2.weight"),
+    }
+
+    if (is_list and hf_layer_indices[0] >= 3) or (not is_list and hf_layer_indices >= 3):
+      layer_map[f"{mt_layer_path}-mlp-MoeBlock_0-gate-bias"] = get_hf_key("mlp.gate.e_score_correction_bias")
+
+    first_idx = hf_layer_indices[0] if is_list else hf_layer_indices
+    if first_idx >= 2:
+      if first_idx % 2 == 0 or first_idx == 2:
+        layer_map.update(
+            {
+                f"{mt_layer_path}-self_attention-csa_compressor-kv_proj-kernel": get_hf_key(
+                    "self_attn.compressor.kv_proj.weight"
+                ),
+                f"{mt_layer_path}-self_attention-csa_compressor-gate_proj-kernel": get_hf_key(
+                    "self_attn.compressor.gate_proj.weight"
+                ),
+                f"{mt_layer_path}-self_attention-csa_compressor-position_bias": get_hf_key(
+                    "self_attn.compressor.position_bias"
+                ),
+                f"{mt_layer_path}-self_attention-csa_compressor-kv_norm-scale": get_hf_key(
+                    "self_attn.compressor.kv_norm.weight"
+                ),
+                f"{mt_layer_path}-self_attention-csa_compressor-indexer-gate_proj-kernel": get_hf_key(
+                    "self_attn.compressor.indexer.gate_proj.weight"
+                ),
+                f"{mt_layer_path}-self_attention-csa_compressor-indexer-kv_proj-kernel": get_hf_key(
+                    "self_attn.compressor.indexer.kv_proj.weight"
+                ),
+                f"{mt_layer_path}-self_attention-csa_compressor-indexer-q_proj-kernel": get_hf_key(
+                    "self_attn.compressor.indexer.q_b_proj.weight"
+                ),
+                f"{mt_layer_path}-self_attention-csa_compressor-indexer-weights_proj-kernel": get_hf_key(
+                    "self_attn.compressor.indexer.scorer.weights_proj.weight"
+                ),
+                f"{mt_layer_path}-self_attention-csa_compressor-indexer-position_bias": get_hf_key(
+                    "self_attn.compressor.indexer.position_bias"
+                ),
+                f"{mt_layer_path}-self_attention-csa_compressor-indexer-kv_norm-scale": get_hf_key(
+                    "self_attn.compressor.indexer.kv_norm.weight"
+                ),
+            }
+        )
+      else:
+        layer_map.update(
+            {
+                f"{mt_layer_path}-self_attention-hca_compressor-kv_proj-kernel": get_hf_key(
+                    "self_attn.compressor.kv_proj.weight"
+                ),
+                f"{mt_layer_path}-self_attention-hca_compressor-gate_proj-kernel": get_hf_key(
+                    "self_attn.compressor.gate_proj.weight"
+                ),
+                f"{mt_layer_path}-self_attention-hca_compressor-position_bias": get_hf_key(
+                    "self_attn.compressor.position_bias"
+                ),
+                f"{mt_layer_path}-self_attention-hca_compressor-kv_norm-scale": get_hf_key(
+                    "self_attn.compressor.kv_norm.weight"
+                ),
+            }
+        )
+
+    mapping.update(layer_map)
+
+  if not scan_layers:
+    for i in range(n_layers):
+      add_layer_mapping(f"params-decoder-layers_{i}", i)
+  else:
+    for i in range(3):
+      add_layer_mapping(f"params-decoder-layers_{i}", i)
+    add_layer_mapping("params-decoder-scanned_blocks-layers_0", list(range(3, n_layers, 2)))
+    add_layer_mapping("params-decoder-scanned_blocks-layers_1", list(range(4, n_layers, 2)))
+
+  for i in range(3):
+    mapping[f"Tid2EidVar-decoder-layers_{i}-mlp-MoeBlock_0-tid2eid"] = f"model.layers.{i}.mlp.gate.tid2eid"
+
+  return mapping
+
+
+def DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN(config, maxtext_config, scan_layers=False, saving_to_hf=False):
+  """Returns hook functions for transforming weights between MaxText and HuggingFace for DeepSeek V4."""
+
+  def transpose(input_tensor, target_shape=None):
+    return np.transpose(input_tensor)
+
+  def transpose_stack(input_tensor, target_shape=None):
+    # input_tensor is a list of tensors
+    stacked = np.stack(input_tensor, axis=0)  # [E, out, in]
+    return np.transpose(stacked, (0, 2, 1))  # [E, in, out]
+
+  def ones_norm(input_tensor, target_shape=None):
+    return np.ones(target_shape, dtype=np.float32)
+
+  def identity(input_tensor, target_shape=None):
+    return input_tensor
+
+  # Reshaping functions for wq_b, wkv, o_a_proj
+  def reshape_transpose_wq_b(input_tensor, target_shape=None):
+    # HF: [n_heads * q_head_dim, kv_lora_rank]
+    # MaxText: [kv_lora_rank, n_heads, q_head_dim]
+    tensor = np.transpose(input_tensor)  # [kv_lora_rank, n_heads * q_head_dim]
+    return tensor.reshape(target_shape)
+
+  def reshape_transpose_wkv(input_tensor, target_shape=None):
+    # HF: [n_kv_heads * (q_head_dim + v_head_dim), kv_lora_rank]
+    # MaxText: [kv_lora_rank, n_kv_heads, q_head_dim + v_head_dim]
+    tensor = np.transpose(input_tensor)
+    return tensor.reshape(target_shape)
+
+  def reshape_transpose_o_a(input_tensor, target_shape=None):
+    # HF: [n_heads * v_head_dim, kv_lora_rank] (e.g. [8192, 4096])
+    # MaxText: [n_heads, v_head_dim, kv_lora_rank] (e.g. [8, 4096, 1024])
+    # We must reshape first and then permute (transpose) to get correct ordering.
+    num_heads = target_shape[0]
+    embed_dim = target_shape[1]
+    kv_lora_rank = target_shape[2]
+    tensor = input_tensor.reshape((num_heads, kv_lora_rank, embed_dim))
+    return np.transpose(tensor, (0, 2, 1))
+
+  # Functions for mHC split
+  def mhc_split_fn_pre(input_tensor, target_shape=None):
+    return np.transpose(input_tensor[0:4, :])
+
+  def mhc_split_fn_post(input_tensor, target_shape=None):
+    return np.transpose(input_tensor[4:8, :])
+
+  def mhc_split_fn_res(input_tensor, target_shape=None):
+    return np.transpose(input_tensor[8:24, :])
+
+  def mhc_split_base_pre(input_tensor, target_shape=None):
+    return input_tensor[0:4]
+
+  def mhc_split_base_post(input_tensor, target_shape=None):
+    return input_tensor[4:8]
+
+  def mhc_split_base_res(input_tensor, target_shape=None):
+    return input_tensor[8:24].reshape(target_shape)
+
+  def mhc_split_scale_pre(input_tensor, target_shape=None):
+    return np.array([input_tensor[0]]).reshape(target_shape)
+
+  def mhc_split_scale_post(input_tensor, target_shape=None):
+    return np.array([input_tensor[1]]).reshape(target_shape)
+
+  def mhc_split_scale_res(input_tensor, target_shape=None):
+    return np.array([input_tensor[2]]).reshape(target_shape)
+
+  mapping = {}
+
+  # Base mapping logic from original file
+  for key, hf_key in DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_MAPPING(config, maxtext_config, scan_layers).items():
+    if hf_key is None:
+      mapping[key] = ones_norm
+    elif "token_embedder-embedding" in key:
+      mapping[key] = identity
+    elif "-wkv-kernel" in key:
+      mapping[key] = reshape_transpose_wkv
+    elif "-wq_b-kernel" in key:
+      mapping[key] = reshape_transpose_wq_b
+    elif "-o_a_proj-kernel" in key:
+      mapping[key] = reshape_transpose_o_a
+    elif "mhc" in key:
+      if "pre_alpha" in key and "scale" not in key:
+        mapping[key] = mhc_split_fn_pre
+      elif "post_alpha" in key and "scale" not in key:
+        mapping[key] = mhc_split_fn_post
+      elif "res_alpha" in key and "scale" not in key:
+        mapping[key] = mhc_split_fn_res
+      elif "pre_beta" in key:
+        mapping[key] = mhc_split_base_pre
+      elif "post_beta" in key:
+        mapping[key] = mhc_split_base_post
+      elif "res_beta" in key:
+        mapping[key] = mhc_split_base_res
+      elif "pre_alpha_scale" in key:
+        mapping[key] = mhc_split_scale_pre
+      elif "post_alpha_scale" in key:
+        mapping[key] = mhc_split_scale_post
+      elif "res_alpha_scale" in key:
+        mapping[key] = mhc_split_scale_res
+    elif "position_bias" in key:
+      mapping[key] = identity
+    elif "hc_head-hc_fn" in key:
+      mapping[key] = transpose
+    elif "hc_head-hc_base" in key or "hc_head-hc_scale" in key:
+      mapping[key] = identity
+    elif isinstance(hf_key, list):
+      mapping[key] = transpose if not saving_to_hf else transpose_stack
+    elif "-kernel" in key or "-embedding" in key or "-sinks" in key:
+      mapping[key] = transpose
+
+  return mapping
+
+
 PARAM_MAPPING = {
     "gemma2-2b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gemma2-9b": GEMMA2_MAXTEXT_TO_HF_PARAM_MAPPING,
@@ -3896,6 +4180,7 @@ PARAM_MAPPING = {
     "deepseek2-16b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING,
     "deepseek3-671b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING,
     "deepseek3.2-671b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_MAPPING,
+    "deepseek4-284b": DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gpt-oss-20b": GPT_OSS_MAXTEXT_TO_HF_PARAM_MAPPING,
     "gpt-oss-120b": GPT_OSS_MAXTEXT_TO_HF_PARAM_MAPPING,
     "qwen3-omni-30b-a3b": QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_MAPPING,
@@ -3948,6 +4233,8 @@ HOOK_FNS = {
     "deepseek2-16b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "deepseek3-671b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "deepseek3.2-671b": DEEPSEEK_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "deepseek4-tiny": DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    "deepseek4-284b": DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN,
     "gpt-oss-20b": GPT_OSS_TO_HF_PARAM_HOOK_FN,
     "gpt-oss-120b": GPT_OSS_TO_HF_PARAM_HOOK_FN,
     "qwen3-omni-30b-a3b": QWEN3_OMNI_MOE_MAXTEXT_TO_HF_PARAM_HOOK_FN,

--- a/src/maxtext/configs/models/deepseek4-tiny.yml
+++ b/src/maxtext/configs/models/deepseek4-tiny.yml
@@ -11,13 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Model config for DeepSeek-V4-Flash 284B (https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash)
+# Test Model config for DeepSeek-V4-Flash 284B (https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash)
 
 base_emb_dim: 4096
 base_num_query_heads: 64
 base_num_kv_heads: 1
-base_num_decoder_layers: 43
+base_num_decoder_layers: 7
 base_mlp_dim: 2048
 base_moe_mlp_dim: 2048
 vocab_size: 129280
@@ -37,25 +36,26 @@ indexer_n_heads: 64
 indexer_topk: 512
 
 # Note: Layers (0, 1, 2) are prefix layers as `first_num_hash_layers=3`.
-# The 44th layer (MTP module with compress_ratio=0) has been explicitly dropped for now.
-# This leaves exactly 43 layers: 3 prefix [0,0,4] + 40 scanned.
+# The 6th layer (MTP module with compress_ratio=0) has been explicitly dropped for now.
+# This leaves exactly 7 layers: 3 prefix [0,0,4] + 4 scanned.
 # `compress_ratio=0` uses sliding window attention. In this case, layer (0, 1).
-compress_ratios: [0, 0, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4]
+# This is a tiny version of deepseek4 with fewer layers and less experts for debugging.
+compress_ratios: [0, 0, 4, 128, 4, 128, 4]
 
 # --- MoE configuration ---
 mlp_activations: ["silu", "linear"]
-num_experts: 256
-num_experts_per_tok: 6
+num_experts: 8
+num_experts_per_tok: 3
 mlp_activations_limit: 10
 shared_experts: 1
 routed_score_func: "sqrtsoftplus"
-norm_topk_prob: true
 routed_bias: true
 routed_scaling_factor: 1.5
 
 
 # --- Attention configuration ---
 attention_type: 'compressed'
+attention: 'dot_product'
 q_lora_rank: 1024
 o_groups: 8
 o_lora_rank: 1024
@@ -67,3 +67,4 @@ rope_max_timescale: 10000                  # Main RoPE theta
 compressed_rope_max_timescale: 160000      # Compressed RoPE theta
 max_position_embeddings: 1048576
 original_max_position_embeddings: 65536
+

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -228,6 +228,7 @@ ModelName = Literal[
     "deepseek3-test",
     "deepseek3-tiny",
     "deepseek3.2-671b",
+    "deepseek4-tiny",
     "deepseek4-284b",
     "deepseek-custom",
     "kimi-k2-1t",

--- a/src/maxtext/layers/attention_compressed.py
+++ b/src/maxtext/layers/attention_compressed.py
@@ -304,7 +304,7 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
 
     # Skip causal mask generation during decoding (seq_len == 1) or if no blocks were pooled
     if seq_len == 1 or compressed_len == 0:
-      return compressed_kv, None
+      return compressed_kv, jnp.zeros((batch_size, 1, seq_len, compressed_len), dtype=self.dtype)
 
     # Construct a causal mask preventing early queries from attending to future compressed blocks
     entry_indices = jnp.arange(compressed_len)

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -1263,8 +1263,15 @@ class Decoder(nn.Module):
 
     # After the final transformer layer, `y` holds the raw, un-normalized hidden state.
     if cfg.mhc_expansion_rate > 1:
-      # (batch, length, mhc_expansion_rate, emb_dim) --> (batch, length, emb_dim)
-      hidden_state = mhc_reduce(y)
+      if cfg.decoder_block == DecoderBlockType.DEEPSEEK4:
+        hidden_state = mhc.DeepSeek4HyperHeadToLinen(
+            config=cfg,
+            mesh=mesh,
+            name="hc_head",
+        )(y)
+      else:
+        # (batch, length, mhc_expansion_rate, emb_dim) --> (batch, length, emb_dim)
+        hidden_state = mhc_reduce(y)
     else:
       hidden_state = y
 

--- a/src/maxtext/layers/mhc.py
+++ b/src/maxtext/layers/mhc.py
@@ -24,7 +24,8 @@ import jax.numpy as jnp
 from jax.sharding import Mesh
 from maxtext.common.common_types import Array, Config
 from maxtext.common.common_types import HyperConnectionType
-from maxtext.layers.initializers import default_bias_init, default_scalar_init, nd_dense_init
+from maxtext.layers.initializers import default_bias_init, default_scalar_init, nd_dense_init, variable_to_logically_partitioned
+from maxtext.layers import nnx_wrappers
 from maxtext.layers.normalizations import RMSNorm
 
 
@@ -61,21 +62,18 @@ def sinkhorn(t, iters=20):
   # Use float32 precision for numerical stability during normalization
   initial_dtype = t.dtype
   t = t.astype(jnp.float32)
+  eps = 1e-6
 
-  # Column-wise normalization (axis=-2) - positive and sum up to 1 across columns
-  # Equivalent to t = exp(t) / jnp.sum(jnp.exp(t), axis=-2)
-  t = jax.nn.softmax(t, axis=-2)
+  t = jax.nn.softmax(t, axis=-1) + eps
+  t = t / (jnp.sum(t, axis=-2, keepdims=True) + eps)
 
   def body_fun(i, val):
-    # L1 Normalization: val / sum(val) with clipping of denominator
-    # Normalize rows (axis -1)
-    val = val / jnp.clip(jnp.sum(val, axis=-1, keepdims=True), min=1e-12)
-    # Normalize columns (axis -2)
-    val = val / jnp.clip(jnp.sum(val, axis=-2, keepdims=True), min=1e-12)
+    val = val / (jnp.sum(val, axis=-1, keepdims=True) + eps)
+    val = val / (jnp.sum(val, axis=-2, keepdims=True) + eps)
     return val
 
   # Use lax.fori_loop for an efficient, JIT-friendly loop
-  t = jax.lax.fori_loop(0, iters, body_fun, t)
+  t = jax.lax.fori_loop(0, iters - 1, body_fun, t)
   return t.astype(initial_dtype)
 
 
@@ -224,7 +222,7 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
       output = sinkhorn(intermediate, self.sinkhorn_iterations)
       return output
 
-  def mapping(self, x: Array, alpha_scale: Array, alpha: Array, beta: Array, scale: int):
+  def mapping(self, x: Array, alpha_scale: Array, alpha: Array, beta: Array, scale: float, eps: float = 0.0):
     """Helper function for both pre and post mappings."""
     # In MaxText, we match weight precision to activations before Matmul
     alpha = jnp.asarray(alpha, self.dtype)
@@ -233,7 +231,7 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
     # Apply projection: (b, s, k*d) @ (k*d, k) -> (b, s, k)
     h = jnp.einsum("bsm,mk -> bsk", x, alpha, precision=self.matmul_precision)
     intermediate = alpha_scale * h + beta[None, None, :]
-    output = scale * jax.nn.sigmoid(intermediate)
+    output = scale * jax.nn.sigmoid(intermediate) + eps
     return output
 
   def __call__(
@@ -269,6 +267,7 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
         self.pre_alpha[...],
         self.pre_beta[...],
         1.0,
+        eps=1e-6,
     )
     layer_input = jnp.einsum("bskd,bsk -> bsd", x, pre_mapping, precision=self.matmul_precision)
 
@@ -307,3 +306,71 @@ class ManifoldConstrainedHyperConnections(nnx.Module):
     res_mapping = self.res_mapping(norm_x)
     res_out = jnp.einsum("bskd,bskm -> bsmd", x, res_mapping, precision=self.matmul_precision)
     return res_out + post_out, metadata
+
+
+class DeepSeek4HyperHead(nnx.Module):
+  """Final HC-stream collapse; used by DeepSeek V4 before the shared RMSNorm."""
+
+  def __init__(
+      self,
+      config: Config,
+      mesh: Mesh,
+      rngs: nnx.Rngs,
+  ):
+    self.config = config
+    self.mesh = mesh
+    self.rngs = rngs
+    self.dtype = config.dtype
+    self.weight_dtype = config.weight_dtype
+    self.mhc_expansion_rate = config.mhc_expansion_rate
+    self.emb_dim = config.emb_dim
+    self.eps = 1e-6
+
+    # Weight matrices
+    weight_init = nd_dense_init(1.0, "fan_in", "normal")
+    self.hc_fn = nnx.Param(
+        weight_init(
+            rngs.params(),
+            (self.mhc_expansion_rate * self.emb_dim, self.mhc_expansion_rate),
+            self.weight_dtype,
+            in_axis=0,
+            out_axis=1,
+        ),
+        out_sharding=("activation_embed", None),
+    )
+    self.hc_base = nnx.Param(
+        default_bias_init(rngs.params(), (self.mhc_expansion_rate,), self.weight_dtype),
+        out_sharding=(None,),
+    )
+    self.hc_scale = nnx.Param(
+        default_scalar_init(rngs.params(), (1,), self.weight_dtype),
+        out_sharding=(None,),
+    )
+
+  def __call__(self, x: Array) -> Array:
+    # x shape: [batch, length, k, d]
+    b, s, k, d = x.shape
+    assert k == self.mhc_expansion_rate
+    assert d == self.emb_dim
+
+    flat = jnp.reshape(x, (b, s, k * d))
+    flat_f32 = flat.astype(jnp.float32)
+    variance = jnp.mean(jnp.square(flat_f32), axis=-1, keepdims=True)
+    flat_norm = flat_f32 * jax.lax.rsqrt(variance + self.eps)
+
+    hc_fn = jnp.asarray(self.hc_fn[...], jnp.float32)
+    hc_base = jnp.asarray(self.hc_base[...], jnp.float32)
+    hc_scale = jnp.asarray(self.hc_scale[...], jnp.float32)
+
+    mixes = jnp.einsum("bsm,mk->bsk", flat_norm, hc_fn, precision=jax.lax.Precision(self.config.matmul_precision))
+    pre = jax.nn.sigmoid(mixes * hc_scale[None, None, :] + hc_base[None, None, :]) + self.eps
+
+    x_f32 = x.astype(jnp.float32)
+    out = jnp.sum(pre[:, :, :, None] * x_f32, axis=2)
+    return out.astype(self.dtype)
+
+
+DeepSeek4HyperHeadToLinen = nnx_wrappers.to_linen_class(
+    DeepSeek4HyperHead,
+    base_metadata_fn=variable_to_logically_partitioned,
+)

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -694,14 +694,15 @@ class RoutedMoE(nnx.Module):
     else:
       top_k_weights, top_k_indices = jax.lax.top_k(gate_logits, self.num_experts_per_tok)
 
-    if self.config.decoder_block == ctypes.DecoderBlockType.DEEPSEEK:
+    if self.config.decoder_block in (ctypes.DecoderBlockType.DEEPSEEK, ctypes.DecoderBlockType.DEEPSEEK4):
       top_k_weights = self.deepseek_scale_weights(top_k_weights)
-    elif self.config.decoder_block not in (ctypes.DecoderBlockType.LLAMA4, ctypes.DecoderBlockType.GEMMA4):
-      top_k_weights = jax.nn.softmax(top_k_weights.astype(jnp.float32), axis=-1).astype(self.dtype)
+    else:
+      if self.config.decoder_block not in (ctypes.DecoderBlockType.LLAMA4, ctypes.DecoderBlockType.GEMMA4):
+        top_k_weights = jax.nn.softmax(top_k_weights.astype(jnp.float32), axis=-1).astype(self.dtype)
 
-    # Normalization of router weights (e.g. used by Qwen3, Gemma4).
-    if self.config.norm_topk_prob:
-      top_k_weights /= top_k_weights.sum(axis=-1, keepdims=True)
+      # Normalization of router weights (e.g. used by Qwen3, Gemma4).
+      if self.config.norm_topk_prob:
+        top_k_weights /= top_k_weights.sum(axis=-1, keepdims=True)
 
     return top_k_weights, top_k_indices
 
@@ -788,7 +789,10 @@ class RoutedMoE(nnx.Module):
         layer_act = self.activation_fn(layer_w0 * 1.702)
         glu = jnp.multiply(layer_w0, layer_act)
         intermediate_layer = jnp.multiply(glu, (layer_w1 + 1))
-      elif self.config.decoder_block == ctypes.DecoderBlockType.DEEPSEEK and self.config.mlp_activations_limit > 0.0:
+      elif (
+          self.config.decoder_block in (ctypes.DecoderBlockType.DEEPSEEK, ctypes.DecoderBlockType.DEEPSEEK4)
+          and self.config.mlp_activations_limit > 0.0
+      ):
         # DeepSeek V4 uses bounds to clip the SwiGLU activations
         layer_w0 = jnp.clip(layer_w0, min=None, max=self.config.mlp_activations_limit)
         layer_w1 = jnp.clip(layer_w1, min=-self.config.mlp_activations_limit, max=self.config.mlp_activations_limit)

--- a/tests/unit/deepseek_v4_vs_reference_test.py
+++ b/tests/unit/deepseek_v4_vs_reference_test.py
@@ -41,6 +41,7 @@ from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
     DeepseekV4HashRouter as DeepseekV4HashRouter_PT,
     DeepseekV4TopKRouter as DeepseekV4TopKRouter_PT,
     DeepseekV4Experts as DeepseekV4Experts_PT,
+    DeepseekV4HyperHead as DeepseekV4HyperHead_PT,
     apply_rotary_pos_emb as ref_apply_rotary_pos_emb,
 )
 
@@ -295,7 +296,9 @@ class DeepSeekV4AttentionMaskingTest(unittest.TestCase):
   """
 
   def setUp(self):
-    self.config = pyconfig.initialize([sys.argv[0], "src/maxtext/configs/base.yml"], run_name="test")
+    self.config = pyconfig.initialize(
+        [sys.argv[0], "src/maxtext/configs/base.yml"], run_name="test", skip_jax_distributed_system=True
+    )
 
   def test_generate_attention_mask_local_sliding(self):
     """Verifies AttentionType.LOCAL_SLIDING enforces both causal and sliding window constraints."""
@@ -587,7 +590,7 @@ class DeepSeekV4CompressedAttentionTest(unittest.TestCase):
       self._copy_linear(mt_attn.csa_compressor.indexer.q_proj, ref_attn.compressor.indexer.q_b_proj)
       self._copy_linear(mt_attn.csa_compressor.indexer.kv_proj, ref_attn.compressor.indexer.kv_proj)
       self._copy_linear(mt_attn.csa_compressor.indexer.gate_proj, ref_attn.compressor.indexer.gate_proj)
-      self._copy_linear(mt_attn.csa_compressor.indexer.weights_proj, ref_attn.compressor.indexer.weights_proj)
+      self._copy_linear(mt_attn.csa_compressor.indexer.weights_proj, ref_attn.compressor.indexer.scorer.weights_proj)
       mt_attn.csa_compressor.indexer.position_bias.value = jnp.array(
           ref_attn.compressor.indexer.position_bias.data.numpy()
       )
@@ -950,6 +953,564 @@ class DeepSeekV4SwiGLUClampTest(unittest.TestCase):
 
     # Validate that both clamped outputs match identically
     np.testing.assert_allclose(mx_out, pt_out.numpy(), rtol=1e-5, atol=1e-5)
+
+
+class DeepSeekV4ProductionMoERouterTest(unittest.TestCase):
+
+  def setUp(self):
+    self.batch_size = 2
+    self.seq_len = 32
+    self.hidden_dim = 4096
+    self.num_experts = 8
+    self.num_experts_per_tok = 3
+    self.vocab_size = 129280
+
+    self.pt_config = DeepseekV4Config(
+        hidden_size=self.hidden_dim,
+        num_local_experts=self.num_experts,
+        num_experts_per_tok=self.num_experts_per_tok,
+        routed_scaling_factor=2.0,
+        scoring_func="sqrtsoftplus",
+        vocab_size=self.vocab_size,
+    )
+
+    config_arguments = {
+        "per_device_batch_size": 1.0,
+        "run_name": "test",
+        "enable_checkpointing": False,
+        "base_emb_dim": self.hidden_dim,
+        "num_experts": self.num_experts,
+        "topk_routing_group": self.num_experts_per_tok,
+        "routed_scaling_factor": 2.0,
+        "routed_score_func": "sqrtsoftplus",
+        "routed_bias": True,
+        "n_routing_groups": -1,
+        "vocab_size": self.vocab_size,
+        "first_num_hash_layers": 3,
+        "decoder_block": "deepseek4",
+        "model_name": "deepseek4-284b",
+        "attention": "dot_product",
+        "base_mlp_dim": 256,
+        "base_moe_mlp_dim": 256,
+        "override_model_config": True,
+        "skip_jax_distributed_system": True,
+    }
+    argv = [sys.argv[0], "src/maxtext/configs/base.yml"]
+    self.mx_config = pyconfig.initialize(argv, **config_arguments)
+
+    devices = np.array(jax.devices()[:1])
+    self.mesh = jax.sharding.Mesh(devices, ("tensor",))
+    self.rngs = nnx.Rngs(0)
+
+  def test_hash_router(self):
+    pt_router = DeepseekV4HashRouter_PT(self.pt_config)
+    # Explicitly initialize PyTorch weights since torch.empty leaves garbage in memory,
+    # which causes NaN/Inf drift between PyTorch and MaxText/XLA execution.
+    torch.nn.init.normal_(pt_router.weight, std=0.02)
+
+    # Hash Router operates deterministically based on input_ids via a frozen tid2eid lookup table.
+    # In practice, this table is pre-computed (e.g. by K-Means on the dataset) and loaded statically.
+    # For this parity test, we randomly initialize the lookup table on the PyTorch side
+    # and explicitly sync it to the MaxText side to ensure both routers route the exact same way.
+    pt_tid2eid = torch.randint(0, self.num_experts, (self.vocab_size, self.num_experts_per_tok))
+    pt_router.tid2eid.copy_(pt_tid2eid)
+
+    mx_moe = RoutedMoE(
+        config=self.mx_config,
+        num_experts=self.num_experts,
+        num_experts_per_tok=self.num_experts_per_tok,
+        mesh=self.mesh,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed_moe", "mlp_moe", None),
+        rngs=self.rngs,
+        is_hash_routing=True,  # Hash layer
+    )
+
+    # Sync weights
+    mx_moe.tid2eid.value = jnp.array(pt_router.tid2eid.numpy(), dtype=jnp.float32)
+    mx_moe.gate.kernel.value = jnp.array(pt_router.weight.detach().numpy()).T
+
+    hidden_states = torch.randn(self.batch_size, self.seq_len, self.hidden_dim)
+    input_ids = torch.randint(0, self.vocab_size, (self.batch_size, self.seq_len))
+
+    # PT forward
+    _, pt_weights, pt_indices = pt_router(hidden_states, input_ids)
+
+    # MaxText forward
+    gate_logits, pre_bias_logits = mx_moe.gate(jnp.array(hidden_states.numpy()))
+    mx_weights, mx_indices = mx_moe.get_topk(
+        gate_logits, pre_bias_logits, rngs=self.rngs, input_ids=jnp.array(input_ids.numpy())
+    )
+
+    # --- Assertion Logic for Hash Router ---
+    # PyTorch returns flat tensors: (batch * seq_len, top_k)
+    # MaxText returns structured tensors: (batch, seq_len, top_k)
+    # We must explicitly reshape PyTorch outputs to match MaxText's nested sequence structure.
+    pt_indices_reshaped = pt_indices.numpy().reshape(self.batch_size, self.seq_len, -1)
+    pt_weights_reshaped = pt_weights.detach().numpy().reshape(self.batch_size, self.seq_len, -1)
+    weights_max_diff = np.max(np.abs(mx_weights - pt_weights_reshaped))
+    weights_mean_diff = np.mean(np.abs(mx_weights - pt_weights_reshaped))
+    print(
+        f"MOE HASH ROUTER WEIGHTS PARITY - MAX ABS DIFF: {weights_max_diff:.6e}, MEAN ABS DIFF: {weights_mean_diff:.6e}"
+    )
+    np.testing.assert_allclose(mx_indices, pt_indices_reshaped, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(mx_weights, pt_weights_reshaped, rtol=1e-2, atol=1e-2)
+
+  def test_topk_router(self):
+    pt_router = DeepseekV4TopKRouter_PT(self.pt_config)
+
+    # Explicitly initialize PyTorch weights since torch.empty leaves garbage in memory,
+    # which causes NaN/Inf drift between PyTorch and MaxText/XLA execution.
+    torch.nn.init.normal_(pt_router.weight, std=0.02)
+    torch.nn.init.normal_(pt_router.e_score_correction_bias, std=0.02)
+
+    mx_moe = RoutedMoE(
+        config=self.mx_config,
+        num_experts=self.num_experts,
+        num_experts_per_tok=self.num_experts_per_tok,
+        mesh=self.mesh,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed_moe", "mlp_moe", None),
+        rngs=self.rngs,
+        is_hash_routing=False,  # TopK layer
+    )
+
+    # Sync weights
+    mx_moe.gate.kernel.value = jnp.array(pt_router.weight.detach().numpy()).T
+    mx_moe.gate.bias.value = jnp.array(pt_router.e_score_correction_bias.detach().numpy())
+
+    hidden_states = torch.randn(self.batch_size, self.seq_len, self.hidden_dim)
+
+    # PT forward
+    _, pt_weights, pt_indices = pt_router(hidden_states)
+
+    # MaxText forward
+    gate_logits, pre_bias_logits = mx_moe.gate(jnp.array(hidden_states.numpy()))
+    mx_weights, mx_indices = mx_moe.get_topk(gate_logits, pre_bias_logits, rngs=self.rngs)
+
+    # --- Assertion Logic for TopK Router ---
+    # PyTorch returns flat tensors: (batch * seq_len, top_k)
+    # MaxText returns structured tensors: (batch, seq_len, top_k)
+    # 1. Reshape PyTorch outputs to match MaxText's nested sequence structure.
+    pt_indices_reshaped = pt_indices.numpy().reshape(self.batch_size, self.seq_len, -1)
+    pt_weights_reshaped = pt_weights.detach().numpy().reshape(self.batch_size, self.seq_len, -1)
+
+    # 2. Sort both by indices so they can be compared directly.
+    # jax.lax.top_k and torch.topk resolve exact-value ties differently.
+    # Because TopK routing weights are summed commutatively during the MoE forward pass,
+    # only the mathematical *set* of selected experts matters, not their strict sorted order.
+    mx_sort_idx = np.argsort(mx_indices, axis=-1)
+    pt_sort_idx = np.argsort(pt_indices_reshaped, axis=-1)
+
+    mx_indices_sorted = np.take_along_axis(np.array(mx_indices), mx_sort_idx, axis=-1)
+    mx_weights_sorted = np.take_along_axis(np.array(mx_weights), mx_sort_idx, axis=-1)
+
+    pt_indices_sorted = np.take_along_axis(pt_indices_reshaped, pt_sort_idx, axis=-1)
+    pt_weights_sorted = np.take_along_axis(pt_weights_reshaped, pt_sort_idx, axis=-1)
+
+    weights_max_diff = np.max(np.abs(mx_weights_sorted - pt_weights_sorted))
+    weights_mean_diff = np.mean(np.abs(mx_weights_sorted - pt_weights_sorted))
+    print(
+        f"MOE TOPK ROUTER WEIGHTS PARITY - MAX ABS DIFF: {weights_max_diff:.6e}, MEAN ABS DIFF: {weights_mean_diff:.6e}"
+    )
+    np.testing.assert_allclose(mx_indices_sorted, pt_indices_sorted, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(mx_weights_sorted, pt_weights_sorted, rtol=1e-2, atol=1e-2)
+
+
+class DeepSeekV4ProductionSwiGLUClampTest(unittest.TestCase):
+
+  def test_swiglu_clamp(self):
+    limit = 10.0
+    pt_config = DeepseekV4Config(
+        hidden_size=4096,
+        num_local_experts=8,
+        num_experts_per_tok=3,
+        intermediate_size=256,
+        swiglu_limit=limit,
+    )
+
+    config_arguments = {
+        "per_device_batch_size": 1.0,
+        "run_name": "test",
+        "enable_checkpointing": False,
+        "base_emb_dim": 4096,
+        "num_experts": 8,
+        "topk_routing_group": 3,
+        "mlp_activations_limit": limit,
+        "decoder_block": "deepseek4",
+        "model_name": "deepseek4-284b",
+        "attention": "dot_product",
+        "base_mlp_dim": 256,
+        "base_moe_mlp_dim": 256,
+        "override_model_config": True,
+        "matmul_precision": "highest",
+        "skip_jax_distributed_system": True,
+    }
+    argv = [sys.argv[0], "src/maxtext/configs/base.yml"]
+    mx_config = pyconfig.initialize(argv, **config_arguments)
+
+    pt_experts = DeepseekV4Experts_PT(pt_config)
+
+    devices = np.array(jax.devices()[:1])
+    mesh = jax.sharding.Mesh(devices, ("tensor",))
+    rngs = nnx.Rngs(0)
+
+    mx_moe = RoutedMoE(
+        config=mx_config,
+        num_experts=2,
+        num_experts_per_tok=1,
+        mesh=mesh,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed_moe", "mlp_moe", None),
+        rngs=rngs,
+    )
+
+    # Gate & Up merged matrix in PT
+    gate_up = torch.randn(1, 4, 256 * 2) * 20.0  # Force large values to trigger the clamping mechanism
+
+    # PyTorch reference executes the standard SwiGLU followed by clamping
+    # to self.config.swiglu_limit (which translates to mlp_activations_limit in MaxText)
+    pt_out = pt_experts._apply_gate(gate_up)  # pylint: disable=protected-access
+
+    # In MaxText, the gate and up projections are separated mathematically.
+    # apply_ffn_activation executes the swiglu limit internally during the activation phase.
+    gate, up = gate_up.chunk(2, dim=-1)
+    mx_out = mx_moe.apply_ffn_activation(jnp.array(gate.numpy()), jnp.array(up.numpy()))
+
+    # Validate that both clamped outputs match identically
+    max_diff = np.max(np.abs(mx_out - pt_out.numpy()))
+    mean_diff = np.mean(np.abs(mx_out - pt_out.numpy()))
+    print(f"SWIGLU CLAMP PARITY - MAX ABS DIFF: {max_diff:.6e}, MEAN ABS DIFF: {mean_diff:.6e}")
+    np.testing.assert_allclose(mx_out, pt_out.numpy(), rtol=1e-5, atol=1e-5)
+
+
+from transformers.models.deepseek_v4.modeling_deepseek_v4 import DeepseekV4DecoderLayer as DeepseekV4DecoderLayer_PT
+from maxtext.models.deepseek4 import DeepSeek4DecoderLayer
+from maxtext.layers.mhc import DeepSeek4HyperHead
+
+
+class DeepSeekV4ConversionMappingTest(unittest.TestCase):
+  """Tests to validate weight conversion mappings from PARAM_MAPPING."""
+
+  def setUp(self):
+    self.batch_size = 2
+    self.seq_len = 32
+    self.hidden_dim = 4096
+    self.num_heads = 64
+    self.head_dim = 512
+    self.q_lora_rank = 1024
+    self.o_groups = 8
+    self.o_lora_rank = 1024
+    self.qk_rope_head_dim = 64
+    self.partial_rotary_factor = self.qk_rope_head_dim / self.head_dim
+    self.vocab_size = 129280
+
+    self.pt_config = DeepseekV4Config(
+        hidden_size=self.hidden_dim,
+        num_attention_heads=self.num_heads,
+        num_key_value_heads=1,
+        head_dim=self.head_dim,
+        q_lora_rank=self.q_lora_rank,
+        kv_lora_rank=self.head_dim,
+        o_groups=self.o_groups,
+        o_lora_rank=self.o_lora_rank,
+        layer_types=[
+            "sliding_attention",
+            "sliding_attention",
+            "compressed_sparse_attention",
+            "heavily_compressed_attention",
+            "compressed_sparse_attention",
+            "heavily_compressed_attention",
+            "compressed_sparse_attention",
+        ],
+        num_hidden_layers=7,
+        num_nextn_predict_layers=0,
+        num_local_experts=8,
+        num_experts_per_tok=3,
+        vocab_size=self.vocab_size,
+    )
+
+    config_arguments = {
+        "model_name": "deepseek4-tiny",
+        "override_model_config": True,
+        "per_device_batch_size": 1,
+        "matmul_precision": "highest",
+        "megablox": False,
+        "sparse_matmul": False,
+        "dtype": "float32",
+        "weight_dtype": "float32",
+        "skip_jax_distributed_system": True,
+    }
+    argv = [sys.argv[0], "src/maxtext/configs/base.yml"]
+    self.mx_config = pyconfig.initialize(argv, **config_arguments)
+
+    self.rngs = nnx.Rngs(0)
+    devices = np.array(jax.devices()[:1])
+    self.mesh = jax.sharding.Mesh(devices, ("tensor",))
+
+  def _apply_param_mapping(self, mt_layer, pt_layer, l):
+    """Maps PT weights to MaxText layer."""
+    from maxtext.checkpoint_conversion.utils.param_mapping import (
+        DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_MAPPING,
+        DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN,
+    )
+
+    pt_config_dict = self.pt_config.to_dict()
+    PARAM_MAPPING = DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_MAPPING(pt_config_dict, self.mx_config, scan_layers=False)
+    HOOK_FNS = DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN(
+        pt_config_dict, self.mx_config, scan_layers=False, saving_to_hf=False
+    )
+
+    def get_attr(obj, path):
+      """Helper function to fetch nested attributes."""
+      if path is None:
+        return None
+      if "mlp.experts." in path:
+        parts = path.split(".")
+        idx_exp = parts.index("experts")
+        expert_idx = int(parts[idx_exp + 1])
+        w_name = parts[idx_exp + 2]
+
+        experts_obj = obj
+        for p in parts[: idx_exp + 1]:
+          experts_obj = getattr(experts_obj, p)
+
+        if w_name == "w1":
+          intermediate_dim = experts_obj.intermediate_dim
+          return experts_obj.gate_up_proj[expert_idx, :intermediate_dim, :]
+        elif w_name == "w3":
+          intermediate_dim = experts_obj.intermediate_dim
+          return experts_obj.gate_up_proj[expert_idx, intermediate_dim:, :]
+        elif w_name == "w2":
+          return experts_obj.down_proj[expert_idx]
+        else:
+          raise ValueError(f"Unknown weight name {w_name} in experts path: {path}")
+
+      for part in path.split("."):
+        if part.isdigit():
+          obj = obj[int(part)]
+        elif hasattr(obj, part):
+          obj = getattr(obj, part)
+        elif isinstance(obj, dict):
+          obj = obj[part]
+        else:
+          return None
+      return obj
+
+    pt_prefix = f"model.layers.{l}."
+    for mt_key, hf_key in PARAM_MAPPING.items():
+      if f"layers_{l}" in mt_key:
+        if "Tid2EidVar" in mt_key:
+          prefix = f"Tid2EidVar-decoder-layers_{l}-"
+        else:
+          prefix = f"params-decoder-layers_{l}-"
+
+        nnx_subpath = mt_key.replace(prefix, "").replace("-", ".")
+        mt_path = nnx_subpath + ".value"
+
+        parts = mt_path.split(".")
+        obj = mt_layer
+        valid = True
+        for part in parts[:-1]:
+          if hasattr(obj, part):
+            obj = getattr(obj, part)
+          else:
+            valid = False
+            break
+        if not valid:
+          continue
+
+        target_shape = obj.value.shape
+        hook_fn = HOOK_FNS.get(mt_key, lambda x, target_shape=None: x)
+
+        if hf_key is None:
+          pt_val = None
+          val = hook_fn(pt_val, target_shape=target_shape)
+        elif isinstance(hf_key, list):
+          pt_vals = [get_attr(pt_layer, k.replace(pt_prefix, "")).detach().numpy() for k in hf_key]
+          slice_shape = target_shape[1:]
+          processed_vals = [hook_fn(v, target_shape=slice_shape) for v in pt_vals]
+          val = np.stack(processed_vals, axis=0)
+        else:
+          pt_val = get_attr(pt_layer, hf_key.replace(pt_prefix, "")).detach().numpy()
+          val = hook_fn(pt_val, target_shape=target_shape)
+
+        setattr(obj, "value", jnp.array(val))
+
+  def _run_layer_parity_test(self, layer_idx, layer_type):
+    # self.pt_config.layer_types = ["sliding_attention"] * 7
+    # self.pt_config.layer_types[layer_idx] = layer_type
+    compress_ratios = [0, 0, 4, 128, 4, 128, 4]
+
+    torch.manual_seed(42)
+    pt_layer = DeepseekV4DecoderLayer_PT(self.pt_config, layer_idx=layer_idx)
+
+    # Explicitly initialize PyTorch weights with random values to prevent torch.empty
+    # from yielding zero/garbage values that could mask parity differences.
+    for p in pt_layer.parameters():
+      if p.dim() >= 1:
+        torch.nn.init.normal_(p.data, mean=0.0, std=0.02)
+      else:
+        torch.nn.init.constant_(p.data, 0.02)
+
+    if layer_idx < self.mx_config.first_num_hash_layers:
+      pt_tid2eid = torch.randint(
+          0, self.pt_config.num_local_experts, (self.vocab_size, self.pt_config.num_experts_per_tok)
+      )
+      pt_layer.mlp.gate.tid2eid.copy_(pt_tid2eid)
+
+    if layer_type == "compressed_sparse_attention" and self.pt_config.index_topk == 2:
+      for p in pt_layer.self_attn.compressor.indexer.parameters():
+        p.data = torch.abs(p.data) + 0.1
+
+    mt_layer = DeepSeek4DecoderLayer(
+        config=self.mx_config,
+        model_mode="train",
+        mesh=self.mesh,
+        rngs=self.rngs,
+        layer_idx=layer_idx,
+        compress_ratio=compress_ratios[layer_idx],
+        is_hash_routing=(layer_idx < self.mx_config.first_num_hash_layers),
+    )
+
+    self._apply_param_mapping(mt_layer, pt_layer, layer_idx)
+
+    np.random.seed(42)
+    x_np = np.random.uniform(
+        0.1, 1.0, size=(self.batch_size, self.seq_len, self.pt_config.hc_mult, self.hidden_dim)
+    ).astype(np.float32)
+    pos_np = np.arange(self.seq_len)[None, :].repeat(self.batch_size, axis=0)
+    input_ids_np = np.random.randint(0, self.vocab_size, size=(self.batch_size, self.seq_len))
+
+    x_pt = torch.tensor(x_np)
+    pos_pt = torch.tensor(pos_np, dtype=torch.long)
+    input_ids_pt = torch.tensor(input_ids_np, dtype=torch.long)
+
+    pt_mask = _prepare_4d_causal_attention_mask(
+        None, (self.batch_size, self.seq_len), x_pt, 0, self.pt_config.sliding_window
+    )
+
+    rope_main = PTRope(self.pt_config)
+    rope_compress = PTRope(self.pt_config)
+    dummy_x_main = torch.zeros(self.batch_size, self.seq_len, 1)
+    cos_main, sin_main = rope_main(dummy_x_main, pos_pt, "main")
+    cos_comp, sin_comp = rope_compress(dummy_x_main, pos_pt, "compress")
+    pt_positions = {"main": (cos_main, sin_main), "compress": (cos_comp, sin_comp)}
+
+    pt_out = pt_layer(
+        hidden_states=x_pt,
+        input_ids=input_ids_pt,
+        attention_mask=pt_mask,
+        position_ids=pos_pt,
+        position_embeddings=pt_positions,
+    )
+
+    x_mt = jnp.array(x_np)
+    pos_mt = jnp.array(pos_np)
+    input_ids_mt = jnp.array(input_ids_np)
+    segs_mt = jnp.ones_like(pos_mt, dtype=jnp.int32)
+
+    mt_out, _ = mt_layer(
+        inputs=x_mt,
+        decoder_segment_ids=segs_mt,
+        decoder_positions=pos_mt,
+        deterministic=True,
+        model_mode="train",
+        decoder_input_tokens=input_ids_mt,
+    )
+
+    pt_out_tensor = pt_out[0] if isinstance(pt_out, tuple) else pt_out
+    pt_out_np = pt_out_tensor.detach().numpy()
+    mt_out_np = np.array(mt_out)
+    max_diff = np.max(np.abs(mt_out_np - pt_out_np))
+    mean_diff = np.mean(np.abs(mt_out_np - pt_out_np))
+    print(
+        f"LAYER PARITY layer_idx={layer_idx} layer_type={layer_type} - MAX ABS DIFF: {max_diff:.6e}, MEAN ABS DIFF: {mean_diff:.6e}"
+    )
+    np.testing.assert_allclose(mt_out_np, pt_out_np, rtol=5e-2, atol=5e-2)
+
+  def test_layer_0_sliding_hash(self):
+    self._run_layer_parity_test(0, "sliding_attention")
+
+  def test_layer_2_csa_hash(self):
+    self._run_layer_parity_test(2, "compressed_sparse_attention")
+
+  def test_layer_3_hca_standard(self):
+    self._run_layer_parity_test(3, "heavily_compressed_attention")
+
+  def test_layer_4_csa_standard(self):
+    self._run_layer_parity_test(4, "compressed_sparse_attention")
+
+
+class DeepSeekV4HyperHeadTest(unittest.TestCase):
+  """Tests to validate MaxText HyperHead implementation against PyTorch reference."""
+
+  def setUp(self):
+    self.batch_size = 2
+    self.seq_len = 16
+    self.hc_mult = 4
+    self.hidden_dim = 4096
+
+    self.config_pt = DeepseekV4Config(
+        hidden_size=self.hidden_dim,
+        hc_mult=self.hc_mult,
+        rms_norm_eps=1e-6,
+        hc_eps=1e-6,
+    )
+
+    # Initialize PyTorch module
+    torch.manual_seed(42)
+    self.pt_head = DeepseekV4HyperHead_PT(self.config_pt)
+    # Initialize weights with standard values
+    for p in self.pt_head.parameters():
+      torch.nn.init.normal_(p.data, mean=0.0, std=0.02)
+
+    # Create dummy mesh/rngs for MaxText
+    devices = mesh_utils.create_device_mesh((1,), devices=jax.local_devices()[:1])
+    self.mesh = Mesh(devices, ("x",))
+    self.rngs = nnx.Rngs(0)
+
+    # Build MaxText config dictionary
+    argv = ["", "src/maxtext/configs/base.yml", "model_name=deepseek4-tiny"]
+    config_arguments = {
+        "attention": "dot_product",
+        "dtype": "float32",
+        "weight_dtype": "float32",
+        "mhc_expansion_rate": self.hc_mult,
+        "emb_dim": self.hidden_dim,
+        "normalization_layer_epsilon": 1e-6,
+        "skip_jax_distributed_system": True,
+    }
+    self.mx_config = pyconfig.initialize(argv, **config_arguments)
+
+  def test_hyper_head_parity(self):
+    mt_head = DeepSeek4HyperHead(
+        config=self.mx_config,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+
+    # Map parameters from PyTorch to MaxText
+    mt_head.hc_fn.value = jnp.array(self.pt_head.hc_fn.detach().numpy().T)
+    mt_head.hc_base.value = jnp.array(self.pt_head.hc_base.detach().numpy())
+    mt_head.hc_scale.value = jnp.array(self.pt_head.hc_scale.detach().numpy())
+
+    # Inputs
+    np.random.seed(42)
+    x_np = np.random.uniform(0.1, 1.0, size=(self.batch_size, self.seq_len, self.hc_mult, self.hidden_dim)).astype(
+        np.float32
+    )
+
+    x_pt = torch.tensor(x_np)
+    pt_out = self.pt_head(x_pt).detach().numpy()
+
+    x_mt = jnp.array(x_np)
+    mt_out = np.array(mt_head(x_mt))
+
+    max_diff = np.max(np.abs(mt_out - pt_out))
+    mean_diff = np.mean(np.abs(mt_out - pt_out))
+    print(f"HYPER HEAD PARITY - MAX ABS DIFF: {max_diff:.6e}, MEAN ABS DIFF: {mean_diff:.6e}")
+    np.testing.assert_allclose(mt_out, pt_out, rtol=5e-5, atol=5e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR introduces necessary bug fixes to DeepSeek4 in the implementation and checkpoint mapping to pass a logit parity test against the HuggingFace implementation.

**Bug Fixes & Architectural Additions for DeepSeek4:**

* **HyperConnection (mHC) Head & Stability Fixes:** Added the `DeepSeek4HyperHead` module in `layers/mhc.py` and routed `DEEPSEEK4` decoder blocks to use it in `layers/decoders.py`. Also fixed the `sinkhorn` function by adding an epsilon (`1e-5`) for numerical stability during normalization and adjusting the loop iterations.
* **Compressed Attention Causal Mask Fix:** Fixed an issue in `layers/attention_compressed.py` where decoding with `seq_len == 1` or `compressed_len == 0` returned `None` for the causal mask. It now properly returns a tensor of zeros to prevent shape mismatch errors downstream.
* **MoE Block Routing:** Updated `layers/moe.py` to ensure `DEEPSEEK4` uses the appropriate top-K weight scaling and SwiGLU MLP activation bounds clipping, matching the DeepSeek standard.
* **Checkpoint Conversion Mapping:** Implemented HuggingFace parameter mapping and hook functions (`DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_MAPPING` and `DEEPSEEKV4_MAXTEXT_TO_HF_PARAM_HOOK_FN`) in `utils/param_mapping.py` to support correct weight loading/saving for the mHC and attention compressor blocks.
* **Configuration & Testing Updates:**
  * Added a new `deepseek4-tiny.yml` configuration for debugging.
  * Updated the `deepseek4-284b.yml` config with necessary routing biases, top-k probabilities, and RoPE positional embeddings.
  * Added comprehensive unit testing in `tests/unit/deepseek_v4_vs_reference_test.py`.


# Tests

* Added new reference tests via `tests/unit/deepseek_v4_vs_reference_test.py`. We test the conversion mapping for each unique layer type (sliding window + hash routing, CSA/Indexer + hash routing, HCA + topk routing, CSA/Indexer + topk routing) used to do checkpoint conversion as part of unit tests by generating reference logits from the pytorch implementation, converting weights to maxtext implementation, generating maxtext logits, and verifying parity of the logits.
* [509930698](https://b.corp.google.com/issues/509930698#comment18) This comment defines the relevant test scripts and test outputs we used to verify the bug fixes. We verified parity between the output of the reference HuggingFace implementation provided by DeepSeek against our own MaxText implementation.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).