### PR TITLE
Fully remove tp_transpose from MaxText

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -492,7 +492,7 @@ compile_xla_flags: "" # Compiler options e.g. compile_xla_flags="--xla_tpu_num_s
 # Parallelism
 shard_mode: "auto" # can be either auto or explicit
 custom_mesh_and_rule: "" # replace default mesh and logical rule by specifying yml name under config/mesh_and_rule/.
-mesh_axes: ['diloco', 'data', 'stage', 'fsdp', 'fsdp_transpose', 'context', 'context_autoregressive', 'tensor', 'tensor_transpose', 'tensor_sequence', 'expert', 'autoregressive']
+mesh_axes: ['diloco', 'data', 'stage', 'fsdp', 'fsdp_transpose', 'context', 'context_autoregressive', 'tensor', 'tensor_sequence', 'expert', 'autoregressive']
 logical_axis_rules: [
                       ['circular_repeats', []],
                       # ==========================================
@@ -501,40 +501,36 @@ logical_axis_rules: [
                       # Vocab Activations
                       ['activation_embed_and_logits_batch', ['data', 'stage', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_embed_and_logits_batch_sequence', ['data', 'stage', 'fsdp', 'fsdp_transpose', 'context', 'expert']],
-                      ['activation_vocab', ['tensor', 'tensor_transpose', 'tensor_sequence']],
-                      ['activation_vocab', ['tensor', 'tensor_transpose']],
+                      ['activation_vocab', ['tensor', 'tensor_sequence']],
+                      ['activation_vocab', ['tensor']],
                       ['activation_vocab', 'tensor_sequence'],
                       # Vocab Weights
-                      ['vocab', ['tensor', 'tensor_transpose', 'tensor_sequence', 'autoregressive']],
+                      ['vocab', ['tensor', 'tensor_sequence', 'autoregressive']],
                       ['embed_vocab', ['fsdp', 'fsdp_transpose', 'context', 'expert']],
                       # ==========================================
                       # Attention
                       # ==========================================
                       # Attention Activations
                       ['activation_batch_attn', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
-                      ['activation_heads', ['tensor', 'tensor_transpose', 'tensor_sequence', 'autoregressive']],
-                      ['activation_kv_heads', ['tensor', 'tensor_transpose', 'tensor_sequence']],
+                      ['activation_heads', ['tensor', 'tensor_sequence', 'autoregressive']],
+                      ['activation_kv_heads', ['tensor', 'tensor_sequence']],
                       ['activation_length_attn', ['context']],
                       ['activation_q_length', ['context']],
                       ['activation_kv_length', []],
-                      ['activation_embed_attn', ['tensor', 'tensor_transpose']],
-                      ['activation_kv', ['tensor', 'tensor_transpose', 'tensor_sequence']],
+                      ['activation_embed_attn', ['tensor']],
+                      ['activation_kv', ['tensor', 'tensor_sequence']],
                       ['activation_kv_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
-                      ['activation_kv_head_dim', ['tensor', 'tensor_transpose', 'tensor_sequence']],
+                      ['activation_kv_head_dim', ['tensor', 'tensor_sequence']],
                       # Attention Weights
-                      ['heads', ['tensor', 'tensor_transpose', 'tensor_sequence', 'autoregressive']],
-                      ['q_heads', ['tensor', 'tensor_transpose', 'tensor_sequence', 'autoregressive']],
-                      ['kv_heads', ['tensor', 'tensor_transpose', 'tensor_sequence', 'autoregressive']],
+                      ['heads', ['tensor', 'tensor_sequence', 'autoregressive']],
+                      ['q_heads', ['tensor', 'tensor_sequence', 'autoregressive']],
+                      ['kv_heads', ['tensor', 'tensor_sequence', 'autoregressive']],
                       ['qkv', []],
                       ['kv', []],
                       ['kv_head_dim', []],
-                      ['q_lora', ['fsdp', 'fsdp_transpose', 'context', 'tensor_transpose', 'expert']],
-                      ['q_lora', ['fsdp', 'context', 'tensor_transpose', 'expert']],
                       ['q_lora', ['fsdp', 'fsdp_transpose', 'context', 'expert']],
                       ['q_lora', ['fsdp', 'context', 'expert']],
                       ["q_lora_up_proj", []],
-                      ['kv_lora', ['fsdp', 'fsdp_transpose', 'context', 'tensor_transpose', 'expert']],
-                      ['kv_lora', ['fsdp', 'context', 'tensor_transpose', 'expert']],
                       ['kv_lora', ['fsdp', 'fsdp_transpose', 'context', 'expert']],
                       ['kv_lora', ['fsdp', 'context', 'expert']],
                       ["kv_lora_up_proj", []],
@@ -545,37 +541,33 @@ logical_axis_rules: [
                       ['activation_batch_moe', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_length_moe', ['context']],
                       ['activation_norm_length_moe', ['tensor_sequence', 'context']],
-                      ['activation_embed_moe', ['tensor', 'tensor_transpose']],
-                      ['activation_mlp_moe', ['tensor', 'tensor_transpose', 'tensor_sequence']],
+                      ['activation_embed_moe', ['tensor']],
+                      ['activation_mlp_moe', ['tensor', 'tensor_sequence']],
                       ['activation_exp', ['expert']],
                       # MoE Weights
                       ['exp', 'expert'],
                       ['mlp_moe', ['fsdp_transpose', 'tensor', 'tensor_sequence', 'autoregressive']],
-                      ['embed_moe', ['fsdp', 'fsdp_transpose', 'tensor_transpose', 'context']],
-                      ['embed_moe', ['fsdp', 'tensor_transpose', 'context']],
                       ['embed_moe', ['fsdp', 'fsdp_transpose', 'context']],
                       ['embed_moe', ['fsdp', 'context']],
                       # ==========================================
                       # Standard MLP / Dense Layers / Model Structure
                       # ==========================================
                       # Dense Activations
-                      ['activation_mlp', ['tensor', 'tensor_transpose', 'tensor_sequence']],
+                      ['activation_mlp', ['tensor', 'tensor_sequence']],
                       # Note activation batch and length also get used in vocab
                       ['activation_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['activation_length', ['context']],
                       ['activation_norm_length', ['tensor_sequence', 'context']],
-                      ['activation_embed', ['tensor', 'tensor_transpose']],
+                      ['activation_embed', ['tensor']],
                       ['activation_stage', 'stage'],
                       # General Weights
                       ['mlp', ['fsdp_transpose', 'tensor', 'tensor_sequence', 'autoregressive']],
                       # GDN (linear-attention) projections shard like 'mlp' during training; the
                       # vLLM serving config overrides this to match tpu-inference's ATTN_HEAD order.
                       ['gdn_head', ['fsdp_transpose', 'tensor', 'tensor_sequence', 'autoregressive']],
-                      ['embed', ['fsdp', 'fsdp_transpose', 'tensor_transpose', 'context', 'expert']],
-                      ['embed', ['fsdp', 'tensor_transpose', 'context', 'expert']],
                       ['embed', ['fsdp', 'fsdp_transpose', 'context', 'expert']],
                       ['embed', ['fsdp', 'context', 'expert']],
-                      ['norm', ['tensor', 'tensor_transpose']],
+                      ['norm', ['tensor']],
                       ['layers', 'stage'],
                       ['diloco', 'diloco'],
                       ['engram_dim', ['tensor']],
@@ -590,7 +582,6 @@ logical_axis_rules: [
                       ['activation_prefill_kv_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['decode_batch', ['data', 'fsdp', 'fsdp_transpose', 'expert']],
                       ['decode_length', []],
-                      ['cache_heads', ['autoregressive', 'tensor', 'tensor_transpose', 'tensor_sequence']],
                       ['cache_heads', ['autoregressive', 'tensor', 'tensor_sequence']],
                       ['paged_kv_heads', ['tensor']],
                       ['cache_batch_prefill', []],
@@ -605,11 +596,10 @@ logical_axis_rules: [
                       # Deprecated / Scheduled for Removal
                       # ==========================================
                       ['mlp_no_fsdp', ['tensor', 'tensor_sequence', 'autoregressive']],
-                      ['embed_tensor_transpose', ['tensor_transpose']],
                       ['exp_with_fsdp', 'fsdp'],
                   ]
 # Axes used for DCN must be earlier in this list than ICI, see (b/339009148) for details
-data_sharding: [['data', 'stage', 'fsdp', 'fsdp_transpose', 'context', 'context_autoregressive', 'tensor', 'tensor_transpose', 'tensor_sequence', 'expert', 'autoregressive']]
+data_sharding: [['data', 'stage', 'fsdp', 'fsdp_transpose', 'context', 'context_autoregressive', 'tensor', 'tensor_sequence', 'expert', 'autoregressive']]
 input_data_sharding_logical_axes: ['activation_embed_and_logits_batch', 'activation_norm_length']
 # Determines which physical axis plays the role of context parallelism for input data processing and load balancing
 # only supports "context" or "expert" (when custom_mesh_and_rule=ep-as-cp)
@@ -630,7 +620,6 @@ dcn_sequence_parallelism: 1  # never recommended
 dcn_context_parallelism: 1
 dcn_context_autoregressive_parallelism: 1
 dcn_tensor_parallelism: 1 # never recommended
-dcn_tensor_transpose_parallelism: 1
 dcn_tensor_sequence_parallelism: 1 # never recommended
 dcn_pipeline_parallelism: 1
 dcn_expert_parallelism: 1
@@ -643,7 +632,6 @@ ici_sequence_parallelism: 1
 ici_context_parallelism: 1
 ici_context_autoregressive_parallelism: 1
 ici_tensor_parallelism: 1
-ici_tensor_transpose_parallelism: 1
 ici_tensor_sequence_parallelism: 1
 ici_autoregressive_parallelism: 1
 ici_pipeline_parallelism: 1

--- a/src/maxtext/configs/decoupled_base_test.yml
+++ b/src/maxtext/configs/decoupled_base_test.yml
@@ -42,7 +42,6 @@ ici_pipeline_parallelism: 1
 ici_expert_parallelism: 1
 ici_sequence_parallelism: 1
 ici_context_parallelism: 1
-ici_tensor_transpose_parallelism: 1
 ici_tensor_sequence_parallelism: 1
 ici_autoregressive_parallelism: 1
 ici_fsdp_parallelism: -1
@@ -57,7 +56,6 @@ dcn_pipeline_parallelism: 1
 dcn_expert_parallelism: 1
 dcn_sequence_parallelism: 1
 dcn_context_parallelism: 1
-dcn_tensor_transpose_parallelism: 1
 dcn_tensor_sequence_parallelism: 1
 dcn_autoregressive_parallelism: 1
 dcn_fsdp_parallelism: 1

--- a/src/maxtext/configs/pyconfig_deprecated.py
+++ b/src/maxtext/configs/pyconfig_deprecated.py
@@ -918,7 +918,6 @@ def create_parallelisms_list(raw_keys):
       raw_keys["ici_context_parallelism"],
       raw_keys["ici_context_autoregressive_parallelism"],
       raw_keys["ici_tensor_parallelism"],
-      raw_keys["ici_tensor_transpose_parallelism"],
       raw_keys["ici_tensor_sequence_parallelism"],
       raw_keys["ici_expert_parallelism"],
       raw_keys["ici_autoregressive_parallelism"],
@@ -932,7 +931,6 @@ def create_parallelisms_list(raw_keys):
       raw_keys["dcn_context_parallelism"],
       raw_keys["dcn_context_autoregressive_parallelism"],
       raw_keys["dcn_tensor_parallelism"],
-      raw_keys["dcn_tensor_transpose_parallelism"],
       raw_keys["dcn_tensor_sequence_parallelism"],
       raw_keys["dcn_expert_parallelism"],
       raw_keys["dcn_autoregressive_parallelism"],
@@ -1029,7 +1027,6 @@ def set_and_validate_pipeline_config(raw_keys):
           raw_keys["ici_context_parallelism"],
           raw_keys["ici_context_autoregressive_parallelism"],
           raw_keys["ici_tensor_parallelism"],
-          raw_keys["ici_tensor_transpose_parallelism"],
           raw_keys["ici_tensor_sequence_parallelism"],
           raw_keys["ici_expert_parallelism"],
           raw_keys["ici_autoregressive_parallelism"],
@@ -1043,7 +1040,6 @@ def set_and_validate_pipeline_config(raw_keys):
           raw_keys["dcn_context_parallelism"],
           raw_keys["dcn_context_autoregressive_parallelism"],
           raw_keys["dcn_tensor_parallelism"],
-          raw_keys["dcn_tensor_transpose_parallelism"],
           raw_keys["dcn_tensor_sequence_parallelism"],
           raw_keys["dcn_expert_parallelism"],
           raw_keys["dcn_autoregressive_parallelism"],
@@ -1057,7 +1053,6 @@ def set_and_validate_pipeline_config(raw_keys):
           "context",
           "context_autoregressive",
           "tensor",
-          "tensor_transpose",
           "tensor_sequence",
           "expert",
           "autoregressive",
@@ -1072,7 +1067,6 @@ def set_and_validate_pipeline_config(raw_keys):
               "context",
               "context_autoregressive",
               "tensor",
-              "tensor_transpose",
               "tensor_sequence",
               "expert",
               "autoregressive",
@@ -1217,9 +1211,7 @@ def validate_shard_expert_on_fsdp(raw_keys):
   if raw_keys["shard_exp_on_fsdp"] and raw_keys["num_experts"] % raw_keys["ici_fsdp_parallelism"] != 0:
     raise ValueError("shard_exp_on_fsdp requires num_experts is divisiable by ici_fsdp_parallelism.")
   if raw_keys["shard_exp_on_fsdp"] and (using_tensor_parallelism(raw_keys) or using_expert_parallelism(raw_keys)):
-    raise ValueError(
-        "shard_exp_on_fsdp requires ici_expert_parallelism = 1 and ici_tensor_parallelism/ici_tensor_transpose_parallelism = 1."
-    )
+    raise ValueError("shard_exp_on_fsdp requires ici_expert_parallelism = 1 and ici_tensor_parallelism = 1.")
 
 
 def validate_ragged_dot(raw_keys):

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -963,7 +963,6 @@ class HardwareAndMesh(BaseModel):
           "context",
           "context_autoregressive",
           "tensor",
-          "tensor_transpose",
           "tensor_sequence",
           "expert",
           "autoregressive",
@@ -1036,7 +1035,6 @@ class DcnParallelism(BaseModel):
   dcn_context_parallelism: int = Field(1, description="DCN axis for context parallelism.")
   dcn_context_autoregressive_parallelism: int = Field(1, description="DCN axis for context autoregressive parallelism.")
   dcn_tensor_parallelism: int = Field(1, description="DCN axis for tensor parallelism (not recommended).")
-  dcn_tensor_transpose_parallelism: int = Field(1, description="DCN axis for tensor transpose parallelism.")
   dcn_tensor_sequence_parallelism: int = Field(
       1, description="DCN axis for tensor sequence parallelism (not recommended)."
   )
@@ -1056,7 +1054,6 @@ class IciParallelism(BaseModel):
   ici_context_parallelism: int = Field(1, description="ICI axis for context parallelism.")
   ici_context_autoregressive_parallelism: int = Field(1, description="ICI axis for context autoregressive parallelism.")
   ici_tensor_parallelism: int = Field(1, description="ICI axis for tensor parallelism.")
-  ici_tensor_transpose_parallelism: int = Field(1, description="ICI axis for tensor transpose parallelism.")
   ici_tensor_sequence_parallelism: int = Field(1, description="ICI axis for tensor sequence parallelism.")
   ici_autoregressive_parallelism: int = Field(1, description="ICI axis for autoregressive parallelism.")
   ici_pipeline_parallelism: int = Field(1, description="ICI axis for pipeline parallelism.")
@@ -3407,7 +3404,6 @@ class MaxTextConfig(
         "context": self.ici_context_parallelism,
         "context_autoregressive": self.ici_context_autoregressive_parallelism,
         "tensor": self.ici_tensor_parallelism,
-        "tensor_transpose": self.ici_tensor_transpose_parallelism,
         "tensor_sequence": self.ici_tensor_sequence_parallelism,
         "model": self.ici_tensor_parallelism,
         "expert": self.ici_expert_parallelism,
@@ -3427,7 +3423,6 @@ class MaxTextConfig(
         "context": self.dcn_context_parallelism,
         "context_autoregressive": self.dcn_context_autoregressive_parallelism,
         "tensor": self.dcn_tensor_parallelism,
-        "tensor_transpose": self.dcn_tensor_transpose_parallelism,
         "tensor_sequence": self.dcn_tensor_sequence_parallelism,
         "model": self.dcn_tensor_parallelism,
         "expert": self.dcn_expert_parallelism,

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -501,9 +501,7 @@ class RoutedMoE(nnx.Module):
     kernel_out_axis = np.arange(1, 2)
     # Pad the MoE input weight kernels for GMM_v2 execution when configured.
     moe_intermediate_dim = (
-        self.config.padded_base_moe_mlp_dim
-        if self.config.padded_base_moe_mlp_dim is not None
-        else self.intermediate_dim
+        self.config.padded_base_moe_mlp_dim if self.config.padded_base_moe_mlp_dim is not None else self.intermediate_dim
     )
 
     if quantizations.in_serve_mode(self.quant):
@@ -653,9 +651,6 @@ class RoutedMoE(nnx.Module):
         size *= self.mesh.shape.get(axis, 1)
       return size
     return self.mesh.shape.get(self._tensor_parallelism_name, 1)
-
-  def get_tensor_transpose_parallelism_size(self):
-    return self.mesh.shape.get("tensor_transpose", 1)
 
   def get_context_autoregressive_parallelism_size(self):
     return self.mesh.shape.get("context_autoregressive", 1)
@@ -1407,18 +1402,10 @@ class RoutedMoE(nnx.Module):
       else:
         batch_logical_axis = "decode_batch_moe"
 
-      if self.get_tensor_transpose_parallelism_size() > 1:
-        input_partition_pspec = self._logical_to_mesh_axes(
-            (batch_logical_axis, "activation_norm_length", "activation_embed")
-        )
-        w0_bias_pspec = self._logical_to_mesh_axes(("exp", None))
-        w1_bias_pspec = self._logical_to_mesh_axes(("exp", None))
-        wo_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_embed"))
-      else:
-        input_partition_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
-        w0_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_mlp"))
-        w1_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_mlp"))
-        wo_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_embed"))
+      input_partition_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
+      w0_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_mlp"))
+      w1_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_mlp"))
+      wo_bias_pspec = self._logical_to_mesh_axes(("exp", "activation_embed"))
 
       gate_logits_pspec = self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", None))
       # NOTE: deepseek2 has a different pattern
@@ -1444,18 +1431,18 @@ class RoutedMoE(nnx.Module):
           wo_pspec = self._logical_to_mesh_axes(self.wo_kernel_axes)
         else:
           # special sharding for dsv3 to remove overhead between gmm/AG
-          w0_pspec = self._logical_to_mesh_axes(("embed_tensor_transpose", None, "mlp_no_fsdp"))
-          w1_pspec = self._logical_to_mesh_axes(("embed_tensor_transpose", None, "mlp_no_fsdp"))
-          wo_pspec = self._logical_to_mesh_axes(("embed_tensor_transpose", "mlp_no_fsdp", None))
+          w0_pspec = self._logical_to_mesh_axes((None, None, "mlp_no_fsdp"))
+          w1_pspec = self._logical_to_mesh_axes((None, None, "mlp_no_fsdp"))
+          wo_pspec = self._logical_to_mesh_axes((None, "mlp_no_fsdp", None))
       elif self.config.use_2d_fsdp_sharding:
-        w0_pspec = self._logical_to_mesh_axes(("embed_tensor_transpose", "mlp_no_fsdp", None))
-        w1_pspec = self._logical_to_mesh_axes(("embed_tensor_transpose", "mlp_no_fsdp", None))
-        wo_pspec = self._logical_to_mesh_axes(("embed_tensor_transpose", "mlp_no_fsdp", None))
+        w0_pspec = self._logical_to_mesh_axes((None, "mlp_no_fsdp", None))
+        w1_pspec = self._logical_to_mesh_axes((None, "mlp_no_fsdp", None))
+        wo_pspec = self._logical_to_mesh_axes((None, "mlp_no_fsdp", None))
       else:
         # These are the main shardings used by default - they use funky rules to AG over FSDP.
-        w0_pspec = self._logical_to_mesh_axes(("exp", "embed_tensor_transpose", "mlp_no_fsdp"))
-        w1_pspec = self._logical_to_mesh_axes(("exp", "embed_tensor_transpose", "mlp_no_fsdp"))
-        wo_pspec = self._logical_to_mesh_axes(("exp", "mlp_no_fsdp", "embed_tensor_transpose"))
+        w0_pspec = self._logical_to_mesh_axes(("exp", None, "mlp_no_fsdp"))
+        w1_pspec = self._logical_to_mesh_axes(("exp", None, "mlp_no_fsdp"))
+        wo_pspec = self._logical_to_mesh_axes(("exp", "mlp_no_fsdp", None))
       return (
           batch_logical_axis,
           input_partition_pspec,
@@ -1669,9 +1656,6 @@ class RoutedMoE(nnx.Module):
         out = gmm_fn(x, w_fused, tiling=wi_tile_size, weight_gather_axes=wi_gather_axes)
         n = out.shape[-1] // 2
         layer_w0, layer_w1 = out[:, :n], out[:, n:]
-        if self.get_tensor_transpose_parallelism_size() > 1:
-          layer_w0 = jax.lax.psum(layer_w0, "tensor_transpose")
-          layer_w1 = jax.lax.psum(layer_w1, "tensor_transpose")
         if self.config.mlp_bias:
           layer_w0 = layer_w0 + w0_bias
           layer_w1 = layer_w1 + w1_bias
@@ -1684,8 +1668,6 @@ class RoutedMoE(nnx.Module):
             tiling=wi_tile_size,
             weight_gather_axes=wi_gather_axes,
         )
-        if self.get_tensor_transpose_parallelism_size() > 1:
-          layer_w0 = jax.lax.psum(layer_w0, "tensor_transpose")
         if self.config.mlp_bias:
           layer_w0 = layer_w0 + w0_bias
         layer_w0 = adc.checkpoint_name(adc.checkpoint_name(layer_w0, "mlpwi_0"), "moe_mlpwi_0")
@@ -1696,8 +1678,6 @@ class RoutedMoE(nnx.Module):
             tiling=wi_tile_size,
             weight_gather_axes=wi_gather_axes,
         )
-        if self.get_tensor_transpose_parallelism_size() > 1:
-          layer_w1 = jax.lax.psum(layer_w1, "tensor_transpose")
         if self.config.mlp_bias:
           layer_w1 = layer_w1 + w1_bias
         layer_w1 = adc.checkpoint_name(layer_w1, "moe_mlpwi_1")
@@ -1884,11 +1864,11 @@ class RoutedMoE(nnx.Module):
 
     if self.config.moe_fsdp_use_two_stage_all_gather:
       # Unshard on fsdp axis
-      w0_kernel = self._maybe_shard_with_logical(w0_kernel, ("exp_with_fsdp", "embed_tensor_transpose", "mlp"))
-      w1_kernel = self._maybe_shard_with_logical(w1_kernel, ("exp_with_fsdp", "embed_tensor_transpose", "mlp"))
+      w0_kernel = self._maybe_shard_with_logical(w0_kernel, ("exp_with_fsdp", None, "mlp"))
+      w1_kernel = self._maybe_shard_with_logical(w1_kernel, ("exp_with_fsdp", None, "mlp"))
 
       # Unshard on fsdp_transpose axis
-      wo_kernel = self._maybe_shard_with_logical(wo_kernel, ("exp_with_fsdp", "mlp", "embed_tensor_transpose"))
+      wo_kernel = self._maybe_shard_with_logical(wo_kernel, ("exp_with_fsdp", "mlp", None))
 
       # Make sure XLA does not optimize by combining above All-Gather to unshard
       # on FSDP axis and the subsequent unshard on fsdp_transpose axis
@@ -1897,14 +1877,11 @@ class RoutedMoE(nnx.Module):
       wo_kernel = jax.lax.optimization_barrier(wo_kernel)
 
       # Unshard on both fsdp and fsdp_transpose transpose
-      w0_kernel = self._maybe_shard_with_logical(w0_kernel, ("exp_with_fsdp", "embed_tensor_transpose", "mlp_no_fsdp"))
-      w1_kernel = self._maybe_shard_with_logical(w1_kernel, ("exp_with_fsdp", "embed_tensor_transpose", "mlp_no_fsdp"))
-      wo_kernel = self._maybe_shard_with_logical(wo_kernel, ("exp_with_fsdp", "mlp_no_fsdp", "embed_tensor_transpose"))
+      w0_kernel = self._maybe_shard_with_logical(w0_kernel, ("exp_with_fsdp", None, "mlp_no_fsdp"))
+      w1_kernel = self._maybe_shard_with_logical(w1_kernel, ("exp_with_fsdp", None, "mlp_no_fsdp"))
+      wo_kernel = self._maybe_shard_with_logical(wo_kernel, ("exp_with_fsdp", "mlp_no_fsdp", None))
 
-    if self.get_tensor_transpose_parallelism_size() > 1:
-      input_axes = (batch_logical_axis, "activation_norm_length", "activation_embed")
-    else:
-      input_axes = (batch_logical_axis, "activation_norm_length", None)
+    input_axes = (batch_logical_axis, "activation_norm_length", None)
 
     gate_logits_axes = (batch_logical_axis, "activation_norm_length", None)
     # NOTE: deepseek2 has a different pattern

--- a/src/maxtext/models/deepseek_batchsplit_fp8.py
+++ b/src/maxtext/models/deepseek_batchsplit_fp8.py
@@ -1004,7 +1004,7 @@ def compute(x, w0, w1, wo, group_sizes, weights, *, config, mesh):
     gating_pspec, linear_pspec = moe_lib.get_batchsplit_init_kernel_axes()
     w0_pspec = nn.logical_to_mesh_axes(gating_pspec)
     wo_pspec = nn.logical_to_mesh_axes(linear_pspec)
-    ignored_axes = ("expert", "tensor", "tensor_transpose")
+    ignored_axes = ("expert", "tensor")
 
     def get_active_sharding_axes(pspec_dim_axes, tensor_dim_index):
       if pspec_dim_axes is None:

--- a/src/maxtext/utils/sharding.py
+++ b/src/maxtext/utils/sharding.py
@@ -176,9 +176,7 @@ def remove_size_one_mesh_axis(spec, mesh):
   return P(*new_spec, unreduced=spec.unreduced, reduced=spec.reduced)
 
 
-def get_nnx_var_named_sharding_with_scan_axis(
-    v: nnx.Variable, mesh
-) -> nnx.Variable:
+def get_nnx_var_named_sharding_with_scan_axis(v: nnx.Variable, mesh) -> nnx.Variable:
   """Compute NamedSharding for an NNX variable, correctly handling the scan axis."""
   val = v.get_value()
   if not hasattr(val, "shape"):
@@ -190,11 +188,7 @@ def get_nnx_var_named_sharding_with_scan_axis(
       return v.replace(jax.tree.map(lambda _: replicated, val))
     return v
   metadata = v.get_metadata()
-  out_sharding = (
-      metadata.get("out_sharding")
-      or metadata.get("sharding_names")
-      or metadata.get("sharding")
-  )
+  out_sharding = metadata.get("out_sharding") or metadata.get("sharding_names") or metadata.get("sharding")
   if not out_sharding:
     pspec = P()
   else:
@@ -202,11 +196,7 @@ def get_nnx_var_named_sharding_with_scan_axis(
     if nnx.PARTITION_NAME in metadata:
       partition_name = metadata[nnx.PARTITION_NAME]
       scan_axis = metadata.get("param_scan_axis", 0)
-      out_sharding = (
-          [out_sharding]
-          if isinstance(out_sharding, str)
-          else list(out_sharding)
-      )
+      out_sharding = [out_sharding] if isinstance(out_sharding, str) else list(out_sharding)
       if partition_name not in out_sharding:
         out_sharding.insert(scan_axis, partition_name)
       out_sharding = tuple(out_sharding)
@@ -215,9 +205,7 @@ def get_nnx_var_named_sharding_with_scan_axis(
     local_rules = metadata.get("sharding_rules", ())
     if context_rules or local_rules:
       local_rules_list = list(local_rules) if local_rules is not None else []
-      context_rules_list = (
-          list(context_rules) if context_rules is not None else []
-      )
+      context_rules_list = list(context_rules) if context_rules is not None else []
       rules = local_rules_list + context_rules_list
       pspec = logical_to_mesh_axes(out_sharding, mesh, rules=rules)
     else:
@@ -344,7 +332,6 @@ def _get_nontrival_mesh_axes(mesh):
       "context",
       "context_autoregressive",
       "tensor",
-      "tensor_transpose",
       "tensor_sequence",
       "stage",
       "expert",
@@ -701,9 +688,7 @@ def maybe_update_params_sharding_with_opt_nnx(
   return prev_params_shardings, updated_state
 
 
-def build_zero1_input_state_mesh_shardings(
-    config, state_mesh_shardings, params_shardings
-):
+def build_zero1_input_state_mesh_shardings(config, state_mesh_shardings, params_shardings):
   """Build the train-step input shardings under shard_optimizer_over_data (Zero-1).
 
   Model params on input use the original pre-Zero-1 sharding (params_shardings),

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -96,18 +96,6 @@ class TrainTests(unittest.TestCase):
           rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
       ]
       + _small_model_overrides,
-      "tp_transpose": [  # tests base config with ici_tensor_transpose_parallelism=4
-          None,
-          get_test_config_path(),
-          f"base_output_directory={_base_output_directory}",
-          "run_name=runner_test",
-          "dataset_type=synthetic",  # use synthetic dataset_type to decrease training time
-          "steps=2",
-          "ici_tensor_transpose_parallelism=4",
-          "enable_goodput_recording=False",
-          rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
-      ]
-      + _small_model_overrides,
       "int8": [  # tests base config with int8
           None,
           get_test_config_path(),

--- a/tests/post_training/unit/train_distill_test.py
+++ b/tests/post_training/unit/train_distill_test.py
@@ -50,7 +50,6 @@ DEFAULT_DATA_SHARDING = [
     "context",
     "context_autoregressive",
     "tensor",
-    "tensor_transpose",
     "tensor_sequence",
     "expert",
     "autoregressive",

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -796,51 +796,6 @@ class RoutedMoeTest(unittest.TestCase):
       self.assertTrue(jax.numpy.allclose(expected_output, actual_output, rtol=1e-02, atol=1e-02, equal_nan=False))
 
   @pytest.mark.tpu_only
-  def test_megablox_tp_transpose_parallelism(self):
-    cfg = pyconfig.initialize(
-        [None, get_test_config_path()],
-        run_name="moe_block_megablox_tp_transpose_test",
-        enable_checkpointing=False,
-        model_name="mixtral-8x7b",
-        dtype="bfloat16",
-        megablox=True,
-        sparse_matmul=True,
-        per_device_batch_size=1,
-        ici_tensor_transpose_parallelism=4,
-        max_target_length=128,
-    )
-
-    cfg2 = pyconfig.initialize(
-        [None, get_test_config_path()],
-        run_name="moe_block_megablox_tp_test",
-        enable_checkpointing=False,
-        model_name="mixtral-8x7b",
-        dtype="bfloat16",
-        megablox=True,
-        sparse_matmul=True,
-        per_device_batch_size=1,
-        ici_tensor_parallelism=4,
-        max_target_length=128,
-    )
-
-    rng = jax.random.PRNGKey(2345)
-    rng_model, rng_hidden_states = jax.random.split(rng)
-    device_count = jax.device_count()
-    hidden_states = jax.random.uniform(
-        rng_hidden_states,
-        (int(cfg.per_device_batch_size) * device_count, cfg.max_target_length, cfg.base_emb_dim),
-        dtype=cfg.dtype,
-    )
-
-    devices_array = maxtext_utils.create_device_mesh(cfg)
-    mesh = Mesh(devices_array, cfg.mesh_axes)
-    with nn_partitioning.axis_rules(cfg.logical_axis_rules):
-      variables, _ = self.get_expected_output(rng_model, hidden_states, cfg, mesh)
-      tp_transpose_output, _, _ = self.get_moe_output(variables, hidden_states, cfg, mesh)
-      tp_output, _, _ = self.get_moe_output(variables, hidden_states, cfg2, mesh)
-      self.assertTrue(jax.numpy.allclose(tp_output, tp_transpose_output, rtol=1e-05, atol=1e-05, equal_nan=False))
-
-  @pytest.mark.tpu_only
   def test_megablox_context_parallelism(self):
     cfg = pyconfig.initialize(
         [None, get_test_config_path()],

--- a/tests/utils/sharding_info/deepseek2-16b/tpu7x-16/slice_1/rule_default/named_shardings.json
+++ b/tests/utils/sharding_info/deepseek2-16b/tpu7x-16/slice_1/rule_default/named_shardings.json
@@ -10,7 +10,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -24,7 +23,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -44,7 +42,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -58,17 +55,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2048
@@ -85,7 +78,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -99,7 +91,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -108,7 +99,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -137,7 +127,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -151,7 +140,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -160,7 +148,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -189,7 +176,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -203,7 +189,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -219,7 +204,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -241,7 +225,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -255,17 +238,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -284,7 +263,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -298,17 +276,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -327,7 +301,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -341,17 +314,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -370,7 +339,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -384,7 +352,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -393,7 +360,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -424,7 +390,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -438,7 +403,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -454,7 +418,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -478,7 +441,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -492,7 +454,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -502,7 +463,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -526,7 +486,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -540,7 +499,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -556,7 +514,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -580,7 +537,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -594,7 +550,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -609,7 +564,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -630,7 +584,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -644,7 +597,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -654,7 +606,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context"
       ],
       null,
@@ -677,7 +628,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -691,7 +641,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -702,7 +651,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -730,7 +678,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -744,7 +691,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -755,7 +701,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -783,7 +728,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -797,7 +741,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -814,7 +757,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -836,7 +778,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -850,7 +791,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -859,7 +799,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -888,7 +827,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -902,7 +840,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -911,7 +848,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -940,7 +876,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -954,7 +889,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -970,7 +904,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -992,7 +925,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1006,17 +938,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1035,7 +963,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1049,17 +976,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1078,7 +1001,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1092,17 +1014,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1121,7 +1039,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1135,7 +1052,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1144,7 +1060,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1175,7 +1090,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1189,7 +1103,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1205,7 +1118,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1229,7 +1141,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1243,7 +1154,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1253,7 +1163,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1277,7 +1186,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1291,7 +1199,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1307,7 +1214,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1331,7 +1237,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1345,7 +1250,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1354,7 +1258,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1381,7 +1284,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1395,7 +1297,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1415,7 +1316,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1429,17 +1329,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2048
@@ -1456,7 +1352,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1470,7 +1365,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1479,7 +1373,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1508,7 +1401,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1522,7 +1414,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1531,7 +1422,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1560,7 +1450,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1574,7 +1463,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1590,7 +1478,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -1612,7 +1499,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1626,17 +1512,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1655,7 +1537,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1669,17 +1550,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1698,7 +1575,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1712,17 +1588,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1741,7 +1613,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1755,7 +1626,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1764,7 +1634,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1795,7 +1664,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1809,7 +1677,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1825,7 +1692,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1849,7 +1715,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1863,7 +1728,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1873,7 +1737,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1897,7 +1760,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1911,7 +1773,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1927,7 +1788,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1951,7 +1811,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1965,7 +1824,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1980,7 +1838,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -2001,7 +1858,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2015,7 +1871,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2025,7 +1880,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context"
       ],
       null,
@@ -2048,7 +1902,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2062,7 +1915,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2073,7 +1925,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -2101,7 +1952,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2115,7 +1965,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2126,7 +1975,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -2154,7 +2002,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2168,7 +2015,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2185,7 +2031,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -2207,7 +2052,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2221,7 +2065,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2230,7 +2073,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2259,7 +2101,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2273,7 +2114,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2282,7 +2122,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2311,7 +2150,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2325,7 +2163,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2341,7 +2178,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -2363,7 +2199,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2377,17 +2212,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -2406,7 +2237,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2420,17 +2250,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -2449,7 +2275,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2463,17 +2288,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -2492,7 +2313,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2506,7 +2326,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2515,7 +2334,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2546,7 +2364,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2560,7 +2377,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2576,7 +2392,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2600,7 +2415,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2614,7 +2428,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2624,7 +2437,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2648,7 +2460,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2662,7 +2473,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2678,7 +2488,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2702,7 +2511,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2716,7 +2524,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2725,7 +2532,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2752,7 +2558,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2766,17 +2571,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2048
@@ -2793,7 +2594,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2807,7 +2607,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2816,7 +2615,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2845,7 +2643,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2859,7 +2656,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2868,7 +2664,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2897,7 +2692,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2911,7 +2705,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2927,7 +2720,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -2949,7 +2741,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2963,17 +2754,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -2992,7 +2779,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3006,17 +2792,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -3035,7 +2817,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3049,17 +2830,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -3078,7 +2855,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3092,7 +2868,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3101,7 +2876,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3132,7 +2906,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3146,7 +2919,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3162,7 +2934,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3186,7 +2957,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3200,7 +2970,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3210,7 +2979,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3234,7 +3002,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3248,7 +3015,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3264,7 +3030,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3288,7 +3053,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3302,7 +3066,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3317,7 +3080,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -3338,7 +3100,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3352,7 +3113,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3362,7 +3122,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context"
       ],
       null,
@@ -3385,7 +3144,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3399,7 +3157,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3410,7 +3167,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -3438,7 +3194,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3452,7 +3207,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3463,7 +3217,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -3491,7 +3244,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3505,7 +3257,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3522,7 +3273,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -3544,7 +3294,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3558,7 +3307,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3567,7 +3315,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3596,7 +3343,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3610,7 +3356,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3619,7 +3364,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3648,7 +3392,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3662,7 +3405,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3678,7 +3420,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -3700,7 +3441,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3714,17 +3454,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -3743,7 +3479,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3757,17 +3492,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -3786,7 +3517,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3800,17 +3530,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -3829,7 +3555,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3843,7 +3568,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3852,7 +3576,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3883,7 +3606,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3897,7 +3619,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3913,7 +3634,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3937,7 +3657,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3951,7 +3670,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3961,7 +3679,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3985,7 +3702,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3999,7 +3715,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4015,7 +3730,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4039,7 +3753,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4053,7 +3766,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4062,7 +3774,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4089,7 +3800,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4103,7 +3813,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1

--- a/tests/utils/sharding_info/deepseek2-16b/v6e-16/slice_1/rule_default_ici_fsdp_parallelism=-1_ici_expert_parallelism=4/named_shardings.json
+++ b/tests/utils/sharding_info/deepseek2-16b/v6e-16/slice_1/rule_default_ici_fsdp_parallelism=-1_ici_expert_parallelism=4/named_shardings.json
@@ -10,7 +10,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -24,7 +23,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -44,7 +42,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -58,17 +55,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2048
@@ -85,7 +78,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -99,7 +91,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -108,7 +99,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -137,7 +127,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -151,7 +140,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -160,7 +148,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -189,7 +176,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -203,7 +189,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -219,7 +204,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -241,7 +225,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -255,17 +238,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -284,7 +263,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -298,17 +276,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -327,7 +301,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -341,17 +314,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -370,7 +339,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -384,7 +352,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -393,7 +360,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -424,7 +390,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -438,7 +403,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -454,7 +418,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -478,7 +441,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -492,7 +454,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -502,7 +463,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -526,7 +486,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -540,7 +499,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -556,7 +514,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -580,7 +537,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -594,7 +550,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -609,7 +564,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -630,7 +584,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -644,7 +597,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -654,7 +606,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context"
       ],
       null,
@@ -677,7 +628,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -691,7 +641,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -702,7 +651,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -730,7 +678,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -744,7 +691,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -755,7 +701,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -783,7 +728,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -797,7 +741,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -814,7 +757,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -836,7 +778,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -850,7 +791,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -859,7 +799,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -888,7 +827,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -902,7 +840,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -911,7 +848,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -940,7 +876,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -954,7 +889,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -970,7 +904,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -992,7 +925,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1006,17 +938,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1035,7 +963,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1049,17 +976,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1078,7 +1001,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1092,17 +1014,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1121,7 +1039,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1135,7 +1052,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1144,7 +1060,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1175,7 +1090,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1189,7 +1103,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1205,7 +1118,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1229,7 +1141,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1243,7 +1154,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1253,7 +1163,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1277,7 +1186,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1291,7 +1199,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1307,7 +1214,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1331,7 +1237,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1345,7 +1250,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1354,7 +1258,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1381,7 +1284,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1395,7 +1297,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1415,7 +1316,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1429,17 +1329,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2048
@@ -1456,7 +1352,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1470,7 +1365,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1479,7 +1373,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1508,7 +1401,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1522,7 +1414,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1531,7 +1422,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1560,7 +1450,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1574,7 +1463,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1590,7 +1478,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -1612,7 +1499,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1626,17 +1512,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1655,7 +1537,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1669,17 +1550,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1698,7 +1575,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1712,17 +1588,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -1741,7 +1613,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1755,7 +1626,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1764,7 +1634,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1795,7 +1664,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1809,7 +1677,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1825,7 +1692,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1849,7 +1715,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1863,7 +1728,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1873,7 +1737,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1897,7 +1760,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1911,7 +1773,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1927,7 +1788,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1951,7 +1811,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1965,7 +1824,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -1980,7 +1838,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -2001,7 +1858,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2015,7 +1871,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2025,7 +1880,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context"
       ],
       null,
@@ -2048,7 +1902,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2062,7 +1915,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2073,7 +1925,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -2101,7 +1952,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2115,7 +1965,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2126,7 +1975,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -2154,7 +2002,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2168,7 +2015,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2185,7 +2031,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -2207,7 +2052,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2221,7 +2065,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2230,7 +2073,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2259,7 +2101,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2273,7 +2114,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2282,7 +2122,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2311,7 +2150,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2325,7 +2163,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2341,7 +2178,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -2363,7 +2199,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2377,17 +2212,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -2406,7 +2237,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2420,17 +2250,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -2449,7 +2275,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2463,17 +2288,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -2492,7 +2313,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2506,7 +2326,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2515,7 +2334,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2546,7 +2364,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2560,7 +2377,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2576,7 +2392,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2600,7 +2415,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2614,7 +2428,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2624,7 +2437,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2648,7 +2460,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2662,7 +2473,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2678,7 +2488,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2702,7 +2511,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2716,7 +2524,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2725,7 +2532,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2752,7 +2558,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2766,17 +2571,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2048
@@ -2793,7 +2594,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2807,7 +2607,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2816,7 +2615,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2845,7 +2643,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2859,7 +2656,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2868,7 +2664,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2897,7 +2692,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2911,7 +2705,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -2927,7 +2720,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -2949,7 +2741,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2963,17 +2754,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -2992,7 +2779,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3006,17 +2792,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -3035,7 +2817,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3049,17 +2830,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -3078,7 +2855,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3092,7 +2868,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3101,7 +2876,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3132,7 +2906,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3146,7 +2919,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3162,7 +2934,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3186,7 +2957,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3200,7 +2970,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3210,7 +2979,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3234,7 +3002,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3248,7 +3015,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3264,7 +3030,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3288,7 +3053,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3302,7 +3066,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3317,7 +3080,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -3338,7 +3100,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3352,7 +3113,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3362,7 +3122,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context"
       ],
       null,
@@ -3385,7 +3144,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3399,7 +3157,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3410,7 +3167,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -3438,7 +3194,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3452,7 +3207,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3463,7 +3217,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -3491,7 +3244,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3505,7 +3257,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3522,7 +3273,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -3544,7 +3294,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3558,7 +3307,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3567,7 +3315,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3596,7 +3343,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3610,7 +3356,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3619,7 +3364,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3648,7 +3392,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3662,7 +3405,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3678,7 +3420,6 @@
       null,
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -3700,7 +3441,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3714,17 +3454,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -3743,7 +3479,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3757,17 +3492,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -3786,7 +3517,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3800,17 +3530,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       null
     ],
     "shape": [
@@ -3829,7 +3555,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3843,7 +3568,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3852,7 +3576,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3883,7 +3606,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3897,7 +3619,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3913,7 +3634,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3937,7 +3657,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3951,7 +3670,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -3961,7 +3679,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3985,7 +3702,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3999,7 +3715,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -4015,7 +3730,6 @@
       null,
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4039,7 +3753,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4053,7 +3766,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1
@@ -4062,7 +3774,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4089,7 +3800,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4103,7 +3813,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 4,
         "autoregressive": 1

--- a/tests/utils/sharding_info/gpt-oss-20b/tpu7x-16/slice_1/rule_default/named_shardings.json
+++ b/tests/utils/sharding_info/gpt-oss-20b/tpu7x-16/slice_1/rule_default/named_shardings.json
@@ -10,7 +10,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -24,7 +23,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -44,7 +42,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -58,17 +55,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2880
@@ -85,7 +78,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -99,7 +91,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -108,7 +99,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -132,7 +122,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -146,7 +135,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -162,7 +150,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -186,7 +173,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -200,7 +186,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -210,7 +195,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -232,7 +216,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -246,7 +229,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -255,7 +237,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -286,7 +267,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -300,7 +280,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -309,7 +288,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -333,7 +311,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -347,7 +324,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -363,7 +339,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -387,7 +362,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -401,7 +375,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -427,7 +400,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -441,7 +413,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -450,7 +421,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -474,7 +444,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -488,7 +457,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -504,7 +472,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -528,7 +495,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -542,7 +508,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -568,7 +533,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -582,7 +546,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -592,7 +555,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -616,7 +578,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -630,7 +591,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -641,7 +601,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -669,7 +628,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -683,7 +641,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -694,7 +651,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -715,7 +671,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -729,7 +684,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -740,7 +694,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -768,7 +721,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -782,7 +734,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -793,7 +744,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -814,7 +764,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -828,7 +777,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -845,7 +793,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -867,7 +814,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -881,7 +827,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -890,10 +835,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -912,7 +854,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -926,17 +867,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -955,7 +892,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -969,17 +905,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -998,7 +930,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1012,7 +943,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1021,7 +951,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1045,7 +974,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1059,7 +987,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1075,7 +1002,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1099,7 +1025,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1113,7 +1038,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1123,7 +1047,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1145,7 +1068,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1159,7 +1081,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1168,7 +1089,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1199,7 +1119,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1213,7 +1132,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1222,7 +1140,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1246,7 +1163,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1260,7 +1176,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1276,7 +1191,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1300,7 +1214,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1314,7 +1227,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1340,7 +1252,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1354,7 +1265,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1363,7 +1273,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1387,7 +1296,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1401,7 +1309,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1417,7 +1324,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1441,7 +1347,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1455,7 +1360,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1481,7 +1385,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1495,7 +1398,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1505,7 +1407,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1529,7 +1430,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1543,7 +1443,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1554,7 +1453,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -1582,7 +1480,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1596,7 +1493,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1607,7 +1503,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -1628,7 +1523,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1642,7 +1536,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1653,7 +1546,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -1681,7 +1573,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1695,7 +1586,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1706,7 +1596,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -1727,7 +1616,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1741,7 +1629,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1758,7 +1645,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -1780,7 +1666,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1794,7 +1679,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1803,10 +1687,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -1825,7 +1706,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1839,17 +1719,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -1868,7 +1744,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1882,17 +1757,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -1911,7 +1782,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1925,7 +1795,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1940,7 +1809,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -1961,7 +1829,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1975,7 +1842,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1984,7 +1850,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2011,7 +1876,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2025,7 +1889,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2045,7 +1908,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2059,17 +1921,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2880
@@ -2086,7 +1944,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2100,7 +1957,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2109,7 +1965,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2133,7 +1988,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2147,7 +2001,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2163,7 +2016,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2187,7 +2039,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2201,7 +2052,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2211,7 +2061,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2233,7 +2082,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2247,7 +2095,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2256,7 +2103,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2287,7 +2133,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2301,7 +2146,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2310,7 +2154,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2334,7 +2177,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2348,7 +2190,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2364,7 +2205,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2388,7 +2228,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2402,7 +2241,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2428,7 +2266,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2442,7 +2279,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2451,7 +2287,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2475,7 +2310,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2489,7 +2323,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2505,7 +2338,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2529,7 +2361,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2543,7 +2374,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2569,7 +2399,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2583,7 +2412,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2593,7 +2421,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2617,7 +2444,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2631,7 +2457,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2642,7 +2467,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -2670,7 +2494,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2684,7 +2507,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2695,7 +2517,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -2716,7 +2537,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2730,7 +2550,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2741,7 +2560,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -2769,7 +2587,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2783,7 +2600,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2794,7 +2610,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -2815,7 +2630,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2829,7 +2643,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2846,7 +2659,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -2868,7 +2680,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2882,7 +2693,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -2891,10 +2701,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -2913,7 +2720,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2927,17 +2733,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -2956,7 +2758,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2970,17 +2771,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -2999,7 +2796,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3013,7 +2809,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3022,7 +2817,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3046,7 +2840,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3060,7 +2853,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3076,7 +2868,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3100,7 +2891,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3114,7 +2904,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3124,7 +2913,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3146,7 +2934,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3160,7 +2947,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3169,7 +2955,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3200,7 +2985,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3214,7 +2998,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3223,7 +3006,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3247,7 +3029,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3261,7 +3042,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3277,7 +3057,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3301,7 +3080,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3315,7 +3093,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3341,7 +3118,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3355,7 +3131,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3364,7 +3139,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3388,7 +3162,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3402,7 +3175,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3418,7 +3190,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3442,7 +3213,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3456,7 +3226,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3482,7 +3251,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3496,7 +3264,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3506,7 +3273,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3530,7 +3296,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3544,7 +3309,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3555,7 +3319,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -3583,7 +3346,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3597,7 +3359,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3608,7 +3369,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -3629,7 +3389,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3643,7 +3402,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3654,7 +3412,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -3682,7 +3439,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3696,7 +3452,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3707,7 +3462,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -3728,7 +3482,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3742,7 +3495,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3759,7 +3511,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -3781,7 +3532,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3795,7 +3545,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3804,10 +3553,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -3826,7 +3572,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3840,17 +3585,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -3869,7 +3610,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3883,17 +3623,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -3912,7 +3648,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3926,7 +3661,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3941,7 +3675,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -3962,7 +3695,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3976,7 +3708,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -3985,7 +3716,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4012,7 +3742,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4026,17 +3755,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2880
@@ -4053,7 +3778,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4067,7 +3791,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4076,7 +3799,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4100,7 +3822,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4114,7 +3835,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4130,7 +3850,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4154,7 +3873,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4168,7 +3886,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4178,7 +3895,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -4200,7 +3916,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4214,7 +3929,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4223,7 +3937,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4254,7 +3967,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4268,7 +3980,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4277,7 +3988,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4301,7 +4011,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4315,7 +4024,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4331,7 +4039,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4355,7 +4062,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4369,7 +4075,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4395,7 +4100,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4409,7 +4113,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4418,7 +4121,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4442,7 +4144,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4456,7 +4157,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4472,7 +4172,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4496,7 +4195,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4510,7 +4208,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4536,7 +4233,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4550,7 +4246,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4560,7 +4255,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -4584,7 +4278,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4598,7 +4291,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4609,7 +4301,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -4637,7 +4328,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4651,7 +4341,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4662,7 +4351,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -4683,7 +4371,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4697,7 +4384,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4708,7 +4394,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -4736,7 +4421,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4750,7 +4434,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4761,7 +4444,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -4782,7 +4464,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4796,7 +4477,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4813,7 +4493,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -4835,7 +4514,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4849,7 +4527,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4858,10 +4535,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -4880,7 +4554,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4894,17 +4567,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -4923,7 +4592,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4937,17 +4605,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -4966,7 +4630,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4980,7 +4643,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -4989,7 +4651,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5013,7 +4674,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5027,7 +4687,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5043,7 +4702,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5067,7 +4725,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5081,7 +4738,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5091,7 +4747,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -5113,7 +4768,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5127,7 +4781,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5136,7 +4789,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5167,7 +4819,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5181,7 +4832,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5190,7 +4840,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5214,7 +4863,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5228,7 +4876,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5244,7 +4891,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5268,7 +4914,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5282,7 +4927,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5308,7 +4952,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5322,7 +4965,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5331,7 +4973,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5355,7 +4996,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5369,7 +5009,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5385,7 +5024,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5409,7 +5047,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5423,7 +5060,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5449,7 +5085,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5463,7 +5098,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5473,7 +5107,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -5497,7 +5130,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5511,7 +5143,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5522,7 +5153,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -5550,7 +5180,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5564,7 +5193,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5575,7 +5203,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -5596,7 +5223,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5610,7 +5236,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5621,7 +5246,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -5649,7 +5273,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5663,7 +5286,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5674,7 +5296,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -5695,7 +5316,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5709,7 +5329,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5726,7 +5345,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -5748,7 +5366,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5762,7 +5379,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5771,10 +5387,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -5793,7 +5406,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5807,17 +5419,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -5836,7 +5444,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5850,17 +5457,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -5879,7 +5482,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5893,7 +5495,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5908,7 +5509,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -5929,7 +5529,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5943,7 +5542,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -5952,7 +5550,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5979,7 +5576,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5993,7 +5589,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1

--- a/tests/utils/sharding_info/gpt-oss-20b/tpu7x-16/slice_1/rule_default_ici_fsdp_parallelism=-1_ici_expert_parallelism=2/named_shardings.json
+++ b/tests/utils/sharding_info/gpt-oss-20b/tpu7x-16/slice_1/rule_default_ici_fsdp_parallelism=-1_ici_expert_parallelism=2/named_shardings.json
@@ -10,7 +10,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -24,7 +23,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -44,7 +42,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -58,17 +55,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2880
@@ -85,7 +78,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -99,7 +91,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -108,7 +99,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -132,7 +122,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -146,7 +135,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -162,7 +150,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -186,7 +173,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -200,7 +186,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -210,7 +195,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -232,7 +216,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -246,7 +229,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -255,7 +237,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -286,7 +267,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -300,7 +280,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -309,7 +288,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -333,7 +311,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -347,7 +324,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -363,7 +339,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -387,7 +362,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -401,7 +375,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -427,7 +400,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -441,7 +413,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -450,7 +421,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -474,7 +444,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -488,7 +457,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -504,7 +472,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -528,7 +495,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -542,7 +508,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -568,7 +533,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -582,7 +546,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -592,7 +555,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -616,7 +578,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -630,7 +591,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -641,7 +601,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -669,7 +628,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -683,7 +641,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -694,7 +651,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -715,7 +671,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -729,7 +684,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -740,7 +694,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -768,7 +721,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -782,7 +734,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -793,7 +744,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -814,7 +764,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -828,7 +777,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -845,7 +793,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -867,7 +814,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -881,7 +827,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -890,10 +835,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -912,7 +854,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -926,17 +867,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -955,7 +892,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -969,17 +905,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -998,7 +930,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1012,7 +943,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1021,7 +951,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1045,7 +974,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1059,7 +987,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1075,7 +1002,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1099,7 +1025,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1113,7 +1038,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1123,7 +1047,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1145,7 +1068,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1159,7 +1081,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1168,7 +1089,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1199,7 +1119,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1213,7 +1132,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1222,7 +1140,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1246,7 +1163,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1260,7 +1176,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1276,7 +1191,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1300,7 +1214,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1314,7 +1227,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1340,7 +1252,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1354,7 +1265,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1363,7 +1273,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1387,7 +1296,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1401,7 +1309,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1417,7 +1324,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1441,7 +1347,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1455,7 +1360,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1481,7 +1385,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1495,7 +1398,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1505,7 +1407,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1529,7 +1430,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1543,7 +1443,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1554,7 +1453,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -1582,7 +1480,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1596,7 +1493,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1607,7 +1503,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -1628,7 +1523,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1642,7 +1536,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1653,7 +1546,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -1681,7 +1573,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1695,7 +1586,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1706,7 +1596,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -1727,7 +1616,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1741,7 +1629,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1758,7 +1645,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -1780,7 +1666,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1794,7 +1679,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1803,10 +1687,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -1825,7 +1706,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1839,17 +1719,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -1868,7 +1744,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1882,17 +1757,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -1911,7 +1782,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1925,7 +1795,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1940,7 +1809,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -1961,7 +1829,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1975,7 +1842,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -1984,7 +1850,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2011,7 +1876,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2025,7 +1889,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2045,7 +1908,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2059,17 +1921,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2880
@@ -2086,7 +1944,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2100,7 +1957,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2109,7 +1965,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2133,7 +1988,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2147,7 +2001,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2163,7 +2016,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2187,7 +2039,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2201,7 +2052,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2211,7 +2061,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2233,7 +2082,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2247,7 +2095,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2256,7 +2103,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2287,7 +2133,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2301,7 +2146,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2310,7 +2154,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2334,7 +2177,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2348,7 +2190,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2364,7 +2205,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2388,7 +2228,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2402,7 +2241,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2428,7 +2266,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2442,7 +2279,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2451,7 +2287,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2475,7 +2310,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2489,7 +2323,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2505,7 +2338,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -2529,7 +2361,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2543,7 +2374,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2569,7 +2399,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2583,7 +2412,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2593,7 +2421,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -2617,7 +2444,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2631,7 +2457,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2642,7 +2467,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -2670,7 +2494,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2684,7 +2507,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2695,7 +2517,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -2716,7 +2537,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2730,7 +2550,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2741,7 +2560,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -2769,7 +2587,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2783,7 +2600,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2794,7 +2610,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -2815,7 +2630,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2829,7 +2643,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2846,7 +2659,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -2868,7 +2680,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2882,7 +2693,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -2891,10 +2701,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -2913,7 +2720,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2927,17 +2733,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -2956,7 +2758,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -2970,17 +2771,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -2999,7 +2796,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3013,7 +2809,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3022,7 +2817,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3046,7 +2840,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3060,7 +2853,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3076,7 +2868,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3100,7 +2891,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3114,7 +2904,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3124,7 +2913,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3146,7 +2934,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3160,7 +2947,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3169,7 +2955,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3200,7 +2985,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3214,7 +2998,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3223,7 +3006,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3247,7 +3029,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3261,7 +3042,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3277,7 +3057,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3301,7 +3080,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3315,7 +3093,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3341,7 +3118,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3355,7 +3131,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3364,7 +3139,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3388,7 +3162,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3402,7 +3175,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3418,7 +3190,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -3442,7 +3213,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3456,7 +3226,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3482,7 +3251,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3496,7 +3264,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3506,7 +3273,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -3530,7 +3296,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3544,7 +3309,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3555,7 +3319,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -3583,7 +3346,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3597,7 +3359,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3608,7 +3369,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -3629,7 +3389,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3643,7 +3402,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3654,7 +3412,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -3682,7 +3439,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3696,7 +3452,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3707,7 +3462,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -3728,7 +3482,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3742,7 +3495,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3759,7 +3511,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -3781,7 +3532,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3795,7 +3545,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3804,10 +3553,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -3826,7 +3572,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3840,17 +3585,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -3869,7 +3610,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3883,17 +3623,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -3912,7 +3648,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3926,7 +3661,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3941,7 +3675,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -3962,7 +3695,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -3976,7 +3708,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -3985,7 +3716,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4012,7 +3742,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4026,17 +3755,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       2880
@@ -4053,7 +3778,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4067,7 +3791,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4076,7 +3799,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4100,7 +3822,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4114,7 +3835,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4130,7 +3850,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4154,7 +3873,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4168,7 +3886,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4178,7 +3895,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -4200,7 +3916,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4214,7 +3929,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4223,7 +3937,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4254,7 +3967,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4268,7 +3980,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4277,7 +3988,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4301,7 +4011,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4315,7 +4024,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4331,7 +4039,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4355,7 +4062,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4369,7 +4075,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4395,7 +4100,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4409,7 +4113,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4418,7 +4121,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4442,7 +4144,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4456,7 +4157,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4472,7 +4172,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -4496,7 +4195,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4510,7 +4208,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4536,7 +4233,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4550,7 +4246,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4560,7 +4255,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -4584,7 +4278,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4598,7 +4291,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4609,7 +4301,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -4637,7 +4328,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4651,7 +4341,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4662,7 +4351,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -4683,7 +4371,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4697,7 +4384,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4708,7 +4394,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -4736,7 +4421,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4750,7 +4434,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4761,7 +4444,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -4782,7 +4464,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4796,7 +4477,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4813,7 +4493,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -4835,7 +4514,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4849,7 +4527,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4858,10 +4535,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -4880,7 +4554,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4894,17 +4567,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -4923,7 +4592,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4937,17 +4605,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -4966,7 +4630,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -4980,7 +4643,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -4989,7 +4651,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5013,7 +4674,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5027,7 +4687,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5043,7 +4702,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5067,7 +4725,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5081,7 +4738,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5091,7 +4747,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -5113,7 +4768,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5127,7 +4781,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5136,7 +4789,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5167,7 +4819,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5181,7 +4832,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5190,7 +4840,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5214,7 +4863,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5228,7 +4876,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5244,7 +4891,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5268,7 +4914,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5282,7 +4927,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5308,7 +4952,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5322,7 +4965,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5331,7 +4973,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5355,7 +4996,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5369,7 +5009,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5385,7 +5024,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5409,7 +5047,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5423,7 +5060,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5449,7 +5085,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5463,7 +5098,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5473,7 +5107,6 @@
       [
         "fsdp",
         "fsdp_transpose",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -5497,7 +5130,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5511,7 +5143,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5522,7 +5153,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -5550,7 +5180,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5564,7 +5193,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5575,7 +5203,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -5596,7 +5223,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5610,7 +5236,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5621,7 +5246,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ],
       [
@@ -5649,7 +5273,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5663,7 +5286,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5674,7 +5296,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence"
       ]
     ],
@@ -5695,7 +5316,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5709,7 +5329,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5726,7 +5345,6 @@
       ],
       [
         "fsdp",
-        "tensor_transpose",
         "context"
       ]
     ],
@@ -5748,7 +5366,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5762,7 +5379,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5771,10 +5387,7 @@
     "partition_spec": [
       "expert",
       "stage",
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       32,
@@ -5793,7 +5406,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5807,17 +5419,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -5836,7 +5444,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5850,17 +5457,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -5879,7 +5482,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5893,7 +5495,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5908,7 +5509,6 @@
       ],
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ]
@@ -5929,7 +5529,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5943,7 +5542,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1
@@ -5952,7 +5550,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -5979,7 +5576,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -5993,7 +5589,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 2,
         "autoregressive": 1

--- a/tests/utils/sharding_info/qwen3-0.6b/tpu7x-16/slice_1/rule_default/named_shardings.json
+++ b/tests/utils/sharding_info/qwen3-0.6b/tpu7x-16/slice_1/rule_default/named_shardings.json
@@ -10,7 +10,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -24,7 +23,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -44,7 +42,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -58,17 +55,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       1024
@@ -85,7 +78,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -99,7 +91,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -108,7 +99,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -137,7 +127,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -151,7 +140,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -160,7 +148,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -189,7 +176,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -203,7 +189,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -219,7 +204,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -241,7 +225,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -255,17 +238,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -284,7 +263,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -298,17 +276,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -327,7 +301,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -341,7 +314,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -357,7 +329,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -381,7 +352,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -395,17 +365,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -424,7 +390,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -438,7 +403,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -447,7 +411,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -478,7 +441,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -492,7 +454,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -508,7 +469,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -532,7 +492,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -546,17 +505,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -575,7 +530,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -589,7 +543,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -605,7 +558,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -629,7 +581,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -643,7 +594,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -652,7 +602,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -679,7 +628,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -693,7 +641,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -713,7 +660,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -727,17 +673,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       1024
@@ -754,7 +696,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -768,7 +709,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -777,7 +717,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -806,7 +745,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -820,7 +758,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -829,7 +766,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -858,7 +794,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -872,7 +807,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -888,7 +822,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -910,7 +843,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -924,17 +856,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -953,7 +881,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -967,17 +894,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -996,7 +919,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1010,7 +932,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1026,7 +947,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1050,7 +970,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1064,17 +983,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -1093,7 +1008,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1107,7 +1021,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1116,7 +1029,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1147,7 +1059,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1161,7 +1072,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1177,7 +1087,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1201,7 +1110,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1215,17 +1123,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -1244,7 +1148,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1258,7 +1161,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1274,7 +1176,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1298,7 +1199,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1312,7 +1212,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1321,7 +1220,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1348,7 +1246,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1362,17 +1259,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ]
+      "tensor"
     ],
     "shape": [
       1024
@@ -1389,7 +1282,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1403,7 +1295,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1412,7 +1303,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1441,7 +1331,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1455,7 +1344,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1464,7 +1352,6 @@
     "partition_spec": [
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ],
@@ -1493,7 +1380,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1507,7 +1393,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1523,7 +1408,6 @@
       "stage",
       [
         "fsdp",
-        "tensor_transpose",
         "context",
         "expert"
       ]
@@ -1545,7 +1429,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1559,17 +1442,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -1588,7 +1467,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1602,17 +1480,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -1631,7 +1505,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1645,7 +1518,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1661,7 +1533,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1685,7 +1556,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1699,17 +1569,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -1728,7 +1594,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1742,7 +1607,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1751,7 +1615,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1782,7 +1645,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1796,7 +1658,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1812,7 +1673,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1836,7 +1696,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1850,17 +1709,13 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
       }
     },
     "partition_spec": [
-      [
-        "tensor",
-        "tensor_transpose"
-      ],
+      "tensor",
       "stage"
     ],
     "shape": [
@@ -1879,7 +1734,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1893,7 +1747,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1909,7 +1762,6 @@
       "stage",
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1933,7 +1785,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1947,7 +1798,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1
@@ -1956,7 +1806,6 @@
     "partition_spec": [
       [
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "autoregressive"
       ],
@@ -1983,7 +1832,6 @@
         "context",
         "context_autoregressive",
         "tensor",
-        "tensor_transpose",
         "tensor_sequence",
         "expert",
         "autoregressive"
@@ -1997,7 +1845,6 @@
         "context": 1,
         "context_autoregressive": 1,
         "tensor": 1,
-        "tensor_transpose": 1,
         "tensor_sequence": 1,
         "expert": 1,
         "autoregressive": 1


### PR DESCRIPTION
Fully remove tp_transpose (tensor transpose parallelism) from MaxText.

This CL removes all references to `tensor_transpose` physical mesh axis,
and the corresponding `ici_tensor_transpose_parallelism` and
`dcn_tensor_transpose_parallelism` configuration parameters.

### Performance Regression Benchmark (FSDP + TP Sharding)
Verified performance on TPU v6e-8 (`v6 lite` 8 cores) using `deepseek2-16b` with FSDP+TP sharding (`ici_fsdp_parallelism=4`, `ici_tensor_parallelism=2`, `ici_expert_parallelism=1`). Compared baseline (`main`) against this PR after syncing with latest `main`.

**Command:**
```bash
python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml \
  base_output_directory=/tmp/maxtext_perf_test \
  run_name=ds2_16b_fsdp_tp_test \
  model_name=deepseek2-16b \
  dataset_type=synthetic \
  enable_checkpointing=false \
  attention=flash \
  sparse_matmul=True \
  use_tokamax_gmm=True \
  dtype=bfloat16 \
  weight_dtype=bfloat16 \
  per_device_batch_size=4 \
  steps=5 \
  max_target_length=1024 \
  ici_fsdp_parallelism=4 \
  ici_tensor_parallelism=2 \
  ici_expert_parallelism=1
```

**Side-by-Side Comparison:**
| Metric | Baseline (`main`) | This PR (`deprecate_tp_transpose`) |
| :--- | :---: | :---: |
| **Memory Utilization** | ~11.12 GB (35.58%) | ~11.12 GB (35.58%) |
| **Peak Throughput** | ~357.55 TFLOP/s/device (~23,628 Tok/s) | ~484.99 TFLOP/s/device (~32,050 Tok/s) |
| **Step 1 Runtime** | 0.173s | 0.128s |
| **Loss Progression** | 12.033 → 11.772 → 11.531 → 11.352 → 11.335 | 12.033 → 11.772 → 11.531 → 11.352 → 11.335 |

**Conclusion**: Bit-for-bit identical loss progression and memory footprint, with zero performance regression under FSDP+TP sharding.

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).

TAG=agy
CONV=dd23384b-3429-471c-8bb2-135cd7e3fed9
