### PR TITLE
[WIP] Resize/pad VL decode works

### DIFF
--- a/src/maxtext/inference/decode.py
+++ b/src/maxtext/inference/decode.py
@@ -186,8 +186,9 @@ def main(argv: Sequence[str]) -> None:
           images=processor_outputs.pixel_values if config.use_multimodal else None,  # pyrefly: ignore[bad-argument-type]
           image_masks=processor_outputs.pixel_mask if config.use_multimodal and "llama4" in config.model_name else None,  # pyrefly: ignore[bad-argument-type]
           videos=getattr(processor_outputs, "video_values", None) if config.use_multimodal else None,
-          audio_values=processor_outputs.audio_values if config.use_audio else None,  # pyrefly: ignore[bad-argument-type]
-          audio_masks=processor_outputs.audio_mask if config.use_audio else None,  # pyrefly: ignore[bad-argument-type]
+          video_masks=getattr(processor_outputs, "video_mask", None) if config.use_multimodal else None,
+          audio_values=processor_outputs.audio_values if config.use_audio else None,
+          audio_masks=processor_outputs.audio_mask if config.use_audio else None,
           true_length=true_length,
           rng=rng_prefill,
           slot=i,

--- a/src/maxtext/layers/embeddings.py
+++ b/src/maxtext/layers/embeddings.py
@@ -1522,24 +1522,39 @@ class Qwen3OmniMoeVisionPosEmbedInterpolate(nnx.Module):
       )
     self.num_grid_per_side = int(self.num_position_embeddings**0.5)
 
-  def _interpolate_single(self, t: int, h: int, w: int) -> tuple[Array, Array]:
-    """Compute bilinear interpolation indices and weights for a single image/video.
+  def __call__(
+      self,
+      actual_t: Array,
+      actual_h: Array,
+      actual_w: Array,
+      num_frames: int,
+      height: int,
+      width: int,
+  ) -> Array:
+    """Interpolate positional embeddings for given dynamic grid dimensions.
 
     Args:
-      t: Number of temporal frames
-      h: Target height in patches
-      w: Target width in patches
+      actual_t: Actual number of temporal frames (batch,)
+      actual_h: Actual height in patches (batch,)
+      actual_w: Actual width in patches (batch,)
+      num_frames: Max number of temporal frames (static)
+      height: Max height in patches (static)
+      width: Max width in patches (static)
 
     Returns:
-      Tuple of (indices, weights) where:
-        - indices: [4, h*w] indices into pos_embed for 4 corners
-        - weights: [4, h*w] bilinear weights for 4 corners
+      Interpolated positional embeddings of shape [batch, num_frames * height * width, hidden_size]
     """
+    batch_size = actual_t.shape[0]
     N = self.num_grid_per_side
 
     # Create interpolation coordinates
-    h_idxs = jnp.linspace(0, N - 1, h)
-    w_idxs = jnp.linspace(0, N - 1, w)
+    h_arange = jnp.arange(height)[None, :]
+    actual_h_col = actual_h[:, None]
+    h_idxs = jnp.minimum(h_arange, actual_h_col - 1) * (N - 1) / jnp.maximum(actual_h_col - 1, 1)
+
+    w_arange = jnp.arange(width)[None, :]
+    actual_w_col = actual_w[:, None]
+    w_idxs = jnp.minimum(w_arange, actual_w_col - 1) * (N - 1) / jnp.maximum(actual_w_col - 1, 1)
 
     # Floor and ceiling indices
     h_idxs_floor = jnp.floor(h_idxs).astype(jnp.int32)
@@ -1551,74 +1566,53 @@ class Qwen3OmniMoeVisionPosEmbedInterpolate(nnx.Module):
     dh = h_idxs - h_idxs_floor
     dw = w_idxs - w_idxs_floor
 
-    # Compute flat indices for 2D grid
-    base_h = h_idxs_floor * N
-    base_h_ceil = h_idxs_ceil * N
+    # Construct the 4 corner indices on the N*N grid
+    floor_h_grid = h_idxs_floor[:, :, None] * N
+    ceil_h_grid = h_idxs_ceil[:, :, None] * N
+    floor_w_grid = w_idxs_floor[:, None, :]
+    ceil_w_grid = w_idxs_ceil[:, None, :]
 
-    # 4 corner indices: (floor_h, floor_w), (floor_h, ceil_w), (ceil_h, floor_w), (ceil_h, ceil_w)
-    indices = jnp.stack(
-        [
-            (base_h[:, None] + w_idxs_floor[None, :]).reshape(-1),
-            (base_h[:, None] + w_idxs_ceil[None, :]).reshape(-1),
-            (base_h_ceil[:, None] + w_idxs_floor[None, :]).reshape(-1),
-            (base_h_ceil[:, None] + w_idxs_ceil[None, :]).reshape(-1),
-        ],
-        axis=0,
-    )  # [4, h*w]
+    idx_00 = floor_h_grid + floor_w_grid
+    idx_01 = floor_h_grid + ceil_w_grid
+    idx_10 = ceil_h_grid + floor_w_grid
+    idx_11 = ceil_h_grid + ceil_w_grid
+
+    # indices shape: (batch, 4, H, W)
+    indices = jnp.stack([idx_00, idx_01, idx_10, idx_11], axis=1)
 
     # Bilinear weights
-    weights = jnp.stack(
-        [
-            ((1 - dh)[:, None] * (1 - dw)[None, :]).reshape(-1),
-            ((1 - dh)[:, None] * dw[None, :]).reshape(-1),
-            (dh[:, None] * (1 - dw)[None, :]).reshape(-1),
-            (dh[:, None] * dw[None, :]).reshape(-1),
-        ],
-        axis=0,
-    )  # [4, h*w]
+    dh_grid = dh[:, :, None]
+    dw_grid = dw[:, None, :]
 
-    return indices, weights
+    w_00 = (1 - dh_grid) * (1 - dw_grid)
+    w_01 = (1 - dh_grid) * dw_grid
+    w_10 = dh_grid * (1 - dw_grid)
+    w_11 = dh_grid * dw_grid
 
-  def __call__(self, num_frames: int, height: int, width: int) -> Array:
-    """Interpolate positional embeddings for given static grid dimensions.
-
-    Args:
-      num_frames: Number of temporal frames (static)
-      height: Height in patches (static)
-      width: Width in patches (static)
-
-    Returns:
-      Interpolated positional embeddings of shape [num_frames * height * width, hidden_size]
-    """
-    # Get interpolation indices and weights
-    indices, weights = self._interpolate_single(num_frames, height, width)  # [4, h*w], [4, h*w]
+    # weights shape: (batch, 4, H, W)
+    weights = jnp.stack([w_00, w_01, w_10, w_11], axis=1)
 
     # Lookup embeddings for all 4 corners
-    corner_embeds = self.pos_embed.value[indices]  # [4, h*w, hidden_size]
+    corner_embeds = self.pos_embed.value[indices]  # [batch, 4, h, w, hidden_size]
 
     # Apply bilinear weights and sum
-    weighted_embeds = corner_embeds * weights[:, :, None]  # [4, h*w, hidden_size]
-    interpolated = jnp.sum(weighted_embeds, axis=0)  # [h*w, hidden_size]
+    weighted_embeds = corner_embeds * weights[:, :, :, :, None]  # [batch, 4, h, w, hidden_size]
+    interpolated = jnp.sum(weighted_embeds, axis=1)  # [batch, h, w, hidden_size]
 
     # Repeat for temporal frames
-    if num_frames > 1:
-      interpolated = jnp.tile(interpolated, (num_frames, 1))  # [t*h*w, hidden_size]
+    interpolated = jnp.expand_dims(interpolated, axis=1)
+    interpolated = jnp.tile(interpolated, (1, num_frames, 1, 1, 1))
 
     # Apply spatial merge permutation
-    # Reshape to [t, h, w, hidden_size] then permute for block-based processing
     merge_size = self.spatial_merge_size
     merged_h = height // merge_size
     merged_w = width // merge_size
 
-    # Reshape: [t*h*w, hidden_size] -> [t, h, w, hidden_size]
-    interpolated = interpolated.reshape(num_frames, height, width, self.hidden_size)
-
-    # Permute for spatial merging: [t, merged_h, merge_size, merged_w, merge_size, hidden_size]
-    interpolated = interpolated.reshape(num_frames, merged_h, merge_size, merged_w, merge_size, self.hidden_size)
-    # -> [t, merged_h, merged_w, merge_size, merge_size, hidden_size]
-    interpolated = jnp.transpose(interpolated, (0, 1, 3, 2, 4, 5))
-    # Flatten back to [t*merged_h*merged_w*merge_size*merge_size, hidden_size]
-    interpolated = interpolated.reshape(-1, self.hidden_size)
+    interpolated = interpolated.reshape(
+        batch_size, num_frames, merged_h, merge_size, merged_w, merge_size, self.hidden_size
+    )
+    interpolated = jnp.transpose(interpolated, (0, 1, 2, 4, 3, 5, 6))
+    interpolated = interpolated.reshape(batch_size, -1, self.hidden_size)
 
     if self.cast_as_fprop_dtype:
       interpolated = interpolated.astype(self.fprop_dtype)

--- a/src/maxtext/layers/encoders.py
+++ b/src/maxtext/layers/encoders.py
@@ -93,10 +93,13 @@ class VisionEncoder(nnx.Module):
     else:
       raise ValueError(f"No VisionEncoder implemented for {self.config.model_name} yet")
 
-  def __call__(self, input_images, deterministic=False):
+  def __call__(self, input_images, input_masks=None, deterministic=False):
     # vision encoder output, frozen params in many cases
     encoder = getattr(self, self.encoder_name)
-    encoder_output = encoder(input_images, deterministic=deterministic)
+    if input_masks is not None and self.config.model_name.startswith("qwen3"):
+      encoder_output = encoder(input_images, input_masks=input_masks, deterministic=deterministic)
+    else:
+      encoder_output = encoder(input_images, deterministic=deterministic)
     deep_feats = None
     if isinstance(encoder_output, tuple):
       embeddings = encoder_output[0]

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -171,8 +171,8 @@ class TransformerLinenPure(nn.Module):
       )
 
     if self.config.use_multimodal and encoder_videos is not None:
-      video_embeddings, deepstack_visual_embeds = self.vision_encoder(  # pyrefly: ignore[not-callable]
-          input_images=encoder_videos, deterministic=not enable_dropout
+      video_embeddings, deepstack_visual_embeds = self.vision_encoder(
+          input_images=encoder_videos, input_masks=encoder_video_masks, deterministic=not enable_dropout
       )
       bidirectional_mask_video = mm_processor.get_bidirectional_mask_vision(
           self.config, decoder_input_tokens, is_video=True
@@ -188,11 +188,12 @@ class TransformerLinenPure(nn.Module):
 
     multimodal_input = None
     if image_embeddings is not None or video_embeddings is not None or audio_embeddings is not None:
+      token_video_mask = mm_processor.downsample_video_mask_to_tokens(self.config, encoder_video_masks)
       multimodal_input = MultimodalInput(
           image_embeddings=image_embeddings,
           image_masks=encoder_image_masks,
-          video_embeddings=video_embeddings,
-          video_masks=encoder_video_masks,
+          video_embeddings=jnp.expand_dims(video_embeddings, axis=-2) if video_embeddings is not None else None,
+          video_masks=token_video_mask,
           audio_embeddings=audio_embeddings,
           audio_masks=audio_masks,
           bidirectional_mask=bidirectional_mask_image,
@@ -499,7 +500,7 @@ class Transformer(nnx.Module):
 
     if self.config.use_multimodal and encoder_videos is not None:
       video_embeddings, deepstack_visual_embeds = self.vision_encoder(  # pyrefly: ignore[not-callable]
-          input_images=encoder_videos, deterministic=not enable_dropout
+          input_images=encoder_videos, input_masks=encoder_video_masks, deterministic=not enable_dropout
       )
       bidirectional_mask_video = mm_processor.get_bidirectional_mask_vision(
           self.config, decoder_input_tokens, is_video=True
@@ -515,11 +516,12 @@ class Transformer(nnx.Module):
 
     multimodal_input = None
     if image_embeddings is not None or video_embeddings is not None or audio_embeddings is not None:
+      token_video_mask = mm_processor.downsample_video_mask_to_tokens(self.config, encoder_video_masks)
       multimodal_input = MultimodalInput(
           image_embeddings=image_embeddings,
           image_masks=encoder_image_masks,
-          video_embeddings=video_embeddings,
-          video_masks=encoder_video_masks,
+          video_embeddings=jnp.expand_dims(video_embeddings, axis=-2) if video_embeddings is not None else None,
+          video_masks=token_video_mask,
           audio_embeddings=audio_embeddings,
           audio_masks=audio_masks,
           bidirectional_mask=bidirectional_mask_image,

--- a/src/maxtext/models/qwen3.py
+++ b/src/maxtext/models/qwen3.py
@@ -1941,6 +1941,7 @@ class Qwen3OmniMoeVisionAttention(nnx.Module):
       num_frames: int,
       height: int,
       width: int,
+      decoder_segment_ids: Array | None = None,
       deterministic: bool = True,
   ) -> Array:
     """
@@ -1949,6 +1950,7 @@ class Qwen3OmniMoeVisionAttention(nnx.Module):
         num_frames: Number of temporal frames (static)
         height: Height in patches (static)
         width: Width in patches (static)
+        decoder_segment_ids: Optional padding mask
         deterministic: Whether to use deterministic mode (disable dropout)
 
     Returns:
@@ -1963,6 +1965,7 @@ class Qwen3OmniMoeVisionAttention(nnx.Module):
     output, _ = self.attn(
         inputs_q=hidden_states,
         inputs_kv=hidden_states,
+        decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         rope_kwargs=rope_kwargs,
     )
@@ -2016,18 +2019,26 @@ class Qwen3OmniMoeVisionBlock(nnx.Module):
       num_frames: int,
       height: int,
       width: int,
+      decoder_segment_ids: Array | None = None,
   ) -> Array:
     """
     Args:
         x: Input tensor of shape (batch, T*H*W, hidden_size)
         num_frames: Number of temporal frames (static)
-        height: Height in patches (static)i
+        height: Height in patches (static)
         width: Width in patches (static)
+        decoder_segment_ids: Optional padding mask
 
     Returns:
         Output tensor of shape (batch, T*H*W, hidden_size)
     """
-    x = x + self.attn(self.ln1(x), num_frames=num_frames, height=height, width=width)
+    x = x + self.attn(
+        self.ln1(x),
+        num_frames=num_frames,
+        height=height,
+        width=width,
+        decoder_segment_ids=decoder_segment_ids,
+    )
     y = self.ln2(x)
     y = self.mlp(y)
     y = jax.nn.gelu(y)
@@ -2088,11 +2099,13 @@ class Qwen3OmniMoeVisionEncoder(nnx.Module):
   def __call__(
       self,
       hidden_states: Array,
+      input_masks: Array | None = None,
       deterministic: bool = True,
   ):
     """
     Args:
         hidden_states: Input visual tokens of shape (batch, in_channels, T*patch_size, H*patch_size, W*patch_size)
+        input_masks: Optional input mask of shape (batch, 1, T*patch_size, H*patch_size, W*patch_size)
         deterministic: Whether to use deterministic mode
 
     Returns:
@@ -2112,18 +2125,33 @@ class Qwen3OmniMoeVisionEncoder(nnx.Module):
         self.config.patch_size_for_vit,
     )
 
+    if input_masks is not None:
+      t_patch = self.config.temporal_patch_size_for_vit
+      s_patch = self.config.patch_size_for_vit
+      patch_mask = input_masks[:, 0, ::t_patch, ::s_patch, ::s_patch]
+      actual_t = jnp.sum(patch_mask[:, :, 0, 0], axis=1)
+      actual_h = jnp.sum(patch_mask[:, 0, :, 0], axis=1)
+      actual_w = jnp.sum(patch_mask[:, 0, 0, :], axis=1)
+    else:
+      patch_mask = None
+      actual_t = jnp.full((batch_size,), num_frames, dtype=jnp.int32)
+      actual_h = jnp.full((batch_size,), height, dtype=jnp.int32)
+      actual_w = jnp.full((batch_size,), width, dtype=jnp.int32)
+
     x, _ = self.patch_embed(hidden_states)
     x = x.reshape(batch_size, -1, self.config.hidden_size_for_vit)
-    pos = self.pos_embed_interpolate(num_frames, height, width)
-
-    pos = pos[jnp.newaxis, :, :]
+    pos = self.pos_embed_interpolate(actual_t, actual_h, actual_w, num_frames, height, width)
     x = x + pos
+
+    flat_patch_mask = None
+    if patch_mask is not None:
+      flat_patch_mask = patch_mask.reshape(batch_size, -1)
 
     h_traj = []
     for i in range(self.depth):
       block_name = f"blocks_{i}"
       blk = getattr(self, block_name)
-      x = blk(x, num_frames=num_frames, height=height, width=width)
+      x = blk(x, num_frames=num_frames, height=height, width=width, decoder_segment_ids=flat_patch_mask)
       h_traj.append(x)
 
     deep_feats = []

--- a/src/maxtext/multimodal/processor.py
+++ b/src/maxtext/multimodal/processor.py
@@ -234,6 +234,19 @@ def get_bidirectional_mask_vision(config, decoder_input_tokens, is_video: bool =
   return bidirectional_mask_vision
 
 
+def downsample_video_mask_to_tokens(config, pixel_mask):
+  """Downsample a pixel-level video mask to a model-specific video token mask."""
+  if pixel_mask is None:
+    return None
+  if config.model_name.startswith("qwen3"):
+    from maxtext.multimodal.processor_qwen3_omni import (  # pylint: disable=import-outside-toplevel
+        downsample_video_mask_to_tokens as qwen3_downsample_video_mask_to_tokens,
+    )
+
+    return qwen3_downsample_video_mask_to_tokens(config, pixel_mask)
+  return None
+
+
 def get_bidirectional_mask_audio(config, decoder_input_tokens):
   """Get the bidirectional mask for specific models."""
   bidirectional_mask_audio = None

--- a/src/maxtext/multimodal/processor_qwen3_omni.py
+++ b/src/maxtext/multimodal/processor_qwen3_omni.py
@@ -137,43 +137,93 @@ class Qwen3OmniPreprocessorOutput(mm_utils.PreprocessorOutput):
   audio_lengths: None | np.ndarray = None
 
 
+def downsample_video_mask_to_tokens(config, pixel_mask: jax.Array | None) -> jax.Array | None:
+  """Downsample a pixel-level video mask to a post-merge video token mask."""
+  if pixel_mask is None:
+    return None
+
+  patch_mask = pixel_mask[
+      :,
+      0,
+      :: config.temporal_patch_size_for_vit,
+      :: config.patch_size_for_vit,
+      :: config.patch_size_for_vit,
+  ]
+  merged_mask = patch_mask[:, :, :: config.spatial_merge_size_for_vit, :: config.spatial_merge_size_for_vit]
+  return merged_mask.reshape(pixel_mask.shape[0], -1)
+
+
 def maybe_pad_video_values_to_max_grid(
-    video_values: np.ndarray,
+    video_processed: np.ndarray,
     video_grid_thw: np.ndarray,
     config,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
-  """Pad Qwen3-Omni video pixels to configured static grid limits when enabled.
+  """Pad Qwen3-Omni video flat patches to configured static grid limits when enabled.
 
   Args:
-    video_values: Video pixels of shape (batch, channels, T*tps, H*patch, W*patch).
+    video_processed: Flat video patches of shape (T*H*W, C*tps*ps*ps).
     video_grid_thw: Actual video grid with shape (1, 3), in Qwen grid units.
     config: Config carrying video_max_grid_t/h/w and ViT patch sizes.
 
   Returns:
     Tuple of:
-    - padded video pixels, or the input when no max grid is configured
+    - padded video pixels of shape (1, C, max_T*tps, max_H*patch, max_W*patch)
     - input grid_thw
-    - pixel-level mask of shape (batch, 1, max_T*tps, max_H*patch, max_W*patch), or None
+    - pixel-level mask of shape (1, 1, max_T*tps, max_H*patch, max_W*patch), or None
   """
+  actual_t, actual_h, actual_w = (int(dim) for dim in video_grid_thw[0])
+  expected_patches = actual_t * actual_h * actual_w
+  expected_patch_dim = config.num_channels_for_vit * config.temporal_patch_size_for_vit * config.patch_size_for_vit**2
+  if video_processed.shape != (expected_patches, expected_patch_dim):
+    raise ValueError(
+        "video_processed must have shape "
+        f"{(expected_patches, expected_patch_dim)} for grid {video_grid_thw[0].tolist()}, got {video_processed.shape}."
+    )
+
   max_grid = (
       getattr(config, "video_max_grid_t", None),
       getattr(config, "video_max_grid_h", None),
       getattr(config, "video_max_grid_w", None),
   )
   if all(dim is None for dim in max_grid):
+    video_values = np.reshape(
+        video_processed,
+        (
+            1,
+            config.num_channels_for_vit,
+            config.temporal_patch_size_for_vit * actual_t,
+            config.patch_size_for_vit * actual_h,
+            config.patch_size_for_vit * actual_w,
+        ),
+    )
     return video_values, video_grid_thw, None
+
   if any(dim is None for dim in max_grid):
     raise ValueError("video_max_grid_t, video_max_grid_h, and video_max_grid_w must be set together.")
-  if video_values.ndim != 5:
-    raise ValueError(f"video_values must have shape (batch, channels, time, height, width), got {video_values.shape}.")
 
-  max_t, max_h, max_w = (int(dim) for dim in max_grid)  # pyrefly: ignore[bad-argument-type]
-  actual_t, actual_h, actual_w = (int(dim) for dim in video_grid_thw[0])
+  max_t, max_h, max_w = (int(dim) for dim in max_grid)
   if actual_t > max_t or actual_h > max_h or actual_w > max_w:
     raise ValueError(
         f"video grid {video_grid_thw[0].tolist()} exceeds max grid {(max_t, max_h, max_w)}. "
         "Scale or resize the video before padding."
     )
+
+  video_patches = np.reshape(video_processed, (actual_t, actual_h, actual_w, expected_patch_dim))
+
+  padded_patches = np.zeros((max_t, max_h, max_w, expected_patch_dim), dtype=video_processed.dtype)
+  padded_patches[:actual_t, :actual_h, :actual_w, :] = video_patches
+  padded_flat = np.reshape(padded_patches, (max_t * max_h * max_w, expected_patch_dim))
+
+  padded_video_values = np.reshape(
+      padded_flat,
+      (
+          1,
+          config.num_channels_for_vit,
+          config.temporal_patch_size_for_vit * max_t,
+          config.patch_size_for_vit * max_h,
+          config.patch_size_for_vit * max_w,
+      ),
+  )
 
   temporal_patch_size = config.temporal_patch_size_for_vit
   patch_size = config.patch_size_for_vit
@@ -184,15 +234,7 @@ def maybe_pad_video_values_to_max_grid(
   max_h_px = max_h * patch_size
   max_w_px = max_w * patch_size
 
-  padded_video_values = np.zeros(
-      (video_values.shape[0], video_values.shape[1], max_t_px, max_h_px, max_w_px),
-      dtype=video_values.dtype,
-  )
-  padded_video_values[:, :, :valid_t_px, :valid_h_px, :valid_w_px] = video_values[
-      :, :, :valid_t_px, :valid_h_px, :valid_w_px
-  ]
-
-  video_mask = np.zeros((video_values.shape[0], 1, max_t_px, max_h_px, max_w_px), dtype=np.int32)
+  video_mask = np.zeros((1, 1, max_t_px, max_h_px, max_w_px), dtype=np.int32)
   video_mask[:, :, :valid_t_px, :valid_h_px, :valid_w_px] = 1
 
   return padded_video_values, video_grid_thw, video_mask
@@ -665,17 +707,7 @@ def preprocess_mm_data_qwen3_omni(config):
   if config.video_path:
     video_array, _ = _read_video_decord(config.video_path)
     video_processed, video_grid_thw = preprocess_video(video_array, config)
-    video_values = np.reshape(
-        video_processed,
-        (
-            1,
-            config.num_channels_for_vit,
-            config.temporal_patch_size_for_vit * video_grid_thw[0, 0],
-            config.patch_size_for_vit * video_grid_thw[0, 1],
-            config.patch_size_for_vit * video_grid_thw[0, 2],
-        ),
-    )
-    video_values, video_grid_thw, video_mask = maybe_pad_video_values_to_max_grid(video_values, video_grid_thw, config)
+    video_values, video_grid_thw, video_mask = maybe_pad_video_values_to_max_grid(video_processed, video_grid_thw, config)
     processor_outputs.video_values = video_values
     processor_outputs.video_grid_thw = video_grid_thw
     processor_outputs.video_mask = video_mask

--- a/tests/unit/qwen3_omni_layers_test.py
+++ b/tests/unit/qwen3_omni_layers_test.py
@@ -401,27 +401,49 @@ class TestQwen3OmniMoeVisionPatchEmbed(BaseVisionTestCase):
     patch_size = self.config.patch_size_for_vit
     in_channels = self.config.num_channels_for_vit
 
-    raw_shape = (
-        batch_size,
-        in_channels,
-        raw_grid[0] * temporal_patch_size,
-        raw_grid[1] * patch_size,
-        raw_grid[2] * patch_size,
-    )
-    raw_hidden_states, _ = create_random_jax_torch(*raw_shape)
     raw_grid_thw = np.asarray([raw_grid], dtype=np.int32)
+    grid_t, grid_h, grid_w = raw_grid[0], raw_grid[1], raw_grid[2]
+
+    # Generate random flat patch sequence (patch-contiguous)
+    flat_shape = (grid_t * grid_h * grid_w, in_channels * temporal_patch_size * patch_size * patch_size)
+    # Use numpy random to match the test style
+    raw_video_processed = np.random.normal(size=flat_shape).astype(np.float32)
+
+    # Reshape to pixel-level grid (preserves patch-contiguity in memory)
+    raw_hidden_states = np.reshape(
+        raw_video_processed,
+        (batch_size, in_channels, grid_t * temporal_patch_size, grid_h * patch_size, grid_w * patch_size)
+    )
 
     padded_hidden_states, padded_grid_thw, video_mask = maybe_pad_video_values_to_max_grid(
-        np.asarray(raw_hidden_states),
+        raw_video_processed,
         raw_grid_thw,
         config_video_pad,
     )
 
-    raw_output, raw_attention_mask = self.jax_model(raw_hidden_states)
+    # Reshape inputs to patch-level (-1, C, tps, ps, ps) as the encoder would
+    raw_hidden_states_reshaped = raw_hidden_states.reshape(
+        -1,
+        in_channels,
+        temporal_patch_size,
+        patch_size,
+        patch_size,
+    )
+    raw_output, raw_attention_mask = self.jax_model(raw_hidden_states_reshaped)
+    raw_output = raw_output.reshape(batch_size, -1, self.config.hidden_size_for_vit)
+
+    padded_hidden_states_reshaped = jnp.asarray(padded_hidden_states).reshape(
+        -1,
+        in_channels,
+        temporal_patch_size,
+        patch_size,
+        patch_size,
+    )
     padded_output, attention_mask = self.jax_model(
-        jnp.asarray(padded_hidden_states),
+        padded_hidden_states_reshaped,
         video_mask=jnp.asarray(video_mask),
     )
+    padded_output = padded_output.reshape(batch_size, -1, self.config.hidden_size_for_vit)
 
     self.assertIsNone(raw_attention_mask)
     np.testing.assert_array_equal(padded_grid_thw, raw_grid_thw)
@@ -461,18 +483,8 @@ class TestQwen3OmniMoeVisionPatchEmbed(BaseVisionTestCase):
     self.assertAlmostEqual(video_grid_thw[0, 2] / video_grid_thw[0, 1], dummy_video_wide_ratio, delta=0.5)
 
     # Verify maybe_pad_video_values_to_max_grid succeeds without ValueError.
-    video_values = np.reshape(
-        video_processed,
-        (
-            1,
-            cfg.num_channels_for_vit,
-            cfg.temporal_patch_size_for_vit * video_grid_thw[0, 0],
-            cfg.patch_size_for_vit * video_grid_thw[0, 1],
-            cfg.patch_size_for_vit * video_grid_thw[0, 2],
-        ),
-    )
     padded_values, padded_grid, _ = maybe_pad_video_values_to_max_grid(
-        video_values,
+        video_processed,
         video_grid_thw,
         cfg,
     )
@@ -615,7 +627,10 @@ class TestQwen3OmniMoeVisionPosEmbedInterpolate(BaseVisionTestCase):
     grid_thw_np = np.array([[num_frames, height, width]], dtype=np.int64)
     grid_thw_torch = torch.from_numpy(grid_thw_np)
 
-    pos_embed_jax = self.jax_model(num_frames, height, width)
+    actual_t = jnp.array([num_frames], dtype=jnp.int32)
+    actual_h = jnp.array([height], dtype=jnp.int32)
+    actual_w = jnp.array([width], dtype=jnp.int32)
+    pos_embed_jax = self.jax_model(actual_t, actual_h, actual_w, num_frames, height, width)[0]
     pos_embed_torch = self.torch_encoder.fast_pos_embed_interpolate(grid_thw_torch)
 
     assert_all_close_jax_torch(pos_embed_jax, pos_embed_torch, rtol=1e-2, atol=1e-2)
@@ -795,6 +810,7 @@ class TestQwen3OmniPreprocessing(unittest.TestCase):
         video_path=self.video_path,
         use_audio_in_video=True,
         max_prefill_predict_length=2048,
+        max_target_length=2560,
     )
 
   def test_preprocess_mm_data(self):


### PR DESCRIPTION
# Description

Dynamic resize and pad to (32, 32, 32) grid -> (32s, 512pix, 512pix)

# Tests

```
# Decode
python -m maxtext.inference.decode maxtext/configs/base.yml tokenizer_type=huggingface model_name=qwen3-vl-2b tokenizer_path=Qwen/Qwen3-VL-2B-Instruct load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-vl-2b/unscanned/2026-07-01-11-55/0/items per_device_batch_size=1 run_name=ht_test scan_layers=false use_multimodal=true prompt=\'What\ is\ the\ classification\ of\ the\ single\ exhibit\ in\ this\ video\?\' video_path=\'tests/assets/test_video.mp4\' max_prefill_predict_length=1240 max_target_length=1280 ici_tensor_parallelism=4 override_model_config=true video_max_grid_t=32 video_max_grid_h=32 video_max_grid_w=32 attention=\'dot_product\' hf_access_token=xxx

# Result
DEBUG TRACE: inputs.shape = (1, 32768, 16, 64), cos_emb.shape = (32768, 64)

Input `<|im_start|>user
<|vision_start|><|video_pad|><|vision_end|>What is the classification ofthe single exhibit in this video?<|im_end|>
<|im_start|>assistant
` -> `The exhibit in the video is a **dinosaur**. More specifically, it is a **model of a multi-headed dinosaur**, which is a type of **dinosaur exhibit**. The exhibit is likely`
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
