### PR TITLE
e2e tests and fixes for qwen3-30b

### DIFF
--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Validates the Qwen3-30B pre-training pipeline using a pre-converted MaxText checkpoint.
+
+# The flow of this script is as follows:
+# 1. Run inference on the pre-converted checkpoint.
+# 2. Run pre-training starting from the pre-converted checkpoint.
+# 3. Run inference on the checkpoint produced by the pre-training run.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID
+# bash test_qwen3.sh $RUN_ID
+
+
+set -ex
+
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+MODEL_NAME='qwen3-30b-a3b-base'
+
+
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
+UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${run_id}/0/items
+SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+
+DATASET_PATH=gs://maxtext-dataset
+
+# Step 1: Run inference on the pre-converted checkpoint
+python3 -m maxtext.inference.decode \
+    model_name=${MODEL_NAME} tokenizer_type="huggingface" \
+    load_parameters_path=${UNSCANNED_CKPT_PATH} \
+    per_device_batch_size=1 run_name=${run_id} \
+    max_prefill_predict_length=8 max_target_length=16 steps=1 async_checkpointing=false \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    scan_layers=false prompt='I love to' attention=\'dot_product\'
+
+# Step 2: Run pre-training starting from the pre-converted checkpoint
+python3 -m maxtext.trainers.pre_train.train \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/train \
+    dataset_path=${DATASET_PATH} tokenizer_type="huggingface" \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    per_device_batch_size=0.125 run_name=${run_id} \
+    max_target_length=64 steps=5 async_checkpointing=false \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    model_name=${MODEL_NAME} scan_layers=true \
+    remat_policy=full \
+    ici_tensor_parallelism=4 ici_fsdp_parallelism=2 weight_dtype=bfloat16 dtype=bfloat16 opt_type=sgd optimizer_memory_host_offload=true
+
+# Step 3: Run inference on the checkpoint produced by the pre-training run
+python3 -m maxtext.inference.decode \
+    model_name=${MODEL_NAME} tokenizer_type="huggingface" \
+    load_parameters_path=${BASE_OUTPUT_DIRECTORY}/train/${run_id}/checkpoints/4/items \
+    per_device_batch_size=1 run_name=${run_id} \
+    max_prefill_predict_length=8 max_target_length=16 steps=4 async_checkpointing=false \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    scan_layers=true prompt='I love to' attention=\'dot_product\'

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_rl.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_rl.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Validates the Qwen3 RL pipeline using a pre-converted MaxText checkpoint.
+
+# The flow of this script is as follows:
+# 1. Run inference on the pre-converted checkpoint.
+# 2. Run RL starting from the pre-converted checkpoint.
+# 3. Run inference on the checkpoint produced by the RL run.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID
+# bash test_qwen3_rl.sh $RUN_ID
+
+set -ex
+
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb
+export VLLM_RAY_EXTRA_ENV_VARS_TO_COPY="PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"
+export VLLM_ENABLE_V1_MULTIPROCESSING=0
+export JAX_RANDOM_WEIGHTS=1
+export SKIP_JAX_PRECOMPILE=1
+export NEW_MODEL_DESIGN=1
+export TPU_MIN_LOG_LEVEL=0
+export TF_CPP_MIN_LOG_LEVEL=0
+export TPU_STDERR_LOG_LEVEL=0
+
+# Force Python to use "spawn" instead of "fork" for multiprocessing to prevent gRPC socket corruption
+cat << 'EOF' > usercustomize.py
+import multiprocessing
+try:
+    multiprocessing.set_start_method("spawn", force=True)
+except Exception:
+    pass
+EOF
+export PYTHONPATH=${PYTHONPATH:-.}:$(pwd)
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+MODEL_NAME='qwen3-30b-a3b-base'
+
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
+UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${run_id}/0/items
+SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items
+
+# Step 1: Run inference on the pre-converted checkpoint
+python3 -m maxtext.inference.vllm_decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    hbm_utilization_vllm=0.85 \
+    prompt='Suggest some famous landmarks in London.' \
+    max_target_length=256 max_num_batched_tokens=256 \
+    ici_tensor_parallelism=8  \
+    allow_split_physical_axes=True prefuse_moe_weights=True \
+    use_chat_template=True scan_layers=True enable_single_controller=True
+
+# Step 2: Run RL starting from the pre-converted checkpoint
+python3 -m maxtext.trainers.post_train.rl.train_rl \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/rl \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    run_name=${run_id} rl.loss_algo='grpo' scan_layers=True \
+    num_batches=5 batch_size=4 train_micro_batch_size=1 num_test_batches=5 \
+    model_name=${MODEL_NAME} enable_single_controller=True \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    rollout_tensor_parallelism=8 \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    vllm_additional_config='{"maxtext_config": {"model_name": "'${MODEL_NAME}'", "allow_split_physical_axes": true, "scan_layers": false, "prefuse_moe_weights": True}}' \
+    remat_policy=full hbm_utilization_vllm=0.55 use_pathways=True \
+    chips_per_vm=8 ici_tensor_parallelism=4\
+    max_target_length=512 weight_dtype=bfloat16 dtype=bfloat16 opt_type=sgd \
+    enable_tunix_perf_metrics=True rl.num_generations=16 \
+    debug.rl=False rl.reshard_chunk_size=1 
+
+# Step 3: Run inference on the checkpoint produced by the RL run
+python3 -m maxtext.inference.vllm_decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${BASE_OUTPUT_DIRECTORY}/rl/${run_id}/checkpoints/actor/4/items \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    hbm_utilization_vllm=0.85 \
+    prompt='Suggest some famous landmarks in London.' \
+    max_target_length=256 max_num_batched_tokens=256 \
+    ici_tensor_parallelism=8  \
+    allow_split_physical_axes=True prefuse_moe_weights=True \
+    use_chat_template=True scan_layers=True enable_single_controller=True

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_sft.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_sft.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Validates the Qwen3 SFT pipeline using a pre-converted MaxText checkpoint.
+
+
+# The flow of this script is as follows:
+# 1. Run inference on the pre-converted checkpoint.
+# 2. Run SFT starting from the pre-converted checkpoint.
+# 3. Run inference on the checkpoint produced by the SFT run.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID
+# bash test_qwen3_sft.sh $RUN_ID
+
+
+set -ex
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+export NEW_MODEL_DESIGN=1
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+MODEL_NAME='qwen3-30b-a3b-base'
+
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}
+UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/unscanned/${run_id}/0/items
+SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/to_maxtext/scanned/${run_id}/0/items
+
+# Step 1: Run inference on the pre-converted checkpoint
+python3 -m maxtext.inference.vllm_decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    hbm_utilization_vllm=0.85 \
+    use_chat_template=True scan_layers=true enable_single_controller=True \
+    ici_tensor_parallelism=4 prompt="Suggest some famous landmarks in London."
+
+# Step 2: Run SFT starting from the pre-converted checkpoint
+python3 -m maxtext.trainers.post_train.sft.train_sft \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/sft \
+    load_parameters_path=${SCANNED_CKPT_PATH} \
+    per_device_batch_size=0.125 run_name=${run_id} \
+    steps=5 scan_layers=true \
+    model_name=${MODEL_NAME} \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    remat_policy=full \
+    ici_tensor_parallelism=1 ici_fsdp_parallelism=1 ici_expert_parallelism=8 \
+    enable_single_controller=True max_target_length=16 weight_dtype=bfloat16 dtype=bfloat16 opt_type=sgd
+
+# Step 3: Run inference on the checkpoint produced by the SFT run
+python3 -m maxtext.inference.vllm_decode \
+    model_name=${MODEL_NAME} \
+    load_parameters_path=${BASE_OUTPUT_DIRECTORY}/sft/${run_id}/checkpoints/5/model_params \
+    vllm_hf_overrides='{architectures: ["MaxTextForCausalLM"]}' \
+    hbm_utilization_vllm=0.85 \
+    use_chat_template=True scan_layers=true enable_single_controller=True \
+    ici_tensor_parallelism=4 prompt="Suggest some famous landmarks in London."

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Converts a MaxText checkpoint to a Hugging Face model checkpoint.
+
+# Usage:
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_hf.sh $RUN_ID $CHECKPOINT_PATH $SCAN_LAYERS
+
+
+set -ex
+
+run_id=$1
+CKPT_PATH=$2
+SCAN_LAYERS=${3:-false}
+
+MODEL_NAME='qwen3-30b-a3b-base'
+BASE_OUTPUT_DIRECTORY="gs://runner-maxtext-logs/${MODEL_NAME}"
+
+if [ "${SCAN_LAYERS,,}" = "true" ]; then
+    scan_status="scanned"
+else
+    scan_status="unscanned"
+fi
+
+# Convert the checkpoint to Hugging Face format
+python3 -m maxtext.checkpoint_conversion.to_huggingface \
+    model_name=${MODEL_NAME} \
+    tokenizer_type="huggingface" \
+    load_parameters_path=${CKPT_PATH} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/to_huggingface/${scan_status}/${run_id} \
+    scan_layers=$SCAN_LAYERS

--- a/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh
+++ b/tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Converts Qwen3-30B HuggingFace checkpoint to MaxText format and validates logit correctness.
+
+# The flow of this script is as follows:
+# 1. Install PyTorch (CPU) required for checkpoint conversion.
+# 2. Convert the HuggingFace checkpoint to MaxText format in both unscanned and scanned formats.
+# 3. Run a forward pass logits check to verify the converted checkpoint matches the original HF model.
+
+# Usage:
+# export HF_TOKEN=<your Hugging Face access token>
+# export RUN_ID=$(date +%Y-%m-%d-%H-%M-%S)
+# bash test_qwen3_to_mt.sh $RUN_ID
+
+set -ex
+
+run_id=${1:-$(date +%Y-%m-%d-%H-%M-%S)}
+MODEL_NAME='qwen3-30b-a3b-base'
+HF_GOLDEN_MODEL='Qwen/Qwen3-30B-A3B-Base'
+
+
+BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs/${MODEL_NAME}/to_maxtext
+
+# Step 1: Install torch
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# Step 2: Convert the checkpoint from Hugging Face
+python3 -m maxtext.checkpoint_conversion.to_maxtext \
+    model_name=${MODEL_NAME} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/unscanned/${run_id} \
+    scan_layers=false \
+    hardware=cpu skip_jax_distributed_system=True \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    --lazy_load_tensors=False \
+    --eager_load_method='safetensors'
+
+UNSCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/unscanned/${run_id}/0/items
+echo "Unscanned checkpoint path: ${UNSCANNED_CKPT_PATH}"
+
+# Convert to scanned format
+python3 -m maxtext.checkpoint_conversion.to_maxtext \
+    model_name=${MODEL_NAME} \
+    base_output_directory=${BASE_OUTPUT_DIRECTORY}/scanned/${run_id} \
+    scan_layers=true \
+    hardware=cpu skip_jax_distributed_system=True \
+    checkpoint_storage_use_zarr3=False checkpoint_storage_use_ocdbt=False \
+    --lazy_load_tensors=False \
+    --eager_load_method='safetensors'
+
+SCANNED_CKPT_PATH=${BASE_OUTPUT_DIRECTORY}/scanned/${run_id}/0/items
+echo "Scanned checkpoint path: ${SCANNED_CKPT_PATH}"
+
+# Step 3: Run forward pass logits check
+python3 -m tests.utils.forward_pass_logit_checker \
+    load_parameters_path=${UNSCANNED_CKPT_PATH} \
+    model_name=${MODEL_NAME} \
+    scan_layers=false \
+    --hf_model_path=${HF_GOLDEN_MODEL} \
+    --max_kl_div=0.03 \
+    --run_hf_model=true \
+    hardware=cpu skip_jax_distributed_system=True


### PR DESCRIPTION

- e2e test for qwen3-30b. Previous code merge failed: https://github.com/AI-Hypercomputer/maxtext/pull/4185


# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.: 
BUGS: b/123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
