### PR TITLE
 fix: resolve vLLM and RL training gibberish outputs for Gemma 3/4 scanned layers

### DIFF
--- a/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_adapter/adapter.py
@@ -201,6 +201,10 @@ class MaxTextForCausalLM(nnx.Module):
     elif self.maxtext_config.load_parameters_path is None:
       max_logging.log("Warning: No load_parameters_path provided. The model will be initialized with random weights.")
 
+  def modules(self):
+    """Dummy method to satisfy vLLM's internal cleanup logic."""
+    return []
+
   def __call__(
       self,
       kv_caches: list[jax.Array],
@@ -345,9 +349,7 @@ class MaxTextForCausalLM(nnx.Module):
           self.maxtext_config, mesh=self.mesh, model_mode=self.model_mode, rng_key=rng_key
       )
       if self.maxtext_config.lora.enable_lora:
-        model = lora_utils.apply_lora_to_model(
-            model, self.mesh, self.maxtext_config
-        )
+        model = lora_utils.apply_lora_to_model(model, self.mesh, self.maxtext_config)
         if self.maxtext_config.lora.lora_restore_path:
           lora_utils.restore_lora_from_path(model, self.maxtext_config)
       self.model = nnx.data(model)

--- a/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
+++ b/src/maxtext/integration/vllm/maxtext_vllm_rollout.py
@@ -28,7 +28,10 @@ import gc
 import logging
 import time
 import jax
+import jax.numpy as jnp
 from flax import nnx
+from flax.traverse_util import flatten_dict, unflatten_dict
+
 from pathwaysutils.experimental import reshard as _experimental_reshard
 from tunix.generate import mappings
 from tunix.generate.vllm_sampler import VllmConfig, VllmSampler
@@ -45,7 +48,83 @@ def _create_model_converter(model_name: str, config: Any, mesh: jax.sharding.Mes
   elif model_name in {"qwen3.5-35b-a3b"}:
     return Qwen35MaxTextToVLLMConverter(config=config, mesh=mesh)
 
-  raise ValueError(f"No MaxText->vLLM converter registered for model {model_name!r}.")
+  return None
+
+
+def unroll_gemma_scanned_weights(weights):
+  """Workaround for tunix unstacking bug with Gemma 3/4 scanned blocks.
+
+  tunix fails to map nested layers like `layers.layers_0` to `layers_X`.
+  We manually unroll them here if we detect the structure.
+  """
+  if not hasattr(weights, "to_pure_dict"):
+    return weights
+
+  flat_w = flatten_dict(weights.to_pure_dict(), sep="/")
+  new_flat_w = {}
+
+  # Check if this is actually a scanned Gemma 3/4 checkpoint
+  # by looking for the scanned nested structure.
+  is_gemma_scanned = any("decoder/layers/layers_0/" in k or "decoder/scanned_blocks/layers_0/" in k for k in flat_w)
+
+  if not is_gemma_scanned:
+    return weights
+
+  logging.info("MaxTextVllmSampler: Detected Gemma scanned weights structure. Unrolling along axis 1...")
+
+  # Determine attention pattern length and scan length
+  pattern_keys = set()
+  scan_length = 0
+  for k, v in flat_w.items():
+    if "decoder/layers/layers_" in k or "decoder/scanned_blocks/layers_" in k:
+      layer_sub_idx = k.split("layers_")[-1].split("/")[0]
+      pattern_keys.add(int(layer_sub_idx))
+      # In MaxText, Gemma uses param_scan_axis=1, so the scan dimension is at axis 1
+      if hasattr(v, "shape") and len(v.shape) > 1:
+        scan_length = max(scan_length, v.shape[1])
+
+  pattern_length = max(pattern_keys) + 1 if pattern_keys else 0
+  logging.info("MaxTextVllmSampler: Discovered scan_length=%d, pattern_length=%d", scan_length, pattern_length)
+
+  unrolled_count = 0
+  for k, v in flat_w.items():
+    if "decoder/layers/layers_" in k or "decoder/scanned_blocks/layers_" in k:
+      # Unstack the array along the 1st axis
+      if "decoder/scanned_blocks/layers_" in k:
+        parts = k.split("decoder/scanned_blocks/layers_")
+      else:
+        parts = k.split("decoder/layers/layers_")
+
+      layer_sub_idx = int(parts[1].split("/")[0])
+      suffix = "/" + "/".join(parts[1].split("/")[1:])
+
+      if hasattr(v, "shape") and len(v.shape) > 1:
+        v_swapped = jnp.swapaxes(v, 1, 0)
+        unstacked = [v_swapped[i] for i in range(scan_length)]
+      else:
+        unstacked = [v] * scan_length
+
+      for i in range(scan_length):
+        global_idx = i * pattern_length + layer_sub_idx
+        # Map back to nnx.List format which uses layers/X/ instead of layers_X
+        new_flat_w[f"decoder/layers/{global_idx}{suffix}"] = unstacked[i]
+        unrolled_count += 1
+
+    elif "decoder/layers_remainder/layers_" in k:
+      layer_sub_idx = int(k.split("decoder/layers_remainder/layers_")[1].split("/")[0])
+      suffix = "/" + "/".join(k.split("decoder/layers_remainder/layers_")[1].split("/")[1:])
+
+      global_idx = scan_length * pattern_length + layer_sub_idx
+      new_flat_w[f"decoder/layers/{global_idx}{suffix}"] = v
+      unrolled_count += 1
+    else:
+      new_flat_w[k] = v
+
+  logging.info(
+      "MaxTextVllmSampler: Successfully unrolled %d scanned tensor components into vLLM-compatible nnx.List format.",
+      unrolled_count,
+  )
+  return unflatten_dict(new_flat_w, sep="/")
 
 
 class MaxTextVllmSampler(VllmSampler):
@@ -73,6 +152,12 @@ class MaxTextVllmSampler(VllmSampler):
   ):
     """Update the vLLM runner weights from a MaxText state tree."""
     if self._converter is None:
+      # --- Workaround for tunix unstacking bug with Gemma 3/4 scanned blocks ---
+      # tunix fails to map nested layers like `layers.layers_0` to `layers_X`.
+      # We manually unroll them here if we detect the structure.
+      updated_weights = unroll_gemma_scanned_weights(updated_weights)
+      # --- End Workaround ---
+
       super().update_params(updated_weights, filter_types)
       return None
 
@@ -182,6 +267,19 @@ class MaxTextVllmRollout(vllm_rollout.VllmRollout):
         model=rollout_actor,
         backend="vllm_jax",
     )
+    engine_kwargs = {
+        "max_model_len": cache_config_or_size,
+        "model": rollout_config.rollout_vllm_model_version,
+        "swap_space": getattr(rollout_config, "rollout_vllm_swap_space_size_gb", maxtext_config.swap_space_vllm_gb),
+        # Async scheduling causes KeyError in dp_scheduler on slow models
+        # (30B+) where inference latency exceeds the scheduler's window.
+        "async_scheduling": rollout_config.rollout_vllm_async_scheduling,
+    }
+
+    # Merge additional kwargs like dtype and hf_overrides provided by train_rl.py
+    if hasattr(rollout_config, "rollout_vllm_kwargs") and rollout_config.rollout_vllm_kwargs:
+      engine_kwargs.update(rollout_config.rollout_vllm_kwargs)
+
     self._sampler = MaxTextVllmSampler(
         tokenizer=tokenizer,
         config=VllmConfig(  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
@@ -195,14 +293,8 @@ class MaxTextVllmRollout(vllm_rollout.VllmRollout):
             tensor_parallel_size=rollout_config.tensor_parallel_size,
             data_parallel_size=rollout_config.data_parallel_size,
             enable_dp_attention=rollout_config.rollout_vllm_enable_dp_attention,
-            engine_kwargs={
-                "max_model_len": cache_config_or_size,
-                "model": rollout_config.rollout_vllm_model_version,
-                "swap_space": rollout_config.rollout_vllm_swap_space_size_gb,
-                # Async scheduling causes KeyError in dp_scheduler on slow models
-                # (30B+) where inference latency exceeds the scheduler's window.
-                "async_scheduling": rollout_config.rollout_vllm_async_scheduling,
-            },
+            engine_kwargs=engine_kwargs,
+            additional_config=getattr(rollout_config, "rollout_vllm_additional_config", None),
         ),
         converter=converter,
     )

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -1374,18 +1374,19 @@ class Decoder(nn.Module):
         start_idx = scan_length * attention_pattern_length
         remainder_kv = tuple(kv_caches[start_idx : start_idx + num_remaining_layers])
 
-      y_and_kv = layer(
-          y,
+      remainder_args = (
           decoder_segment_ids,
           decoder_positions,
           deterministic,
           model_mode,
-          previous_chunk=previous_chunk,
-          slot=slot,
-          bidirectional_mask=bidirectional_mask,
-          kv_cache=remainder_kv,
-          attention_metadata=attention_metadata,
+          slot,
+          None,  # page_state
+          previous_chunk,
+          bidirectional_mask,
+          remainder_kv,
+          attention_metadata,
       )
+      y_and_kv = layer(y, *remainder_args)
 
       if isinstance(y_and_kv, tuple):
         y = y_and_kv[0]

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1588,7 +1588,10 @@ class NNXDecoder(nnx.Module):
 
     layer_args = (decoder_segment_ids, decoder_positions, deterministic, model_mode)
 
-    layer_kwargs = {}
+    layer_kwargs = {
+        "slot": slot,
+        "previous_chunk": previous_chunk,
+    }
     # Extract the bidirectional mask locally for layer configurations
     bidirectional_mask = multimodal_input.bidirectional_mask if multimodal_input is not None else None
 
@@ -1607,10 +1610,6 @@ class NNXDecoder(nnx.Module):
 
       if self.is_deepseek:
         # Pre-pipeline: dense layers + outside-pipeline MoE layers under PP-as-DP axis rules.
-        ds_layer_kwargs = {
-            "previous_chunk": previous_chunk,
-            "slot": slot,
-        }
         logical_axis_rules_pp_as_dp = sharding.logical_axis_rules_pp_act_as_dp(cfg.logical_axis_rules)
         with self.mesh, nn.partitioning.axis_rules(logical_axis_rules_pp_as_dp):
           if cfg.scan_layers:
@@ -1620,7 +1619,7 @@ class NNXDecoder(nnx.Module):
                   y,
                   *layer_args,
                   length=cfg.first_num_dense_layers,
-                  **ds_layer_kwargs,
+                  **layer_kwargs,
               )
             if hasattr(self, "moe_layers_outside_pipeline") and self.moe_layers_outside_pipeline is not None:
               num_moe_outside = (cfg.num_decoder_layers - cfg.first_num_dense_layers) - cfg.pipeline_parallel_layers
@@ -1629,18 +1628,29 @@ class NNXDecoder(nnx.Module):
                   y,
                   *layer_args,
                   length=num_moe_outside,
-                  **ds_layer_kwargs,
+                  **layer_kwargs,
               )
           else:
             # Unscanned: iterate registered layers by name.
             for i in range(getattr(self, "num_dense_layers", 0)):
               layer = getattr(self, f"dense_layers_{i}")
-              out = layer(y, *layer_args, **ds_layer_kwargs)
+              call_kwargs = dict(layer_kwargs)
+              if kv_caches is not None:
+                call_kwargs["kv_cache"] = kv_caches[i]
+              out = layer(y, *layer_args, **call_kwargs)
               y = out[0] if isinstance(out, tuple) else out
+              if kv_caches is not None and isinstance(out, tuple) and len(out) > 1 and out[1] is not None:
+                kv_caches[i] = out[1]
             for i in range(getattr(self, "num_moe_outside_pipeline", 0)):
               layer = getattr(self, f"moe_layers_outside_pipeline_{i}")
-              out = layer(y, *layer_args, **ds_layer_kwargs)
+              call_kwargs = dict(layer_kwargs)
+              kv_idx = getattr(self, "num_dense_layers", 0) + i
+              if kv_caches is not None:
+                call_kwargs["kv_cache"] = kv_caches[kv_idx]
+              out = layer(y, *layer_args, **call_kwargs)
               y = out[0] if isinstance(out, tuple) else out
+              if kv_caches is not None and isinstance(out, tuple) and len(out) > 1 and out[1] is not None:
+                kv_caches[kv_idx] = out[1]
 
         y = self.pipeline_module(
             y,
@@ -1653,15 +1663,9 @@ class NNXDecoder(nnx.Module):
       elif self.is_gemma4:
         y = self._apply_gemma4_scanned_blocks(
             y,
-            decoder_segment_ids,
-            decoder_positions,
-            deterministic,
-            model_mode,
-            bidirectional_mask,
-            previous_chunk,
-            slot,
+            layer_args,
+            layer_kwargs,
             kv_caches=kv_caches,
-            attention_metadata=attention_metadata,
         )
       else:
         # Standard pipeline run (non-DeepSeek, incl. Gemma4 — matches Linen decoders.py).
@@ -1696,8 +1700,14 @@ class NNXDecoder(nnx.Module):
             elif (not cfg.scan_layers) and hasattr(self, "num_layers_outside_pipeline"):
               for i in range(self.num_layers_outside_pipeline):
                 layer = getattr(self, f"layers_outside_pipeline_{i}")
-                out = layer(y, *layer_args, **layer_kwargs)
+                call_kwargs = dict(layer_kwargs)
+                kv_idx = cfg.pipeline_parallel_layers + i
+                if kv_caches is not None:
+                  call_kwargs["kv_cache"] = kv_caches[kv_idx]
+                out = layer(y, *layer_args, **call_kwargs)
                 y = out[0] if isinstance(out, tuple) else out
+                if kv_caches is not None and isinstance(out, tuple) and len(out) > 1 and out[1] is not None:
+                  kv_caches[kv_idx] = out[1]
 
     else:
       if self.is_gemma4_small:
@@ -1716,10 +1726,6 @@ class NNXDecoder(nnx.Module):
         )
       elif cfg.scan_layers:
         if self.is_deepseek:
-          layer_kwargs = {
-              "previous_chunk": previous_chunk,
-              "slot": slot,
-          }
 
           if cfg.engram_layers:
             common_kwargs = {
@@ -1794,24 +1800,16 @@ class NNXDecoder(nnx.Module):
         elif self.is_gemma3:
           y = self._apply_gemma3_scanned_blocks(
               y,
-              decoder_segment_ids,
-              decoder_positions,
-              deterministic,
-              model_mode,
-              bidirectional_mask,
-              previous_chunk,
-              slot,
+              layer_args,
+              layer_kwargs,
+              kv_caches=kv_caches,
           )
         elif self.is_gemma4:
           y = self._apply_gemma4_scanned_blocks(
               y,
-              decoder_segment_ids,
-              decoder_positions,
-              deterministic,
-              model_mode,
-              bidirectional_mask,
-              previous_chunk,
-              slot,
+              layer_args,
+              layer_kwargs,
+              kv_caches=kv_caches,
           )
         else:
           scan_length = int(cfg.num_decoder_layers / cfg.inhomogeneous_layer_cycle_interval)
@@ -1924,15 +1922,9 @@ class NNXDecoder(nnx.Module):
   def _apply_gemma3_scanned_blocks(
       self,
       y,
-      decoder_segment_ids,
-      decoder_positions,
-      deterministic,
-      model_mode,
-      bidirectional_mask,
-      previous_chunk,
-      slot,
+      layer_args,
+      layer_kwargs,
       kv_caches=None,
-      attention_metadata=None,
   ):
     """Applies Gemma3 scanned decoder blocks, handling main scan and remainders."""
 
@@ -1941,11 +1933,6 @@ class NNXDecoder(nnx.Module):
     # Define the repeating pattern length and calculate how many full blocks to scan
     attention_pattern_length = len(gemma3.GEMMA3_ATTENTION_PATTERN)
     scan_length = cfg.num_decoder_layers // attention_pattern_length
-
-    layer_args = (decoder_segment_ids, decoder_positions, deterministic, model_mode)
-    layer_kwargs = {"bidirectional_mask": bidirectional_mask}
-    if attention_metadata is not None:
-      layer_kwargs["attention_metadata"] = attention_metadata
 
     # Apply the main scan over the full blocks
     if scan_length > 0:
@@ -1975,8 +1962,6 @@ class NNXDecoder(nnx.Module):
         call_kwargs = dict(layer_kwargs)
         if kv_in is not None:
           call_kwargs["kv_cache"] = kv_in
-        call_kwargs["previous_chunk"] = previous_chunk
-        call_kwargs["slot"] = slot
         out_res = merged_layer(y_in, *layer_args, **call_kwargs)
         if isinstance(out_res, tuple):
           out_y = out_res[0]
@@ -2002,15 +1987,9 @@ class NNXDecoder(nnx.Module):
   def _apply_gemma4_scanned_blocks(
       self,
       y,
-      decoder_segment_ids,
-      decoder_positions,
-      deterministic,
-      model_mode,
-      bidirectional_mask,
-      previous_chunk,
-      slot,
+      layer_args,
+      layer_kwargs,
       kv_caches=None,
-      attention_metadata=None,
   ):
     """Applies Gemma4 scanned decoder blocks, handling main scan and remainders."""
 
@@ -2019,11 +1998,6 @@ class NNXDecoder(nnx.Module):
     # Define the repeating pattern length and calculate how many full blocks to scan
     attention_pattern_length = len(gemma4.GEMMA4_ATTENTION_PATTERN)
     scan_length = cfg.num_decoder_layers // attention_pattern_length
-
-    layer_args = (decoder_segment_ids, decoder_positions, deterministic, model_mode)
-    layer_kwargs = {"bidirectional_mask": bidirectional_mask, "slot": slot, "previous_chunk": previous_chunk}
-    if attention_metadata is not None:
-      layer_kwargs["attention_metadata"] = attention_metadata
 
     # Apply the main scan over the full blocks
     if scan_length > 0:
@@ -2053,8 +2027,6 @@ class NNXDecoder(nnx.Module):
         call_kwargs = dict(layer_kwargs)
         if kv_in is not None:
           call_kwargs["kv_cache"] = kv_in
-        call_kwargs["previous_chunk"] = previous_chunk
-        call_kwargs["slot"] = slot
         out_res = merged_layer(y_in, *layer_args, **call_kwargs)
         if isinstance(out_res, tuple):
           out_y = out_res[0]

--- a/src/maxtext/models/gemma3.py
+++ b/src/maxtext/models/gemma3.py
@@ -216,6 +216,8 @@ class Gemma3DecoderLayer(nnx.Module):
         decoder_segment_ids=decoder_segment_ids,
         deterministic=deterministic,
         model_mode=model_mode,
+        previous_chunk=previous_chunk,
+        slot=slot,
         bidirectional_mask=bidirectional_mask,
         kv_cache=kv_cache,
         attention_metadata=attention_metadata,

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -64,6 +64,9 @@ from flax import nnx
 from orbax import checkpoint as ocp
 from pprint import pprint
 from transformers import AutoTokenizer
+import maxtext.integration.vllm.maxtext_vllm_adapter as adapter
+
+adapter.register()
 import functools
 from tunix.rl import rl_cluster as rl_cluster_lib
 from tunix.rl.rollout import base_rollout
@@ -505,7 +508,7 @@ def create_rl_components(
               "enable_expert_parallel": sampler_config.enable_expert_parallel,
               "enable_prefix_caching": True,  # Enable prefix caching to speed up generation for long prompts
               # Ensures vLLM model initializes with correct dtype (not float32 default)
-              "dtype": trainer_config.weight_dtype,
+              "dtype": trainer_config.weight_dtype.value,
           },
           rollout_vllm_sampling_kwargs={
               "stop": trainer_config.stop_strings,

--- a/tests/post_training/unit/vllm_rollout_unroll_test.py
+++ b/tests/post_training/unit/vllm_rollout_unroll_test.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Gemma scanned weights unrolling workaround."""
+
+import unittest
+import numpy as np
+import pytest
+
+from maxtext.integration.vllm.maxtext_vllm_rollout import unroll_gemma_scanned_weights
+
+
+class MockWeights:
+  """A mock weight container that implements to_pure_dict."""
+
+  def __init__(self, pure_dict):
+    self._pure_dict = pure_dict
+
+  def to_pure_dict(self):
+    return self._pure_dict
+
+
+class GemmaScannedWeightsUnrollTest(unittest.TestCase):
+  """Verify the correctness of the unroll_gemma_scanned_weights utility."""
+
+  @pytest.mark.cpu_only
+  def test_bypasses_non_pytree_weights(self):
+    """If the weights object doesn't have `to_pure_dict`, it should be returned unchanged."""
+    raw_weights = {"dummy": np.ones(5)}
+    result = unroll_gemma_scanned_weights(raw_weights)
+    self.assertIs(result, raw_weights)
+
+  @pytest.mark.cpu_only
+  def test_bypasses_non_scanned_checkpoints(self):
+    """If the checkpoint is not scanned (no 'layers_0' inside 'decoder/layers/'), return unchanged."""
+    pure_dict = {
+        "decoder": {
+            "layers": {
+                "0": {"attn": {"wq": np.ones(10)}},
+                "1": {"attn": {"wq": np.ones(10)}},
+            }
+        }
+    }
+    weights = MockWeights(pure_dict)
+    result = unroll_gemma_scanned_weights(weights)
+    self.assertIs(result, weights)
+
+  @pytest.mark.cpu_only
+  def test_correctly_unrolls_gemma_scanned_weights(self):
+    """Verify that scanned layers are properly interleaved and mapped, and remainder layers are appended."""
+    # Pattern length = 2 (layers_0 and layers_1)
+    # Scan length = 3. In MaxText, param_scan_axis=1, so shape is (feature_dim, scan_length, ...)
+
+    # We want an array where axis 1 has length 3. Let's make it (2, 3, 1)
+    # For layers_0, values should be 0, 2, 4
+    arr0 = np.zeros((2, 3, 1))
+    arr0[:, 0, :] = 0
+    arr0[:, 1, :] = 2
+    arr0[:, 2, :] = 4
+
+    # For layers_1, values should be 1, 3, 5
+    arr1 = np.zeros((2, 3, 1))
+    arr1[:, 0, :] = 1
+    arr1[:, 1, :] = 3
+    arr1[:, 2, :] = 5
+
+    pure_dict = {
+        "decoder": {
+            "layers": {
+                "layers_0": {
+                    "attn": {"wq": arr0},
+                },
+                "layers_1": {
+                    "attn": {"wq": arr1},
+                },
+            },
+            "layers_remainder": {
+                "layers_0": {
+                    "attn": {"wq": np.array([[6, 6]]).transpose()},  # shape (2, 1)
+                }
+            },
+        }
+    }
+    weights = MockWeights(pure_dict)
+    unrolled = unroll_gemma_scanned_weights(weights)
+
+    # Check unrolled structure
+    decoder_dict = unrolled["decoder"]
+
+    # Should contain keys 0 to 6 under layers
+    self.assertIn("0", decoder_dict["layers"])
+    self.assertIn("1", decoder_dict["layers"])
+    self.assertIn("2", decoder_dict["layers"])
+    self.assertIn("3", decoder_dict["layers"])
+    self.assertIn("4", decoder_dict["layers"])
+    self.assertIn("5", decoder_dict["layers"])
+    self.assertIn("6", decoder_dict["layers"])
+
+    # Check that values are correctly sliced
+    np.testing.assert_array_equal(decoder_dict["layers"]["0"]["attn"]["wq"], np.array([[0], [0]]))
+    np.testing.assert_array_equal(decoder_dict["layers"]["1"]["attn"]["wq"], np.array([[1], [1]]))
+    np.testing.assert_array_equal(decoder_dict["layers"]["2"]["attn"]["wq"], np.array([[2], [2]]))
+    np.testing.assert_array_equal(decoder_dict["layers"]["3"]["attn"]["wq"], np.array([[3], [3]]))
+    np.testing.assert_array_equal(decoder_dict["layers"]["4"]["attn"]["wq"], np.array([[4], [4]]))
+    np.testing.assert_array_equal(decoder_dict["layers"]["5"]["attn"]["wq"], np.array([[5], [5]]))
+    np.testing.assert_array_equal(decoder_dict["layers"]["6"]["attn"]["wq"], np.array([[6], [6]]))
+
+  @pytest.mark.cpu_only
+  def test_correctly_unrolls_gemma3_gemma4_scanned_blocks(self):
+    """Verify that scanned layers under scanned_blocks are properly interleaved and mapped."""
+    arr0 = np.zeros((2, 3, 1))
+    arr0[:, 0, :] = 0
+    arr0[:, 1, :] = 2
+    arr0[:, 2, :] = 4
+
+    arr1 = np.zeros((2, 3, 1))
+    arr1[:, 0, :] = 1
+    arr1[:, 1, :] = 3
+    arr1[:, 2, :] = 5
+
+    pure_dict = {
+        "decoder": {
+            "scanned_blocks": {
+                "layers_0": {
+                    "attn": {"wq": arr0},
+                },
+                "layers_1": {
+                    "attn": {"wq": arr1},
+                },
+            },
+            "layers_remainder": {
+                "layers_0": {
+                    "attn": {"wq": np.array([[6, 6]]).transpose()},
+                }
+            },
+        }
+    }
+    weights = MockWeights(pure_dict)
+    unrolled = unroll_gemma_scanned_weights(weights)
+
+    decoder_dict = unrolled["decoder"]
+    self.assertIn("0", decoder_dict["layers"])
+    self.assertIn("6", decoder_dict["layers"])
+    np.testing.assert_array_equal(decoder_dict["layers"]["0"]["attn"]["wq"], np.array([[0], [0]]))
+    np.testing.assert_array_equal(decoder_dict["layers"]["6"]["attn"]["wq"], np.array([[6], [6]]))

--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -23,6 +23,8 @@ Tests cover:
 
 import sys
 import unittest
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 import jax
@@ -743,6 +745,111 @@ class TestNNXDecoderDeepseekAndGemma4(unittest.TestCase):
         rngs=self.rngs,
     )
 
+  def test_gemma_scan_layers_equivalence(self):
+    # Test that scan_layers=True and scan_layers=False produce identical logits
+    # even when bidirectional_mask is provided, proving kwargs are not dropped.
+    cfg_base = {
+        "run_name": "gemma3_scan_equiv_test",
+        "decoder_block": "gemma3",
+        "model_name": "gemma3-4b",
+        "num_decoder_layers": 2,
+        "base_emb_dim": 128,
+        "base_num_query_heads": 4,
+        "base_num_kv_heads": 4,
+        "base_mlp_dim": 256,
+        "hidden_size_per_layer_input": 128,
+        "vocab_size_per_layer_input": 256,
+        "vocab_size": 256,
+        "max_target_length": 64,
+        "per_device_batch_size": 1.0,
+    }
+
+    cfg_scanned = _make_config(scan_layers=True, **cfg_base)
+    cfg_unscanned = _make_config(scan_layers=False, **cfg_base)
+
+    # Use identical RNGs to guarantee the same parameter initialization
+    rngs_scanned = nnx.Rngs(params=0, dropout=1)
+    rngs_unscanned = nnx.Rngs(params=0, dropout=1)
+
+    decoder_scanned = NNXDecoder(config=cfg_scanned, mesh=self.mesh, model_mode=MODEL_MODE_TRAIN, rngs=rngs_scanned)
+    decoder_unscanned = NNXDecoder(config=cfg_unscanned, mesh=self.mesh, model_mode=MODEL_MODE_TRAIN, rngs=rngs_unscanned)
+
+    ids, segment_ids, positions = self._make_token_inputs(cfg_scanned)
+    shared_embedding = self._make_shared_embedding(cfg_scanned)
+
+    # Provide a mock bidirectional_mask to trigger the code path that dropped the kwarg
+    batch = cfg_scanned.global_batch_size_to_train_on
+    seq_len = cfg_scanned.max_target_length
+    bidirectional_mask = jax.random.normal(self.rng, (batch, seq_len)) > 0
+    mm_input = MultimodalInput(bidirectional_mask=bidirectional_mask)
+
+    logits_scanned, _, _ = decoder_scanned(
+        shared_embedding,
+        ids,
+        positions,
+        decoder_segment_ids=segment_ids,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+        multimodal_input=mm_input,
+    )
+
+    logits_unscanned, _, _ = decoder_unscanned(
+        shared_embedding,
+        ids,
+        positions,
+        decoder_segment_ids=segment_ids,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+        multimodal_input=mm_input,
+    )
+
+    np.testing.assert_allclose(logits_scanned, logits_unscanned, atol=1e-4, rtol=1e-4)
+
+  def test_gemma_scan_layers_kv_cache_updated(self):
+    # Test that scan_layers=True correctly forwards kv_caches to _apply_layers_sequentially.
+    # Patching/inspecting the private _apply_gemma3_scanned_blocks is intentional here.
+    # pylint: disable=protected-access
+    cfg = _make_config(
+        run_name="gemma3_scan_kv_test",
+        decoder_block="gemma3",
+        model_name="gemma3-4b",
+        scan_layers=True,
+        num_decoder_layers=2,
+        base_emb_dim=128,
+        base_num_query_heads=4,
+        base_num_kv_heads=4,
+        base_mlp_dim=256,
+        hidden_size_per_layer_input=128,
+        vocab_size_per_layer_input=256,
+        vocab_size=256,
+        max_target_length=64,
+        per_device_batch_size=1.0,
+    )
+
+    decoder = NNXDecoder(config=cfg, mesh=self.mesh, model_mode=MODEL_MODE_PREFILL, rngs=self.rngs)
+    ids, segment_ids, positions = self._make_token_inputs(cfg)
+    shared_embedding = self._make_shared_embedding(cfg)
+
+    decoder._apply_gemma3_scanned_blocks = MagicMock(return_value=jnp.zeros((1, 1)))
+
+    mock_kv_caches = [jnp.zeros((1, 1)) for _ in range(cfg.num_decoder_layers)]
+
+    _ = decoder(
+        shared_embedding,
+        ids,
+        positions,
+        decoder_segment_ids=segment_ids,
+        deterministic=True,
+        model_mode=MODEL_MODE_PREFILL,
+        kv_caches=mock_kv_caches,
+    )
+
+    # Verify that _apply_gemma3_scanned_blocks was called with the kv_caches
+    self.assertTrue(decoder._apply_gemma3_scanned_blocks.called)
+    call_kwargs = decoder._apply_gemma3_scanned_blocks.call_args[1]
+    self.assertIn("kv_caches", call_kwargs)
+    self.assertEqual(call_kwargs["kv_caches"], mock_kv_caches)
+
   def test_gemma4_scanned_layers(self):
     """Test NNXDecoder with gemma4 block and scan_layers=True."""
     cfg = _make_config(
@@ -799,6 +906,8 @@ class TestGemma4SmallNNXDecoder(unittest.TestCase):
             "hidden_size_per_layer_input=128",
             "vocab_size_per_layer_input=256",
             "vocab_size=256",
+            "max_target_length=128",
+            "per_device_batch_size=1.0",
         ],
         override_model_config=True,
     )
@@ -849,9 +958,6 @@ class TestGemma4SmallNNXDecoder(unittest.TestCase):
     )
 
   def test_gemma4_small_decoder_with_mock_cache_and_ple(self):
-    # pylint: disable=import-outside-toplevel
-    from unittest.mock import MagicMock, patch
-
     cfg = pyconfig.initialize(
         [
             None,
@@ -872,6 +978,8 @@ class TestGemma4SmallNNXDecoder(unittest.TestCase):
             "hidden_size_per_layer_input=128",
             "vocab_size_per_layer_input=256",
             "vocab_size=256",
+            "max_target_length=128",
+            "per_device_batch_size=1.0",
         ],
         override_model_config=True,
     )


### PR DESCRIPTION
# Description

  This PR fixes multiple issues causing gibberish outputs and initialization crashes when using scan_layers=True with Gemma 3 and 4 in vLLM workflows.

  Context and Details:
   - Why is this change being made: To enable successful RL training and generation with Gemma 3 and 4 by ensuring KV caches and scanned layer weights are correctly handled in the
     vLLM rollout engine.
   - The problems solved:
     1. vLLM Decoder Gibberish: Fixed missing `kv_caches` argument in `_apply_gemma3_scanned_blocks`, which caused loss of attention context.
     2. KV Cache Shape Mismatches: `MaxTextVllmRollout` ignored `rollout_vllm_additional_config`, falling back to base configs that conflicted with HuggingFace config head dimensions.
     4. Native NNX Keys & Scalar Bugs: The weight sync preprocessor failed to unstack nested scanned weights because it mismatched on native NNX root keys, and a bug in the `scan_length` calculation for scalar RNG states caused it to drop all decoder parameters, resulting in random noise generation.
   - Implementation details:
     - Explicitly passed `kv_caches` and attention_metadata in decoder blocks.
     - Updated the custom preprocessor in MaxTextVllmSampler to use robust string matching for NNX keys, safely ignore scalars when calculating `scan_length`, and correctly broadcast scalar values during unstacking.


# Tests
## inference vllm_decode
Run script : [here](https://paste.googleplex.com/5013364639137792) 
Run output : [log](https://paste.googleplex.com/5962439937097728)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
