### PR TITLE
Fix pylint pre-commit hook scanning entire repo on PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,6 @@ repos:
           - '--disable=R0401,R0917,W0201,W0613'
           - "--ignore-patterns='.pytype,.*pyi$'"
           - '--ignore-paths=src/maxtext/input_pipeline/protos'
-          - 'benchmarks'
-          - 'src'
-          - 'tests'
 
   #  - repo: https://github.com/google/pytype
   #    rev: 2024.10.11


### PR DESCRIPTION
Removing these hardcoded directories allows pre-commit to pass only the changed Python files during PR checks (and all Python files when invoked with `--all-files`), matching the behavior of `pyink` and other pre-commit hooks.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
