### PR TITLE
fix(test): improve test_scan_layers_mismatch_tpu assertion

### DIFF
--- a/tests/integration/checkpointing_test.py
+++ b/tests/integration/checkpointing_test.py
@@ -228,5 +228,9 @@ def test_scan_layers_mismatch_tpu():
   with pytest.raises(ValueError) as excinfo:
     train_main(mismatch_command)
 
-  assert "Configuration mismatch" in str(excinfo.value) or "Failed to restore checkpoint" in str(excinfo.value)
+  assert (
+      "Configuration mismatch" in str(excinfo.value)
+      or "Failed to restore checkpoint" in str(excinfo.value)
+      or "Checkpoint does not match the model" in str(excinfo.value)
+  )
   assert "scan_layers" in str(excinfo.value)


### PR DESCRIPTION
# Description

Fixes the assertion in `test_scan_layers_mismatch_tpu` to expect the correct error message.

- **Why is this change being made:** The integration test `test_scan_layers_mismatch_tpu` was failing because the framework raises `"Checkpoint does not match the model..."` when attempting to restore a checkpoint with mismatched `scan_layers` in the pre-training workflow. The test was still asserting an outdated error message (`"Configuration mismatch"` or `"Failed to restore checkpoint"`).
- **The problem being solved:** `test_scan_layers_mismatch_tpu` was producing false negatives (failing tests when the underlying code correctly caught the issue). 
- **Why this is a good solution:** Instead of modifying the correct, working logic inside the pre-training workflow (which correctly bypasses metadata syncing for deterministic configuration matching and gracefully catches the mismatch during weight loading), we simply update the test's assertions to align with the framework's actual behavior.
- **Specific implementation:** Appended `"Checkpoint does not match the model"` to the list of accepted error strings in `tests/integration/checkpointing_test.py::test_scan_layers_mismatch_tpu`.
- **Shortcomings/future improvements:** We could potentially unify the error messages emitted by `from_pretrained` (metadata check) and `train_main` (weight alignment check) in the future to improve consistency.

Bug : https://b.corp.google.com/issues/532182112 


# Tests

- **Testing instructions:**
  Run the affected unit test using `pytest` to ensure it passes with the new assertions:
  ```bash
  pytest tests/integration/checkpointing_test.py::test_scan_layers_mismatch_tpu
  ```
  The test will successfully catch the `ValueError` and correctly validate the exception message.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).