### PR TITLE
fix(nnx): filter transient runtime variables during checkpoint restore

### DIFF
--- a/src/maxtext/utils/layerwise_quantization.py
+++ b/src/maxtext/utils/layerwise_quantization.py
@@ -339,7 +339,12 @@ class LayerwiseQuantization:
 
     # Convert-mode state has both `kernel` (full precision) and `AqtDotGeneral_0.qrhs.frozen`
     # at every quantized DenseGeneral; the serve-mode reader expects only the latter.
-    convert_state = nnx.state(convert_model).to_pure_dict()
+    # We filter out transient runtime state (RngState, Cache, Intermediate, BatchStat) so only persistent weights are saved.
+    convert_state = (
+        nnx.state(convert_model)
+        .filter(lambda path, var: not isinstance(var, (nnx.RngState, nnx.Cache, nnx.Intermediate, nnx.BatchStat)))
+        .to_pure_dict()
+    )
     serve_state = self._strip_kernels_at_quantized_paths(convert_state)
 
     if config.save_quantized_params_path:

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -829,6 +829,7 @@ def verify_and_sync_scan_layers(config):
   return config
 
 
+# pylint: disable=too-many-positional-arguments
 def from_pretrained(
     config,
     mesh=None,
@@ -910,27 +911,21 @@ def from_pretrained(
 
   config = verify_and_sync_scan_layers(config)
 
+  # Compute abstract model and logical-axis specs for downstream checkpoint alignment.
+  # We invoke create_nnx_abstract_model once (a lightweight abstract trace with no physical memory cost)
+  # both to initialize pure NNX sharded models and to cleanly extract the logical PartitionSpec tree
+  # (e.g., axis names like "kv_heads", "mlp_moe") required by _align_checkpoint_to_model_shapes.
+  _create_model, abstract_model = create_nnx_abstract_model(
+      config, mesh, devices, model_mode, rng_key, quant_mode_str=quant_mode_str
+  )
+  _, _abs_state_for_specs = nnx.split(abstract_model)
+  specs = nnx.get_partition_spec(_abs_state_for_specs)
+
   if config.pure_nnx:
-    _create_model, abstract_model = create_nnx_abstract_model(
-        config, mesh, devices, model_mode, rng_key, quant_mode_str=quant_mode_str
-    )
     model = maxtext_utils_nnx.create_nnx_sharded_model(abstract_model, _create_model, mesh=mesh)
     # TODO: print debug_sharding info
   else:
     model = create_nnx_sharded_model_hybrid(config, mesh, devices, model_mode, rng_key)
-
-  # Compute logical-axis specs for downstream checkpoint alignment.
-  # The model-creation helpers above resolve specs internally for sharding, but
-  # the checkpoint-loading branch below needs the logical PartitionSpec tree
-  # (axis names like "kv_heads", "mlp_moe") for repeat/zero-pad dispatch in
-  # _align_checkpoint_to_model_shapes. nnx.eval_shape is cheap (abstract trace).
-  _create_model_for_specs = get_nnx_create_model_fn(
-      config, mesh, devices, model_mode, rng_key, quant_mode_str=quant_mode_str
-  )
-  with nn.logical_axis_rules(config.logical_axis_rules):
-    _abs_model_for_specs = nnx.eval_shape(_create_model_for_specs)
-  _, _abs_state_for_specs = nnx.split(_abs_model_for_specs)
-  specs = nnx.get_partition_spec(_abs_state_for_specs)
 
   sharded_state = nnx.state(model)
 
@@ -999,6 +994,17 @@ def from_pretrained(
 
         return new_target
 
+      # Filter out transient runtime variables and rngs from NNX state before constructing target_for_restore.
+      # Checkpoints on disk only store persistent weight-like parameters. If we pass the full
+      # sharded_state directly, Orbax checks the disk for transient runtime state (like the layer
+      # dropout RNG seeds) and throws a structure mismatch error when it fails to find them.
+      # Note: We cannot use `nnx.split_state(sharded_state, nnx.Param)` to isolate weights because AQT
+      # serve-mode quantized models store their scale factors and integer payloads in custom AQT variable
+      # types (e.g. `qrhs.frozen`), which are NOT subclasses of `nnx.Param`. Negative filtering with
+      # `not isinstance(...)` safely retains all weight-like leaves while excluding transient runtime state.
+      param_state = sharded_state.filter(
+          lambda path, var: not isinstance(var, (nnx.RngState, nnx.Cache, nnx.Intermediate, nnx.BatchStat))
+      )
       is_nnx_checkpoint = True
       if (
           "params" in metadata.item_metadata.tree.keys()
@@ -1008,7 +1014,7 @@ def from_pretrained(
         is_nnx_checkpoint = False
         target_for_restore = jax.tree.map(
             lambda v: v[...],
-            sharded_state,
+            param_state,
             is_leaf=lambda n: isinstance(n, nnx.Variable),
         )
 
@@ -1031,8 +1037,8 @@ def from_pretrained(
         # NNX checkpoint: {'decoder': {'value': ...}}, or NNX-RL with extra 'base' nesting.
         # Restore only nnx.Param — RNG variable shapes may differ between checkpoint and model,
         # and pure-dict checkpoints written by `layerwise_quantization._load_and_quantize_nnx`
-        # don't carry RNG/dropout state at all (they only persist nnx.Param leaves, including
-        # AQT serve-mode `qrhs.frozen` which is a Param subclass).
+        # don't carry RNG/dropout state at all (they only persist weight-like leaves, including
+        # AQT serve-mode `qrhs.frozen` which is not an aqt Variable subclass).
         def _build_value_target(v):
           # `v[...]` (a.k.a. `v.get_value(index=...)`) descends into the inner
           # value with `value[Ellipsis]`. AQT serve-mode `qrhs.frozen` variables
@@ -1060,14 +1066,11 @@ def from_pretrained(
 
         # Keep persisted weight-like leaves: `nnx.Param` plus AQT serve-mode
         # `qrhs.frozen` (a separate `aqt` Variable type, NOT a Param subclass).
-        # Excluded: `nnx.RngState` (regenerated per load, shapes can drift) and
-        # `nnx.Cache` (PREFILL/AR scratch, not persisted). Pure-dict checkpoints
-        # written by `layerwise_quantization._load_and_quantize_nnx` carry both
-        # Param kernels and `aqt`-typed `qrhs.frozen` quantized payloads.
-        if hasattr(sharded_state, "filter"):
-          param_state = sharded_state.filter(lambda path, var: not isinstance(var, (nnx.RngState, nnx.Cache)))
-        else:
-          param_state = sharded_state
+        # Excluded: `nnx.RngState` (regenerated per load, shapes can drift),
+        # `nnx.Cache` (PREFILL/AR scratch, not persisted), `nnx.Intermediate`
+        # (transient forward-pass activations), and `nnx.BatchStat` (runtime statistics).
+        # Pure-dict checkpoints written by `layerwise_quantization._load_and_quantize_nnx`
+        # carry both Param kernels and `aqt`-typed `qrhs.frozen` quantized payloads.
         target_for_restore = jax.tree.map(
             _build_value_target,
             param_state,
@@ -1083,10 +1086,12 @@ def from_pretrained(
         restore_args = {"base": restore_args} if has_base_key else restore_args
 
       # Free memory used by initial sharded_state before restore, to make room for the incoming checkpoint arrays.
-      # Skip nnx.Cache variables — they hold runtime state (e.g. GDN conv/recurrent state) that is
-      # not present in the checkpoint and must remain valid after the restore.
+      # Skip transient runtime variables (RngState, Cache, Intermediate, BatchStat) — they hold runtime state
+      # that is not present in the checkpoint and must remain valid after the restore.
       def _free_device_memory(node):
-        if isinstance(node, nnx.Variable) and not isinstance(node, (nnx.RngState, nnx.Cache)):
+        if isinstance(node, nnx.Variable) and not isinstance(
+            node, (nnx.RngState, nnx.Cache, nnx.Intermediate, nnx.BatchStat)
+        ):
           inner = node.get_value() if hasattr(node, "get_value") else node[...]
           # AQT serve-mode `qrhs.frozen` wraps a QTensor (composite pytree) rather
           # than a single jax.Array. Walking via tree_leaves frees the qvalue/scale


### PR DESCRIPTION
# Description

Error: 18 of 18 model parameter paths were not found in the checkpoint

Changes:

- model_creation_utils.from_pretrained: From sharded_state (the checkpoint restore target) exclude transient runtime variables (nnx.RngState, nnx.Cache, nnx.Intermediate, and nnx.BatchStat). This prevents Orbax from checking checkpoint against the sharded_state for runtime RNG/cache/intermediate leaves when restoring checkpoints
- model_creation_utils.from_pretrained: Deduplicate abstract model creation and PartitionSpec extraction by computing specs once and reusing abstract_model.
- layerwise_quantization._load_and_quantize_nnx: Apply identical negative exclusion filtering before converting convert_model state to pure dict, ensuring transient runtime state is excluded from serve-mode AQT checkpoints.

FIXES: b/532182476


# Tests
decode_tests.py pass:

```
mkdir -p ~/my_tpu_logs && TPU_LOG_DIR=~/my_tpu_logs GLOG_log_dir=~/my_tpu_logs PYTHONPATH=. GLOG_logtostderr=1 python -m pytest tests/integration/decode_tests.py -s -o log_cli=true -o log_cli_level=INFO | tee log
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
