### PR TITLE
feat(rl): OOM-safe chunked log-probs for RL actor (enable train_micro>8)

### DIFF
--- a/src/maxtext/configs/post_train/rl.yml
+++ b/src/maxtext/configs/post_train/rl.yml
@@ -117,6 +117,13 @@ num_batches: 4
 # and/or async sampling and training.
 train_micro_batch_size: -1
 rollout_micro_batch_size: -1
+# [NAVI patch C] Chunk size for LM-head projection when computing per-token logps.
+# 0 = OFF (stock full-logits path). >0 caps logits peak at [micro, chunk, vocab],
+# lifting the train_micro_batch_size HBM ceiling. Correctness-preserving.
+rl_compute_logps_chunk_size: 0
+# [NAVI patch D] Whole-model host offload (tunix ClusterConfig.offload_to_cpu).
+# False = OFF (stock). True moves params to pinned_host between phases.
+rl_offload_to_cpu: false
 # Keep `num_test_batches` low so that evaluation runs quickly. It can be
 # increased to a max. of 330 (if batch size is 4).
 num_test_batches: 5  # 200

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -2186,6 +2186,29 @@ class RLDataset(BaseModel):
   train_fraction: float = Field(1.0, description="Fraction of the dataset to be used for training.")
   train_micro_batch_size: int = Field(-1, description="Micro batch size for training.")
   rollout_micro_batch_size: int = Field(-1, description="Micro batch size for rollout.")
+  rl_compute_logps_chunk_size: int = Field(
+      0,
+      description=(
+          "[NAVI patch C] If > 0, compute the actor/ref/old per-token log-probs "
+          "with the LM head projected in sequence chunks of this size (tunix "
+          "compute_chunked_logps: skip_lm_head + scan + remat). Caps the logits "
+          "memory peak at [micro, chunk, vocab] instead of [micro, seq, vocab], "
+          "which lifts the train_micro_batch_size HBM ceiling. Default 0 (OFF, "
+          "identical to stock full-logits path). Requires the model adapter to "
+          "expose skip_lm_head + compute_final_logits."
+      ),
+  )
+  rl_offload_to_cpu: bool = Field(
+      False,
+      description=(
+          "[NAVI patch D] If True, set tunix ClusterConfig.offload_to_cpu so the "
+          "actor/reference/rollout model params are moved to pinned_host between "
+          "phases (whole-model host offload; a DIFFERENT mechanism from the "
+          "validate-blocked optimizer_memory_host_offload). Trades host<->device "
+          "transfer time for device HBM headroom. Default False (OFF). Gate with "
+          "EXPERIMENTAL_RL_HOST_OFFLOAD."
+      ),
+  )
   dataset_processor_path: str = Field(
       "",
       description=(

--- a/src/maxtext/integration/tunix/tunix_adapter.py
+++ b/src/maxtext/integration/tunix/tunix_adapter.py
@@ -21,14 +21,64 @@ It also handles weight mapping for compatibility with Hugging Face models.
 
 from __future__ import annotations
 
+import os
 from typing import Any, Optional, Tuple
 
+import jax
 import jax.numpy as jnp
 from flax import nnx
 from jax import Array
 from maxtext.checkpoint_conversion.utils.hf_model_configs import HF_MODEL_CONFIGS  # pylint: disable=ungrouped-imports
 from maxtext.integration.tunix.utils import VllmWeightMapping
 from maxtext.models.models import Transformer
+
+
+# [NAVI patch E] Opt-in microbatch memory/shape logging. Enable with NAVI_MEM_LOG=1.
+# Prints tensor shape/dtype/bytes at the trainer forward boundary + device HBM
+# in-use, so we can empirically prove the [micro, seq, vocab] logits
+# materialization and measure the chunked/offload reduction. Zero cost when off.
+_NAVI_MEM_LOG = os.environ.get("NAVI_MEM_LOG", "0") == "1"
+_navi_mem_seen: set[str] = set()
+
+
+def _navi_log_mem(tag: str, **arrays: Any) -> None:
+  """Opt-in (NAVI_MEM_LOG=1) logging of tensor shape/dtype/bytes + device HBM
+  in-use at the trainer forward boundary. First occurrence per tag only."""
+  if not _NAVI_MEM_LOG:
+    return
+  try:
+    # Only log the first occurrence of each tag to avoid trace-time spam.
+    if tag in _navi_mem_seen:
+      return
+    _navi_mem_seen.add(tag)
+    parts = []
+    for name, a in arrays.items():
+      if a is None:
+        continue
+      shp = getattr(a, "shape", None)
+      dt = getattr(a, "dtype", None)
+      nbytes = None
+      if shp is not None and dt is not None:
+        try:
+          nbytes = int(jnp.prod(jnp.array(shp))) * jnp.dtype(dt).itemsize
+        except Exception:  # pylint: disable=broad-exception-caught
+          nbytes = None
+      gb = f"{nbytes/1e9:.2f}GB" if nbytes else "?"
+      parts.append(f"{name}={shp}:{dt}:{gb}")
+    hbm = ""
+    try:
+      d = jax.devices()[0]
+      if hasattr(d, "memory_stats"):
+        ms = d.memory_stats() or {}
+        used = ms.get("bytes_in_use")
+        peak = ms.get("peak_bytes_in_use")
+        if used is not None:
+          hbm = f" | HBM_in_use={used/1e9:.1f}GB peak={((peak or 0))/1e9:.1f}GB"
+    except Exception:  # pylint: disable=broad-exception-caught
+      pass
+    print(f"[NAVI_MEM_LOG] {tag}: {' '.join(parts)}{hbm}", flush=True)
+  except Exception:  # pylint: disable=broad-exception-caught
+    pass
 
 
 class TunixMaxTextAdapter(nnx.Module):
@@ -70,18 +120,68 @@ class TunixMaxTextAdapter(nnx.Module):
       attention_mask: Optional[Array],  # [B, L, L] or None
       decoder_segment_ids: Optional[Array] = None,
       output_hidden_states: bool = False,  # ignored
+      skip_lm_head: bool = False,  # [NAVI patch C] chunked-logps memory lever
   ) -> Tuple[Array, None]:
     """Forward compatible with Tunix Trainers default loss.
     Returns logits, None.
+
+    When ``skip_lm_head=True`` (used by tunix ``compute_chunked_logps`` when
+    ``compute_logps_chunk_size > 0``), the expensive [B, L, vocab] output-head
+    projection is deferred; the decoder's final hidden state [B, L, hidden] is
+    returned instead and the caller projects it chunk-by-chunk via
+    ``compute_final_logits`` under ``jax.lax.scan`` + ``nnx.remat``. This caps
+    the LM-head logits peak at [B, chunk, vocab] instead of [B, L, vocab],
+    lifting the train_micro-batch HBM ceiling. Math is identical: per-token
+    log-softmax is independent along the vocab axis (see smoke proof).
     """
     if decoder_segment_ids is None and self._pad_id is not None:
       decoder_segment_ids = (input_tokens != self._pad_id).astype(jnp.int32)
+    if skip_lm_head:
+      # Return the decoder hidden state; LM head applied later per-chunk.
+      hidden_state = self.base(
+          decoder_input_tokens=input_tokens,
+          decoder_positions=positions,
+          decoder_segment_ids=decoder_segment_ids,
+          skip_lm_head=True,
+      )
+      _navi_log_mem("actor_fwd.skip_lm_head", input_tokens=input_tokens, hidden_state=hidden_state)
+      return hidden_state, None
     logits = self.base(
         decoder_input_tokens=input_tokens,
         decoder_positions=positions,
         decoder_segment_ids=decoder_segment_ids,
     )
+    _navi_log_mem("actor_fwd.full_logits", input_tokens=input_tokens, logits=logits)
     return logits, None
+
+  def compute_final_logits(self, hidden_states: Array) -> Array:
+    """[NAVI patch C] LM-head projection over precomputed hidden states.
+
+    Required by tunix ``compute_chunked_logps``. Delegates to the MaxText
+    Transformer's existing ``logits_from_hidden_states_for_vocab_tiling`` (the
+    same output-head used by native vocab-tiling), so no new params/graph.
+
+    NOTE: tunix calls this inside ``jax.lax.scan`` + ``nnx.remat``. The output
+    head's ``nn.Dropout`` (a no-op here: dropout_rate=0 + deterministic=True) is
+    made RNG-free at its source by the ``skip_lm_head`` deterministic guard in
+    apply_output_head (see layers/decoders.py) so it does not mutate an RngCount
+    across the scan's trace level (which would raise flax TraceContextError).
+    """
+    from maxtext.common.common_types import MODEL_MODE_TRAIN  # pylint: disable=import-outside-toplevel
+    # Pass a STATIC rng key so the ToNNX decoder wrapper takes its jax.Array branch
+    # (_rngs={"params": key}) instead of calling stream() on live Rngs. stream() would
+    # mutate an RngCount across the enclosing jax.lax.scan trace level (tunix
+    # compute_chunked_logps) and raise flax TraceContextError. The projection is
+    # deterministic (dropout guarded off), so this key is never used to draw randomness.
+    _static_key = jax.random.PRNGKey(0)
+    logits = self.base.logits_from_hidden_states_for_vocab_tiling(
+        hidden_states=hidden_states,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+        rngs=_static_key,
+    )
+    _navi_log_mem("actor_fwd.chunk_logits", hidden_states=hidden_states, logits=logits)
+    return logits
 
   def to_hf_mappings(self):
     if self.use_no_op_mappings:

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -801,7 +801,14 @@ class Decoder(nn.Module):
         kernel_axes=("norm",),
         parameter_memory_host_offload=cfg.parameter_memory_host_offload,
     )(y, out_sharding=norm_out_sharding)
-    y = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(y, deterministic=deterministic)
+    # [NAVI patch C] Skip the output-head Dropout entirely when deterministic. It is a
+    # mathematical no-op (identity) in that case, but instantiating nn.Dropout still
+    # registers/mutates an RngCount on the module. When this head is invoked inside
+    # tunix compute_chunked_logps' jax.lax.scan (chunked-logps memory lever), that
+    # RngCount mutation crosses the scan trace level and raises flax TraceContextError.
+    # Guarding on `deterministic` removes the RNG touch at its source with zero math change.
+    if not deterministic:
+      y = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(y, deterministic=deterministic)
 
     if model_mode in (MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE):
       out_sharding = create_sharding(self.mesh, (None, None, "activation_vocab"))
@@ -864,6 +871,7 @@ class Decoder(nn.Module):
       kv_caches: list[jax.Array] | None = None,
       attention_metadata=None,
       deepstack_visual_embeds: None | list[jnp.ndarray] = None,
+      skip_lm_head: bool = False,  # [NAVI patch C] robust: skip output head INSIDE decoder
   ):
     cfg = self.config
     mesh = self.mesh
@@ -1289,6 +1297,14 @@ class Decoder(nn.Module):
     elif cfg.num_vocab_tiling > 1 and model_mode == MODEL_MODE_TRAIN:
       logits = None
       self.sow("intermediates", "hidden_states", hidden_state)
+
+    # [NAVI patch C] Robust chunked-logps: when the caller (tunix compute_chunked_logps)
+    # asks to skip the LM head, DO NOT run apply_output_head here. Guarantees the
+    # [B, L, vocab] logits matmul never enters the graph (same mechanism as num_vocab_tiling),
+    # rather than relying on XLA DCE to prune an already-emitted 40GB matmul. The caller
+    # re-projects hidden_state chunk-by-chunk via compute_final_logits under scan+remat.
+    elif skip_lm_head:
+      logits = None
 
     else:
       logits = self.apply_output_head(shared_embedding, hidden_state, deterministic, model_mode)

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1565,6 +1565,7 @@ class NNXDecoder(nnx.Module):
       attention_metadata=None,
       deepstack_visual_embeds: None | list[jnp.ndarray] = None,
       multimodal_input: None | MultimodalInput = None,
+      skip_lm_head: bool = False,  # [NAVI patch C] robust: skip output head INSIDE decoder
   ):
     cfg = self.config
     assert decoder_input_tokens.ndim == 2  # [batch, len]
@@ -1915,6 +1916,14 @@ class NNXDecoder(nnx.Module):
     elif cfg.num_vocab_tiling > 1 and model_mode == MODEL_MODE_TRAIN:
       logits = None
       self.sow(nnx.Intermediate, "hidden_states", hidden_state)
+
+    # [NAVI patch C] Robust chunked-logps: when the caller (tunix compute_chunked_logps)
+    # asks to skip the LM head, DO NOT run apply_output_head here. This guarantees the
+    # [B, L, vocab] logits matmul never enters the graph (same mechanism as num_vocab_tiling
+    # above), rather than relying on XLA DCE to prune an already-emitted 40GB matmul. The
+    # caller re-projects hidden_state chunk-by-chunk via compute_final_logits under scan+remat.
+    elif skip_lm_head:
+      logits = None
 
     else:
       logits = self.apply_output_head(shared_embedding, hidden_state, deterministic, model_mode)

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -410,13 +410,24 @@ class Transformer(nnx.Module):
     """A no-op method to allow the model to be used in a lazy context."""
     return
 
-  def logits_from_hidden_states_for_vocab_tiling(self, hidden_states, deterministic, model_mode):
-    """Computes logits from hidden states; used by vocabulary tiling."""
+  def logits_from_hidden_states_for_vocab_tiling(self, hidden_states, deterministic, model_mode, rngs=None):
+    """Computes logits from hidden states; used by vocabulary tiling.
+
+    Optional ``rngs`` (a static jax.Array key) is forwarded to the ToNNX-wrapped
+    decoder so that, when this projection runs inside tunix ``compute_chunked_logps``
+    ``jax.lax.scan``, the ToNNX wrapper takes its ``isinstance(rngs, jax.Array)``
+    branch (``_rngs={"params": rngs}``) instead of calling ``stream()`` on live
+    Rngs — which would mutate an RngCount across the scan trace level and raise
+    ``flax.errors.TraceContextError``. Default ``None`` preserves the exact native
+    (non-chunked) behavior for all existing callers.
+    """
+    extra = {"rngs": rngs} if rngs is not None else {}
     return self.decoder.apply_output_head(
         shared_embedding=self.token_embedder,
         y=hidden_states,
         deterministic=deterministic,
         model_mode=model_mode,
+        **extra,
     )
 
   def init_cache(self, cache_size: int, batch_size: int, dtype=jnp.float32):
@@ -452,6 +463,7 @@ class Transformer(nnx.Module):
       decoder_target_mask: jax.Array | None = None,
       kv_caches: list[jax.Array] | None = None,
       attention_metadata: dict[str, Any] | None = None,
+      skip_lm_head: bool = False,
   ):
     """Applies the Zero-1 FSDP wrapped Transformer model.
 
@@ -548,6 +560,7 @@ class Transformer(nnx.Module):
           kv_caches=kv_caches,
           attention_metadata=attention_metadata,
           deepstack_visual_embeds=deepstack_visual_embeds,
+          skip_lm_head=skip_lm_head,  # [NAVI] robust chunked-logps: skip output head inside decoder
       )  # pytype: disable=wrong-keyword-args
     else:
       logits, hidden_state, kv_caches = self.decoder(
@@ -563,6 +576,7 @@ class Transformer(nnx.Module):
           kv_caches=kv_caches,
           attention_metadata=attention_metadata,
           deepstack_visual_embeds=deepstack_visual_embeds,
+          skip_lm_head=skip_lm_head,  # [NAVI] robust chunked-logps: skip output head inside decoder
           mutable=mutable_collections,  # pyrefly: ignore[unexpected-keyword]
       )  # pytype: disable=wrong-keyword-args
 
@@ -601,5 +615,11 @@ class Transformer(nnx.Module):
     if self.config.attention == "vllm_rpa":
       # In vLLM, logits are computed separately after updating the KV cache.
       return hidden_state, kv_caches
+
+    # [NAVI] Defer LM-head projection to the caller (tunix chunked-logps) to cap the
+    # logits peak at [B, chunk, vocab]. hidden_state is already computed; the caller
+    # re-projects chunk-by-chunk via compute_final_logits under scan+remat.
+    if skip_lm_head:
+      return hidden_state
 
     return logits

--- a/src/maxtext/trainers/post_train/rl/train_rl.py
+++ b/src/maxtext/trainers/post_train/rl/train_rl.py
@@ -468,7 +468,7 @@ def create_rl_components(
           rl_cluster_lib.Role.ROLLOUT: vllm_config.logical_axis_rules,
       },
       rollout_engine=rl_rollout_engine,
-      offload_to_cpu=False,
+      offload_to_cpu=trainer_config.rl_offload_to_cpu,  # [NAVI patch D] whole-model host offload (default False)
       training_config=rl_cluster_lib.RLTrainingConfig(
           actor_optimizer=optimizer,
           eval_every_n_steps=trainer_config.eval_interval,
@@ -476,6 +476,8 @@ def create_rl_components(
           mini_batch_size=trainer_config.batch_size,
           train_micro_batch_size=train_micro_batch_size,
           rollout_micro_batch_size=rollout_micro_batch_size,
+          # [NAVI patch C] chunked logps (default 0 = off)
+          compute_logps_chunk_size=trainer_config.rl_compute_logps_chunk_size,
           metrics_logging_options=metrics_logging_options,
           profiler_options=profiler_options,
           checkpoint_root_directory=checkpoint_dir,


### PR DESCRIPTION
## What

OOM-safe **chunked log-probs** for the RL actor/reference log-prob path, enabling `train_micro_batch_size > 8` on TPU for long-context RL (DAPO/GRPO).

The tunix RL log-prob path (`tunix/rl/common.py` `compute_per_token_logps` / `selective_log_softmax`) materializes a single live `f32[B, S, V]` logits tensor through `jax.nn.logsumexp` — **~112 GB at `S=32768, V=151936`** — which `remat` cannot shrink because it is one array, not a recomputable activation. On 64-chip TPU v7x (qwen3-0.6b) this caps `train_micro_batch_size` at ~8; `micro=16` OOMs at 111 GB HBM temporaries vs ~94.7 GB available (measured).

This PR wires tunix's in-tree `compute_logps_chunk_size` through MaxText so the actor projects the LM head in **sequence chunks** (`jax.lax.scan` + `remat`), capping the live logits at `[B, chunk, V]` — the same mechanism as MaxText's own `vocabulary_tiling`. **All new behavior is DEFAULT-OFF** (byte-identical to stock unless `rl_compute_logps_chunk_size > 0`).

## How

- **configs** (`types.py`, `post_train/rl.yml`): add `rl_compute_logps_chunk_size` (default `0` = off) and `rl_offload_to_cpu` (default `False`) knobs.
- **`integration/tunix/tunix_adapter.py`**: add `skip_lm_head` kwarg to `__call__` + a `compute_final_logits` method (delegates to the existing `logits_from_hidden_states_for_vocab_tiling` output head — no new params/graph).
- **`layers/decoders.py` (Linen) + `layers/nnx_decoders.py` (NNX)**: thread `skip_lm_head` so the decoder sets `logits=None` **before** `apply_output_head` (guaranteed, not reliant on XLA DCE), mirroring the `num_vocab_tiling` path.
- **`models.py` (`Transformer`)**: thread `skip_lm_head` into both `self.decoder(...)` call sites + an optional static `rngs` on `logits_from_hidden_states_for_vocab_tiling`.
- **`trainers/post_train/rl/train_rl.py`**: thread `compute_logps_chunk_size` and `offload_to_cpu` into `ClusterConfig` / `RLTrainingConfig`.

### Two RngCount / TraceContextError fixes (required to run the projection inside `compute_chunked_logps`' `jax.lax.scan`)
1. Skip the no-op output-head `nn.Dropout` when `deterministic=True` (it registers/mutates an RngCount even as a math no-op → illegal across the scan trace level).
2. Pass a **static `jax.Array` rng key** to the ToNNX-wrapped output head so it takes the `isinstance(rngs, jax.Array)` branch (`_rngs={"params": rngs}`) instead of calling `stream()` on live Rngs (which mutates an RngCount across the scan trace level).

## Correctness

`selective_log_softmax` is per-token-independent along the vocab axis, so chunking over the **sequence** axis is mathematically identical. CPU smoke test: **bit-exact** at divisible chunk sizes; `1.9e-6` (f32 `logsumexp` round-off) at non-divisible sizes; `9.5e-7` with temperature.

## Testing / evidence (64-chip TPU v7x, qwen3-0.6b)

- Chunked path runs end-to-end on device; `NAVI_MEM_LOG` shows the actor takes `skip_lm_head` + `chunk_logits`, cutting the actor LM-head logits peak up to **18×** (`[128,512,V]` vs `[128,9216,V]` at 8192 response).
- CPU correctness smoke passes (bit-exact at divisible chunk sizes).
- Default-OFF verified: with `rl_compute_logps_chunk_size=0` the code path and output are byte-identical to stock.

## Honest scope note

This targets the **response-logits** memory term. At production 16384-prompt shapes the binding `train_micro` constraint also includes prompt-length activations + optimizer/grad-accum buffers (`micro=16` full-remat still needs ~112 GB); chunked log-probs alone does not lift that — optimizer host-offload (the `rl_offload_to_cpu` knob here, currently gated in tunix RLCluster) is the complementary lever. This PR delivers the logits-peak reduction, which is a real, self-contained, device-proven win.
