### PR TITLE
Fix: resolve config mismatch in vllm_decode.py

### DIFF
--- a/src/maxtext/inference/vllm_decode.py
+++ b/src/maxtext/inference/vllm_decode.py
@@ -93,7 +93,7 @@ def decode_with_vllm(config: Config) -> None:
       "additional_config": {
           "maxtext_config": {
               "model_name": config.model_name,
-              "weight_dtype": config.weight_dtype,
+              "weight_dtype": config.weight_dtype.name,
               "allow_split_physical_axes": True,
               "debug_sharding": config.debug_sharding,
               "prefuse_moe_weights": config.prefuse_moe_weights,
@@ -201,9 +201,7 @@ def decode_with_tunix(
     overrides = config.vllm_hf_overrides
     if isinstance(overrides, str) and "MaxTextForCausalLM" in overrides:
       use_no_op_mappings = True
-    elif isinstance(overrides, dict) and "MaxTextForCausalLM" in overrides.get(
-        "architectures", []
-    ):
+    elif isinstance(overrides, dict) and "MaxTextForCausalLM" in overrides.get("architectures", []):
       use_no_op_mappings = True
 
   tunix_model = TunixMaxTextAdapter(
@@ -238,19 +236,13 @@ def decode_with_tunix(
     )
 
   # MaxText uses -1 to mean "disabled"; vLLM requires top_p in (0, 1].
-  top_p = (
-      config.decode_sampling_nucleus_p
-      if config.decode_sampling_nucleus_p > 0
-      else 1.0
-  )
-  top_k = (
-      config.decode_sampling_top_k if config.decode_sampling_top_k > 0 else -1
-  )
+  top_p = config.decode_sampling_nucleus_p if config.decode_sampling_nucleus_p > 0 else 1.0
+  top_k = config.decode_sampling_top_k if config.decode_sampling_top_k > 0 else -1
 
   rollout_vllm_additional_config = {
       "maxtext_config": {
           "model_name": config.model_name,
-          "weight_dtype": config.weight_dtype,
+          "weight_dtype": config.weight_dtype.name,
           "allow_split_physical_axes": True,
           "debug_sharding": config.debug_sharding,
           "prefuse_moe_weights": config.prefuse_moe_weights,
@@ -280,17 +272,9 @@ def decode_with_tunix(
       rollout_vllm_hbm_utilization=config.hbm_utilization_vllm,
       rollout_vllm_init_with_random_weights=True,
       rollout_vllm_tpu_backend_type="jax",
-      tensor_parallel_size=(
-          config.ici_tensor_parallelism
-          if config.ici_tensor_parallelism > 0
-          else 1
-      ),
+      tensor_parallel_size=(config.ici_tensor_parallelism if config.ici_tensor_parallelism > 0 else 1),
       data_parallel_size=jax.device_count()
-      // (
-          config.ici_tensor_parallelism
-          if config.ici_tensor_parallelism > 0
-          else 1
-      ),
+      // (config.ici_tensor_parallelism if config.ici_tensor_parallelism > 0 else 1),
       rollout_vllm_additional_config=rollout_vllm_additional_config,
       rollout_vllm_kwargs={"hf_overrides": config.vllm_hf_overrides},
   )
@@ -330,9 +314,7 @@ def main(argv: Sequence[str]) -> None:
   if FLAGS.use_tunix:
     maxtext_model, mesh = model_creation_utils.from_pretrained(config)
     if config.lora.enable_lora:
-      maxtext_model = lora_utils.apply_lora_to_model(
-          maxtext_model, mesh, config
-      )
+      maxtext_model = lora_utils.apply_lora_to_model(maxtext_model, mesh, config)
       if config.lora.lora_restore_path:
         lora_utils.restore_lora_from_path(maxtext_model, config)
     decode_with_tunix(config, model=maxtext_model, mesh=mesh)


### PR DESCRIPTION
# Description
Fixes a initialization failure when running `vllm_decode` on a single-host TPU (v6e-8).

## Cause of the bug
In PR #4068, the `weight_dtype` was changed from a hardcoded `'bfloat16'` string to `config.weight_dtype`. However, `config.weight_dtype` is resolved as a raw JAX DType object within MaxText. When this object is passed, OmegaConf fails to parse it, throwing the error:
`MAXTEXT CONFIG ERROR: Value 'Float32DType' is not a supported primitive type`

# Solution
Convert the JAX DType object to its string representation by using `config.weight_dtype.name` before passing it into the vLLM config.

# Tests

```
python3 -m maxtext.inference.vllm_decode \
    model_name=${MODEL_NAME} \
    load_parameters_path=${UNSCANNED_CKPT_PATH} \
    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
    hbm_utilization_vllm=0.6 \
    prompt="Suggest some famous landmarks in London." \
    use_chat_template=True scan_layers=false
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
