### PR TITLE
draft

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -1057,7 +1057,7 @@ xprof_e2e_enable_fw_power_level_event: false
 xprof_e2e_enable_fw_thermal_event: false
 profile_power_events: false # Set to true to enable TPU-specific power/thermal profiling events. Defaults to false to avoid breaking GPU xplane tracing.
 
-log_config: true # Prints the config (after defaults have been set by pyconfig logic)
+log_config: false # Prints the config (after defaults have been set by pyconfig logic)
 debug_sharding: false # Prints model weights sharding info
 
 # Checkpoint Structured logging

--- a/src/maxtext/kernels/megablox/ops.py
+++ b/src/maxtext/kernels/megablox/ops.py
@@ -194,6 +194,7 @@ def _gmm_fwd(
         lhs=lhs,
         rhs=rhs,
         group_sizes=group_sizes,
+        # group_offset=group_offset,
         tile_info=gmm_v2.TileSizes(
             tile_m=tiling[0],
             tile_k=tiling[1],
@@ -320,6 +321,7 @@ def _gmm_bwd(
           lhs=dlhs_dout,
           rhs=dlhs_rhs.swapaxes(1, 2),  # requires rhs to be [g, n, k]
           group_sizes=group_sizes,
+          # group_offset=group_offset,
           tile_info=gmm_v2.TileSizes(
               tile_m=tiling[3],
               tile_k=tiling[4],

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -47,6 +47,29 @@ from maxtext.utils.sharding import logical_to_mesh_axes, remove_expert_from_part
 import numpy as np
 import qwix
 from qwix.contrib.sparsity import sparsity_module
+
+
+# ---- TEMP DEBUG: NaN probe (remove after debugging) ----
+def _nan_probe(x, tag):
+  """Identity that prints NaN counts of value (fwd) and cotangent (bwd)."""
+
+  @jax.custom_vjp
+  def probe(x):
+    return x
+
+  def probe_fwd(x):
+    jax.debug.print("[NANPROBE fwd " + tag + "] nans={n} shape=" + str(x.shape), n=jnp.sum(jnp.isnan(x)))
+    return x, None
+
+  def probe_bwd(_, g):
+    jax.debug.print("[NANPROBE bwd " + tag + "] nans={n} shape=" + str(g.shape), n=jnp.sum(jnp.isnan(g)))
+    return (g,)
+
+  probe.defvjp(probe_fwd, probe_bwd)
+  return probe(x)
+
+
+# ---- END TEMP DEBUG ----
 import qwix.pallas as qpl
 import tokamax
 
@@ -1788,13 +1811,16 @@ class RoutedMoE(nnx.Module):
         x, logits, pre_bias_logits, w0, w1, wo, w0_bias, w1_bias, wo_bias, sharded_input_ids, rngs
     ):
       batch_size, sequence_length, _ = x.shape
+      x = _nan_probe(x, "input")
       x, routing, route_metadata = route(x, logits, pre_bias_logits, rngs, input_ids=sharded_input_ids)
+      x = _nan_probe(x, "after_route(sorted_inputs)")
 
       if self.config.mlp_bias:
         w0_bias, w1_bias, wo_bias = self.transform_bias(routing.selected_experts, w0_bias, w1_bias, wo_bias)
 
       gmm_fn = get_gmm_for_local_experts(x, routing, route_metadata)
       intermediate_layer = gmm_up(x, w0, w1, w0_bias, w1_bias, gmm_fn, weight_gather)
+      intermediate_layer = _nan_probe(intermediate_layer, "after_gmm_up")
 
       wo_gather_axes, wo_tile_size = get_wo_gmm_params()
       intermediate_output = gmm_fn(
@@ -1803,6 +1829,7 @@ class RoutedMoE(nnx.Module):
           tiling=wo_tile_size,
           weight_gather_axes=wo_gather_axes,
       )
+      intermediate_output = _nan_probe(intermediate_output, "after_wo_gmm")
       if self.get_tensor_parallelism_size() > 1:
         intermediate_output = jax.lax.psum_scatter(
             intermediate_output, self._tensor_parallelism_name, scatter_dimension=1, tiled=True
@@ -1822,12 +1849,14 @@ class RoutedMoE(nnx.Module):
             use_custom_sort_vjp=self.config.use_custom_sort_vjp,
             group_sizes=routing.group_sizes,
         )
+        output = _nan_probe(output, "after_unpermute")
 
         # Sum up the partial outputs across the expert shards.
         output = jnp.reshape(
             output, (-1, sequence_length, self.moe_expert_input_dim // self.get_tensor_parallelism_size())
         )
         output = jax.lax.psum_scatter(output, self._expert_parallelism_name, scatter_dimension=0, tiled=True)
+        output = _nan_probe(output, "after_psum_scatter")
         return output, routing.lb_loss, routing.bias_updates
 
       if self.get_expert_parallelism_size() > 1:

--- a/test.py
+++ b/test.py
@@ -1,0 +1,186 @@
+import jax
+import jax.numpy as jnp
+from maxtext.configs import pyconfig
+from maxtext.layers import moe
+from maxtext.layers.initializers import nd_dense_init
+from maxtext.utils import maxtext_utils
+from jax.sharding import Mesh
+from flax.linen import partitioning as nn_partitioning
+from tests.utils.test_helpers import get_test_config_path
+
+
+def _build_cfg(use_ragged_sort):
+  effective_buffer_factor = 1.5 if use_ragged_sort else -1.0
+  return pyconfig.initialize(
+      [None, get_test_config_path()],
+      run_name=f"debug_nan_{use_ragged_sort}",
+      enable_checkpointing=False,
+      model_name="mixtral-8x7b",
+      override_model_config=True,
+      base_emb_dim=2048,
+      base_mlp_dim=256,
+      base_moe_mlp_dim=256,
+      dtype="bfloat16",
+      megablox=True,
+      use_tokamax_gmm=False,
+      use_gmm_v2=False,
+      sparse_matmul=True,
+      per_device_batch_size=4,
+      ici_expert_parallelism=2,
+      use_ring_of_experts=True,
+      max_target_length=128,
+      use_ragged_sort=use_ragged_sort,
+      ragged_buffer_factor=effective_buffer_factor,
+      log_config=False,
+  )
+
+
+def _build_model(cfg, mesh):
+  return moe.get_routed_moe(
+      name="MoeBlock",
+      config=cfg,
+      num_experts=cfg.num_experts,
+      num_experts_per_tok=cfg.num_experts_per_tok,
+      mesh=mesh,
+      kernel_init=nd_dense_init(1.0, "fan_in", "truncated_normal"),
+      kernel_axes=("embed", "mlp"),
+      intermediate_dim=cfg.mlp_dim,
+      dtype=cfg.dtype,
+  )
+
+
+def get_loss_and_grads(model, variables, x):
+  # Forward-only inspection with intermediates captured
+  (out, lb_loss, _), mutables = model.apply(variables, x, capture_intermediates=True, mutable=["intermediates"])
+  intermediates = mutables.get("intermediates", {})
+
+  has_nan_fwd = jnp.any(jnp.isnan(out))
+  max_fwd = jnp.max(jnp.abs(out))
+  has_nan_lb = jnp.any(jnp.isnan(lb_loss)) if lb_loss is not None else False
+
+  # Loss and Grad calculation
+  def loss_fn(params, x_in):
+    out, lb_loss, _ = model.apply({"params": params}, x_in)
+    return jnp.mean(out.astype(jnp.float32) ** 2)
+
+  loss, (params_grad, x_grad) = jax.value_and_grad(loss_fn, argnums=(0, 1))(variables["params"], x)
+  return loss, params_grad, x_grad, has_nan_fwd, max_fwd, has_nan_lb, intermediates
+
+
+# PyTree helpers
+def tree_has_nan(tree):
+  flat_tree, _ = jax.tree_util.tree_flatten(tree)
+  return any(jnp.any(jnp.isnan(leaf)) for leaf in flat_tree)
+
+
+def compare_pytrees_detailed(tree1, tree2, rtol, atol, tree_name="Tree"):
+  # Flatten with paths so we can print exactly which node/layer fails
+  flat1, _ = jax.tree_util.tree_flatten_with_path(tree1)
+  flat2, _ = jax.tree_util.tree_flatten_with_path(tree2)
+
+  if len(flat1) != len(flat2):
+    print(f"  -> {tree_name} structure mismatch! Lengths: {len(flat1)} vs {len(flat2)}")
+    return False, 0.0
+
+  all_match = True
+  max_diff = 0.0
+
+  for (path1, t1), (path2, t2) in zip(flat1, flat2):
+    path_str = jax.tree_util.keystr(path1)
+
+    if t1.shape != t2.shape:
+      print(f"  -> Shape mismatch at {path_str}: {t1.shape} vs {t2.shape}")
+      all_match = False
+      continue
+
+    match = jnp.allclose(t1, t2, rtol=rtol, atol=atol)
+    diff = jnp.max(jnp.abs(t1 - t2))
+
+    if not match:
+      print(f"  -> Mismatch at {path_str} | Max abs diff: {diff}")
+
+    all_match = all_match and match
+    max_diff = jnp.maximum(max_diff, diff)
+
+  return bool(all_match), float(max_diff)
+
+
+rng = jax.random.PRNGKey(2345)
+rng_model, rng_hidden_states = jax.random.split(rng)
+device_count = jax.device_count()
+
+# Build configs
+cfg_rs = _build_cfg(use_ragged_sort=True)
+cfg_nors = _build_cfg(use_ragged_sort=False)
+
+# Build shared inputs
+hidden_states = jax.random.uniform(
+    rng_hidden_states,
+    (int(cfg_rs.per_device_batch_size) * device_count, cfg_rs.max_target_length, cfg_rs.base_emb_dim),
+    dtype=cfg_rs.dtype,
+)
+
+# Setup mesh
+devices_array = maxtext_utils.create_device_mesh(cfg_rs)
+mesh = Mesh(devices_array, cfg_rs.mesh_axes)
+
+model_rs = _build_model(cfg_rs, mesh)
+model_nors = _build_model(cfg_nors, mesh)
+
+jitted_get_loss_and_grads = jax.jit(get_loss_and_grads, static_argnums=(0,))
+
+with jax.set_mesh(mesh), nn_partitioning.axis_rules(cfg_rs.logical_axis_rules):
+  variables_rs = model_rs.init({"params": rng_model, "dropout": rng_model}, hidden_states)
+  variables_nors = model_nors.init({"params": rng_model, "dropout": rng_model}, hidden_states)
+
+  # Run for ragged_sort = True
+  print("\n--- Running with ragged_sort=True ---")
+  loss_rs, params_grad_rs, x_grad_rs, nan_fwd_rs, max_fwd_rs, nan_lb_rs, int_rs = jitted_get_loss_and_grads(
+      model_rs, variables_rs, hidden_states
+  )
+  print(f"Forward output has NaN: {nan_fwd_rs}")
+  print(f"Forward output max: {max_fwd_rs}")
+  print(f"Loss (no lb): {loss_rs}")
+  print(f"x_grad has NaN: {jnp.any(jnp.isnan(x_grad_rs))}")
+  print(f"params_grad has NaN: {tree_has_nan(params_grad_rs)}")
+
+  # Run for ragged_sort = False
+  print("\n--- Running with ragged_sort=False ---")
+  loss_nors, params_grad_nors, x_grad_nors, nan_fwd_nors, max_fwd_nors, nan_lb_nors, int_nors = jitted_get_loss_and_grads(
+      model_nors, variables_nors, hidden_states
+  )
+  print(f"Forward output has NaN: {nan_fwd_nors}")
+  print(f"Forward output max: {max_fwd_nors}")
+  print(f"Loss (no lb): {loss_nors}")
+  print(f"x_grad has NaN: {jnp.any(jnp.isnan(x_grad_nors))}")
+  print(f"params_grad has NaN: {tree_has_nan(params_grad_nors)}")
+
+  print("\n--- Side-by-Side Comparison ---")
+  rtol = 1e-3
+  atol = 1e-4
+
+  # Intermediates comparison
+  print("Checking intermediate activations...")
+  int_match, max_int_diff = compare_pytrees_detailed(int_rs, int_nors, rtol, atol, tree_name="Intermediates")
+  print(f"Intermediates match: {int_match} (max abs diff: {max_int_diff})\n")
+
+  # Loss comparison
+  loss_diff = jnp.abs(loss_rs - loss_nors)
+  loss_match = jnp.allclose(loss_rs, loss_nors, rtol=rtol, atol=atol)
+  print(f"Losses match: {loss_match} (abs diff: {loss_diff})\n")
+
+  # x_grad comparison
+  x_grad_match = jnp.allclose(x_grad_rs, x_grad_nors, rtol=rtol, atol=atol)
+  max_x_grad_diff = jnp.max(jnp.abs(x_grad_rs - x_grad_nors))
+  print(f"x_grad match: {x_grad_match} (max abs diff: {max_x_grad_diff})")
+  if not x_grad_match:
+    diff_mask = ~jnp.isclose(x_grad_rs, x_grad_nors, rtol=rtol, atol=atol)
+    mismatch_count = jnp.sum(diff_mask)
+    print(f"  -> Mismatched x_grad elements: {mismatch_count} / {x_grad_rs.size}\n")
+
+  # params_grad comparison
+  print("Checking param gradients...")
+  params_match, max_params_diff = compare_pytrees_detailed(
+      params_grad_rs, params_grad_nors, rtol, atol, tree_name="Param Gradients"
+  )
+  print(f"params_grad match: {params_match} (max abs diff: {max_params_diff})")

--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -636,6 +636,8 @@ class RoutedMoeTest(unittest.TestCase):
           use_ring_of_experts=use_ring_of_experts,
           max_target_length=128,
           use_ragged_sort=use_ragged_sort,
+          use_tokamax_gmm=False,
+          use_gmm_v2=False,
           ragged_buffer_factor=effective_buffer_factor,
           ragged_gather_fallback=ragged_gather_fallback,
           ragged_gather_reduce_fallback=ragged_gather_reduce_fallback,


### PR DESCRIPTION
# Description

Test output: 
```
--- Running with ragged_sort=True ---
[NANPROBE fwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd after_route(sorted_inputs)] nans=0 shape=(1536, 2048)
[NANPROBE fwd after_route(sorted_inputs)] nans=0 shape=(1536, 2048)
[NANPROBE fwd after_route(sorted_inputs)] nans=0 shape=(1536, 2048)
[NANPROBE fwd after_route(sorted_inputs)] nans=0 shape=(1536, 2048)
[NANPROBE fwd after_gmm_up] nans=0 shape=(1536, 256)
[NANPROBE fwd after_gmm_up] nans=0 shape=(1536, 256)
[NANPROBE fwd after_gmm_up] nans=0 shape=(1536, 256)
[NANPROBE fwd after_wo_gmm] nans=0 shape=(1536, 2048)
[NANPROBE fwd after_gmm_up] nans=0 shape=(1536, 256)
[NANPROBE fwd after_wo_gmm] nans=0 shape=(1536, 2048)
[NANPROBE fwd after_wo_gmm] nans=0 shape=(1536, 2048)
[NANPROBE fwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE fwd after_wo_gmm] nans=0 shape=(1536, 2048)
[NANPROBE fwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE fwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE fwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE fwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE bwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE bwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_wo_gmm] nans=5962 shape=(1536, 2048)
[NANPROBE bwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE bwd after_wo_gmm] nans=0 shape=(1536, 2048)
[NANPROBE bwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE bwd after_gmm_up] nans=14 shape=(1536, 256)
[NANPROBE bwd after_gmm_up] nans=0 shape=(1536, 256)
[NANPROBE bwd after_wo_gmm] nans=0 shape=(1536, 2048)
[NANPROBE bwd after_wo_gmm] nans=3980 shape=(1536, 2048)
[NANPROBE bwd after_route(sorted_inputs)] nans=0 shape=(1536, 2048)
[NANPROBE bwd after_route(sorted_inputs)] nans=0 shape=(1536, 2048)
[NANPROBE bwd after_gmm_up] nans=0 shape=(1536, 256)
[NANPROBE bwd after_gmm_up] nans=4105 shape=(1536, 256)
[NANPROBE bwd after_route(sorted_inputs)] nans=0 shape=(1536, 2048)
[NANPROBE bwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_route(sorted_inputs)] nans=0 shape=(1536, 2048)
[NANPROBE bwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd input] nans=0 shape=(4, 128, 2048)
Forward output has NaN: False
Forward output max: 0.0917969
Loss (no lb): 0.00017628437490202487
x_grad has NaN: False
params_grad has NaN: False

--- Running with ragged_sort=False ---
[NANPROBE fwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd after_route(sorted_inputs)] nans=0 shape=(2048, 2048)
[NANPROBE fwd after_route(sorted_inputs)] nans=0 shape=(2048, 2048)
[NANPROBE fwd after_route(sorted_inputs)] nans=0 shape=(2048, 2048)
[NANPROBE fwd after_route(sorted_inputs)] nans=0 shape=(2048, 2048)
[NANPROBE fwd after_gmm_up] nans=0 shape=(2048, 256)
[NANPROBE fwd after_gmm_up] nans=0 shape=(2048, 256)
[NANPROBE fwd after_gmm_up] nans=0 shape=(2048, 256)
[NANPROBE fwd after_wo_gmm] nans=0 shape=(2048, 2048)
[NANPROBE fwd after_gmm_up] nans=0 shape=(2048, 256)
[NANPROBE fwd after_wo_gmm] nans=0 shape=(2048, 2048)
[NANPROBE fwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE fwd after_wo_gmm] nans=0 shape=(2048, 2048)
[NANPROBE fwd after_wo_gmm] nans=0 shape=(2048, 2048)
[NANPROBE fwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE fwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE fwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE fwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE fwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_psum_scatter] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE bwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE bwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE bwd after_wo_gmm] nans=0 shape=(2048, 2048)
[NANPROBE bwd after_unpermute] nans=0 shape=(4, 128, 4096)
[NANPROBE bwd after_wo_gmm] nans=0 shape=(2048, 2048)
[NANPROBE bwd after_wo_gmm] nans=0 shape=(2048, 2048)
[NANPROBE bwd after_gmm_up] nans=0 shape=(2048, 256)
[NANPROBE bwd after_wo_gmm] nans=0 shape=(2048, 2048)
[NANPROBE bwd after_gmm_up] nans=0 shape=(2048, 256)
[NANPROBE bwd after_route(sorted_inputs)] nans=0 shape=(2048, 2048)
[NANPROBE bwd after_gmm_up] nans=0 shape=(2048, 256)
[NANPROBE bwd after_route(sorted_inputs)] nans=0 shape=(2048, 2048)
[NANPROBE bwd after_gmm_up] nans=0 shape=(2048, 256)
[NANPROBE bwd after_route(sorted_inputs)] nans=0 shape=(2048, 2048)
[NANPROBE bwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd after_route(sorted_inputs)] nans=0 shape=(2048, 2048)
[NANPROBE bwd input] nans=0 shape=(4, 128, 2048)
[NANPROBE bwd input] nans=0 shape=(4, 128, 2048)
Forward output has NaN: False
Forward output max: 0.0952148
Loss (no lb): 0.0002588563074823469
x_grad has NaN: False
params_grad has NaN: False

--- Side-by-Side Comparison ---
Checking intermediate activations...
  -> Mismatch at ['__call__'][0][0] | Max abs diff: 0.112793
Intermediates match: False (max abs diff: 0.11279296875)

Losses match: True (abs diff: 8.257193258032203e-05)

x_grad match: True (max abs diff: 1.69966e-08)
Checking param gradients...
params_grad match: True (max abs diff: 1.9550323486328125e-05)
```

moe_test output:
```
FAILED tests/unit/moe_test.py::RoutedMoeTest::test_ragged_sort_loss_and_grad_ring_of_experts_ragged_buffer - AssertionError: Array(False, dtype=bool) is not true : Hidden-state gradient mismatch: max abs diff=0.12060546875
```

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
