### PR TITLE
Fix NNX sequential layer naming and PyTree structure

### DIFF
--- a/src/maxtext/inference/maxengine/maxengine.py
+++ b/src/maxtext/inference/maxengine/maxengine.py
@@ -485,7 +485,11 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
           lambda x: jax.sharding.NamedSharding(self._mesh, jax.sharding.PartitionSpec(None, *x.spec)),
           self.prefill_kv_cache_shardings,
       )
-      self.prefill_kv_cache_shardings = {"decoder": {"layers": self.prefill_kv_cache_shardings["decoder"]["layers"][0]}}
+      if "layers" in self.prefill_kv_cache_shardings["decoder"]:
+        first_layer_sharding = self.prefill_kv_cache_shardings["decoder"]["layers"][0]
+      else:
+        first_layer_sharding = self.prefill_kv_cache_shardings["decoder"]["layers_0"]
+      self.prefill_kv_cache_shardings = {"decoder": {"layers": first_layer_sharding}}
     # scan_layers=True is already stacked on axis 0; shardings stay as-is and stack/unstack are no-ops.
     # AR-mode abstract model so axis names use CACHE_BATCH (not CACHE_BATCH_PREFILL);
     # bulk_insert / _insert_jit search for "cache_batch" in the per-leaf logical axes.
@@ -609,10 +613,16 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
       if self.config.scan_layers:
         # scan_layers already stacks the per-layer KV cache on axis 0; nothing to restack.
         return cache
-      # scan_layers=False: stack the per-layer subtrees under decoder/layers into one
+      # scan_layers=False: stack the per-layer subtrees under decoder into one
       # subtree with a leading layer axis (matching the scan_layers=True shape).
-      layers = cache["decoder"]["layers"]
-      stacked = jax.tree.map(lambda *c: jnp.stack(c), *[layers[i] for i in range(self.config.num_decoder_layers)])
+      if "layers" in cache["decoder"]:
+        layers = cache["decoder"]["layers"]
+        layer_cache = [layers[i] for i in range(self.config.num_decoder_layers)]
+      else:
+        layer_keys = [f"layers_{i}" for i in range(self.config.num_decoder_layers)]
+        layer_cache = [cache["decoder"][key] for key in layer_keys]
+
+      stacked = jax.tree.map(lambda *c: jnp.stack(c), *layer_cache)
       return {"decoder": {"layers": stacked}}
 
     layer_keys = []
@@ -635,8 +645,10 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
         return cache
       # scan_layers=False: split the leading layer axis back into per-layer subtrees.
       stacked = cache["decoder"]["layers"]
-      layers = {i: jax.tree.map(lambda x, i=i: x[i], stacked) for i in range(self.config.num_decoder_layers)}
-      return {"decoder": {"layers": layers}}
+      res_cache = {"decoder": {}}
+      for i in range(self.config.num_decoder_layers):
+        res_cache["decoder"][f"layers_{i}"] = jax.tree.map(lambda x, i=i: x[i], stacked)
+      return res_cache
 
     flat_cache, treedef = jax.tree.flatten(cache)
     layer_cache = [jax.tree.unflatten(treedef, flat_cache_vars) for flat_cache_vars in zip(*flat_cache, strict=True)]

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -690,11 +690,11 @@ class NNXDecoder(nnx.Module):
           **layer_kwargs,
       )
     else:
-      self.layers = nnx.List([])
+      self.layers = []
 
   def _init_sequential_layers(self, decoder_block_classes, rngs):
     """Initializes decoder layers sequentially (no scanning)."""
-    self.layers = nnx.List([])
+    self.layers = []
 
     if self.is_deepseek:
       self._init_sequential_deepseek(decoder_block_classes, rngs)
@@ -706,9 +706,9 @@ class NNXDecoder(nnx.Module):
     config = self.config
     dense_cls, moe_cls = decoder_block_classes
     for i in range(config.first_num_dense_layers):
-      self._create_and_register_layer(dense_cls, rngs, "dense_layer", i)
+      self._create_and_register_named_layer(dense_cls, rngs, "dense_layers", i)
     for i in range(config.num_decoder_layers - config.first_num_dense_layers):
-      self._create_and_register_layer(moe_cls, rngs, "moe_layer", i)
+      self._create_and_register_named_layer(moe_cls, rngs, "moe_layers", i)
 
   def _init_sequential_generic(self, decoder_block_classes, rngs):
     """Initializes sequential generic decoder layers with per-architecture layer_kwargs."""
@@ -736,7 +736,7 @@ class NNXDecoder(nnx.Module):
       elif config.decoder_block == DecoderBlockType.OLMO3:
         layer_kwargs = {"attention_type": olmo3.get_attention_type(layer_id=lyr)}
 
-      self._create_and_register_layer(layer_cls, rngs, "layers", lyr, **layer_kwargs)
+      self._create_and_register_named_layer(layer_cls, rngs, "layers", lyr, **layer_kwargs)
 
   def _init_gemma4_small_layers(self, rngs):
     """Eagerly builds the Gemma4-small (E2B/E4B) per-layer-input embedder and one DISTINCT
@@ -749,7 +749,7 @@ class NNXDecoder(nnx.Module):
     ``_create_and_register_layer``.
     """
     cfg = self.config
-    self.layers = nnx.List([])
+    self.layers = []
     # Only register the PLE submodule when it exists (mirrors the optional position_embedder
     # pattern); assigning None first would make nnx treat the attribute as static.
     if cfg.hidden_size_per_layer_input > 0 and cfg.vocab_size_per_layer_input > 0:
@@ -767,7 +767,6 @@ class NNXDecoder(nnx.Module):
           rngs=rngs,
       )
       setattr(self, f"layers_{lyr}", layer)
-      self.layers.append(layer)
 
   def _get_pipeline_stage_module(self, decoder_blocks, rngs):
     """Retrieves the wrapper module formatted for single pipeline stage execution."""
@@ -1861,7 +1860,15 @@ class NNXDecoder(nnx.Module):
 
         checkpointed_fn = jax.checkpoint(pure_layer_fn, policy=policy, prevent_cse=prevent_cse)
 
-        for lyr, layer in enumerate(self.layers):
+        for lyr in range(cfg.num_decoder_layers):
+          if self.is_deepseek:
+            if lyr < cfg.first_num_dense_layers:
+              layer = getattr(self, f"dense_layers_{lyr}")
+            else:
+              moe_idx = lyr - cfg.first_num_dense_layers
+              layer = getattr(self, f"moe_layers_{moe_idx}")
+          else:
+            layer = getattr(self, f"layers_{lyr}", self.layers[lyr] if hasattr(self, "layers") and self.layers else None)
           graphdef, state = nnx.split(layer)
           if kv_caches is not None:
             if cfg.decoder_block in (DecoderBlockType.QWEN3_NEXT, DecoderBlockType.QWEN3_5):

--- a/src/maxtext/utils/lora_utils.py
+++ b/src/maxtext/utils/lora_utils.py
@@ -433,10 +433,10 @@ def _get_lora_module_path(mt_config: pyconfig.HyperParameters) -> str:
 
   raw_path = lora_configs.get(matched_key, "decoder/layers/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))")
 
-  # This regex makes the layer index optional, matching both scanned and unscanned layer paths
-  # (e.g. 'layers/0/mlp/...' vs 'layers/mlp/...').
-  optional_layer_index = "(?:[0-9]+/)?"
-  final_path = str(raw_path).replace("layers/", f"layers/{optional_layer_index}")
+  # This regex makes the layer index optional, matching scanned, unscanned named (layers_0),
+  # and unscanned index (layers/0) layer paths.
+  layer_pattern = r"layers(?:_[0-9]+|/[0-9]+)?/"
+  final_path = str(raw_path).replace("layers/", layer_pattern)
 
   max_logging.log(f"Using lora_module_path: {final_path}")
   return final_path

--- a/tests/post_training/unit/lora_utils_test.py
+++ b/tests/post_training/unit/lora_utils_test.py
@@ -88,7 +88,7 @@ class LoraUtilsTest(unittest.TestCase):
     path = lora_utils._get_lora_module_path(mock_config)
     self.assertEqual(
         path,
-        "decoder/layers/(?:[0-9]+/)?.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))",
+        "decoder/layers(?:_[0-9]+|/[0-9]+)?/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))",
     )
 
     mock_config.model_name = "gemma4-9b"
@@ -106,7 +106,7 @@ class LoraUtilsTest(unittest.TestCase):
     # Fallback to default
     self.assertEqual(
         path,
-        "decoder/layers/(?:[0-9]+/)?.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))",
+        "decoder/layers(?:_[0-9]+|/[0-9]+)?/.*(self_attention/(query|key|value|out)|mlp/(wi_0|wi_1|wo))",
     )
 
     mock_config.lora.lora_module_path = "custom/path"


### PR DESCRIPTION
# Description

This is for checkpoint loading

Fix the Errors:
1. DeepSeek Unscanned Checkpoint Mismatch:

When restoring unscanned DeepSeek checkpoints, loading failed with: 
```
ValueError: Checkpoint structure mismatch: 374 of 377 model parameter paths were not found... 
Example missing paths: decoder.dense_layer_0...
```

Cause: `_init_sequential_deepseek` registered layers as singular `dense_layer` and `moe_layer`, producing PyTree paths like `decoder.dense_layer_0`. However, Linen checkpoints and MaxText converter scripts format layer keys as plural (`decoder.dense_layers_0`, `decoder.moe_layers_0`).

2. Generic Unscanned Model Checkpoint Mismatch (GPT-OSS, Llama4, etc.):

When restoring unscanned generic models, loading failed with: 
```
ValueError: Checkpoint structure mismatch: 456 of 459 model parameter paths were not found
... 
Example missing paths: decoder.layers.0
...
```

Cause: `_init_sequential_generic` used `_create_and_register_layer` which appended to `self.layers` initialized as `nnx.List([])`. In Flax NNX, tracking submodules in an `nnx.List` container forces state PyTree extraction to use list-index paths (`decoder.layers.0`) instead of named attribute paths (`decoder.layers_0`), breaking compatibility with on-disk Linen checkpoints.

Summary of Fixes:
- Updated `_init_sequential_deepseek` to use plural prefixes (`dense_layers`, `moe_layers`).
- Used `_create_and_register_named_layer` in sequential initialization (`_init_sequential_deepseek`, `_init_sequential_generic`) so submodules register exclusively under named string attributes (`layers_0`, `layers_1`).
- Replaced `nnx.List` with a plain Python list for `self.layers` and updated the forward pass to retrieve named attributes via `getattr(self, f'layers_{lyr}')`.
- MaxEngine KV-Cache Stacking & Sharding (maxengine.py): Updated `self.prefill_kv_cache_shardings`, `_maybe_stack_prefill_result_cache`, and `_maybe_unstack_prefill_result_cache` to handle named per-layer keys (`layers_0`, `layers_1`) in addition to stacked `layers` keys when scan_layers=False.
- LoRA Module Regex Pattern Matching (lora_utils.py & lora_utils_test.py):
       - Updated `_get_lora_module_path` regex replacement to `r'layers(?:_[0-9]+|/[0-9]+)?/'` so LoRA target verification matches named attributes (`decoder/layers_0/...`) as well as indexed (`decoder/layers/0/...`) and scanned (`decoder/layers/...`) paths.
       - Updated expected regex string assertions in test_get_lora_module_path.

FIXES: b/532719643
FIXES: b/532731449
FIXES: b/532916578

# Tests

1. llama4-17b-16e
```
python3 -m tests.utils.forward_pass_logit_checker \
    src/maxtext/configs/base.yml \
    tokenizer_path=meta-llama/Llama-4-Scout-17B-16E \
    load_parameters_path=gs://ml-auto-solutions/output/jax_models_and_performance/maxtext/chained_tests_llama4_nightly-2026-07-06-01-30-12/unscanned/0/items \
    model_name=llama4-17b-16e \
   ...
```
2. gpt-oss-20b
```
python3 -m tests.utils.forward_pass_logit_checker \
    src/maxtext/configs/base.yml \
    model_name=gpt-oss-20b \
    load_parameters_path=gs://ml-auto-solutions/output/unowned/maxtext_stable_gpt-oss-20b-v5p-8-2026-07-06-04-15-19/unscanned/0/items \
   ...
```
5. deepseek2-16b
```
python3 -m maxtext.inference.decode src/maxtext/configs/base.yml \
  run_name=decode \
  model_name=deepseek2-16b \
  tokenizer_type=huggingface \
  tokenizer_path=deepseek-ai/DeepSeek-V2-Lite \
  load_parameters_path=gs://ml-auto-solutions/output/unowned/maxtext_nightly_deepseek2-16b-v5p-8-2026-07-01-07-56-03/unscanned/0/items \
```
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
