### PR TITLE
fix(ci): correct notebook check logic nesting

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -97,7 +97,8 @@ jobs:
           if echo "$CHANGED_FILES" | grep -E '(^|/)(src/dependencies/|\.github/workflows/)' > /dev/null; then
             echo "Core files (dependencies, workflows) changed, enabling all tests and notebooks."
             echo "run_tests=true" >> $GITHUB_OUTPUT
-            echo "run_notebooks=true" >> $GITHUB_OUTPUT
+            # TODO: Temporarily disabled because notebook jobs are blocked; revert to "run_notebooks=true" after the fix is merged.
+            echo "run_notebooks=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -110,21 +111,20 @@ jobs:
 
           # 4. Check for source code changes (anything not .md and not .ipynb)
           if echo "$CHANGED_FILES" | grep -v -E '\.(md|ipynb)$' > /dev/null; then
-            echo "Source code changed, enabling unit tests and notebooks."
+            echo "Source code changed, enabling unit tests."
             echo "run_tests=true" >> $GITHUB_OUTPUT
-            echo "run_notebooks=true" >> $GITHUB_OUTPUT
           else
             echo "No source code changes (only notebook/doc), skipping unit tests."
             echo "run_tests=false" >> $GITHUB_OUTPUT
+          fi
 
-            # 5. Check for notebook (.ipynb) changes
-            if echo "$CHANGED_FILES" | grep '\.ipynb$' > /dev/null; then
-              echo "Notebook files changed, enabling notebook run."
-              echo "run_notebooks=true" >> $GITHUB_OUTPUT
-            else
-              echo "No notebook changes, skipping notebook run."
-              echo "run_notebooks=false" >> $GITHUB_OUTPUT
-            fi
+          # 5. Check for notebook (.ipynb) changes
+          if echo "$CHANGED_FILES" | grep '\.ipynb$' > /dev/null; then
+            echo "Notebook files changed, enabling notebook run."
+            echo "run_notebooks=true" >> $GITHUB_OUTPUT
+          else
+            echo "No notebook changes, skipping notebook run."
+            echo "run_notebooks=false" >> $GITHUB_OUTPUT
           fi
 
   code_quality_check:


### PR DESCRIPTION

# Description

This reverts the commit that triggered the notebook workflow for all source code changes, which overwhelmed the limited 8-TPU runner pool. Now, notebooks will only run when .ipynb files are modified.

FIXES: [b/534935957](https://b.corp.google.com/issues/534935957)

# Tests

We run on ci/cd workflow manually.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
