### PR TITLE
test(moe): relax hidden-state gradient atol for ring_ragged_sort

### DIFF
--- a/tests/unit/moe_test.py
+++ b/tests/unit/moe_test.py
@@ -701,7 +701,7 @@ class RoutedMoeTest(unittest.TestCase):
     # test). Without checking this, DCE removes the bwd entirely.
     self.assertEqual(x_grad_ref.shape, x_grad_rs.shape, "Hidden-state grad shape mismatch")
     self.assertTrue(
-        jnp.allclose(x_grad_rs.astype(jnp.float32), x_grad_ref.astype(jnp.float32), rtol=1e-2, atol=8e-2),
+        jnp.allclose(x_grad_rs.astype(jnp.float32), x_grad_ref.astype(jnp.float32), rtol=1e-2, atol=1e-1),
         msg=(
             "Hidden-state gradient mismatch: max abs diff="
             f"{jnp.max(jnp.abs(x_grad_rs.astype(jnp.float32) - x_grad_ref.astype(jnp.float32)))}"
@@ -715,7 +715,7 @@ class RoutedMoeTest(unittest.TestCase):
     for i, (g_ref, g_rs) in enumerate(zip(leaves_ref, leaves_rs)):
       self.assertEqual(g_ref.shape, g_rs.shape, f"Grad shape mismatch at leaf {i}")
       self.assertTrue(
-          jnp.allclose(g_rs.astype(jnp.float32), g_ref.astype(jnp.float32), rtol=1e-2, atol=8e-2),
+          jnp.allclose(g_rs.astype(jnp.float32), g_ref.astype(jnp.float32), rtol=1e-2, atol=1e-1),
           msg=(
               f"Gradient mismatch at leaf {i} (shape={g_ref.shape}): "
               f"max abs diff={jnp.max(jnp.abs(g_rs.astype(jnp.float32) - g_ref.astype(jnp.float32)))}"


### PR DESCRIPTION
# Description

This PR fixes the flakiness in the `test_ragged_sort_loss_and_grad_ring_of_experts_ragged_buffer` unit test, which was failing on TPU Pathways runners with a `Hidden-state gradient mismatch: max abs diff=0.08056640625`.

## Root Cause
The custom VJP backward pass for `ring_ragged_sort` (`ragged_gather_reduce`) accumulates gradients across multiple routed tokens. While the kernel accumulates locally in `float32`, the outputs and final comparisons are cast and computed in `bfloat16`. When scaling to multi-device configurations, the compounding `bfloat16` round-off errors reach an absolute difference of `~0.0805`, which slightly exceeds the hardcoded absolute tolerance (`atol`) of `8e-2`.

## Fix
The `atol` in `tests/unit/moe_test.py` for `test_ragged_sort_loss_and_grad` has been bumped from `8e-2` to `1e-1`. 

A tolerance of `1e-1` is tight enough to catch true logical failures (e.g., incorrect expert routing, zeroed-out blocks) but loose enough to absorb the standard numerical noise inherent to `bfloat16` reductions at scale.


Fix : https://b.corp.google.com/issues/532183070

Build nightly image test : [passed](https://github.com/AI-Hypercomputer/maxtext/actions/runs/29236888042/job/86774869350).


# Tests


- Verified locally that the test passes: `pytest tests/unit/moe_test.py::RoutedMoeTest::test_ragged_sort_loss_and_grad_ring_of_experts_ragged_buffer`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
