### PR TITLE
Enable MoE ragged sort tests on TPU7X (remove skip_on_tpu7x)

### DIFF
--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -723,34 +723,28 @@ class RoutedMoeTest(unittest.TestCase):
       )
 
   @pytest.mark.tpu_only
-  @pytest.mark.skip_on_tpu7x
   def test_ragged_sort_loss_and_grad_ring_of_experts(self):
     self._run_ragged_sort_loss_and_grad(use_ring_of_experts=True)
 
   @pytest.mark.tpu_only
-  @pytest.mark.skip_on_tpu7x
   def test_ragged_sort_loss_and_grad_ring_of_experts_ragged_buffer(self):
     self._run_ragged_sort_loss_and_grad(use_ring_of_experts=True, ragged_buffer_factor=1.5)
 
   @pytest.mark.tpu_only
-  @pytest.mark.skip_on_tpu7x
   def test_ragged_sort_loss_and_grad_ring_of_experts_fallback(self):
     self._run_ragged_sort_loss_and_grad(
         use_ring_of_experts=True, ragged_gather_fallback=True, ragged_gather_reduce_fallback=True
     )
 
   @pytest.mark.tpu_only
-  @pytest.mark.skip_on_tpu7x
   def test_ragged_sort_loss_and_grad_no_ring_of_experts(self):
     self._run_ragged_sort_loss_and_grad(use_ring_of_experts=False)
 
   @pytest.mark.tpu_only
-  @pytest.mark.skip_on_tpu7x
   def test_ragged_sort_loss_and_grad_no_ring_of_experts_ragged_buffer(self):
     self._run_ragged_sort_loss_and_grad(use_ring_of_experts=False, ragged_buffer_factor=1.5)
 
   @pytest.mark.tpu_only
-  @pytest.mark.skip_on_tpu7x
   def test_ragged_sort_loss_and_grad_no_ring_of_experts_fallback(self):
     self._run_ragged_sort_loss_and_grad(
         use_ring_of_experts=False, ragged_gather_fallback=True, ragged_gather_reduce_fallback=True


### PR DESCRIPTION
# Description

This PR enables TPU7X execution for Mixture of Experts (MoE) ragged sort unit tests by removing all `@pytest.mark.skip_on_tpu7x` skip decorators from `tests/unit/moe_test.py`.

### Why Were These Tests Skipped Originally?
* During initial TPU7X CI fleet onboarding (`commit 41060207`), `@pytest.mark.skip_on_tpu7x` was added to `test_ragged_sort_loss_and_grad_ring_of_experts` and `test_ragged_sort_loss_and_grad_no_ring_of_experts`. At the time, multi-device SPMD lowering and custom VJP kernel execution on the early TPU7X compiler stack experienced timeouts on 8-core slices.

### Why Are They Passing Now?
* Compiler lowering and Pallas/ragged sort kernel execution on the current stable JAX/libtpu stack now compile and run natively on 4-chip / 8-core TPU7X runners (`linux-x86-tpu7x-224-4tpu`).

FIXES: b/527504273
BUGS: b/527504273

# Tests

Ran the workflow: https://github.com/AI-Hypercomputer/maxtext/actions/runs/28973185236/job/85974254379

TPU7x moe tests are passing. The failures are unrelated to this bug or PR and are being separately addressed.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
