### PR TITLE
Avoid Possible MXLA hangs by eagerly scaling up in Elasticity

### DIFF
--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -1094,8 +1094,8 @@ def maybe_save_checkpoint(checkpoint_manager, state, config, data_iterator, step
     checkpoint_saved = save_checkpoint(checkpoint_manager, actual_step, state, config, data_iterator, force_ckpt_save)
     if checkpoint_saved:
       print_save_message(actual_step, config.async_checkpointing)
-      if config.elastic_enabled:
-        elastic_utils.maybe_elastic_scale_up(config, checkpoint_manager)
+    if config.elastic_enabled:
+      elastic_utils.maybe_elastic_scale_up(config, checkpoint_manager)
   except elastic_utils.manager.ScaleUpSignalError as e:
     if config.elastic_enabled:
       max_logging.log(f"Elastic event detected, letting exception bubble up: {e}")

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -680,6 +680,8 @@ def training_loop_iteration(
   dump_hlo_upload_all = immutable_data["dump_hlo_upload_all"]
 
   prof.maybe_activate_profiler(step, state)
+  if config.elastic_enabled:
+    elastic_utils.maybe_elastic_scale_up(config, checkpoint_manager)
 
   with jax.profiler.StepTraceAnnotation("train", step_num=step):
     example_batch = data_loader.load_next_batch(rampup_manager=rampup_manager)

--- a/tests/unit/train_state_nnx_checkpoint_test.py
+++ b/tests/unit/train_state_nnx_checkpoint_test.py
@@ -363,6 +363,7 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
         "enable_multi_tier_checkpointing": False,
         "local_checkpoint_period": 0,
         "enable_autocheckpoint": False,
+        "elastic_enabled": False,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -597,6 +598,26 @@ class TestMaybeSaveCheckpointStepAlignment(unittest.TestCase):
     mgr.reached_preemption.assert_called_once_with(5)
     to_checkpoint_dict_mock.assert_called_once_with(state)
     save_checkpoint_mock.assert_called_once()
+
+  def test_maybe_save_checkpoint_checks_scale_up_after_unsaved_dispatch(self):
+    """Elastic scale-up is checked after save dispatch even when no checkpoint was saved."""
+    state = mock.Mock()
+    config = self._config(checkpoint_period=1, elastic_enabled=True)
+    mgr = mock.MagicMock()
+    mgr.latest_step.return_value = None
+    mgr.reached_preemption.return_value = False
+    save_checkpoint_mock = mock.MagicMock(return_value=False)
+
+    with (
+        mock.patch.object(checkpointing, "save_checkpoint", save_checkpoint_mock),
+        mock.patch.object(train_state_nnx, "to_checkpoint_dict", return_value={}) as to_checkpoint_dict_mock,
+        mock.patch.object(checkpointing.elastic_utils, "maybe_elastic_scale_up") as mock_maybe_scale_up,
+    ):
+      checkpointing.maybe_save_checkpoint(mgr, state, config, data_iterator=None, step=5)
+
+    to_checkpoint_dict_mock.assert_called_once_with(state)
+    save_checkpoint_mock.assert_called_once()
+    mock_maybe_scale_up.assert_called_once_with(config, mgr)
 
 
 class TestLinenCheckpointFormatConverters(unittest.TestCase):


### PR DESCRIPTION
# Description

Make elastic scale up handling more eager.

When an elastic scale up is pending, we should scale up before starting checkpointing work on the old topology. Otherwise, the process can continue issuing work against stale devices, which can surface as MXLA hangs or later DATA_LOSS timeouts.

FIXES: b/532239140

# Tests

Unit tests and tests against internal cluster

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
