### PR TITLE
Split TPU and GPU nightly image builds to run E2E tests in parallel:

### DIFF
--- a/.github/workflows/nightly_images_pipeline.yml
+++ b/.github/workflows/nightly_images_pipeline.yml
@@ -50,7 +50,7 @@ jobs:
       device_name: v4-8
       cloud_runner: linux-x86-n2-16-buildkit
 
-  build_and_push_docker_image:
+  build_and_push_tpu_docker_images:
     name: Build ${{ matrix.name }} Docker Image
     needs: build_maxtext_package
     strategy:
@@ -75,6 +75,25 @@ jobs:
             workflow: post-training
             image_name: maxtext_post_training_nightly
             dockerfile: maxtext_tpu_dependencies.Dockerfile
+    uses: ./.github/workflows/build_and_push_docker_image.yml
+    with:
+      image_name: ${{ inputs.image_suffix != '' && format('{0}_{1}', matrix.image_name, inputs.image_suffix) || matrix.image_name }}
+      device: ${{ matrix.device }}
+      build_mode: ${{ matrix.build_mode }}
+      workflow: ${{ matrix.workflow }}
+      dockerfile: ${{ matrix.dockerfile }}
+      maxtext_sha: ${{ needs.build_maxtext_package.outputs.maxtext_sha }}
+      include_test_assets: true
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  build_and_push_gpu_docker_images:
+    name: Build ${{ matrix.name }} Docker Image
+    needs: build_maxtext_package
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - name: "GPU Pre-Training Stable"
             device: gpu
             build_mode: stable
@@ -94,14 +113,14 @@ jobs:
       build_mode: ${{ matrix.build_mode }}
       workflow: ${{ matrix.workflow }}
       dockerfile: ${{ matrix.dockerfile }}
-      maxtext_sha: ${{ needs.build_and_upload_maxtext_package.outputs.maxtext_sha }}
+      maxtext_sha: ${{ needs.build_maxtext_package.outputs.maxtext_sha }}
       include_test_assets: true
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   run_e2e_tests:
     name: Run E2E tests
-    needs: build_and_push_docker_image
+    needs: build_and_push_tpu_docker_images
     uses: ./.github/workflows/run_e2e_tests.yml
     with:
       mode: ${{ inputs.image_suffix != '' && format('{0}_{1}', 'nightly', inputs.image_suffix) || 'nightly' }}
@@ -111,7 +130,7 @@ jobs:
 
   notify_failure:
     name: Notify failed build
-    needs: [build_and_push_docker_image, run_e2e_tests]
+    needs: [build_and_push_tpu_docker_images, build_and_push_gpu_docker_images, run_e2e_tests]
     if: ${{ failure() && inputs.image_suffix == '' }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
- Split the single `build_and_push_docker_image` matrix job into parallel `build_and_push_tpu_docker_images` and `build_and_push_gpu_docker_images` jobs.
- Update `run_e2e_tests` to depend only on the TPU builds, allowing the Airflow E2E tests to trigger immediately after TPU pre/post-training images are pushed.
- Ensure GPU CI tests run in parallel with the Airflow E2E tests, drastically reducing overall pipeline runtime.
- Correct the `maxtext_sha` reference to use the correct job ID `build_maxtext_package`.
- Update `notify_failure` to monitor both build jobs and the E2E tests.

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.: 
BUGS: b/123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
