### PR TITLE
fix(testing): resolve tokenizer loading error and UnboundLocalError in logit checker

### DIFF
--- a/src/maxtext/utils/globals.py
+++ b/src/maxtext/utils/globals.py
@@ -85,6 +85,7 @@ HF_IDS = {
     "qwen3.5-397b-a17b": "Qwen/Qwen3.5-397B-A17B",
     "qwen3.5-35b-a3b": "Qwen/Qwen3.5-35B-A3B",
     "mixtral-8x7b": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "mistral-7b": "mistralai/Mistral-7B-v0.1",
     "mixtral-8x22b": "mistralai/Mixtral-8x22B-Instruct-v0.1",
     "olmo3-7b": "allenai/Olmo-3-7B-Instruct",
     "olmo3-7b-pt": "allenai/Olmo-3-1025-7B",

--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -78,7 +78,7 @@ from google.cloud import storage
 import jax
 import jax.numpy as jnp
 from maxtext.configs import pyconfig
-from maxtext.utils.globals import MAXTEXT_TEST_ASSETS_ROOT
+from maxtext.utils.globals import MAXTEXT_TEST_ASSETS_ROOT, HF_IDS
 from maxtext.checkpoint_conversion.utils.hf_utils import convert_jax_weight_to_torch
 from maxtext.common.common_types import DECODING_ACTIVE_SEQUENCE_INDICATOR, MODEL_MODE_TRAIN
 from maxtext.layers import quantizations
@@ -232,13 +232,13 @@ def check_kl_divergence(model_logits, golden_logits, atol=0.02, clip_logits_epsi
 
 def get_data(golden_data_point, config):
   """Get the golden data for the test indexed at golden_data_index"""
+  model_prefix = config.model_name.split("-")[0]
 
   max_logging.log(f"config.global_batch_size_to_train_on={config.global_batch_size_to_train_on}")
   if config.use_multimodal:
     assert "pixel_values" in golden_data_point, "no image found in golden data while use_multimodal=True"
     pixel_values = np.asarray(golden_data_point["pixel_values"], dtype=np.float32)
     max_logging.log(f"pixel_values.shape = {pixel_values.shape}")
-    model_prefix = config.model_name.split("-")[0]
     # Gemma3 and Gemma4 models expect (num_images, height, width, channels)
     if model_prefix in ["gemma3", "gemma4"]:
       if pixel_values.ndim == 2:
@@ -328,22 +328,28 @@ def main(config, test_args):  # pylint: disable=W0621
   # 1. Pre-loaded golden logits comparison (multimodal input)
   # 2. On-the-fly HuggingFace model comparison (text only input)
   hf_token = config.hf_access_token
-  try:
-    if test_args.hf_model_path:
-      max_logging.log(f"Loading tokenizer from {test_args.hf_model_path}.")
-      tokenizer = AutoTokenizer.from_pretrained(
-          test_args.hf_model_path, token=hf_token, trust_remote_code=test_args.trust_remote_code
-      )
-    else:
-      max_logging.log(f"Loading tokenizer from {config.tokenizer_path}.")
-      tokenizer = AutoTokenizer.from_pretrained(
-          config.tokenizer_path, token=hf_token, trust_remote_code=test_args.trust_remote_code
-      )
-  except Exception as e:  # pylint: disable=broad-except
-    max_logging.log(f"Tokenizer loading error: {e}.\nLoading tokenizer from {config.tokenizer_path}.")
-    tokenizer = AutoTokenizer.from_pretrained(
-        config.tokenizer_path, token=hf_token, trust_remote_code=test_args.trust_remote_code
-    )
+  tokenizer_load_paths = []
+  if test_args.hf_model_path:
+    tokenizer_load_paths.append(test_args.hf_model_path)
+  tokenizer_load_paths.append(config.tokenizer_path)
+
+  hf_model_id = HF_IDS.get(config.model_name)
+  if hf_model_id:
+    tokenizer_load_paths.append(hf_model_id)
+
+  tokenizer = None
+  last_exception = None
+  for path in tokenizer_load_paths:
+    try:
+      max_logging.log(f"Loading tokenizer from {path}.")
+      tokenizer = AutoTokenizer.from_pretrained(path, token=hf_token, trust_remote_code=test_args.trust_remote_code)
+      break
+    except Exception as e:  # pylint: disable=broad-except,broad-exception-caught
+      last_exception = e
+      max_logging.log(f"Failed to load tokenizer from {path}: {e}")
+
+  if tokenizer is None:
+    raise last_exception
 
   if config.model_name.startswith(("llama3.1", "mixtral")):
     tokenizer.pad_token = tokenizer.eos_token


### PR DESCRIPTION
# Description

This PR fixes two regression bugs that cause the ```mistral-7b```nightly E2E test to crash in ```forward_pass_logit_checker.py```:

[DAG Error Log](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_end_to_end/grid?search=maxtext_end_to_end&task_id=maxtext-nightly-mistral-7b-v5p-8.run_model.wait_for_workload_completion&tab=logs&dag_run_id=scheduled__2026-07-11T07%3A00%3A00%2B00%3A00)
 1. UnicodeDecodeError / OSError during tokenizer loading when reading local binary SentencePiece ```.model``` files.
 2. UnboundLocalError due to ```model_prefix``` being referenced outside its defined conditional block for text-only models.

# Changes

1. Added ```mistral-7b``` Online ID Mapping
-   File Modified: ```src/maxtext/utils/globals.py```
-   Details: Added ```"mistral-7b": "mistralai/Mistral-7B-v0.1"``` to the HF_IDS dictionary. This enables the logit checker to fall back to the correct online Hugging Face repository if local loading fails.

2. Implemented Robust Tokenizer Loading Fallback (Fixes Unicode Crash)

- File Modified: ```tests/utils/forward_pass_logit_checker.py```
- Details: 
   1. Imported ```HF_IDS``` from ```globals.py```.
   2. Enhanced the tokenizer loading logic in ```main()```: If loading from the local ```config.tokenizer_path``` fails (which occurs because ```tokenizer.mistral-v1``` is a binary SentencePiece ```.model``` file instead of JSON), the script now catches the exception and falls back to loading the mapped Hugging Face ID from ```HF_IDS```.

3. Fixed ```model_prefix``` Variable Scope (Fixes UnboundLocalError Crash)

- File Modified: ```tests/utils/forward_pass_logit_checker.py```
- Details: 
   1. Moved the initialization of ```model_prefix``` from inside the ```if config.use_multimodal```: block to the very top of ```get_data()```.
   2. This ensures ```model_prefix``` is always defined, preventing text-only models (like ```mistral-7b```) from crashing when the script checks the Qwen3 RoPE 3D position ID logic.

# Tests

1. Ran ```pytest tests/unit/configs_test.py``` locally: All 76 tests passed successfully.
2. 
```
python3 -m tests.utils.forward_pass_logit_checker \
    src/maxtext/configs/base.yml \
    base_output_directory=gs://runner-maxtext-logs/2026-07-12 \
    load_parameters_path=gs://runner-maxtext-logs/2026-07-12/7b/scanned_ckpt/0/items \
    run_name=matmul_forward_pass_test \
    per_device_batch_size=1 \
    model_name=mistral-7b \
    tokenizer_path=/deps/src/maxtext/assets/tokenizer.mistral-v1 \
    max_prefill_predict_length=11 \
    max_target_length=11 \
    dataset_type=synthetic \
    dtype=float32 \
    megablox=False \
    sparse_matmul=False \
    --atol=3 \
    --rtol=1 \
    --token_size=4
```

Log: https://paste.googleplex.com/4641417803726848

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
