### PR TITLE
fix(ci): Remove hardcoded cloud_runner from maxtext_jupyter_notebooks

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -147,9 +147,9 @@ jobs:
         fail-fast: false
     with:
       device_type: tpu
-      device_name: v6e-8
+      device_name: v6e-4
       base_image: maxtext-unit-test-tpu:py312
-      cloud_runner: linux-x86-ct6e-180-8tpu
+      cloud_runner: linux-x86-ct6e-180-4tpu
       maxtext_sha: ${{ needs.build_and_upload_maxtext_package.outputs.maxtext_sha }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/run_jupyter_notebooks.yml
+++ b/.github/workflows/run_jupyter_notebooks.yml
@@ -107,11 +107,15 @@ jobs:
           $PYTHON_EXE -m ipykernel install --user --name maxtext_venv
 
           # Run Hugging Face authentication
-          hf auth login --token "$HF_TOKEN"
+          if [ -n "$HF_TOKEN" ]; then
+            hf auth login --token "$HF_TOKEN"
+          else
+            echo "Warning: HF_TOKEN is empty (likely because this is a PR from a fork). Skipping Hugging Face authentication."
+          fi
 
           for notebook in "$MAXTEXT_NOTEBOOKS_ROOT"/*.ipynb; do
             filename=$(basename "$notebook")
-            if [[ "$filename" == "sft_llama3_demo_gpu.ipynb" || "$filename" == "maxtext_with_gepa.ipynb" || "$filename" == "demo_decoding.ipynb" ]]; then
+            if [[ "$filename" == "sft_llama3_demo_gpu.ipynb" || "$filename" == "maxtext_with_gepa.ipynb" || "$filename" == "rl_llama3_demo.ipynb" || "$filename" == "demo_decoding.ipynb" ]]; then
               echo "Skipping $filename"
               continue
             fi
@@ -127,6 +131,16 @@ jobs:
             echo "Post-notebook disk cleanup for $filename ..."
             rm -rf "$MAXTEXT_PKG_DIR"/*_output
             rm -rf "$HOME/.cache/huggingface/hub"
+
+            # papermill's kernel teardown can time out on heavy notebooks (e.g.
+            # sft_multimodal_gemma3_demo), leaving the ipykernel process alive and
+            # still holding the TPU + /tmp/libtpu_lockfile. That breaks TPU init for
+            # the next notebook ("ABORTED: ... libtpu multi-process lockfile"). Reap
+            # any surviving kernel and clear the lock before the next iteration.
+            echo "Post-notebook TPU cleanup for $filename ..."
+            pkill -9 -f ipykernel_launcher 2>/dev/null || true
+            sleep 2
+            rm -f /tmp/libtpu_lockfile
           done
       - name: Upload Outputs
         if: always()

--- a/.github/workflows/run_jupyter_notebooks.yml
+++ b/.github/workflows/run_jupyter_notebooks.yml
@@ -132,15 +132,21 @@ jobs:
             rm -rf "$MAXTEXT_PKG_DIR"/*_output
             rm -rf "$HOME/.cache/huggingface/hub"
 
-            # papermill's kernel teardown can time out on heavy notebooks (e.g.
-            # sft_multimodal_gemma3_demo), leaving the ipykernel process alive and
-            # still holding the TPU + /tmp/libtpu_lockfile. That breaks TPU init for
-            # the next notebook ("ABORTED: ... libtpu multi-process lockfile"). Reap
-            # any surviving kernel and clear the lock before the next iteration.
+            # Kill EVERY process still holding a vfio/accel fd (by device, not by name),
+            # clear the lock, then wait for the device to actually be released before the next notebook.
             echo "Post-notebook TPU cleanup for $filename ..."
+            for pid in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+              if ls -l /proc/"$pid"/fd 2>/dev/null | grep -qE '/dev/(vfio|accel)'; then
+                echo "  killing pid $pid ($(cat /proc/"$pid"/comm 2>/dev/null)) holding TPU"
+                kill -9 "$pid" 2>/dev/null || true
+              fi
+            done
             pkill -9 -f ipykernel_launcher 2>/dev/null || true
-            sleep 2
             rm -f /tmp/libtpu_lockfile
+            for _ in $(seq 1 30); do
+              ls -l /proc/*/fd 2>/dev/null | grep -qE '/dev/(vfio|accel)' || break
+              sleep 2
+            done
           done
       - name: Upload Outputs
         if: always()

--- a/.github/workflows/run_jupyter_notebooks.yml
+++ b/.github/workflows/run_jupyter_notebooks.yml
@@ -132,21 +132,6 @@ jobs:
             rm -rf "$MAXTEXT_PKG_DIR"/*_output
             rm -rf "$HOME/.cache/huggingface/hub"
 
-            # Kill EVERY process still holding a vfio/accel fd (by device, not by name),
-            # clear the lock, then wait for the device to actually be released before the next notebook.
-            echo "Post-notebook TPU cleanup for $filename ..."
-            for pid in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
-              if ls -l /proc/"$pid"/fd 2>/dev/null | grep -qE '/dev/(vfio|accel)'; then
-                echo "  killing pid $pid ($(cat /proc/"$pid"/comm 2>/dev/null)) holding TPU"
-                kill -9 "$pid" 2>/dev/null || true
-              fi
-            done
-            pkill -9 -f ipykernel_launcher 2>/dev/null || true
-            rm -f /tmp/libtpu_lockfile
-            for _ in $(seq 1 30); do
-              ls -l /proc/*/fd 2>/dev/null | grep -qE '/dev/(vfio|accel)' || break
-              sleep 2
-            done
           done
       - name: Upload Outputs
         if: always()


### PR DESCRIPTION
# Description
  This PR fixes two critical issues blocking the maxtext_jupyter_notebooks CI job from running successfully, particularly for Pull Requests originating from forks.

  1. Reverted Notebook Runner to v6e-4 to Unblock the CI Queue
  In commit f940dfd39 (April 29th), the notebook CI was updated to use v6e-8 and request a linux-x86-ct6e-180-8tpu runner to accommodate rl_llama3_demo.ipynb. However, because there are no 8-chip runners available in the CI pool, GitHub Actions queues the job indefinitely, blocking all PRs. 
   * Fix: Fully reverted the notebook CI configuration back to the known-working 4-chip setup. 
     * Downgraded device_name back to v6e-4.
     * Explicitly requested the available linux-x86-ct6e-180-4tpu cloud runner.
     * Re-added rl_llama3_demo.ipynb to the skip list in run_jupyter_notebooks.yml (as it OOMs on 4 chips).

  2. Gracefully Handle Empty Hugging Face Tokens in Fork PRs
  Due to GitHub Actions security restrictions, PRs originating from forks cannot access repository secrets. Consequently, ${{ secrets.HF_TOKEN }} evaluates to an empty string. This caused the hf auth login --token "$HF_TOKEN" command to crash with an Illegal header value b'Bearer ' exception.
   * Fix: Added a conditional check around the Hugging Face authentication step in run_jupyter_notebooks.yml. If the token is empty, the script now gracefully logs a warning and skips authentication rather than crashing the entire
     workflow. 

  Motivation and Context
  These fixes are necessary to restore a passing baseline for the MaxText CI pipeline. Currently, the notebook job either hangs forever (due to the missing runner) or crashes immediately (due to the empty token on fork PRs). 

  How has this been tested?
   * Verified that the CI correctly requests the self-hosted, tpu, v6e-4 labels.
   * Verified that the workflow proceeds past the Hugging Face authentication step gracefully when HF_TOKEN is empty.


# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
