### PR TITLE
Fix RL LR schedule default

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -111,6 +111,13 @@ debug:
 enable_tunix_perf_metrics: false
 
 # ====== Training ======
+# RL computes actual optimizer updates as:
+# num_batches * rl.num_iterations * train_fraction * num_epoch.
+# Keep these at -1 so the RL optimizer falls back to that computed max_train_steps
+# unless a recipe explicitly pins a schedule horizon.
+steps: -1
+learning_rate_schedule_steps: -1
+
 batch_size: 1
 # Increase `batch_size` and `MAX_STEPS` for better results.
 # num_batches: 3738

--- a/src/maxtext/trainers/post_train/rl/utils_rl.py
+++ b/src/maxtext/trainers/post_train/rl/utils_rl.py
@@ -586,6 +586,17 @@ def get_optimizer(tmvp_config: Any, max_train_steps: int) -> optax.GradientTrans
   schedule_steps = getattr(tmvp_config, "learning_rate_schedule_steps", -1)
   if schedule_steps is None or schedule_steps <= 0:
     schedule_steps = max_train_steps
+  elif schedule_steps != max_train_steps:
+    max_logging.log(
+        "WARNING: RL learning_rate_schedule_steps is set to "
+        f"{schedule_steps}, but the computed RL training length is "
+        f"{max_train_steps} optimizer updates. This may be intentional for a "
+        "fixed LR schedule horizon; otherwise set both steps and "
+        "learning_rate_schedule_steps to -1 so RL falls back to "
+        "max_train_steps. With warmup_steps_fraction="
+        f"{tmvp_config.warmup_steps_fraction}, warmup will last "
+        f"{int(tmvp_config.warmup_steps_fraction * schedule_steps)} steps."
+    )
   schedule = optax.schedules.warmup_cosine_decay_schedule(
       init_value=0.0,
       peak_value=tmvp_config.learning_rate,


### PR DESCRIPTION
RL computes its real training length from num_batches, rl.num_iterations, train_fraction, and num_epoch, but rl.yml inherited base.yml steps=150001. Config normalization then converted learning_rate_schedule_steps=-1 into that inherited step count before the RL optimizer saw max_train_steps, causing warmup/decay to use a much longer horizon than the actual RL run.

Set both steps and learning_rate_schedule_steps to -1 in the RL base config so the optimizer falls back to the computed max_train_steps unless a recipe explicitly pins the schedule horizon. Also warn when a positive learning_rate_schedule_steps differs from the computed RL training length, since that may be intentional but is easy to inherit accidentally.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
