### PR TITLE
[NNX] Checkpoint: persist rngs/dropout across resumes; policy for missing weights

### DIFF
--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -24,7 +24,6 @@ from etils import epath
 from flax import nnx
 from flax.training import train_state
 import jax
-import jax.numpy as jnp
 from maxtext.utils.globals import DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE
 from maxtext.input_pipeline.multihost_dataloading import MultiHostDataLoadIterator
 from maxtext.input_pipeline.multihost_dataloading import RemoteIteratorWrapper
@@ -170,48 +169,79 @@ class GrainCheckpointRestore(ocp.args.CheckpointArgs):
   process_count: Optional[int] = None
 
 
-def _default_for_sds(sds):
-  """Returns a deterministic value matching `sds` shape/dtype/sharding.
+def _weight_mismatches(want, have, path=()):
+  """Returns `(path, problem)` for each weight in `want` that `have` didn't restore faithfully.
 
-  Used to fill NNX-only state (rngs/dropout) that the Linen on-disk layout never
-  carried. Materializes under jit with the target out_shardings so it works on
-  multi-host meshes (device_put can't place a global sharding whose devices
-  aren't
-  all addressable from this process).
+  A weight is wrong if the checkpoint didn't carry it -- absent, or left by Orbax as an
+  unmaterialized ShapeDtypeStruct -- or carried it at a different shape. Only the shape can
+  disagree: Orbax casts a restored array to the target's dtype.
   """
-  if not (hasattr(sds, "dtype") and hasattr(sds, "shape")):
-    return sds
+  if isinstance(want, dict):
+    out = []
+    for k, v in want.items():
+      out.extend(_weight_mismatches(v, have.get(k) if isinstance(have, dict) else None, path + (k,)))
+    return out
+  name = "/".join(str(p) for p in path)
+  if have is None or isinstance(have, jax.ShapeDtypeStruct):
+    return [(name, f"missing (model expects {getattr(want, 'shape', '?')} {getattr(want, 'dtype', '?')})")]
+  want_shape, got_shape = getattr(want, "shape", None), getattr(have, "shape", None)
+  if want_shape is not None and got_shape is not None and tuple(want_shape) != tuple(got_shape):
+    return [(name, f"shape {tuple(got_shape)} but the model expects {tuple(want_shape)}")]
+  return []
 
-  def _make():
-    if "key" in str(sds.dtype):
-      base = jax.random.key(0)
-      return base if sds.shape == () else jax.random.split(base, int(np.prod(sds.shape))).reshape(sds.shape)
-    return jnp.zeros(sds.shape, dtype=sds.dtype)
 
-  sharding = getattr(sds, "sharding", None)
-  if sharding is None:
-    return _make()
-  return jax.jit(_make, out_shardings=sharding)()
+def _expected_and_restored_params(abstract_nnx_state, restored_linen):
+  """Returns the model's expected weights and the checkpoint's restored weights, as pure dicts.
 
-
-def _populate_pure_dict_from_partial(abstract_pure, partial_concrete):
-  """Fills `abstract_pure` with values from `partial_concrete` (by path), defaulting the rest.
-
-  Paths present in `partial_concrete` take the restored value; paths absent from
-  it
-  (NNX-only state the Linen checkpoint never had) get `_default_for_sds`.
+  Splits the abstract by Variable type (nnx.Param) so only real weights are compared --
+  rngs/dropout/batch stats live in `nnx_aux` and are restored separately.
   """
-  if isinstance(abstract_pure, dict):
-    return {
-        k: _populate_pure_dict_from_partial(
-            v,
-            partial_concrete.get(k) if isinstance(partial_concrete, dict) else None,
-        )
-        for k, v in abstract_pure.items()
-    }
-  if partial_concrete is not None and not isinstance(partial_concrete, dict):
-    return partial_concrete
-  return _default_for_sds(abstract_pure)
+  want = nnx.split_state(abstract_nnx_state, nnx.Param, ...)[0].to_pure_dict().get("model", {})
+  have = restored_linen.get("params", {}).get("params", {})
+  return want, have
+
+
+def _raise_on_weight_mismatch(want, have):
+  """Raises if the restored weights (`have`) don't match what the model expects (`want`).
+
+  Both are pure dicts, so this works for any structure. `partial_restore` returns a weight the
+  checkpoint doesn't carry as an unmaterialized ShapeDtypeStruct, and Orbax restores a stored
+  array at its own shape rather than the target's. Either way it reaches the model as an
+  untrained init value (a silent accuracy loss) or fails much later, deep in the first step,
+  without naming the weight.
+  """
+  problems = _weight_mismatches(want, have)
+  if not problems:
+    return
+  lines = "\n".join(f"  - '{p}': {why}" for p, why in problems)
+  raise ValueError(
+      "Checkpoint does not match the model:\n"
+      f"{lines}\n"
+      "Verify the checkpoint matches the model architecture (emb_dim, mlp_dim, num layers, scan_layers)."
+  )
+
+
+def _linen_items_to_nnx(restored_linen, abstract_nnx_state):
+  """Reshapes a restored Linen-layout `items` dict into an NNX state.
+
+  The inverse of `to_checkpoint_dict`, over the same `split_for_checkpoint` partition. The Linen
+  weights + optimizer fill `linen_state`; the `nnx_aux` state (rngs/dropout, batch stats, custom
+  variables) fills `aux`; the two are recombined with `nnx.merge_state`. The split copies, so the
+  caller's abstract is untouched. Leaves the checkpoint didn't carry -- including the caches it
+  never stores -- stay unmaterialized `ShapeDtypeStruct`s; the caller fills them from a fresh init.
+  """
+  linen_state, aux_state, ephemeral = train_state_nnx.split_for_checkpoint(abstract_nnx_state)
+  weights = train_state_nnx.from_linen_checkpoint_dict(restored_linen)
+  if "model" in weights:
+    nnx.replace_by_pure_dict(linen_state, {"model": weights["model"]})
+  if "optimizer" in weights:
+    nnx.replace_by_pure_dict(linen_state, {"optimizer": weights["optimizer"]})
+
+  nnx_aux = restored_linen.get("nnx_aux")
+  if nnx_aux:
+    nnx.replace_by_pure_dict(aux_state, nnx_aux)
+
+  return nnx.merge_state(linen_state, aux_state, ephemeral)
 
 
 def _load_linen_checkpoint_into_nnx(
@@ -223,12 +253,12 @@ def _load_linen_checkpoint_into_nnx(
 ):
   """Restores a Linen-layout checkpoint into an NNX state (pure_nnx resume).
 
-  Restores against a Linen-shape abstract, reshapes back via
-  `from_linen_checkpoint_dict`, then fills NNX-only rngs/dropout with defaults.
+  Restores a Linen-shape target that includes `nnx_aux`, then reshapes back via
+  `_linen_items_to_nnx`. rngs/dropout/batch stats come from `items/nnx_aux` when
+  present, else keep their fresh init value. A genuinely-missing weight raises.
   """
   max_logging.log(f"Restoring Linen-layout checkpoint into NNX state at {path}")
-  nnx_abstract_pure = abstract_nnx_state.to_pure_dict()
-  linen_abstract = train_state_nnx.to_linen_checkpoint_dict(nnx_abstract_pure)
+  linen_abstract = train_state_nnx.to_checkpoint_dict(abstract_nnx_state)
   ckptr = ocp.Checkpointer(
       ocp.PyTreeCheckpointHandler(
           restore_concurrent_gb=checkpoint_storage_concurrent_gb,
@@ -240,8 +270,8 @@ def _load_linen_checkpoint_into_nnx(
   restore_args = ocp.checkpoint_utils.construct_restore_args(linen_abstract)
   restored = ocp.args.PyTreeRestore(item=linen_abstract, restore_args=restore_args, partial_restore=True)
   restored = ckptr.restore(epath.Path(path), args=restored)
-  partial_nnx = train_state_nnx.from_linen_checkpoint_dict(restored)
-  return _populate_pure_dict_from_partial(nnx_abstract_pure, partial_nnx)
+  _raise_on_weight_mismatch(*_expected_and_restored_params(abstract_nnx_state, restored))
+  return _linen_items_to_nnx(restored, abstract_nnx_state)
 
 
 def _restore_emergency_linen_checkpoint_into_nnx(
@@ -250,10 +280,14 @@ def _restore_emergency_linen_checkpoint_into_nnx(
     abstract_nnx_state,
     map_to_pspec,
 ):
-  """Restores an emergency Linen-layout checkpoint into an NNX state."""
+  """Restores an emergency Linen-layout checkpoint into an NNX state.
+
+  The `nnx_aux` subtree is stored inside `items`, so an emergency checkpoint
+  carries it too; it's restored when present and otherwise kept at its fresh
+  init value. A genuinely-missing weight raises.
+  """
   max_logging.log(f"Restoring emergency Linen-layout checkpoint into NNX state at step {step}")
-  nnx_abstract_pure = abstract_nnx_state.to_pure_dict()
-  linen_abstract = train_state_nnx.to_linen_checkpoint_dict(nnx_abstract_pure)
+  linen_abstract = train_state_nnx.to_checkpoint_dict(abstract_nnx_state)
   restore_args = jax.tree_util.tree_map(map_to_pspec, linen_abstract)
   checkpoint_args = ocp.args.PyTreeRestore(
       item=linen_abstract,
@@ -261,52 +295,8 @@ def _restore_emergency_linen_checkpoint_into_nnx(
       partial_restore=True,
   )
   restored = checkpoint_manager.restore(step, args=Composite(state=checkpoint_args)).state
-  partial_nnx = train_state_nnx.from_linen_checkpoint_dict(restored)
-  return _populate_pure_dict_from_partial(nnx_abstract_pure, partial_nnx)
-
-
-def _rebuild_nnx_with_values(abstract_nnx_state, concrete_weights):
-  """Fills each Variable in `abstract_nnx_state` with the matching restored array."""
-  leaves, treedef = jax.tree_util.tree_flatten(abstract_nnx_state, is_leaf=lambda x: isinstance(x, nnx.Variable))
-  concrete = jax.tree_util.tree_leaves(concrete_weights)
-  if len(leaves) != len(concrete):
-    raise ValueError(
-        f"Params load leaf-count mismatch: {len(leaves)} abstract Variables vs" f" {len(concrete)} restored."
-    )
-  new_leaves = [v.replace(value=a) if isinstance(v, nnx.Variable) else a for v, a in zip(leaves, concrete)]
-  return jax.tree_util.tree_unflatten(treedef, new_leaves)
-
-
-def _load_linen_params_into_nnx(
-    path,
-    nnx_params_abstract,
-    checkpoint_storage_concurrent_gb,
-    use_ocdbt,
-    use_zarr3,
-):
-  """Weight-only load of a Linen-layout checkpoint into an NNX params state.
-
-  Reuses `to_linen_checkpoint_dict` (wrapping the params under `model`) to build
-  the
-  `params/params/...` restore target, then rebinds the restored weights into the
-  NNX params Variables.
-  """
-  max_logging.log(f"Restoring Linen-layout params into NNX state at {path}")
-  linen_abstract = train_state_nnx.to_linen_checkpoint_dict({"model": nnx_params_abstract.to_pure_dict()})
-  ckptr = ocp.Checkpointer(
-      ocp.PyTreeCheckpointHandler(
-          restore_concurrent_gb=checkpoint_storage_concurrent_gb,
-          save_concurrent_gb=checkpoint_storage_concurrent_gb,
-          use_ocdbt=use_ocdbt,
-          use_zarr3=use_zarr3,
-      )
-  )
-  restore_args = ocp.checkpoint_utils.construct_restore_args(linen_abstract)
-  restored = ckptr.restore(
-      epath.Path(path),
-      args=ocp.args.PyTreeRestore(item=linen_abstract, restore_args=restore_args, partial_restore=True),
-  )
-  return _rebuild_nnx_with_values(nnx_params_abstract, restored["params"]["params"])
+  _raise_on_weight_mismatch(*_expected_and_restored_params(abstract_nnx_state, restored))
+  return _linen_items_to_nnx(restored, abstract_nnx_state)
 
 
 def _load_full_state_from_path(
@@ -340,6 +330,11 @@ def _load_full_state_from_path(
 
   if enable_orbax_v1:
     if source_checkpoint_layout == "orbax":
+      # pure_nnx saves in the Linen on-disk layout; reshape it back into the NNX state.
+      if isinstance(abstract_unboxed_pre_state, nnx.State):
+        return _load_linen_checkpoint_into_nnx(
+            path, abstract_unboxed_pre_state, checkpoint_storage_concurrent_gb, use_ocdbt, use_zarr3
+        )
       context = ocp_v1.Context(checkpoint_layout=ocp_v1.options.CheckpointLayout.ORBAX)
       with context:
         return ocp_v1.load_pytree(path, abstract_unboxed_pre_state)
@@ -378,11 +373,8 @@ def _load_full_state_from_path(
         use_ocdbt=use_ocdbt,
         use_zarr3=use_zarr3,
     )
-    # NNX checkpoints are saved as pure dicts (see maybe_save_checkpoint); the
-    # restore target must match — a boxed nnx.State wouldn't.
+    # Only Linen TrainState reaches here; nnx.State returned above.
     restore_target = abstract_unboxed_pre_state
-    if isinstance(abstract_unboxed_pre_state, nnx.State):
-      restore_target = abstract_unboxed_pre_state.to_pure_dict()
     # Provide sharding info to ensure restoration returns JAX arrays (not NumPy arrays).
     restore_args = jax.tree_util.tree_map(
         lambda x: ocp.type_handlers.ArrayRestoreArgs(sharding=x.sharding),
@@ -792,27 +784,36 @@ def load_state_if_possible(
         )
         ocp.type_handlers.register_type_handler(jax.Array, array_handler, override=True)
 
-      # pure_nnx saves in the Linen on-disk layout; reshape it back into the NNX state.
+      # pure_nnx saves in the Linen on-disk layout; restore that layout (weights +
+      # opt_state + step + nnx_aux), restoring the grain iterator in place when
+      # present, then reshape it back into the NNX state.
       # (Emergency managers use their own restore path below.)
       if isinstance(abstract_unboxed_pre_state, nnx.State) and not isinstance(
           checkpoint_manager,
           (EmergencyCheckpointManager, EmergencyReplicatorCheckpointManager),
       ):
-        checkpoint_path = str(checkpoint_manager.directory / str(step) / "items")
-        restored_nnx = _load_linen_checkpoint_into_nnx(
-            checkpoint_path,
-            abstract_unboxed_pre_state,
-            checkpoint_storage_concurrent_gb,
-            use_ocdbt,
-            use_zarr3,
-        )
+        linen_abstract = train_state_nnx.to_checkpoint_dict(abstract_unboxed_pre_state)
+        restore_args = jax.tree_util.tree_map(map_to_pspec, linen_abstract)
+        checkpoint_args = ocp.args.PyTreeRestore(item=linen_abstract, restore_args=restore_args, partial_restore=True)
+        if (
+            dataset_type == "grain"
+            and data_iterator
+            and not isinstance(data_iterator, PlaceHolderDataIterator)
+            and (checkpoint_manager.directory / str(step) / "iter").exists()
+        ):
+          restored, _ = _restore_grain_iterator(
+              checkpoint_manager, step, data_iterator, checkpoint_args, expansion_factor_real_data
+          )
+        else:
+          restored = checkpoint_manager.restore(step, args=Composite(items=checkpoint_args))
+        _raise_on_weight_mismatch(*_expected_and_restored_params(abstract_unboxed_pre_state, restored["items"]))
+        restored_nnx = _linen_items_to_nnx(restored["items"], abstract_unboxed_pre_state)
         return ({"items": restored_nnx}, None)
 
       if isinstance(abstract_unboxed_pre_state, nnx.State) and isinstance(
           checkpoint_manager,
           (EmergencyCheckpointManager, EmergencyReplicatorCheckpointManager),
       ):
-        checkpoint_path = str(checkpoint_manager.directory / str(step))
         restored = _restore_emergency_linen_checkpoint_into_nnx(
             checkpoint_manager,
             step,
@@ -824,11 +825,8 @@ def load_state_if_possible(
             None,
         )
 
-      # Convert nnx.State to pure dict to match how checkpoints are saved for NNX
+      # Only Linen TrainState reaches here; the NNX cases returned above.
       restore_target = abstract_unboxed_pre_state
-      if isinstance(abstract_unboxed_pre_state, nnx.State):
-        restore_target = abstract_unboxed_pre_state.to_pure_dict()
-
       restore_args = jax.tree_util.tree_map(map_to_pspec, restore_target)
       checkpoint_args = ocp.args.PyTreeRestore(
           item=restore_target,
@@ -836,7 +834,6 @@ def load_state_if_possible(
           partial_restore=True,
       )
 
-      checkpoint_path = str(checkpoint_manager.directory / str(step))
       match (checkpoint_manager, dataset_type, data_iterator):
         # Case 1: Matches if 'checkpoint_manager' is an instance of either EmergencyCheckpointManager
         # or EmergencyReplicatorCheckpointManager. The '_' indicates that 'dataset_type' and
@@ -945,16 +942,12 @@ def load_params_from_path(
   assert load_parameters_from_path, "load_parameters_from_path is not defined."
   max_logging.log(f"restoring params from {load_parameters_from_path}")
 
-  # NNX target: the on-disk checkpoint is in Linen layout; reshape it into the
-  # NNX params state.
-  if isinstance(abstract_unboxed_params, nnx.State):
-    return _load_linen_params_into_nnx(
-        load_parameters_from_path,
-        abstract_unboxed_params,
-        checkpoint_storage_concurrent_gb,
-        use_ocdbt,
-        use_zarr3,
-    )
+  # On disk the weights live at `params/params/...`: an outer key naming the item, and Flax's
+  # `params` collection inside it. A Linen TrainState.params is that collection; an NNX params
+  # state sits one level below it (bare weights), so wrap it going in and unwrap it coming out.
+  is_nnx = isinstance(abstract_unboxed_params, nnx.State)
+  want = abstract_unboxed_params.to_pure_dict() if is_nnx else abstract_unboxed_params
+  params_collection = {"params": want} if is_nnx else want
 
   # *_concurrent_gb should be set for large models, the default is 96.
   max_logging.log(f"Creating checkpoint manager with ocdbt={use_ocdbt} and zarr3={use_zarr3}")
@@ -971,14 +964,23 @@ def load_params_from_path(
   # Rather than pass the entire abstract state, which could unnecessarily restore opt_state and such and waste
   # memory, we instead specify here that we are just restoring the params field of the checkpoint
   # (which itself may be a dictionary containing a key named 'params').
-  restore_args = ocp.checkpoint_utils.construct_restore_args(abstract_unboxed_params)
+  restore_args = ocp.checkpoint_utils.construct_restore_args(params_collection)
   restored = ckptr.restore(
       epath.Path(load_parameters_from_path),
-      item={"params": abstract_unboxed_params},
+      item={"params": params_collection},
       transforms={},
       restore_args={"params": restore_args},
   )
-  return restored["params"]
+  restored_collection = restored["params"]
+  # `transforms={}` lets Orbax return an unmaterialized leaf for a weight the checkpoint lacks,
+  # and a stored array at its own shape rather than the target's. Either reaches the model and
+  # fails much later without naming the weight, so check here -- the params-only load
+  # (load_parameters_path, e.g. SFT) has no init state to fall back on.
+  _raise_on_weight_mismatch(want, restored_collection["params"] if is_nnx else restored_collection)
+  if is_nnx:
+    nnx.replace_by_pure_dict(abstract_unboxed_params, restored_collection["params"])
+    return abstract_unboxed_params
+  return restored_collection
 
 
 def save_params_to_path(checkpoint_dir, params, use_ocdbt=True, use_zarr3=True):
@@ -1078,7 +1080,9 @@ def maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator, step
       step_value = state.step.get_value() if hasattr(state.step, "get_value") else state.step
       state = train_state_nnx.to_linen_checkpoint_dict({"model": state.params, "optimizer": {"step": step_value}})
     else:
-      state = train_state_nnx.to_linen_checkpoint_dict(state.to_pure_dict())
+      # rngs/dropout/batch-stats are packed under items/nnx_aux so the RNG/dropout
+      # stream continues across resumes instead of resetting to a base key.
+      state = train_state_nnx.to_checkpoint_dict(state)
 
   try:
     checkpoint_saved = save_checkpoint(checkpoint_manager, actual_step, state, config, data_iterator, force_ckpt_save)

--- a/src/maxtext/common/train_state_nnx.py
+++ b/src/maxtext/common/train_state_nnx.py
@@ -59,14 +59,16 @@ class TrainStateNNX(nnx.Module):
 # On-disk checkpoint format.
 #
 # A pure_nnx run saves in the same on-disk layout as a Linen run, so the two are
-# interchangeable. The NNX state pure dict differs from Linen's in three ways,
-# all
+# interchangeable. The NNX state pure dict differs from Linen's in three ways, all
 # reshaped below at save time:
 #   1. top-level keys: {model, optimizer:{step, opt_state}} -> {params:{params:...}, step, opt_state}
 #   2. weights: model/... -> params/params/... (Linen `params` collection)
 #   3. opt_state: int-keyed dict (empty entries skipped) -> list with None for EmptyState,
 #      and mu/nu wrapped under the `params` collection
-# NNX-only rngs/dropout state is dropped (Linen never had it).
+# Persistent NNX state Linen's params/opt_state/step layout can't hold -- rngs/dropout,
+# batch stats, and any custom non-Param variable -- is split out by Variable type and stored
+# under an `nnx_aux` subtree of `items` (see `to_checkpoint_dict`), so it survives a resume
+# instead of resetting.
 
 _NNX_RNG_STATE_KEYS = ("rngs", "dropout")
 
@@ -119,11 +121,10 @@ def _as_chain_index(key):
 
 
 def _opt_state_to_linen(opt_state):
-  """Reshapes the NNX optax-chain opt_state to Linen's list-with-None layout.
+  """Reshapes the NNX opt_state to Linen's on-disk layout.
 
-  NNX serializes the chain as an int-keyed dict, skipping empty entries; Linen
-  uses a list with `None` for each `EmptyState`. A single-element chain is
-  returned unwrapped to match Linen's un-chained optimizers (e.g. adam_pax).
+  A chain (optax.adamw) is an int-keyed dict -> list-with-None. An un-chained
+  optimizer (adam_pax) is flat (count/mu/nu) and stays a dict.
   """
   if not isinstance(opt_state, dict):
     return opt_state
@@ -133,7 +134,7 @@ def _opt_state_to_linen(opt_state):
   chain = [None] * (max(indices) + 1)
   for key, idx in zip(opt_state.keys(), indices):
     chain[idx] = _wrap_mu_nu_with_params(opt_state[key])
-  return chain[0] if len(chain) == 1 else chain
+  return chain
 
 
 def to_linen_checkpoint_dict(nnx_pure_dict):
@@ -163,12 +164,17 @@ def _strip_mu_nu_params(state):
 
 
 def _opt_state_from_linen(opt_state):
-  """Inverse of `_opt_state_to_linen`: Linen list-with-None -> NNX int-keyed dict."""
+  """Inverse of `_opt_state_to_linen`: Linen layout -> NNX opt_state.
+
+  A chain (optax.adamw) is a list -> int-keyed dict. An un-chained state (adam_pax:
+  `{count, mu, nu}`) stays flat -- re-wrapping it under a `0` index would not line
+  up with the model's opt_state.
+  """
   if isinstance(opt_state, list):
     return {i: _strip_mu_nu_params(e) for i, e in enumerate(opt_state) if isinstance(e, dict)}
   if not isinstance(opt_state, dict):
     return opt_state
-  return {0: _strip_mu_nu_params(opt_state)}
+  return _strip_mu_nu_params(opt_state)
 
 
 def from_linen_checkpoint_dict(linen_pure_dict):
@@ -193,3 +199,47 @@ def from_linen_checkpoint_dict(linen_pure_dict):
   if optimizer:
     result["optimizer"] = optimizer
   return result
+
+
+def split_for_checkpoint(state: nnx.State):
+  """Partitions an nnx.State by its on-disk destination.
+
+  Named by on-disk destination. Returns `(linen_state, aux, ephemeral)`:
+    linen_state: trainable weights (nnx.Param) and the optimizer -> Linen params/opt_state/step.
+      Its model side is pure nnx.Param, so it maps to the Linen `params` collection cleanly.
+    aux:         rngs/dropout, batch stats, and any other persistent model variable (e.g. a
+      frozen routing table) -> nnx_aux.
+    ephemeral:   caches and intermediates, which are recomputed and so are not checkpointed.
+
+  The type-based catch-all `rest` mixes the optimizer (under "optimizer") with any custom
+  persistent variable (under "model"); they route to different places, so they're split apart
+  here. Grouping by the ephemeral types rather than whitelisting nnx.Param means a new Variable
+  subclass persists (via `aux`) instead of being silently dropped. Save and restore must
+  partition identically, so both go through here.
+  """
+  params, rng_state, batch_stats, caches, intermediates, rest = nnx.split_state(
+      state, nnx.Param, nnx.RngState, nnx.BatchStat, nnx.Cache, nnx.Intermediate, ...
+  )
+  optimizer = nnx.State({"optimizer": rest["optimizer"]}) if "optimizer" in rest else nnx.State({})
+  custom = nnx.State({"model": rest["model"]}) if "model" in rest else nnx.State({})
+  linen_state = nnx.merge_state(params, optimizer)
+  aux = nnx.merge_state(rng_state, batch_stats, custom)
+  ephemeral = nnx.merge_state(caches, intermediates)
+  return linen_state, aux, ephemeral
+
+
+def to_checkpoint_dict(state: nnx.State):
+  """Reshapes an nnx.State into the on-disk checkpoint layout.
+
+  Weights (nnx.Param) map to the Linen `params` collection and the optimizer to
+  opt_state/step, so pure_nnx and Linen checkpoints stay interchangeable. Everything else that
+  must persist -- rngs/dropout, batch stats, and any custom variable -- goes under an `nnx_aux`
+  subtree. Works on a concrete state (save) or an abstract state (restore target).
+  """
+  linen_state, aux_state, _ = split_for_checkpoint(state)
+  pure = linen_state.to_pure_dict()
+  linen_dict = to_linen_checkpoint_dict({"model": pure.get("model", {}), "optimizer": pure.get("optimizer", {})})
+  aux = aux_state.to_pure_dict()
+  if aux:
+    linen_dict["nnx_aux"] = aux
+  return linen_dict

--- a/src/maxtext/utils/maxtext_utils.py
+++ b/src/maxtext/utils/maxtext_utils.py
@@ -1501,32 +1501,54 @@ def setup_initial_state(
     # Partial or fully restored
     was_restored = bool(restored is not None or raw_params is not None)
 
-    if restored:
-      if isinstance(
-          checkpoint_manager,
-          (
-              emergency_checkpoint_manager.CheckpointManager,
-              emergency_replicator_checkpoint_manager.ReplicatorCheckpointManager,
-          ),
-      ):
-        state = restored
-      else:
-        # The update of data_iterator state happens in place, no need to assign explicitly
-        state = restored["items"]
+    init_state_partial = init_state_fn
+    init_state_partial.__name__ = "initialize_state"
 
-      # For NNX, convert the pure dict to nnx.State using the abstract state as template
-      if config.pure_nnx:
-        nnx.replace_by_pure_dict(unboxed_abstract_state, state)
-        state = unboxed_abstract_state
+    if config.pure_nnx:
+      # Always build the concrete init state, then overlay whatever we loaded. Anything the
+      # checkpoint didn't carry (or a params-only load didn't touch) keeps its real init
+      # value, so restore doesn't depend on knowing exactly what was saved.
+      state = jax.jit(
+          lambda: nnx.state(init_state_partial()),  # Get state only, mapping to out_sharding structure
+          in_shardings=None,
+          out_shardings=state_mesh_shardings,
+      )()
+      if restored:
+        is_emergency = isinstance(
+            checkpoint_manager,
+            (
+                emergency_checkpoint_manager.CheckpointManager,
+                emergency_replicator_checkpoint_manager.ReplicatorCheckpointManager,
+            ),
+        )
+        # data_iterator state is updated in place during restore.
+        # The restore already overlaid the checkpoint onto a copy of the abstract, so a leaf it
+        # didn't carry is still an unmaterialized placeholder. Fill those from the fresh init: a
+        # present leaf comes from the checkpoint, an absent one keeps its init value.
+        overlay = restored if is_emergency else restored["items"]
+        merged = jax.tree.map(
+            lambda ckpt, init: init if isinstance(ckpt, jax.ShapeDtypeStruct) else ckpt,
+            overlay.to_pure_dict(),
+            state.to_pure_dict(),
+            is_leaf=lambda x: isinstance(x, jax.ShapeDtypeStruct),
+        )
+        nnx.replace_by_pure_dict(state, merged)
+      elif raw_params:
+        # params-only load: overlay the restored weights, keep init for everything else.
+        nnx.update(state.model, raw_params)
     else:
-      init_state_partial = init_state_fn
-      init_state_partial.__name__ = "initialize_state"
-      if config.pure_nnx:
-        state = jax.jit(
-            lambda: nnx.state(init_state_partial()),  # Get state only, mapping to out_sharding structure
-            in_shardings=None,
-            out_shardings=state_mesh_shardings,
-        )()
+      if restored:
+        if isinstance(
+            checkpoint_manager,
+            (
+                emergency_checkpoint_manager.CheckpointManager,
+                emergency_replicator_checkpoint_manager.ReplicatorCheckpointManager,
+            ),
+        ):
+          state = restored
+        else:
+          # The update of data_iterator state happens in place, no need to assign explicitly
+          state = restored["items"]
       else:
         # pylint: disable=not-callable
         state = jax.jit(
@@ -1534,11 +1556,7 @@ def setup_initial_state(
             in_shardings=None,
             out_shardings=state_mesh_shardings,
         )()
-      if raw_params:  # If we loaded a partial state, we need to merge it.
-        if config.pure_nnx:
-          # raw_params should have the same sharding info as in the model
-          nnx.update(state.model, raw_params)
-        else:
+        if raw_params:  # If we loaded a partial state, we need to merge it.
           sparsity_enabled = config.weight_sparsity_n and config.weight_sparsity_m
           if sparsity_enabled:
             # Sparsity-init keeps freshly initialized params for any leaf still

--- a/tests/unit/checkpointing_nnx_load_test.py
+++ b/tests/unit/checkpointing_nnx_load_test.py
@@ -36,65 +36,71 @@ class _Model(nnx.Module):
     self.linear = nnx.Linear(2, 1, rngs=rngs)
 
 
+class _ModelDropout(nnx.Module):
+  """Linear + dropout, so the state carries rngs that split out into nnx_aux."""
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 1, rngs=rngs)
+    self.dropout = nnx.Dropout(rate=0.5, rngs=rngs)
+
+  def __call__(self, x, deterministic=False):
+    return self.dropout(self.linear(x), deterministic=deterministic)
+
+
 def _abstract_nnx_state():
   """Build an nnx.State from a TrainStateNNX — same shape that pre_train passes in."""
   model = _Model(rngs=nnx.Rngs(0))
-  optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+  optimizer = nnx.Optimizer(model, optax.scale_by_adam(), wrt=nnx.Param)
   return nnx.state(train_state_nnx.TrainStateNNX(model, optimizer))
+
+
+def _dropout_state(seed):
+  """A concrete TrainStateNNX state for `_ModelDropout` with its dropout stream advanced."""
+  model = _ModelDropout(nnx.Rngs(seed))
+  state = train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, optax.scale_by_adam(), wrt=nnx.Param))
+  grads = nnx.grad(lambda m: jnp.mean(m(jnp.ones((4, 2)), deterministic=False) ** 2))(state.model)
+  state.apply_gradients(grads)  # advances step + dropout rng count off the base 0
+  return nnx.state(state)
+
+
+def _abstract_dropout_state():
+  def make():
+    model = _ModelDropout(nnx.Rngs(9))
+    return nnx.state(train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, optax.scale_by_adam(), wrt=nnx.Param)))
+
+  return nnx.eval_shape(make)
 
 
 class TestLoadStateIfPossibleNNX(unittest.TestCase):
   """Cover the NNX branches in load_state_if_possible."""
 
-  def test_emergency_linen_restore_converts_back_to_nnx(self):
-    kernel_abstract = jax.ShapeDtypeStruct((2, 1), jnp.float32)
-    step_abstract = jax.ShapeDtypeStruct((), jnp.uint32)
-    abstract_nnx_pure = {
-        "model": {
-            "linear": {"kernel": kernel_abstract},
-            "dropout": {"rngs": {"params": {"count": step_abstract}}},
-        },
-        "optimizer": {"step": step_abstract},
-    }
-    abstract_nnx_state = mock.Mock()
-    abstract_nnx_state.to_pure_dict.return_value = abstract_nnx_pure
-    restored_linen = {
-        "params": {"params": {"linear": {"kernel": jnp.ones((2, 1))}}},
-        "step": jnp.asarray(7, dtype=jnp.int32),
-    }
-    checkpoint_manager = mock.Mock()
-    checkpoint_manager.restore.return_value = mock.Mock(state=restored_linen)
+  def test_emergency_restore_recovers_nnx_aux(self):
+    """Emergency restore reshapes back to NNX and recovers rngs/dropout from items/nnx_aux."""
+    concrete = _dropout_state(0)
+    orig_count = int(concrete.to_pure_dict()["model"]["dropout"]["rngs"]["count"])
+    self.assertGreater(orig_count, 0)
+    # The single state tree an emergency manager writes (weights + opt_state + step + nnx_aux).
+    saved_linen = train_state_nnx.to_checkpoint_dict(concrete)
+    self.assertIn("nnx_aux", saved_linen)
 
+    checkpoint_manager = mock.Mock()
+    checkpoint_manager.restore.return_value = mock.Mock(state=saved_linen)
     restored = checkpointing._restore_emergency_linen_checkpoint_into_nnx(  # pylint: disable=protected-access
         checkpoint_manager,
         14,
-        abstract_nnx_state,
-        lambda leaf: ocp.type_handlers.ArrayRestoreArgs(
-            global_shape=leaf.shape,
-            dtype=leaf.dtype,
-        ),
+        _abstract_dropout_state(),
+        lambda leaf: ocp.type_handlers.ArrayRestoreArgs(global_shape=leaf.shape, dtype=leaf.dtype),
     )
+    restored = restored.to_pure_dict()
 
-    checkpoint_manager.restore.assert_called_once()
-    restore_args = checkpoint_manager.restore.call_args.kwargs["args"].state
-    self.assertEqual(
-        set(restore_args.item.keys()),
-        {"params", "step"},
-    )
-    self.assertNotIn("model", restore_args.item)
-    self.assertNotIn("optimizer", restore_args.item)
-    self.assertTrue(restore_args.partial_restore)
+    # The restore target the manager was handed carries nnx_aux, so emergency checkpoints persist it.
+    restore_target = checkpoint_manager.restore.call_args.kwargs["args"].state.item
+    self.assertIn("nnx_aux", restore_target)
+    # Reshaped back to NNX, with the dropout stream recovered (not reset to 0).
     self.assertIn("model", restored)
     self.assertIn("optimizer", restored)
     self.assertNotIn("params", restored)
-    self.assertNotIn("opt_state", restored)
-    self.assertTrue(bool(jnp.array_equal(restored["model"]["linear"]["kernel"], jnp.ones((2, 1)))))
-    self.assertEqual(restored["optimizer"]["step"].dtype, jnp.uint32)
-    self.assertEqual(int(restored["optimizer"]["step"]), 7)
-    self.assertEqual(
-        restored["model"]["dropout"]["rngs"]["params"]["count"].shape,
-        (),
-    )
+    self.assertEqual(int(restored["model"]["dropout"]["rngs"]["count"]), orig_count)
 
   def test_load_parameters_from_path_splits_nnx_state_for_param_view(self):
     """When abstract_unboxed_pre_state is an nnx.State, the function must call
@@ -183,6 +189,268 @@ class TestLoadParamsIntoNNX(unittest.TestCase):
     pure = restored.to_pure_dict()
     self.assertTrue(jnp.array_equal(pure["linear"]["kernel"], weights["linear"]["kernel"]))
     self.assertTrue(jnp.array_equal(pure["linear"]["bias"], weights["linear"]["bias"]))
+
+  def test_linen_params_dict_restores_as_the_params_collection(self):
+    """The same function serves Linen: a TrainState.params dict is already the `params` collection.
+
+    Guards the non-NNX half of `load_params_from_path`, which returns the collection dict as-is
+    rather than writing values back into Variables.
+    """
+    weights = {"linear": {"kernel": jnp.arange(2, dtype=jnp.float32).reshape(2, 1), "bias": jnp.array([5.0])}}
+    linen_params = jax.tree.map(jnp.zeros_like, {"params": weights})  # the shape TrainState.params has
+
+    with tempfile.TemporaryDirectory() as d:  # pylint: disable=consider-using-with
+      path = os.path.join(d, "ckpt")
+      ocp.PyTreeCheckpointer(use_ocdbt=True, use_zarr3=True).save(
+          epath.Path(path),
+          {"params": {"params": weights}, "step": jnp.array(3)},
+          force=True,
+      )
+      restored = checkpointing.load_params_from_path(path, linen_params, 8)
+
+    self.assertNotIsInstance(restored, nnx.State)
+    self.assertEqual(set(restored.keys()), {"params"})  # the collection, not the bare weights
+    self.assertTrue(jnp.array_equal(restored["params"]["linear"]["kernel"], weights["linear"]["kernel"]))
+    self.assertTrue(jnp.array_equal(restored["params"]["linear"]["bias"], weights["linear"]["bias"]))
+
+
+class TestToCheckpointDict(unittest.TestCase):
+  """train_state_nnx.to_checkpoint_dict splits the NNX state by Variable type."""
+
+  def test_splits_params_optimizer_and_nnx_aux(self):
+    model = _ModelDropout(nnx.Rngs(0))
+    state = nnx.state(train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, optax.scale_by_adam(), wrt=nnx.Param)))
+    ckpt = train_state_nnx.to_checkpoint_dict(state)
+    # Learnable weights land in the Linen params collection; optimizer + step alongside.
+    self.assertEqual(set(ckpt["params"]["params"].keys()), {"linear"})
+    self.assertIn("opt_state", ckpt)
+    self.assertIn("step", ckpt)
+    # rngs/dropout land in nnx_aux, not in params.
+    self.assertIn("dropout", ckpt["nnx_aux"]["model"])
+    self.assertNotIn("dropout", ckpt["params"]["params"])
+
+  def test_custom_variable_is_persisted(self):
+    """A custom nnx.Variable (e.g. a frozen routing table) is checkpointed, not silently dropped.
+
+    It goes under `nnx_aux` (with rngs/batch stats), not the Linen `params` collection, which
+    stays pure nnx.Param. Regression guard: the split used to route it into the un-checkpointed
+    group, so it reverted to its init value on resume with no warning -- the missing-weight check
+    only inspects nnx.Param.
+    """
+
+    class _Table(nnx.Variable):
+      pass
+
+    class _WithTable(nnx.Module):
+
+      def __init__(self, rngs):
+        self.linear = nnx.Linear(2, 1, rngs=rngs)
+        self.table = _Table(jnp.arange(6, dtype=jnp.float32).reshape(3, 2))
+        self.cache = nnx.Cache(jnp.zeros((2,)))
+
+    model = _WithTable(nnx.Rngs(0))
+    state = nnx.state(train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, optax.scale_by_adam(), wrt=nnx.Param)))
+    ckpt = train_state_nnx.to_checkpoint_dict(state)
+    self.assertEqual(set(ckpt["params"]["params"].keys()), {"linear"})  # params/params stays pure Param
+    self.assertIn("table", ckpt["nnx_aux"]["model"])  # the custom variable persists here instead
+    self.assertNotIn("cache", ckpt["nnx_aux"]["model"])  # caches are recomputed, never stored
+
+    restored = checkpointing._linen_items_to_nnx(ckpt, nnx.eval_shape(lambda: state))  # pylint: disable=protected-access
+    pure = restored.to_pure_dict()
+    self.assertTrue(jnp.array_equal(pure["model"]["table"], model.table.value))
+    self.assertIsInstance(pure["model"]["cache"], jax.ShapeDtypeStruct)  # left for the init to fill
+
+  def test_batch_stats_split_out_from_weights(self):
+    """BatchNorm scale/bias are weights; its running mean/var are batch stats -> nnx_aux."""
+
+    class _BN(nnx.Module):
+
+      def __init__(self, rngs):
+        self.bn = nnx.BatchNorm(2, rngs=rngs)
+
+    state = nnx.state(train_state_nnx.TrainStateNNX(_BN(nnx.Rngs(0)), None))
+    ckpt = train_state_nnx.to_checkpoint_dict(state)
+    self.assertEqual(set(ckpt["params"]["params"]["bn"].keys()), {"scale", "bias"})
+    self.assertEqual(set(ckpt["nnx_aux"]["model"]["bn"].keys()), {"mean", "var"})
+
+  def test_flat_opt_state_round_trips_without_chain_wrapper(self):
+    """A flat (un-chained) opt_state survives to_linen -> from_linen unchanged.
+
+    Regression guard: from_linen used to re-wrap a flat opt_state under a `0` chain index,
+    which then failed to overlay onto the model's flat opt_state on resume.
+    """
+    model = _Model(nnx.Rngs(0))
+    pure = nnx.state(
+        train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, optax.scale_by_adam(), wrt=nnx.Param))
+    ).to_pure_dict()
+    linen = train_state_nnx.to_linen_checkpoint_dict(pure)
+    back = train_state_nnx.from_linen_checkpoint_dict(linen)
+    self.assertEqual(set(back["optimizer"]["opt_state"].keys()), set(pure["optimizer"]["opt_state"].keys()))
+    self.assertIn("count", back["optimizer"]["opt_state"])  # flat, not nested under a `0` index
+
+  def test_chained_opt_state_restores_onto_model(self):
+    """A chained optimizer's opt_state must round-trip back onto the state.
+
+    Regression guard: to_linen used to flatten a single-entry chain `{0: ...}`, so the overlay
+    didn't line up with the model's int-keyed opt_state and the restore raised. A scalar lr gives
+    that shape; MaxText passes a schedule, whose state sits at a higher index, so it never did.
+    """
+
+    def make():
+      model = _Model(nnx.Rngs(0))
+      return nnx.state(train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, optax.adamw(1e-3), wrt=nnx.Param)))
+
+    saved = make()
+    self.assertIn(0, saved.to_pure_dict()["optimizer"]["opt_state"])  # chained -> int-keyed, not flat
+    overlay = train_state_nnx.from_linen_checkpoint_dict(train_state_nnx.to_checkpoint_dict(saved))
+    nnx.replace_by_pure_dict(make(), overlay)  # raised before the fix
+
+  def test_cache_and_intermediates_excluded(self):
+    """Non-weight model variables (caches/intermediates) are not checkpointed."""
+
+    class _Cached(nnx.Module):
+
+      def __init__(self, rngs):
+        self.linear = nnx.Linear(2, 1, rngs=rngs)
+        self.cache = nnx.Cache(jnp.zeros((2,)))
+
+    state = nnx.state(train_state_nnx.TrainStateNNX(_Cached(nnx.Rngs(0)), None))
+    ckpt = train_state_nnx.to_checkpoint_dict(state)
+    self.assertEqual(set(ckpt["params"]["params"].keys()), {"linear"})  # cache dropped
+    self.assertNotIn("nnx_aux", ckpt)
+
+  def test_no_nnx_aux_when_state_has_none(self):
+    state = _abstract_nnx_state()  # plain linear, no rngs/batch stats
+    self.assertNotIn("nnx_aux", train_state_nnx.to_checkpoint_dict(state))
+
+
+class TestLinenItemsToNnx(unittest.TestCase):
+  """checkpointing._linen_items_to_nnx reshapes restored items into the NNX-layout overlay."""
+
+  def _to_nnx(self, restored):
+    """Reshape `restored` against the `_ModelDropout` abstract, as the restore paths do."""
+    state = checkpointing._linen_items_to_nnx(restored, _abstract_dropout_state())  # pylint: disable=protected-access
+    return state.to_pure_dict()
+
+  def test_materialized_aux_is_kept(self):
+    restored = {
+        "params": {"params": {"linear": {"kernel": jnp.ones((2, 1))}}},
+        "step": jnp.asarray(3, jnp.int32),
+        "nnx_aux": {"model": {"dropout": {"rngs": {"count": jnp.asarray(42, jnp.uint32)}}}},
+    }
+    out = self._to_nnx(restored)
+    self.assertEqual(int(out["model"]["dropout"]["rngs"]["count"]), 42)  # from the checkpoint
+    self.assertTrue(jnp.array_equal(out["model"]["linear"]["kernel"], jnp.ones((2, 1))))
+
+  def test_weights_and_aux_are_unioned_not_clobbered(self):
+    """Weights and nnx_aux both nest under `model/` -- merging must keep both, at the leaf level."""
+    restored = {
+        "params": {"params": {"linear": {"kernel": jnp.ones((2, 1))}}},
+        "step": jnp.asarray(3, jnp.int32),
+        "nnx_aux": {"model": {"dropout": {"rngs": {"count": jnp.asarray(7, jnp.uint32)}}}},
+    }
+    out = self._to_nnx(restored)
+    self.assertIn("linear", out["model"])  # weights survived the aux merge
+    self.assertIn("dropout", out["model"])  # aux survived the weights merge
+    self.assertTrue(jnp.array_equal(out["model"]["linear"]["kernel"], jnp.ones((2, 1))))
+    self.assertEqual(int(out["model"]["dropout"]["rngs"]["count"]), 7)
+
+  def test_unmaterialized_leaf_kept_as_placeholder(self):
+    """A leaf the checkpoint didn't carry stays a ShapeDtypeStruct; the caller fills it from init."""
+    restored = {
+        "params": {"params": {"linear": {"kernel": jnp.ones((2, 1))}}},
+        "step": jnp.asarray(3, jnp.int32),
+        "nnx_aux": {"model": {"dropout": {"rngs": {"count": jax.ShapeDtypeStruct((), jnp.uint32)}}}},
+    }
+    out = self._to_nnx(restored)
+    self.assertIsInstance(out["model"]["dropout"]["rngs"]["count"], jax.ShapeDtypeStruct)  # placeholder, not defaulted
+    self.assertIsInstance(out["model"]["linear"]["bias"], jax.ShapeDtypeStruct)  # absent weight -> placeholder
+    self.assertTrue(jnp.array_equal(out["model"]["linear"]["kernel"], jnp.ones((2, 1))))
+
+  def test_no_aux_key_leaves_rng_as_placeholder(self):
+    """No nnx_aux on disk -> the rng leaves stay placeholders (init supplies them later)."""
+    restored = {
+        "params": {"params": {"linear": {"kernel": jnp.ones((2, 1))}}},
+        "step": jnp.asarray(3, jnp.int32),
+    }
+    out = self._to_nnx(restored)
+    self.assertIsInstance(out["model"]["dropout"]["rngs"]["count"], jax.ShapeDtypeStruct)
+
+  def test_weights_only_checkpoint_leaves_optimizer_as_placeholder(self):
+    """No step and no opt_state on disk -> the optimizer subtree stays a placeholder, weights still land."""
+    restored = {"params": {"params": {"linear": {"kernel": jnp.ones((2, 1))}}}}
+    out = self._to_nnx(restored)
+    self.assertTrue(jnp.array_equal(out["model"]["linear"]["kernel"], jnp.ones((2, 1))))
+    self.assertIsInstance(out["optimizer"]["step"], jax.ShapeDtypeStruct)
+
+
+class TestWeightMismatch(unittest.TestCase):
+  """A weight the checkpoint didn't carry, or carried at the wrong shape, always raises."""
+
+  def _want(self):
+    """The weights the model expects, as a pure dict (what `_expected_and_restored_params` returns)."""
+    return {
+        "linear": {"kernel": jax.ShapeDtypeStruct((2, 1), jnp.float32), "bias": jax.ShapeDtypeStruct((1,), jnp.float32)}
+    }
+
+  def _have(self, with_bias=True):
+    """The weights the checkpoint carried, as a pure dict; drop the bias to simulate a missing weight."""
+    have = {"linear": {"kernel": jnp.ones((2, 1))}}
+    if with_bias:
+      have["linear"]["bias"] = jnp.ones((1,))
+    return have
+
+  def test_all_weights_present_passes(self):
+    checkpointing._raise_on_weight_mismatch(self._want(), self._have())  # pylint: disable=protected-access
+
+  def test_missing_weight_raises_naming_path(self):
+    with self.assertRaises(ValueError) as ctx:
+      checkpointing._raise_on_weight_mismatch(self._want(), self._have(with_bias=False))  # pylint: disable=protected-access
+    self.assertIn("linear/bias", str(ctx.exception))
+    self.assertIn("missing", str(ctx.exception))
+
+  def test_surviving_shape_dtype_struct_counts_as_missing(self):
+    have = self._have()
+    have["linear"]["bias"] = jax.ShapeDtypeStruct((1,), jnp.float32)
+    with self.assertRaises(ValueError) as ctx:
+      checkpointing._raise_on_weight_mismatch(self._want(), have)  # pylint: disable=protected-access
+    self.assertIn("linear/bias", str(ctx.exception))
+
+  def test_shape_mismatch_raises_naming_path(self):
+    """Orbax restores a stored array at its own shape, so a shape disagreement must be caught here."""
+    have = self._have()
+    have["linear"]["kernel"] = jnp.ones((2, 5))  # model expects (2, 1)
+    with self.assertRaises(ValueError) as ctx:
+      checkpointing._raise_on_weight_mismatch(self._want(), have)  # pylint: disable=protected-access
+    msg = str(ctx.exception)
+    self.assertIn("linear/kernel", msg)
+    self.assertIn("(2, 5)", msg)  # what the checkpoint had
+    self.assertIn("(2, 1)", msg)  # what the model expects
+
+  def test_weight_mismatches_finds_absent_sds_and_shape(self):
+    want = {
+        "a": {
+            "k": jax.ShapeDtypeStruct((2,), jnp.float32),
+            "b": jax.ShapeDtypeStruct((1,), jnp.float32),
+            "c": jax.ShapeDtypeStruct((3,), jnp.float32),
+        }
+    }
+    have = {"a": {"k": jnp.ones((2,)), "c": jnp.ones((4,))}}  # b absent, c wrong shape
+    problems = dict(checkpointing._weight_mismatches(want, have))  # pylint: disable=protected-access
+    self.assertEqual(sorted(problems), ["a/b", "a/c"])
+    self.assertIn("missing", problems["a/b"])
+    self.assertIn("shape", problems["a/c"])
+
+  def test_expected_and_restored_params_splits_by_param_type(self):
+    """Only nnx.Param weights land in `want`; rngs/dropout (nnx.RngState) are excluded from the check."""
+    model = _ModelDropout(nnx.Rngs(0))
+    abstract = nnx.state(train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)))
+    restored = {"params": {"params": {"linear": {"kernel": jnp.ones((2, 1)), "bias": jnp.ones((1,))}}}}
+    want, have = checkpointing._expected_and_restored_params(abstract, restored)  # pylint: disable=protected-access
+    self.assertEqual(set(want.keys()), {"linear"})  # only the Param weights, no dropout rng
+    self.assertNotIn("dropout", want)
+    self.assertEqual(have, restored["params"]["params"])
+    checkpointing._raise_on_weight_mismatch(want, have)  # pylint: disable=protected-access
 
 
 if __name__ == "__main__":

--- a/tests/unit/checkpointing_nnx_missing_param_test.py
+++ b/tests/unit/checkpointing_nnx_missing_param_test.py
@@ -1,0 +1,194 @@
+# Copyright 2025-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end coverage of the missing-weight check on NNX restore.
+
+Drives the real create_orbax_checkpoint_manager -> maybe_save_checkpoint ->
+load_state_if_possible stack (no mocks). `partial_restore` returns a weight the checkpoint
+lacks as an unmaterialized ShapeDtypeStruct; restore raises naming it rather than training on
+an untrained init value. The check filters by nnx.Param, so rngs/dropout absence never trips it.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+from flax import nnx
+import jax
+from maxtext.common import checkpointing
+from maxtext.common import train_state_nnx
+import optax
+
+
+class _Model(nnx.Module):
+  """Linear + dropout, so the state carries rngs that split out into nnx_aux."""
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 1, rngs=rngs)
+    self.dropout = nnx.Dropout(rate=0.5, rngs=rngs)
+
+  def __call__(self, x, deterministic=False):
+    return self.dropout(self.linear(x), deterministic=deterministic)
+
+
+class _ModelExtraLayer(nnx.Module):
+  """`_Model` plus a layer absent from a `_Model` checkpoint, i.e. a weight with no array on disk."""
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 1, rngs=rngs)
+    self.dropout = nnx.Dropout(rate=0.5, rngs=rngs)
+    self.extra = nnx.Linear(1, 1, rngs=rngs)
+
+  def __call__(self, x, deterministic=False):
+    return self.extra(self.dropout(self.linear(x), deterministic=deterministic))
+
+
+class _WiderModel(nnx.Module):
+  """`_Model` with a wider linear -- every weight is present but at a different shape."""
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 4, rngs=rngs)
+    self.dropout = nnx.Dropout(rate=0.5, rngs=rngs)
+
+  def __call__(self, x, deterministic=False):
+    return self.dropout(self.linear(x), deterministic=deterministic)
+
+
+_TX = optax.adam(1e-3)
+
+
+def _config():
+  """Minimal config with the fields save/restore reads for a pure_nnx run."""
+  return SimpleNamespace(
+      pure_nnx=True,
+      enable_diloco=False,
+      enable_checkpointing=True,
+      enable_continuous_checkpointing=False,
+      enable_emergency_checkpoint=False,
+      enable_multi_tier_checkpointing=False,
+      enable_autocheckpoint=False,
+      checkpoint_period=1,
+      local_checkpoint_period=0,
+      async_checkpointing=False,
+      dataset_type="tfds",
+      lora=None,
+      checkpoint_storage_target_data_file_size_bytes=checkpointing.DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE,
+      elastic_enabled=False,
+  )
+
+
+def _abstract_state(model_cls):
+  """An abstract (ShapeDtypeStruct) nnx.State for `model_cls`, the restore blueprint."""
+  mesh = jax.sharding.Mesh(jax.devices(), ("x",))
+  sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+
+  def make():
+    model = model_cls(nnx.Rngs(9))
+    return nnx.state(train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, _TX, wrt=nnx.Param)))
+
+  abstract = nnx.eval_shape(make)
+  return jax.tree.map(
+      lambda x: jax.ShapeDtypeStruct(x.shape, x.dtype, sharding=sharding) if hasattr(x, "shape") else x,
+      abstract,
+  )
+
+
+class TestMissingParamRoundTrip(unittest.TestCase):
+  """Real save->restore covering the missing-weight policy end to end."""
+
+  def setUp(self):
+    self._dir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, self._dir, ignore_errors=True)
+
+  def _save_model(self):
+    """Saves a one-step `_Model` checkpoint and returns its manager."""
+    manager = checkpointing.create_orbax_checkpoint_manager(
+        os.path.join(self._dir, "ckpt"),
+        enable_checkpointing=True,
+        use_async=False,
+        save_interval_steps=1,
+        dataset_type="tfds",
+    )
+    model = _Model(nnx.Rngs(0))
+    state = train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, _TX, wrt=nnx.Param))
+    checkpointing.maybe_save_checkpoint(manager, nnx.state(state), _config(), data_iterator=None, step=1)
+    manager.wait_until_finished()
+    return manager
+
+  def _load_overlay(self, manager, model_cls):
+    """Returns the restore overlay load_state_if_possible produces (leaves not on disk kept as placeholders)."""
+    full, _ = checkpointing.load_state_if_possible(
+        manager,
+        data_iterator=None,
+        load_parameters_from_path="",
+        load_full_state_from_path="",
+        checkpoint_storage_concurrent_gb=8,
+        abstract_unboxed_pre_state=_abstract_state(model_cls),
+        dataset_type="tfds",
+        maxtext_config=_config(),
+    )
+    return full["items"].to_pure_dict()
+
+  def test_missing_weight_raises_naming_the_path(self):
+    """A full-state resume against a model with an extra layer raises, naming that layer."""
+    manager = self._save_model()
+    with self.assertRaises(ValueError) as ctx:
+      self._load_overlay(manager, _ModelExtraLayer)
+    msg = str(ctx.exception)
+    self.assertIn("extra", msg)  # the exact offending parameter path
+    self.assertIn("missing", msg)
+
+  def test_params_only_load_missing_weight_raises(self):
+    """The params-only route (load_parameters_path, e.g. SFT) checks too, instead of failing later.
+
+    Without the check the weight comes back as a ShapeDtypeStruct, reaches the model, and fails
+    deep in the first step with a TypeError that never names it.
+    """
+    self._save_model()  # a `_Model` checkpoint: linear only, no `extra`
+    items = os.path.join(self._dir, "ckpt", "1", "items")
+    # The real caller hands over an abstract params state, as load_state_if_possible does.
+    params_abstract = nnx.eval_shape(lambda: nnx.split(_ModelExtraLayer(nnx.Rngs(0)), nnx.Param, ...)[1])
+    with self.assertRaises(ValueError) as ctx:
+      checkpointing.load_params_from_path(items, params_abstract, 8)
+    self.assertIn("extra", str(ctx.exception))
+    self.assertIn("missing", str(ctx.exception))
+
+  def test_params_only_load_shape_mismatch_raises(self):
+    """Orbax restores a stored array at its own shape, so a wider model must be caught here.
+
+    Without the check the model silently receives the checkpoint's shape and fails later on a
+    broadcast, or trains on the wrong weights if the shapes happen to broadcast.
+    """
+    self._save_model()  # `_Model` has linear (2, 1)
+    items = os.path.join(self._dir, "ckpt", "1", "items")
+    params_abstract = nnx.eval_shape(lambda: nnx.split(_WiderModel(nnx.Rngs(0)), nnx.Param, ...)[1])
+    with self.assertRaises(ValueError) as ctx:
+      checkpointing.load_params_from_path(items, params_abstract, 8)
+    msg = str(ctx.exception)
+    self.assertIn("linear/kernel", msg)
+    self.assertIn("(2, 1)", msg)  # what the checkpoint had
+    self.assertIn("(2, 4)", msg)  # what the model expects
+
+  def test_matching_config_restores_clean(self):
+    """Negative control: an exact-arch restore doesn't raise and the overlay carries the weight."""
+    manager = self._save_model()
+    overlay = self._load_overlay(manager, _Model)  # must not raise the missing-weight error
+    self.assertEqual(overlay["model"]["linear"]["kernel"].shape, (2, 1))
+    self.assertNotIsInstance(overlay["model"]["linear"]["kernel"], jax.ShapeDtypeStruct)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/checkpointing_nnx_roundtrip_test.py
+++ b/tests/unit/checkpointing_nnx_roundtrip_test.py
@@ -1,0 +1,396 @@
+# Copyright 2025-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end NNX checkpoint round trips through the real save/restore stack.
+
+Drives create_orbax_checkpoint_manager -> maybe_save_checkpoint ->
+load_state_if_possible against a real on-disk Orbax checkpoint (no mocks). Covers
+what training actually hits: exact full-state fidelity, per-component restore
+(weights, optimizer, dropout rng, batch stats), the fallback for a checkpoint
+with no nnx_aux, exclusion of non-weight variables (caches), that the restored
+state loads back into a live model, resume continuity, and the
+load_full_state_from_path route.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+from flax import nnx
+import jax
+import jax.numpy as jnp
+from maxtext.common import checkpointing
+from maxtext.common import train_state_nnx
+import optax
+
+
+class _Model(nnx.Module):
+  """Linear + batch-norm + dropout: exercises weights, batch stats, and rng together."""
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 3, rngs=rngs)
+    self.bn = nnx.BatchNorm(3, rngs=rngs)
+    self.dropout = nnx.Dropout(rate=0.5, rngs=rngs)
+
+  def __call__(self, x, deterministic=False):
+    x = self.bn(self.linear(x), use_running_average=deterministic)
+    return self.dropout(x, deterministic=deterministic)
+
+
+class _PlainModel(nnx.Module):
+  """Linear only, so its checkpoint carries no nnx_aux, like a Linen-trained one."""
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 3, rngs=rngs)
+
+  def __call__(self, x, deterministic=False):
+    return self.linear(x)
+
+
+class _CacheModel(nnx.Module):
+  """Linear + dropout + a cache, to check non-weight variables are not checkpointed."""
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 3, rngs=rngs)
+    self.dropout = nnx.Dropout(rate=0.5, rngs=rngs)
+    self.cache = nnx.Cache(jnp.zeros((3,)))
+
+  def __call__(self, x, deterministic=False):
+    return self.dropout(self.linear(x), deterministic=deterministic)
+
+
+# A chain with a scalar lr reduces to a single-entry opt_state ({0: ...}) -- the shape to_linen used to
+# flatten. Exercises the chained reshape end to end; setup_initial_state_nnx_test covers the flat one.
+_TX = optax.adamw(1e-3)
+
+# Rows must differ: batch-norm centres identical rows to zero, which zeroes the gradients and leaves
+# the adam moments at zero, so a dropped-moment restore would go unnoticed.
+_TRAIN_X = jnp.arange(8, dtype=jnp.float32).reshape(4, 2)
+
+
+def _config():
+  """Minimal config with the fields save/restore reads for a pure_nnx run."""
+  return SimpleNamespace(
+      pure_nnx=True,
+      enable_diloco=False,
+      enable_checkpointing=True,
+      enable_continuous_checkpointing=False,
+      enable_emergency_checkpoint=False,
+      enable_multi_tier_checkpointing=False,
+      enable_autocheckpoint=False,
+      checkpoint_period=1,
+      local_checkpoint_period=0,
+      async_checkpointing=False,
+      dataset_type="tfds",
+      lora=None,
+      checkpoint_storage_target_data_file_size_bytes=checkpointing.DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE,
+      elastic_enabled=False,
+  )
+
+
+def _abstract_state(model_cls):
+  """An abstract (ShapeDtypeStruct) nnx.State for `model_cls`, the restore blueprint.
+
+  Mirrors what get_abstract_state hands load_state_if_possible: SDS leaves with a
+  replicated sharding so Orbax can build restore args in single- or multi-host CI.
+  """
+  mesh = jax.sharding.Mesh(jax.devices(), ("x",))
+  sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+
+  def make():
+    model = model_cls(nnx.Rngs(9))
+    return nnx.state(train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, _TX, wrt=nnx.Param)))
+
+  abstract = nnx.eval_shape(make)
+  return jax.tree.map(
+      lambda x: jax.ShapeDtypeStruct(x.shape, x.dtype, sharding=sharding) if hasattr(x, "shape") else x,
+      abstract,
+  )
+
+
+def _leaf_equal(a, b):
+  """Value equality that also handles PRNG-key leaves (compared by key_data)."""
+  a, b = jnp.asarray(a), jnp.asarray(b)
+  if a.shape != b.shape or a.dtype != b.dtype:
+    return False
+  if jnp.issubdtype(a.dtype, jax.dtypes.prng_key):
+    return bool(jnp.array_equal(jax.random.key_data(a), jax.random.key_data(b)))
+  return bool(jnp.allclose(a, b))
+
+
+class TestNNXCheckpointRoundTrip(unittest.TestCase):
+  """Real save->restore cycles through create_orbax_checkpoint_manager + load_state_if_possible."""
+
+  def setUp(self):
+    self._dir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, self._dir, ignore_errors=True)
+
+  # --- helpers ---------------------------------------------------------------
+
+  def _manager(self):
+    return checkpointing.create_orbax_checkpoint_manager(
+        os.path.join(self._dir, "ckpt"),
+        enable_checkpointing=True,
+        use_async=False,
+        save_interval_steps=1,
+        dataset_type="tfds",
+    )
+
+  def _trained(self, model):
+    """One training step: advances step + dropout rng + batch stats + optimizer moments."""
+    state = train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, _TX, wrt=nnx.Param))
+    grads = nnx.grad(lambda m: jnp.mean(m(_TRAIN_X, deterministic=False) ** 2))(state.model)
+    state.apply_gradients(grads)
+    return state
+
+  def _save(self, manager, state, step=1):
+    checkpointing.maybe_save_checkpoint(manager, nnx.state(state), _config(), data_iterator=None, step=step)
+    manager.wait_until_finished()
+
+  def _init_state(self, model_cls, seed=123):
+    """A fresh concrete init state (real weights/rng, optimizer zeros) for `model_cls`."""
+    model = model_cls(nnx.Rngs(seed))
+    return nnx.state(train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, _TX, wrt=nnx.Param)))
+
+  def _restore(self, manager, model_cls):
+    """The trainer's restore: fill the leaves the checkpoint didn't carry from a fresh init."""
+    full, _ = checkpointing.load_state_if_possible(
+        manager,
+        data_iterator=None,
+        load_parameters_from_path="",
+        load_full_state_from_path="",
+        checkpoint_storage_concurrent_gb=8,
+        abstract_unboxed_pre_state=_abstract_state(model_cls),
+        dataset_type="tfds",
+        maxtext_config=_config(),
+    )
+    init = self._init_state(model_cls)
+    merged = jax.tree.map(
+        lambda ckpt, i: i if isinstance(ckpt, jax.ShapeDtypeStruct) else ckpt,
+        full["items"].to_pure_dict(),  # checkpoint values, with placeholders where it carried nothing
+        init.to_pure_dict(),
+        is_leaf=lambda x: isinstance(x, jax.ShapeDtypeStruct),
+    )
+    nnx.replace_by_pure_dict(init, merged)  # missing leaves keep their init value
+    return init.to_pure_dict()
+
+  # --- full-state fidelity ---------------------------------------------------
+
+  def test_full_state_round_trip_is_exact(self):
+    """Every leaf -- weights, optimizer, dropout rng, batch stats -- round-trips unchanged."""
+    manager = self._manager()
+    state = self._trained(_Model(nnx.Rngs(0)))
+    saved = nnx.state(state).to_pure_dict()
+    self._save(manager, state)
+    restored = self._restore(manager, _Model)
+
+    self.assertEqual(jax.tree_util.tree_structure(saved), jax.tree_util.tree_structure(restored))
+    matches = jax.tree_util.tree_map(_leaf_equal, saved, restored)
+    mismatched = [jax.tree_util.keystr(p) for p, ok in jax.tree_util.tree_leaves_with_path(matches) if not ok]
+    self.assertEqual(mismatched, [], f"leaves differ after round trip: {mismatched}")
+
+  # --- per-component restore -------------------------------------------------
+
+  def test_weights_restored_exactly(self):
+    manager = self._manager()
+    state = self._trained(_Model(nnx.Rngs(0)))
+    saved_kernel = nnx.state(state).to_pure_dict()["model"]["linear"]["kernel"]
+    self._save(manager, state)
+    restored = self._restore(manager, _Model)
+    self.assertTrue(jnp.allclose(restored["model"]["linear"]["kernel"], saved_kernel))
+
+  def test_optimizer_state_restored_from_checkpoint(self):
+    """Optimizer step + adam moments come from the checkpoint, not reset to init."""
+    manager = self._manager()
+    state = self._trained(_Model(nnx.Rngs(0)))
+    saved = nnx.state(state).to_pure_dict()["optimizer"]["opt_state"][0]
+    self._save(manager, state)
+    restored = self._restore(manager, _Model)
+    self.assertEqual(int(restored["optimizer"]["step"]), 1)
+
+    # mu/nu specifically: a fresh init leaves them all-zero, and the `count` scalar alone must not
+    # be able to satisfy this. The first assert also fails loudly if the fixture stops training.
+    restored_opt = restored["optimizer"]["opt_state"][0]
+    for moment in ("mu", "nu"):
+      saved_leaves = jax.tree.leaves(saved[moment])
+      restored_leaves = jax.tree.leaves(restored_opt[moment])
+      self.assertTrue(any(float(jnp.abs(x).sum()) > 0 for x in saved_leaves), f"fixture: saved {moment} is zero")
+      self.assertEqual(len(saved_leaves), len(restored_leaves))
+      for want, got in zip(saved_leaves, restored_leaves):
+        self.assertTrue(jnp.allclose(want, got))
+
+  def test_dropout_rng_stream_restored(self):
+    """The dropout rng continues across a save/restore instead of resetting to 0."""
+    manager = self._manager()
+    state = self._trained(_Model(nnx.Rngs(0)))
+    orig_count = int(nnx.state(state).to_pure_dict()["model"]["dropout"]["rngs"]["count"])
+    self.assertGreater(orig_count, 0)
+    self._save(manager, state)
+    restored = self._restore(manager, _Model)
+    self.assertEqual(int(restored["model"]["dropout"]["rngs"]["count"]), orig_count)
+
+  def test_batch_stats_restored(self):
+    """BatchNorm running mean/var are restored, not reset to their init."""
+    manager = self._manager()
+    state = self._trained(_Model(nnx.Rngs(0)))
+    saved_mean = nnx.state(state).to_pure_dict()["model"]["bn"]["mean"]
+    self._save(manager, state)
+    restored = self._restore(manager, _Model)
+    self.assertTrue(jnp.allclose(restored["model"]["bn"]["mean"], saved_mean))
+
+  # --- fallback / backward compatibility -------------------------------------
+
+  def test_old_checkpoint_without_nnx_aux_keeps_init_value(self):
+    """A Linen-era checkpoint carries every weight but no nnx_aux; the rng/cache keep their init."""
+    manager = self._manager()
+    trained = self._trained(_PlainModel(nnx.Rngs(0)))  # linear + optimizer on disk, no nnx_aux
+    saved_kernel = nnx.state(trained).to_pure_dict()["model"]["linear"]["kernel"]
+    self._save(manager, trained)
+    init_state = self._init_state(_CacheModel).to_pure_dict()
+    restored = self._restore(manager, _CacheModel)  # _CacheModel adds a dropout rng and a cache
+
+    # The linear weights really came from the ckpt, not from init -- compare values, not shapes.
+    self.assertTrue(jnp.allclose(restored["model"]["linear"]["kernel"], saved_kernel))
+    self.assertFalse(jnp.allclose(restored["model"]["linear"]["kernel"], init_state["model"]["linear"]["kernel"]))
+    # The rng and cache were absent from the ckpt -> kept at their init, not zero/key(0)-filled.
+    self.assertEqual(
+        int(restored["model"]["dropout"]["rngs"]["count"]), int(init_state["model"]["dropout"]["rngs"]["count"])
+    )
+    self.assertTrue(jnp.allclose(restored["model"]["cache"], init_state["model"]["cache"]))
+
+  def test_missing_weight_raises_naming_the_path(self):
+    """A weight the checkpoint doesn't carry is an error, not a silent untrained init value."""
+    manager = self._manager()
+    self._save(manager, self._trained(_PlainModel(nnx.Rngs(0))))  # no batch-norm weights on disk
+    with self.assertRaises(ValueError) as ctx:
+      self._restore(manager, _Model)  # _Model's bn scale/bias are nnx.Param
+    self.assertIn("bn/scale", str(ctx.exception))
+    self.assertIn("missing", str(ctx.exception))
+
+  def test_plain_model_round_trip_writes_no_nnx_aux(self):
+    """A model with no rng/batch stats round-trips weights + optimizer and no nnx_aux."""
+    manager = self._manager()
+    state = self._trained(_PlainModel(nnx.Rngs(0)))
+    saved_kernel = nnx.state(state).to_pure_dict()["model"]["linear"]["kernel"]
+    self._save(manager, state)
+    restored = self._restore(manager, _PlainModel)
+    self.assertTrue(jnp.allclose(restored["model"]["linear"]["kernel"], saved_kernel))
+    self.assertEqual(int(restored["optimizer"]["step"]), 1)
+
+  # --- exclusion of non-weight variables -------------------------------------
+
+  def test_caches_excluded_from_checkpoint(self):
+    """A cache is not written to the checkpoint, so a restore keeps the init value, not the saved one."""
+    manager = self._manager()
+    model = _CacheModel(nnx.Rngs(0))
+    model.cache.value = jnp.ones((3,))  # the value that would come back if caches were checkpointed
+    state = self._trained(model)
+    self._save(manager, state)
+    restored = self._restore(manager, _CacheModel)  # init cache is zeros
+    # Cache is the init value (zeros), not the saved ones -> it was not checkpointed...
+    self.assertTrue(jnp.allclose(restored["model"]["cache"], jnp.zeros((3,))))
+    # ...while the dropout rng was still restored from nnx_aux.
+    orig_count = int(nnx.state(state).to_pure_dict()["model"]["dropout"]["rngs"]["count"])
+    self.assertEqual(int(restored["model"]["dropout"]["rngs"]["count"]), orig_count)
+
+  # --- restored state is a usable model --------------------------------------
+
+  def test_restored_state_loads_into_model_and_runs(self):
+    """The restored pure dict fills a live nnx model (as pre_train does) and runs a forward pass."""
+    manager = self._manager()
+    self._save(manager, self._trained(_Model(nnx.Rngs(0))))
+    restored = self._restore(manager, _Model)
+
+    abstract = _abstract_state(_Model)
+    nnx.replace_by_pure_dict(abstract, restored)  # same call the trainer makes
+    graphdef, _ = nnx.split(_Model(nnx.Rngs(0)))
+    model = nnx.merge(graphdef, abstract["model"])
+    out = model(jnp.ones((4, 2)), deterministic=True)
+    self.assertEqual(out.shape, (4, 3))
+
+  # --- resume continuity -----------------------------------------------------
+
+  def test_resume_continues_step_and_rng(self):
+    """Restoring then training again continues the rng stream instead of resetting it."""
+    manager = self._manager()
+    state = self._trained(_Model(nnx.Rngs(0)))
+    count_at_save = int(nnx.state(state).to_pure_dict()["model"]["dropout"]["rngs"]["count"])
+    self._save(manager, state)
+
+    restored = self._restore(manager, _Model)
+    abstract = _abstract_state(_Model)
+    nnx.replace_by_pure_dict(abstract, restored)
+    graphdef, _ = nnx.split(_Model(nnx.Rngs(0)))
+    model = nnx.merge(graphdef, abstract["model"])
+    resumed = train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, _TX, wrt=nnx.Param))
+    # The restored model carries the saved rng stream; one more step advances it past that point.
+    grads = nnx.grad(lambda m: jnp.mean(m(_TRAIN_X, deterministic=False) ** 2))(resumed.model)
+    resumed.apply_gradients(grads)
+    count_after = int(nnx.state(resumed).to_pure_dict()["model"]["dropout"]["rngs"]["count"])
+    self.assertGreater(count_after, count_at_save)  # stream advanced past the restored point
+
+  # --- alternate restore route -----------------------------------------------
+
+  def test_load_full_state_from_path_route(self):
+    """The explicit load_full_state_from_path route reshapes items/ back to NNX with nnx_aux."""
+    manager = self._manager()
+    state = self._trained(_Model(nnx.Rngs(0)))
+    orig_count = int(nnx.state(state).to_pure_dict()["model"]["dropout"]["rngs"]["count"])
+    self._save(manager, state)
+
+    items_path = os.path.join(self._dir, "ckpt", "1", "items")
+    full, _ = checkpointing.load_state_if_possible(
+        checkpoint_manager=None,
+        data_iterator=None,
+        load_parameters_from_path="",
+        load_full_state_from_path=items_path,
+        checkpoint_storage_concurrent_gb=8,
+        abstract_unboxed_pre_state=_abstract_state(_Model),
+        dataset_type="tfds",
+        enable_orbax_v1=False,
+        maxtext_config=_config(),
+    )
+    restored = full["items"].to_pure_dict()
+    self.assertEqual(int(restored["model"]["dropout"]["rngs"]["count"]), orig_count)
+    self.assertEqual(int(restored["optimizer"]["step"]), 1)
+
+  def test_load_full_state_from_path_route_orbax_v1(self):
+    """Under enable_orbax_v1, the "orbax" layout routes an nnx.State through the same Linen -> NNX reshape."""
+    manager = self._manager()
+    state = self._trained(_Model(nnx.Rngs(0)))
+    orig_count = int(nnx.state(state).to_pure_dict()["model"]["dropout"]["rngs"]["count"])
+    self._save(manager, state)
+
+    items_path = os.path.join(self._dir, "ckpt", "1", "items")
+    full, _ = checkpointing.load_state_if_possible(
+        checkpoint_manager=None,
+        data_iterator=None,
+        load_parameters_from_path="",
+        load_full_state_from_path=items_path,
+        checkpoint_storage_concurrent_gb=8,
+        abstract_unboxed_pre_state=_abstract_state(_Model),
+        dataset_type="tfds",
+        enable_orbax_v1=True,
+        source_checkpoint_layout="orbax",
+        maxtext_config=_config(),
+    )
+    restored = full["items"].to_pure_dict()
+    self.assertEqual(int(restored["model"]["dropout"]["rngs"]["count"]), orig_count)
+    self.assertEqual(int(restored["optimizer"]["step"]), 1)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/setup_initial_state_nnx_test.py
+++ b/tests/unit/setup_initial_state_nnx_test.py
@@ -1,0 +1,250 @@
+# Copyright 2025-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test for the real setup_initial_state NNX restore (init + overlay).
+
+Drives maxtext_utils.setup_initial_state end to end on CPU: it builds a concrete
+init state and overlays a real on-disk checkpoint onto it, so anything the
+checkpoint carried comes from disk and anything it didn't keeps its init value.
+Only get_abstract_state is patched (to swap the full model-creation machinery for
+a tiny model); the restore/init/overlay path under test runs for real. This is the
+unit-level guard for the train->save->resume flow verified on TPU.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from flax import nnx
+import jax
+import jax.numpy as jnp
+from maxtext.common import checkpointing
+from maxtext.common import train_state_nnx
+from maxtext.utils import maxtext_utils
+import optax
+import orbax.checkpoint.experimental.emergency.checkpoint_manager as emergency_checkpoint_manager
+
+_TX = optax.scale_by_adam()  # flat opt_state {count, mu, nu}, as an un-chained optimizer (e.g. adam_pax) produces
+
+# Rows must differ: batch-norm centres identical rows to zero, which zeroes the gradients and leaves
+# the adam moments at zero, so a dropped-moment restore would go unnoticed.
+_TRAIN_X = jnp.arange(8, dtype=jnp.float32).reshape(4, 2)
+
+
+class _Model(nnx.Module):
+  """Linear + batch-norm + dropout: weights, batch stats, and an rng stream."""
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 3, rngs=rngs)
+    self.bn = nnx.BatchNorm(3, rngs=rngs)
+    self.dropout = nnx.Dropout(rate=0.5, rngs=rngs)
+
+  def __call__(self, x, deterministic=False):
+    return self.dropout(self.bn(self.linear(x), use_running_average=deterministic), deterministic=deterministic)
+
+
+class _PlainModel(nnx.Module):
+  """Linear only -> checkpoint has no batch stats / rng (like a Linen-trained one)."""
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 3, rngs=rngs)
+
+  def __call__(self, x, deterministic=False):
+    return self.linear(x)
+
+
+class _RngModel(nnx.Module):
+  """Same weights as _PlainModel plus a dropout rng -> the extra state is non-Param."""
+
+  def __init__(self, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(2, 3, rngs=rngs)
+    self.dropout = nnx.Dropout(rate=0.5, rngs=rngs)
+
+  def __call__(self, x, deterministic=False):
+    return self.dropout(self.linear(x), deterministic=deterministic)
+
+
+def _init_fn(model_cls, seed):
+  def fn():
+    model = model_cls(nnx.Rngs(seed))
+    return train_state_nnx.TrainStateNNX(model, nnx.Optimizer(model, _TX, wrt=nnx.Param))
+
+  return fn
+
+
+def _config():
+  """A config with every field setup_initial_state + load_state_if_possible + save read for pure_nnx."""
+  return SimpleNamespace(
+      pure_nnx=True,
+      enable_diloco=False,
+      enable_checkpointing=True,
+      enable_continuous_checkpointing=False,
+      enable_emergency_checkpoint=False,
+      enable_multi_tier_checkpointing=False,
+      enable_autocheckpoint=False,
+      checkpoint_period=1,
+      local_checkpoint_period=0,
+      async_checkpointing=False,
+      dataset_type="tfds",
+      lora=None,
+      checkpoint_storage_target_data_file_size_bytes=checkpointing.DEFAULT_OCDBT_TARGET_DATA_FILE_SIZE,
+      elastic_enabled=False,
+      logical_axis_rules=[],
+      load_parameters_path="",
+      load_full_state_path="",
+      checkpoint_storage_concurrent_gb=8,
+      enable_single_replica_ckpt_restoring=False,
+      checkpoint_storage_use_ocdbt=True,
+      checkpoint_storage_use_zarr3=True,
+      enable_orbax_v1=False,
+      checkpoint_conversion_fn=None,
+      source_checkpoint_layout="orbax",
+      expansion_factor_real_data=-1,
+      scan_layers=False,
+  )
+
+
+class TestSetupInitialStateNNX(unittest.TestCase):
+  """Drive the real setup_initial_state restore path with a tiny model on CPU."""
+
+  def setUp(self):
+    self._dir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, self._dir, ignore_errors=True)
+    self._mesh = jax.sharding.Mesh(jax.devices(), ("x",))
+
+  def _manager(self):
+    return checkpointing.create_orbax_checkpoint_manager(
+        os.path.join(self._dir, "ckpt"),
+        enable_checkpointing=True,
+        use_async=False,
+        save_interval_steps=1,
+        dataset_type="tfds",
+    )
+
+  def _sharded_abstract(self, init_fn):
+    repl = jax.sharding.NamedSharding(self._mesh, jax.sharding.PartitionSpec())
+    abstract = nnx.eval_shape(lambda: nnx.state(init_fn()))
+    return jax.tree.map(
+        lambda x: jax.ShapeDtypeStruct(x.shape, x.dtype, sharding=repl) if hasattr(x, "shape") else x, abstract
+    )
+
+  def _setup(self, manager, init_fn, config):
+    """Call the real setup_initial_state, patching only get_abstract_state for the tiny model."""
+    abstract = self._sharded_abstract(init_fn)
+    repl = jax.sharding.NamedSharding(self._mesh, jax.sharding.PartitionSpec())
+    shardings = jax.tree.map(lambda _: repl, abstract)
+    with mock.patch.object(maxtext_utils, "get_abstract_state", return_value=(abstract, None, shardings)):
+      state, *_ = maxtext_utils.setup_initial_state(None, config, self._mesh, manager, init_fn, True)
+    return state.to_pure_dict()
+
+  def _train_and_save(self, manager, model_cls, config, seed=0):
+    """One training step (advances step/rng/batch-stats/optimizer), then save; return the saved pure dict."""
+    ts = _init_fn(model_cls, seed)()
+    grads = nnx.grad(lambda m: jnp.mean(m(_TRAIN_X, deterministic=False) ** 2))(ts.model)
+    ts.apply_gradients(grads)
+    saved = nnx.state(ts).to_pure_dict()
+    checkpointing.maybe_save_checkpoint(manager, nnx.state(ts), config, data_iterator=None, step=1)
+    manager.wait_until_finished()
+    return saved
+
+  def test_restores_full_state_via_overlay(self):
+    """setup_initial_state overlays the checkpoint onto init: weights + optimizer + rng + batch stats come from disk."""
+    config = _config()
+    manager = self._manager()
+    saved = self._train_and_save(manager, _Model, config, seed=0)
+    restored = self._setup(manager, _init_fn(_Model, 999), config)  # a DIFFERENT init seed than the ckpt
+    self.assertTrue(jnp.allclose(restored["model"]["linear"]["kernel"], saved["model"]["linear"]["kernel"]))
+    self.assertEqual(int(restored["optimizer"]["step"]), int(saved["optimizer"]["step"]))
+    self.assertEqual(int(restored["model"]["dropout"]["rngs"]["count"]), int(saved["model"]["dropout"]["rngs"]["count"]))
+    self.assertTrue(jnp.allclose(restored["model"]["bn"]["mean"], saved["model"]["bn"]["mean"]))
+    # mu/nu specifically: a fresh init leaves them all-zero, and the `count` scalar alone must not
+    # be able to satisfy this. The first assert also fails loudly if the fixture stops training.
+    for moment in ("mu", "nu"):
+      saved_leaves = jax.tree.leaves(saved["optimizer"]["opt_state"][moment])
+      restored_leaves = jax.tree.leaves(restored["optimizer"]["opt_state"][moment])
+      self.assertTrue(any(float(jnp.abs(x).sum()) > 0 for x in saved_leaves), f"fixture: saved {moment} is zero")
+      for want, got in zip(saved_leaves, restored_leaves):
+        self.assertTrue(jnp.allclose(want, got))
+
+  def test_no_checkpoint_returns_fresh_init(self):
+    """With nothing on disk, setup_initial_state returns a plain init state."""
+    config = _config()
+    manager = self._manager()  # nothing saved
+    init_kernel = nnx.state(_init_fn(_Model, 7)()).to_pure_dict()["model"]["linear"]["kernel"]
+    state = self._setup(manager, _init_fn(_Model, 7), config)
+    self.assertTrue(jnp.allclose(state["model"]["linear"]["kernel"], init_kernel))
+
+  def test_old_checkpoint_without_nnx_aux_keeps_init_value(self):
+    """A checkpoint carrying every weight but no nnx_aux keeps the rng at its init, not key(0)."""
+    config = _config()
+    manager = self._manager()
+    saved = self._train_and_save(manager, _PlainModel, config, seed=0)  # linear + optimizer, no nnx_aux
+    init = nnx.state(_init_fn(_RngModel, 999)()).to_pure_dict()
+    restored = self._setup(manager, _init_fn(_RngModel, 999), config)
+    # The rng was absent from the ckpt -> kept at its init.
+    self.assertEqual(int(restored["model"]["dropout"]["rngs"]["count"]), int(init["model"]["dropout"]["rngs"]["count"]))
+    # The linear weights really came from the ckpt, not from init -- compare values, not shapes.
+    self.assertTrue(jnp.allclose(restored["model"]["linear"]["kernel"], saved["model"]["linear"]["kernel"]))
+    self.assertFalse(jnp.allclose(restored["model"]["linear"]["kernel"], init["model"]["linear"]["kernel"]))
+
+  def test_missing_weight_raises_naming_the_path(self):
+    """A weight the checkpoint doesn't carry is an error, not a silent untrained init value."""
+    config = _config()
+    manager = self._manager()
+    self._train_and_save(manager, _PlainModel, config, seed=0)  # no batch-norm weights on disk
+    with self.assertRaises(ValueError) as ctx:
+      self._setup(manager, _init_fn(_Model, 999), config)  # _Model's bn scale/bias are nnx.Param
+    self.assertIn("bn/scale", str(ctx.exception))
+
+  def test_emergency_manager_overlay_is_not_unwrapped(self):
+    """An emergency manager hands back the overlay directly, not under an `items` key."""
+    config = _config()
+    trained = _init_fn(_Model, 0)()
+    grads = nnx.grad(lambda m: jnp.mean(m(_TRAIN_X, deterministic=False) ** 2))(trained.model)
+    trained.apply_gradients(grads)
+    overlay = nnx.state(trained)  # what _restore_emergency_linen_checkpoint_into_nnx returns
+    manager = mock.Mock(spec=emergency_checkpoint_manager.CheckpointManager)
+
+    with mock.patch.object(checkpointing, "load_state_if_possible", return_value=(overlay, None)):
+      restored = self._setup(manager, _init_fn(_Model, 999), config)  # a DIFFERENT init seed
+
+    # Indexing `restored["items"]` on an nnx.State would raise, so reaching here proves the
+    # emergency side ran; the values confirm the overlay, not the init, won.
+    saved = overlay.to_pure_dict()
+    self.assertTrue(jnp.allclose(restored["model"]["linear"]["kernel"], saved["model"]["linear"]["kernel"]))
+    self.assertEqual(int(restored["optimizer"]["step"]), int(saved["optimizer"]["step"]))
+
+  def test_params_only_load_overlays_weights_and_keeps_init(self):
+    """A params-only load (load_parameters_path) writes the weights and leaves everything else at init."""
+    config = _config()
+    _, weights, _ = nnx.split(_init_fn(_Model, 0)().model, nnx.Param, ...)
+    init = nnx.state(_init_fn(_Model, 999)()).to_pure_dict()
+
+    with mock.patch.object(checkpointing, "load_state_if_possible", return_value=(None, weights)):
+      restored = self._setup(self._manager(), _init_fn(_Model, 999), config)
+
+    # Weights come from the params load...
+    want = weights.to_pure_dict()
+    self.assertTrue(jnp.allclose(restored["model"]["linear"]["kernel"], want["linear"]["kernel"]))
+    self.assertFalse(jnp.allclose(restored["model"]["linear"]["kernel"], init["model"]["linear"]["kernel"]))
+    # ...while the optimizer and rng stream stay at their fresh init.
+    self.assertEqual(int(restored["optimizer"]["step"]), int(init["optimizer"]["step"]))
+    self.assertEqual(int(restored["model"]["dropout"]["rngs"]["count"]), int(init["model"]["dropout"]["rngs"]["count"]))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/train_state_nnx_checkpoint_test.py
+++ b/tests/unit/train_state_nnx_checkpoint_test.py
@@ -505,13 +505,16 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
     mgr = mock.MagicMock()
     mgr.reached_preemption.return_value = False
 
-    with mock.patch.object(checkpointing, "save_checkpoint") as save_checkpoint_mock:
+    with (
+        mock.patch.object(checkpointing, "save_checkpoint") as save_checkpoint_mock,
+        mock.patch.object(train_state_nnx, "to_checkpoint_dict") as to_checkpoint_dict_mock,
+    ):
       checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=3)
 
     mgr.latest_step.assert_not_called()
     mgr.reached_preemption.assert_called_once_with(3)
     mgr.wait_until_finished.assert_not_called()
-    state.to_pure_dict.assert_not_called()
+    to_checkpoint_dict_mock.assert_not_called()
     save_checkpoint_mock.assert_not_called()
 
   def test_maybe_save_checkpoint_handles_preemption_on_non_checkpoint_step(
@@ -523,14 +526,17 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
     mgr = mock.MagicMock()
     mgr.reached_preemption.return_value = True
 
-    with mock.patch.object(checkpointing, "save_checkpoint") as save_checkpoint_mock:
+    with (
+        mock.patch.object(checkpointing, "save_checkpoint") as save_checkpoint_mock,
+        mock.patch.object(train_state_nnx, "to_checkpoint_dict") as to_checkpoint_dict_mock,
+    ):
       with self.assertRaises(checkpointing.exceptions.StopTraining):
         checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=3)
 
     mgr.latest_step.assert_not_called()
     mgr.reached_preemption.assert_called_once_with(3)
     mgr.wait_until_finished.assert_called_once_with()
-    state.to_pure_dict.assert_not_called()
+    to_checkpoint_dict_mock.assert_not_called()
     save_checkpoint_mock.assert_not_called()
 
   def test_maybe_save_checkpoint_allows_local_checkpoint_period(self):
@@ -541,10 +547,6 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
     ):
       with self.subTest(checkpoint_flag=checkpoint_flag):
         state = mock.Mock()
-        state.to_pure_dict.return_value = {
-            "model": {},
-            "optimizer": {"step": 5},
-        }
         config = self._config(
             checkpoint_period=100,
             local_checkpoint_period=5,
@@ -555,13 +557,16 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
         mgr.reached_preemption.return_value = False
         save_checkpoint_mock = mock.MagicMock(return_value=False)
 
-        with mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock):
+        with (
+            mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock),
+            mock.patch.object(train_state_nnx, "to_checkpoint_dict") as to_checkpoint_dict_mock,
+        ):
           checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=5)
 
         mgr.latest_step.assert_called_once_with()
         mgr.reached_preemption.assert_called_once_with(5)
         mgr.wait_until_finished.assert_not_called()
-        state.to_pure_dict.assert_called_once_with()
+        to_checkpoint_dict_mock.assert_called_once_with(state)
         save_checkpoint_mock.assert_called_once()
 
   def test_maybe_save_checkpoint_allows_mtc_period_with_continuous_policy(
@@ -569,7 +574,6 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
   ):
     """Continuous checkpointing should not suppress MTC local saves."""
     state = mock.Mock()
-    state.to_pure_dict.return_value = {"model": {}, "optimizer": {"step": 5}}
     config = self._config(
         checkpoint_period=100,
         enable_continuous_checkpointing=True,
@@ -582,13 +586,16 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
     mgr.reached_preemption.return_value = False
     save_checkpoint_mock = mock.MagicMock(return_value=False)
 
-    with mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock):
+    with (
+        mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock),
+        mock.patch.object(train_state_nnx, "to_checkpoint_dict") as to_checkpoint_dict_mock,
+    ):
       checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=5)
 
     mgr.should_save.assert_called_once_with(5)
     mgr.latest_step.assert_called_once_with()
     mgr.reached_preemption.assert_called_once_with(5)
-    state.to_pure_dict.assert_called_once_with()
+    to_checkpoint_dict_mock.assert_called_once_with(state)
     save_checkpoint_mock.assert_called_once()
 
 


### PR DESCRIPTION
## Description

A pure_nnx run saves in the Linen on-disk layout, which has no place for NNX-only `rngs`/`dropout` and batch stats, so that state was dropped on save and refilled on resume from a base `jax.random.key(0)`. Every preemption reset the dropout RNG stream even though the data iterator was correctly restored. The optimizer state was silently reset too (see the `_opt_state_from_linen` fix below).

`to_checkpoint_dict` now partitions the state by Variable type via `split_for_checkpoint` into `(persistent, aux, ephemeral)`. `persistent` is the weights, the optimizer, and any other variable that has to survive a resume; it maps to the Linen `params`/`opt_state`/`step` layout. `aux` is `nnx.RngState` and `nnx.BatchStat`, which Linen never carried, and goes under an `nnx_aux` subtree of `items`. `ephemeral` is `nnx.Cache` and `nnx.Intermediate`, which are recomputed and so are not checkpointed. Selecting the ephemeral types rather than whitelisting `nnx.Param` matters: a custom `nnx.Variable` — such as the frozen `tid2eid` routing table DeepSeek V4 hash routing reads (`deepseek4-284b.yml` sets `first_num_hash_layers: 3`) — otherwise falls out of the checkpoint silently and reverts to zeros on resume, sending every token to expert 0. The missing-weight check only inspects `nnx.Param`, so nothing would warn.

- `nnx_aux` lives inside the single `items` tree, not as a sibling item, so every manager persists it — including the emergency manager, which writes one state tree (an emergency preemption previously lost the RNG stream). A Linen restore targets only `params`/`opt_state`/`step` and ignores the extra `items/nnx_aux`, so the two formats stay interchangeable.
- Restore is the inverse of save. `_linen_items_to_nnx` loads the checkpoint's two disjoint pieces — weights + optimizer, and rngs/dropout/batch stats — back into the matching pieces of `split_for_checkpoint(abstract)` and recombines them with `nnx.merge_state`. The split copies, so the result is the abstract with the checkpoint's values in place and unmaterialized `ShapeDtypeStruct`s wherever the checkpoint carried nothing. `setup_initial_state` builds a fresh concrete init and fills only those placeholders: a present leaf comes from the checkpoint, an absent one keeps its real init value — no zero or `key(0)` defaults. Restore never depends on knowing exactly what was saved, so an old checkpoint with no `nnx_aux`, or a weight the model added, simply keeps its init value. `setup_initial_state` no longer overlays onto the abstract itself and no longer mutates it.
- Fixes a latent bug in `_opt_state_from_linen`: it re-wrapped MaxText's flat opt_state (`{count, mu, nu}`) under a `{0: ...}` chain index, so on resume the optimizer silently reset to zero under the old default-fill. It now round-trips flat, and the step and adam moments are genuinely restored.
- Makes `_opt_state_to_linen` symmetric: it flattened a chain whose only non-empty entry sits at index 0, which `from_linen` cannot rebuild. It now maps a chain to the list-with-None layout and back. This one is latent rather than a live crash — `get_optimizer` always passes a learning-rate schedule, and `scale_by_schedule` carries state at a higher chain index, so MaxText's own optimizers (`adamw` → `{0, 2}`, `sgd` → `{1}`, `adam_pax` → flat) never reduce to the single-entry shape. A scalar learning rate (`optax.adamw(1e-3)`) does, and reproduces the failure.
- `checkpoint_missing_param_policy` gives visibility into a weight the checkpoint doesn't carry. Weights are filtered by Variable type (`nnx.Param`) so only real weights are checked — rngs/dropout/batch stats are never flagged. `warn` (default) logs a warning naming the weight and keeps its init value; `error` raises.
- The params-only load folds back into `load_params_from_path`. On disk the weights live at `params/params/...`: an outer key naming the item, and Flax's `params` collection inside it. A Linen `TrainState.params` is that collection; an NNX params state sits one level below it, so it is wrapped going in and unwrapped coming out. The single-use `_load_linen_params_into_nnx` and `_rebuild_nnx_with_values` are gone, and native `nnx.replace_by_pure_dict` writes the restored values back into the state.

Also addressed in review: the NNX full-state branch restores the grain data iterator; two dead `isinstance(..., nnx.State)` checks were removed; the orbax-v1 "orbax" layout routes `nnx.State` through the Linen→NNX conversion; and a TODO marks that `checkpoint_missing_param_policy` is only enforced on the full-state restore, not on the params-only route.

## Tests

- `tests/unit/checkpointing_nnx_load_test.py` (24) — `TestToCheckpointDict` (typed split: params/opt_state/step vs `nnx_aux`; batch stats split from weights; caches/intermediates excluded; a custom `nnx.Variable` persists rather than being silently dropped; a flat opt_state round-trips without a `{0}` chain wrapper; a chained opt_state round-trips back onto the state), `TestLinenItemsToNnx` (present aux kept; a leaf not on disk kept as a placeholder; no `nnx_aux` key leaves rng as a placeholder; a weights-only checkpoint leaves the optimizer as a placeholder), `TestMissingWeightPolicy` (the `nnx.Param`-type check: present weights pass; a missing weight raises naming its path under `error`; a surviving `ShapeDtypeStruct` counts as missing; `warn` logs and keeps init; `_expected_and_restored_params` splits weights from rng/dropout), and `TestLoadParamsIntoNNX` (a Linen-layout params checkpoint restores into the NNX params state, and the same function returns a Linen `TrainState.params` collection unchanged), plus the emergency-recovers-`nnx_aux` and param-view-split cases.
- `tests/unit/checkpointing_nnx_roundtrip_test.py` (12) — end-to-end through the real `create_orbax_checkpoint_manager → maybe_save_checkpoint → load_state_if_possible` stack, on a chained optimizer so the opt_state reshape is exercised for real: exact full-state fidelity (weights + optimizer + dropout rng + batch stats), per-component restore, old-checkpoint-missing-fields-keep-init, cache exclusion, the restored state loading into a live model and running, resume continuity of the rng stream, and the `load_full_state_from_path` route under both orbax v0 and v1.
- `tests/unit/setup_initial_state_nnx_test.py` (5) — drives the real `setup_initial_state` on CPU (patching only `get_abstract_state` for a tiny model), on an un-chained optimizer so the flat opt_state path is covered too: full restore via overlay, fresh init when no checkpoint exists, missing fields keeping their init value, the emergency manager's un-wrapped overlay, and a params-only load that writes the weights and leaves the optimizer and rng stream at init.
- `tests/unit/checkpointing_nnx_missing_param_test.py` (3) — end-to-end through the real save/restore stack: `error` raises naming the weight, `warn` keeps init (the missing weight stays a placeholder the trainer fills), and a matching-arch restore carries the weight.
- `tests/unit/train_state_nnx_checkpoint_test.py` (19) — the save path now reshapes with `to_checkpoint_dict(state)` (which splits by Variable type) instead of `to_linen_checkpoint_dict(state.to_pure_dict())`, so the `maybe_save_checkpoint` tests probe that call to assert save work is dispatched on a checkpoint step and skipped otherwise.
- Verified end-to-end on a v6e-8, for both opt_state shapes: a pure_nnx `train → save → resume` on `adam_pax` (flat) and on `adamw` (chained) each continues past the checkpoint step. Inspecting the on-disk checkpoint for the adamw run confirms `opt_state` is the chain layout with `count=10` and all 16 mu/nu leaves non-zero (a fresh init would be all zeros), and `nnx_aux` carries the advanced RNG stream (`dropout/rngs/dropout/count=20`) rather than a base `key(0)`. The checkpoint the `(persistent, aux, ephemeral)` split writes is path-for-path identical to the one the earlier `nnx.Param` split wrote (82 leaves, same tree), so the fix changes nothing for a model without custom `nnx.Variable`s.
- 44 passed across the four files above, plus `train_state_nnx_checkpoint_test.py` (19, covering nested-chain optimizers).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
