### PR TITLE
fix(test): ignore the serialized Mosaic kernel when diffing HLO

### DIFF
--- a/tests/integration/hlo_diff_test.py
+++ b/tests/integration/hlo_diff_test.py
@@ -43,6 +43,12 @@ SECTION_CONTENT_REGEX = re.compile(r'^\d+ (?:"[^"]*"|\{[^\}]*\})$')
 # Filters and normalizes an HLO line to ignore environment-specific details.
 STACK_FRAME_REGEX = re.compile(r"stack_frame_id=\d+")
 
+# The serialized Mosaic kernel of a Pallas custom call embeds the absolute path of the installed
+# jax package, so it differs between a venv install and a Docker image install even though the
+# compiled graph is the same. The kernel's shapes and block sizes are still checked, since they
+# appear as plain text elsewhere in the dump.
+CUSTOM_CALL_BODY_REGEX = re.compile(r'("custom_call_config":\{"body":")[^"]*(")')
+
 
 def filter_line(line):
   # Matches operation sections content like: 1234 {"sharding parameters", ...} or 1234 "operation metadata"
@@ -50,6 +56,8 @@ def filter_line(line):
     return None
   # Replace stack_frame_id=... with stack_frame_id=0
   line = STACK_FRAME_REGEX.sub("stack_frame_id=0", line)
+  # Replace the serialized Mosaic kernel with a placeholder
+  line = CUSTOM_CALL_BODY_REGEX.sub(r"\1<mosaic_body>\2", line)
   return line
 
 


### PR DESCRIPTION
## Description

The three `tests/integration/hlo_diff_test.py` cases fail on every scheduled image build ([run 29261172318](https://github.com/AI-Hypercomputer/maxtext/actions/runs/29261172318/job/86856093946)), and have since the stable-image test job was added in #4401 (`052fda676`). The compiled graph is not deviating — the test is comparing the install path of jax.

Splash attention is a Pallas kernel, so XLA serializes its Mosaic module into the custom call and dumps it as base64 under `backend_config.custom_call_config.body`. That payload carries the kernel's MLIR location info, which holds the **absolute path of `splash_attention_kernel.py`** — and that path depends on where jax was installed:

| environment | path baked into the HLO |
| --- | --- |
| wheel + venv (presubmit, where the reference is generated) | `/__w/maxtext/maxtext/.venv/lib/python3.12/site-packages/jax/...` |
| Docker image (system python, tests run from `/deps`) | `/usr/local/lib/python3.12/site-packages/jax/...` |

Decoding the payload out of the failing job's log shows that single string is the entire deviation. Each of the three references differs from its dump by exactly one line, and mask the base64 body and all three are byte-identical. Same jax, same libtpu, same graph — different directory.

`filter_line` already exists to normalize this class of environment noise (it zeroes `stack_frame_id` and drops the sharding/metadata section lines), so the Mosaic payload is normalized there too. The kernel is still covered by the rest of the dump: its operand shapes and layouts are plain text, and its block sizes are in the plain-text `xprof_metadata` on the neighboring line.

**The reference files do not need regenerating.** `filter_line` runs over the fresh dump and the stored reference alike at compare time, so the committed references — runner path and all — normalize to the same masked form. This is also why running the *Update HLO References* workflow does nothing: it regenerates in the venv environment, which already matches, and the commit step then fails with "nothing to commit".

The `--ignore=tests/integration/hlo_diff_test.py` carried for the jax-nightly image is left alone. That image runs a different jax and XLA, so it may deviate for reasons that are real; worth revisiting separately once the stable image is green.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
