### PR TITLE
fix(nnx): optimize scan memory by excluding read-only parameters from…

### DIFF
--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -356,13 +356,17 @@ class NNXScannedPipelineStage(nnx.Module):
           **kwargs,
       )
       new_carry = layer_out[0] if isinstance(layer_out, tuple) else layer_out
-      return new_carry, nnx.state(layer)
+      # Avoid returning and stacking read-only parameters inside the scan body.
+      # This prevents huge unnecessary memory allocation.
+      _, _, updated_state = nnx.split(layer, nnx.Param, ...)
+      return new_carry, updated_state
 
     final_carry, scanned_state = jax.lax.scan(layer_fn, inputs, (params, state))
 
     if scan_axis != 0:
       scanned_params, scanned_other = scanned_state.split(nnx.Param, ...)
-      scanned_params = jax.tree.map(lambda x: jnp.moveaxis(x, 0, scan_axis), scanned_params)
+      if scanned_params:
+        scanned_params = jax.tree.map(lambda x: jnp.moveaxis(x, 0, scan_axis), scanned_params)
       scanned_state = nnx.State.merge(scanned_params, scanned_other)
 
     nnx.update(self.scanned_layers, scanned_state)
@@ -957,7 +961,10 @@ class NNXDecoder(nnx.Module):
         returned_params = updated_params
         new_current_state = nnx.State.merge(returned_params, updated_state)
       else:
-        new_current_state = nnx.state(layer)
+        # Avoid returning and stacking read-only parameters inside the scan body.
+        # This prevents huge unnecessary memory allocation.
+        _, _, updated_state = nnx.split(layer, nnx.Param, ...)
+        new_current_state = updated_state
 
       if use_kv:
         return new_carry, (new_current_state, updated_kv)


### PR DESCRIPTION
### Summary
Address the issue in b/532605802. Optimizes memory consumption during the sequential layer forward pass in NNX decoders by preventing the JAX `scan` loop body from returning and stacking read-only model parameters (`nnx.Param`). This resolves `RESOURCE_EXHAUSTED` (Out of Memory) issues during DeepSeek-V3 and V3.2 forward logit checker runs and matches the memory profile of the pre-migrated Linen model path.

### Root Cause Analysis
During the default Flax NNX migration, `NNXScannedLayers.__call__` and `_apply_layers_sequentially` were updated to run sequential block execution using `jax.lax.scan`. 
* **The Issue:** The loop bodies returned the complete state of the layer (`nnx.state(layer)`). Under Flax NNX, this state includes both mutable variables (like RNG state or cache) and read-only model parameters (`nnx.Param`).
* **The Impact:** Because JAX compiles the scan block to stack all returned loop variables across the scanned dimension, JAX compiled an output of shape `[num_layers, parameter_size]` for the read-only parameters. On massive models like DeepSeek-V3 (671B parameters), this forced the TPU/accelerator to allocate a massive duplicated array buffer (~12.69 GB per host) for parameters that never mutate during the forward pass, triggering a runtime memory exhaustion error:
  ```
  jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED: E0100: RuntimeBufferAllocationFailure:
  Error allocating device buffer: Attempting to allocate 12.69G. That was not possible. There are 3.96G free.
  ```

### Resolution
Modified `/src/maxtext/layers/nnx_decoders.py` to separate model parameters from the scan body's output state:
1. **Scan Body Modification (`NNXScannedLayers.__call__` & `_apply_layers_sequentially`)**: Prior to returning from the scan loop body, the layer state is split via `nnx.split(layer, nnx.Param, ...)` and only the non-parameter `updated_state` is returned.
2. **Post-Scan Alignment**: Handled optional `scan_axis` shifts and parameter tracking updates gracefully to ensure `nnx.update(layers, scanned_state)` merges only non-parameter updates without attempting to update the static read-only parameters.

This aligns the NNX scan execution memory structure **exactly** with the pre-migrated Linen path, reducing the scanned parameter-stacking overhead to **0 bytes**.

### Verification
Test with `2_test_deepseek.sh` in the DAG (b/532605802):
[Main branch](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22mlperf-v5p%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22maxtext-deepseek-unpatched-control-1-slice-job-0-0-%22%0Aseverity%3E%3DDEFAULT;storageScope=project;cursorTimestamp=2026-07-22T03:00:07.343445920Z;duration=P1D?project=cloud-tpu-multipod-dev)
[Patch](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22cloud-tpu-multipod-dev%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22mlperf-v5p%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22maxtext-deepseek-scan-oom-fix-mlperf-1-slice-job-0-0-%22%0Aseverity%3E%3DDEFAULT%0ASEARCH%2528%22KL%22%2529;storageScope=project;cursorTimestamp=2026-07-22T02:44:51.034435741Z;duration=P1D?project=cloud-tpu-multipod-dev)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).