### PR TITLE
Eliminate duplicated softmax recomputation in indexer loss.

### DIFF
--- a/src/maxtext/layers/attention_mla.py
+++ b/src/maxtext/layers/attention_mla.py
@@ -1077,6 +1077,8 @@ class MLA(Attention):
 
     # Aggregate heads: [b, h, t, s] -> [b, t, s]
     attention_probs = jnp.sum(attention_probs, axis=1)
+    # Force materialization and prevent fusion across this point to reuse the intermediate tensor
+    attention_probs = jax.lax.optimization_barrier(attention_probs)
     # L1 normalize aggregated target distribution
     attention_probs = attention_probs / (jnp.sum(attention_probs, axis=-1, keepdims=True) + EPS)
 


### PR DESCRIPTION
  # Description
  
  This PR eliminates a duplicated softmax computation in the indexer loss calculation of DeepSeek-V3.2. 
  
  ### Why is this change being made?
  In the original implementation, the compiler (XLA) failed to reuse the head-aggregated attention probabilities for the subsequent sequence reduction (L1 normalization). Instead, it recomputed the entire softmax pipeline from the raw QK scores redundantly.
  
  ### Solution
  By inserting `jax.lax.optimization_barrier` after the head aggregation step in `calculate_indexer_loss`, we force the compiler to materialize and reuse the head-aggregated intermediate tensor for the subsequent sequence reduction instead of recomputing the entire softmax from raw QK scores.
  
 It was observed that this reduces execution time for 128K sequence length long context, therefore it should be less of an issue for storing softmax tensor in shorter sequences. 
 
  ### Implementation Details
  * Modified `calculate_indexer_loss` in `src/maxtext/layers/attention_mla.py` to insert the barrier.
    
  # Tests
  
All tests passed.  

* [Baseline xprof](https://xprof.corp.google.com/overview_page/zjiahao-13925005173721863237) Step time: 77 s
* [After proposed implementation xprof](https://xprof.corp.google.com/trace_viewer/zjiahao-11703138246004582441?view_start=21453.410&view_end=21579.096). Step time 73 s
  
  # Checklist

  Before submitting this PR, please make sure (put X in square brackets):
  - [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
  - [x] I have necessary comments in my code, particularly in hard-to-understand areas.
  - [x] I have run end-to-end tests tests and provided workload links above if applicable.
  - [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-
documentation-files).

  TAG=agy
  CONV=5ff94b54-4171-4309-8704-6046df05eb13