### PR TITLE
re-normalize probability distribution when clip_logits_epsilon is used.

### DIFF
--- a/tests/utils/forward_pass_logit_checker.py
+++ b/tests/utils/forward_pass_logit_checker.py
@@ -167,7 +167,7 @@ def compare_top_tokens(converted_tokens, golden_tokens):
   max_logging.log(table_str)
 
 
-def check_kl_divergence(model_logits, golden_logits, atol=0.02):
+def check_kl_divergence(model_logits, golden_logits, atol=0.02, clip_logits_epsilon=None):
   """
   Calculates KL divergence D_KL(P_golden || Q_model) over a batch of sequences.
 
@@ -189,7 +189,16 @@ def check_kl_divergence(model_logits, golden_logits, atol=0.02):
 
   # 3. Get the probability distributions.
   golden_probabilities = F.softmax(golden_logits_reshaped, dim=-1)
-  model_log_probabilities = F.log_softmax(model_logits_reshaped, dim=-1)
+
+  # Apply clipping and re-normalization to predicted probabilities ONLY
+  if clip_logits_epsilon is not None:
+    model_probabilities = F.softmax(model_logits_reshaped, dim=-1)
+    model_probabilities = torch.clamp(model_probabilities, min=clip_logits_epsilon)
+    model_probabilities = model_probabilities / model_probabilities.sum(dim=-1, keepdim=True)
+    # Compute manual log-probabilities of the model. Safe because of clamping.
+    model_log_probabilities = torch.log(model_probabilities)
+  else:
+    model_log_probabilities = F.log_softmax(model_logits_reshaped, dim=-1)
 
   # 4. Calculate avg KL divergence for all token distributions.
   # use 'batchmean'; the sum of the KL divergences for each token in the batch
@@ -464,6 +473,9 @@ def main(config, test_args):  # pylint: disable=W0621
       if test_args.clip_logits_epsilon is not None:
         model_probabilities = jnp.clip(jax.nn.softmax(train_logits_slice, axis=-1), min=test_args.clip_logits_epsilon)
         golden_probabilities = jnp.clip(jax.nn.softmax(golden_logits_slice, axis=-1), min=test_args.clip_logits_epsilon)
+        # Re-normalize so probabilities sum to 1.
+        golden_probabilities = golden_probabilities / jnp.sum(golden_probabilities, axis=-1, keepdims=True)
+        model_probabilities = model_probabilities / jnp.sum(model_probabilities, axis=-1, keepdims=True)
       else:
         model_probabilities = jax.nn.softmax(train_logits_slice, axis=-1)
         golden_probabilities = jax.nn.softmax(golden_logits_slice, axis=-1)
@@ -661,6 +673,7 @@ def main(config, test_args):  # pylint: disable=W0621
           mt_logits_torch[0, start_index:].unsqueeze(0),
           hf_logits_torch[0, start_index:].unsqueeze(0),
           atol=test_args.max_kl_div,
+          clip_logits_epsilon=test_args.clip_logits_epsilon,
       )
       if jax.process_index() == 0 and test_args.output_logits_path:
         data_to_save = {
@@ -728,9 +741,6 @@ if __name__ == "__main__":
   assert (
       test_args.atol is not None or test_args.max_kl_div is not None
   ), "At least one of --atol or --max_kl_div must be specified to define the test criteria."
-
-  if test_args.run_hf_model and test_args.clip_logits_epsilon is not None:
-    raise ValueError("--clip_logits_epsilon is not supported when running HF model on-the-fly (run_hf_model=True).")
 
   if cfg.use_multimodal:
     assert not test_args.run_hf_model, (


### PR DESCRIPTION
# Description

Fixes b/534432708

This PR renormalizes the probability distribution when clamping using `clip_logits_epsilon` for calculating kl divergence. Also enables using clip_logits_epsilon when run_hf_model=True.

# Tests

Used llama3.1-8b with clip_logits_epsilon=1e-8.

```
--- Prompt: I love to ---
INFO:absl:
--- MaxText model top 10 tokens ---
[transformers] Ignoring clean_up_tokenization_spaces=True for BPE tokenizer TokenizersBackend. The clean_up_tokenization post-processing step is designed for WordPiece tokenizers and is destructive for BPE (it strips spaces before punctuation). Set clean_up_tokenization_spaces=False to suppress this warning, or set clean_up_tokenization_spaces_for_bpe_even_though_it_will_corrupt_output=True to force cleanup anyway.
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 1518       | see                  | 14.3817    |
| 1373       | read                 | 13.2008    |
| 6865       | hear                 | 12.9473    |
| 5944       | travel               | 12.9390    |
| 4394       | cook                 | 12.8764    |
| 3139       | grow                 | 12.8584    |
| 8343       | eat                  | 12.8224    |
| 1005       | use                  | 12.6565    |
| 3821       | watch                | 12.4830    |
| 3137       | talk                 | 12.3774    |

INFO:absl:
--- HF model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 1518       | see                  | 14.3889    |
| 1373       | read                 | 13.2144    |
| 5944       | travel               | 12.9658    |
| 6865       | hear                 | 12.9652    |
| 4394       | cook                 | 12.8976    |
| 3139       | grow                 | 12.8762    |
| 8343       | eat                  | 12.8403    |
| 1005       | use                  | 12.6674    |
| 3821       | watch                | 12.4977    |
| 3137       | talk                 | 12.3810    |

INFO:absl:
--- Similarity Metrics of Top Tokens ---
INFO:absl:| Metric                         | Value                |
|--------------------------------|----------------------|
| overlap_count                  | 10/10                |
| jaccard_similarity             | 1.0                  |
| rank_agreement_percentage      | 80.0                 |

INFO:absl:
Average KL divergence per token (D_KL(P_golden || Q_model)): 3.56e-04
INFO:absl:Per-token KL Divergences: 
['5.8001e-05', '4.1124e-04', '3.5516e-04', '5.9813e-04']
INFO:absl:
Max KL divergence for a single token in the set: 5.98e-04
INFO:absl:
--- Prompt: Today is a ---
INFO:absl:
--- MaxText model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 1938       | day                  | 13.4890    |
| 1695       | good                 | 13.2722    |
| 1633       | very                 | 13.2558    |
| 2466       | big                  | 13.1216    |
| 2294       | great                | 13.0514    |
| 3361       | special              | 12.8912    |
| 502        | new                  | 11.9839    |
| 6366       | beautiful            | 11.5664    |
| 12703      | sad                  | 11.3384    |
| 13560      | holiday              | 11.3374    |

INFO:absl:
--- HF model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 1938       | day                  | 13.4852    |
| 1695       | good                 | 13.2647    |
| 1633       | very                 | 13.2567    |
| 2466       | big                  | 13.1190    |
| 2294       | great                | 13.0474    |
| 3361       | special              | 12.8965    |
| 502        | new                  | 11.9764    |
| 6366       | beautiful            | 11.5652    |
| 13560      | holiday              | 11.3234    |
| 12703      | sad                  | 11.3214    |

INFO:absl:
--- Similarity Metrics of Top Tokens ---
INFO:absl:| Metric                         | Value                |
|--------------------------------|----------------------|
| overlap_count                  | 10/10                |
| jaccard_similarity             | 1.0                  |
| rank_agreement_percentage      | 80.0                 |

INFO:absl:
Average KL divergence per token (D_KL(P_golden || Q_model)): 4.35e-04
INFO:absl:Per-token KL Divergences: 
['5.8001e-05', '5.0937e-04', '5.6535e-04', '6.0815e-04']
INFO:absl:
Max KL divergence for a single token in the set: 6.08e-04
INFO:absl:
--- Prompt: What is the ---
INFO:absl:
--- MaxText model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 6811       | difference           | 11.0520    |
| 1888       | best                 | 10.7357    |
| 1455       | most                 | 10.6928    |
| 1925       | main                 | 10.0193    |
| 7580       | purpose              | 9.9071     |
| 3560       | role                 | 9.8912     |
| 6864       | capital              | 9.5586     |
| 7438       | meaning              | 9.5398     |
| 12939      | importance           | 9.4890     |
| 5536       | impact               | 9.4724     |

INFO:absl:
--- HF model top 10 tokens ---
INFO:absl:| Token ID   | Token                | Score      |
|------------|----------------------|------------|
| 6811       | difference           | 11.0629    |
| 1888       | best                 | 10.7349    |
| 1455       | most                 | 10.6874    |
| 1925       | main                 | 10.0299    |
| 7580       | purpose              | 9.9002     |
| 3560       | role                 | 9.8755     |
| 6864       | capital              | 9.5623     |
| 7438       | meaning              | 9.5414     |
| 12939      | importance           | 9.4840     |
| 5536       | impact               | 9.4479     |

INFO:absl:
--- Similarity Metrics of Top Tokens ---
INFO:absl:| Metric                         | Value                |
|--------------------------------|----------------------|
| overlap_count                  | 10/10                |
| jaccard_similarity             | 1.0                  |
| rank_agreement_percentage      | 100.0                |

INFO:absl:
Average KL divergence per token (D_KL(P_golden || Q_model)): 3.17e-04
INFO:absl:Per-token KL Divergences: 
['5.8001e-05', '5.2395e-04', '2.8289e-04', '4.0487e-04']
INFO:absl:
Max KL divergence for a single token in the set: 5.24e-04
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
