### PR TITLE
Fix XLA SPMD partitioning hang for kvcache_test.py on 8-device runner and re-enable in TPU7X unit CI

### DIFF
--- a/.github/workflows/run_tests_coordinator.yml
+++ b/.github/workflows/run_tests_coordinator.yml
@@ -195,7 +195,7 @@ jobs:
             "tpu-integration": "--ignore=tests/post_training",
             "tpu-post-training-unit": "",
             "tpu-post-training-integration": "",
-            "tpu7x-unit": "--ignore=tests/post_training --ignore=tests/inference/kvcache_test.py",
+            "tpu7x-unit": "--ignore=tests/post_training",
             "tpu7x-integration": "--ignore=tests/post_training",
             "tpu7x-post-training-unit": "",
             "tpu7x-post-training-integration": "",

--- a/tests/inference/kvcache_test.py
+++ b/tests/inference/kvcache_test.py
@@ -29,7 +29,7 @@ class MlaKVCacheTest(unittest.TestCase):
   def setUp(self):
     super().setUp()
     self.rng = jax.random.PRNGKey(42)
-    self.batchsize = 8
+    self.batchsize = 4
     self.prefill_len = 100
     self.target_len = 196
     self.dtype = jnp.bfloat16


### PR DESCRIPTION
# Description

This PR fixes the XLA SPMD partitioning compilation hang for `tests/inference/kvcache_test.py` on 8-device runners (`jax.device_count() == 8`) and removes the temporary `--ignore=tests/inference/kvcache_test.py` exclusion from the `tpu7x-unit` workflow suite.

### Problem & Context
Previously, `tests/inference/kvcache_test.py` (`MlaKVCacheTest::test_update_kv_cache`) hung indefinitely during unit testing on 4-chip / 8-core TPU7X runners (`linux-x86-tpu7x-224-4tpu`), hitting ~35-minute pod timeouts. Investigation revealed:
* `MlaKVCacheTest.setUp()` initialized an arbitrary test batch size of `self.batchsize = 8`.
* When run on an 8-device TPU7X VM without an explicit SPMD mesh, JAX's default TPU partitioner auto-sharded `batchsize = 8` across 8 physical cores (exactly 1 item per core).
* During autoregressive steps (`MODEL_MODE_AUTOREGRESSIVE`), `kv_cache_autoregressive` calls `jax.lax.dynamic_update_index_in_dim` to slice and update `nnx.Cache` token-by-token. Compiling 1-element slice communication across 8 cores without a logical sharding rules map triggered an infinite compiler loop in `libtpu`.

### Why This is a Good Solution
* Changing `self.batchsize = 8` to `self.batchsize = 4` prevents XLA from attempting un-meshed 8-way SPMD auto-partitioning across 8 physical cores.
* Because `kvcache_test.py` is a standalone unit test designed to verify pure Python/NNX class logic (`MlaKVCache` buffer initialization, shape correctness, and slice updates) rather than multi-device sharding communication, testing with batch size 4 preserves 100% functional and numerical coverage while completing in **~7.5 seconds**.


FIXES: b/529360553
BUGS: b/529360553

# Tests

Tested using gh workflow command: https://github.com/AI-Hypercomputer/maxtext/actions/runs/28822821097/job/85478727356

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
