### PR TITLE
deprecate version guard in ragged kernels

### DIFF
--- a/src/maxtext/kernels/ragged/ragged_gather.py
+++ b/src/maxtext/kernels/ragged/ragged_gather.py
@@ -21,25 +21,6 @@ import jax.numpy as jnp
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 from jax.experimental.pallas import tpu_sc as plsc
-from packaging.version import Version
-
-# JAX <= 0.10.0 used `out_shape`/`scratch_shapes` kwargs for `pl.kernel`; later
-# versions renamed them to `out_type`/`scratch_types`.
-if Version(jax.__version__) <= Version("0.10.0"):
-  _OUT_KW = "out_shape"
-  _SCRATCH_KW = "scratch_shapes"
-  _COMPILER_PARAMS = {
-      "use_tc_tiling_on_sc": True,
-      "disable_bounds_checks": True,
-  }
-else:
-  _OUT_KW = "out_type"
-  _SCRATCH_KW = "scratch_types"
-  _COMPILER_PARAMS = {
-      "use_tc_tiling_on_sc": True,
-      "disable_bounds_checks": True,
-      "needs_layout_passes": False,
-  }
 
 
 def main_kernel(
@@ -453,8 +434,11 @@ def ragged_gather(
           subcore_axis_name=vector_mesh.subcore_axis_name,
           has_weights=has_weights,
       ),
-      compiler_params=pltpu.CompilerParams(  # pytype: disable=wrong-keyword-args
-          **_COMPILER_PARAMS,  # pyrefly: ignore[bad-argument-type]
+      out_type=jax.ShapeDtypeStruct((out_size + out_pad_size, aligned_hidden_size), dtype),
+      compiler_params=pltpu.CompilerParams(
+          use_tc_tiling_on_sc=True,
+          disable_bounds_checks=True,
+          needs_layout_passes=False,
       ),
       cost_estimate=get_cost_estimate(
           out_size=out_size + out_pad_size,
@@ -464,17 +448,14 @@ def ragged_gather(
           flops_override=flops_override,
           bytes_accessed_override=bytes_accessed_override,
       ),
+      scratch_types=[
+          pltpu.VMEM((num_simd_lanes,), jnp.int32),
+          pltpu.VMEM((num_simd_lanes,), jnp.int32),
+          pltpu.VMEM((num_simd_lanes, col_size), jnp.uint32),
+          pltpu.VMEM((num_simd_lanes,), jnp.int32),
+          pltpu.VMEM((num_simd_lanes,), jnp.float32),
+          pltpu.SemaphoreType.DMA((2,)),
+      ],
       mesh=vector_mesh,
       name="sc_ragged_gather",
-      **{  # pyrefly: ignore[bad-argument-type]
-          _OUT_KW: jax.ShapeDtypeStruct((out_size + out_pad_size, aligned_hidden_size), dtype),
-          _SCRATCH_KW: [
-              pltpu.VMEM((num_simd_lanes,), jnp.int32),
-              pltpu.VMEM((num_simd_lanes,), jnp.int32),
-              pltpu.VMEM((num_simd_lanes, col_size), jnp.uint32),
-              pltpu.VMEM((num_simd_lanes,), jnp.int32),
-              pltpu.VMEM((num_simd_lanes,), jnp.float32),
-              pltpu.SemaphoreType.DMA((2,)),
-          ],
-      },
   )(start, end, x, indices, weights)[:out_size, :hidden_size]

--- a/src/maxtext/kernels/ragged/ragged_gather_reduce.py
+++ b/src/maxtext/kernels/ragged/ragged_gather_reduce.py
@@ -22,26 +22,6 @@ from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 from jax.experimental.pallas import tpu_sc as plsc
 import jax.numpy as jnp
-from packaging.version import Version
-
-
-# JAX <= 0.10.0 used `out_shape`/`scratch_shapes` kwargs for `pl.kernel`; later
-# versions renamed them to `out_type`/`scratch_types`.
-if Version(jax.__version__) <= Version("0.10.0"):
-  _OUT_KW = "out_shape"
-  _SCRATCH_KW = "scratch_shapes"
-  _COMPILER_PARAMS = {
-      "use_tc_tiling_on_sc": True,
-      "disable_bounds_checks": True,
-  }
-else:
-  _OUT_KW = "out_type"
-  _SCRATCH_KW = "scratch_types"
-  _COMPILER_PARAMS = {
-      "use_tc_tiling_on_sc": True,
-      "disable_bounds_checks": True,
-      "needs_layout_passes": False,
-  }
 
 
 # ceil up to the nearest multiple of b.
@@ -558,8 +538,14 @@ def ragged_gather_reduce(
           num_row_partitions=num_rows_partitions,
           num_column_partitions=num_column_partitions,
       ),
-      compiler_params=pltpu.CompilerParams(  # pytype: disable=wrong-keyword-args
-          **_COMPILER_PARAMS,  # pyrefly: ignore[bad-argument-type]
+      out_type=jax.ShapeDtypeStruct(
+          (padded_input_size // reduce_group_size, aligned_hidden_size),
+          jnp.float32,
+      ),
+      compiler_params=pltpu.CompilerParams(
+          use_tc_tiling_on_sc=True,
+          disable_bounds_checks=True,
+          needs_layout_passes=False,
       ),
       cost_estimate=get_cost_estimate(
           padded_input_size=padded_input_size,
@@ -569,23 +555,17 @@ def ragged_gather_reduce(
           flops_override=flops_override,
           bytes_accessed_override=bytes_accessed_override,
       ),
+      scratch_types=dict(  # pylint: disable=use-dict-literal
+          num_rows_per_row_partition_vmem_ref=pltpu.VMEM((num_simd_lanes,), jnp.int32),
+          out_vmem_ref=pltpu.VMEM((num_simd_lanes, col_size), jnp.uint32),
+          prev_iter_last_row_vmem_ref=pltpu.VMEM((1, col_size), jnp.uint32),
+          src_indices_vmem_ref=pltpu.VMEM((num_simd_lanes,), jnp.int32),
+          dst_indices_vmem_ref=pltpu.VMEM((num_simd_lanes,), jnp.int32),
+          topk_weights_vmem_ref=pltpu.VMEM((num_simd_lanes,), jnp.float32),
+          sem_ref=pltpu.SemaphoreType.DMA((2,)),
+      ),
       mesh=vector_mesh,
       name="sc_ragged_gather_reduce",
-      **{  # pyrefly: ignore[bad-argument-type]
-          _OUT_KW: jax.ShapeDtypeStruct(
-              (padded_input_size // reduce_group_size, aligned_hidden_size),
-              jnp.float32,
-          ),
-          _SCRATCH_KW: dict(  # pylint: disable=use-dict-literal
-              num_rows_per_row_partition_vmem_ref=pltpu.VMEM((num_simd_lanes,), jnp.int32),
-              out_vmem_ref=pltpu.VMEM((num_simd_lanes, col_size), jnp.uint32),
-              prev_iter_last_row_vmem_ref=pltpu.VMEM((1, col_size), jnp.uint32),
-              src_indices_vmem_ref=pltpu.VMEM((num_simd_lanes,), jnp.int32),
-              dst_indices_vmem_ref=pltpu.VMEM((num_simd_lanes,), jnp.int32),
-              topk_weights_vmem_ref=pltpu.VMEM((num_simd_lanes,), jnp.float32),
-              sem_ref=pltpu.SemaphoreType.DMA((2,)),
-          ),
-      },
   )(num_src_rows_per_row_partition, x, src_indices, dst_indices, topk_weights)
 
   # If there is no valid source row in a reduce group, set that group's output


### PR DESCRIPTION
# Description

Remove version guard protecting ragged kernels due to recent maxtext upgrading to JAX==0.10.2.

# Tests

CI test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
