### PR TITLE
Fix CI: Run notebooks only on notebook changes

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -110,21 +110,20 @@ jobs:
 
           # 4. Check for source code changes (anything not .md and not .ipynb)
           if echo "$CHANGED_FILES" | grep -v -E '\.(md|ipynb)$' > /dev/null; then
-            echo "Source code changed, enabling unit tests and notebooks."
+            echo "Source code changed, enabling unit tests."
             echo "run_tests=true" >> $GITHUB_OUTPUT
-            echo "run_notebooks=true" >> $GITHUB_OUTPUT
           else
             echo "No source code changes (only notebook/doc), skipping unit tests."
             echo "run_tests=false" >> $GITHUB_OUTPUT
+          fi
 
-            # 5. Check for notebook (.ipynb) changes
-            if echo "$CHANGED_FILES" | grep '\.ipynb$' > /dev/null; then
-              echo "Notebook files changed, enabling notebook run."
-              echo "run_notebooks=true" >> $GITHUB_OUTPUT
-            else
-              echo "No notebook changes, skipping notebook run."
-              echo "run_notebooks=false" >> $GITHUB_OUTPUT
-            fi
+          # 5. Check for notebook (.ipynb) changes
+          if echo "$CHANGED_FILES" | grep '\.ipynb$' > /dev/null; then
+            echo "Notebook files changed, enabling notebook run."
+            echo "run_notebooks=true" >> $GITHUB_OUTPUT
+          else
+            echo "No notebook changes, skipping notebook run."
+            echo "run_notebooks=false" >> $GITHUB_OUTPUT
           fi
 
   code_quality_check:

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -85,6 +85,13 @@ jobs:
           echo "run_tests=true" >> $GITHUB_OUTPUT
           echo "run_notebooks=true" >> $GITHUB_OUTPUT
 
+          # Pre-calculate if notebooks changed
+          if echo "$CHANGED_FILES" | grep '\.ipynb$' > /dev/null; then
+            NOTEBOOKS_CHANGED="true"
+          else
+            NOTEBOOKS_CHANGED="false"
+          fi
+
           # 1. Check if only documentation files (.md) were changed
           if ! echo "$CHANGED_FILES" | grep -v -E '\.md$' > /dev/null; then
             echo "Documentation-only files changed, skipping all tests and notebooks."
@@ -95,16 +102,17 @@ jobs:
 
           # 2. Check if dependencies or Github workflows were changed
           if echo "$CHANGED_FILES" | grep -E '(^|/)(src/dependencies/|\.github/workflows/)' > /dev/null; then
-            echo "Core files (dependencies, workflows) changed, enabling all tests and notebooks."
+            echo "Core files (dependencies, workflows) changed, enabling all tests (notebooks only if changed)."
             echo "run_tests=true" >> $GITHUB_OUTPUT
-            echo "run_notebooks=true" >> $GITHUB_OUTPUT
+            echo "run_notebooks=$NOTEBOOKS_CHANGED" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           # 3. Check if post-training files were changed
           if echo "$CHANGED_FILES" | grep -E 'src/maxtext/trainers/post_train/' > /dev/null; then
+            echo "Post-training files changed, enabling all tests (notebooks only if changed)."
             echo "run_tests=true" >> $GITHUB_OUTPUT
-            echo "run_notebooks=true" >> $GITHUB_OUTPUT
+            echo "run_notebooks=$NOTEBOOKS_CHANGED" >> $GITHUB_OUTPUT
             exit 0
           fi
 


### PR DESCRIPTION
# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.: 
BUGS: b/123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
