### PR TITLE
[Deepseek V4] Decoding Support & Integration with MaxEngine

### DIFF
--- a/benchmarks/api_server/encoding/encoding_dsv4.py
+++ b/benchmarks/api_server/encoding/encoding_dsv4.py
@@ -1,0 +1,736 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: this is a copy from Hugging Face DeepSeek-v4 model
+# https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/encoding/encoding_dsv4.py
+
+# Disable the pylint check and keep original reference copy
+# pylint: disable=line-too-long,bare-except,missing-function-docstring,use-dict-literal,consider-using-f-string,missing-module-docstring
+
+"""
+DeepSeek-V4 Encoding
+A self-contained implementation for encoding/decoding DeepSeek-V4 chat messages
+with tool calling, thinking mode, and quick instruction task support.
+"""
+
+from typing import Any, Dict, List, Union, Optional, Tuple
+import copy
+import json
+import re
+
+# ============================================================
+# Special Tokens
+# ============================================================
+
+bos_token: str = "<｜begin▁of▁sentence｜>"
+eos_token: str = "<｜end▁of▁sentence｜>"
+thinking_start_token: str = "<think>"
+thinking_end_token: str = "</think>"
+dsml_token: str = "｜DSML｜"
+
+USER_SP_TOKEN = "<｜User｜>"
+ASSISTANT_SP_TOKEN = "<｜Assistant｜>"
+LATEST_REMINDER_SP_TOKEN = "<｜latest_reminder｜>"
+
+# Task special tokens for internal classification tasks
+DS_TASK_SP_TOKENS = {
+    "action": "<｜action｜>",
+    "query": "<｜query｜>",
+    "authority": "<｜authority｜>",
+    "domain": "<｜domain｜>",
+    "title": "<｜title｜>",
+    "read_url": "<｜read_url｜>",
+}
+VALID_TASKS = set(DS_TASK_SP_TOKENS.keys())
+
+# ============================================================
+# Templates
+# ============================================================
+
+system_msg_template: str = "{content}"
+user_msg_template: str = "{content}"
+latest_reminder_msg_template: str = "{content}"
+assistant_msg_template: str = "{reasoning}{content}{tool_calls}" + eos_token
+assistant_msg_wo_eos_template: str = "{reasoning}{content}{tool_calls}"
+thinking_template: str = "{reasoning_content}"
+
+response_format_template: str = (
+    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}"
+)
+tool_call_template: str = '<{dsml_token}invoke name="{name}">\n{arguments}\n</{dsml_token}invoke>'
+tool_calls_template = "<{dsml_token}{tc_block_name}>\n{tool_calls}\n</{dsml_token}{tc_block_name}>"
+tool_calls_block_name: str = "tool_calls"
+
+tool_output_template: str = "<tool_result>{content}</tool_result>"
+
+REASONING_EFFORT_MAX = (
+    "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+    "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
+    "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+)
+
+TOOLS_TEMPLATE = """## Tools
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}tool_calls>" block like the following:
+<{dsml_token}tool_calls>
+<{dsml_token}invoke name="$TOOL_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$TOOL_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}tool_calls>
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+If thinking_mode is enabled (triggered by {thinking_start_token}), you MUST output your complete reasoning inside {thinking_start_token}...{thinking_end_token} BEFORE any tool calls or final response.
+Otherwise, output directly after {thinking_end_token} with tool calls or final response.
+### Available Tool Schemas
+{tool_schemas}
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"""
+
+# ============================================================
+# Utility Functions
+# ============================================================
+
+
+def to_json(value: Any) -> str:
+  """Serialize a value to JSON string."""
+  try:
+    return json.dumps(value, ensure_ascii=False)
+  except:
+    return json.dumps(value, ensure_ascii=True)
+
+
+def tools_from_openai_format(tools):
+  """Extract function definitions from OpenAI-format tool list."""
+  return [tool["function"] for tool in tools]
+
+
+def tool_calls_from_openai_format(tool_calls):
+  """Convert OpenAI-format tool calls to internal format."""
+  return [
+      {
+          "name": tool_call["function"]["name"],
+          "arguments": tool_call["function"]["arguments"],
+      }
+      for tool_call in tool_calls
+  ]
+
+
+def tool_calls_to_openai_format(tool_calls):
+  """Convert internal tool calls to OpenAI format."""
+  return [
+      {
+          "type": "function",
+          "function": {
+              "name": tool_call["name"],
+              "arguments": tool_call["arguments"],
+          },
+      }
+      for tool_call in tool_calls
+  ]
+
+
+def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
+  """
+  Encode tool call arguments into DSML parameter format.
+  Args:
+      tool_call: Dict with "name" and "arguments" (JSON string) keys.
+  Returns:
+      DSML-formatted parameter string.
+  """
+  p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
+  P_dsml_strs = []
+
+  try:
+    arguments = json.loads(tool_call["arguments"])
+  except (json.JSONDecodeError, TypeError, ValueError):
+    arguments = {"arguments": tool_call["arguments"]}
+
+  for k, v in arguments.items():
+    p_dsml_str = p_dsml_template.format(
+        dsml_token=dsml_token,
+        key=k,
+        is_str="true" if isinstance(v, str) else "false",
+        value=v if isinstance(v, str) else to_json(v),
+    )
+    P_dsml_strs.append(p_dsml_str)
+
+  return "\n".join(P_dsml_strs)
+
+
+def decode_dsml_to_arguments(tool_name: str, tool_args: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
+  """
+  Decode DSML parameters back to a tool call dict.
+  Args:
+      tool_name: Name of the tool.
+      tool_args: Dict mapping param_name -> (value, is_string_flag).
+  Returns:
+      Dict with "name" and "arguments" (JSON string) keys.
+  """
+
+  def _decode_value(key: str, value: str, string: str):
+    if string == "true":
+      value = to_json(value)
+    return f"{to_json(key)}: {value}"
+
+  tool_args_json = "{" + ", ".join([_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()]) + "}"
+  return dict(name=tool_name, arguments=tool_args_json)
+
+
+def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:
+  """
+  Render tool schemas into the system prompt format.
+  Args:
+      tools: List of tool schema dicts (each with name, description, parameters).
+  Returns:
+      Formatted tools section string.
+  """
+  tools_json = [to_json(t) for t in tools]
+
+  return TOOLS_TEMPLATE.format(
+      tool_schemas="\n".join(tools_json),
+      dsml_token=dsml_token,
+      thinking_start_token=thinking_start_token,
+      thinking_end_token=thinking_end_token,
+  )
+
+
+def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
+  """Find the index of the last user/developer message."""
+  last_user_index = -1
+  for idx in range(len(messages) - 1, -1, -1):
+    if messages[idx].get("role") in ["user", "developer"]:
+      last_user_index = idx
+      break
+  return last_user_index
+
+
+# ============================================================
+# Message Rendering
+# ============================================================
+
+
+def _format_tool_content(tool_content: Any) -> str:
+  """Helper to format tool result content from list or string."""
+  if not isinstance(tool_content, list):
+    return str(tool_content)
+  text_parts = []
+  for b in tool_content:
+    if b.get("type") == "text":
+      text_parts.append(b.get("text", ""))
+    else:
+      text_parts.append(f"[Unsupported {b.get('type')}]")
+  return "\n\n".join(text_parts)
+
+
+def render_message(
+    index: int,
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    drop_thinking: bool = True,
+    reasoning_effort: Optional[str] = None,
+) -> str:
+  """
+  Render a single message at the given index into its encoded string form.
+  This is the core function that converts each message in the conversation
+  into the DeepSeek-V4 format.
+  Args:
+      index: Index of the message to render.
+      messages: Full list of messages in the conversation.
+      thinking_mode: Either "chat" or "thinking".
+      drop_thinking: Whether to drop reasoning content from earlier turns.
+      reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+  Returns:
+      Encoded string for this message.
+  """
+  assert 0 <= index < len(messages)
+  assert thinking_mode in ["chat", "thinking"], f"Invalid thinking_mode `{thinking_mode}`"
+
+  prompt = ""
+  msg = messages[index]
+  last_user_idx = find_last_user_index(messages)
+
+  role = msg.get("role")
+  content = msg.get("content")
+  tools = msg.get("tools")
+  response_format = msg.get("response_format")
+  tool_calls = msg.get("tool_calls")
+  reasoning_content = msg.get("reasoning_content")
+  wo_eos = msg.get("wo_eos", False)
+
+  if tools:
+    tools = tools_from_openai_format(tools)
+  if tool_calls:
+    tool_calls = tool_calls_from_openai_format(tool_calls)
+
+  # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
+  assert reasoning_effort in ["max", None, "high"], f"Invalid reasoning effort: {reasoning_effort}"
+  if index == 0 and thinking_mode == "thinking" and reasoning_effort == "max":
+    prompt += REASONING_EFFORT_MAX
+
+  if role == "system":
+    prompt += system_msg_template.format(content=content or "")
+    if tools:
+      prompt += "\n\n" + render_tools(tools)
+    if response_format:
+      prompt += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+  elif role == "developer":
+    assert content, f"Invalid message for role `{role}`: {msg}"
+
+    content_developer = USER_SP_TOKEN
+    content_developer += content
+
+    if tools:
+      content_developer += "\n\n" + render_tools(tools)
+    if response_format:
+      content_developer += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+    prompt += user_msg_template.format(content=content_developer)
+
+  elif role == "user":
+    prompt += USER_SP_TOKEN
+
+    # Handle content blocks (tool results mixed with text)
+    content_blocks = msg.get("content_blocks")
+    if content_blocks:
+      parts = []
+      for block in content_blocks:
+        block_type = block.get("type")
+        if block_type == "text":
+          parts.append(block.get("text", ""))
+        elif block_type == "tool_result":
+          tool_content = _format_tool_content(block.get("content", ""))
+          parts.append(tool_output_template.format(content=tool_content))
+        else:
+          parts.append(f"[Unsupported {block_type}]")
+      prompt += "\n\n".join(parts)
+    else:
+      prompt += content or ""
+
+  elif role == "latest_reminder":
+    prompt += LATEST_REMINDER_SP_TOKEN + latest_reminder_msg_template.format(content=content)
+
+  elif role == "tool":
+    raise NotImplementedError("deepseek_v4 merges tool messages into user; please preprocess with merge_tool_messages()")
+
+  elif role == "assistant":
+    thinking_part = ""
+    tc_content = ""
+
+    if tool_calls:
+      tc_list = [
+          tool_call_template.format(dsml_token=dsml_token, name=tc.get("name"), arguments=encode_arguments_to_dsml(tc))
+          for tc in tool_calls
+      ]
+      tc_content += "\n\n" + tool_calls_template.format(
+          dsml_token=dsml_token,
+          tool_calls="\n".join(tc_list),
+          tc_block_name=tool_calls_block_name,
+      )
+
+    summary_content = content or ""
+    rc = reasoning_content or ""
+
+    # Check if previous message has a task - if so, this is a task output (no thinking)
+    prev_has_task = index - 1 >= 0 and messages[index - 1].get("task") is not None
+
+    if thinking_mode == "thinking" and not prev_has_task:
+      if not drop_thinking or index > last_user_idx:
+        thinking_part = thinking_template.format(reasoning_content=rc) + thinking_end_token
+      else:
+        thinking_part = ""
+
+    if wo_eos:
+      prompt += assistant_msg_wo_eos_template.format(
+          reasoning=thinking_part,
+          content=summary_content,
+          tool_calls=tc_content,
+      )
+    else:
+      prompt += assistant_msg_template.format(
+          reasoning=thinking_part,
+          content=summary_content,
+          tool_calls=tc_content,
+      )
+  else:
+    raise NotImplementedError(f"Unknown role: {role}")
+
+  # Append transition tokens based on what follows
+  if index + 1 < len(messages) and messages[index + 1].get("role") not in ["assistant", "latest_reminder"]:
+    return prompt
+
+  task = messages[index].get("task")
+  if task is not None:
+    # Task special token for internal classification tasks
+    assert task in VALID_TASKS, f"Invalid task: '{task}'. Valid tasks are: {list(VALID_TASKS)}"
+    task_sp_token = DS_TASK_SP_TOKENS[task]
+
+    if task != "action":
+      # Non-action tasks: append task sp token directly after the message
+      prompt += task_sp_token
+    else:
+      # Action task: append Assistant + thinking token + action sp token
+      prompt += ASSISTANT_SP_TOKEN
+      prompt += thinking_end_token if thinking_mode != "thinking" else thinking_start_token
+      prompt += task_sp_token
+
+  elif messages[index].get("role") in ["user", "developer"]:
+    # Normal generation: append Assistant + thinking token
+    prompt += ASSISTANT_SP_TOKEN
+    if not drop_thinking and thinking_mode == "thinking":
+      prompt += thinking_start_token
+    elif drop_thinking and thinking_mode == "thinking" and index >= last_user_idx:
+      prompt += thinking_start_token
+    else:
+      prompt += thinking_end_token
+
+  return prompt
+
+
+# ============================================================
+# Preprocessing
+# ============================================================
+
+
+def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+  """
+  Merge tool messages into the preceding user message using content_blocks format.
+  DeepSeek-V4 does not have a standalone "tool" role; instead, tool results
+  are encoded as <tool_result> blocks within user messages.
+  This function converts a standard OpenAI-format conversation (with separate
+  "tool" role messages) into V4 format where tool results are merged into
+  user messages.
+  Args:
+      messages: List of message dicts in OpenAI format.
+  Returns:
+      Processed message list with tool messages merged into user messages.
+  """
+  merged: List[Dict[str, Any]] = []
+
+  for msg in messages:
+    msg = copy.deepcopy(msg)
+    role = msg.get("role")
+
+    if role == "tool":
+      # Convert tool message to a user message with tool_result block
+      tool_block = {
+          "type": "tool_result",
+          "tool_use_id": msg.get("tool_call_id", ""),
+          "content": msg.get("content", ""),
+      }
+      # Merge into previous message if it's already a user (merged tool)
+      if merged and merged[-1].get("role") == "user" and "content_blocks" in merged[-1]:
+        merged[-1]["content_blocks"].append(tool_block)
+      else:
+        merged.append(
+            {
+                "role": "user",
+                "content_blocks": [tool_block],
+            }
+        )
+    elif role == "user":
+      text_block = {"type": "text", "text": msg.get("content", "")}
+      if (
+          merged
+          and merged[-1].get("role") == "user"
+          and "content_blocks" in merged[-1]
+          and merged[-1].get("task") is None
+      ):
+        merged[-1]["content_blocks"].append(text_block)
+      else:
+        new_msg = {
+            "role": "user",
+            "content": msg.get("content", ""),
+            "content_blocks": [text_block],
+        }
+        # Preserve extra fields (task, wo_eos, mask, etc.)
+        for key in ("task", "wo_eos", "mask"):
+          if key in msg:
+            new_msg[key] = msg[key]
+        merged.append(new_msg)
+    else:
+      merged.append(msg)
+
+  return merged
+
+
+def sort_tool_results_by_call_order(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+  """
+  Sort tool_result blocks within user messages by the order of tool_calls
+  in the preceding assistant message.
+  Args:
+      messages: Preprocessed message list (after merge_tool_messages).
+  Returns:
+      Message list with sorted tool result blocks.
+  """
+  last_tool_call_order: Dict[str, int] = {}
+
+  for msg in messages:
+    role = msg.get("role")
+    if role == "assistant" and msg.get("tool_calls"):
+      last_tool_call_order = {}
+      for idx, tc in enumerate(msg["tool_calls"]):
+        tc_id = tc.get("id") or tc.get("function", {}).get("id", "")
+        if tc_id:
+          last_tool_call_order[tc_id] = idx
+
+    elif role == "user" and msg.get("content_blocks"):
+      tool_blocks = [b for b in msg["content_blocks"] if b.get("type") == "tool_result"]
+      if len(tool_blocks) > 1 and last_tool_call_order:
+        sorted_blocks = sorted(tool_blocks, key=lambda b: last_tool_call_order.get(b.get("tool_use_id", ""), 0))
+        sorted_idx = 0
+        new_blocks = []
+        for block in msg["content_blocks"]:
+          if block.get("type") == "tool_result":
+            new_blocks.append(sorted_blocks[sorted_idx])
+            sorted_idx += 1
+          else:
+            new_blocks.append(block)
+        msg["content_blocks"] = new_blocks
+
+  return messages
+
+
+# ============================================================
+# Main Encoding Function
+# ============================================================
+
+
+def encode_messages(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+    reasoning_effort: Optional[str] = None,
+) -> str:
+  """
+  Encode a list of messages into the DeepSeek-V4 prompt format.
+  This is the main entry point for encoding conversations. It handles:
+  - BOS token insertion
+  - Thinking mode with optional reasoning content dropping
+  - Tool message merging into user messages
+  - Multi-turn conversation context
+  Args:
+      messages: List of message dicts to encode.
+      thinking_mode: Either "chat" or "thinking".
+      context: Optional preceding context messages (already encoded prefix).
+      drop_thinking: If True, drop reasoning_content from earlier assistant turns
+                    (only keep reasoning for messages after the last user message).
+      add_default_bos_token: Whether to prepend BOS token at conversation start.
+      reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+  Returns:
+      The encoded prompt string.
+  """
+  context = context if context else []
+
+  # Preprocess: merge tool messages and sort tool results
+  messages = merge_tool_messages(messages)
+  messages = sort_tool_results_by_call_order(context + messages)[len(context) :]
+  if context:
+    context = merge_tool_messages(context)
+    context = sort_tool_results_by_call_order(context)
+
+  full_messages = context + messages
+
+  prompt = bos_token if add_default_bos_token and len(context) == 0 else ""
+
+  # Resolve drop_thinking: if any message has tools defined, don't drop thinking
+  effective_drop_thinking = drop_thinking
+  if any(m.get("tools") for m in full_messages):
+    effective_drop_thinking = False
+
+  if thinking_mode == "thinking" and effective_drop_thinking:
+    full_messages = _drop_thinking_messages(full_messages)
+    # After dropping, recalculate how many messages to render
+    # (context may have shrunk too)
+    num_to_render = len(full_messages) - len(_drop_thinking_messages(context))
+    context_len = len(full_messages) - num_to_render
+  else:
+    num_to_render = len(messages)
+    context_len = len(context)
+
+  for idx in range(num_to_render):
+    prompt += render_message(
+        idx + context_len,
+        full_messages,
+        thinking_mode=thinking_mode,
+        drop_thinking=effective_drop_thinking,
+        reasoning_effort=reasoning_effort,
+    )
+
+  return prompt
+
+
+def _drop_thinking_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+  """
+  Drop reasoning_content and non-essential messages before the last user message.
+  Behavior:
+  - Messages with role in ["user", "system", "tool", "latest_reminder"] are always kept.
+  - Messages at or after the last user index are always kept.
+  - Assistant messages before the last user get reasoning_content removed.
+  - Developer messages before the last user are dropped entirely.
+  """
+  last_user_idx = find_last_user_index(messages)
+  result = []
+  keep_roles = {"user", "system", "tool", "latest_reminder", "direct_search_results"}
+
+  for idx, msg in enumerate(messages):
+    role = msg.get("role")
+    if role in keep_roles or idx >= last_user_idx:
+      result.append(msg)
+    elif role == "assistant":
+      msg = copy.copy(msg)
+      msg.pop("reasoning_content", None)
+      result.append(msg)
+    # developer and other roles before last_user_idx are dropped
+
+  return result
+
+
+# ============================================================
+# Parsing (Decoding model output)
+# ============================================================
+
+
+def _read_until_stop(index: int, text: str, stop: List[str]) -> Tuple[int, str, Optional[str]]:
+  """
+  Read text from index until one of the stop strings is found.
+  Returns:
+      Tuple of (new_index, content_before_stop, matched_stop_string_or_None).
+  """
+  min_pos = len(text)
+  matched_stop = None
+
+  for s in stop:
+    pos = text.find(s, index)
+    if pos != -1 and pos < min_pos:
+      min_pos = pos
+      matched_stop = s
+
+  if matched_stop:
+    content = text[index:min_pos]
+    return min_pos + len(matched_stop), content, matched_stop
+  else:
+    content = text[index:]
+    return len(text), content, None
+
+
+def parse_tool_calls(index: int, text: str) -> Tuple[int, Optional[str], List[Dict[str, str]]]:
+  """
+  Parse DSML tool calls from text starting at the given index.
+  Args:
+      index: Starting position in text.
+      text: The full text to parse.
+  Returns:
+      Tuple of (new_index, last_stop_token, list_of_tool_call_dicts).
+      Each tool call dict has "name" and "arguments" keys.
+  """
+  tool_calls: List[Dict[str, Any]] = []
+  stop_token = None
+  tool_calls_end_token = f"</{dsml_token}{tool_calls_block_name}>"
+
+  while index < len(text):
+    index, _, stop_token = _read_until_stop(index, text, [f"<{dsml_token}invoke", tool_calls_end_token])
+    if _ != ">\n":
+      raise ValueError(f"Tool call format error: expected '>\\n' but got '{_}'")
+
+    if stop_token == tool_calls_end_token:
+      break
+
+    if stop_token is None:
+      raise ValueError("Missing special token in tool calls")
+
+    index, tool_name_content, stop_token = _read_until_stop(
+        index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"]
+    )
+
+    p_tool_name = re.findall(r'^\s*name="(.*?)">\n$', tool_name_content, flags=re.DOTALL)
+    if len(p_tool_name) != 1:
+      raise ValueError(f"Tool name format error: '{tool_name_content}'")
+    tool_name = p_tool_name[0]
+
+    tool_args: Dict[str, Tuple[str, str]] = {}
+    while stop_token == f"<{dsml_token}parameter":
+      index, param_content, stop_token = _read_until_stop(index, text, [f"/{dsml_token}parameter"])
+
+      param_kv = re.findall(r'^ name="(.*?)" string="(true|false)">(.*?)<$', param_content, flags=re.DOTALL)
+      if len(param_kv) != 1:
+        raise ValueError(f"Parameter format error: '{param_content}'")
+      param_name, string, param_value = param_kv[0]
+
+      if param_name in tool_args:
+        raise ValueError(f"Duplicate parameter name: '{param_name}'")
+      tool_args[param_name] = (param_value, string)
+
+      index, content, stop_token = _read_until_stop(index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"])
+      if content != ">\n":
+        raise ValueError(f"Parameter format error: expected '>\\n' but got '{content}'")
+
+    tool_call = decode_dsml_to_arguments(tool_name=tool_name, tool_args=tool_args)
+    tool_calls.append(tool_call)
+
+  return index, stop_token, tool_calls
+
+
+def parse_message_from_completion_text(text: str, thinking_mode: str) -> Dict[str, Any]:
+  """
+  Parse a model completion text into a structured assistant message.
+  This function takes the raw text output from the model (a single assistant turn)
+  and extracts:
+  - reasoning_content (thinking block)
+  - content (summary/response)
+  - tool_calls (if any)
+  NOTE: This function is designed to parse only correctly formatted strings and
+  will raise ValueError for malformed output.
+  Args:
+      text: The raw completion text (including EOS token).
+      thinking_mode: Either "chat" or "thinking".
+  Returns:
+      Dict with keys: "role", "content", "reasoning_content", "tool_calls".
+      tool_calls are in OpenAI format.
+  """
+  summary_content, reasoning_content, tool_calls = "", "", []
+  index, stop_token = 0, None
+  tool_calls_start_token = f"\n\n<{dsml_token}{tool_calls_block_name}"
+
+  is_thinking = thinking_mode == "thinking"
+  is_tool_calling = False
+
+  if is_thinking:
+    index, content_delta, stop_token = _read_until_stop(index, text, [thinking_end_token, tool_calls_start_token])
+    reasoning_content = content_delta
+    if stop_token is not None and stop_token != thinking_end_token and stop_token != tool_calls_start_token:
+      pass  # Incomplete text is fine, just stop parsing further
+    if stop_token is None:
+      # Reached end of text without closing tag (e.g. max_tokens)
+      pass
+
+  index, content_delta, stop_token = _read_until_stop(index, text, [eos_token, tool_calls_start_token])
+  summary_content = content_delta
+  if stop_token == tool_calls_start_token:
+    is_tool_calling = True
+
+  if is_tool_calling:
+    index, stop_token, tool_calls = parse_tool_calls(index, text)
+    index, _, stop_token = _read_until_stop(index, text, [eos_token])
+
+  return {
+      "role": "assistant",
+      "content": summary_content,
+      "reasoning_content": reasoning_content,
+      "tool_calls": tool_calls_to_openai_format(tool_calls),
+  }

--- a/benchmarks/api_server/maxtext_server.py
+++ b/benchmarks/api_server/maxtext_server.py
@@ -59,7 +59,7 @@ from benchmarks.api_server.server_models import (
     ChatMessage,
 )
 from benchmarks.api_server import server_utils
-from benchmarks.api_server.encoding import encoding_dsv32
+from benchmarks.api_server.encoding import encoding_dsv32, encoding_dsv4
 
 # ----------------------------
 # Init
@@ -187,14 +187,25 @@ def _build_chat_completion_response(request, completion_result, llm):
     except (ValueError, IndexError) as e:
       logger.error("Harmony parsing failed for gpt-oss: %s. Falling back to raw text.", e, exc_info=True)
 
+  t_mode = getattr(request, "thinking_mode", "thinking")
+
   if server_utils.is_dsv32_encoding_enabled(request.model):
     try:
       # DeepSeek-V3.2 models often generate thinking block.
-      parsed = encoding_dsv32.parse_message_from_completion_text(text_out, thinking_mode="thinking")
+      parsed = encoding_dsv32.parse_message_from_completion_text(text_out, thinking_mode=t_mode)
       text_out = parsed.get("content", text_out)
       reasoning_out = parsed.get("reasoning_content")
     except (AssertionError, ValueError, IndexError) as e:
       logger.error("DeepSeek-V3.2 parsing failed: %s. Falling back to raw text.", e, exc_info=True)
+
+  if server_utils.is_dsv4_encoding_enabled(request.model):
+    try:
+      # DeepSeek-V4 models often generate thinking block.
+      parsed = encoding_dsv4.parse_message_from_completion_text(text_out, thinking_mode=t_mode)
+      text_out = parsed.get("content", text_out)
+      reasoning_out = parsed.get("reasoning_content")
+    except (AssertionError, ValueError, IndexError) as e:
+      logger.error("DeepSeek-V4 parsing failed: %s. Falling back to raw text.", e, exc_info=True)
 
   want_top_logprobs = (
       (request.top_logprobs or 0) > 0 if isinstance(request, ChatCompletionRequest) else (request.logprobs or 0) > 0
@@ -322,9 +333,17 @@ def _prepare_batch_for_broadcast(batched_items):
   request_info_map = []
   for req_id, req in batched_items:
     is_chat = isinstance(req, ChatCompletionRequest)
-    prompts_for_req = server_utils.get_prompts_for_request(req, LLM)
-    all_prompts.extend(prompts_for_req)
-    request_info_map.append((req_id, req, is_chat, len(prompts_for_req)))
+    try:
+      prompts_for_req = server_utils.get_prompts_for_request(req, LLM)
+      all_prompts.extend(prompts_for_req)
+      request_info_map.append((req_id, req, is_chat, len(prompts_for_req)))
+    except ValueError as e:
+      logger.error("Failed to parse request %s: %s", req_id, e)
+      with response_lock:
+        response_dict[req_id] = {"error": f"Invalid request format or missing chat template: {e}"}
+
+  if not all_prompts:
+    return 0, b"", []  # Signal other ranks to skip if all requests failed
 
   broadcast_payload = {"prompts": all_prompts, "params": params}
   payload_bytes = json.dumps(broadcast_payload).encode("utf-8")

--- a/benchmarks/api_server/server_models.py
+++ b/benchmarks/api_server/server_models.py
@@ -190,12 +190,14 @@ class ChatCompletionRequest(SamplingParams):
       messages: A list of `ChatMessage` objects representing the conversation history.
       logprobs: Whether to return log probabilities.
       top_logprobs: The number of top log probabilities to return if `logprobs` is true.
+      thinking_mode: Optional flag to toggle thinking mode ("thinking" or "chat").
   """
 
   model: str
   messages: List[ChatMessage]
   logprobs: Optional[bool] = False
   top_logprobs: Optional[int] = None
+  thinking_mode: Optional[str] = "thinking"
 
 
 class ChatCompletionChoice(BaseModel):

--- a/benchmarks/api_server/server_utils.py
+++ b/benchmarks/api_server/server_utils.py
@@ -32,7 +32,7 @@ from fastapi import HTTPException
 
 from benchmarks.api_server.maxtext_generator import MaxTextGenerator
 from benchmarks.api_server.server_models import LogProbsPayload
-from benchmarks.api_server.encoding import encoding_dsv32
+from benchmarks.api_server.encoding import encoding_dsv32, encoding_dsv4
 
 # ----------------------------
 # Debugging
@@ -42,9 +42,10 @@ DEBUG_MODE = os.environ.get("MAXTEXT_SERVER_DEBUG", "0") == "1"
 DEBUG_LOG_FILE = os.environ.get("MAXTEXT_DEBUG_LOG_FILE", "benchmarks/api_server/server_debug_log.jsonl")
 logger = logging.getLogger(__name__)
 
-# Indicate if we should disable specific encoding for DeepSeek-V3.2 family.
-# Encoding is needed for v3.2 and v3.2-speciale, but not deepseek v3.2-exp.
+# Indicate if we should disable specific encoding for DeepSeek V3.2 or V4 family.
+# Encoding is needed for v3.2, v3.2-speciale, and v4 but not deepseek v3.2-exp.
 DISABLE_DSV32_ENCODING = os.environ.get("DISABLE_DSV32_ENCODING", "0") == "1"
+DISABLE_DSV4_ENCODING = os.environ.get("DISABLE_DSV4_ENCODING", "0") == "1"
 
 
 def is_dsv32_encoding_enabled(model_name: str) -> bool:
@@ -54,6 +55,16 @@ def is_dsv32_encoding_enabled(model_name: str) -> bool:
   if DISABLE_DSV32_ENCODING:
     return False
   return "deepseek3.2" in model_name.lower()
+
+
+def is_dsv4_encoding_enabled(model_name: str) -> bool:
+  """
+  Checks if DeepSeek-V4 specific encoding should be applied to the given model.
+  """
+  if DISABLE_DSV4_ENCODING:
+    return False
+  model_name_lower = model_name.lower()
+  return "deepseek4" in model_name_lower or "deepseekv4" in model_name_lower or "deepseek-v4" in model_name_lower
 
 
 def log_debug_event(request_id: str, event_type: str, content: dict):
@@ -128,10 +139,17 @@ def get_prompts_for_request(req: any, llm: MaxTextGenerator) -> List[str]:
       A list of string prompts.
   """
   if hasattr(req, "messages"):  # ChatCompletionRequest
+    t_mode = getattr(req, "thinking_mode", "thinking")
+
     if is_dsv32_encoding_enabled(req.model):
       messages = [m.model_dump(exclude_none=True) for m in req.messages]
-      encode_config = {"thinking_mode": "thinking", "drop_thinking": True, "add_default_bos_token": True}
+      encode_config = {"thinking_mode": t_mode, "drop_thinking": True, "add_default_bos_token": True}
       return [encoding_dsv32.encode_messages(messages, **encode_config)]
+
+    if is_dsv4_encoding_enabled(req.model):
+      messages = [m.model_dump(exclude_none=True) for m in req.messages]
+      encode_config = {"thinking_mode": t_mode, "drop_thinking": True, "add_default_bos_token": True}
+      return [encoding_dsv4.encode_messages(messages, **encode_config)]
 
     messages = [m.model_dump() for m in req.messages]
     formatted_prompt = llm.tokenizer.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)

--- a/benchmarks/api_server/test_batching_chat_completions.py
+++ b/benchmarks/api_server/test_batching_chat_completions.py
@@ -1,0 +1,87 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Client test script for verifying concurrent chat completion batching against the MaxText API server."""
+
+import concurrent.futures
+import time
+import requests
+
+URL = "http://localhost:8000/v1/chat/completions"
+HEADERS = {"Content-Type": "application/json"}
+
+PROMPTS = [
+    "What is attention in transformers?",
+    "Explain the concept of backpropagation.",
+    "How does a Convolutional Neural Network work?",
+    "What are the benefits of using a learning rate scheduler?",
+]
+
+
+def send_request(req_id, prompt):
+  """Send a single chat completion request to the API server."""
+  print(f"[{req_id}] Sending request: '{prompt}'")
+  start_time = time.time()
+
+  payload = {
+      "model": "deepseekv4",
+      "messages": [{"role": "user", "content": prompt}],
+      "thinking_mode": "chat",
+      "max_tokens": 20,
+      "temperature": 0.7,
+      "top_p": 0.95,
+  }
+
+  try:
+    response = requests.post(URL, json=payload, headers=HEADERS)
+    duration = time.time() - start_time
+    print(f"[{req_id}] Received response in {duration:.2f}s. Status: {response.status_code}")
+    return req_id, prompt, response.json()
+  except (requests.RequestException, ValueError) as e:
+    print(f"[{req_id}] Request failed: {e}")
+    return req_id, prompt, None
+
+
+def test_batching():
+  """Run concurrent requests to test batching."""
+  num_requests = len(PROMPTS)
+  print(f"Testing batching by firing {num_requests} concurrent requests with different prompts...")
+
+  # Use a ThreadPoolExecutor to fire requests simultaneously
+  with concurrent.futures.ThreadPoolExecutor(max_workers=num_requests) as executor:
+    # Submit all tasks at once
+    futures = {executor.submit(send_request, i, prompt): i for i, prompt in enumerate(PROMPTS)}
+
+    # Wait for all of them to finish
+    for future in concurrent.futures.as_completed(futures):
+      req_id = futures[future]
+      try:
+        ret_req_id, prompt, data = future.result()
+        if data and "choices" in data and len(data["choices"]) > 0:
+          choice = data["choices"][0]
+          message = choice.get("message", {})
+          content = message.get("content", "")
+          reasoning = message.get("reasoning_content", "")
+
+          print(f"\n--- Result for Request [{ret_req_id}] ---")
+          print(f"Prompt: {prompt}")
+          if reasoning:
+            print(f"Thinking: {reasoning.strip()}")
+          print(f"Output: {content.strip()}")
+      except (RuntimeError, ValueError) as exc:
+        print(f"[{req_id}] Generated an exception: {exc}")
+
+
+if __name__ == "__main__":
+  test_batching()

--- a/benchmarks/api_server/test_batching_text_completions.py
+++ b/benchmarks/api_server/test_batching_text_completions.py
@@ -1,0 +1,162 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Client test script for verifying concurrent text completion batching against the MaxText API server."""
+
+import concurrent.futures
+import requests
+import time
+
+URL = "http://localhost:8000/v1/completions"
+HEADERS = {"Content-Type": "application/json"}
+
+PROMPTS = [
+    """The following are multiple choice questions about history.
+
+Question: In what year did the French Revolution begin?
+A. 1776
+B. 1789
+C. 1793
+D. 1804
+Answer: B
+
+Question: Which French monarch was known as the "Sun King"?
+A. Louis XIV
+B. Louis XVI
+C. Henry IV
+D. Francis I
+Answer: A
+
+Question: Napoleon Bonaparte was exiled to which island first?
+A. Elba
+B. Corsica
+C. Malta
+D. Sicily
+Answer:""",
+    """The following are multiple choice questions about science.
+
+Question: What is the chemical symbol for gold?
+A. Au
+B. Ag
+C. Go
+D. Gd
+Answer: A
+
+Question: What planet is known as the Red Planet?
+A. Venus
+B. Mars
+C. Jupiter
+D. Saturn
+Answer: B
+
+Question: What is the hardest natural substance on Earth?
+A. Platinum
+B. Diamond
+C. Graphene
+D. Quartz
+Answer:""",
+    """The following are multiple choice questions about geography.
+
+Question: Which is the longest river in the world?
+A. Amazon
+B. Nile
+C. Yangtze
+D. Mississippi
+Answer: B
+
+Question: What is the capital of Japan?
+A. Kyoto
+B. Osaka
+C. Tokyo
+D. Seoul
+Answer: C
+
+Question: Which desert is the largest hot desert in the world?
+A. Gobi
+B. Mojave
+C. Sahara
+D. Kalahari
+Answer:""",
+    """The following are multiple choice questions about literature.
+
+Question: Who wrote "To Kill a Mockingbird"?
+A. Mark Twain
+B. Harper Lee
+C. John Steinbeck
+D. F. Scott Fitzgerald
+Answer: B
+
+Question: In which play does the character Hamlet appear?
+A. Macbeth
+B. Othello
+C. Hamlet
+D. King Lear
+Answer: C
+
+Question: Who is the author of "1984"?
+A. George Orwell
+B. Aldous Huxley
+C. Ray Bradbury
+D. H.G. Wells
+Answer:""",
+]
+
+
+def send_request(req_id, prompt):
+  """Send a single text completion request to the API server."""
+  print(f"[{req_id}] Sending completion request...")
+  start_time = time.time()
+
+  payload = {"model": "deepseekv4", "prompt": prompt, "max_tokens": 5, "temperature": 0.0, "top_p": 1.0}
+
+  try:
+    response = requests.post(URL, json=payload, headers=HEADERS)
+    duration = time.time() - start_time
+    print(f"[{req_id}] Received response in {duration:.2f}s. Status: {response.status_code}")
+    return req_id, prompt, response.json()
+  except (requests.RequestException, ValueError) as e:
+    print(f"[{req_id}] Request failed: {e}")
+    return req_id, prompt, None
+
+
+def test_batching():
+  """Run concurrent requests to test batching for completions."""
+  num_requests = len(PROMPTS)
+  print(f"Testing batching by firing {num_requests} concurrent requests for text completions...")
+
+  # Use a ThreadPoolExecutor to fire requests simultaneously
+  with concurrent.futures.ThreadPoolExecutor(max_workers=num_requests) as executor:
+    # Submit all tasks at once
+    futures = {executor.submit(send_request, i, prompt): i for i, prompt in enumerate(PROMPTS)}
+
+    # Wait for all of them to finish
+    for future in concurrent.futures.as_completed(futures):
+      req_id = futures[future]
+      try:
+        ret_req_id, prompt, data = future.result()
+        if data and "choices" in data and len(data["choices"]) > 0:
+          choice = data["choices"][0]
+          text_out = choice.get("text", "")
+
+          print(f"\n--- Result for Request [{ret_req_id}] ---")
+          # Print the last few lines of the prompt for context
+          prompt_tail = "\n".join(prompt.strip().split("\n")[-5:])
+          print(f"Prompt (tail):\n...\n{prompt_tail}")
+          print(f"Model Output: {text_out.strip()}")
+      except (RuntimeError, ValueError) as exc:
+        print(f"[{req_id}] Generated an exception: {exc}")
+
+
+if __name__ == "__main__":
+  test_batching()

--- a/src/maxtext/inference/kvcache.py
+++ b/src/maxtext/inference/kvcache.py
@@ -14,7 +14,7 @@
 
 """Implementation of the kvcache."""
 
-from typing import Any
+from typing import Any, Optional, Callable
 
 import jax
 import jax.numpy as jnp
@@ -175,6 +175,9 @@ def kv_cache_as_linen(
     use_chunked_prefill: bool = False,
     model_mode: str = MODEL_MODE_PREFILL,
     is_gdn: bool = False,
+    is_deepseek_v4: bool = False,
+    compress_rate: int = 1,
+    is_indexer: bool = False,
     conv_kernel_size: int = 0,
     conv_dim: int = 0,
     name: str | None = None,
@@ -228,6 +231,9 @@ def kv_cache_as_linen(
       use_chunked_prefill=use_chunked_prefill,
       model_mode=model_mode,
       is_gdn=is_gdn,
+      is_deepseek_v4=is_deepseek_v4,
+      compress_rate=compress_rate,
+      is_indexer=is_indexer,
       conv_kernel_size=conv_kernel_size,
       conv_dim=conv_dim,
       metadata_fn=variable_to_logically_partitioned,
@@ -272,6 +278,9 @@ class KVCache(BaseCache):
       use_chunked_prefill: bool = False,
       model_mode: str = MODEL_MODE_PREFILL,
       is_gdn: bool = False,
+      is_deepseek_v4: bool = False,
+      compress_rate: int = 1,
+      is_indexer: bool = False,
       conv_kernel_size: int = 0,
       conv_dim: int = 0,
       *,
@@ -324,12 +333,41 @@ class KVCache(BaseCache):
     self.model_mode = model_mode
     self.use_chunked_prefill = use_chunked_prefill
     self.is_gdn = is_gdn
+    self.is_deepseek_v4 = is_deepseek_v4
+    self.compress_rate = compress_rate
+    self.is_indexer = is_indexer
     self.conv_kernel_size = conv_kernel_size
     self.conv_dim = conv_dim
 
     if model_mode in (MODEL_MODE_PREFILL, MODEL_MODE_AUTOREGRESSIVE):
       self._initialize_prefill_caches(model_mode)
       self._initialize_ar_cache_vars(model_mode)
+
+      if self.is_deepseek_v4 and self.compress_rate > 1:
+        cache_batch_axis_name = CACHE_BATCH_PREFILL if model_mode == MODEL_MODE_PREFILL else CACHE_BATCH
+
+        self.entry_count = nnx.Cache(
+            jnp.zeros((self.batch, 1), dtype=jnp.int32), out_sharding=(cache_batch_axis_name, None)
+        )
+        self.accumulator_index = nnx.Cache(
+            jnp.zeros((self.batch, 1), dtype=jnp.int32), out_sharding=(cache_batch_axis_name, None)
+        )
+        self.leftover_buffer_kv = nnx.Cache(
+            jnp.zeros((self.batch, self.compress_rate, self.key_heads, self.key_head_size), dtype=dtype),
+            out_sharding=(cache_batch_axis_name, None, None, None),
+        )
+        self.leftover_buffer_gate = nnx.Cache(
+            jnp.zeros((self.batch, self.compress_rate, self.key_heads, self.key_head_size), dtype=dtype),
+            out_sharding=(cache_batch_axis_name, None, None, None),
+        )
+        self.overlap_kv = nnx.Cache(
+            jnp.zeros((self.batch, self.key_heads, self.compress_rate, self.key_head_size), dtype=dtype),
+            out_sharding=(cache_batch_axis_name, None, None, None),
+        )
+        self.overlap_gate = nnx.Cache(
+            jnp.zeros((self.batch, self.key_heads, self.compress_rate, self.key_head_size), dtype=dtype),
+            out_sharding=(cache_batch_axis_name, None, None, None),
+        )
 
   @property
   def prefill_key_vars(self):
@@ -718,6 +756,7 @@ class KVCache(BaseCache):
     if decoder_segment_ids is not None:
       assert cached_prefill_segment_id_var is not None
       cached_prefill_segment_id_var.set_value(decoder_segment_ids)
+
     return key, value, decoder_segment_ids
 
   def update_ar_key_value(
@@ -928,6 +967,132 @@ class KVCache(BaseCache):
         cached_ar_segment_id_var.get_value(),
         cache_ar_lengths_var.get_value(),
     )
+
+    return cached_prefill, cached_ar
+
+  def kv_cache_autoregressive_v4(
+      self,
+      key: Array,
+      value: Array,
+      gate: Optional[Array] = None,
+      use_ragged_attention: bool = False,
+      compressor_fn: Optional[Callable] = None,
+  ):
+    """DeepSeek-V4 aware token-by-token caching matrix (Functionally Pure for JAX tracing)."""
+    if self.compress_rate == 1:
+      return self.kv_cache_autoregressive(key, value, use_ragged_attention)
+
+    assert gate is not None, "gate cannot be None when compress_rate > 1 in DeepSeek-V4 autoregressive cache."
+    assert self.cached_ar_key is not None, "cached_ar_key cannot be None when updating autoregressive cache."
+
+    incoming_batch = key.shape[0]
+
+    # 1. Update the Accumulator Buffers
+    current_index_array = self.accumulator_index.get_value()
+    current_index = jnp.reshape(current_index_array, (-1,))[0]
+
+    buffer_kv = jax.lax.dynamic_update_slice_in_dim(self.leftover_buffer_kv.get_value(), key, current_index, 1)
+    buffer_gate = jax.lax.dynamic_update_slice_in_dim(self.leftover_buffer_gate.get_value(), gate, current_index, 1)
+
+    self.leftover_buffer_kv.set_value(buffer_kv)
+    self.leftover_buffer_gate.set_value(buffer_gate)
+
+    next_index = current_index + 1
+    window_complete = next_index == self.compress_rate
+
+    # 2. Compute the compressed block using the layer's math callback
+    if compressor_fn is not None:
+      compressed_block, next_overlap_kv, next_overlap_gate = compressor_fn(buffer_kv, buffer_gate)
+
+      # Conditionally update the overlap registers only if the window finished
+      if next_overlap_kv is not None:
+        new_overlap_kv = jnp.where(window_complete, next_overlap_kv, self.overlap_kv.get_value())
+        self.overlap_kv.set_value(new_overlap_kv)
+
+      if next_overlap_gate is not None:
+        new_overlap_gate = jnp.where(window_complete, next_overlap_gate, self.overlap_gate.get_value())
+        self.overlap_gate.set_value(new_overlap_gate)
+    else:
+      gate_weights = jax.nn.softmax(buffer_gate, axis=1).astype(buffer_kv.dtype)
+      compressed_block = jnp.sum(buffer_kv * gate_weights, axis=1, keepdims=True)
+
+    potential_update_key = compressed_block
+
+    operand_shape = self.cached_ar_key.get_value().shape
+    if potential_update_key.shape[3] < operand_shape[3]:
+      # DeepSeek-V4 compressed latent dimension d_c can be smaller than cached key_head_size
+      # (which is often padded to power-of-two / systolic array boundaries for TPU efficiency).
+      # Pad trailing zeros along head_dim (axis 3) to match cache operand shape.
+      pad_amt = operand_shape[3] - potential_update_key.shape[3]
+      potential_update_key = jnp.pad(potential_update_key, ((0, 0), (0, 0), (0, 0), (0, pad_amt)))
+
+    # If window incomplete, we will just write dummy zeros
+    dummy_key = jnp.zeros_like(potential_update_key)
+    update_key = jnp.where(window_complete, potential_update_key, dummy_key)
+
+    # 3. Fetch current AR cache state variables
+    (
+        cached_ar_key_vars,
+        cached_ar_value_vars,
+        cached_ar_segment_id_var,
+        _,
+        cache_ar_lengths_var,
+    ) = self._get_ar_cache_vars()
+    assert cached_ar_segment_id_var is not None, "cached_ar_segment_id_var cannot be None"
+    ar_index = self.cache_ar_index.get_value()
+
+    # 4. Write to the cache array
+    self.update_ar_key_value(
+        update_key,
+        update_key,  # Value is identical to key for DeepSeek V4 compressed states
+        cached_ar_key_vars,
+        cached_ar_value_vars,
+        ar_index,
+        cache_ar_lengths_var.get_value(),
+        use_ragged_attention,
+    )
+
+    # 5. Conditionally write the segment ID mask for the incoming batch
+    active_indicator = jnp.zeros((incoming_batch, 1), dtype=jnp.int32) + DECODING_ACTIVE_SEQUENCE_INDICATOR
+    zero_indicator = jnp.zeros_like(active_indicator)
+    indicator_to_write = jnp.where(window_complete, active_indicator, zero_indicator)
+
+    temp_ar_seg = cached_ar_segment_id_var.get_value()
+
+    new_ar_seg = jax.lax.dynamic_update_index_in_dim(temp_ar_seg, indicator_to_write, jnp.squeeze(ar_index), 1)
+    cached_ar_segment_id_var.set_value(new_ar_seg)
+
+    # 6. Conditionally advance all the pointers and counters
+    next_ar_index = jnp.mod(ar_index + 1, self.max_target_length - self.max_prefill_length)
+    self.cache_ar_index.set_value(jnp.where(window_complete, next_ar_index, ar_index))
+
+    self.entry_count.set_value(jnp.where(window_complete, self.entry_count.get_value() + 1, self.entry_count.get_value()))
+
+    cache_ar_lengths_var.set_value(
+        jnp.where(window_complete, cache_ar_lengths_var.get_value() + 1, cache_ar_lengths_var.get_value())
+    )
+
+    self.accumulator_index.set_value(
+        jnp.full_like(current_index_array, jnp.where(window_complete, jnp.int32(0), next_index))
+    )
+
+    # --- 7. UNPACK JAX ARRAYS TO MATCH STANDARD ATTENTION PIPELINE ---
+    cached_prefill_key_vars, cached_prefill_value_vars, cached_prefill_segment_id_var = self._get_prefill_cache_vars()
+    assert cached_prefill_segment_id_var is not None, "cached_prefill_segment_id_var cannot be None"
+
+    cached_prefill = (
+        self.get_cached_values(cached_prefill_key_vars, key.dtype, self.prefill_cache_axis_order),
+        self.get_cached_values(cached_prefill_value_vars, value.dtype, self.prefill_cache_axis_order),
+        cached_prefill_segment_id_var.get_value(),
+    )
+
+    cached_ar = (
+        self.get_cached_values(cached_ar_key_vars, key.dtype, self.ar_cache_axis_order),
+        self.get_cached_values(cached_ar_value_vars, value.dtype, self.ar_cache_axis_order),
+        cached_ar_segment_id_var.get_value(),
+        cache_ar_lengths_var.get_value(),
+    )
+
     return cached_prefill, cached_ar
 
   def __call__(
@@ -938,6 +1103,8 @@ class KVCache(BaseCache):
       model_mode: str,
       use_ragged_attention: bool = False,
       previous_chunk: Any = None,
+      gate: Optional[Array] = None,
+      compressor_fn: Optional[Callable] = None,
   ) -> tuple:
     """KV cache takes the current state and updates the state accordingly.
 
@@ -962,6 +1129,8 @@ class KVCache(BaseCache):
       else:
         return self.kv_cache_prefill(key, value, decoder_segment_ids), None
     elif model_mode == MODEL_MODE_AUTOREGRESSIVE:
+      if self.is_deepseek_v4 and self.compress_rate > 1:
+        return self.kv_cache_autoregressive_v4(key, value, gate, use_ragged_attention, compressor_fn)
       return self.kv_cache_autoregressive(key, value, use_ragged_attention)
     else:
       raise ValueError(f"Model Mode isn't supported! {model_mode=}")
@@ -1134,6 +1303,7 @@ class MlaKVCache(KVCache):
       model_mode: str,
       use_ragged_attention: bool = False,
       previous_chunk: Any = None,
+      gate: Optional[Array] = None,
   ) -> tuple[
       None | tuple[Array, Array, Array],
       None | tuple[Array, Array, Array, Array],

--- a/src/maxtext/inference/maxengine/maxengine.py
+++ b/src/maxtext/inference/maxengine/maxengine.py
@@ -57,6 +57,16 @@ config_lib, engine_api, token_utils, tokenizer_api, _token_params_ns = jetstream
 TokenizerParameters = getattr(_token_params_ns, "TokenizerParameters", object)  # type: ignore[assignment]
 TokenizerType = getattr(_token_params_ns, "TokenizerType", object)  # type: ignore[assignment]
 
+_DEEPSEEK_V4_CACHE_KEYS = frozenset(
+    (
+        "entry_count",
+        "accumulator_index",
+        "leftover_buffer_kv",
+        "leftover_buffer_gate",
+        "overlap_kv",
+        "overlap_gate",
+    )
+)
 
 warnings.simplefilter("ignore", category=FutureWarning)
 DecodeState = Any
@@ -1495,6 +1505,12 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
       if batch_idx < 0:
         raise ValueError(f"Batch index {batch_idx=} shouldn't be less than zero for {path_key}, got {annotations=}")
 
+      if path_key in _DEEPSEEK_V4_CACHE_KEYS:
+        # Copy these states by explicitly overwriting the target slots matching current request id
+        for slot in slots:
+          full_cache = jax.lax.dynamic_update_index_in_dim(full_cache, partial_cache, slot, batch_idx)
+        return full_cache
+
       for slot in slots:
         if path_key == "cache_ar_segment_id":
           ### goal: zero this out in case there is existing data
@@ -1609,6 +1625,10 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
 
       if batch_idx < 0:
         raise ValueError(f"Batch index {batch_idx=} shouldn't be less than zero for {path_key}, got {annotations=}")
+
+      if path_key in _DEEPSEEK_V4_CACHE_KEYS:
+        # Copy these states by explicitly overwriting the target slot matching current request id
+        return jax.lax.dynamic_update_index_in_dim(full_cache, partial_cache, slot, batch_idx)
 
       if path_key == "cache_ar_segment_id":
         s = list(full_cache.shape)
@@ -1743,6 +1763,10 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
 
       if batch_idx < 0:
         raise ValueError(f"Batch index {batch_idx=} shouldn't be less than zero for {path_key}, got {annotations=}")
+
+      if path_key in _DEEPSEEK_V4_CACHE_KEYS:
+        # Direct batch slot index overwrite for fixed-size metadata trackers
+        return jax.lax.dynamic_update_index_in_dim(full_cache, partial_cache, slot, batch_idx)
 
       if path_key == "cache_ar_segment_id":
         ### goal: zero this out in case there is existing data

--- a/src/maxtext/layers/attention_compressed.py
+++ b/src/maxtext/layers/attention_compressed.py
@@ -15,12 +15,14 @@
 """Compressed Attention Layer (DeepSeek-V4)."""
 
 
+import enum
 from typing import Any, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
 from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh
+from maxtext.utils import max_utils
 
 from flax import nnx
 
@@ -29,6 +31,7 @@ from maxtext.common.common_types import (
     Config,
     DType,
     MODEL_MODE_TRAIN,
+    MODEL_MODE_AUTOREGRESSIVE,
     AttentionType,
     DEFAULT_MASK_VALUE,
 )
@@ -41,17 +44,27 @@ from maxtext.layers.linears import DenseGeneral, DeepSeekV4GroupedLinear
 from maxtext.layers.normalizations import RMSNorm
 from maxtext.layers.quantizations import AqtQuantization as Quant
 from maxtext.inference.kvcache import KVQuant
+from maxtext.inference import kvcache
+
+
+class CSAPoolingConfig(enum.IntEnum):
+  """Configuration constants for Compressed Sparse Attention (CSA) overlap pooling.
+
+  Attributes:
+    OVERLAP_WINDOWS: Number of overlapping prior windows (W) carried forward from cache.
+  """
+
+  OVERLAP_WINDOWS = 1
 
 
 def csa_overlap_pooling(
-    hidden_states: Array,
-    kv_proj: Any,
-    gate_proj: Any,
-    position_bias: Array,
+    chunk_kv: Array,
+    chunk_gate: Array,
     kv_norm: Any,
-    compress_rate: int,
     head_dim: int,
-) -> Array:
+    prior_kv: Optional[Array] = None,
+    prior_gate: Optional[Array] = None,
+) -> Tuple[Array, Array, Array]:
   """Shared utility for Compressed Sparse Attention (CSA) overlap pooling.
 
   Implements the overlapping Ca/Cb pooling logic shared by both the CSA Compressor
@@ -60,79 +73,337 @@ def csa_overlap_pooling(
   overlapping windows over which softmax gating is applied.
 
   Args:
-    hidden_states: Input token embeddings. Shape: `[batch, seq_len, emb_dim]`.
-    kv_proj: Dense layer projecting to `2 * head_dim`.
-    gate_proj: Dense layer projecting to `2 * head_dim`.
-    position_bias: Bias tensor. Shape: `[compress_rate, 2 * head_dim]`.
-    kv_norm: RMSNorm instance.
-    compress_rate: Compression rate for CSA.
-    head_dim: Standard head dimension.
+    chunk_kv: Input KV projection chunks. Shape: `[batch, n_windows, compress_rate, 2 * head_dim]`.
+    chunk_gate: Input gate projection chunks. Shape: `[batch, n_windows, compress_rate, 2 * head_dim]`.
+    kv_norm: RMSNorm instance applied to the aggregated representations.
+    head_dim: Target head dimension.
+    prior_kv: Previous window KV prior from cache (optional).
+    prior_gate: Previous window gate prior from cache (optional).
 
   Returns:
-    compressed: The pooled overlapping states. Shape: `[batch, n_windows, head_dim]`.
+    Tuple of (compressed, next_prior_kv, next_prior_gate):
+      - compressed: The pooled overlapping states. Shape: `[batch, n_windows, head_dim]`.
+      - next_prior_kv: Updated KV prior for the next window.
+      - next_prior_gate: Updated gate prior for the next window.
 
   Shape Transformations:
-    1. Projections: `[batch, seq_len, emb_dim]` -> `[batch, seq_len, 2 * head_dim]`
-    2. Reshape: -> `[batch, n_windows, compress_rate, 2 * head_dim]`
-    3. Split: -> 2x `[batch, n_windows, compress_rate, head_dim]`
-    4. Shift: Ca shifted forward by one window.
-    5. Concat (Ca + Cb): -> `[batch, n_windows, 2 * compress_rate, head_dim]`
-    6. Gating & Sum: -> `[batch, n_windows, head_dim]`
+    1. Split: `[batch, n_windows, compress_rate, 2 * head_dim]` -> 2x `[batch, n_windows, compress_rate, head_dim]`
+    2. Shift: Ca shifted forward by one window (prepending cache prior if available).
+    3. Concat (Ca + Cb): -> `[batch, n_windows, 2 * compress_rate, head_dim]`
+    4. Gating & Sum: -> `[batch, n_windows, head_dim]`
   """
-  batch_size, seq_len, _ = hidden_states.shape
+  # D2 is 2 * head_dim
+  B, _, C, D2 = chunk_kv.shape
+  # w is the number of overlapping windows carried forward across chunk boundaries (W=1)
+  w = int(CSAPoolingConfig.OVERLAP_WINDOWS)
+  expected_size = B * w * C * D2
 
-  # [batch, seq_len, emb_dim] -> [batch, seq_len, 2 * head_dim]
-  kv = kv_proj(hidden_states)
-  # [batch, seq_len, emb_dim] -> [batch, seq_len, 2 * head_dim]
-  gate = gate_proj(hidden_states)
-
-  usable = (seq_len // compress_rate) * compress_rate
-  chunk_kv = kv[:, :usable]
-  chunk_gate = gate[:, :usable]
-
-  # Return zero tensor if there are no full windows available for pooling
-  if chunk_kv.shape[1] == 0:
-    return jnp.zeros((batch_size, 0, head_dim), dtype=hidden_states.dtype)
-
-  n_windows = chunk_kv.shape[1] // compress_rate
-
-  # Reshape flat sequence into discrete compression windows
-  # -> [batch, n_windows, compress_rate, 2 * head_dim]
-  chunk_kv = chunk_kv.reshape((batch_size, n_windows, compress_rate, 2 * head_dim))
-  chunk_gate = chunk_gate.reshape((batch_size, n_windows, compress_rate, 2 * head_dim)) + position_bias
-
-  # Split the projections into Ca and Cb components for overlapping
-  # 2x [batch, n_windows, compress_rate, head_dim]
+  # 1. Split the projections into Ca and Cb components for overlapping
+  # -> 2x [batch, n_windows, compress_rate, head_dim]
   a_kv, b_kv = jnp.split(chunk_kv, 2, axis=-1)
   a_gate, b_gate = jnp.split(chunk_gate, 2, axis=-1)
 
-  # Shift Ca forward by one window to align with the next Cb
-  a_kv_shifted = jnp.concatenate(
-      [
-          jnp.zeros((batch_size, 1, compress_rate, head_dim), dtype=a_kv.dtype),
-          a_kv[:, :-1],
-      ],
-      axis=1,
-  )
-  a_gate_shifted = jnp.concatenate(
-      [
-          jnp.full((batch_size, 1, compress_rate, head_dim), -jnp.inf, dtype=a_gate.dtype),
-          a_gate[:, :-1],
-      ],
-      axis=1,
-  )
+  # 2. Safely handle cache priors (using OVERLAP_WINDOWS for the prior window count w)
+  if prior_kv is None or prior_kv.size != expected_size:
+    prior_a_kv = jnp.zeros((B, w, C, head_dim), dtype=a_kv.dtype)
+    # Note: Empty gate prior must be -inf so softmax(gate) = 0
+    prior_a_gate = jnp.full((B, w, C, head_dim), -jnp.inf, dtype=a_gate.dtype)
+  else:
+    prior_kv = prior_kv.reshape((B, w, C, D2))
+    prior_gate = prior_gate.reshape((B, w, C, D2))
+    prior_a_kv, _ = jnp.split(prior_kv, 2, axis=-1)
+    prior_a_gate, _ = jnp.split(prior_gate, 2, axis=-1)
 
-  # Concatenate shifted Ca and unshifted Cb to form the final overlapping window
+    # KVCache initializes with zeros. If it's the very first step,
+    # gate must be -inf for softmax to equal 0.
+    is_empty = jnp.all(prior_a_kv == 0)
+    prior_a_gate = jnp.where(is_empty, -jnp.inf, prior_a_gate)
+
+  # 3. Shift Ca forward by one window
+  # We prepend the prior window to the current chunks, and drop the last window of Ca
+  a_kv_shifted = jnp.concatenate([prior_a_kv, a_kv[:, :-1]], axis=1)
+  a_gate_shifted = jnp.concatenate([prior_a_gate, a_gate[:, :-1]], axis=1)
+
+  # 4. Concatenate shifted Ca and unshifted Cb to form the 2m overlapping window
   # -> [batch, n_windows, 2 * compress_rate, head_dim]
   new_kv = jnp.concatenate([a_kv_shifted, b_kv], axis=2)
   new_gate = jnp.concatenate([a_gate_shifted, b_gate], axis=2)
 
-  # Apply softmax gating and sum across the overlapping window dimension
+  # 5. Apply softmax gating and sum across the overlapping window dimension
   gate_weights = jax.nn.softmax(new_gate, axis=2).astype(new_kv.dtype)
-  # -> [batch, n_windows, head_dim]
-  compressed = kv_norm(jnp.sum(new_kv * gate_weights, axis=2))
+  compressed = jnp.sum(new_kv * gate_weights, axis=2)
 
-  return compressed
+  # 6. Apply the projection norm
+  if kv_norm is not None:
+    compressed = kv_norm(compressed)
+
+  # 7. Extract the next priors (Keep the full D2 so it fits the cache)
+  # We grab the full last window of the current chunk to pass into the next chunk
+  next_prior_kv = chunk_kv[:, -1:, :, :]
+  next_prior_gate = chunk_gate[:, -1:, :, :]
+
+  return compressed, next_prior_kv, next_prior_gate
+
+
+def update_ar_cache_and_get_validity_mask(
+    kv: Array,
+    gate: Array,
+    cache: Any,
+    model_mode: str,
+    compressor_fn: Any,
+    comp_dim: int,
+    batch_size: int,
+    mask_ndims: Optional[int] = None,
+) -> Tuple[Array, Optional[Array]]:
+  """Helper for autoregressive decoding: updates KV cache and computes the AR validity mask.
+
+  Delegates token-by-token compression and cache state updates to `cache(...)`, concatenates
+  the cached prefill and autoregressive blocks, and optionally computes a binary validity mask
+  to prevent queries from attending to statically allocated padding slots.
+
+  Args:
+    kv: Projected KV representations. Shape: `[batch, 1, emb_dim]`.
+    gate: Projected gate representations. Shape: `[batch, 1, emb_dim]`.
+    cache: KV cache instance for the compressor.
+    model_mode: Execution mode (`MODEL_MODE_AUTOREGRESSIVE`).
+    compressor_fn: Component-specific callback function that compresses a window of tokens.
+    comp_dim: Target head dimension (`head_dim` or `index_head_dim`).
+    batch_size: Original unpadded batch size.
+    mask_ndims: Number of dimensions for the output validity mask (e.g. 4 for `[B, 1, 1, L]`,
+      3 for `[B, 1, L]`, or None to skip mask calculation).
+
+  Returns:
+    Tuple of (compressed, is_valid_mask):
+      - compressed: The unpadded concatenated compressed representations. Shape: `[batch, total_len, comp_dim]`.
+      - is_valid_mask: Boolean array indicating valid (non-padded) cache positions, or None if `mask_ndims` is None.
+  """
+  kv_exp = jnp.expand_dims(kv, 2)
+  gate_exp = jnp.expand_dims(gate, 2)
+
+  cached_prefill, cached_ar = cache(
+      key=kv_exp,
+      value=kv_exp,
+      gate=gate_exp,
+      decoder_segment_ids=None,
+      model_mode=model_mode,
+      compressor_fn=compressor_fn,
+  )
+
+  compressed_full = jnp.concatenate([cached_prefill[0], cached_ar[0]], axis=1)
+  compressed = compressed_full[:batch_size, :, 0, :comp_dim]
+
+  if mask_ndims is None:
+    return compressed, None
+
+  # --- AUTOREGRESSIVE VALIDITY MASK ---
+  # In autoregressive mode, the total compressed KV sequence is the concatenation of:
+  #   1. The prefill cache region: indices [0, max_prefill_comp)
+  #   2. The AR cache region:      indices [max_prefill_comp, max_prefill_comp + ar_max_len)
+  # Because both regions are statically padded to maximum capacity, we construct a binary mask
+  # so queries attend only to valid, completed compression blocks:
+  #   - Prefill blocks are valid if index < prefill_blocks_count (total entry count - AR valid count).
+  #   - AR blocks are valid if their offset (index - max_prefill_comp) < ar_valid.
+  max_prefill_comp = cached_prefill[0].shape[1]
+  ar_valid = jnp.expand_dims(cached_ar[3], axis=1)  # [B, 1]
+  assert cache.entry_count is not None, "cache.entry_count cannot be None for compressed attention"
+  prefill_blocks_count = cache.entry_count.get_value() - ar_valid  # [B, 1]
+
+  total_len = compressed.shape[1]
+  shape_prefix = (1,) * (mask_ndims - 1) + (total_len,)
+  entry_indices = jnp.arange(total_len).reshape(shape_prefix)
+
+  if mask_ndims == 4:
+    # Expand to [B, 1, 1, 1] for [B, 1, 1, L] mask
+    prefill_count_exp = jnp.expand_dims(prefill_blocks_count, axis=(1, 3))
+    ar_valid_exp = jnp.expand_dims(ar_valid, axis=(1, 3))
+  elif mask_ndims == 3:
+    # Expand to [B, 1, 1] for [B, 1, L] mask
+    prefill_count_exp = jnp.expand_dims(prefill_blocks_count, axis=1)
+    ar_valid_exp = jnp.expand_dims(ar_valid, axis=1)
+  else:
+    raise ValueError(f"Unsupported mask_ndims={mask_ndims}; expected 3, 4, or None.")
+
+  is_prefill = entry_indices < max_prefill_comp
+  is_valid_prefill = is_prefill & (entry_indices < prefill_count_exp)
+
+  is_ar = entry_indices >= max_prefill_comp
+  is_valid_ar = is_ar & ((entry_indices - max_prefill_comp) < ar_valid_exp)
+
+  is_valid_mask = is_valid_prefill | is_valid_ar
+
+  return compressed, is_valid_mask
+
+
+def compute_csa_prefill_chunk_pooling(
+    kv: Array,
+    gate: Array,
+    seq_len: int,
+    batch_size: int,
+    compress_rate: int,
+    position_ids: Array,
+    position_bias: Array,
+    kv_norm: Any,
+    rotary_emb: Any,
+    head_dim: int,
+    dtype: Any,
+    cache: Optional[Any] = None,
+) -> Tuple[Array, int, Optional[Array], Optional[Array], int]:
+  """Helper for CSA prefill chunking, overlap pooling, and RoPE embedding.
+
+  Args:
+    kv: Projected KV representations.
+    gate: Projected gate representations.
+    seq_len: Total sequence length.
+    batch_size: Batch size.
+    compress_rate: Compression rate.
+    position_ids: Absolute token positions.
+    position_bias: Position bias tensor.
+    kv_norm: Normalization layer.
+    rotary_emb: Rotary embedding layer.
+    head_dim: Target head dimension (`head_dim` or `index_head_dim`).
+    dtype: Computation dtype.
+    cache: Optional KVCache instance.
+
+  Returns:
+    Tuple of (compressed, compressed_len, next_prior_kv, next_prior_gate, usable).
+  """
+  usable = (seq_len // compress_rate) * compress_rate
+  chunk_kv = kv[:, :usable]
+  chunk_gate = gate[:, :usable]
+
+  if cache is not None:
+    assert cache.overlap_kv is not None, "cache.overlap_kv cannot be None"
+    assert cache.overlap_gate is not None, "cache.overlap_gate cannot be None"
+    prior_kv = cache.overlap_kv.get_value()
+    prior_gate = cache.overlap_gate.get_value()
+  else:
+    prior_kv, prior_gate = None, None
+
+  if chunk_kv.shape[1] > 0:
+    n_windows = chunk_kv.shape[1] // compress_rate
+    chunk_kv_reshaped = chunk_kv.reshape((batch_size, n_windows, compress_rate, -1))
+    chunk_gate_reshaped = chunk_gate.reshape((batch_size, n_windows, compress_rate, -1)) + position_bias
+
+    compressed, next_prior_kv, next_prior_gate = csa_overlap_pooling(
+        chunk_kv_reshaped, chunk_gate_reshaped, kv_norm, head_dim, prior_kv, prior_gate
+    )
+    compressed_len = compressed.shape[1]
+
+    positions = jnp.arange(compressed_len) * compress_rate + position_ids[:, 0:1]
+    compressed = rotary_emb(compressed, positions, unsqueeze_dim=None)
+  else:
+    compressed = jnp.zeros((batch_size, 0, head_dim), dtype=dtype)
+    compressed_len = 0
+    next_prior_kv = prior_kv
+    next_prior_gate = prior_gate
+
+  return compressed, compressed_len, next_prior_kv, next_prior_gate, usable
+
+
+def prime_prefill_cache_state(
+    kv: Array,
+    gate: Array,
+    compressed_kv: Array,
+    seq_len: int,
+    usable: int,
+    compress_rate: int,
+    cache: Any,
+    next_prior_kv: Optional[Array] = None,
+    next_prior_gate: Optional[Array] = None,
+) -> None:
+  """Shared utility to initialize and prime KVCache state during prefill.
+
+  Handles:
+    1. Leftover token buffering when `seq_len` is not divisible by `compress_rate`.
+    2. Transposition, head-dim padding, sequence-len slicing, and batch-repeating of
+       compressed blocks before inserting them into `cache.cached_prefill_key`.
+    3. Updating `cache.entry_count` with the initial compressed length.
+    4. Writing trailing Ca window priors to `cache.overlap_kv` / `cache.overlap_gate`
+       for overlapping CSA compressors.
+
+  Args:
+    kv: Projected KV representations. Shape: `[batch, seq_len, head_dim]`.
+    gate: Projected gate representations. Shape: `[batch, seq_len, head_dim]`.
+    compressed_kv: Prefill compressed KV blocks. Shape: `[batch, compressed_len, 1, comp_dim]`.
+    seq_len: Total uncompressed sequence length.
+    usable: Number of tokens divisible by `compress_rate` that were compressed.
+    compress_rate: Compression rate factor.
+    cache: Target KVCache instance.
+    next_prior_kv: Trailing window KV prior to write to overlap cache (optional).
+    next_prior_gate: Trailing window gate prior to write to overlap cache (optional).
+  """
+  if compressed_kv.ndim == 3:
+    compressed_kv = jnp.expand_dims(compressed_kv, 2)
+  remainder = seq_len % compress_rate
+  if remainder > 0:
+    leftover_kv = kv[:, usable:]
+    leftover_gate = gate[:, usable:]
+    pad_len = compress_rate - remainder
+    padded_kv = jnp.expand_dims(jnp.pad(leftover_kv, ((0, 0), (0, pad_len), (0, 0))), 2)
+    padded_gate = jnp.expand_dims(jnp.pad(leftover_gate, ((0, 0), (0, pad_len), (0, 0))), 2)
+
+    assert cache.leftover_buffer_kv is not None, "leftover_buffer_kv cannot be None"
+    assert cache.leftover_buffer_gate is not None, "leftover_buffer_gate cannot be None"
+    assert cache.accumulator_index is not None, "accumulator_index cannot be None"
+    actual_batch = cache.leftover_buffer_kv.get_value().shape[0]
+    # Note: We copy/repeat the same batch across the cache batch dimension so that
+    # leftover buffers are initialized for all concurrent decode slots.
+    if padded_kv.shape[0] != actual_batch:
+      repeats = actual_batch // padded_kv.shape[0]
+      padded_kv = jnp.repeat(padded_kv, repeats, axis=0)
+      padded_gate = jnp.repeat(padded_gate, repeats, axis=0)
+
+    cache.leftover_buffer_kv.set_value(padded_kv)
+    cache.leftover_buffer_gate.set_value(padded_gate)
+    cache.accumulator_index.set_value(jnp.full((actual_batch, 1), remainder, dtype=jnp.int32))
+
+  compressed_len = compressed_kv.shape[1]
+  if compressed_len > 0:
+    cache_key_var = cache.cached_prefill_key
+    assert cache_key_var is not None, "cached_prefill_key cannot be None"
+
+    # Transpose from [B, L, H, D] -> [L, H, B, D] to match the cache's physical layout
+    update_blocks = jnp.transpose(compressed_kv, cache.prefill_cache_axis_order)
+
+    operand_shape = cache_key_var.get_value().shape
+    # Pad the Head Dim (axis 3) if needed (e.g. 64 -> 128)
+    if update_blocks.shape[3] < operand_shape[3]:
+      pad_amt = operand_shape[3] - update_blocks.shape[3]
+      update_blocks = jnp.pad(update_blocks, ((0, 0), (0, 0), (0, 0), (0, pad_amt)))
+
+    update_blocks = update_blocks[:, : operand_shape[1], ...]
+
+    operand = cache_key_var.get_value()
+    batch_axis = cache.prefill_cache_axis_order.index(0)
+
+    # Broadcast batch=1 prefill requests to fit the max_concurrent_decodes cache
+    # Note: We repeat the same batch across the cache batch dimension (when prefill batch size
+    # < max_concurrent_decodes) so that the prefill state is copied to all concurrent decode slots.
+    if operand.shape[batch_axis] != update_blocks.shape[batch_axis]:
+      repeats = operand.shape[batch_axis] // update_blocks.shape[batch_axis]
+      update_blocks = jnp.repeat(update_blocks, repeats, axis=batch_axis)
+
+    cache_key_var.set_value(jax.lax.dynamic_update_slice_in_dim(operand, update_blocks, 0, axis=0))
+    # Ensure entry_count update matches the physical cache batch size
+    assert cache.entry_count is not None, "entry_count cannot be None"
+    actual_batch = cache.entry_count.get_value().shape[0]
+    cache.entry_count.set_value(jnp.full((actual_batch, 1), compressed_len, dtype=jnp.int32))
+
+    if next_prior_kv is not None and next_prior_gate is not None:
+      overlap_kv_to_write = next_prior_kv
+      overlap_gate_to_write = next_prior_gate
+
+      # Note: We copy/repeat the same batch across the cache batch dimension so that
+      # overlap registers are initialized for all concurrent decode slots.
+      assert cache.overlap_kv is not None, "overlap_kv cannot be None"
+      assert cache.overlap_gate is not None, "overlap_gate cannot be None"
+      if overlap_kv_to_write.shape[0] != cache.overlap_kv.get_value().shape[0]:
+        repeats = cache.overlap_kv.get_value().shape[0] // overlap_kv_to_write.shape[0]
+        overlap_kv_to_write = jnp.repeat(overlap_kv_to_write, repeats, axis=0)
+        overlap_gate_to_write = jnp.repeat(overlap_gate_to_write, repeats, axis=0)
+
+      cache.overlap_kv.set_value(overlap_kv_to_write)
+      cache.overlap_gate.set_value(overlap_gate_to_write)
 
 
 class BaseDeepseekCompressor(nnx.Module):
@@ -264,6 +535,8 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
       hidden_states: Array,
       q_normed: Array,
       position_ids: Array,
+      model_mode: str,
+      cache: Optional[Any] = None,
   ) -> Tuple[Array, Array]:
     """Forward pass for the HCA compressor.
 
@@ -271,6 +544,8 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
       hidden_states: Input token embeddings. Shape: `[batch, seq_len, emb_dim]`.
       q_normed: Latent query representation (unused in HCA).
       position_ids: Absolute token positions. Shape: `[batch, seq_len]`.
+      model_mode: The execution mode (e.g. train, prefill, or autoregressive).
+      cache: Optional KV cache instance used during inference.
 
     Returns:
       compressed_kv: The pooled KV tensors. Shape: `[batch, n_windows, 1, head_dim]`.
@@ -278,13 +553,37 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
                               Shape: `[batch, 1, seq_len, n_windows]`.
     """
     batch_size, seq_len, _ = hidden_states.shape
-
     # Project hidden states to KV and Gate components
     # [batch, seq_len, emb_dim] -> [batch, seq_len, head_dim]
     kv = self.kv_proj(hidden_states)
     # [batch, seq_len, emb_dim] -> [batch, seq_len, head_dim]
     gate = self.gate_proj(hidden_states)
 
+    if model_mode == MODEL_MODE_AUTOREGRESSIVE and cache is not None:
+
+      def hca_compressor_fn(buf_kv, buf_gate):
+        gate_weights = jax.nn.softmax(buf_gate + self.position_bias.value[:, None, :], axis=1).astype(buf_kv.dtype)
+        compressed = self.kv_norm(jnp.sum(buf_kv * gate_weights, axis=1))
+        block_pos = position_ids - (self.compress_rate - 1)
+        compressed = self.rotary_emb(compressed, block_pos, unsqueeze_dim=None)
+        return jnp.expand_dims(compressed, 2), None, None
+
+      compressed, is_valid = update_ar_cache_and_get_validity_mask(
+          kv=kv,
+          gate=gate,
+          cache=cache,
+          model_mode=model_mode,
+          compressor_fn=hca_compressor_fn,
+          comp_dim=self.head_dim,
+          batch_size=batch_size,
+          mask_ndims=4,
+      )
+      compressed_kv = jnp.expand_dims(compressed, 2)  # [B, N, 1, D]
+      compressed_mask = jnp.where(is_valid, 0.0, DEFAULT_MASK_VALUE).astype(self.dtype)
+
+      return compressed_kv, compressed_mask
+
+    # --- PREFILL CHUNKING & PRIMING ---
     # Truncate sequence to the nearest multiple of the compression rate
     usable = (seq_len // self.compress_rate) * self.compress_rate
     chunk_kv = kv[:, :usable]
@@ -301,8 +600,8 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
       chunk_gate = chunk_gate.reshape((batch_size, n_windows, self.compress_rate, -1)) + self.position_bias.value
 
       # Apply gating mechanism over each compression window
-      gate_weights = jax.nn.softmax(chunk_gate, axis=2).astype(chunk_kv.dtype)
       # -> [batch, n_windows, head_dim]
+      gate_weights = jax.nn.softmax(chunk_gate, axis=2).astype(chunk_kv.dtype)
       compressed = self.kv_norm(jnp.sum(chunk_kv * gate_weights, axis=2))
 
       # Calculate positions for the compressed blocks
@@ -320,14 +619,26 @@ class DeepseekV4HCACompressor(BaseDeepseekCompressor):
     compressed_kv = jnp.expand_dims(compressed, axis=2)
     compressed_len = compressed_kv.shape[1]
 
+    # --- PREFILL CACHE PRIMING ---
+    if cache is not None:
+      prime_prefill_cache_state(
+          kv=kv,
+          gate=gate,
+          compressed_kv=compressed_kv,
+          seq_len=seq_len,
+          usable=usable,
+          compress_rate=self.compress_rate,
+          cache=cache,
+      )
+
     # Skip causal mask generation during decoding (seq_len == 1) or if no blocks were pooled
     if seq_len == 1 or compressed_len == 0:
-      return compressed_kv, jnp.zeros((batch_size, 1, seq_len, compressed_len), dtype=self.dtype)
+      compressed_mask = jnp.zeros((batch_size, 1, seq_len, compressed_len), dtype=self.dtype)
+      return compressed_kv, compressed_mask
 
     # Construct a causal mask preventing early queries from attending to future compressed blocks
     entry_indices = jnp.arange(compressed_len)
     causal_threshold = (position_ids + 1) // self.compress_rate
-
     future_mask = entry_indices[None, None, None, :] >= jnp.expand_dims(causal_threshold, axis=(1, 3))
     compressed_causal_mask = jnp.where(future_mask, DEFAULT_MASK_VALUE, 0.0).astype(self.dtype)
 
@@ -453,90 +764,134 @@ class DeepseekV4Indexer(nnx.Module):
       q_latent: Array,
       position_ids: Array,
       attention_mask: Optional[Array] = None,
+      model_mode: str = MODEL_MODE_TRAIN,
+      cache: Optional[Any] = None,
   ) -> Array:
+    """Forward pass for the DeepSeek-V4 Indexer.
+
+    Args:
+      hidden_states: Input token embeddings.
+      q_latent: Latent query representation for index score computation.
+      position_ids: Absolute token positions.
+      attention_mask: Optional attention mask.
+      model_mode: Execution mode (train, prefill, or autoregressive).
+      cache: Optional Indexer KV cache instance for inference.
+
+    Returns:
+      Top-K selected indices for each query position.
+    """
     batch_size, seq_len, _ = hidden_states.shape
+    future_mask = None
+    kv = self.kv_proj(hidden_states)
+    gate = self.gate_proj(hidden_states)
 
-    # Process overlapping pooling independently for the Indexer using its own head dimension
-    # -> [batch, n_windows, index_head_dim]
-    compressed = csa_overlap_pooling(
-        hidden_states,
-        self.kv_proj,
-        self.gate_proj,
-        self.position_bias.value,
-        self.kv_norm,
-        self.compress_rate,
-        self.index_head_dim,
-    )
-    compressed_len = compressed.shape[1]
+    if model_mode == MODEL_MODE_AUTOREGRESSIVE and cache is not None:
 
-    # Apply rotary positional embeddings to the compressed blocks if valid windows exist
-    if compressed_len > 0:
-      first_window_position = position_ids[:, 0:1]
-      positions = jnp.arange(compressed_len) * self.compress_rate + first_window_position
+      def indexer_compressor_fn(buf_kv, buf_gate):
+        chunk_kv_reshaped = jnp.swapaxes(buf_kv, 1, 2)
+        chunk_gate_reshaped = jnp.swapaxes(buf_gate, 1, 2) + self.position_bias.value
 
-      compressed = self.rotary_emb(compressed, positions, unsqueeze_dim=None)
+        assert cache.overlap_kv is not None, "cache.overlap_kv cannot be None"
+        assert cache.overlap_gate is not None, "cache.overlap_gate cannot be None"
+        prior_kv = cache.overlap_kv.get_value()
+        prior_gate = cache.overlap_gate.get_value()
+
+        compressed, next_prior_kv, next_prior_gate = csa_overlap_pooling(
+            chunk_kv_reshaped, chunk_gate_reshaped, self.kv_norm, self.index_head_dim, prior_kv, prior_gate
+        )
+
+        block_pos = position_ids - (self.compress_rate - 1)
+        compressed = self.rotary_emb(compressed, block_pos, unsqueeze_dim=None)
+
+        return (
+            jnp.expand_dims(compressed, 2),
+            next_prior_kv,
+            next_prior_gate,
+        )
+
+      compressed, is_valid = update_ar_cache_and_get_validity_mask(
+          kv=kv,
+          gate=gate,
+          cache=cache,
+          model_mode=model_mode,
+          compressor_fn=indexer_compressor_fn,
+          comp_dim=self.index_head_dim,
+          batch_size=batch_size,
+          mask_ndims=3,
+      )
+      compressed_len = compressed.shape[1]
+      future_mask = ~is_valid
+
+    # --- PREFILL CHUNKING & PRIMING ---
     else:
-      # Return empty top-k selections when sequence is too short to form any windows
-      return jnp.zeros(
-          (batch_size, seq_len, min(self.index_topk, compressed_len)),
-          dtype=jnp.int32,
+      compressed, compressed_len, next_prior_kv, next_prior_gate, usable = compute_csa_prefill_chunk_pooling(
+          kv=kv,
+          gate=gate,
+          seq_len=seq_len,
+          batch_size=batch_size,
+          compress_rate=self.compress_rate,
+          position_ids=position_ids,
+          position_bias=self.position_bias.value,
+          kv_norm=self.kv_norm,
+          rotary_emb=self.rotary_emb,
+          head_dim=self.index_head_dim,
+          dtype=self.dtype,
+          cache=cache,
       )
 
-    # Broadcast the compressed KV representations across all indexer heads
-    # -> [batch, 1, n_windows, index_head_dim]
+      # Prefill Cache Insertion
+      if cache is not None:
+        prime_prefill_cache_state(
+            kv=kv,
+            gate=gate,
+            compressed_kv=compressed,
+            seq_len=seq_len,
+            usable=usable,
+            compress_rate=self.compress_rate,
+            cache=cache,
+            next_prior_kv=next_prior_kv,
+            next_prior_gate=next_prior_gate,
+        )
+
+    if compressed_len == 0:
+      return jnp.zeros((batch_size, seq_len, min(self.index_topk, compressed_len)), dtype=jnp.int32)
+
+    # --- TOP-K ROUTING MATH (Executes in both Prefill and AR) ---
     compressed_kv = jnp.expand_dims(compressed, axis=1)
-    # -> [batch, index_n_heads, n_windows, index_head_dim]
-    compressed_kv = jnp.broadcast_to(
-        compressed_kv,
-        (batch_size, self.index_n_heads, compressed_len, self.index_head_dim),
-    )
+    compressed_kv = jnp.broadcast_to(compressed_kv, (batch_size, self.index_n_heads, compressed_len, self.index_head_dim))
 
-    # Project the latent query to match the Indexer's dimensions
-    # [batch, seq_len, index_n_heads * index_head_dim] -> [batch, seq_len, index_n_heads, index_head_dim]
     q = self.q_proj(q_latent).reshape((batch_size, seq_len, self.index_n_heads, self.index_head_dim))
-    # -> [batch, index_n_heads, seq_len, index_head_dim]
     q = jnp.transpose(q, (0, 2, 1, 3))
-
-    # Apply standard Rotary Positional Embeddings to queries
     q = self.rotary_emb(q, position_ids, unsqueeze_dim=1)
 
     q = q.astype(jnp.float32)
     compressed_kv = compressed_kv.astype(jnp.float32)
 
-    # Compute dot product between Queries and Compressed KV Blocks
-    # -> [batch, index_n_heads, seq_len, n_windows]
     scores = jnp.einsum("bhsd,bhwd->bhsw", q, compressed_kv)
     scores = jax.nn.relu(scores) * self.softmax_scale
-
-    # Compute routing weights to combine scores across indexer heads
-    # [batch, seq_len, emb_dim] -> [batch, seq_len, index_n_heads]
     weights = self.weights_proj(hidden_states).astype(jnp.float32) * self.weights_scaling
-
-    # Combine individual head scores according to routing weights
-    # -> [batch, seq_len, n_windows]
     index_scores = jnp.einsum("bhsw,bsh->bsw", scores, weights)
 
     k = min(self.index_topk, compressed_len)
 
-    # Mask out future compressed blocks to ensure causal routing
-    causal_threshold = (position_ids + 1) // self.compress_rate
-    entry_indices = jnp.arange(compressed_len)
-    future_mask = entry_indices[None, None, :] >= jnp.expand_dims(causal_threshold, axis=-1)
+    # --- ONLY RUN MATHEMATICAL CAUSAL MASK IN PREFILL/TRAIN ---
+    if future_mask is None:
+      causal_threshold = (position_ids + 1) // self.compress_rate
+      entry_indices_mask = jnp.arange(compressed_len)
+      future_mask = entry_indices_mask[None, None, :] >= jnp.expand_dims(causal_threshold, axis=-1)
 
+    # Apply the mask to the scores
     index_scores = jnp.where(future_mask, jnp.full_like(index_scores, -jnp.inf), index_scores)
 
-    # Apply standard segment attention mask (additive 0 and -inf)
     if attention_mask is not None:
       index_scores += attention_mask[:, :, :compressed_len]
 
-    # Retrieve the top-k highest scoring block indices for each token
     top_k_indices = jax.lax.top_k(index_scores, k)[1]
+    invalid = jnp.take_along_axis(future_mask, top_k_indices, axis=-1)
 
-    # Invalidate any top-k selections that point to future blocks (edge case safety)
-    invalid = top_k_indices >= jnp.expand_dims(causal_threshold, axis=-1)
-    top_k_indices = jnp.where(invalid, jnp.full_like(top_k_indices, -1), top_k_indices)
+    final_indices = jnp.where(invalid, jnp.full_like(top_k_indices, -1), top_k_indices)
 
-    return top_k_indices
+    return final_indices
 
 
 class DeepseekV4CSACompressor(BaseDeepseekCompressor):
@@ -601,58 +956,106 @@ class DeepseekV4CSACompressor(BaseDeepseekCompressor):
       q_latent: Array,
       position_ids: Array,
       attention_mask: Optional[Array] = None,
+      model_mode: str = MODEL_MODE_TRAIN,
+      cache: Optional[Any] = None,
+      indexer_cache: Optional[Any] = None,
   ) -> Tuple[Array, Array]:
     """Forward pass for the CSA compressor.
 
     Args:
-      hidden_states: Input token embeddings. Shape: `[batch, seq_len, emb_dim]`.
-      q_latent: Latent query representation. Shape: `[batch, seq_len, emb_dim]`.
-      position_ids: Absolute token positions. Shape: `[batch, seq_len]`.
+      hidden_states: Input token embeddings.
+      q_latent: Latent query representation for index score computation.
+      position_ids: Absolute token positions.
+      attention_mask: Optional attention mask.
+      model_mode: Execution mode (train, prefill, or autoregressive).
+      cache: Optional CSA compressor KV cache instance for inference.
+      indexer_cache: Optional Indexer KV cache instance for inference.
 
     Returns:
-      compressed_kv: The pooled KV tensors. Shape: `[batch, n_windows, 1, head_dim]`.
-      compressed_mask: Causal and routing mask dynamically selected by the Indexer.
-                       Shape: `[batch, 1, seq_len, n_windows]`.
+      compressed_kv: The pooled KV tensors.
+      compressed_mask: The sparse attention mask computed by the indexer.
     """
     batch_size, seq_len, _ = hidden_states.shape
 
-    # Retrieve top-k blocks dynamically chosen for each query
-    # -> [batch, seq_len, index_topk]
-    top_k_indices = self.indexer(hidden_states, q_latent, position_ids, attention_mask)
+    # 1. ALWAYS Run Indexer (It fetches its own history inside AR)
+    top_k_indices = self.indexer(hidden_states, q_latent, position_ids, attention_mask, model_mode, indexer_cache)
 
-    # Perform overlapping pooling over the sequence
-    # -> [batch, n_windows, head_dim]
-    compressed = csa_overlap_pooling(
-        hidden_states,
-        self.kv_proj,
-        self.gate_proj,
-        self.position_bias.value,
-        self.kv_norm,
-        self.compress_rate,
-        self.head_dim,
-    )
-    compressed_len = compressed.shape[1]
+    kv = self.kv_proj(hidden_states)
+    gate = self.gate_proj(hidden_states)
 
-    # Apply rotary positional embeddings to the pooled blocks if there are any full windows
-    if compressed_len > 0:
-      first_window_position = position_ids[:, 0:1]
-      positions = jnp.arange(compressed_len) * self.compress_rate + first_window_position
+    if model_mode == MODEL_MODE_AUTOREGRESSIVE and cache is not None:
 
-      compressed = self.rotary_emb(compressed, positions, unsqueeze_dim=None)
+      def csa_compressor_fn(buf_kv, buf_gate):
+        chunk_kv_reshaped = jnp.swapaxes(buf_kv, 1, 2)
+        chunk_gate_reshaped = jnp.swapaxes(buf_gate, 1, 2) + self.position_bias.value
 
-    # Expand to standard KV format
-    # -> [batch, n_windows, 1, head_dim]
-    compressed_kv = jnp.expand_dims(compressed, axis=2)
+        assert cache.overlap_kv is not None, "cache.overlap_kv cannot be None"
+        assert cache.overlap_gate is not None, "cache.overlap_gate cannot be None"
+        prior_kv = cache.overlap_kv.get_value()
+        prior_gate = cache.overlap_gate.get_value()
 
-    # Return early if no compressed blocks could be formed (e.g. sequence too short)
+        compressed, next_prior_kv, next_prior_gate = csa_overlap_pooling(
+            chunk_kv_reshaped, chunk_gate_reshaped, self.kv_norm, self.head_dim, prior_kv, prior_gate
+        )
+
+        block_pos = position_ids - (self.compress_rate - 1)
+        compressed = self.rotary_emb(compressed, block_pos, unsqueeze_dim=None)
+
+        return (
+            jnp.expand_dims(compressed, 2),
+            next_prior_kv,
+            next_prior_gate,
+        )
+
+      compressed, _ = update_ar_cache_and_get_validity_mask(
+          kv=kv,
+          gate=gate,
+          cache=cache,
+          model_mode=model_mode,
+          compressor_fn=csa_compressor_fn,
+          comp_dim=self.head_dim,
+          batch_size=batch_size,
+          mask_ndims=None,
+      )
+      compressed_kv = jnp.expand_dims(compressed, 2)
+      compressed_len = compressed_kv.shape[1]
+
+    # --- PREFILL CHUNKING & PRIMING ---
+    else:
+      compressed, compressed_len, next_prior_kv, next_prior_gate, usable = compute_csa_prefill_chunk_pooling(
+          kv=kv,
+          gate=gate,
+          seq_len=seq_len,
+          batch_size=batch_size,
+          compress_rate=self.compress_rate,
+          position_ids=position_ids,
+          position_bias=self.position_bias.value,
+          kv_norm=self.kv_norm,
+          rotary_emb=self.rotary_emb,
+          head_dim=self.head_dim,
+          dtype=self.dtype,
+          cache=cache,
+      )
+      compressed_kv = jnp.expand_dims(compressed, 2)
+
+      if cache is not None:
+        prime_prefill_cache_state(
+            kv=kv,
+            gate=gate,
+            compressed_kv=compressed_kv,
+            seq_len=seq_len,
+            usable=usable,
+            compress_rate=self.compress_rate,
+            cache=cache,
+            next_prior_kv=next_prior_kv,
+            next_prior_gate=next_prior_gate,
+        )
+
     if compressed_len == 0:
       return compressed_kv, jnp.zeros((batch_size, 1, seq_len, 0), dtype=self.dtype)
 
-    # Construct the final dynamic mask applying the Indexer's selections
-    # -> [batch, 1, seq_len, n_windows]
+    # 3. Apply Dynamic Masking Logic
     k = top_k_indices.shape[-1]
-
-    # Only compute and apply the complex block mask if top-k selections exist
     if k > 0:
       valid = top_k_indices >= 0
       entry_indices = jnp.arange(compressed_len)[None, None, :]
@@ -919,10 +1322,69 @@ class CompressedAttention(Attention):
         rngs=self.rngs,
     )
 
+    if self.model_mode != MODEL_MODE_TRAIN and self.compress_ratio > 0:
+      batch_size, _ = max_utils.get_batch_seq_len_for_mode(self.config, MODEL_MODE_AUTOREGRESSIVE)
+
+      max_prefill_comp = max(1, self.max_prefill_predict_length // self.compress_ratio)
+      max_target_comp = max(max_prefill_comp + 1, self.max_target_length // self.compress_ratio)
+
+      comp_head_dim = self.head_dim if self.compress_ratio > 4 else 2 * self.head_dim
+
+      self.compressor_cache = kvcache.KVCache(
+          max_prefill_length=max_prefill_comp,
+          max_target_length=max_target_comp,
+          batch=batch_size,
+          key_seq_len=max_target_comp,
+          value_seq_len=max_target_comp,
+          key_heads=1,
+          value_heads=1,
+          key_head_size=comp_head_dim,
+          value_head_size=comp_head_dim,
+          dtype=self.dtype,
+          model_mode=self.model_mode,
+          is_deepseek_v4=True,
+          compress_rate=self.compress_ratio,
+          rngs=self.rngs,
+      )
+    else:
+      self.compressor_cache = None
+
+    if self.model_mode != MODEL_MODE_TRAIN and self.compress_ratio == 4:
+      self.indexer_cache = kvcache.KVCache(
+          max_prefill_length=max_prefill_comp,
+          max_target_length=max_target_comp,
+          batch=batch_size,
+          key_seq_len=max_prefill_comp,
+          value_seq_len=max_prefill_comp,
+          key_heads=1,
+          value_heads=1,
+          key_head_size=2 * self.config.indexer_head_dim,
+          value_head_size=2 * self.config.indexer_head_dim,
+          dtype=self.dtype,
+          model_mode=self.model_mode,
+          is_deepseek_v4=True,
+          compress_rate=self.compress_ratio,
+          is_indexer=True,
+          rngs=self.rngs,
+      )
+    else:
+      self.indexer_cache = None
+
   @property
   def out_head_dim(self) -> int:
     """Returns the head dimension used prior to the output projection."""
     return self.head_dim
+
+  def _apply_rotary_embedding_v4(
+      self, inputs: Array, inputs_positions: Array, unsqueeze_dim: int = -2, reverse: bool = False
+  ) -> Array:
+    """Applies rotary position embeddings, dispatching keyword arguments safely based on capability."""
+    if isinstance(self.rotary_embedding, DeepSeekV4RotaryEmbedding):
+      return self.rotary_embedding(inputs, inputs_positions, unsqueeze_dim=unsqueeze_dim, reverse=reverse)
+    elif reverse and hasattr(self.rotary_embedding, "reverse"):
+      return self.rotary_embedding(inputs, inputs_positions, reverse=True)
+    else:
+      return self.rotary_embedding(inputs, inputs_positions)
 
   def compressed_query_projection(self, inputs_q: Array, inputs_positions: Array, model_mode) -> Array:
     """Query projection for Compressed Attention.
@@ -954,7 +1416,7 @@ class CompressedAttention(Attention):
     q_up_normed = self.q_up_norm(q_up)
 
     # -> [batch, seq_len, num_query_heads, head_dim]
-    q_out = self.rotary_embedding(q_up_normed, inputs_positions, unsqueeze_dim=-2)
+    q_out = self._apply_rotary_embedding_v4(q_up_normed, inputs_positions, unsqueeze_dim=-2)
 
     # Scale queries by 1/sqrt(head_dim) prior to attention to prevent softmax saturation
     # -> [batch, seq_len, num_query_heads, head_dim]
@@ -986,7 +1448,7 @@ class CompressedAttention(Attention):
 
     kv_up_normed = self.kv_norm(kv_up)
 
-    kv_out = self.rotary_embedding(kv_up_normed, inputs_positions, unsqueeze_dim=-2)
+    kv_out = self._apply_rotary_embedding_v4(kv_up_normed, inputs_positions, unsqueeze_dim=-2)
 
     return kv_out, kv_out
 
@@ -1021,28 +1483,48 @@ class CompressedAttention(Attention):
       5. Grouped Linear (o_a_proj): -> `[batch, q_length, o_groups, out_features_per_group]`.
       6. Flatten & Dense (o_b_proj): -> `[batch, q_length, emb_dim]`.
     """
+    kv_cache = kwargs.get("kv_cache", None)
+
     q, q_normed = self.compressed_query_projection(inputs_q, inputs_positions, model_mode)
     q = checkpoint_name(q, "query_proj")
     kv, _ = self.compressed_kv_projection(inputs_kv, inputs_positions, model_mode)
 
+    current_kv_cache = kv_cache
+
+    # 1. Update the Local (Sliding Window) KV Cache with the uncompressed tokens
+    if model_mode != MODEL_MODE_TRAIN and getattr(self, "KVCache_0", None) is not None:
+      current_kv_cache = self.update_kv_caches(
+          kv, kv, decoder_segment_ids, model_mode, kwargs.get("previous_chunk", None)
+      )
+
     # Generate compressed representations based on the configured layer type
     compressed_kv = None
     compressed_mask = None
-    # Generate the standard segment mask
     compressed_segment_mask = None
+
     if decoder_segment_ids is not None and self.compress_ratio > 0:
+      # Generate the standard segment mask
       segment_mask = decoder_segment_ids[:, :, None] == decoder_segment_ids[:, None, :]
       segment_mask_additive = jnp.where(segment_mask, 0.0, DEFAULT_MASK_VALUE)
-
       # Downsample the kv dimension
       compress_rate = self.compress_ratio
       compressed_segment_mask = segment_mask_additive[:, :, ::compress_rate]
 
     # Route to the appropriate compressor depending on the layer's role in the architecture
     if self.compress_ratio > 4:
-      compressed_kv, compressed_mask = self.hca_compressor(inputs_kv, q_normed, inputs_positions)
+      compressed_kv, compressed_mask = self.hca_compressor(
+          inputs_kv, q_normed, inputs_positions, model_mode, self.compressor_cache
+      )
     elif self.compress_ratio == 4:
-      compressed_kv, compressed_mask = self.csa_compressor(inputs_kv, q_normed, inputs_positions, compressed_segment_mask)
+      compressed_kv, compressed_mask = self.csa_compressor(
+          inputs_kv,
+          q_normed,
+          inputs_positions,
+          compressed_segment_mask,
+          model_mode,
+          self.compressor_cache,
+          self.indexer_cache,
+      )
 
     # Apply segment masking to the compressed blocks
     if compressed_segment_mask is not None and compressed_mask is not None:
@@ -1052,10 +1534,8 @@ class CompressedAttention(Attention):
           compressed_segment_mask[:, :, : compressed_mask.shape[-1]], axis=1
       )
 
-    # Extend local KV tensors with the compressed blocks
-    if compressed_kv is not None:
-      kv = jnp.concatenate([kv, compressed_kv], axis=1)
-
+    # Note: Unlike standard pre-attention concatenation (extending local KV tensors with compressed blocks),
+    # compressed_kv is passed separately to attention_op to support custom kernels and decoding caching.
     kv = checkpoint_name(kv, "kv_proj")
 
     # Prepare the mask shape for the underlying AttentionOp
@@ -1066,8 +1546,7 @@ class CompressedAttention(Attention):
     if self.query_pre_attn_scalar and self.query_pre_attn_scalar != 1.0:
       q = q * self.query_pre_attn_scalar
 
-    # Compute Attention
-    # -> [batch, q_length, num_query_heads, head_dim]
+    # Compute Attention (Now safely passing kv_cache so the kernel doesn't assert!)
     attn_out = self.attention_op(
         q,
         kv,
@@ -1075,12 +1554,14 @@ class CompressedAttention(Attention):
         decoder_segment_ids,
         inputs_positions,
         model_mode,
-        sinks=self.sinks.value,
+        sinks=self.sinks.value if self.sinks is not None else None,
         compressed_mask=compressed_mask,
+        compressed_kv=compressed_kv,
+        cached_values=current_kv_cache,
     )
 
     # Reverse RoPE on Values
-    attn_out = self.rotary_embedding(attn_out, inputs_positions, unsqueeze_dim=-2, reverse=True)
+    attn_out = self._apply_rotary_embedding_v4(attn_out, inputs_positions, unsqueeze_dim=-2, reverse=True)
 
     attn_out = checkpoint_name(attn_out, "attention_out")
 
@@ -1088,18 +1569,16 @@ class CompressedAttention(Attention):
     b, s, h, d = attn_out.shape
     # -> [batch, q_length, o_groups, in_features_per_group]
     grouped_out = attn_out.reshape(b, s, self.config.o_groups, (h * d) // self.config.o_groups)
-
     # -> [batch, q_length, o_groups, out_features_per_group]
     grouped_out = self.o_a_proj(grouped_out)
-
     # -> [batch, q_length, o_groups * out_features_per_group]
     grouped_flat = grouped_out.reshape(b, s, -1)
-
     # -> [batch, q_length, emb_dim]
     final_out = self.o_b_proj(grouped_flat)
     final_out = checkpoint_name(final_out, "out_proj")
 
-    return final_out, None
+    # Return the Tuple expected by the transformer block
+    return final_out, current_kv_cache
 
 
 def compressed_attention(

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -771,7 +771,7 @@ class AttentionOp(nnx.Module):
     use_segment_positions = (
         segment_positions is not None
         and self.config.context_parallel_load_balance
-        and self.mesh.shape.get(self.config.context_sharding, 1) > 1
+        and (self.mesh is not None and self.mesh.shape.get(self.config.context_sharding, 1) > 1)
         and previous_chunk is None
         and model_mode != MODEL_MODE_AUTOREGRESSIVE
     )
@@ -821,32 +821,77 @@ class AttentionOp(nnx.Module):
         sliding_mask = sliding_mask[:, None, None, :, :]
       output_mask = sliding_mask * output_mask
     elif self.attention_type == AttentionType.COMPRESSED:
-      if compressed_mask is None:
-        raise ValueError("compressed_mask must be provided for COMPRESSED attention type")
-      c_len = compressed_mask.shape[-1]
+      c_len = compressed_mask.shape[-1] if compressed_mask is not None else 0
       s_len = kv_seq_len - c_len
 
-      # Build causal and sliding window mask for the uncompressed sequence
-      # -> [q_seq_len, s_len]
-      row_ids = jax.lax.broadcasted_iota(jnp.int32, (q_seq_len, s_len), 0) + next_pos
-      # -> [1, s_len]
-      col_ids = jax.lax.broadcasted_iota(jnp.int32, (1, s_len), 1)
-      uncompressed_mask = col_ids <= row_ids
-      if self.sliding_window_size is not None:
-        uncompressed_mask = uncompressed_mask & (col_ids > (row_ids - self.sliding_window_size))
+      def get_sliding_mask(s_len):
+        # Safely use segment_positions, or fall back to next_pos if None
+        if segment_positions is not None:
+          abs_q = segment_positions[:, :, None]
+        else:
+          local_next = next_pos[:, None] if isinstance(next_pos, jax.Array) else next_pos
+          abs_q = jnp.arange(q_seq_len)[None, :, None] + local_next
 
-      # Broadcast uncompressed_mask to match compressed_mask's layout
+        if model_mode == MODEL_MODE_AUTOREGRESSIVE and q_seq_len == 1:
+          if decoder_segment_ids is not None:
+            is_valid = decoder_segment_ids[:, :s_len] == DECODING_ACTIVE_SEQUENCE_INDICATOR
+            valid_indices = jnp.where(is_valid, jnp.arange(s_len)[None, :], -1)
+            max_valid = jnp.max(valid_indices, axis=-1, keepdims=True)  # [batch, 1]
+
+            # Let each sequence in the batch independently determine its AR vs prefill position
+            is_ar_cache = max_valid[:, :, None] >= 0  # [batch, 1, 1]
+
+            i = jnp.arange(s_len)[None, None, :]
+            abs_k_ar = abs_q - max_valid[:, :, None] + i
+            abs_k_prefill = jnp.broadcast_to(i, abs_k_ar.shape)
+
+            abs_k = jnp.where(is_ar_cache, abs_k_ar, abs_k_prefill)
+            distance = abs_q - abs_k
+            in_window = (distance < self.sliding_window_size) if self.sliding_window_size is not None else True
+            return in_window & (distance >= 0)
+
+        # For prefill and training phases (q_seq_len > 1)
+        abs_k = jnp.arange(s_len)[None, None, :]
+        distance = abs_q - abs_k
+        in_window = (distance < self.sliding_window_size) if self.sliding_window_size is not None else True
+        return in_window & (distance >= 0)
+
+      uncompressed_mask = get_sliding_mask(s_len)
+
+      max_ndim = max(
+          uncompressed_mask.ndim,
+          compressed_mask.ndim if compressed_mask is not None else 0,
+          output_mask.ndim if output_mask is not None else 0,
+          4,
+      )
+
+      def _align_mask(m, target_ndim):
+        if m is None or m.ndim >= target_ndim:
+          return m
+        return m.reshape(m.shape[:1] + (1,) * (target_ndim - m.ndim) + m.shape[1:])
+
+      expanded_uncompressed_mask = _align_mask(uncompressed_mask, max_ndim)
+
+      if compressed_mask is None:
+        if output_mask is not None:
+          output_mask = _align_mask(output_mask, max_ndim)
+          output_mask = expanded_uncompressed_mask * output_mask
+        else:
+          output_mask = expanded_uncompressed_mask
+        return jnp.where(output_mask, 0.0, DEFAULT_MASK_VALUE)
+
+      compressed_mask = _align_mask(compressed_mask, max_ndim)
       target_shape = compressed_mask.shape[:-1] + (s_len,)
-      padded_shape = (1,) * (len(target_shape) - 2) + uncompressed_mask.shape
-      uncompressed_mask = jnp.broadcast_to(uncompressed_mask.reshape(padded_shape), target_shape)
+      expanded_uncompressed_mask = jnp.broadcast_to(expanded_uncompressed_mask, target_shape)
 
-      # Apply document-packing mask if it exists
       if output_mask is not None:
-        uncompressed_mask = uncompressed_mask & output_mask[..., :s_len]
+        output_mask_aligned = _align_mask(output_mask, max_ndim)
+        expanded_uncompressed_mask = expanded_uncompressed_mask & output_mask_aligned[..., :s_len]
 
-      uncompressed_mask = jnp.where(uncompressed_mask, 0.0, DEFAULT_MASK_VALUE)
-
-      return jnp.concatenate([uncompressed_mask, compressed_mask], axis=-1)
+      expanded_uncompressed_mask = jnp.where(expanded_uncompressed_mask, 0.0, DEFAULT_MASK_VALUE).astype(
+          compressed_mask.dtype
+      )
+      return jnp.concatenate([expanded_uncompressed_mask, compressed_mask], axis=-1)
 
     elif self.attention_type == AttentionType.CHUNK and output_mask is not None:
       if use_segment_positions:
@@ -2252,6 +2297,7 @@ class AttentionOp(nnx.Module):
       sinks=None,
       indexer_mask: Optional[Array] = None,
       compressed_mask: Optional[Array] = None,
+      compressed_kv: Optional[Array] = None,
       slot: Optional[int] = None,
       record_max_logits: bool = False,
   ):
@@ -2262,19 +2308,25 @@ class AttentionOp(nnx.Module):
     if model_mode != MODEL_MODE_TRAIN:
       assert prefill_kv_cache
       key, value, decoder_segment_ids = prefill_kv_cache
+    pass_comp_to_prefill = (compressed_kv is not None) and (ar_kv_cache is None)
+    k_prefill = key
+    v_prefill = value
+    if pass_comp_to_prefill:
+      k_prefill = jnp.concatenate([k_prefill, compressed_kv], axis=1)
+      v_prefill = jnp.concatenate([v_prefill, compressed_kv], axis=1)
 
     indexer_mask_prefill = None
     indexer_mask_ar = None
     if indexer_mask is not None:
-      prefill_len = key.shape[1]
+      prefill_len = key.shape[1]  # Use original key shape before concat
       indexer_mask_prefill = indexer_mask[:, :, :prefill_len]
       if ar_kv_cache is not None:
         indexer_mask_ar = indexer_mask[:, :, prefill_len:]
 
     prefill_unnormalized_output, prefill_exponentials_max, prefill_exponentials_sum = self.apply_attention(
         query=query,
-        key=key,
-        value=value,
+        key=k_prefill,
+        value=v_prefill,
         decoder_segment_ids=decoder_segment_ids,
         segment_positions=inputs_positions,
         lengths=None,
@@ -2284,31 +2336,35 @@ class AttentionOp(nnx.Module):
         bidirectional_mask=bidirectional_mask,
         sinks=sinks,
         indexer_mask=indexer_mask_prefill,
-        compressed_mask=compressed_mask,
+        compressed_mask=compressed_mask if pass_comp_to_prefill else None,
         record_max_logits=record_max_logits,
         qk_product_einsum=self.AqtEinsum_0,
         wv_product_einsum=self.AqtEinsum_1,
     )
 
-    # Return the "prefill" cache if it actually the combined prefill+ar kv cache
     if ar_kv_cache is None:
       if prefill_exponentials_sum is not None:
         return prefill_unnormalized_output / prefill_exponentials_sum
       return prefill_unnormalized_output
 
-    key, value, decoder_segment_ids, lengths = ar_kv_cache
+    key_ar, value_ar, decoder_segment_ids_ar, lengths = ar_kv_cache
+
+    if compressed_kv is not None:
+      key_ar = jnp.concatenate([key_ar, compressed_kv], axis=1)
+      value_ar = jnp.concatenate([value_ar, compressed_kv], axis=1)
 
     ar_unnormalized_output, ar_exponentials_max, ar_exponentials_sum = self.apply_attention(
         query=query,
-        key=key,
-        value=value,
-        decoder_segment_ids=decoder_segment_ids,
+        key=key_ar,
+        value=value_ar,
+        decoder_segment_ids=decoder_segment_ids_ar,
         segment_positions=inputs_positions,
         lengths=lengths,
         model_mode=model_mode,
         use_ragged_attention=self.use_ragged_attention,
         bidirectional_mask=bidirectional_mask,
         indexer_mask=indexer_mask_ar,
+        compressed_mask=compressed_mask,
         qk_product_einsum=self.AqtEinsum_2,
         wv_product_einsum=self.AqtEinsum_3,
     )

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -713,7 +713,8 @@ class RoutedMoE(nnx.Module):
       tid2eid_int = self.tid2eid.value
       # Cast the float32 array to int32 (JAX automatically assigns 0.0 gradients to integer casts)
       tid2eid_int = tid2eid_int.astype(jnp.int32)
-      top_k_indices = tid2eid_int[input_ids]
+      # Cast input_ids to int32 to safely index the hash routing table
+      top_k_indices = tid2eid_int[input_ids.astype(jnp.int32)]
       top_k_weights = jnp.take_along_axis(pre_bias_logits, top_k_indices, axis=-1)
     # NOTE: deepseek2 has a different pattern
     elif self.config.model_name.startswith(("deepseek3", "deepseek4")):

--- a/tests/unit/attention_test.py
+++ b/tests/unit/attention_test.py
@@ -3185,6 +3185,75 @@ class DeepSeekV4AttentionMaskingTest(unittest.TestCase):
     np.testing.assert_allclose(mask_np[:, s_len + 1], 0.0)
     print("Mask logic for uncompressed & compressed attention passed perfectly.")
 
+  def test_generate_attention_mask_compressed_all_modes(self):
+    """Verifies AttentionType.COMPRESSED across train, prefill, and autoregressive modes."""
+    batch_size = 2
+    s_len = 8
+    c_len = 2
+    kv_len = s_len + c_len
+
+    op = AttentionOp(
+        config=self.config,
+        num_query_heads=4,
+        num_kv_heads=1,
+        max_target_length=128,
+        mesh=None,
+        attention_kernel="dot_product",
+        attention_type=AttentionType.COMPRESSED,
+        sliding_window_size=3,
+    )
+
+    # 1. Training mode (batch_size=2, 4D compressed_mask)
+    q_train = jnp.zeros((batch_size, s_len, 1, 128))
+    k_train = jnp.zeros((batch_size, kv_len, 1, 128))
+    c_mask_4d = jnp.zeros((batch_size, 1, s_len, c_len), dtype=jnp.float32)
+    mask_train = op.generate_attention_mask(
+        query=q_train,
+        key=k_train,
+        decoder_segment_ids=None,
+        model_mode="train",
+        compressed_mask=c_mask_4d,
+    )
+    self.assertEqual(mask_train.shape, (batch_size, 1, s_len, kv_len))
+
+    # 2. Prefill mode (batch_size=2, 5D compressed_mask with segment_positions)
+    c_mask_5d = jnp.zeros((batch_size, 1, 1, s_len, c_len), dtype=jnp.float32)
+    seg_pos = jnp.arange(s_len)[None, :].repeat(batch_size, axis=0)
+    mask_prefill = op.generate_attention_mask(
+        query=q_train,
+        key=k_train,
+        decoder_segment_ids=None,
+        model_mode="prefill",
+        compressed_mask=c_mask_5d,
+        segment_positions=seg_pos,
+    )
+    self.assertEqual(mask_prefill.shape, (batch_size, 1, 1, s_len, kv_len))
+
+    # 3. Autoregressive mode (q_seq_len=1, batch_size=2, decoder_segment_ids)
+    q_ar = jnp.zeros((batch_size, 1, 1, 128))
+    k_ar = jnp.zeros((batch_size, kv_len, 1, 128))
+    c_mask_ar = jnp.zeros((batch_size, 1, 1, c_len), dtype=jnp.float32)
+    seg_ids = jnp.ones((batch_size, 16), dtype=jnp.int32)
+    mask_ar = op.generate_attention_mask(
+        query=q_ar,
+        key=k_ar,
+        decoder_segment_ids=seg_ids,
+        model_mode="autoregressive",
+        compressed_mask=c_mask_ar,
+    )
+    self.assertEqual(mask_ar.shape, (batch_size, 1, 1, 1, kv_len))
+
+    # 4. Compressed mask is None (fallback to uncompressed mask shape)
+    mask_none = op.generate_attention_mask(
+        query=q_train,
+        key=k_train,
+        decoder_segment_ids=None,
+        model_mode="train",
+        compressed_mask=None,
+    )
+    self.assertEqual(mask_none.ndim, 4)
+    self.assertEqual(mask_none.shape[-1], kv_len)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description

# Enable End-to-End DeepSeek-V4 Decoding, Caching, and API Server Support

## Overview

This pr enables end-to-end decoding and inference server support for **DeepSeek-V4** architectures, which rely on Compressed Attention (Hybrid Compressed Attention and Compressed Sliding Attention) and interleaved Rotary Positional Embeddings.

This PR enables full **autoregressive decoding, KV cache management, and OpenAI-compatible API server serving** for DeepSeek-V4 models in MaxText and MaxEngine.

---

## Key architectural Changes

### 1. Multi-Tier Autoregressive KV Caching (`src/maxtext/inference/`)

- **DeepSeek-V4 Cache State (`KVCache`)**: Extends `KVCache` to manage DeepSeek-V4's multi-component cache state alongside standard key/value buffers:
  - **Accumulator Buffers** (`leftover_buffer_kv`, `leftover_buffer_gate`): Buffers incoming tokens until a full compression window is reached.
  - **Overlap Registers** (`overlap_kv`, `overlap_gate`): Carries trailing window state across sequence chunks for Compressed Sliding Attention (CSA).
  - **Block Trackers**: Tracks total entry counts and valid autoregressive block lengths per sequence.
- **MaxEngine Integration (`maxengine.py`)**: Adds DeepSeek-V4 cache leaves (`_DEEPSEEK_V4_CACHE_KEYS`) to engine slot operations (`bulk_insert`, `insert`, `replace`), using XLA `DynamicUpdateSlice` primitives to update concurrent decode slots in-place without HBM copies.


### 2. Compressed Attention Decoding Pipeline (`src/maxtext/layers/`)

- **Autoregressive Token-by-Token Compression (`attention_compressed.py`)**:
  - Implements decoding execution paths for both **HCA** (non-overlapping pooling) and **CSA / Indexer** (overlapping window pooling).
  - Integrates clean helper abstractions for prefill chunk pooling, cache state priming, and safe RoPE keyword argument dispatching.
- **Dynamic Validity Masking**:
  - Constructs 3D/4D binary validity masks combining statically padded prefill blocks and autoregressive blocks so queries attend only to completed, valid compressed representations.
- **Batched Sliding-Window Attention (`attention_op.py`)**:
  - Ensures each sequence in a batched decoding request independently evaluates its sliding-window token positions (`abs_k`), supporting multi-sequence workloads where active autoregressive sequences and newly started prompts coexist in the same batch.
  

### 3. API Server & Tokenization (`benchmarks/api_server/`)

- **Harmony Tokenizer (`encoding_dsv4.py`)**: Adds native DeepSeek-V4 / Harmony tokenization and formatting support.
- **Server Integration**: Updates `maxtext_server.py`, `server_models.py`, and `server_utils.py` to route DeepSeek-V4 requests, configure special tokens, and support generation parameters.
- **Concurrent Benchmark Tests**: Adds `test_batching_chat_completions.py` and `test_batching_text_completions.py` for verifying multi-request serving and throughput.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456

# Tests

## Forward pass logit checker

 - Script: https://paste.googleplex.com/4927710567727104
 - Result: https://paste.googleplex.com/4776313389973504. Successful run based on comment in [b/509930698#comment18](https://b.corp.google.com/issues/509930698#comment18)

## Api_server Run

XPK Cmd: https://paste.googleplex.com/5792652892176384

#### Sample Curl Request for 500 tokens decoding
 - Cmd: https://paste.googleplex.com/4719573701099520
 - Output: https://paste.googleplex.com/5832623954984960

#### test_batching_chat_completions.py
 - Result: https://paste.googleplex.com/4510990040432640

## Training run on deepseek4-tiny.yml (on v5p-8 TPU vm)

 - Script: https://paste.googleplex.com/4891722382442496
 - Result: https://paste.googleplex.com/5805793009074176



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
