### PR TITLE
[CI] Split TPU and GPU nightly builds to run E2E tests in parallel

### DIFF
--- a/.github/workflows/nightly_images_pipeline.yml
+++ b/.github/workflows/nightly_images_pipeline.yml
@@ -50,7 +50,7 @@ jobs:
       device_name: v4-8
       cloud_runner: linux-x86-n2-16-buildkit
 
-  build_and_push_docker_image:
+  build_and_push_tpu_docker_images:
     name: Build ${{ matrix.name }} Docker Image
     needs: build_maxtext_package
     strategy:
@@ -75,6 +75,25 @@ jobs:
             workflow: post-training
             image_name: maxtext_post_training_nightly
             dockerfile: maxtext_tpu_dependencies.Dockerfile
+    uses: ./.github/workflows/build_and_push_docker_image.yml
+    with:
+      image_name: ${{ inputs.image_suffix != '' && format('{0}_{1}', matrix.image_name, inputs.image_suffix) || matrix.image_name }}
+      device: ${{ matrix.device }}
+      build_mode: ${{ matrix.build_mode }}
+      workflow: ${{ matrix.workflow }}
+      dockerfile: ${{ matrix.dockerfile }}
+      maxtext_sha: ${{ needs.build_maxtext_package.outputs.maxtext_sha }}
+      include_test_assets: true
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  build_and_push_gpu_docker_images:
+    name: Build ${{ matrix.name }} Docker Image
+    needs: build_maxtext_package
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - name: "GPU Pre-Training Stable"
             device: gpu
             build_mode: stable
@@ -94,14 +113,14 @@ jobs:
       build_mode: ${{ matrix.build_mode }}
       workflow: ${{ matrix.workflow }}
       dockerfile: ${{ matrix.dockerfile }}
-      maxtext_sha: ${{ needs.build_and_upload_maxtext_package.outputs.maxtext_sha }}
+      maxtext_sha: ${{ needs.build_maxtext_package.outputs.maxtext_sha }}
       include_test_assets: true
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   run_e2e_tests:
     name: Run E2E tests
-    needs: build_and_push_docker_image
+    needs: build_and_push_tpu_docker_images
     uses: ./.github/workflows/run_e2e_tests.yml
     with:
       mode: ${{ inputs.image_suffix != '' && format('{0}_{1}', 'nightly', inputs.image_suffix) || 'nightly' }}
@@ -111,7 +130,7 @@ jobs:
 
   notify_failure:
     name: Notify failed build
-    needs: [build_and_push_docker_image, run_e2e_tests]
+    needs: [build_and_push_tpu_docker_images, build_and_push_gpu_docker_images, run_e2e_tests]
     if: ${{ failure() && inputs.image_suffix == '' }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Re-submitting fork changes to trigger CI.

Original description:
- Split the single build_and_push_docker_image matrix job into parallel build_and_push_tpu_docker_images and build_and_push_gpu_docker_images jobs.
- Update run_e2e_tests to depend only on the TPU builds, allowing the Airflow E2E tests to trigger immediately after TPU pre/post-training images are pushed.
- Ensure GPU CI tests run in parallel with the Airflow E2E tests, drastically reducing overall pipeline runtime.
- Correct the maxtext_sha reference to use the correct job ID build_maxtext_package.
- Update notify_failure to monitor both build jobs and the E2E tests.