### PR TITLE
Add v6e-8 GSM8K RL convergence benchmark config

### DIFF
--- a/src/maxtext/configs/post_train/rl_gsm8k_qwen35_35b_v5p64.yml
+++ b/src/maxtext/configs/post_train/rl_gsm8k_qwen35_35b_v5p64.yml
@@ -1,0 +1,159 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+base_config: "rl.yml"
+
+# ====== Model ======
+model_name: qwen3.5-35b-a3b
+tokenizer_path: Qwen/Qwen3.5-35B-A3B
+tokenizer_type: huggingface
+scan_layers: true
+
+# ====== Hardware ======
+# v5p-64 = v5p-8 (4 chips) * 8 nodes
+# Inference: 4 nodes
+# Training: 4 nodes
+trainer_devices_fraction: 0.5
+sampler_devices_fraction: 0.5
+chips_per_vm: 4
+use_pathways: true
+allow_split_physical_axes: true
+
+# Rollout: TP = 4 (across 4 chips).
+use_standalone_converter: false
+rollout_data_parallelism: -1
+rollout_tensor_parallelism: 4
+rollout_expert_parallelism: 1
+
+# Use the MaxText vLLM adapter so actor and rollout share the same Qwen3.5
+# parameter layout. These overrides were previously supplied only by the
+# experiment JobSet.
+vllm_hf_overrides:
+  architectures: ["MaxTextForCausalLM"]
+vllm_additional_config:
+  maxtext_config:
+    model_name: qwen3.5-35b-a3b
+    model_call_mode: inference
+    attention: vllm_rpa
+    allow_split_physical_axes: true
+    log_config: false
+    weight_dtype: bfloat16
+    prefuse_moe_weights: true
+
+# One checkpoint restore plus an in-memory clone avoids reading/converting the
+# same model twice during startup.
+load_checkpoint_only_once: true
+
+# ====== GRPO ======
+rl:
+  num_generations: 4
+  num_iterations: 1
+  grpo_beta: 0.08
+  grpo_epsilon: 0.2
+  loss_algo: "grpo"
+  loss_agg_mode: "sequence-mean-token-mean"
+  use_agentic_rollout: false
+
+# ====== Training Schedule ======
+# GSM8K train yields 934 full batches at batch_size=8 (7,472 examples, with
+# drop_remainder=True). One epoch covers the full training split once.
+batch_size: 8
+num_batches: 934
+num_epoch: 1
+train_fraction: 1.0
+learning_rate_schedule_steps: 934
+
+train_micro_batch_size: 1
+rollout_micro_batch_size: 8
+
+learning_rate: 3e-6
+warmup_steps_fraction: 0.1
+adam_b1: 0.9
+adam_b2: 0.99
+adam_weight_decay: 0.1
+gradient_clipping_threshold: 0.1
+
+log_period: 20
+eval_interval: 100
+
+# ====== Evaluation ======
+# 20 * 32 = 640 held-out GSM8K prompts per eval pass.
+num_test_batches: 20
+eval_batch_size: 32
+# Qwen3.5 is a thinking model; greedy decoding can fall into endless token
+# loops. Match the model's published sampling defaults.
+eval_sampling_strategy: "standard"
+generation_configs:
+  standard:
+    eval_temperature: 1.0
+    eval_top_k: 20
+    eval_top_p: 0.95
+num_eval_passes: 1
+eval_mode: "pass_at_1"
+
+# ====== Rollout / Generation ======
+max_prefill_predict_length: 256
+max_target_length: 1024
+kv_cache_buffer: 256
+
+decode_sampling_temperature: 1.0
+decode_sampling_top_k: 20
+decode_sampling_nucleus_p: 0.95
+
+hbm_utilization_vllm: 0.60
+swap_space_vllm_gb: 2
+max_num_seqs: 32
+max_num_batched_tokens: 16384
+async_scheduling: false
+enable_dp_attention: false
+# The MaxText Qwen3.5 adapter does not save and restore GDN recurrent state in
+# vLLM's block-addressed prefix cache. Reusing only the attention prefix would
+# pair it with unrelated recurrent state and corrupt generation.
+enable_prefix_caching: false
+
+# ====== Checkpointing ======
+enable_checkpointing: true
+async_checkpointing: false
+checkpoint_period: 250
+max_num_checkpoints_to_keep: 4
+
+# ====== Dataset ======
+dataset_name: "openai/gsm8k"
+eval_dataset_name: "openai/gsm8k"
+train_split: "train"
+eval_split: "test"
+hf_subset: "main"
+data_template_path: "maxtext/examples/chat_templates/qwen35_math_rl.json"
+reasoning_start_token: "<think>"
+reasoning_end_token: "</think>"
+reasoning_start_token_in_prompt: true
+
+# Qwen3.5's chat template opens its native <think> block in the prompt. The
+# model closes it, then emits the task-specific answer block requested above.
+stop_strings: ["</answer>"]
+
+# ====== Reward ======
+reward_exact_answer: 1.0
+reward_white_space_format_match: 1.0
+reward_exact_format_match: 0.1
+reward_partial_format_match: 0.0
+reward_ratio_guess_to_answer_high: 0.0
+reward_ratio_guess_to_answer_low: 0.0
+penalty_incorrect_format: 0.0
+penalty_incorrect_answer: 0.0
+
+math_verify_timeout: 120
+math_verify_num_procs: null
+
+debug: false

--- a/src/maxtext/configs/post_train/rl_gsm8k_qwen3_4b_v6e8.yml
+++ b/src/maxtext/configs/post_train/rl_gsm8k_qwen3_4b_v6e8.yml
@@ -1,0 +1,142 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Production-scale non-agentic GRPO recipe for GSM8K on a single v6e-8 host.
+#
+# This inherits the shared post-train RL wiring from rl.yml and replaces the
+# smoke-test values with a long GSM8K run. The default model is Qwen3-4B because
+# MaxText's non-agentic path uses vLLM rollouts and full-model training by
+# default. Try Qwen3-8B or Llama 3.1 8B with CLI overrides after this recipe is
+# stable on your TPU.
+#
+# Example 8B overrides:
+#   model_name=qwen3-8b tokenizer_path=Qwen/Qwen3-8B
+#   model_name=llama3.1-8b tokenizer_path=meta-llama/Llama-3.1-8B-Instruct
+
+base_config: "rl.yml"
+
+# ====== Model ======
+model_name: qwen3-4b
+tokenizer_path: Qwen/Qwen3-4B
+tokenizer_type: huggingface
+
+# ====== Hardware ======
+# v6e-8 exposes 8 TPU chips on a single VM. With the current single-slice
+# device setup, this keeps trainer and rollout colocated on all 8 chips.
+trainer_devices_fraction: 0.5
+sampler_devices_fraction: 0.5
+chips_per_vm: 8
+use_pathways: true
+
+# One one-chip vLLM replica per sampler device. In colocated v6e-8 mode this
+# resolves to 8 rollout replicas for batch_size=8, num_generations=4.
+rollout_data_parallelism: -1
+rollout_tensor_parallelism: 1
+rollout_expert_parallelism: 1
+
+# One checkpoint restore plus an in-memory clone avoids reading/converting the
+# same model twice during startup.
+load_checkpoint_only_once: true
+
+# ====== GRPO ======
+rl:
+  num_generations: 4
+  num_iterations: 1
+  grpo_beta: 0.08
+  grpo_epsilon: 0.2
+  loss_algo: "grpo"
+  loss_agg_mode: "sequence-mean-token-mean"
+  use_agentic_rollout: false
+
+# ====== Training Schedule ======
+# GSM8K train yields 934 full batches at batch_size=8 (7,472 examples, with
+# drop_remainder=True). One epoch keeps this recipe short enough for benchmark
+# comparisons while still covering the full training split once.
+batch_size: 8
+num_batches: 934
+num_epoch: 1
+train_fraction: 1.0
+# Keep MaxText's generic step count and LR schedule horizon aligned with the
+# RL trainer's 934 * 1 = 934 optimizer updates.
+steps: 934
+learning_rate_schedule_steps: 934
+
+# Keep activation memory predictable on the 4-device trainer mesh.
+train_micro_batch_size: 1
+rollout_micro_batch_size: 8
+
+learning_rate: 3e-6
+warmup_steps_fraction: 0.1
+adam_b1: 0.9
+adam_b2: 0.99
+adam_weight_decay: 0.1
+gradient_clipping_threshold: 0.1
+
+log_period: 20
+eval_interval: 100
+
+# ====== Evaluation ======
+# 20 * 32 = 640 held-out GSM8K prompts per eval pass. Increase this once the
+# run is stable if you need lower-variance reporting.
+num_test_batches: 20
+eval_batch_size: 32
+eval_sampling_strategy: "greedy"
+num_eval_passes: 1
+eval_mode: "pass_at_1"
+
+# ====== Rollout / Generation ======
+max_prefill_predict_length: 256
+max_target_length: 1024
+kv_cache_buffer: 256
+
+decode_sampling_temperature: 0.9
+decode_sampling_top_k: 50
+decode_sampling_nucleus_p: 1.0
+
+hbm_utilization_vllm: 0.60
+swap_space_vllm_gb: 2
+max_num_seqs: 32
+max_num_batched_tokens: null
+async_scheduling: true
+enable_dp_attention: false
+
+# ====== Checkpointing ======
+enable_checkpointing: true
+async_checkpointing: false
+checkpoint_period: 250
+max_num_checkpoints_to_keep: 4
+
+# ====== Dataset ======
+dataset_name: "openai/gsm8k"
+eval_dataset_name: "openai/gsm8k"
+train_split: "train"
+eval_split: "test"
+hf_name: "main"
+data_template_path: "maxtext/examples/chat_templates/gsm8k_rl.json"
+
+# ====== Reward ======
+reward_exact_answer: 1.0
+reward_white_space_format_match: 1.0
+reward_exact_format_match: 0.1
+reward_partial_format_match: 0.0
+reward_ratio_guess_to_answer_high: 0.0
+reward_ratio_guess_to_answer_low: 0.0
+penalty_incorrect_format: 0.0
+penalty_incorrect_answer: 0.0
+
+math_verify_timeout: 120
+math_verify_num_procs: null
+
+debug:
+  rl: false

--- a/src/maxtext/examples/chat_templates/qwen35_math_rl.json
+++ b/src/maxtext/examples/chat_templates/qwen35_math_rl.json
@@ -1,0 +1,4 @@
+{
+  "SYSTEM_PROMPT": "Solve the problem step by step. After your reasoning, place only the final numerical answer between {solution_start_token} and {solution_end_token}.",
+  "TEMPLATE": "{system_prompt}\n\n{question}"
+}

--- a/tests/post_training/unit/qwen35_recipe_test.py
+++ b/tests/post_training/unit/qwen35_recipe_test.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static checks for the Qwen3.5 35B GSM8K post-training recipe."""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+pytestmark = [pytest.mark.post_training, pytest.mark.cpu_only]
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_RECIPE_PATH = _REPO_ROOT / "src/maxtext/configs/post_train/rl_gsm8k_qwen35_35b_v5p64.yml"
+_TEMPLATE_PATH = _REPO_ROOT / "src/maxtext/examples/chat_templates/qwen35_math_rl.json"
+
+
+def test_qwen35_recipe_keeps_only_reproducible_runtime_configuration():
+  recipe = yaml.safe_load(_RECIPE_PATH.read_text(encoding="utf-8"))
+
+  assert recipe["model_name"] == "qwen3.5-35b-a3b"
+  assert recipe["scan_layers"]
+  assert recipe["vllm_hf_overrides"] == {"architectures": ["MaxTextForCausalLM"]}
+  assert recipe["vllm_additional_config"]["maxtext_config"] == {
+      "model_name": "qwen3.5-35b-a3b",
+      "model_call_mode": "inference",
+      "attention": "vllm_rpa",
+      "allow_split_physical_axes": True,
+      "log_config": False,
+      "weight_dtype": "bfloat16",
+      "prefuse_moe_weights": True,
+  }
+  assert not recipe["enable_prefix_caching"]
+  assert recipe["reasoning_start_token_in_prompt"]
+  assert recipe["stop_strings"] == ["</answer>"]
+  assert not recipe["debug"]
+
+  experiment_only_keys = {
+      "base_output_directory",
+      "enable_tunix_perf_metrics",
+      "load_parameters_path",
+      "run_name",
+  }
+  assert experiment_only_keys.isdisjoint(recipe)
+
+
+def test_qwen35_template_does_not_nest_model_specific_chat_or_reasoning_tags():
+  template = json.loads(_TEMPLATE_PATH.read_text(encoding="utf-8"))
+
+  assert "{solution_start_token}" in template["SYSTEM_PROMPT"]
+  assert "{solution_end_token}" in template["SYSTEM_PROMPT"]
+  assert "{reasoning_start_token}" not in template["SYSTEM_PROMPT"]
+  assert "{reasoning_end_token}" not in template["SYSTEM_PROMPT"]
+  assert "<|im_start|>" not in template["TEMPLATE"]
+  assert "<start_of_turn>" not in template["TEMPLATE"]


### PR DESCRIPTION
Add a Qwen3-4B non-agentic GRPO recipe for GSM8K on a single v6e-8 host. The config pins the v6e-8 trainer/rollout allocation, uses a one-epoch benchmark budget, and keeps the explicit step count and LR schedule horizon aligned with the computed optimizer updates.

# Tests

Tested on a v6e-8 TPU node. The model quality (mean rewards) improves significantly (from ~0.75 to ~1.05) after ~200 training steps.  

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
