### PR TITLE
Feature/sft windowing

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -720,6 +720,27 @@ use_dpo: false
 use_sft: false
 # sft_train_on_completion_only=false trains on both prompt and completion tokens; trains only on completion tokens otherwise
 sft_train_on_completion_only: false
+# How to handle SFT examples longer than max_target_length (grain SFT pipeline):
+#   'truncate' (default) - head-truncate to max_target_length. NOTE: this drops the tail of long
+#                examples, including the turn terminator (e.g. <end_of_turn>), from BOTH inputs and
+#                targets, so the stop token never enters the loss for long examples and the model is
+#                trained on a stop-less completion prefix (learns to never stop on long generations).
+#   'window'   - split a long example into multiple <=max_target_length records via a prompt-pinned
+#                sliding window: the conversation-prefix-so-far is replayed as masked (context-only)
+#                tokens in front of each window, the completion is tiled across windows with DISJOINT
+#                loss (every completion token trained exactly once), and the final window retains the
+#                turn terminator. Requires sft_train_on_completion_only=True. Examples that already fit
+#                yield a single record identical to 'truncate'.
+sft_long_example_handling: 'truncate'
+# For sft_long_example_handling='window': completion tokens carried over as masked context between
+# consecutive windows (local continuity across the split). Clamped to <= max_target_length // 8.
+sft_window_overlap: 256
+# For 'window': max tokens of conversation-prefix context pinned (masked) in front of each window.
+# -1 = auto (max_target_length // 2). Bounds per-example fan-out for very long prompts.
+sft_window_context_cap: -1
+# For 'window': hard cap on records emitted per example (runaway guard). Loss tokens beyond the cap
+# are dropped and logged.
+sft_window_max_fan_out: 32
 
 # dataset_type must be synthetic, hf, grain, tfds
 # details in: https://github.com/AI-Hypercomputer/maxtext/blob/main/docs/guides/data_input_pipeline.md

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1355,6 +1355,34 @@ class FineTuning(BaseModel):
   sft_train_on_completion_only: bool = Field(
       False, description="If True, trains only on the completion part of the text."
   )
+  sft_long_example_handling: Literal["truncate", "window"] = Field(
+      "truncate",
+      description=(
+          "How to handle SFT examples longer than max_target_length (grain pipeline). "
+          "'truncate' head-truncates (drops the tail, incl. the turn terminator <end_of_turn>, "
+          "from long examples). 'window' splits a long example into multiple <=max_target_length "
+          "records via a prompt-pinned sliding window so the terminator always enters the loss; "
+          "requires sft_train_on_completion_only=True."
+      ),
+  )
+  sft_window_overlap: int = Field(
+      256,
+      description=(
+          "For sft_long_example_handling='window': completion tokens carried as masked context "
+          "between consecutive windows. Clamped to <= max_target_length // 8."
+      ),
+  )
+  sft_window_context_cap: int = Field(
+      -1,
+      description=(
+          "For 'window': max tokens of conversation-prefix context pinned (masked) in front of "
+          "each window. -1 = auto (max_target_length // 2)."
+      ),
+  )
+  sft_window_max_fan_out: int = Field(
+      32,
+      description="For 'window': hard cap on records emitted per example (runaway guard).",
+  )
   formatting_func_path: str = Field(
       "",
       description="Path to the custom data formatting function for SFT.",

--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -370,14 +370,38 @@ def sft_preprocessing_pipeline(
         )
     )
 
-  dataset = dataset.map(
-      input_pipeline_utils.SFTPromptMasking(
-          text_column_name=data_columns[0],
-          completion_only=config.sft_train_on_completion_only,
-          max_target_length=config.max_target_length,
-          unk_id=pad_id,
-      )
-  )
+  long_handling = getattr(config, "sft_long_example_handling", "truncate")
+  if long_handling == "window":
+    assert (
+        config.sft_train_on_completion_only
+    ), "sft_long_example_handling='window' requires sft_train_on_completion_only=True"
+    # Split examples longer than max_target_length into windows (one-to-many) instead of
+    # head-truncating them, so the turn terminator (<end_of_turn>) always enters the loss.
+    windows = input_pipeline_utils.SFTPromptMaskingWindows(
+        text_column_name=data_columns[0],
+        completion_only=config.sft_train_on_completion_only,
+        max_target_length=config.max_target_length,
+        unk_id=pad_id,
+        overlap=config.sft_window_overlap,
+        context_cap=config.sft_window_context_cap,
+        max_fan_out=config.sft_window_max_fan_out,
+    )
+    # grain applies a FlatMapTransform via IterDataset.apply() in newer releases and via the
+    # FlatMapIterDataset constructor in older ones (<=0.2.12). Support both so this works
+    # regardless of the grain version pinned in the runner image.
+    if hasattr(dataset, "apply"):
+      dataset = dataset.apply(windows)
+    else:
+      dataset = grain.experimental.FlatMapIterDataset(dataset, windows)
+  else:
+    dataset = dataset.map(
+        input_pipeline_utils.SFTPromptMasking(
+            text_column_name=data_columns[0],
+            completion_only=config.sft_train_on_completion_only,
+            max_target_length=config.max_target_length,
+            unk_id=pad_id,
+        )
+    )
   data_columns = ("inputs", "targets")
 
   batch_size = data_processing_utils.get_local_batch_size(config)

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 import grain.python as grain
 import numpy as np
 from grain._src.python.dataset.sources.tfrecord_dataset import _TFRecordReader, _TFRecordDatasetIterator  # pylint: disable=protected-access
-from grain.experimental import TFRecordIterDataset
+from grain.experimental import FlatMapTransform, TFRecordIterDataset
 from maxtext.input_pipeline.protos import example_pb2
 from maxtext.input_pipeline import tokenizer
 from maxtext.multimodal import processor as mm_processor
@@ -350,6 +350,111 @@ class SFTPromptMasking(grain.MapTransform):
         "inputs": np.asarray(inputs[: self.max_target_length], dtype=np.int32),
         "targets": np.asarray(targets[: self.max_target_length], dtype=np.int32),
     }
+
+
+@dataclasses.dataclass
+class SFTPromptMaskingWindows(FlatMapTransform):
+  """Construct SFT inputs/targets for completion-only training, splitting examples longer than
+  ``max_target_length`` into multiple ``<= max_target_length`` records via a prompt-pinned sliding
+  window instead of head-truncating them.
+
+  Motivation: the 1:1 :class:`SFTPromptMasking` truncates the concatenated sequence with
+  ``[:max_target_length]``. For any example longer than ``max_target_length`` this drops the tail —
+  including the turn terminator (e.g. ``<end_of_turn>``) — from both ``inputs`` and ``targets``, so
+  the stop token never enters the loss and the model is trained on a stop-less completion prefix.
+
+  This transform instead emits, per completion segment of an over-length example, a sequence of
+  windows. Each window is ``[ conversation-prefix-so-far (front-capped, masked) ] +
+  [ small completion overlap (masked) ] + [ a slice of new completion tokens (loss) ]``. The loss
+  slices tile the completion with NO overlap, so every completion token — including the terminator
+  in the final window — contributes to the loss exactly once. Examples that already fit yield a
+  single record byte-identical to :class:`SFTPromptMasking`.
+
+  Only completion-only SFT is supported (the context/overlap tokens are masked with ``unk_id``).
+  """
+
+  max_fan_out: int = 32
+
+  def __init__(
+      self,
+      text_column_name,
+      completion_only,
+      max_target_length,
+      unk_id=0,
+      overlap=256,
+      context_cap=-1,
+      max_fan_out=32,
+  ):
+    self.text_column_name = text_column_name
+    self.completion_only = completion_only
+    self.max_target_length = max_target_length
+    self.unk_id = unk_id
+    self.overlap = overlap
+    self.context_cap = context_cap
+    self.max_fan_out = max_fan_out
+
+  def _single_record(self, segments, is_prompt):
+    """Fast path identical to SFTPromptMasking.map for examples that fit in max_target_length."""
+    inputs, targets = [], []
+    for seg, is_p in zip(segments, is_prompt):
+      seg = list(seg)
+      inputs += seg
+      targets += [self.unk_id] * len(seg) if (self.completion_only and is_p) else seg
+    return {
+        "inputs": np.asarray(inputs, dtype=np.int32),
+        "targets": np.asarray(targets, dtype=np.int32),
+    }
+
+  def flat_map(self, element):
+    """Emit one or more ``<= max_target_length`` records for a single SFT example (see class docstring)."""
+    length = self.max_target_length
+    segments = element[self.text_column_name]
+    is_prompt = element["is_prompt"]
+
+    total = sum(len(seg) for seg in segments)
+    if total <= length:
+      return [self._single_record(segments, is_prompt)]
+
+    # Clamp window geometry so every window always leaves room for >=1 loss token:
+    #   ctx (<= cap) + overlap (<= overlap_cap) + min_room <= length.
+    overlap_cap = max(0, min(self.overlap, length // 8))
+    min_room = max(1, length // 8)
+    auto_cap = self.context_cap if (self.context_cap and self.context_cap > 0) else length // 2
+    cap = max(1, min(auto_cap, length - overlap_cap - min_room))
+
+    records = []
+    prefix = []  # all tokens of preceding segments, replayed (masked) as grounding context
+    for seg, is_p in zip(segments, is_prompt):
+      seg = list(seg)
+      if self.completion_only and is_p:
+        prefix += seg
+        continue
+      comp = seg
+      if not comp:
+        continue
+      ctx = prefix[-cap:] if len(prefix) > cap else list(prefix)
+      i, n = 0, len(comp)
+      while i < n:
+        if len(records) >= self.max_fan_out:
+          max_logging.log(
+              f"SFTPromptMaskingWindows: hit max_fan_out={self.max_fan_out}; dropping {n - i} "
+              "trailing completion token(s) (including the turn terminator) for one example."
+          )
+          return records
+        overlap_tokens = comp[max(0, i - overlap_cap) : i]
+        room = length - len(ctx) - len(overlap_tokens)
+        loss_tokens = comp[i : i + room]
+        n_mask = len(ctx) + len(overlap_tokens)
+        records.append(
+            {
+                "inputs": np.asarray(ctx + overlap_tokens + loss_tokens, dtype=np.int32),
+                "targets": np.asarray([self.unk_id] * n_mask + loss_tokens, dtype=np.int32),
+            }
+        )
+        i += len(loss_tokens)
+      prefix += comp
+
+    return records
 
 
 @dataclasses.dataclass

--- a/tests/post_training/unit/sft_prompt_masking_windows_test.py
+++ b/tests/post_training/unit/sft_prompt_masking_windows_test.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure-logic tests for SFTPromptMaskingWindows (no tokenizer / no GCS).
+
+Validates that long SFT examples keep the turn terminator (e.g. <end_of_turn>) in the loss by
+windowing instead of head-truncating, and that the fast path matches SFTPromptMasking exactly.
+"""
+import pytest
+
+pytestmark = [pytest.mark.post_training, pytest.mark.cpu_only]
+
+import numpy as np
+
+from maxtext.input_pipeline.input_pipeline_utils import SFTPromptMasking, SFTPromptMaskingWindows
+
+PAD = 0
+EOT = 129  # stand-in for <end_of_turn>
+
+
+def _loss_tokens(record):
+  """Tokens that actually contribute to the loss = targets != pad."""
+  t = record["targets"]
+  return [int(x) for x in t[t != PAD]]
+
+
+def test_short_example_matches_sftpromptmasking():
+  """An example that fits in max_target_length yields one record, identical to SFTPromptMasking."""
+  length = 20
+  element = {"text": [[1, 2, 3], [101, 102, 103, EOT]], "is_prompt": [True, False]}
+  windows = SFTPromptMaskingWindows("text", completion_only=True, max_target_length=length, unk_id=PAD)
+  recs = windows.flat_map({k: list(v) for k, v in element.items()})
+
+  baseline = SFTPromptMasking("text", completion_only=True, max_target_length=length, unk_id=PAD)
+  expected = baseline.map({k: list(v) for k, v in element.items()})
+
+  assert len(recs) == 1
+  assert np.array_equal(recs[0]["inputs"], expected["inputs"])
+  assert np.array_equal(recs[0]["targets"], expected["targets"])
+
+
+def test_truncate_baseline_drops_eot():
+  """Sanity: the old 1:1 transform drops the terminator for an over-length example (the bug)."""
+  length = 20
+  prompt = [1, 2, 3]
+  completion = list(range(100, 129)) + [EOT]  # 30 tokens, terminator last
+  baseline = SFTPromptMasking("text", completion_only=True, max_target_length=length, unk_id=PAD)
+  out = baseline.map({"text": [prompt, completion], "is_prompt": [True, False]})
+  assert len(out["inputs"]) == length
+  assert EOT not in set(int(x) for x in out["targets"])  # terminator truncated away → not in loss
+
+
+def test_long_single_turn_keeps_eot_and_covers_completion_once():
+  """A long single-turn example is split into windows; the terminator stays in the loss and every
+  completion token is trained exactly once (disjoint loss), with the prompt pinned as context."""
+  length = 20
+  prompt = [1, 2, 3]
+  completion = list(range(100, 129)) + [EOT]  # 30 tokens
+  windows = SFTPromptMaskingWindows("text", completion_only=True, max_target_length=length, unk_id=PAD, overlap=2)
+  recs = windows.flat_map({"text": [prompt, completion], "is_prompt": [True, False]})
+
+  assert len(recs) >= 2
+  for r in recs:
+    assert len(r["inputs"]) == len(r["targets"]) <= length
+    # prompt pinned (masked) as context in every window
+    assert [int(x) for x in r["inputs"][: len(prompt)]] == prompt
+    assert [int(x) for x in r["targets"][: len(prompt)]] == [PAD] * len(prompt)
+
+  # disjoint + complete + ordered coverage of the completion
+  covered = []
+  for r in recs:
+    covered += _loss_tokens(r)
+  assert covered == completion
+
+  # terminator is in the loss of the LAST window
+  assert _loss_tokens(recs[-1])[-1] == EOT
+
+
+def test_multi_turn_each_turn_terminator_in_loss():
+  """A multi-turn over-length example keeps each assistant turn's terminator in the loss."""
+  length = 16
+  # system+user1 | answer1+EOT | user2 | answer2+EOT  (total > length)
+  segments = [
+      [1, 2, 3, 4, 5],  # prompt (system+user1)
+      [201, 202, 203, EOT],  # completion 1
+      [6, 7, 8],  # prompt (user2)
+      [211, 212, 213, 214, 215, EOT],  # completion 2
+  ]
+  is_prompt = [True, False, True, False]
+  windows = SFTPromptMaskingWindows("text", completion_only=True, max_target_length=length, unk_id=PAD, overlap=2)
+  recs = windows.flat_map({"text": segments, "is_prompt": is_prompt})
+
+  covered = []
+  for r in recs:
+    assert len(r["inputs"]) == len(r["targets"]) <= length
+    covered += _loss_tokens(r)
+
+  # both completions fully covered, each exactly once, terminators included
+  assert covered == [201, 202, 203, EOT, 211, 212, 213, 214, 215, EOT]
+  assert covered.count(EOT) == 2
+
+
+def test_fan_out_cap_is_respected():
+  """max_fan_out bounds the number of emitted records (runaway guard)."""
+  length = 12
+  prompt = [1, 2]
+  completion = list(range(100, 200))  # very long
+  windows = SFTPromptMaskingWindows(
+      "text", completion_only=True, max_target_length=length, unk_id=PAD, overlap=1, max_fan_out=3
+  )
+  recs = windows.flat_map({"text": [prompt, completion], "is_prompt": [True, False]})
+  assert len(recs) == 3
+  for r in recs:
+    assert len(r["inputs"]) <= length
+
+
+if __name__ == "__main__":
+  for name, fn in sorted(globals().items()):
+    if name.startswith("test_") and callable(fn):
+      fn()
+      print(f"PASS {name}")
+  print("ALL PASS")


### PR DESCRIPTION
# Description

Completion-only SFT (grain pipeline) currently **head-truncates** any example longer
than `max_target_length`: `SFTPromptMasking` concatenates the prompt/completion into
`inputs`/`targets` and slices `[:max_target_length]`. For any over-length example this
drops the tail — **including the turn terminator `<end_of_turn>`** — from both `inputs`
and `targets`. The stop token therefore never enters the loss for long examples, and the
model is trained on a stop-less completion prefix, which teaches it to keep generating
and not stop on long outputs (observed as long-generation repetition after SFT).

This PR adds an **opt-in** long-example handling mode, `sft_long_example_handling='window'`,
implemented as `SFTPromptMaskingWindows` — a one-to-many `FlatMapTransform`. Instead of
truncating, an over-length example is split into multiple `<= max_target_length` records
via a prompt-pinned sliding window:

- the conversation-prefix-so-far is replayed (front-capped) as **masked** context in front
  of each window,
- a small **masked** completion overlap gives local continuity across the split,
- the new completion tokens are tiled across windows with **disjoint loss** — every
  completion token is trained exactly once,
- the **final window retains `<end_of_turn>`**, so the terminator always enters the loss.

Examples that already fit within `max_target_length` yield a single record byte-identical
to `SFTPromptMasking`. The default stays `'truncate'`, so behavior is unchanged unless the
new mode is explicitly enabled — **fully backward compatible**.

Why windowing rather than simply dropping over-length examples: dropping discards training
signal and biases the dataset toward short conversations; windowing keeps every completion
token (including the terminator) in the loss while still respecting `max_target_length`, at
the cost of a bounded per-example fan-out.

**Config knobs** (all with backward-compatible defaults):
- `sft_long_example_handling: 'truncate' | 'window'` — default `'truncate'`
- `sft_window_overlap` — default `256`; masked completion carryover between consecutive
  windows (clamped to `<= max_target_length // 8`)
- `sft_window_context_cap` — default `-1` (auto = `max_target_length // 2`); max masked
  conversation-prefix context pinned in front of each window
- `sft_window_max_fan_out` — default `32`; hard cap on records emitted per example
  (runaway guard; excess trailing tokens are dropped and logged)

`'window'` requires `sft_train_on_completion_only=True` (context/overlap tokens are masked
with `unk_id`).

**Implementation:**
- `input_pipeline/input_pipeline_utils.py`: new `SFTPromptMaskingWindows` transform +
  `FlatMapTransform` import.
- `input_pipeline/grain_data_processing.py`: `sft_preprocessing_pipeline` branches on
  `sft_long_example_handling`; the transform is applied grain-version-robustly
  (`IterDataset.apply()` on newer grain, `grain.experimental.FlatMapIterDataset(...)` on
  `<= 0.2.12`).
- `configs/base.yml` and `configs/types.py`: the four knobs are declared in both (base.yml
  for docs/defaults; the Pydantic `FineTuning` model because `MaxTextConfig` is
  `extra="forbid"` and would reject the keys at startup otherwise).

**Shortcomings / future work:**
- Only completion-only SFT is supported; the non-completion-only path still truncates.
- The pinned context is a raw token-tail cap, not semantically boundary-aware.
- Multimodal SFT is out of scope.

<!-- If this fixes a bug/issue, add e.g. `FIXES: #123456` here. -->

# Tests

New pure-logic unit tests (no tokenizer / no GCS) at
`tests/post_training/unit/sft_prompt_masking_windows_test.py`:

- `test_short_example_matches_sftpromptmasking` — an example that fits yields exactly one
  record, identical to `SFTPromptMasking`.
- `test_truncate_baseline_drops_eot` — sanity check that the existing 1:1 transform drops
  the terminator for an over-length example (the bug).
- `test_long_single_turn_keeps_eot_and_covers_completion_once` — a long single-turn example
  is windowed; the prompt is pinned+masked in every window, the completion is covered
  exactly once (disjoint), and the terminator is in the loss of the last window.
- `test_multi_turn_each_turn_terminator_in_loss` — a multi-turn over-length example keeps
  each assistant turn's terminator in the loss.
- `test_fan_out_cap_is_respected` — `max_fan_out` bounds the number of emitted records.

Run:

```bash
python -m pytest tests/post_training/unit/sft_prompt_masking_windows_test.py -v
```

The tests are CPU-only (marked `post_training` / `cpu_only`).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).