### PR TITLE
fix: restore two-layer defense to load checkpoint 

### DIFF
--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -237,6 +237,19 @@ def _stored_metadata_tree(read_tree):
   return tree if isinstance(tree, dict) else None
 
 
+def _pre_restore_weight_check(want, have):
+  """Runs the weight check against stored metadata, but only when `have` was located.
+
+  An empty `have` means the params collection wasn't found where this layout expects it
+  (an unfamiliar on-disk nesting), not that the checkpoint is missing every weight -- so
+  skip rather than hard-fail a valid restore with a "missing" for every weight. A real
+  partial mismatch leaves the other weights in `have`, so it still raises here; a
+  genuinely empty checkpoint is caught after restore.
+  """
+  if isinstance(have, dict) and have:
+    _raise_on_weight_mismatch(want, have)
+
+
 def _linen_items_to_nnx(restored_linen, abstract_nnx_state):
   """Reshapes a restored Linen-layout `items` dict into an NNX state.
 
@@ -822,7 +835,7 @@ def load_state_if_possible(
         # ("items" must be indexed, not attribute-accessed: Composite.items is a method.)
         stored_tree = _stored_metadata_tree(lambda: checkpoint_manager.item_metadata(step)["items"].tree)
         if stored_tree is not None:
-          _raise_on_weight_mismatch(*_expected_and_restored_params(abstract_unboxed_pre_state, stored_tree))
+          _pre_restore_weight_check(*_expected_and_restored_params(abstract_unboxed_pre_state, stored_tree))
         if (
             dataset_type == "grain"
             and data_iterator
@@ -993,7 +1006,7 @@ def load_params_from_path(
   stored_tree = _stored_metadata_tree(lambda: ckptr.metadata(epath.Path(load_parameters_from_path)).item_metadata.tree)
   if stored_tree is not None:
     stored_collection = stored_tree.get("params", {})
-    _raise_on_weight_mismatch(want, stored_collection.get("params", {}) if is_nnx else stored_collection)
+    _pre_restore_weight_check(want, stored_collection.get("params", {}) if is_nnx else stored_collection)
 
   # This is a memory optimization. We don't want to restore the entire checkpoint - only the params.
   # Rather than pass the entire abstract state, which could unnecessarily restore opt_state and such and waste

--- a/src/maxtext/common/checkpointing.py
+++ b/src/maxtext/common/checkpointing.py
@@ -174,7 +174,8 @@ def _weight_mismatches(want, have, path=()):
 
   A weight is wrong if the checkpoint didn't carry it -- absent, or left by Orbax as an
   unmaterialized ShapeDtypeStruct -- or carried it at a different shape. Only the shape can
-  disagree: Orbax casts a restored array to the target's dtype.
+  disagree: Orbax casts a restored array to the target's dtype. `have` accepts stored
+  *metadata* leaves too (anything with a `.shape`), so this also works pre-restore.
   """
   if isinstance(want, dict):
     out = []
@@ -208,7 +209,8 @@ def _raise_on_weight_mismatch(want, have):
   checkpoint doesn't carry as an unmaterialized ShapeDtypeStruct, and Orbax restores a stored
   array at its own shape rather than the target's. Either way it reaches the model as an
   untrained init value (a silent accuracy loss) or fails much later, deep in the first step,
-  without naming the weight.
+  without naming the weight. Complements the config-level `verify_and_sync_scan_layers`
+  pre-flight.
   """
   problems = _weight_mismatches(want, have)
   if not problems:
@@ -219,6 +221,20 @@ def _raise_on_weight_mismatch(want, have):
       f"{lines}\n"
       "Verify the checkpoint matches the model architecture (emb_dim, mlp_dim, num layers, scan_layers)."
   )
+
+
+def _stored_metadata_tree(read_tree):
+  """Best-effort read of a checkpoint's stored item-metadata tree for pre-restore checks.
+
+  Returns None on any failure so the check is skipped -- a metadata problem must not block
+  a restore that Orbax's own validation might still complete.
+  """
+  try:
+    tree = read_tree()
+  except Exception as e:  # pylint: disable=broad-except
+    max_logging.log(f"Warning: skipping pre-restore weight check: {e}")
+    return None
+  return tree if isinstance(tree, dict) else None
 
 
 def _linen_items_to_nnx(restored_linen, abstract_nnx_state):
@@ -801,6 +817,12 @@ def load_state_if_possible(
         linen_abstract = train_state_nnx.to_checkpoint_dict(abstract_unboxed_pre_state)
         restore_args = jax.tree_util.tree_map(map_to_pspec, linen_abstract)
         checkpoint_args = ocp.args.PyTreeRestore(item=linen_abstract, restore_args=restore_args, partial_restore=True)
+        # Pre-restore check against stored metadata: names the offending weight, which
+        # Orbax's own strict shape error would not.
+        # ("items" must be indexed, not attribute-accessed: Composite.items is a method.)
+        stored_tree = _stored_metadata_tree(lambda: checkpoint_manager.item_metadata(step)["items"].tree)
+        if stored_tree is not None:
+          _raise_on_weight_mismatch(*_expected_and_restored_params(abstract_unboxed_pre_state, stored_tree))
         if (
             dataset_type == "grain"
             and data_iterator
@@ -966,6 +988,13 @@ def load_params_from_path(
       )
   )
 
+  # Pre-restore check against stored metadata, so a mismatch fails before the weights
+  # are downloaded.
+  stored_tree = _stored_metadata_tree(lambda: ckptr.metadata(epath.Path(load_parameters_from_path)).item_metadata.tree)
+  if stored_tree is not None:
+    stored_collection = stored_tree.get("params", {})
+    _raise_on_weight_mismatch(want, stored_collection.get("params", {}) if is_nnx else stored_collection)
+
   # This is a memory optimization. We don't want to restore the entire checkpoint - only the params.
   # Rather than pass the entire abstract state, which could unnecessarily restore opt_state and such and waste
   # memory, we instead specify here that we are just restoring the params field of the checkpoint
@@ -978,10 +1007,9 @@ def load_params_from_path(
       restore_args={"params": restore_args},
   )
   restored_collection = restored["params"]
-  # `transforms={}` lets Orbax return an unmaterialized leaf for a weight the checkpoint lacks,
-  # and a stored array at its own shape rather than the target's. Either reaches the model and
-  # fails much later without naming the weight, so check here -- the params-only load
-  # (load_parameters_path, e.g. SFT) has no init state to fall back on.
+  # `transforms={}` lets Orbax return an unmaterialized leaf for a weight the checkpoint
+  # lacks, and a stored array at its own shape; either would reach the model unnoticed --
+  # the params-only load (load_parameters_path, e.g. SFT) has no init state to fall back on.
   _raise_on_weight_mismatch(want, restored_collection["params"] if is_nnx else restored_collection)
   if is_nnx:
     nnx.replace_by_pure_dict(abstract_unboxed_params, restored_collection["params"])
@@ -1009,13 +1037,39 @@ def load_checkpoint_metadata(checkpoint_dir_path: str) -> dict[str, Any]:
     present or loading fails.
   """
   checkpoint_dir = epath.Path(checkpoint_dir_path)
+  # CheckpointManager saves write custom_metadata at the step directory, one level above
+  # the `items` dir that load_parameters_path conventionally points at -- read there first.
+  lookup_dirs = [checkpoint_dir.parent, checkpoint_dir] if checkpoint_dir.name == "items" else [checkpoint_dir]
+  ckptr = ocp.Checkpointer(ocp.StandardCheckpointHandler())
   try:
-    ckptr = ocp.StandardCheckpointer()
-    metadata = ckptr.metadata(checkpoint_dir)
-    return metadata.custom_metadata or {}
+    for lookup_dir in lookup_dirs:
+      custom_metadata = ckptr.metadata(lookup_dir).custom_metadata or {}
+      if custom_metadata:
+        return custom_metadata
+    return {}
   except Exception as e:  # pylint: disable=broad-except
     max_logging.log(f"Warning: Failed to load checkpoint metadata: {e}")
     return {}
+  finally:
+    ckptr.close()
+
+
+def latest_checkpoint_step_dir(checkpoint_dir: str) -> Optional[epath.Path]:
+  """Returns the step directory of the newest checkpoint under `checkpoint_dir`, or None.
+
+  Lets a run pre-flight the checkpoint it would resume from before the CheckpointManager
+  -- and the model -- exist. Handles prefixed step-directory names (e.g. `checkpoint_100`).
+  """
+  if not checkpoint_dir:
+    return None
+  try:
+    step_paths = ocp.utils.checkpoint_steps_paths(epath.Path(checkpoint_dir))
+  except Exception as e:  # pylint: disable=broad-except
+    max_logging.log(f"Warning: could not list checkpoint steps under {checkpoint_dir}: {e}")
+    return None
+  if not step_paths:
+    return None
+  return max(step_paths, key=lambda p: ocp.utils.step_from_checkpoint_name(p.name))
 
 
 def _uses_local_checkpoint_period(config):

--- a/src/maxtext/trainers/pre_train/train.py
+++ b/src/maxtext/trainers/pre_train/train.py
@@ -65,6 +65,7 @@ from maxtext.utils import gcs_utils
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils import maxtext_utils
+from maxtext.utils import model_creation_utils
 from maxtext.utils import qk_clip_utils
 from maxtext.utils import sharding
 from maxtext.utils import maxtext_utils_nnx
@@ -920,6 +921,15 @@ def initialize(argv: Sequence[str]) -> tuple[pyconfig.HyperParameters, Any]:
   config = pyconfig.initialize(argv)
   max_utils.print_system_information()
   train_utils.validate_train_config(config)
+  # Pre-flight scan_layers against the checkpoint this run will resume from, before any
+  # model is built: the run's own latest checkpoint wins (the emergency manager also
+  # restores from checkpoint_dir), else load_parameters_path / load_full_state_path.
+  resume_step_dir = (
+      checkpointing.latest_checkpoint_step_dir(config.checkpoint_dir)
+      if config.enable_checkpointing or config.enable_emergency_checkpoint
+      else None
+  )
+  config = model_creation_utils.verify_and_sync_scan_layers(config, checkpoint_path=resume_step_dir)
   jax.config.update("jax_use_shardy_partitioner", config.shardy)
   jax.config.update("jax_remove_size_one_mesh_axis_from_type", config.remove_size_one_mesh_axis_from_type)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path or ""

--- a/src/maxtext/utils/model_creation_utils.py
+++ b/src/maxtext/utils/model_creation_utils.py
@@ -791,12 +791,27 @@ def create_models_and_meshes(trainer_config, sampler_config, trainer_devices, sa
   return reference_model, reference_mesh, actor_model, actor_mesh, rollout_mesh
 
 
-def verify_and_sync_scan_layers(config):
-  """Verify and sync scan_layers based on checkpoint metadata."""
-  if not config.load_parameters_path:
+def verify_and_sync_scan_layers(config, checkpoint_path=None):
+  """Verifies and syncs `config.scan_layers` against checkpoint metadata.
+
+  The config-level pre-flight for checkpoint restores, run before the model is
+  built: reads the `scan_layers` value the checkpoint was saved with (Orbax
+  custom_metadata). An explicitly-set conflicting value raises a "Configuration
+  mismatch" error here; an unset one is synced to the checkpoint's value so the
+  model is built to match. Weight-level problems metadata can't see are caught
+  after restore by `checkpointing._raise_on_weight_mismatch`.
+
+  Args:
+    config: The run config; `scan_layers` may differ on the returned copy.
+    checkpoint_path: Checkpoint directory to read metadata from. Defaults to
+      `config.load_parameters_path` or `config.load_full_state_path`. Pass a
+      step directory explicitly when resuming from a run's own checkpoints.
+  """
+  checkpoint_path = checkpoint_path or config.load_parameters_path or config.load_full_state_path
+  if not checkpoint_path:
     return config
 
-  custom_metadata = checkpointing.load_checkpoint_metadata(config.load_parameters_path)
+  custom_metadata = checkpointing.load_checkpoint_metadata(checkpoint_path)
   saved_scan_layers = custom_metadata.get("scan_layers")
   if not isinstance(saved_scan_layers, bool):
     return config

--- a/tests/integration/checkpointing_test.py
+++ b/tests/integration/checkpointing_test.py
@@ -197,36 +197,74 @@ def test_with_dot_product():
   run_checkpointing("gpu", "dot_product")
 
 
+def _get_mismatch_cmd(run_date, steps, metrics_file):
+  """Command for the mismatch tests: synthetic data, local output."""
+  return get_checkpointing_command(
+      run_date,
+      hardware="tpu",
+      steps=steps,
+      metrics_file=metrics_file,
+      attention_type="autoselected",
+      dataset_type="synthetic",
+      dataset_path="/tmp/gcsfuse",
+      base_output_directory="/tmp/maxtext_local_output",
+  )
+
+
 @pytest.mark.integration_test
 @pytest.mark.tpu_only
 @pytest.mark.scheduled_only
 def test_scan_layers_mismatch_tpu():
-  """Tests scan_layers mismatch checkpoint loading raises ValueError on TPU."""
-  hardware = "tpu"
-  attention_type = "autoselected"
-  run_date = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-  local_ckpt_dir = "/tmp/maxtext_local_output"
+  """An explicit scan_layers conflicting with checkpoint metadata raises the config-level error.
 
-  def get_cmd(steps, metrics_file):
-    return get_checkpointing_command(
-        run_date,
-        hardware=hardware,
-        steps=steps,
-        metrics_file=metrics_file,
-        attention_type=attention_type,
-        dataset_type="synthetic",
-        dataset_path="/tmp/gcsfuse",
-        base_output_directory=local_ckpt_dir,
-    )
+  The metadata pre-flight (`verify_and_sync_scan_layers`) must reject the run
+  before any model is built or any weight is read.
+  """
+  run_date = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
   # 1. Save checkpoint with scan_layers=True (default) and steps=1
-  train_main(get_cmd(steps=1, metrics_file="saved_metrics_mismatch.txt"))
+  train_main(_get_mismatch_cmd(run_date, steps=1, metrics_file="saved_metrics_mismatch.txt"))
 
-  # 2. Attempt to restore with scan_layers=False and assert ValueError
-  mismatch_command = get_cmd(steps=2, metrics_file="restored_metrics_mismatch.txt") + ["scan_layers=False"]
+  # 2. Attempt to restore with an explicit scan_layers=False and assert ValueError
+  mismatch_command = _get_mismatch_cmd(run_date, steps=2, metrics_file="restored_metrics_mismatch.txt") + [
+      "scan_layers=False"
+  ]
 
   with pytest.raises(ValueError) as excinfo:
     train_main(mismatch_command)
 
-  assert "Configuration mismatch" in str(excinfo.value) or "Failed to restore checkpoint" in str(excinfo.value)
-  assert "scan_layers" in str(excinfo.value)
+  message = str(excinfo.value)
+  assert "Configuration mismatch" in message
+  assert "scan_layers" in message
+
+
+@pytest.mark.integration_test
+@pytest.mark.tpu_only
+@pytest.mark.scheduled_only
+def test_weight_mismatch_tpu():
+  """A checkpoint missing weights the model needs raises the weight-level error.
+
+  Both runs use unscanned layers with matching scan_layers metadata, so the
+  config pre-flight passes; run 2's model has one more decoder layer than the
+  checkpoint carries, so the weight check (`_raise_on_weight_mismatch`) must
+  name it.
+  """
+  run_date = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+
+  # 1. Save an unscanned single-layer checkpoint (base_num_decoder_layers=1) at steps=1
+  train_main(
+      _get_mismatch_cmd(run_date, steps=1, metrics_file="saved_metrics_weight_mismatch.txt") + ["scan_layers=False"]
+  )
+
+  # 2. Restore into a two-layer model: layer 1 exists only in the model
+  mismatch_command = [
+      "base_num_decoder_layers=2" if str(arg).startswith("base_num_decoder_layers=") else arg
+      for arg in _get_mismatch_cmd(run_date, steps=2, metrics_file="restored_metrics_weight_mismatch.txt")
+  ] + ["scan_layers=False"]
+
+  with pytest.raises(ValueError) as excinfo:
+    train_main(mismatch_command)
+
+  message = str(excinfo.value)
+  assert "Checkpoint does not match the model" in message
+  assert "decoder/layers/1/" in message

--- a/tests/post_training/unit/lora_utils_test.py
+++ b/tests/post_training/unit/lora_utils_test.py
@@ -317,7 +317,7 @@ class LoraUtilsTest(unittest.TestCase):
     mock_metadata = mock.MagicMock()
     mock_metadata.custom_metadata = {"lora": {"lora_rank": 32, "lora_alpha": 64.0}}
 
-    with mock.patch("orbax.checkpoint.StandardCheckpointer.metadata", return_value=mock_metadata):
+    with mock.patch("orbax.checkpoint.Checkpointer.metadata", return_value=mock_metadata):
       lora_utils.sync_lora_metadata(cfg)
       self.assertEqual(cfg.lora.lora_rank, 32)
       self.assertEqual(cfg.lora.lora_alpha, 64.0)
@@ -335,7 +335,7 @@ class LoraUtilsTest(unittest.TestCase):
     mock_metadata = mock.MagicMock()
     mock_metadata.custom_metadata = {"lora": {"lora_rank": 32, "lora_alpha": 64.0}}
 
-    with mock.patch("orbax.checkpoint.StandardCheckpointer.metadata", return_value=mock_metadata):
+    with mock.patch("orbax.checkpoint.Checkpointer.metadata", return_value=mock_metadata):
       # Should not raise ValueError
       lora_utils.sync_lora_metadata(cfg)
       self.assertEqual(cfg.lora.lora_rank, 32)
@@ -354,7 +354,7 @@ class LoraUtilsTest(unittest.TestCase):
     mock_metadata = mock.MagicMock()
     mock_metadata.custom_metadata = {"lora": {"lora_rank": 32, "lora_alpha": 64.0}}
 
-    with mock.patch("orbax.checkpoint.StandardCheckpointer.metadata", return_value=mock_metadata):
+    with mock.patch("orbax.checkpoint.Checkpointer.metadata", return_value=mock_metadata):
       with self.assertRaisesRegex(ValueError, "Configured lora_rank .* does not match"):
         lora_utils.sync_lora_metadata(cfg)
 
@@ -371,7 +371,7 @@ class LoraUtilsTest(unittest.TestCase):
     mock_metadata = mock.MagicMock()
     mock_metadata.custom_metadata = {"lora": {"lora_rank": 32, "lora_alpha": 64.0}}
 
-    with mock.patch("orbax.checkpoint.StandardCheckpointer.metadata", return_value=mock_metadata):
+    with mock.patch("orbax.checkpoint.Checkpointer.metadata", return_value=mock_metadata):
       with self.assertRaisesRegex(ValueError, "Configured lora_alpha .* does not match"):
         lora_utils.sync_lora_metadata(cfg)
 

--- a/tests/unit/checkpointing_metadata_test.py
+++ b/tests/unit/checkpointing_metadata_test.py
@@ -1,0 +1,152 @@
+# Copyright 2023–2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for checkpoint custom-metadata reading, resume-step discovery, and the
+pre-restore weight checks. custom_metadata is written at the *step* directory."""
+
+import shutil
+import tempfile
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import orbax.checkpoint as ocp
+
+from maxtext.common import checkpointing
+
+
+def _save_manager_checkpoint(root, step, custom_metadata):
+  """Saves a tiny pytree the way MaxText's save_checkpoint does (Composite items=...)."""
+  state = {"params": {"params": {"w": np.ones((2, 2), np.float32)}}}
+  manager = ocp.CheckpointManager(root)
+  manager.save(
+      step,
+      args=ocp.args.Composite(items=ocp.args.PyTreeSave(item=state)),
+      custom_metadata=custom_metadata,
+  )
+  manager.wait_until_finished()
+  manager.close()
+
+
+class LoadCheckpointMetadataTest(unittest.TestCase):
+  """load_checkpoint_metadata must see manager-saved custom_metadata from either path form."""
+
+  def setUp(self):
+    self.root = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+  def test_reads_metadata_at_step_dir(self):
+    _save_manager_checkpoint(self.root, 0, {"scan_layers": True})
+    metadata = checkpointing.load_checkpoint_metadata(f"{self.root}/0")
+    self.assertEqual(metadata.get("scan_layers"), True)
+
+  def test_reads_metadata_at_items_dir_via_parent(self):
+    """The documented load_parameters_path form (…/<step>/items) must also find the metadata."""
+    _save_manager_checkpoint(self.root, 0, {"scan_layers": False})
+    metadata = checkpointing.load_checkpoint_metadata(f"{self.root}/0/items")
+    self.assertEqual(metadata.get("scan_layers"), False)
+
+  def test_missing_checkpoint_returns_empty(self):
+    metadata = checkpointing.load_checkpoint_metadata(f"{self.root}/does_not_exist")
+    self.assertEqual(metadata, {})
+
+
+class LatestCheckpointStepDirTest(unittest.TestCase):
+  """latest_checkpoint_step_dir must return the newest step directory, or None."""
+
+  def setUp(self):
+    self.root = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+  def test_returns_newest_step(self):
+    _save_manager_checkpoint(self.root, 0, {"scan_layers": True})
+    _save_manager_checkpoint(self.root, 3, {"scan_layers": True})
+    step_dir = checkpointing.latest_checkpoint_step_dir(self.root)
+    self.assertIsNotNone(step_dir)
+    self.assertEqual(step_dir.name, "3")
+
+  def test_empty_dir_returns_none(self):
+    self.assertIsNone(checkpointing.latest_checkpoint_step_dir(self.root))
+
+  def test_missing_dir_returns_none(self):
+    self.assertIsNone(checkpointing.latest_checkpoint_step_dir(f"{self.root}/nope"))
+
+  def test_empty_path_returns_none(self):
+    self.assertIsNone(checkpointing.latest_checkpoint_step_dir(""))
+
+  def test_step_dir_metadata_roundtrip(self):
+    """The step dir found by discovery carries the metadata the run was saved with."""
+    _save_manager_checkpoint(self.root, 0, {"scan_layers": True})
+    step_dir = checkpointing.latest_checkpoint_step_dir(self.root)
+    metadata = checkpointing.load_checkpoint_metadata(step_dir)
+    self.assertEqual(metadata.get("scan_layers"), True)
+
+
+class PreRestoreWeightCheckTest(unittest.TestCase):
+  """The pre-restore checks must name shape AND missing mismatches from metadata alone."""
+
+  def setUp(self):
+    self.root = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+    _save_manager_checkpoint(self.root, 0, {"scan_layers": True})
+    # item_metadata materializes only when the manager knows the item's handler,
+    # mirroring create_orbax_checkpoint_manager's registration.
+    manager = ocp.CheckpointManager(
+        self.root, item_names=("items",), item_handlers={"items": ocp.PyTreeCheckpointHandler()}
+    )
+    self.addCleanup(manager.close)
+    # Indexed, not attribute access: Composite.items is a method.
+    self.stored_params = manager.item_metadata(0)["items"].tree["params"]["params"]
+
+  def test_shape_change_is_named_before_restore(self):
+    want = {"w": jax.ShapeDtypeStruct((4, 4), jnp.float32)}  # stored is (2, 2)
+    with self.assertRaises(ValueError) as ctx:
+      checkpointing._raise_on_weight_mismatch(want, self.stored_params)  # pylint: disable=protected-access
+    message = str(ctx.exception)
+    self.assertIn("Checkpoint does not match the model", message)
+    self.assertIn("'w'", message)
+    self.assertIn("(2, 2)", message)
+
+  def test_missing_weight_is_named_before_restore(self):
+    want = {
+        "w": jax.ShapeDtypeStruct((2, 2), jnp.float32),
+        "w_extra": jax.ShapeDtypeStruct((2, 2), jnp.float32),
+    }
+    with self.assertRaises(ValueError) as ctx:
+      checkpointing._raise_on_weight_mismatch(want, self.stored_params)  # pylint: disable=protected-access
+    message = str(ctx.exception)
+    self.assertIn("Checkpoint does not match the model", message)
+    self.assertIn("'w_extra'", message)
+    self.assertIn("missing", message)
+
+  def test_matching_weights_pass(self):
+    want = {"w": jax.ShapeDtypeStruct((2, 2), jnp.float32)}
+    checkpointing._raise_on_weight_mismatch(want, self.stored_params)  # pylint: disable=protected-access
+
+  def test_params_only_path_metadata_names_shape_change(self):
+    """load_params_from_path's pre-check form: Checkpointer.metadata at the items dir."""
+    ckptr = ocp.Checkpointer(ocp.PyTreeCheckpointHandler())
+    self.addCleanup(ckptr.close)
+    stored_tree = ckptr.metadata(f"{self.root}/0/items").item_metadata.tree
+    want = {"w": jax.ShapeDtypeStruct((4, 4), jnp.float32)}  # stored is (2, 2)
+    with self.assertRaises(ValueError) as ctx:
+      checkpointing._raise_on_weight_mismatch(want, stored_tree["params"]["params"])  # pylint: disable=protected-access
+    message = str(ctx.exception)
+    self.assertIn("Checkpoint does not match the model", message)
+    self.assertIn("(2, 2)", message)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/checkpointing_metadata_test.py
+++ b/tests/unit/checkpointing_metadata_test.py
@@ -147,6 +147,21 @@ class PreRestoreWeightCheckTest(unittest.TestCase):
     self.assertIn("Checkpoint does not match the model", message)
     self.assertIn("(2, 2)", message)
 
+  def test_pre_restore_check_skips_when_collection_not_located(self):
+    """An empty stored collection (unfamiliar layout) must skip, not report every weight missing."""
+    want = {"w": jax.ShapeDtypeStruct((2, 2), jnp.float32)}
+    checkpointing._pre_restore_weight_check(want, {})  # pylint: disable=protected-access
+
+  def test_pre_restore_check_still_raises_on_real_mismatch(self):
+    """A located-but-mismatched collection must still fail before restore."""
+    want = {
+        "w": jax.ShapeDtypeStruct((2, 2), jnp.float32),
+        "w_extra": jax.ShapeDtypeStruct((2, 2), jnp.float32),  # not in the checkpoint
+    }
+    with self.assertRaises(ValueError) as ctx:
+      checkpointing._pre_restore_weight_check(want, self.stored_params)  # pylint: disable=protected-access
+    self.assertIn("'w_extra'", str(ctx.exception))
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/unit/checkpointing_test.py
+++ b/tests/unit/checkpointing_test.py
@@ -308,7 +308,7 @@ class SourceCheckpointLoadingTest(parameterized.TestCase):
 class CheckpointMetadataTest(parameterized.TestCase):
   """Tests for loading checkpoint custom metadata."""
 
-  @mock.patch.object(checkpointing.ocp, "StandardCheckpointer")
+  @mock.patch.object(checkpointing.ocp, "Checkpointer")
   def test_load_checkpoint_metadata(self, mock_checkpointer_cls):
     mock_ckptr = mock_checkpointer_cls.return_value
     mock_metadata = mock.MagicMock()
@@ -319,7 +319,7 @@ class CheckpointMetadataTest(parameterized.TestCase):
     self.assertEqual(loaded_metadata.get("lora"), {"lora_rank": 8, "lora_alpha": 16.0})
     mock_ckptr.metadata.assert_called_once()
 
-  @mock.patch.object(checkpointing.ocp, "StandardCheckpointer")
+  @mock.patch.object(checkpointing.ocp, "Checkpointer")
   def test_load_checkpoint_metadata_handles_exceptions(self, mock_checkpointer_cls):
     mock_ckptr = mock_checkpointer_cls.return_value
     mock_ckptr.metadata.side_effect = Exception("Checkpoint read error")

--- a/tests/unit/model_creation_utils_test.py
+++ b/tests/unit/model_creation_utils_test.py
@@ -919,6 +919,37 @@ class TestVerifyAndSyncScanLayers(unittest.TestCase):
     self.assertFalse(synced_cfg2.scan_layers)
     mock_log.assert_called_once_with("Setting scan_layers=False loaded from checkpoint metadata.")
 
+  @patch("maxtext.utils.model_creation_utils.checkpointing.load_checkpoint_metadata")
+  def test_explicit_checkpoint_path_overrides_config_paths(self, mock_load_meta):
+    """An explicit checkpoint_path is read even when the config carries no load path (run-dir resume)."""
+    mock_load_meta.return_value = {"scan_layers": False}
+    cfg = _make_config(enable_checkpointing=True)
+    self.assertFalse(cfg.load_parameters_path)
+
+    synced_cfg = model_creation_utils.verify_and_sync_scan_layers(cfg, checkpoint_path="gs://fake/run/checkpoints/0")
+
+    mock_load_meta.assert_called_once_with("gs://fake/run/checkpoints/0")
+    self.assertFalse(synced_cfg.scan_layers)
+
+  @patch("maxtext.utils.model_creation_utils.checkpointing.load_checkpoint_metadata")
+  def test_falls_back_to_load_full_state_path(self, mock_load_meta):
+    """Without checkpoint_path or load_parameters_path, load_full_state_path is checked."""
+    mock_load_meta.return_value = {"scan_layers": False}
+    cfg = _make_config(enable_checkpointing=True, load_full_state_path="gs://fake/full_state/0/items")
+
+    synced_cfg = model_creation_utils.verify_and_sync_scan_layers(cfg)
+
+    mock_load_meta.assert_called_once_with("gs://fake/full_state/0/items")
+    self.assertFalse(synced_cfg.scan_layers)
+
+  @patch("maxtext.utils.model_creation_utils.checkpointing.load_checkpoint_metadata")
+  def test_no_paths_skips_metadata_read(self, mock_load_meta):
+    """With no resume source at all, the pre-flight is a no-op."""
+    cfg = _make_config(enable_checkpointing=True)
+    synced_cfg = model_creation_utils.verify_and_sync_scan_layers(cfg)
+    mock_load_meta.assert_not_called()
+    self.assertIs(synced_cfg, cfg)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
# Description

Restores the two-layer defense against loading a checkpoint that does not fit
the model in the training flow, and fixes a metadata-lookup bug that silently
disabled the config-level check everywhere it was already wired in.

## Problem

MaxText has two protections that were designed to work together:

1. **Config-level pre-flight** — `verify_and_sync_scan_layers` reads the
   `scan_layers` value recorded in the checkpoint's custom metadata and either
   rejects the run early with `Configuration mismatch` (user explicitly set a
   conflicting value) or silently syncs the config (user left it unset).
2. **Weight-level backstop** — `_raise_on_weight_mismatch` compares the model's
   expected weights against what the checkpoint carries and raises
   `Checkpoint does not match the model`, naming every offending weight.

A June refactor (`f5f3af7e7`) deleted the training-side mismatch handling while
the replacement metadata check was only wired into `from_pretrained` and
`to_huggingface` — the training entrypoint never ran it. A `scan_layers`
mismatch on a training resume was therefore only caught late, by the generic
weight error, which is why `test_scan_layers_mismatch_tpu` stopped seeing the
`Configuration mismatch` message it asserts on.

A second, independent bug made the pre-flight useless even where it *was*
wired in: `CheckpointManager.save(custom_metadata=…)` writes metadata at the
**step directory** (`…/0/`), but the documented `load_parameters_path`
convention points at `…/0/items`, and `load_checkpoint_metadata` read exactly
the given path — so it always returned `{}` and the check silently skipped.

# Tests

**Integration (TPU, `scheduled_only`)** — `tests/integration/checkpointing_test.py`:

- `test_scan_layers_mismatch_tpu` — saves with default `scan_layers=True`,
  reruns with explicit `scan_layers=False`; asserts the config-level
  `Configuration mismatch` + `scan_layers`. Exercises the pre-flight layer.
- `test_weight_mismatch_tpu` (new) — saves an unscanned single-layer
  checkpoint, reruns with `base_num_decoder_layers=2` and the same
  `scan_layers=False` (metadata matches, pre-flight passes); asserts
  `Checkpoint does not match the model` + `decoder/layers/1/`. Exercises the
  weight-level layer in isolation.

**Unit** — run with `python -m pytest` from the repo root:

- `tests/unit/checkpointing_metadata_test.py` (new) — against real Orbax:
  metadata readable at the step dir and at `…/items` via the parent-first
  lookup, `{}` for missing checkpoints; `latest_checkpoint_step_dir` newest
  step / `None` cases; `PreRestoreWeightCheckTest` drives
  `_raise_on_weight_mismatch` from real stored `item_metadata` on both the
  manager form (pinning the indexed `["items"]` access — `Composite.items` is
  a method, attribute access would silently no-op the check) and the
  params-only form.
- `tests/unit/model_creation_utils_test.py` — pre-flight honors an explicit
  `checkpoint_path`, falls back to `load_full_state_path`, and is a no-op with
  no resume source.
- `tests/unit/checkpointing_test.py` — metadata mocks updated to patch
  `ocp.Checkpointer`, matching the sync-checkpointer refactor.

Local runs: metadata + model-creation suites 52 passed / 25 skipped
(TPU-only/scheduled markers); checkpointing unit file 10 passed. CI pathways
integration jobs (both TPU mismatch tests) and all unit jobs green on the
pushed head.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
