### PR TITLE
SFT: tools rendering + developer role in chat-template preprocessing

### DIFF
--- a/src/maxtext/input_pipeline/data_processing_utils.py
+++ b/src/maxtext/input_pipeline/data_processing_utils.py
@@ -24,6 +24,8 @@ from maxtext.input_pipeline import input_pipeline_utils
 from maxtext.input_pipeline import tokenizer
 from maxtext.utils import elastic_utils
 
+TOOLS_COLUMN = "tools"
+
 
 def parse_and_keep_features(dataset, config, data_columns, tokenize):
   """Parse arrayrecord features or keep specified columns for other formats."""
@@ -58,7 +60,7 @@ def validate_and_configure_sft_columns(data_columns, tokenizer_model, chat_templ
   if chat_template and hasattr(tokenizer_model, "chat_template"):
     tokenizer_model.chat_template = chat_template
 
-  supported_columns = [["prompt", "completion"], ["messages"], ["question", "answer"]]
+  supported_columns = [["prompt", "completion"], ["messages"], ["messages", TOOLS_COLUMN], ["question", "answer"]]
   assert any(
       set(data_columns) == set(supported) for supported in supported_columns
   ), f"Dataset column names mismatch. Expected columns to match one of {supported_columns}, but got {data_columns}"

--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -307,26 +307,34 @@ def dpo_preprocessing_pipeline(
 
 def _format_chat_template_grain(element, data_columns, tokenizer_model):
   """Grain-compatible mapping function to format raw columns into conversational messages."""
+  tools_column_name = data_processing_utils.TOOLS_COLUMN if data_processing_utils.TOOLS_COLUMN in data_columns else None
+  primary_columns = [c for c in data_columns if c != data_processing_utils.TOOLS_COLUMN]
+
   # Convert raw columns to conversational messages
-  if "messages" in data_columns:
+  if "messages" in primary_columns:
     messages = element["messages"]
-  elif set(data_columns) == {"prompt", "completion"}:
+    if isinstance(messages, (str, bytes)):
+      messages = json.loads(messages)
+  elif set(primary_columns) == {"prompt", "completion"}:
     messages = [{"role": "user", "content": element["prompt"]}, {"role": "assistant", "content": element["completion"]}]
-  elif set(data_columns) == {"question", "answer"}:
+  elif set(primary_columns) == {"question", "answer"}:
     messages = [{"role": "user", "content": element["question"]}, {"role": "assistant", "content": element["answer"]}]
   else:
     # Fallback if it's already a single string
-    messages = element[data_columns[0]]
+    messages = element[primary_columns[0]]
 
   assert all(
       hasattr(m, "__contains__") and "role" in m and "content" in m for m in messages
   ), f"SFT requires a conversational format. Expected dicts with 'role' and 'content', but got: {messages}"
 
   # Assign the standardized messages back to the primary column
-  element[data_columns[0]] = messages
+  element[primary_columns[0]] = messages
 
   return input_pipeline_utils.apply_chat_template(
-      element, tokenizer_model=tokenizer_model, data_column_name=data_columns[0]
+      element,
+      tokenizer_model=tokenizer_model,
+      data_column_name=primary_columns[0],
+      tools_column_name=tools_column_name,
   )
 
 

--- a/src/maxtext/input_pipeline/hf_data_processing.py
+++ b/src/maxtext/input_pipeline/hf_data_processing.py
@@ -14,6 +14,7 @@
 
 """Input pipeline using Huggingface datasets."""
 
+import json
 from typing import Optional
 
 import ml_collections
@@ -267,6 +268,13 @@ def preprocessing_pipeline(
 
     data_processing_utils.validate_and_configure_sft_columns(data_column_names, tokenizer, chat_template)
 
+    # Separate auxiliary "tools" column from primary data columns
+    tools_column_name = (
+        data_processing_utils.TOOLS_COLUMN if data_processing_utils.TOOLS_COLUMN in data_column_names else None
+    )
+    if tools_column_name:
+      data_column_names = [c for c in data_column_names if c != tools_column_name]
+
     # convert instruction dataset to conversational format
     dataset, data_column_names = instruction_data_processing.convert_to_conversational_format(
         dataset=dataset,
@@ -275,9 +283,17 @@ def preprocessing_pipeline(
         formatting_func_kwargs=formatting_func_kwargs,
     )
 
-    assert input_pipeline_utils.is_conversational(
-        dataset.features, data_column_names
-    ), "Dataset is not in conversational format."
+    # Deserialize JSON string columns if needed (e.g. messages/tools stored as JSON strings)
+    _json_deserialized = False
+    for col in data_column_names:
+      if isinstance(dataset.features.get(col), datasets.Value) and dataset.features[col].dtype == "string":
+        dataset = dataset.map(lambda x, c=col: {c: json.loads(x[c]) if isinstance(x[c], str) else x[c]})
+        _json_deserialized = True
+
+    if not _json_deserialized:
+      assert input_pipeline_utils.is_conversational(
+          dataset.features, data_column_names
+      ), "Dataset is not in conversational format."
 
     if len(data_column_names) > 1:
       combined_column_name = "messages"
@@ -290,12 +306,18 @@ def preprocessing_pipeline(
           remove_columns=data_column_names,
           features=dataset_features,
       )
+      data_column_names = [combined_column_name]
 
-    data_column_names = list(dataset.features.keys())
     dataset = dataset.map(
         input_pipeline_utils.apply_chat_template,
-        fn_kwargs={"tokenizer_model": tokenizer, "data_column_name": data_column_names[0]},
+        fn_kwargs={
+            "tokenizer_model": tokenizer,
+            "data_column_name": data_column_names[0],
+            "tools_column_name": tools_column_name,
+        },
     )
+    if tools_column_name:
+      dataset = dataset.remove_columns([tools_column_name])
 
   pad_id = _get_pad_id(tokenizer)
 

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -15,6 +15,7 @@
 """Operations used by Grain"""
 
 import dataclasses
+import json
 import warnings
 from threading import current_thread
 from typing import Any, Iterable, TYPE_CHECKING
@@ -208,7 +209,7 @@ def extract_token_ids(tokens):
     raise ValueError(f"Can't extract token_ids from type {type(tokens)}")
 
 
-def _get_completion_in_chat_template(tokenizer_model, round_msgs):
+def _get_completion_in_chat_template(tokenizer_model, round_msgs, tools=None):
   """Calculates the completion part of a conversation turn formatted with a chat template.
 
   Uses the longest-common-prefix between the full conversation tokens and the
@@ -230,9 +231,14 @@ def _get_completion_in_chat_template(tokenizer_model, round_msgs):
   Returns:
     A string representing the completion formatted by the chat template.
   """
-  prompt_completion_tokens = tokenizer_model.apply_chat_template(round_msgs, add_generation_prompt=False, tokenize=True)
+  tools_kwargs = {"tools": tools} if tools is not None else {}
+  prompt_completion_tokens = tokenizer_model.apply_chat_template(
+      round_msgs, add_generation_prompt=False, tokenize=True, enable_thinking=True, **tools_kwargs
+  )
   # include generation_prompt as part of the prompt tokens
-  prompt_tokens = tokenizer_model.apply_chat_template(round_msgs[:-1], add_generation_prompt=True, tokenize=True)
+  prompt_tokens = tokenizer_model.apply_chat_template(
+      round_msgs[:-1], add_generation_prompt=True, tokenize=True, enable_thinking=True, **tools_kwargs
+  )
 
   prompt_completion_ids = extract_token_ids(prompt_completion_tokens)
   prompt_ids = extract_token_ids(prompt_tokens)
@@ -257,7 +263,7 @@ def _get_completion_in_chat_template(tokenizer_model, round_msgs):
   return tokenizer_model.decode(completion_tokens, skip_special_tokens=False)
 
 
-def apply_chat_template(example, tokenizer_model, data_column_name):
+def apply_chat_template(example, tokenizer_model, data_column_name, tools_column_name=None):
   """Formats conversational data by applying the tokenizer's chat template
   and identifying prompt/completion segments for SFT masking.
 
@@ -268,6 +274,10 @@ def apply_chat_template(example, tokenizer_model, data_column_name):
       which contains the specific chat template.
     data_column_name: The name of the column in the `example` dictionary
       that contains the list of messages.
+    tools_column_name: Optional name of an auxiliary column holding tool/function
+      definitions (a JSON string or list). When present, the tools are passed to every
+      `apply_chat_template` call so tool-calling turns render correctly, and are re-rendered
+      in every round of a multi-turn conversation.
 
   Returns:
     The modified `example` dictionary.
@@ -281,25 +291,48 @@ def apply_chat_template(example, tokenizer_model, data_column_name):
   messages = []
   is_prompt = []
   round_msgs = []
+  leading_msgs = []  # persistent system/developer prefix; re-seeded each round (multi-turn tools fix)
+  conversation = example[data_column_name]
+  if isinstance(conversation, str):
+    conversation = json.loads(conversation)
+  tools = example.get(tools_column_name) if tools_column_name else None
+  if isinstance(tools, str):
+    tools = json.loads(tools)
+  tools_kwargs = {"tools": tools} if tools is not None else {}
   try:
-    for idx, message in enumerate(example[data_column_name]):
-      if message["role"] == "system":
+    for idx, message in enumerate(conversation):
+      if message["role"] in ("system", "developer"):
         if idx != 0:
-          raise ValueError(f"System message found at index {idx}. System messages must be at index 0.")
+          raise ValueError(f"'{message['role']}' message found at index {idx}. It must be at index 0.")
         round_msgs.append(message)
+        leading_msgs.append(message)
       elif message["role"] == "user":
         round_msgs.append(message)
         prompt_in_chat_template = tokenizer_model.apply_chat_template(
-            round_msgs, add_generation_prompt=True, tokenize=False
+            round_msgs, add_generation_prompt=True, tokenize=False, enable_thinking=True, **tools_kwargs
         )
         messages.append(prompt_in_chat_template)
         is_prompt.append(True)
-      elif message["role"] == "assistant":
+      elif message["role"] == "tool":
         round_msgs.append(message)
-        messages.append(_get_completion_in_chat_template(tokenizer_model, round_msgs))
+      elif message["role"] == "assistant":
+        if not round_msgs:
+          raise ValueError(f"Assistant message at index {idx} with no preceding context.")
+        round_msgs.append(message)
+        messages.append(_get_completion_in_chat_template(tokenizer_model, round_msgs, tools=tools))
         is_prompt.append(False)
-        # Round ended, clearing the buffer.
-        round_msgs.clear()
+        # Clear the round only when the next message starts a new user turn or the conversation
+        # ends. This preserves context for consecutive assistant/tool messages.
+        next_idx = idx + 1
+        if next_idx >= len(conversation) or conversation[next_idx]["role"] == "user":
+          # Re-seed with the leading system/developer turn instead of clearing it, so every
+          # subsequent multi-turn round still renders the tools/persona. Clearing dropped the
+          # leading turn -> later rounds rendered as a bare <bos>user prompt with no tools, and
+          # completion-only loss trained those rounds' tool-calls as (no-tools -> call), so the
+          # model emits spurious tool calls at inference.
+          round_msgs = list(leading_msgs)
+      else:
+        raise ValueError(f"Unsupported message role '{message['role']}' at index {idx}.")
   except ValueError as e:
     max_logging.log(f"Unable to apply chat template: {e}")
     raise e
@@ -582,13 +615,18 @@ class ParseFeatures(grain.MapTransform):
     self.data_columns = list(data_columns)
     self.tokenize = tokenize
 
+  # Columns that may legitimately be absent from a record (e.g. datasets without
+  # function-calling data). Missing optional columns are skipped, not an error,
+  # so a single mixture can blend tools/non-tools datasets.
+  OPTIONAL_COLUMNS = frozenset({"tools"})
+
   def map(self, element):
     """Parse a serialized tf.train.Example proto and extract features."""
     example = example_pb2.Example()
     example.ParseFromString(element)
     features = example.features.feature
 
-    missing = [c for c in self.data_columns if c not in features]
+    missing = [c for c in self.data_columns if c not in features and c not in self.OPTIONAL_COLUMNS]
     if missing:
       raise ValueError(
           f"Column {missing} not found in dataset. Available columns: {sorted(features.keys())}. "
@@ -629,11 +667,21 @@ class NormalizeFeatures(grain.MapTransform):
     self.column_names = column_names
     self.tokenize = tokenize
 
+  # Columns that may legitimately be absent from a record (e.g. datasets
+  # without function-calling data). Missing optional columns are skipped
+  # instead of raising, so a single mixture can blend tools/non-tools datasets.
+  OPTIONAL_COLUMNS = frozenset({"tools"})
+
   def map(self, element):
-    if self.tokenize:
-      return {col: element[col][0].decode() for col in self.column_names}
-    else:
-      return {col: element[col] for col in self.column_names}
+    """Normalize feature keys, skipping optional columns (e.g. `tools`) absent from a record."""
+    out = {}
+    for col in self.column_names:
+      if col not in element:
+        if col in self.OPTIONAL_COLUMNS:
+          continue  # e.g. a dataset that has no `tools` column
+        raise KeyError(f"Required column '{col}' missing from record. Present columns: {sorted(element.keys())}")
+      out[col] = element[col][0].decode() if self.tokenize else element[col]
+    return out
 
 
 @dataclasses.dataclass
@@ -650,9 +698,12 @@ class KeepFeatures(grain.MapTransform):
     self.feature_names = feature_names
     self.tokenize = tokenize
 
+  # See ParseFeatures.OPTIONAL_COLUMNS — absent optional columns are skipped, not an error.
+  OPTIONAL_COLUMNS = frozenset({"tools"})
+
   def map(self, element: dict[str, Any]) -> dict[str, Any]:
     """Applies the feature filtering to the input element."""
-    missing = [n for n in self.feature_names if n not in element]
+    missing = [n for n in self.feature_names if n not in element and n not in self.OPTIONAL_COLUMNS]
     if missing:
       raise ValueError(
           f"Column {missing} not found in dataset. Available columns: {sorted(element.keys())}. "


### PR DESCRIPTION
# Description

Add first-class support for **tool-calling SFT data** and the **`developer` role** to the
grain/HF chat-template preprocessing, so tool-augmented conversations render and mask correctly —
including across multi-turn conversations. Today the SFT pipeline only understands `system`/`user`/
`assistant` turns and a single primary data column; there is no way to feed tool/function
definitions to the chat template, the `developer` role is silently dropped, and a multi-turn
conversation loses its leading turn after the first round.

This change is fully opt-in and backward compatible: datasets without a `tools` column and without
`developer` turns behave exactly as before (`tools_column_name` defaults to `None`).

## What this adds

**Tools column.** A dataset may now provide an auxiliary `tools` column alongside `messages`
(supported column set `["messages", "tools"]`). The tools (a JSON string or a list of tool
definitions) are split off the primary data column, threaded through `apply_chat_template`, rendered
into every `apply_chat_template` call so tool-calling turns tokenize correctly, and dropped from the
dataset afterward. The chat-template wrapper also learns the `tool` role (tool results accumulate
into the current round without emitting an extra prompt/completion segment).

- `data_processing_utils.py`: `TOOLS_COLUMN = "tools"`; accept `["messages", "tools"]`.
- `hf_data_processing.py` / `grain_data_processing.py`: separate the `tools` column, thread it into
  `apply_chat_template`, drop it afterward (HF path also deserializes JSON string columns).
- `input_pipeline_utils.py`: `apply_chat_template` / `_get_completion_in_chat_template` accept the
  tools and pass them to every chat-template call; `enable_thinking=True` keeps the
  completion-boundary detection correct for thinking-channel templates (e.g. Gemma).

**Developer role.** `developer` is treated like `system` (a leading, index-0 role). Any other/
unknown role now raises instead of being silently ignored.

**Optional tools column (mixture-friendly).** `ParseFeatures` / `NormalizeFeatures` / `KeepFeatures`
treat `tools` as optional (`OPTIONAL_COLUMNS = {"tools"}`): a record without it is skipped rather
than raising, so a single grain mixture can blend tools and non-tools datasets. Required columns
still raise when missing.

**Multi-turn tools persistence.** Each new round is re-seeded with the leading system/developer turn
(`leading_msgs`) instead of clearing `round_msgs`. Clearing dropped the leading turn, so rounds 2+
of a multi-turn conversation rendered as a bare `<bos>user` prompt with no tools; under
completion-only loss that trained those rounds' tool-calls as (no-tools → call), which makes the
model emit spurious tool calls at inference. Re-seeding keeps the tools/persona rendered in every
round.

## Backward compatibility

- `tools_column_name` defaults to `None` → existing `messages`-only / `prompt,completion` /
  `question,answer` datasets are unchanged.
- The `developer` role and the optional-`tools` handling are additive; no existing behavior changes
  unless the data uses them.

## Shortcomings / future work

- Tools are rendered whenever present; there is no per-turn tool visibility control.
- `enable_thinking=True` is currently unconditional (kept for correct completion-boundary detection
  on thinking-channel templates); making it configurable is a possible follow-up.

# Tests

The change preserves the existing `apply_chat_template` signature for non-tools callers, so the
existing SFT data-processing tests (`tests/post_training/unit/sft_data_processing_test.py`) continue
to exercise the system/user/assistant paths for the qwen3 / llama2 / gemma4 tokenizers:

```bash
python -m pytest tests/post_training/unit/sft_data_processing_test.py -v
```

The new control-flow (developer role, unknown-role error, `tool`-role accumulation, multi-turn
leading-turn re-seeding, and the optional-`tools` skipping) was validated against the migrated
functions with a mock tokenizer:
- `developer` accepted as a leading (index-0) turn with tools passed through; `developer` at a
  non-zero index raises.
- an unsupported role raises (the new `else` branch).
- a `tool` message accumulates into the round and emits no extra segment.
- round 2 of a multi-turn conversation still renders the leading `developer` turn + tools (not a
  bare user prompt).
- `NormalizeFeatures`/`KeepFeatures` skip an absent `tools` column but still raise on an absent
  required column.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).