### PR TITLE
fix: checkpoint structure mismatch during NNX restore

### DIFF
--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -1065,7 +1065,7 @@ def from_pretrained(
         # written by `layerwise_quantization._load_and_quantize_nnx` carry both
         # Param kernels and `aqt`-typed `qrhs.frozen` quantized payloads.
         if hasattr(sharded_state, "filter"):
-          param_state = sharded_state.filter(lambda path, var: not isinstance(var, (nnx.RngState, nnx.Cache)))
+          param_state = sharded_state.filter(lambda path, var: isinstance(var, nnx.Param) or type(var).__name__ == "aqt")
         else:
           param_state = sharded_state
         target_for_restore = jax.tree.map(

--- a/tests/unit/model_creation_utils_test.py
+++ b/tests/unit/model_creation_utils_test.py
@@ -657,6 +657,50 @@ class TestCreateNnxModel(unittest.TestCase):
     model = model_creation_utils.from_pretrained(cfg, self.mesh)
     self.assertIsInstance(model, models.Transformer)
 
+  @patch("maxtext.utils.model_creation_utils.ocp")
+  @patch("maxtext.utils.model_creation_utils.get_transformer_model")
+  def test_from_pretrained_filters_out_rng_state(self, mock_get_model, mock_ocp):
+    """Verify that from_pretrained explicitly retains only nnx.Param and aqt variables."""
+
+    class DummyAqt(nnx.Variable):
+      pass
+
+    class DummyModel(nnx.Module):
+
+      def __init__(self):
+        self.p = nnx.Param(jnp.ones(1))
+        self.r_count = nnx.RngCount(jnp.zeros(1, dtype=jnp.uint32))
+        self.r_key = nnx.RngKey(jnp.zeros(2, dtype=jnp.uint32))
+        self.aqt_var = DummyAqt(jnp.ones(1))
+
+    DummyAqt.__name__ = "aqt"
+
+    dummy_model = DummyModel()
+    mock_get_model.return_value = dummy_model
+
+    mock_ckptr = MagicMock()
+    mock_ckptr.metadata.return_value = self._make_nnx_metadata_mock()
+    mock_ckptr.restore.side_effect = lambda path, item=None, **kw: item
+    mock_ocp.Checkpointer.return_value = mock_ckptr
+    mock_ocp.checkpoint_utils.construct_restore_args.return_value = {}
+    mock_ocp.ArrayRestoreArgs = ocp.ArrayRestoreArgs
+
+    cfg = _make_config(enable_checkpointing=True, load_parameters_path="gs://fake/ckpt", scan_layers=True)
+
+    with patch(
+        "maxtext.utils.model_creation_utils.checkpointing.load_checkpoint_metadata", return_value={"scan_layers": True}
+    ):
+      model_creation_utils.from_pretrained(cfg, self.mesh)
+
+    # target_for_restore is the first argument passed to construct_restore_args
+    call_args = mock_ocp.checkpoint_utils.construct_restore_args.call_args
+    target = call_args[0][0]
+
+    self.assertIn("p", target)
+    self.assertIn("aqt_var", target)
+    self.assertNotIn("r_count", target)
+    self.assertNotIn("r_key", target)
+
   # ---- checkpoint loading: mocked paths ----
 
   def _make_linen_metadata_mock(self):


### PR DESCRIPTION
# Description

When restoring parameters into an NNX model, `target_for_restore` improperly included `dropout.rngs.params` leaves (like `RngCount` and `RngKey`). These runtime state variables are absent from the pretrained checkpoint, leading to a `Checkpoint structure mismatch` ValueError during decoding.

This fix updates the `sharded_state` filtering in `from_pretrained()` to explicitly retain only `nnx.Param` leaves and AQT variables (for `qrhs.frozen`) rather than just excluding `RngState` and `Cache`. This correctly matches the checkpoint structure on disk and fixes integration test failures while preserving AQT quantization logic.

Bug: [b/532182476](https://b.corp.google.com/issues/532182476)

# Tests

- Verified `pytest tests/integration/decode_tests.py` passes locally.
- Verified `pytest tests/unit/aqt_serve_roundtrip_nnx_test.py::ServeModeRoundTripTest::test_save_then_reload_preserves_qrhs_frozen` passes locally (validates AQT quantization logic).
- Verified full unit test suite `pytest tests/unit/model_creation_utils_test.py` passes (62/62 passing).
- Ran full suite of scheduled tests (`pytest -m "scheduled_only"`). All scheduled tests related to this change pass successfully. Unrelated failures in `checkpointing_test.py` and `standalone_dl_ckpt_test.py` were investigated and confirmed to be pre-existing issues on the `main` branch.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
