### PR TITLE
Support load-balanced CP chunk masks

### DIFF
--- a/src/maxtext/configs/pyconfig_deprecated.py
+++ b/src/maxtext/configs/pyconfig_deprecated.py
@@ -249,12 +249,11 @@ def validate_keys(keys):
         keys["global_rampup_samples"],
     )
 
-  context_parallel_size = get_context_parallel_size(keys)
   # TODO remove after b/435512699 resolved
-  if context_parallel_size > 1 and keys["context_parallel_load_balance"] and keys["attention_type"] == "chunk":
-    raise ValueError("Currently load-balanced context parallelism is not supported for chunk attention.")
 
-  validate_context_parallel_strategy_ring(context_parallel_size, keys["context_parallel_strategy"], keys["hardware"])
+  validate_context_parallel_strategy_ring(
+      keys["context_parallel_size"], keys["context_parallel_strategy"], keys["hardware"]
+  )
 
   if keys["mtp_eval_target_module"] < 0:
     raise ValueError("mtp_eval_target_module cannot be negative. Set to 0 to disable evaluation.")
@@ -816,6 +815,7 @@ class _HyperParameters:
 
     raw_keys["num_slices"] = max_utils.get_num_slices(raw_keys)
     raw_keys["quantization_local_shard_count"] = get_quantization_local_shard_count(raw_keys)
+    raw_keys["context_parallel_size"] = get_context_parallel_size(raw_keys)
     raw_keys = create_parallelisms_list(raw_keys)
     raw_keys = set_and_validate_pipeline_config(raw_keys)
 

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -615,6 +615,7 @@ class AttentionOp(nnx.Module):
       previous_chunk: Any = None,
       bidirectional_mask: Any = None,
       compressed_mask: Optional[Array] = None,
+      segment_positions: Array | None = None,
   ) -> Array | None:
     """Generates a combined attention mask for Transformer models.
 
@@ -675,6 +676,9 @@ class AttentionOp(nnx.Module):
       compressed_mask: Optional `Array`. A pre-computed attention mask for
         compressed kv blocks (e.g., DeepSeek-V4 compressed attention). If provided, it is
         concatenated with the dynamically generated uncompressed mask.
+      segment_positions: Optional `Array` of shape `[batch_size,
+        q_sequence_length]`. Identifies original positions for load-balanced
+        context-parallel inputs.
 
     Returns:
       An `Array` representing the attention mask, with shape
@@ -710,20 +714,33 @@ class AttentionOp(nnx.Module):
     elif model_mode == MODEL_MODE_AUTOREGRESSIVE and q_seq_len == 1:
       # In autoregression, the query position is the last position in the KV sequence.
       next_pos = kv_seq_len - 1
+    use_segment_positions = (
+        segment_positions is not None
+        and self.config.context_parallel_load_balance
+        and self.mesh.shape.get(self.config.context_sharding, 1) > 1
+        and previous_chunk is None
+        and model_mode != MODEL_MODE_AUTOREGRESSIVE
+    )
+    if use_segment_positions:
+      position_row_ids = segment_positions[:, :, None]
+      position_col_ids = segment_positions[:, None, :]
 
     causal_mask = None
     if model_mode != MODEL_MODE_AUTOREGRESSIVE and self.attention_type not in (
         AttentionType.FULL,
         AttentionType.COMPRESSED,
     ):
-      mask_shape = (q_seq_len, kv_seq_len)
-      # row_ids indicates the position of query
-      # col_ids indicates the position of kv
-      row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
-      col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
-      # Attention mask for chunked prefill is generated in the same way
-      # as mentioned in SARATHI - https://arxiv.org/abs/2308.16369
-      causal_mask = (col_ids <= row_ids + next_pos)[None, None, None, :, :]
+      if use_segment_positions:
+        causal_mask = (position_col_ids <= position_row_ids)[:, None, None, :, :]
+      else:
+        mask_shape = (q_seq_len, kv_seq_len)
+        # row_ids indicates the position of query
+        # col_ids indicates the position of kv
+        row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+        col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+        # Attention mask for chunked prefill is generated in the same way
+        # as mentioned in SARATHI - https://arxiv.org/abs/2308.16369
+        causal_mask = (col_ids <= row_ids + next_pos)[None, None, None, :, :]
 
     output_mask = None
     if (mask is not None) and (causal_mask is not None):
@@ -737,11 +754,17 @@ class AttentionOp(nnx.Module):
       if self.sliding_window_size is None:
         raise ValueError("Sliding_window_size must be set if Local Sliding attention type")
 
-      row_ids_sliding = jax.lax.broadcasted_iota(jnp.int32, (q_seq_len, 1), 0) + next_pos
-      col_ids_sliding = jax.lax.broadcasted_iota(jnp.int32, (1, kv_seq_len), 1)
+      if use_segment_positions:
+        row_ids_sliding = position_row_ids
+        col_ids_sliding = position_col_ids
+      else:
+        row_ids_sliding = jax.lax.broadcasted_iota(jnp.int32, (q_seq_len, 1), 0) + next_pos
+        col_ids_sliding = jax.lax.broadcasted_iota(jnp.int32, (1, kv_seq_len), 1)
       sliding_mask = (col_ids_sliding > (row_ids_sliding - self.sliding_window_size)) & (
           col_ids_sliding <= row_ids_sliding
       )
+      if use_segment_positions:
+        sliding_mask = sliding_mask[:, None, None, :, :]
       output_mask = sliding_mask * output_mask
     elif self.attention_type == AttentionType.COMPRESSED:
       if compressed_mask is None:
@@ -772,12 +795,17 @@ class AttentionOp(nnx.Module):
       return jnp.concatenate([uncompressed_mask, compressed_mask], axis=-1)
 
     elif self.attention_type == AttentionType.CHUNK and output_mask is not None:
-      mask_shape = (q_seq_len, kv_seq_len)
-      chunk_mask = _generate_chunk_attention_mask(
-          mask_shape=(q_seq_len, kv_seq_len),
-          chunk_size=self.chunk_attn_window_size,
-          q_offset=next_pos,
-      )
+      if use_segment_positions:
+        same_chunk = (position_row_ids // self.chunk_attn_window_size) == (
+            position_col_ids // self.chunk_attn_window_size
+        )
+        chunk_mask = (same_chunk & (position_row_ids >= position_col_ids))[:, None, None, :, :]
+      else:
+        chunk_mask = _generate_chunk_attention_mask(
+            mask_shape=(q_seq_len, kv_seq_len),
+            chunk_size=self.chunk_attn_window_size,
+            q_offset=next_pos,
+        )
       output_mask = chunk_mask * output_mask
 
     if bidirectional_mask is not None:
@@ -976,6 +1004,7 @@ class AttentionOp(nnx.Module):
           decoder_segment_ids,
           model_mode,
           previous_chunk,
+          segment_positions=segment_positions,
           bidirectional_mask=bidirectional_mask,
           sinks=sinks,
           indexer_mask=indexer_mask,
@@ -1301,10 +1330,17 @@ class AttentionOp(nnx.Module):
       if self.chunk_attn_window_size is None:
         raise ValueError("chunk_attn_window_size must be set for chunk attention type")
 
-      mask &= ChunkedCausalMask(
-          shape=(query.shape[2], key.shape[2]),
-          chunk_size=self.chunk_attn_window_size,
-      )
+      if use_load_balanced_cp:
+        mask &= LoadBalancedChunkedCausalMask(
+            shape=(query.shape[2], key.shape[2]),
+            chunk_size=self.chunk_attn_window_size,
+            cp_size=cp_size,
+        )
+      else:
+        mask &= ChunkedCausalMask(
+            shape=(query.shape[2], key.shape[2]),
+            chunk_size=self.chunk_attn_window_size,
+        )
 
     max_logit_value = None
     if self.config.use_tokamax_splash:
@@ -1588,6 +1624,8 @@ class AttentionOp(nnx.Module):
         and self.config.context_parallel_strategy == "ring"
         and self.config.context_parallel_load_balance
     )
+    if using_context_parallelism and self.attention_type == AttentionType.CHUNK:
+      raise ValueError("Chunk attention is not supported with CUDNN context parallelism.")
 
     # Initialize default attention configuration
     sliding_window_size = None
@@ -1815,6 +1853,7 @@ class AttentionOp(nnx.Module):
       decoder_segment_ids: Array | None,
       model_mode: str = MODEL_MODE_TRAIN,
       previous_chunk: Any = None,
+      segment_positions: Array | None = None,
       bidirectional_mask: Any = None,
       sinks: Array | None = None,
       indexer_mask: Array | None = None,
@@ -1880,6 +1919,7 @@ class AttentionOp(nnx.Module):
         previous_chunk,
         bidirectional_mask,
         compressed_mask=compressed_mask,
+        segment_positions=segment_positions,
     )
 
     if self.config.moba:
@@ -2253,4 +2293,22 @@ class LoadBalancedLocalMask(splash_attention_mask.LocalMask):
     )
     # LocalMask uses shard_count for mask-shard validation. cp_size is the
     # context-parallel size used for the load-balanced query order.
+    self.q_sequence = _load_balanced_q_sequence(shape, cp_size)
+
+
+class LoadBalancedChunkedCausalMask(ChunkedCausalMask):
+  """Lazy chunked mask with load-balanced query positions."""
+
+  def __init__(
+      self,
+      shape: tuple[int, int],
+      chunk_size: int,
+      cp_size: int,
+      shard_count: int = 1,
+  ):
+    super().__init__(
+        shape=shape,
+        chunk_size=chunk_size,
+        shard_count=shard_count,
+    )
     self.q_sequence = _load_balanced_q_sequence(shape, cp_size)

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -350,12 +350,104 @@ class LoadBalancedMaskTest(unittest.TestCase):
 
     np.testing.assert_array_equal((causal_mask & local_mask)[:, :], expected_mask)
 
+  def test_load_balanced_chunk_window(self):
+    seq_len = 8
+    chunk_size = 2
+    q_sequence = np.asarray([0, 1, 6, 7, 2, 3, 4, 5])
+    kv_sequence = np.arange(seq_len)
+    causal_mask = attention_op.LoadBalancedCausalMask(shape=(seq_len, seq_len), cp_size=2)
+    chunk_mask = attention_op.LoadBalancedChunkedCausalMask(
+        shape=(seq_len, seq_len),
+        chunk_size=chunk_size,
+        cp_size=2,
+    )
+
+    expected_mask = (kv_sequence[None, :] <= q_sequence[:, None]) & (
+        q_sequence[:, None] // chunk_size == kv_sequence[None, :] // chunk_size
+    )
+
+    np.testing.assert_array_equal((causal_mask & chunk_mask)[:, :], expected_mask)
+
+  def test_dot_product_local_mask_uses_segment_positions(self):
+    config = types.SimpleNamespace(context_parallel_load_balance=True, context_sharding="context")
+    mesh = types.SimpleNamespace(shape={"context": 4})
+    seq_len = 16
+    sliding_window_size = 4
+    positions = jnp.asarray(attention_op.LoadBalancedCausalMask(shape=(seq_len, seq_len), cp_size=4).q_sequence[None, :])
+    query = jnp.zeros((1, seq_len, 1, 128))
+    key = jnp.zeros((1, seq_len, 1, 128))
+    decoder_segment_ids = jnp.ones((1, seq_len), dtype=jnp.int32)
+    op = AttentionOp(
+        config=config,
+        num_query_heads=1,
+        num_kv_heads=1,
+        max_target_length=seq_len,
+        mesh=mesh,
+        attention_kernel="dot_product",
+        attention_type=AttentionType.LOCAL_SLIDING,
+        sliding_window_size=sliding_window_size,
+    )
+
+    mask = op.generate_attention_mask(
+        query,
+        key,
+        decoder_segment_ids,
+        MODEL_MODE_TRAIN,
+        segment_positions=positions,
+    )
+
+    expected_mask = np.zeros((seq_len, seq_len), dtype=np.bool_)
+    for r, q_pos in enumerate(np.asarray(positions[0])):
+      for c, kv_pos in enumerate(np.asarray(positions[0])):
+        if q_pos - sliding_window_size < kv_pos <= q_pos:
+          expected_mask[r, c] = True
+
+    np.testing.assert_array_equal(np.asarray(mask == 0.0)[0, 0, 0], expected_mask)
+
+  def test_dot_product_chunk_mask_uses_segment_positions(self):
+    config = types.SimpleNamespace(context_parallel_load_balance=True, context_sharding="context")
+    mesh = types.SimpleNamespace(shape={"context": 4})
+    seq_len = 16
+    chunk_size = 4
+    positions = jnp.asarray(attention_op.LoadBalancedCausalMask(shape=(seq_len, seq_len), cp_size=4).q_sequence[None, :])
+    query = jnp.zeros((1, seq_len, 1, 128))
+    key = jnp.zeros((1, seq_len, 1, 128))
+    decoder_segment_ids = jnp.ones((1, seq_len), dtype=jnp.int32)
+    op = AttentionOp(
+        config=config,
+        num_query_heads=1,
+        num_kv_heads=1,
+        max_target_length=seq_len,
+        mesh=mesh,
+        attention_kernel="dot_product",
+        attention_type=AttentionType.CHUNK,
+        chunk_attn_window_size=chunk_size,
+    )
+
+    mask = op.generate_attention_mask(
+        query,
+        key,
+        decoder_segment_ids,
+        MODEL_MODE_TRAIN,
+        segment_positions=positions,
+    )
+
+    expected_mask = np.zeros((seq_len, seq_len), dtype=np.bool_)
+    for r, q_pos in enumerate(np.asarray(positions[0])):
+      for c, kv_pos in enumerate(np.asarray(positions[0])):
+        if q_pos >= kv_pos and q_pos // chunk_size == kv_pos // chunk_size:
+          expected_mask[r, c] = True
+
+    np.testing.assert_array_equal(np.asarray(mask == 0.0)[0, 0, 0], expected_mask)
+
 
 class CudnnTePackedSequenceDescriptorTest(unittest.TestCase):
   """Tests packed Transformer Engine attention metadata handling."""
 
-  def _call_packed_attention(self, sequence_descriptor):
-    """Runs packed TE attention with fake Transformer Engine modules."""
+  def _call_te_attention(
+      self, sequence_descriptor, config=None, mesh=None, attention_type=AttentionType.GLOBAL, chunk_attn_window_size=None
+  ):
+    """Runs TE attention with fake Transformer Engine modules."""
     sequence_descriptor.calls = []
 
     class FakeWrappedAttention:
@@ -382,17 +474,19 @@ class CudnnTePackedSequenceDescriptorTest(unittest.TestCase):
         "transformer_engine.jax.attention": attention_module,
     }
 
-    config = types.SimpleNamespace(
-        context_sharding="context",
-        context_parallel_strategy="ring",
-        context_parallel_load_balance=False,
-        packing=True,
-        dataset_type="grain",
-        max_segments_per_seq=4,
-        head_dim=2,
-        attention_kernel="cudnn_flash_te",
-    )
-    mesh = types.SimpleNamespace(shape={"context": 1})
+    if config is None:
+      config = types.SimpleNamespace(
+          context_sharding="context",
+          context_parallel_strategy="ring",
+          context_parallel_load_balance=False,
+          packing=True,
+          dataset_type="grain",
+          max_segments_per_seq=4,
+          head_dim=2,
+          attention_kernel="cudnn_flash_te",
+      )
+    if mesh is None:
+      mesh = types.SimpleNamespace(shape={"context": 1})
     attention = AttentionOp(
         config=config,
         mesh=mesh,
@@ -401,6 +495,8 @@ class CudnnTePackedSequenceDescriptorTest(unittest.TestCase):
         num_query_heads=2,
         num_kv_heads=2,
         dtype=jnp.float32,
+        attention_type=attention_type,
+        chunk_attn_window_size=chunk_attn_window_size,
     )
     query = jnp.zeros((1, 4, 2, 2), dtype=jnp.float32)
     key = jnp.zeros((1, 4, 2, 2), dtype=jnp.float32)
@@ -433,7 +529,7 @@ class CudnnTePackedSequenceDescriptorTest(unittest.TestCase):
           raise TypeError("older Transformer Engine does not accept THD metadata")
         return kwargs
 
-    output, descriptor_calls = self._call_packed_attention(SequenceDescriptor)
+    output, descriptor_calls = self._call_te_attention(SequenceDescriptor)
 
     self.assertEqual(len(descriptor_calls), 2)
     for call in descriptor_calls:
@@ -442,13 +538,37 @@ class CudnnTePackedSequenceDescriptorTest(unittest.TestCase):
     self.assertIs(output, descriptor_calls[0])
 
     SequenceDescriptor.reject_thd_kwargs = True
-    output, descriptor_calls = self._call_packed_attention(SequenceDescriptor)
+    output, descriptor_calls = self._call_te_attention(SequenceDescriptor)
     self.assertEqual(len(descriptor_calls), 4)
     self.assertIn("is_thd", descriptor_calls[0])
     self.assertNotIn("is_thd", descriptor_calls[1])
     self.assertIn("is_thd", descriptor_calls[2])
     self.assertNotIn("is_thd", descriptor_calls[3])
     self.assertIs(output, descriptor_calls[1])
+
+  def test_context_parallel_chunk_attention_rejected(self):
+    class SequenceDescriptor:
+      pass
+
+    config = types.SimpleNamespace(
+        context_sharding="context",
+        context_parallel_strategy="all_gather",
+        context_parallel_load_balance=False,
+        packing=False,
+        dataset_type="synthetic",
+        max_segments_per_seq=1,
+        head_dim=2,
+        attention_kernel="cudnn_flash_te",
+    )
+    mesh = types.SimpleNamespace(shape={"context": 2})
+    with self.assertRaisesRegex(ValueError, "Chunk attention"):
+      self._call_te_attention(
+          SequenceDescriptor,
+          config=config,
+          mesh=mesh,
+          attention_type=AttentionType.CHUNK,
+          chunk_attn_window_size=2,
+      )
 
 
 class AttentionTest(parameterized.TestCase):

--- a/tests/unit/configs_value_test.py
+++ b/tests/unit/configs_value_test.py
@@ -96,6 +96,28 @@ class ConfigTest(absltest.TestCase):
     with self.assertRaises(pydantic.ValidationError):
       pyconfig.initialize(argv)
 
+  def test_load_balanced_chunk_context_parallel_config(self):
+    argv = [
+        "",
+        _BASE_CONFIG_PATH,
+        "run_name=test",
+        "steps=1",
+        "attention_type=chunk",
+        "chunk_attn_window_size=256",
+        "context_parallel_load_balance=True",
+        "ici_context_parallelism=2",
+        "hardware=tpu",
+        "packing=False",
+        "dataset_type=synthetic",
+        "skip_jax_distributed_system=True",
+    ]
+    mock_devices = [unittest.mock.MagicMock(slice_index=0) for _ in range(8)]
+    with unittest.mock.patch("jax.devices", return_value=mock_devices):
+      config = pyconfig.initialize(argv)
+
+    self.assertEqual(config.attention_type, "chunk")
+    self.assertTrue(config.context_parallel_load_balance)
+
   @unittest.mock.patch.dict(os.environ, {pyconfig.yaml_key_to_env_key("steps"): "123"})
   def test_env_override(self):
     """Tests that environment variables override YAML values."""


### PR DESCRIPTION
# Description

Enables `attention_type=chunk` with load-balanced CP by making the chunk mask use the same query ordering as the load-balanced causal mask.

This PR:
- adds `LoadBalancedChunkedCausalMask` for Splash attention
- uses `segment_positions` for dot-product chunk and local-sliding masks under load-balanced CP


FIXES: b/435512699

# Tests

Ran:

```bash
pyink --check --pyink-indentation=2 --line-length=122 \
  src/maxtext/layers/attention_op.py \
  tests/unit/attention_test.py \
  tests/unit/configs_value_test.py \
  src/maxtext/configs/pyconfig_deprecated.py

python3 -m pytest tests/unit/attention_test.py -k 'load_balanced_chunk_window or dot_product_chunk_mask_uses_segment_positions or dot_product_local_mask_uses_segment_positions or context_parallel_chunk_attention_rejected'

python3 -m pytest tests/unit/configs_value_test.py::ConfigTest::test_load_balanced_chunk_context_parallel_config

python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
  run_name=lb_cp_chunk_e2e \
  model_name=llama3.1-8b \
  dataset_type=synthetic \
  steps=1 \
  enable_checkpointing=false \
  packing=false \
  attention=flash \
  attention_type=chunk \
  chunk_attn_window_size=256 \
  context_parallel_load_balance=True \
  ici_context_parallelism=4 \
  ici_fsdp_parallelism=16 \
  per_device_batch_size=0.25 \
  max_target_length=2048

on v5p-128 with EXIT_CODE=0.
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
