### PR TITLE
[CI] Decouple TPU CI tests to run in parallel with E2E Airflow tests

### DIFF
--- a/.github/workflows/build_and_push_docker_image.yml
+++ b/.github/workflows/build_and_push_docker_image.yml
@@ -42,6 +42,10 @@ on:
         required: false
         type: boolean
         default: false
+      run_tests:
+        required: false
+        type: boolean
+        default: true
     outputs:
       build_result:
         description: 'The result of build_and_push job.'
@@ -184,7 +188,7 @@ jobs:
   run_ci_tests:
     name: Run Unit and Integration Tests
     needs: [pre_build_check, build_and_push]
-    if: needs.pre_build_check.outputs.should_run == 'true' && inputs.include_test_assets == true
+    if: needs.pre_build_check.outputs.should_run == 'true' && inputs.include_test_assets == true && inputs.run_tests == true
     uses: ./.github/workflows/run_ci_tests.yml
     with:
       image_name: ${{ inputs.image_name }}

--- a/.github/workflows/nightly_images_pipeline.yml
+++ b/.github/workflows/nightly_images_pipeline.yml
@@ -50,7 +50,7 @@ jobs:
       device_name: v4-8
       cloud_runner: linux-x86-n2-16-buildkit
 
-  build_and_push_docker_image:
+  build_and_push_tpu_docker_images:
     name: Build ${{ matrix.name }} Docker Image
     needs: build_maxtext_package
     strategy:
@@ -75,6 +75,26 @@ jobs:
             workflow: post-training
             image_name: maxtext_post_training_nightly
             dockerfile: maxtext_tpu_dependencies.Dockerfile
+    uses: ./.github/workflows/build_and_push_docker_image.yml
+    with:
+      image_name: ${{ inputs.image_suffix != '' && format('{0}_{1}', matrix.image_name, inputs.image_suffix) || matrix.image_name }}
+      device: ${{ matrix.device }}
+      build_mode: ${{ matrix.build_mode }}
+      workflow: ${{ matrix.workflow }}
+      dockerfile: ${{ matrix.dockerfile }}
+      maxtext_sha: ${{ needs.build_maxtext_package.outputs.maxtext_sha }}
+      include_test_assets: true
+      run_tests: false
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  build_and_push_gpu_docker_images:
+    name: Build ${{ matrix.name }} Docker Image
+    needs: build_maxtext_package
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - name: "GPU Pre-Training Stable"
             device: gpu
             build_mode: stable
@@ -94,14 +114,40 @@ jobs:
       build_mode: ${{ matrix.build_mode }}
       workflow: ${{ matrix.workflow }}
       dockerfile: ${{ matrix.dockerfile }}
-      maxtext_sha: ${{ needs.build_and_upload_maxtext_package.outputs.maxtext_sha }}
+      maxtext_sha: ${{ needs.build_maxtext_package.outputs.maxtext_sha }}
       include_test_assets: true
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
+  run_tpu_ci_tests:
+    name: Run TPU ${{ matrix.name }} CI Tests
+    needs: build_and_push_tpu_docker_images
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Pre-Training Stable"
+            image_name: maxtext_jax_stable
+            device: tpu
+            workflow: pre-training
+          - name: "Pre-Training Nightly"
+            image_name: maxtext_jax_nightly
+            device: tpu
+            workflow: pre-training
+          - name: "Post-Training Nightly"
+            image_name: maxtext_post_training_nightly
+            device: tpu
+            workflow: post-training
+    uses: ./.github/workflows/run_ci_tests.yml
+    with:
+      image_name: ${{ inputs.image_suffix != '' && format('{0}_{1}', matrix.image_name, inputs.image_suffix) || matrix.image_name }}
+      image_tag: ${{ github.run_id }}
+      device: ${{ matrix.device }}
+      workflow: ${{ matrix.workflow }}
+
   run_e2e_tests:
     name: Run E2E tests
-    needs: build_and_push_docker_image
+    needs: build_and_push_tpu_docker_images
     uses: ./.github/workflows/run_e2e_tests.yml
     with:
       mode: ${{ inputs.image_suffix != '' && format('{0}_{1}', 'nightly', inputs.image_suffix) || 'nightly' }}
@@ -111,7 +157,7 @@ jobs:
 
   notify_failure:
     name: Notify failed build
-    needs: [build_and_push_docker_image, run_e2e_tests]
+    needs: [build_and_push_tpu_docker_images, build_and_push_gpu_docker_images, run_tpu_ci_tests, run_e2e_tests]
     if: ${{ failure() && inputs.image_suffix == '' }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Description

This PR decouples the TPU unit/integration CI tests from the nightly image build workflow, allowing them to run in parallel with the TPU E2E Airflow tests once the TPU Docker images are pushed.

Specifically:
- Adds a `run_tests` parameter (default `true`) to `build_and_push_docker_image.yml` to control whether unit/integration tests are run inside the build workflow.
- Restructures `nightly_images_pipeline.yml` to disable nested CI tests during TPU builds (`run_tests: false`).
- Adds a top-level `run_tpu_ci_tests` matrix job in `nightly_images_pipeline.yml` that runs the TPU unit/integration tests concurrently with `run_e2e_tests` (Airflow E2E tests).
- Keeps GPU CI tests nested inside the GPU build job (default `run_tests: true`) as GPU does not trigger E2E tests.
- Updates the `notify_failure` dependencies to monitor all top-level parallel steps.

# Tests

- Verified via execution run [Run #29006178590](https://github.com/AI-Hypercomputer/maxtext/actions/runs/29006178590), where the TPU CI and E2E Airflow tests triggered and completed in parallel while the GPU nightly builds were still running.

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
