### PR TITLE
Fix packed-sequence masking in cudnn_flash_jax and add cutlass_flash GPU backend

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -396,7 +396,7 @@ param_scan_axis: 1
 
 # The attention parameter dictates the specific algorithm/methodology used to compute the attention scores
 # The attention_type parameter determines the variants of attention, e.g. global or local_sliding
-attention: 'autoselected' # Supported attention: autoselected, dot_product, flash, cudnn_flash_te
+attention: 'autoselected' # Supported attention: autoselected, dot_product, flash, cudnn_flash_te, cutlass_flash (GPU FlashAttention-2, head_dim<=256; needs flash-attn-jax, which currently pins jax<0.9)
 attention_type: 'global' # Supported attention_type: global, local_sliding, chunk, mla, full, compressed, block_diffusion
 share_kv_projections: false # Note: Not compatible with attention_type='mla'
 attention_bias: false # If true, adds a learnable bias to the query, key, and value projections

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -380,7 +380,7 @@ param_scan_axis: 1
 
 # The attention parameter dictates the specific algorithm/methodology used to compute the attention scores
 # The attention_type parameter determines the variants of attention, e.g. global or local_sliding
-attention: 'autoselected' # Supported attention: autoselected, dot_product, flash, cudnn_flash_te
+attention: 'autoselected' # Supported attention: autoselected, dot_product, flash, cudnn_flash_te, cutlass_flash (GPU FlashAttention-2, head_dim<=256; needs flash-attn-jax, which currently pins jax<0.9)
 attention_type: 'global' # Supported attention_type: global, local_sliding, chunk, mla
 share_kv_projections: false # Note: Not compatible with attention_type='mla'
 attention_bias: false # If true, adds a learnable bias to the query, key, and value projections

--- a/src/maxtext/configs/pyconfig_deprecated.py
+++ b/src/maxtext/configs/pyconfig_deprecated.py
@@ -105,6 +105,7 @@ def validate_attention_kernel(s: str) -> None:
       "flash",
       "cudnn_flash_te",
       "cudnn_flash_jax",
+      "cutlass_flash",
       "vllm_rpa",
       "vllm_batched_rpa",
   )

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -4198,8 +4198,20 @@ class MaxTextConfig(
           "STRIPED reorder strategy requires Transformer Engine and is only supported on GPUs. "
           f"Got hardware={self.hardware!r}."
       )
-    if self.hardware == "gpu" and self.packing and self.attention == "cudnn_flash_te" and self.max_segments_per_seq <= 0:
-      raise ValueError("max_segments_per_seq must be set when using TransformerEngine attention and packing")
+    # Mirrors AttentionOp._needs_packed_masking: synthetic data carries no real
+    # segments, so the packed path is never taken and the bound is not needed.
+    if (
+        self.hardware == "gpu"
+        and self.packing
+        and self.dataset_type != DatasetType.SYNTHETIC
+        and self.attention in ("cudnn_flash_te", "cudnn_flash_jax", "cutlass_flash")
+        and self.max_segments_per_seq <= 0
+    ):
+      raise ValueError(
+          f"max_segments_per_seq must be set to the maximum number of packed segments per "
+          f"sequence when using attention={self.attention!r} with packing; these kernels need "
+          f"that bound at trace time to lay out per-segment metadata."
+      )
     dcn_product = (
         self.dcn_data_parallelism
         * self.dcn_pipeline_parallelism

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -3487,8 +3487,20 @@ class MaxTextConfig(
           "STRIPED reorder strategy requires Transformer Engine and is only supported on GPUs. "
           f"Got hardware={self.hardware!r}."
       )
-    if self.hardware == "gpu" and self.packing and self.attention == "cudnn_flash_te" and self.max_segments_per_seq <= 0:
-      raise ValueError("max_segments_per_seq must be set when using TransformerEngine attention and packing")
+    # Mirrors AttentionOp._needs_packed_masking: synthetic data carries no real
+    # segments, so the packed path is never taken and the bound is not needed.
+    if (
+        self.hardware == "gpu"
+        and self.packing
+        and self.dataset_type != DatasetType.SYNTHETIC
+        and self.attention in ("cudnn_flash_te", "cudnn_flash_jax", "cutlass_flash")
+        and self.max_segments_per_seq <= 0
+    ):
+      raise ValueError(
+          f"max_segments_per_seq must be set to the maximum number of packed segments per "
+          f"sequence when using attention={self.attention!r} with packing; these kernels need "
+          f"that bound at trace time to lay out per-segment metadata."
+      )
     dcn_product = (
         self.dcn_data_parallelism
         * self.dcn_pipeline_parallelism

--- a/src/maxtext/kernels/attention/cutlass_flash.py
+++ b/src/maxtext/kernels/attention/cutlass_flash.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CUTLASS FlashAttention-2 wrapper (via flash-attn-jax) for MaxText.
+
+Feature parity with the GPU ``flash`` (pallas) path:
+  - causal self-attention with optional sliding window (LOCAL_SLIDING),
+  - native GQA/MQA (num_kv_heads < num_query_heads, no KV repeat),
+  - sequence packing via segment ids, lowered to FA2's varlen kernel with
+    cu_seqlens built inside jit (fixed-size, empty tail sequences are skipped
+    by the kernel).
+
+Constraints (callers must fall back for these): head_dim <= 256, sm80+,
+training/prefill only (no decode), no attention sinks / logit soft-cap.
+
+flash-attn-jax is not a declared dependency: it pins ``jax<0.9`` while MaxText
+needs ``jax>=0.10``, so installing it downgrades jax and breaks the rest of the
+package. ``attention=cutlass_flash`` therefore stays opt-in, and the import is
+guarded so every other kernel keeps working without it.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from flash_attn_jax import flash_mha, flash_mha_varlen
+
+
+def _cu_seqlens_from_segment_ids(segment_ids: jax.Array, max_segments_per_row: int) -> jax.Array:
+  """Builds FA2 cu_seqlens (int32, [num_seqs + 1]) from MaxText segment ids.
+
+  A new sequence starts at every row start and at every within-row segment-id
+  change (packing never spans rows). Each row holds at most max_segments_per_row
+  segments plus one trailing padding run (id 0), which also counts as a run
+  start, so the result has a fixed size of ``batch * (max_segments_per_row + 1)
+  + 1``; unused entries repeat their row's end offset, i.e. zero-length
+  sequences that FA2 skips.
+
+  The selection is per row rather than over the flattened batch, so a row with
+  more runs than the budget can only merge two of its own segments. Selecting
+  globally would let the surviving sequence run to the end of the batch and
+  cover unrelated rows.
+  """
+  batch, seq_len = segment_ids.shape
+  total = batch * seq_len
+  positions = jnp.arange(seq_len, dtype=jnp.int32)[None, :] + jnp.arange(batch, dtype=jnp.int32)[:, None] * seq_len
+  prev = jnp.concatenate([jnp.full((batch, 1), -1, dtype=segment_ids.dtype), segment_ids[:, :-1]], axis=1)
+  is_start = (positions % seq_len == 0) | (segment_ids != prev)
+  # Real starts sort to the front of their row, fillers (the row end) behind
+  # them, which keeps the concatenation non-decreasing across rows.
+  row_end = (jnp.arange(batch, dtype=jnp.int32)[:, None] + 1) * seq_len
+  start_positions = jnp.where(is_start, positions, row_end)
+  per_row = max_segments_per_row + 1
+  starts = jax.lax.sort(start_positions, dimension=1)[:, :per_row]
+  return jnp.concatenate([starts.reshape(batch * per_row), jnp.full((1,), total, dtype=jnp.int32)])
+
+
+def cutlass_flash_attention(
+    query: jax.Array,
+    key: jax.Array,
+    value: jax.Array,
+    segment_ids: jax.Array | None,
+    *,
+    sm_scale: float = 1.0,
+    window: int | None = None,
+    max_segments_per_row: int = 1,
+) -> jax.Array:
+  """Causal (optionally sliding-window) attention on [B, S, H, D] tensors.
+
+  ``window`` follows the MaxText LOCAL_SLIDING convention: query i attends
+  keys j with ``i - window < j <= i``. FA2's window_size=(left, right) counts
+  additional positions, hence ``left = window - 1``.
+  """
+  batch, seq_len, num_q_heads, head_dim = query.shape
+  window_size = (window - 1, 0) if window is not None else (-1, -1)
+
+  # With at most one segment per row, causal masking alone already isolates rows
+  # (right-padding is never attended by earlier tokens), so the cheaper dense
+  # kernel is exact and skips the varlen scheduling overhead.
+  if segment_ids is None or max_segments_per_row <= 1:
+    return flash_mha(query, key, value, softmax_scale=sm_scale, is_causal=True, window_size=window_size)
+
+  cu_seqlens = _cu_seqlens_from_segment_ids(segment_ids, max_segments_per_row)
+  q_flat = query.reshape(batch * seq_len, num_q_heads, head_dim)
+  k_flat = key.reshape(batch * seq_len, key.shape[-2], head_dim)
+  v_flat = value.reshape(batch * seq_len, value.shape[-2], head_dim)
+  out = flash_mha_varlen(
+      q_flat,
+      k_flat,
+      v_flat,
+      cu_seqlens,
+      max_seqlen_q=seq_len,
+      max_seqlen_k=seq_len,
+      softmax_scale=sm_scale,
+      is_causal=True,
+      window_size=window_size,
+  )
+  return out.reshape(batch, seq_len, num_q_heads, head_dim)

--- a/src/maxtext/kernels/attention/gpu_pallas_flash.py
+++ b/src/maxtext/kernels/attention/gpu_pallas_flash.py
@@ -1,0 +1,806 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pallas (Triton) GPU flash attention with sliding-window, soft-cap and
+large-head-dim support.
+
+Forked from jax.experimental.pallas.ops.gpu.attention with extensions needed
+to run Gemma-style models efficiently on Ampere (sm80):
+
+  1. ``window``: causal sliding-window attention (query at position i attends
+     keys j with ``i - window < j <= i``, matching MaxText's LOCAL_SLIDING
+     mask), implemented as FlashAttention-2 style loop-bound narrowing plus an
+     in-block mask, so local layers do O(seq * window) work instead of O(seq^2).
+  2. ``soft_cap``: gemma2-style attention-logit soft cap
+     (``cap * tanh(logits / cap)``), applied in the natural-log domain with the
+     matching ``1 - tanh^2`` chain rule in the backward pass.
+  3. head_dim > 128 (256, 512): cuDNN fused attention has no sm80 kernel and
+     FlashAttention-2 caps at 256. QK^T / PV products are accumulated over
+     ``dim_chunk``-sized slices of head_dim so SMEM tile sizes stay bounded
+     regardless of head_dim.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+import math
+from typing import Any
+
+import jax
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import triton as plgpu
+import jax.numpy as jnp
+
+from maxtext.common.common_types import DEFAULT_MASK_VALUE
+
+# pl.dot is deprecated in jax 0.11 in favour of pallas.triton.dot, which does
+# not exist in 0.10. The repo supports jax>=0.10, so pick whichever is there.
+_dot = getattr(plgpu, "dot", None) or pl.dot
+
+_LOG2E = math.log2(math.e)
+
+
+def _scaled_logits(qk, sm_scale: float, soft_cap: float | None):
+  """Applies sm_scale and optional tanh soft-cap (both in the natural-log
+  domain), then converts to base-2 domain for exp2-based softmax.
+
+  Returns (base2 logits, tanh value or None) — the tanh is reused by the
+  backward pass, whose chain rule needs ``1 - tanh^2``.
+  """
+  if sm_scale != 1.0:
+    qk = qk * sm_scale
+  t = None
+  if soft_cap is not None:
+    t = jnp.tanh(qk / soft_cap)
+    qk = soft_cap * t
+  return qk * _LOG2E, t
+
+
+def _pick_dim_chunk(head_dim_padded: int) -> int:
+  """head_dim <= 256 keeps the original single-slab layout (tuned); larger
+  head dims accumulate over 128-wide chunks to bound SMEM tile sizes."""
+  return head_dim_padded if head_dim_padded <= 256 else 128
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BlockSizes:
+  """Tile sizes parameterizing the attention kernel."""
+
+  block_q: int
+  block_k: int
+  block_q_dkv: int | None = None
+  block_kv_dkv: int | None = None
+  block_q_dq: int | None = None
+  block_kv_dq: int | None = None
+
+  @classmethod
+  def get_default(cls):
+    return BlockSizes(
+        block_q=128,
+        block_k=128,
+        block_q_dkv=32,
+        block_kv_dkv=32,
+        block_q_dq=32,
+        block_kv_dq=32,
+    )
+
+  @classmethod
+  def get_for_head_dim(cls, head_dim: int):
+    """Tile sizes picked by autotuning on sm80."""
+    if head_dim <= 128:
+      return cls.get_default()
+    if head_dim <= 256:
+      return BlockSizes(
+          block_q=64,
+          block_k=64,
+          block_q_dkv=32,
+          block_kv_dkv=32,
+          block_q_dq=32,
+          block_kv_dq=32,
+      )
+    # d > 256: chunked accumulation bounds SMEM; smaller q blocks bound the
+    # fp32 accumulator register footprint (block_q x head_dim).
+    return BlockSizes(
+        block_q=32,
+        block_k=64,
+        block_q_dkv=32,
+        block_kv_dkv=32,
+        block_q_dq=32,
+        block_kv_dq=32,
+    )
+
+  @property
+  def has_backward_blocks(self) -> bool:
+    backward_blocks = (self.block_q_dkv, self.block_kv_dkv, self.block_q_dq, self.block_kv_dq)
+    return all(b is not None for b in backward_blocks)
+
+
+def segment_mask(q_segment_ids: jax.Array, kv_segment_ids: jax.Array):
+  q_segment_ids = jnp.expand_dims(q_segment_ids, axis=-1)
+  if kv_segment_ids.ndim == 1:
+    kv_segment_ids = jnp.expand_dims(kv_segment_ids, axis=0)
+  else:
+    kv_segment_ids = jnp.expand_dims(kv_segment_ids, axis=1)
+  return jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+
+def _combined_mask(span_q, span_k, q_segment_ids, kv_segment_ids, causal, window):
+  """Builds the block-local mask combining segments, causality and the sliding window."""
+  mask = None
+  if q_segment_ids is not None:
+    mask = segment_mask(q_segment_ids, kv_segment_ids)
+  if causal:
+    causal_mask = span_q[:, None] >= span_k[None, :]
+    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+  if window is not None:
+    # MaxText LOCAL_SLIDING convention: k > q - window (jointly with k <= q).
+    window_mask = span_q[:, None] - span_k[None, :] < window
+    mask = window_mask if mask is None else jnp.logical_and(mask, window_mask)
+  return mask
+
+
+def _chunk_slices(head_dim_padded: int, dim_chunk: int):
+  assert head_dim_padded % dim_chunk == 0
+  return [pl.dslice(c * dim_chunk, dim_chunk) for c in range(head_dim_padded // dim_chunk)]
+
+
+def _chunk_masks(head_dim: int, head_dim_padded: int, dim_chunk: int):
+  return [(jnp.arange(dim_chunk) + c * dim_chunk < head_dim)[None, :] for c in range(head_dim_padded // dim_chunk)]
+
+
+def _load_chunks(ref, row_slice, chunk_slices, chunk_masks):
+  return [plgpu.load(ref.at[row_slice, cs], mask=cm, other=0.0) for cs, cm in zip(chunk_slices, chunk_masks)]
+
+
+def mha_forward_kernel(
+    q_ref,
+    k_ref,
+    v_ref,
+    segment_ids_ref: jax.Array | None,
+    o_ref: Any,
+    *residual_refs: Any,
+    sm_scale: float,
+    causal: bool,
+    window: int | None,
+    soft_cap: float | None,
+    block_q: int,
+    block_k: int,
+    head_dim: int,
+    dim_chunk: int,
+):
+  """Fused forward kernel: online-softmax attention over K/V blocks."""
+  seq_len = k_ref.shape[0]
+  start_q = pl.program_id(0)
+  head_dim_padded = q_ref.shape[-1]
+  cslices = _chunk_slices(head_dim_padded, dim_chunk)
+  cmasks = _chunk_masks(head_dim, head_dim_padded, dim_chunk)
+  num_chunks = len(cslices)
+
+  m_i = jnp.zeros(block_q, dtype=jnp.float32) - float("inf")
+  l_i = jnp.zeros(block_q, dtype=jnp.float32)
+  o_chunks = tuple(jnp.zeros((block_q, dim_chunk), dtype=jnp.float32) for _ in range(num_chunks))
+
+  curr_q_slice = pl.dslice(start_q * block_q, block_q)
+  q_chunks = _load_chunks(q_ref, slice(None), cslices, cmasks)
+  q_segment_ids = None if segment_ids_ref is None else segment_ids_ref[curr_q_slice]
+
+  def body(start_k, carry):
+    o_prev, m_prev, l_prev = carry
+    curr_k_slice = pl.dslice(start_k * block_k, block_k)
+
+    qk = jnp.zeros((block_q, block_k), dtype=jnp.float32)
+    for c in range(num_chunks):
+      k_c = plgpu.load(k_ref.at[curr_k_slice, cslices[c]], mask=cmasks[c], other=0.0)
+      qk += _dot(q_chunks[c], k_c.T)
+    qk, _ = _scaled_logits(qk, sm_scale, soft_cap)
+
+    if causal or window is not None or segment_ids_ref is not None:
+      span_q = start_q * block_q + jnp.arange(block_q)
+      span_k = start_k * block_k + jnp.arange(block_k)
+      kv_segment_ids = None if segment_ids_ref is None else segment_ids_ref[curr_k_slice]
+      mask = _combined_mask(span_q, span_k, q_segment_ids, kv_segment_ids, causal, window)
+      assert mask is not None
+      qk = jnp.where(mask, qk, DEFAULT_MASK_VALUE)
+
+    m_curr = jnp.max(qk, axis=-1)
+    m_next = jnp.maximum(m_prev, m_curr)
+    correction = jnp.exp2(m_prev - m_next)
+    l_prev_corr = correction * l_prev
+    s_curr = jnp.exp2(qk - m_next[:, None])
+    l_curr = s_curr.sum(axis=-1)
+    l_next = l_prev_corr + l_curr
+
+    o_next = []
+    for c in range(num_chunks):
+      v_c = plgpu.load(v_ref.at[curr_k_slice, cslices[c]], mask=cmasks[c], other=0.0)
+      o_next.append(correction[:, None] * o_prev[c] + _dot(s_curr.astype(v_c.dtype), v_c))
+    return tuple(o_next), m_next, l_next
+
+  if causal:
+    upper_bound = lax.div(block_q * (start_q + 1) + block_k - 1, block_k)
+  else:
+    upper_bound = pl.cdiv(seq_len, block_k)
+  if window is not None:
+    # First key any query in this block can attend: q_min - window + 1.
+    first_k = block_q * start_q - window + 1
+    lower_bound = lax.max(0, lax.div(first_k, block_k))
+  else:
+    lower_bound = 0
+  o_chunks, m_i, l_i = lax.fori_loop(lower_bound, upper_bound, body, (o_chunks, m_i, l_i))
+
+  # Fully-masked rows (can happen with packing) produce l_i == 0; avoid NaNs.
+  l_safe = jnp.where(l_i == 0.0, 1.0, l_i)[:, None]
+
+  if residual_refs:
+    # A fully-masked row leaves m_i at -inf, and the backward reads lse back as
+    # exp2(qk - lse), so -inf here would come back as NaN. Store a finite value;
+    # the backward masks those entries to zero anyway.
+    lse_ref = residual_refs[0]
+    lse_ref[...] = jnp.where(l_i == 0.0, 0.0, m_i + jnp.log2(l_i))
+  for cslice, cmask, o_chunk in zip(cslices, cmasks, o_chunks):
+    plgpu.store(o_ref.at[:, cslice], (o_chunk / l_safe).astype(o_ref.dtype), mask=cmask)
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=[4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "sm_scale",
+        "causal",
+        "window",
+        "soft_cap",
+        "block_sizes",
+        "backward_pass_impl",
+        "num_warps",
+        "num_stages",
+        "grid",
+        "interpret",
+        "debug",
+        "return_residuals",
+    ],
+)
+def mha(
+    q,
+    k,
+    v,
+    segment_ids: jnp.ndarray | None,
+    sm_scale: float = 1.0,
+    causal: bool = False,
+    window: int | None = None,
+    soft_cap: float | None = None,
+    block_sizes: BlockSizes | None = None,
+    backward_pass_impl: str = "auto",
+    num_warps: int | None = None,
+    num_stages: int | None = None,
+    grid: tuple[int, ...] | None = None,
+    interpret: bool = False,
+    debug: bool = False,
+    return_residuals: bool = False,
+):
+  """Flash attention over [batch, seq, heads, head_dim] inputs (custom VJP)."""
+  del backward_pass_impl
+  batch_size, q_seq_len, num_heads, head_dim = q.shape
+  kv_seq_len = k.shape[1]
+  if block_sizes is None:
+    block_sizes = BlockSizes.get_for_head_dim(head_dim)
+  block_q = min(block_sizes.block_q, q_seq_len)
+  block_k = min(block_sizes.block_k, kv_seq_len)
+  head_dim_padded = pl.next_power_of_2(head_dim)
+  dim_chunk = _pick_dim_chunk(head_dim_padded)
+  if (q.shape[-1] != k.shape[-1]) or (q.shape[-1] != v.shape[-1]):
+    raise ValueError(
+        f"This kernel expects q, k, and v to have the same head dimension, but"
+        f" found {q.shape=}, {k.shape=}, {v.shape=}."
+    )
+  if q_seq_len % block_q != 0:
+    raise ValueError(f"{q_seq_len=} must be a multiple of {block_q=}")
+  if kv_seq_len % block_k != 0:
+    raise ValueError(f"{kv_seq_len=} must be a multiple of {block_k=}")
+  if window is not None and window <= 0:
+    raise ValueError(f"{window=} must be positive when set")
+
+  grid_ = grid
+  if grid_ is None:
+    grid_ = (pl.cdiv(q_seq_len, block_q), batch_size, num_heads)
+
+  num_warps_ = num_warps
+  if num_warps_ is None:
+    # Autotuned on A100: 4 warps wins at head_dim <= 64 and at 256 (register
+    # pressure from the wide fp32 accumulator); 8 warps wins at 128 and 512.
+    num_warps_ = 4 if head_dim <= 64 or head_dim_padded == 256 else 8
+  num_stages_ = num_stages
+  if num_stages_ is None:
+    # Chunked loads bound tile sizes, but at d512 double-buffering still sits
+    # ~1KB above sm80's 164KB SMEM budget — drop to single-stage there.
+    num_stages_ = 1 if head_dim_padded > 256 else 2
+
+  kernel = functools.partial(
+      mha_forward_kernel,
+      sm_scale=sm_scale,
+      block_q=block_q,
+      block_k=block_k,
+      head_dim=head_dim,
+      dim_chunk=dim_chunk,
+      causal=causal,
+      window=window,
+      soft_cap=soft_cap,
+  )
+
+  in_specs: list[pl.BlockSpec | None] = [
+      pl.BlockSpec((None, block_q, None, head_dim_padded), lambda i, j, k: (j, i, k, 0)),
+      pl.BlockSpec((None, kv_seq_len, None, head_dim_padded), lambda _, j, k: (j, 0, k, 0)),
+      pl.BlockSpec((None, kv_seq_len, None, head_dim_padded), lambda _, j, k: (j, 0, k, 0)),
+  ]
+  in_specs.append(None if segment_ids is None else pl.BlockSpec((None, kv_seq_len), lambda _, j, k: (j, 0)))
+  out_shape = [q]
+  out_specs = [pl.BlockSpec((None, block_q, None, head_dim_padded), lambda i, j, k: (j, i, k, 0))]
+  if return_residuals:
+    out_shape.append(jax.ShapeDtypeStruct(shape=(batch_size, num_heads, q_seq_len), dtype=jnp.float32))
+    out_specs.append(pl.BlockSpec((None, None, block_q), lambda i, j, k: (j, k, i)))
+  out = pl.pallas_call(
+      kernel,
+      grid=grid_,
+      in_specs=in_specs,
+      out_specs=out_specs,
+      compiler_params=plgpu.CompilerParams(num_warps=num_warps_, num_stages=num_stages_),
+      out_shape=out_shape,
+      debug=debug,
+      interpret=interpret,
+      name="mha_forward_sw",
+  )(q, k, v, segment_ids)
+  return out if return_residuals else out[0]
+
+
+def _mha_forward(
+    q,
+    k,
+    v,
+    segment_ids: jax.Array | None,
+    sm_scale: float,
+    causal: bool,
+    window: int | None,
+    soft_cap: float | None,
+    block_sizes: BlockSizes | None,
+    backward_pass_impl: str,
+    num_warps: int | None,
+    num_stages: int | None,
+    grid: Any,
+    interpret: bool,
+    debug: bool,
+    return_residuals: bool,
+):
+  """Forward-pass wrapper: pads head_dim, launches the kernel, keeps residuals."""
+  out, lse = mha(
+      q,
+      k,
+      v,
+      segment_ids=segment_ids,
+      sm_scale=sm_scale,
+      causal=causal,
+      window=window,
+      soft_cap=soft_cap,
+      block_sizes=block_sizes,
+      backward_pass_impl=backward_pass_impl,
+      num_warps=num_warps,
+      num_stages=num_stages,
+      grid=grid,
+      interpret=interpret,
+      debug=debug,
+      return_residuals=True,
+  )
+  residuals = (q, k, v, segment_ids, out, lse)
+  ret = (out, lse) if return_residuals else out
+  return ret, residuals
+
+
+def _preprocess_backward_kernel(out_ref, dout_ref, delta_ref, head_dim: int, dim_chunk: int):
+  head_dim_padded = out_ref.shape[-1]
+  cslices = _chunk_slices(head_dim_padded, dim_chunk)
+  cmasks = _chunk_masks(head_dim, head_dim_padded, dim_chunk)
+  delta = jnp.zeros(out_ref.shape[0], dtype=jnp.float32)
+  for cs, cm in zip(cslices, cmasks):
+    o_c = plgpu.load(out_ref.at[:, cs], mask=cm, other=0.0)
+    do_c = plgpu.load(dout_ref.at[:, cs], mask=cm, other=0.0)
+    delta += jnp.sum(o_c * do_c, axis=1)
+  delta_ref[...] = delta.astype(delta_ref.dtype)
+
+
+@jax.named_scope("preprocess_backward")
+def _preprocess_backward(out, do, lse, block_q: int, debug: bool, interpret: bool):
+  """Computes the per-row delta = sum(out * do) residual used by the backward kernels."""
+  batch_size, seq_len, num_heads, head_dim = out.shape
+  head_dim_padded = pl.next_power_of_2(head_dim)
+  dim_chunk = _pick_dim_chunk(head_dim_padded)
+  out_shape = jax.ShapeDtypeStruct(lse.shape, lse.dtype)
+  delta = pl.pallas_call(
+      functools.partial(_preprocess_backward_kernel, head_dim=head_dim, dim_chunk=dim_chunk),
+      grid=(pl.cdiv(seq_len, block_q), batch_size, num_heads),
+      in_specs=[
+          pl.BlockSpec((None, block_q, None, head_dim_padded), lambda i, j, k: (j, i, k, 0)),
+          pl.BlockSpec((None, block_q, None, head_dim_padded), lambda i, j, k: (j, i, k, 0)),
+      ],
+      out_specs=pl.BlockSpec((None, None, block_q), lambda i, j, k: (j, k, i)),
+      compiler_params=plgpu.CompilerParams(num_warps=4, num_stages=3),
+      out_shape=out_shape,
+      debug=debug,
+      interpret=interpret,
+      name="mha_preprocess_backward",
+  )(out, do)
+  return delta
+
+
+def mha_backward_kernel(
+    # Inputs
+    q_ref,
+    k_ref,
+    v_ref,
+    segment_ids_ref: jax.Array | None,
+    out_ref,
+    do_scaled_ref,
+    lse_ref,
+    delta_ref,
+    # Outputs
+    dq_ref,
+    dk_ref,
+    dv_ref,
+    *,
+    sm_scale: float,
+    causal: bool,
+    window: int | None,
+    soft_cap: float | None,
+    block_q_dkv: int,
+    block_kv_dkv: int,
+    block_q_dq: int,
+    block_kv_dq: int,
+    head_dim: int,
+    dim_chunk: int,
+):
+  """Fused backward kernel computing dQ, dK and dV from forward residuals."""
+  del out_ref
+  q_seq_len = q_ref.shape[0]
+  kv_seq_len = k_ref.shape[0]
+  head_dim_padded = q_ref.shape[-1]
+  cslices = _chunk_slices(head_dim_padded, dim_chunk)
+  cmasks = _chunk_masks(head_dim, head_dim_padded, dim_chunk)
+  num_chunks = len(cslices)
+
+  # Scan #1: dK and dV.
+  start_k = pl.program_id(2)
+  curr_k_slice = pl.dslice(start_k * block_kv_dkv, block_kv_dkv)
+
+  dv_chunks = tuple(jnp.zeros([block_kv_dkv, dim_chunk], dtype=jnp.float32) for _ in range(num_chunks))
+  dk_chunks = tuple(jnp.zeros([block_kv_dkv, dim_chunk], dtype=jnp.float32) for _ in range(num_chunks))
+
+  k_chunks = _load_chunks(k_ref, curr_k_slice, cslices, cmasks)
+  v_chunks = _load_chunks(v_ref, curr_k_slice, cslices, cmasks)
+  span_k = start_k * block_kv_dkv + jnp.arange(block_kv_dkv)
+  kv_segment_ids = None if segment_ids_ref is None else segment_ids_ref[curr_k_slice]
+
+  def inner_loop_dkdv(start_q, carry):
+    dv, dk = carry
+    curr_q_slice = pl.dslice(start_q * block_q_dkv, block_q_dkv)
+
+    q_chunks = _load_chunks(q_ref, curr_q_slice, cslices, cmasks)
+    do_chunks = _load_chunks(do_scaled_ref, curr_q_slice, cslices, cmasks)
+
+    qk = jnp.zeros((block_q_dkv, block_kv_dkv), dtype=jnp.float32)
+    for c in range(num_chunks):
+      qk += _dot(q_chunks[c], k_chunks[c].T)
+    qk, tanh_val = _scaled_logits(qk, sm_scale, soft_cap)
+
+    if causal or window is not None or segment_ids_ref is not None:
+      span_q = start_q * block_q_dkv + jnp.arange(block_q_dkv)
+      q_segment_ids = None if segment_ids_ref is None else segment_ids_ref[curr_q_slice]
+      mask = _combined_mask(span_q, span_k, q_segment_ids, kv_segment_ids, causal, window)
+      assert mask is not None
+      qk = jnp.where(mask, qk, DEFAULT_MASK_VALUE)
+
+    lse = lse_ref[curr_q_slice]
+    di = delta_ref[curr_q_slice]
+
+    p = jnp.exp2(qk - lse[:, None])
+    dp = jnp.zeros((block_q_dkv, block_kv_dkv), dtype=jnp.float32) - di[:, None]
+    for c in range(num_chunks):
+      dp += _dot(do_chunks[c], v_chunks[c].T)
+    ds = p * dp
+    if soft_cap is not None:
+      ds = ds * (1.0 - tanh_val * tanh_val)
+    if sm_scale != 1.0:
+      ds = ds * sm_scale
+
+    p_t = p.astype(do_chunks[0].dtype).T
+    ds_t = ds.astype(q_ref.dtype).T
+    dv = tuple(dv[c] + _dot(p_t, do_chunks[c]) for c in range(num_chunks))
+    dk = tuple(dk[c] + _dot(ds_t, q_chunks[c]) for c in range(num_chunks))
+    return dv, dk
+
+  lower_bound_dkdv = lax.div(start_k * block_kv_dkv, block_q_dkv) if causal else 0
+  if window is not None:
+    # Last query that can attend key k_min is k_min + window - 1; queries in
+    # later blocks see none of this KV block.
+    last_q = (start_k + 1) * block_kv_dkv + window - 1
+    upper_bound_dkdv = lax.min(pl.cdiv(q_seq_len, block_q_dkv), lax.div(last_q + block_q_dkv - 1, block_q_dkv))
+  else:
+    upper_bound_dkdv = pl.cdiv(q_seq_len, block_q_dkv)
+  dv_chunks, dk_chunks = lax.fori_loop(lower_bound_dkdv, upper_bound_dkdv, inner_loop_dkdv, (dv_chunks, dk_chunks))
+  for c in range(num_chunks):
+    plgpu.store(dv_ref.at[:, cslices[c]], dv_chunks[c].astype(dv_ref.dtype), mask=cmasks[c])
+    plgpu.store(dk_ref.at[:, cslices[c]], dk_chunks[c].astype(dk_ref.dtype), mask=cmasks[c])
+
+  # Scan #2: dQ.
+  start_q = pl.program_id(2)
+  curr_q_slice = pl.ds(start_q * block_q_dq, block_q_dq)
+  span_q = start_q * block_q_dq + jnp.arange(block_q_dq)
+  dq_chunks = tuple(jnp.zeros([block_q_dq, dim_chunk], dtype=jnp.float32) for _ in range(num_chunks))
+
+  q_chunks = _load_chunks(q_ref, curr_q_slice, cslices, cmasks)
+  do_chunks = _load_chunks(do_scaled_ref, curr_q_slice, cslices, cmasks)
+  q_segment_ids = None if segment_ids_ref is None else segment_ids_ref[curr_q_slice]
+  lse = lse_ref[curr_q_slice]
+  di = delta_ref[curr_q_slice]
+
+  def inner_loop_dq(start_k, dq):
+    curr_k_slice = pl.dslice(start_k * block_kv_dq, block_kv_dq)
+    k_chunks_dq = _load_chunks(k_ref, curr_k_slice, cslices, cmasks)
+    v_chunks_dq = _load_chunks(v_ref, curr_k_slice, cslices, cmasks)
+
+    qk = jnp.zeros((block_q_dq, block_kv_dq), dtype=jnp.float32)
+    for c in range(num_chunks):
+      qk += _dot(q_chunks[c], k_chunks_dq[c].T)
+    qk, tanh_val = _scaled_logits(qk, sm_scale, soft_cap)
+
+    if causal or window is not None or segment_ids_ref is not None:
+      span_k = start_k * block_kv_dq + jnp.arange(block_kv_dq)
+      kv_segment_ids = None if segment_ids_ref is None else segment_ids_ref[curr_k_slice]
+      mask = _combined_mask(span_q, span_k, q_segment_ids, kv_segment_ids, causal, window)
+      assert mask is not None
+      qk = jnp.where(mask, qk, DEFAULT_MASK_VALUE)
+
+    p = jnp.exp2(qk - lse[:, None])
+    dp = jnp.zeros((block_q_dq, block_kv_dq), dtype=jnp.float32) - di[:, None]
+    for c in range(num_chunks):
+      dp += _dot(do_chunks[c], v_chunks_dq[c].T)
+    ds = p * dp
+    if soft_cap is not None:
+      ds = ds * (1.0 - tanh_val * tanh_val)
+    if sm_scale != 1.0:
+      ds = ds * sm_scale
+
+    ds_cast = ds.astype(k_ref.dtype)
+    return tuple(dq[c] + _dot(ds_cast, k_chunks_dq[c]).astype(dq[c].dtype) for c in range(num_chunks))
+
+  if causal:
+    upper_bound_dq = pl.cdiv((start_q + 1) * block_q_dq, block_kv_dq)
+  else:
+    upper_bound_dq = pl.cdiv(kv_seq_len, block_kv_dq)
+  if window is not None:
+    first_k_dq = start_q * block_q_dq - window + 1
+    lower_bound_dq = lax.max(0, lax.div(first_k_dq, block_kv_dq))
+  else:
+    lower_bound_dq = 0
+
+  dq_chunks = lax.fori_loop(lower_bound_dq, upper_bound_dq, inner_loop_dq, dq_chunks)
+  for c in range(num_chunks):
+    plgpu.store(dq_ref.at[:, cslices[c]], dq_chunks[c].astype(dq_ref.dtype), mask=cmasks[c])
+
+
+def _xla_backward_from_residuals(q, k, v, segment_ids, out, do, lse, *, sm_scale, causal, window, soft_cap):
+  """Unfused XLA backward reusing the kernel's saved residuals (out, lse).
+
+  Unlike ``jax.vjp(mha_reference)`` this never re-runs the forward: softmax
+  probabilities are reconstructed from ``lse`` (base-2 domain) and only the
+  five essential matmuls (QK^T, dP, dQ, dK, dV) are computed.
+  """
+  q_seq_len, kv_seq_len = q.shape[1], k.shape[1]
+  x = jnp.einsum("bqhc,bkhc->bhqk", q, k, preferred_element_type=jnp.float32)
+  if sm_scale != 1.0:
+    x = x * sm_scale
+  t = None
+  if soft_cap is not None:
+    t = jnp.tanh(x / soft_cap)
+    x = soft_cap * t
+
+  mask = None
+  if segment_ids is not None:
+    mask = jnp.expand_dims(segment_mask(segment_ids, segment_ids), 1)
+  row_ids = jax.lax.broadcasted_iota(jnp.int32, (q_seq_len, kv_seq_len), 0)
+  col_ids = jax.lax.broadcasted_iota(jnp.int32, (q_seq_len, kv_seq_len), 1)
+  if causal:
+    causal_mask = (col_ids <= row_ids)[None, None, :, :]
+    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+  if window is not None:
+    window_mask = (row_ids - col_ids < window)[None, None, :, :]
+    mask = window_mask if mask is None else jnp.logical_and(mask, window_mask)
+
+  x2 = x * _LOG2E
+  if mask is not None:
+    x2 = jnp.where(mask, x2, DEFAULT_MASK_VALUE)
+  p = jnp.exp2(x2 - lse[..., None])  # [b, h, q, kv]
+
+  # Keep matmul operands in bf16 (tensor cores) and accumulate in fp32.
+  do_lp = do.astype(q.dtype)
+  di = jnp.einsum("bqhc,bqhc->bhq", out, do_lp, preferred_element_type=jnp.float32)
+  dp = jnp.einsum("bqhc,bkhc->bhqk", do_lp, v, preferred_element_type=jnp.float32)
+  ds = p * (dp - di[..., None])
+  if soft_cap is not None:
+    ds = ds * (1.0 - t * t)
+  if sm_scale != 1.0:
+    ds = ds * sm_scale
+
+  ds_lp = ds.astype(q.dtype)
+  p_lp = p.astype(q.dtype)
+  dq = jnp.einsum("bhqk,bkhc->bqhc", ds_lp, k, preferred_element_type=jnp.float32)
+  dk = jnp.einsum("bhqk,bqhc->bkhc", ds_lp, q, preferred_element_type=jnp.float32)
+  dv = jnp.einsum("bhqk,bqhc->bkhc", p_lp, do_lp, preferred_element_type=jnp.float32)
+  return dq.astype(q.dtype), dk.astype(k.dtype), dv.astype(v.dtype), None
+
+
+def _mha_backward(
+    sm_scale: float,
+    causal: bool,
+    window: int | None,
+    soft_cap: float | None,
+    block_sizes: BlockSizes | None,
+    backward_pass_impl: str,
+    num_warps: int | None,
+    num_stages: int | None,
+    grid: Any,
+    interpret: bool,
+    debug: bool,
+    return_residuals: bool,
+    res,
+    do,
+):
+  """Backward-pass wrapper: dispatches to the fused kernel or the XLA fallback."""
+  if return_residuals:
+    raise ValueError("Kernel differentiation is not supported if return_residuals is True.")
+  q, k, v, segment_ids, out, lse = res
+  del grid, return_residuals
+
+  if backward_pass_impl == "auto":
+    # Always the fused kernel. The XLA fallback materializes [b, h, q, kv], so
+    # its peak grows with the square of the sequence length: measured on an A100
+    # at batch 2, 8 heads, head_dim 320, it needs 12.5GiB at 8k tokens against
+    # 3.3GiB fused, and 3.3GiB at 4k. It is the more accurate of the two (bf16
+    # gradients agree with the reference to ~4e-3 versus ~2e-2), so it stays
+    # reachable by asking for it, but it does not scale.
+    backward_pass_impl = "triton"
+
+  if backward_pass_impl == "xla":
+    return _xla_backward_from_residuals(
+        q, k, v, segment_ids, out, do, lse, sm_scale=sm_scale, causal=causal, window=window, soft_cap=soft_cap
+    )
+  elif backward_pass_impl == "triton":
+    batch_size, q_seq_len, num_heads, head_dim = q.shape
+    kv_seq_len = k.shape[1]
+    if block_sizes is None:
+      block_sizes = BlockSizes.get_for_head_dim(head_dim)
+    if not block_sizes.has_backward_blocks:
+      raise ValueError("Backward block sizes must all be set.")
+
+    block_q = min(block_sizes.block_q, q_seq_len)
+    block_q_dkv = min(block_sizes.block_q_dkv, q_seq_len)
+    block_kv_dkv = min(block_sizes.block_kv_dkv, kv_seq_len)
+    block_q_dq = min(block_sizes.block_q_dq, q_seq_len)
+    block_kv_dq = min(block_sizes.block_kv_dq, kv_seq_len)
+    head_dim_padded = pl.next_power_of_2(head_dim)
+    dim_chunk = _pick_dim_chunk(head_dim_padded)
+
+    if q_seq_len // block_q_dq != kv_seq_len // block_kv_dkv:
+      raise ValueError(
+          "q_seq_len and kv_seq_len must be divided into the same number of blocks for the fused backward pass."
+      )
+
+    delta = _preprocess_backward(out, do, lse, block_q, debug, interpret)
+    out_shapes = [
+        jax.ShapeDtypeStruct(q.shape, q.dtype),
+        jax.ShapeDtypeStruct(k.shape, k.dtype),
+        jax.ShapeDtypeStruct(v.shape, v.dtype),
+    ]
+
+    in_specs: list[pl.BlockSpec | None] = [
+        pl.BlockSpec((None, q_seq_len, None, head_dim_padded), lambda i, j, _: (i, 0, j, 0)),
+        pl.BlockSpec((None, kv_seq_len, None, head_dim_padded), lambda i, j, _: (i, 0, j, 0)),
+        pl.BlockSpec((None, kv_seq_len, None, head_dim_padded), lambda i, j, _: (i, 0, j, 0)),
+        pl.BlockSpec((None, q_seq_len, None, head_dim_padded), lambda i, j, _: (i, 0, j, 0)),
+        pl.BlockSpec((None, q_seq_len, None, head_dim_padded), lambda i, j, _: (i, 0, j, 0)),
+        pl.BlockSpec((None, None, q_seq_len), lambda i, j, _: (i, j, 0)),
+        pl.BlockSpec((None, None, q_seq_len), lambda i, j, _: (i, j, 0)),
+    ]
+    if segment_ids is None:
+      in_specs.insert(3, None)
+    else:
+      in_specs.insert(3, pl.BlockSpec((None, kv_seq_len), lambda i, j, _: (i, 0)))
+
+    grid_bwd = (batch_size, num_heads, pl.cdiv(kv_seq_len, block_kv_dkv))
+    num_warps_ = num_warps
+    if num_warps_ is None:
+      if block_q_dkv * block_kv_dkv < 128 * 128 or block_q_dq * block_kv_dq < 128 * 128:
+        num_warps_ = 4
+      else:
+        num_warps_ = 8
+    num_stages_ = num_stages
+    if num_stages_ is None:
+      num_stages_ = 1 if head_dim_padded > 256 else 2
+
+    dq, dk, dv = pl.pallas_call(
+        functools.partial(
+            mha_backward_kernel,
+            sm_scale=sm_scale,
+            causal=causal,
+            window=window,
+            soft_cap=soft_cap,
+            block_q_dkv=block_q_dkv,
+            block_kv_dkv=block_kv_dkv,
+            block_q_dq=block_q_dq,
+            block_kv_dq=block_kv_dq,
+            head_dim=head_dim,
+            dim_chunk=dim_chunk,
+        ),
+        out_shape=out_shapes,
+        in_specs=in_specs,
+        grid=grid_bwd,
+        out_specs=[
+            pl.BlockSpec((None, block_q_dq, None, head_dim_padded), lambda i, j, k: (i, k, j, 0)),
+            pl.BlockSpec((None, block_kv_dkv, None, head_dim_padded), lambda i, j, k: (i, k, j, 0)),
+            pl.BlockSpec((None, block_kv_dkv, None, head_dim_padded), lambda i, j, k: (i, k, j, 0)),
+        ],
+        name="mha_backward_sw",
+        debug=debug,
+        interpret=interpret,
+        compiler_params=plgpu.CompilerParams(num_warps=num_warps_, num_stages=num_stages_),
+    )(q, k, v, segment_ids, out, do, lse, delta)
+  else:
+    raise ValueError(f"Invalid backward pass implementation: {backward_pass_impl}")
+  return dq.astype(q.dtype), dk, dv, None
+
+
+mha.defvjp(_mha_forward, _mha_backward)
+
+
+@functools.partial(jax.jit, static_argnames=["sm_scale", "causal", "window", "soft_cap"])
+def mha_reference(
+    q,
+    k,
+    v,
+    segment_ids: jnp.ndarray | None,
+    sm_scale=1.0,
+    causal: bool = False,
+    window: int | None = None,
+    soft_cap: float | None = None,
+):
+  """Unfused reference implementation (for testing)."""
+  q_seq_len = q.shape[1]
+  kv_seq_len = k.shape[1]
+  logits = jnp.einsum("bqhc,bkhc->bhqk", q, k, preferred_element_type=jnp.float32)
+  mask = None
+  if segment_ids is not None:
+    mask = jnp.expand_dims(segment_mask(segment_ids, segment_ids), 1)
+    mask = jnp.broadcast_to(mask, logits.shape)
+  row_ids = jax.lax.broadcasted_iota(jnp.int32, (q_seq_len, kv_seq_len), 0)
+  col_ids = jax.lax.broadcasted_iota(jnp.int32, (q_seq_len, kv_seq_len), 1)
+  if causal:
+    causal_mask = jnp.broadcast_to((col_ids <= row_ids)[None, None, :, :], logits.shape)
+    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+  if window is not None:
+    window_mask = jnp.broadcast_to((row_ids - col_ids < window)[None, None, :, :], logits.shape)
+    mask = window_mask if mask is None else jnp.logical_and(mask, window_mask)
+  logits = logits * sm_scale
+  if soft_cap is not None:
+    logits = soft_cap * jnp.tanh(logits / soft_cap)
+  logits = logits if mask is None else jnp.where(mask, logits, float("-inf"))
+  weights = jax.nn.softmax(logits)
+  return jnp.einsum("bhqk,bkhc->bqhc", weights, v, preferred_element_type=jnp.float32)

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -55,6 +55,7 @@ from maxtext.common.common_types import (
     DType,
     D_KV,
     HEAD,
+    KV_HEAD,
     KV_LENGTH,
     LENGTH,
     MODEL_MODE_AUTOREGRESSIVE,
@@ -64,6 +65,7 @@ from maxtext.common.common_types import (
     Q_LENGTH,
 )
 from maxtext.inference.kvcache import KVQuant, KVTensor
+from maxtext.kernels.attention import gpu_pallas_flash
 from maxtext.kernels.attention import jax_flash_attention
 from maxtext.kernels.attention import tokamax_ring_attention
 from maxtext.kernels.attention import ulysses_attention
@@ -73,6 +75,7 @@ from maxtext.kernels.attention.ragged_attention import ragged_mha
 from maxtext.layers import nnx_wrappers
 from maxtext.layers.initializers import variable_to_logically_partitioned
 from maxtext.layers.quantizations import AqtQuantization as Quant
+from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils.sharding import logical_to_mesh_axes, maybe_shard_with_pspec, get_logical_axis_rules
 import numpy as np
@@ -80,6 +83,12 @@ from tokamax._src.ops.attention import base as tokamax_attention_base
 from tokamax._src.ops.attention import pallas_triton as tokamax_pallas_triton
 from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_kernel as tokamax_splash_kernel
 from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_mask as tokamax_splash_mask
+
+try:  # optional dependency (flash-attn-jax); the pallas kernel covers its absence
+  from maxtext.kernels.attention import cutlass_flash as cutlass_flash_lib
+except ImportError:
+  cutlass_flash_lib = None
+
 # pylint: disable=line-too-long, g-doc-args, g-doc-return-or-yield, bad-continuation, g-inconsistent-quotes
 # pytype: disable=attribute-error
 
@@ -133,6 +142,16 @@ def apply_mask_to_logits(logits: Array, mask: Array):
     Masked logits.
   """
   return jnp.where((mask >= DEFAULT_MASK_VALUE * 0.5), logits, DEFAULT_MASK_VALUE)
+
+
+@functools.cache
+def _cudnn_jax_supports_packed_layout() -> bool:
+  """jax's cuDNN SDPA packed (offsets) layout requires Hopper (sm90) or newer."""
+  compute_capability = getattr(jax.local_devices()[0], "compute_capability", None)
+  try:
+    return compute_capability is not None and float(compute_capability) >= 9.0
+  except ValueError:
+    return False
 
 
 def validate_gpu_flash_attention(sinks: Array | None, record_max_logits: bool) -> None:
@@ -1286,6 +1305,103 @@ class AttentionOp(nnx.Module):
     moba_mask = jax.vmap(self.generate_moba_mask_single_item, in_axes=(0, 0, None))(query, key, q_positions)
     return moba_mask
 
+  def _gpu_flash_window(self, key: Array) -> int | None:
+    """Sliding-window size for the GPU flash kernels (None for global attention)."""
+    if self.attention_type == AttentionType.LOCAL_SLIDING and self.sliding_window_size is not None:
+      return min(self.sliding_window_size, key.shape[1])
+    return None
+
+  def _shard_mapped_gpu_flash(self, kernel_fn, query, key, value, decoder_segment_ids, kv_heads_repeated):
+    """Runs a per-shard GPU flash kernel under shard_map.
+
+    shard_map keeps GSPMD from all-gathering sharded activations around the
+    opaque pallas/FFI call. The kernels mask from shard-local positions, so
+    context parallelism (sequence-sharded queries) is not supported.
+
+    `kv_heads_repeated` says whether the caller expanded K/V to one head per
+    query head, which decides between the query and kv head axes.
+    """
+    if self.mesh.shape.get(self.config.context_sharding, 1) > 1:
+      raise ValueError(
+          f"attention={self.attention_kernel!r} on GPU does not support context parallelism; "
+          "use attention='cudnn_flash_te'."
+      )
+    q_spec = self._logical_to_mesh_axes((BATCH_ATTN, LENGTH, HEAD, D_KV))
+    kv_head_axis = HEAD if kv_heads_repeated else KV_HEAD
+    kv_spec = self._logical_to_mesh_axes((BATCH_ATTN, KV_LENGTH, kv_head_axis, D_KV))
+    seg_spec = None if decoder_segment_ids is None else self._logical_to_mesh_axes((BATCH_ATTN, KV_LENGTH))
+
+    @functools.partial(
+        jax.shard_map,
+        mesh=self.mesh,
+        in_specs=(q_spec, kv_spec, kv_spec, seg_spec),
+        out_specs=q_spec,
+        check_vma=False,
+    )
+    def wrapped(q, k, v, seg):
+      return kernel_fn(q, k, v, seg)
+
+    return wrapped(query, key, value, decoder_segment_ids)
+
+  def _gpu_pallas_flash_attention(self, query, key, value, decoder_segment_ids, window, soft_cap=None):
+    """Runs the maxtext pallas (Triton) flash kernel on per-device shards.
+
+    Not the tokamax kernel `attention='flash'` uses: that one has no backward
+    for soft caps or for head_dim > 256, which are the shapes this backend
+    exists to cover. It can go away once those are supported upstream.
+    """
+    head_axis = -2
+    num_query_heads = query.shape[head_axis]
+    num_kv_heads = key.shape[head_axis]
+    if num_query_heads != num_kv_heads:
+      if num_query_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"Number of query heads ({num_query_heads}) must be divisible"
+            f" by number of key/value heads ({num_kv_heads})."
+        )
+      q_heads_per_kv_head = num_query_heads // num_kv_heads
+      key = jnp.repeat(key, q_heads_per_kv_head, axis=head_axis)
+      value = jnp.repeat(value, q_heads_per_kv_head, axis=head_axis)
+
+    def kernel(q, k, v, seg):
+      return gpu_pallas_flash.mha(q, k, v, seg, sm_scale=1.0, causal=True, window=window, soft_cap=soft_cap)
+
+    return self._shard_mapped_gpu_flash(kernel, query, key, value, decoder_segment_ids, kv_heads_repeated=True)
+
+  def _cutlass_flash_attention(self, query, key, value, decoder_segment_ids, window, model_mode):
+    """Runs FlashAttention-2 (CUTLASS, via flash-attn-jax) on per-device shards."""
+    # The dense kernel is exact for unpacked batches; only pay the varlen
+    # overhead when segment boundaries actually need masking.
+    max_segments = self.config.max_segments_per_seq if self._needs_packed_masking(decoder_segment_ids, model_mode) else 1
+
+    def kernel(q, k, v, seg):
+      return cutlass_flash_lib.cutlass_flash_attention(
+          q, k, v, seg, sm_scale=1.0, window=window, max_segments_per_row=max_segments
+      )
+
+    # FA2 takes K/V with their own head count, so they keep the kv head axis.
+    return self._shard_mapped_gpu_flash(kernel, query, key, value, decoder_segment_ids, kv_heads_repeated=False)
+
+  def _gpu_flash_backend_dispatch(self, query, key, value, decoder_segment_ids, model_mode):
+    """Selects and runs a fused GPU flash backend (CUTLASS FA2 or pallas).
+
+    FA2 is used when eligible (half precision, head_dim <= 256, no soft cap, and
+    a set max_segments_per_seq when packed); everything else uses the pallas
+    kernel.
+    """
+    window = self._gpu_flash_window(key)
+    soft_cap = self.attn_logits_soft_cap if self.attn_logits_soft_cap else None
+    use_cutlass = (
+        cutlass_flash_lib is not None
+        and soft_cap is None
+        and query.shape[-1] <= 256
+        and query.dtype in (jnp.bfloat16, jnp.float16)
+        and (not self._needs_packed_masking(decoder_segment_ids, model_mode) or self.config.max_segments_per_seq >= 1)
+    )
+    if use_cutlass:
+      return self._cutlass_flash_attention(query, key, value, decoder_segment_ids, window, model_mode)
+    return self._gpu_pallas_flash_attention(query, key, value, decoder_segment_ids, window, soft_cap)
+
   def _validate_tpu_tokamax_ring_runtime(
       self,
       *,
@@ -1503,6 +1619,34 @@ class AttentionOp(nnx.Module):
           gpu_flash_attn = tokamax_pallas_triton.PallasTritonFlashAttention()
           out = gpu_flash_attn(query, key, value, logits_scale=1.0, mask=mask)
           return out, None, None
+    elif self.attention_kernel == "cutlass_flash":
+      # FlashAttention-2 (flash-attn-jax FFI) with native GQA, sliding window and
+      # varlen packing; layers FA2 cannot run (head_dim > 256) fall to pallas.
+      validate_gpu_flash_attention(sinks, record_max_logits)
+      if isinstance(key, KVTensor):
+        key = key.dequant()
+      if isinstance(value, KVTensor):
+        value = value.dequant()
+      if model_mode == MODEL_MODE_AUTOREGRESSIVE:
+        # No decode path in FA2; fall back to unfused attention.
+        return self.apply_attention_dot(
+            query,
+            key,
+            value,
+            decoder_segment_ids,
+            model_mode,
+            bidirectional_mask=bidirectional_mask,
+            record_max_logits=record_max_logits,
+            qk_product_einsum=qk_product_einsum,
+            wv_product_einsum=wv_product_einsum,
+        )
+      if cutlass_flash_lib is None:
+        raise ValueError("attention='cutlass_flash' requires the flash-attn-jax package.")
+      # Soft caps, fp32 and head_dim > 256 all fall through to the pallas kernel
+      # below. Rejecting them here instead would send callers to
+      # attention='flash', which drops the soft cap without saying so.
+      out = self._gpu_flash_backend_dispatch(query, key, value, decoder_segment_ids, model_mode)
+      return out, None, None
     elif self.attention_kernel == "cudnn_flash_te":
       validate_gpu_flash_attention(sinks, record_max_logits)
       if isinstance(key, KVTensor):
@@ -1525,6 +1669,25 @@ class AttentionOp(nnx.Module):
         key = key.dequant()
       if isinstance(value, KVTensor):
         value = value.dequant()
+      if self._needs_packed_masking(decoder_segment_ids, model_mode) and not _cudnn_jax_supports_packed_layout():
+        # jax's cuDNN SDPA only accepts the packed (offsets) layout on Hopper+;
+        # on older GPUs run a fused flash kernel that masks segment boundaries
+        # rather than silently attending across them.
+        if self.dropout_rate > 0:
+          raise ValueError(
+              "attention='cudnn_flash_jax' with packing and dropout_rate > 0 needs Hopper or "
+              "newer: the pre-Hopper fallback kernels have no dropout, so the same config would "
+              "train with dropout on one GPU generation and without it on another. Use "
+              "attention='cudnn_flash_te' or set dropout_rate=0."
+          )
+        max_logging.log(
+            "cudnn_flash_jax: packed sequences need Hopper+ for the cuDNN packed layout; "
+            "falling back to a fused GPU flash kernel (CUTLASS FA2 or pallas). Note this "
+            "fallback also applies the sliding window and logit soft cap, which the cuDNN "
+            "path ignores."
+        )
+        out = self._gpu_flash_backend_dispatch(query, key, value, decoder_segment_ids, model_mode)
+        return out, None, None
       return (
           *self.cudnn_jax_flash_attention(query, key, value, decoder_segment_ids, model_mode),
           None,
@@ -2369,6 +2532,42 @@ class AttentionOp(nnx.Module):
     )
     return dpa_layer(query, key, value, sequence_descriptor=attn_mask)
 
+  def _needs_packed_masking(self, decoder_segment_ids: Array | None, model_mode: str) -> bool:
+    """Whether train-mode attention must mask across packed segment boundaries."""
+    return (
+        model_mode == MODEL_MODE_TRAIN
+        and self.config.packing
+        and self.config.dataset_type != "synthetic"
+        and decoder_segment_ids is not None
+    )
+
+  def _segment_ids_to_seqlens_offsets(self, decoder_segment_ids: Array) -> tuple[Array, Array]:
+    """Converts packed segment ids to cuDNN SDPA per-segment seqlens/offsets.
+
+    Segment ids are contiguous runs numbered 1..max_segments_per_seq within each
+    row, with 0 marking padding. Returns (seqlens [B, M], offsets [B, M+1]) with
+    -1 filling absent segments, as required by jax cudnn dot_product_attention's
+    q_seqlen/q_offsets.
+
+    Not every packing implementation caps the run count at max_segments_per_seq
+    (grain 'best_fit' and 'concat_then_split' do not), so ids above the bound are
+    folded into the last segment. Those tokens then attend across one boundary,
+    which is wrong but bounded; leaving them out of every segment would instead
+    hand cuDNN uninitialized memory for them.
+    """
+    max_segments = max(1, self.config.max_segments_per_seq)
+    ids = decoder_segment_ids.astype(jnp.int32)
+    ids = jnp.where(ids > max_segments, max_segments, ids)
+    segment_numbers = jnp.arange(1, max_segments + 1, dtype=jnp.int32)
+    matches = ids[:, None, :] == segment_numbers[None, :, None]  # [B, M, S]
+    lengths = jnp.sum(matches, axis=-1, dtype=jnp.int32)  # [B, M]
+    starts = jnp.argmax(matches, axis=-1).astype(jnp.int32)  # [B, M], 0 when absent
+    present = lengths > 0
+    seqlens = jnp.where(present, lengths, -1)
+    offsets = jnp.where(present, starts, -1)
+    tail = jnp.full((ids.shape[0], 1), -1, dtype=jnp.int32)
+    return seqlens, jnp.concatenate([offsets, tail], axis=-1)
+
   def cudnn_jax_flash_attention(
       self,
       query: Array,
@@ -2397,6 +2596,26 @@ class AttentionOp(nnx.Module):
           q_seqlen=lengths,
           kv_seqlen=lengths,
           mask_type=MaskType.PADDING,
+          scale=1.0,
+          dropout_rate=self.dropout_rate,
+          qkv_layout="BTNH",
+          return_residual=True,
+      )
+    elif self._needs_packed_masking(decoder_segment_ids, model_mode):
+      # Packed sequences: causal attention must not cross segment boundaries.
+      # cuDNN consumes packing as per-segment seqlens/offsets (THD ragged
+      # format), which cuDNN only accepts on Hopper+ (the pre-Hopper fallback
+      # lives at the apply_attention dispatch).
+      seqlens, offsets = self._segment_ids_to_seqlens_offsets(decoder_segment_ids)
+      output, lse = dot_product_attention(
+          query,
+          key,
+          value,
+          q_seqlen=seqlens,
+          kv_seqlen=seqlens,
+          q_offsets=offsets,
+          kv_offsets=offsets,
+          mask_type=MaskType.PADDING_CAUSAL,
           scale=1.0,
           dropout_rate=self.dropout_rate,
           qkv_layout="BTNH",

--- a/src/maxtext/layers/attention_op.py
+++ b/src/maxtext/layers/attention_op.py
@@ -54,6 +54,7 @@ from maxtext.common.common_types import (
     DType,
     D_KV,
     HEAD,
+    KV_HEAD,
     KV_LENGTH,
     LENGTH,
     MODEL_MODE_AUTOREGRESSIVE,
@@ -63,13 +64,16 @@ from maxtext.common.common_types import (
     Q_LENGTH,
 )
 from maxtext.inference.kvcache import KVQuant, KVTensor
+from maxtext.kernels.attention import gpu_pallas_flash
 from maxtext.kernels.attention import jax_flash_attention
 from maxtext.kernels.attention import tokamax_ring_attention
+
 from maxtext.kernels.attention.ragged_attention import ragged_gqa
 from maxtext.kernels.attention.ragged_attention import ragged_mha
 from maxtext.layers import nnx_wrappers
 from maxtext.layers.initializers import variable_to_logically_partitioned
 from maxtext.layers.quantizations import AqtQuantization as Quant
+from maxtext.utils import max_logging
 from maxtext.utils import max_utils
 from maxtext.utils.sharding import logical_to_mesh_axes, maybe_shard_with_pspec, get_logical_axis_rules
 import numpy as np
@@ -77,6 +81,12 @@ from tokamax._src.ops.attention import base as tokamax_attention_base
 from tokamax._src.ops.attention import pallas_triton as tokamax_pallas_triton
 from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_kernel as tokamax_splash_kernel
 from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_mask as tokamax_splash_mask
+
+try:  # optional dependency (flash-attn-jax); the pallas kernel covers its absence
+  from maxtext.kernels.attention import cutlass_flash as cutlass_flash_lib
+except ImportError:
+  cutlass_flash_lib = None
+
 # pylint: disable=line-too-long, g-doc-args, g-doc-return-or-yield, bad-continuation, g-inconsistent-quotes
 # pytype: disable=attribute-error
 
@@ -120,6 +130,16 @@ def apply_mask_to_logits(logits: Array, mask: Array):
     Masked logits.
   """
   return jnp.where((mask >= DEFAULT_MASK_VALUE * 0.5), logits, DEFAULT_MASK_VALUE)
+
+
+@functools.cache
+def _cudnn_jax_supports_packed_layout() -> bool:
+  """jax's cuDNN SDPA packed (offsets) layout requires Hopper (sm90) or newer."""
+  compute_capability = getattr(jax.local_devices()[0], "compute_capability", None)
+  try:
+    return compute_capability is not None and float(compute_capability) >= 9.0
+  except ValueError:
+    return False
 
 
 def validate_gpu_flash_attention(sinks: Array | None, record_max_logits: bool) -> None:
@@ -998,6 +1018,103 @@ class AttentionOp(nnx.Module):
     moba_mask = jax.vmap(self.generate_moba_mask_single_item, in_axes=(0, 0, None))(query, key, q_positions)
     return moba_mask
 
+  def _gpu_flash_window(self, key: Array) -> int | None:
+    """Sliding-window size for the GPU flash kernels (None for global attention)."""
+    if self.attention_type == AttentionType.LOCAL_SLIDING and self.sliding_window_size is not None:
+      return min(self.sliding_window_size, key.shape[1])
+    return None
+
+  def _shard_mapped_gpu_flash(self, kernel_fn, query, key, value, decoder_segment_ids, kv_heads_repeated):
+    """Runs a per-shard GPU flash kernel under shard_map.
+
+    shard_map keeps GSPMD from all-gathering sharded activations around the
+    opaque pallas/FFI call. The kernels mask from shard-local positions, so
+    context parallelism (sequence-sharded queries) is not supported.
+
+    `kv_heads_repeated` says whether the caller expanded K/V to one head per
+    query head, which decides between the query and kv head axes.
+    """
+    if self.mesh.shape.get(self.config.context_sharding, 1) > 1:
+      raise ValueError(
+          f"attention={self.attention_kernel!r} on GPU does not support context parallelism; "
+          "use attention='cudnn_flash_te'."
+      )
+    q_spec = self._logical_to_mesh_axes((BATCH_ATTN, LENGTH, HEAD, D_KV))
+    kv_head_axis = HEAD if kv_heads_repeated else KV_HEAD
+    kv_spec = self._logical_to_mesh_axes((BATCH_ATTN, KV_LENGTH, kv_head_axis, D_KV))
+    seg_spec = None if decoder_segment_ids is None else self._logical_to_mesh_axes((BATCH_ATTN, KV_LENGTH))
+
+    @functools.partial(
+        jax.shard_map,
+        mesh=self.mesh,
+        in_specs=(q_spec, kv_spec, kv_spec, seg_spec),
+        out_specs=q_spec,
+        check_vma=False,
+    )
+    def wrapped(q, k, v, seg):
+      return kernel_fn(q, k, v, seg)
+
+    return wrapped(query, key, value, decoder_segment_ids)
+
+  def _gpu_pallas_flash_attention(self, query, key, value, decoder_segment_ids, window, soft_cap=None):
+    """Runs the maxtext pallas (Triton) flash kernel on per-device shards.
+
+    Not the tokamax kernel `attention='flash'` uses: that one has no backward
+    for soft caps or for head_dim > 256, which are the shapes this backend
+    exists to cover. It can go away once those are supported upstream.
+    """
+    head_axis = -2
+    num_query_heads = query.shape[head_axis]
+    num_kv_heads = key.shape[head_axis]
+    if num_query_heads != num_kv_heads:
+      if num_query_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"Number of query heads ({num_query_heads}) must be divisible"
+            f" by number of key/value heads ({num_kv_heads})."
+        )
+      q_heads_per_kv_head = num_query_heads // num_kv_heads
+      key = jnp.repeat(key, q_heads_per_kv_head, axis=head_axis)
+      value = jnp.repeat(value, q_heads_per_kv_head, axis=head_axis)
+
+    def kernel(q, k, v, seg):
+      return gpu_pallas_flash.mha(q, k, v, seg, sm_scale=1.0, causal=True, window=window, soft_cap=soft_cap)
+
+    return self._shard_mapped_gpu_flash(kernel, query, key, value, decoder_segment_ids, kv_heads_repeated=True)
+
+  def _cutlass_flash_attention(self, query, key, value, decoder_segment_ids, window, model_mode):
+    """Runs FlashAttention-2 (CUTLASS, via flash-attn-jax) on per-device shards."""
+    # The dense kernel is exact for unpacked batches; only pay the varlen
+    # overhead when segment boundaries actually need masking.
+    max_segments = self.config.max_segments_per_seq if self._needs_packed_masking(decoder_segment_ids, model_mode) else 1
+
+    def kernel(q, k, v, seg):
+      return cutlass_flash_lib.cutlass_flash_attention(
+          q, k, v, seg, sm_scale=1.0, window=window, max_segments_per_row=max_segments
+      )
+
+    # FA2 takes K/V with their own head count, so they keep the kv head axis.
+    return self._shard_mapped_gpu_flash(kernel, query, key, value, decoder_segment_ids, kv_heads_repeated=False)
+
+  def _gpu_flash_backend_dispatch(self, query, key, value, decoder_segment_ids, model_mode):
+    """Selects and runs a fused GPU flash backend (CUTLASS FA2 or pallas).
+
+    FA2 is used when eligible (half precision, head_dim <= 256, no soft cap, and
+    a set max_segments_per_seq when packed); everything else uses the pallas
+    kernel.
+    """
+    window = self._gpu_flash_window(key)
+    soft_cap = self.attn_logits_soft_cap if self.attn_logits_soft_cap else None
+    use_cutlass = (
+        cutlass_flash_lib is not None
+        and soft_cap is None
+        and query.shape[-1] <= 256
+        and query.dtype in (jnp.bfloat16, jnp.float16)
+        and (not self._needs_packed_masking(decoder_segment_ids, model_mode) or self.config.max_segments_per_seq >= 1)
+    )
+    if use_cutlass:
+      return self._cutlass_flash_attention(query, key, value, decoder_segment_ids, window, model_mode)
+    return self._gpu_pallas_flash_attention(query, key, value, decoder_segment_ids, window, soft_cap)
+
   def _validate_tpu_tokamax_ring_runtime(
       self,
       *,
@@ -1147,6 +1264,34 @@ class AttentionOp(nnx.Module):
           gpu_flash_attn = tokamax_pallas_triton.PallasTritonFlashAttention()
           out = gpu_flash_attn(query, key, value, logits_scale=1.0, mask=mask)
           return out, None, None
+    elif self.attention_kernel == "cutlass_flash":
+      # FlashAttention-2 (flash-attn-jax FFI) with native GQA, sliding window and
+      # varlen packing; layers FA2 cannot run (head_dim > 256) fall to pallas.
+      validate_gpu_flash_attention(sinks, record_max_logits)
+      if isinstance(key, KVTensor):
+        key = key.dequant()
+      if isinstance(value, KVTensor):
+        value = value.dequant()
+      if model_mode == MODEL_MODE_AUTOREGRESSIVE:
+        # No decode path in FA2; fall back to unfused attention.
+        return self.apply_attention_dot(
+            query,
+            key,
+            value,
+            decoder_segment_ids,
+            model_mode,
+            bidirectional_mask=bidirectional_mask,
+            record_max_logits=record_max_logits,
+            qk_product_einsum=qk_product_einsum,
+            wv_product_einsum=wv_product_einsum,
+        )
+      if cutlass_flash_lib is None:
+        raise ValueError("attention='cutlass_flash' requires the flash-attn-jax package.")
+      # Soft caps, fp32 and head_dim > 256 all fall through to the pallas kernel
+      # below. Rejecting them here instead would send callers to
+      # attention='flash', which drops the soft cap without saying so.
+      out = self._gpu_flash_backend_dispatch(query, key, value, decoder_segment_ids, model_mode)
+      return out, None, None
     elif self.attention_kernel == "cudnn_flash_te":
       validate_gpu_flash_attention(sinks, record_max_logits)
       if isinstance(key, KVTensor):
@@ -1169,6 +1314,25 @@ class AttentionOp(nnx.Module):
         key = key.dequant()
       if isinstance(value, KVTensor):
         value = value.dequant()
+      if self._needs_packed_masking(decoder_segment_ids, model_mode) and not _cudnn_jax_supports_packed_layout():
+        # jax's cuDNN SDPA only accepts the packed (offsets) layout on Hopper+;
+        # on older GPUs run a fused flash kernel that masks segment boundaries
+        # rather than silently attending across them.
+        if self.dropout_rate > 0:
+          raise ValueError(
+              "attention='cudnn_flash_jax' with packing and dropout_rate > 0 needs Hopper or "
+              "newer: the pre-Hopper fallback kernels have no dropout, so the same config would "
+              "train with dropout on one GPU generation and without it on another. Use "
+              "attention='cudnn_flash_te' or set dropout_rate=0."
+          )
+        max_logging.log(
+            "cudnn_flash_jax: packed sequences need Hopper+ for the cuDNN packed layout; "
+            "falling back to a fused GPU flash kernel (CUTLASS FA2 or pallas). Note this "
+            "fallback also applies the sliding window and logit soft cap, which the cuDNN "
+            "path ignores."
+        )
+        out = self._gpu_flash_backend_dispatch(query, key, value, decoder_segment_ids, model_mode)
+        return out, None, None
       return (
           *self.cudnn_jax_flash_attention(query, key, value, decoder_segment_ids, model_mode),
           None,
@@ -1844,6 +2008,42 @@ class AttentionOp(nnx.Module):
     )
     return dpa_layer(query, key, value, sequence_descriptor=attn_mask)
 
+  def _needs_packed_masking(self, decoder_segment_ids: Array | None, model_mode: str) -> bool:
+    """Whether train-mode attention must mask across packed segment boundaries."""
+    return (
+        model_mode == MODEL_MODE_TRAIN
+        and self.config.packing
+        and self.config.dataset_type != "synthetic"
+        and decoder_segment_ids is not None
+    )
+
+  def _segment_ids_to_seqlens_offsets(self, decoder_segment_ids: Array) -> tuple[Array, Array]:
+    """Converts packed segment ids to cuDNN SDPA per-segment seqlens/offsets.
+
+    Segment ids are contiguous runs numbered 1..max_segments_per_seq within each
+    row, with 0 marking padding. Returns (seqlens [B, M], offsets [B, M+1]) with
+    -1 filling absent segments, as required by jax cudnn dot_product_attention's
+    q_seqlen/q_offsets.
+
+    Not every packing implementation caps the run count at max_segments_per_seq
+    (grain 'best_fit' and 'concat_then_split' do not), so ids above the bound are
+    folded into the last segment. Those tokens then attend across one boundary,
+    which is wrong but bounded; leaving them out of every segment would instead
+    hand cuDNN uninitialized memory for them.
+    """
+    max_segments = max(1, self.config.max_segments_per_seq)
+    ids = decoder_segment_ids.astype(jnp.int32)
+    ids = jnp.where(ids > max_segments, max_segments, ids)
+    segment_numbers = jnp.arange(1, max_segments + 1, dtype=jnp.int32)
+    matches = ids[:, None, :] == segment_numbers[None, :, None]  # [B, M, S]
+    lengths = jnp.sum(matches, axis=-1, dtype=jnp.int32)  # [B, M]
+    starts = jnp.argmax(matches, axis=-1).astype(jnp.int32)  # [B, M], 0 when absent
+    present = lengths > 0
+    seqlens = jnp.where(present, lengths, -1)
+    offsets = jnp.where(present, starts, -1)
+    tail = jnp.full((ids.shape[0], 1), -1, dtype=jnp.int32)
+    return seqlens, jnp.concatenate([offsets, tail], axis=-1)
+
   def cudnn_jax_flash_attention(
       self,
       query: Array,
@@ -1872,6 +2072,26 @@ class AttentionOp(nnx.Module):
           q_seqlen=lengths,
           kv_seqlen=lengths,
           mask_type=MaskType.PADDING,
+          scale=1.0,
+          dropout_rate=self.dropout_rate,
+          qkv_layout="BTNH",
+          return_residual=True,
+      )
+    elif self._needs_packed_masking(decoder_segment_ids, model_mode):
+      # Packed sequences: causal attention must not cross segment boundaries.
+      # cuDNN consumes packing as per-segment seqlens/offsets (THD ragged
+      # format), which cuDNN only accepts on Hopper+ (the pre-Hopper fallback
+      # lives at the apply_attention dispatch).
+      seqlens, offsets = self._segment_ids_to_seqlens_offsets(decoder_segment_ids)
+      output, lse = dot_product_attention(
+          query,
+          key,
+          value,
+          q_seqlen=seqlens,
+          kv_seqlen=seqlens,
+          q_offsets=offsets,
+          kv_offsets=offsets,
+          mask_type=MaskType.PADDING_CAUSAL,
           scale=1.0,
           dropout_rate=self.dropout_rate,
           qkv_layout="BTNH",

--- a/tests/unit/gpu_attention_packing_test.py
+++ b/tests/unit/gpu_attention_packing_test.py
@@ -1,0 +1,192 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests packed-sequence masking of GPU flash attention kernels.
+
+With sequence packing, causal attention must not cross packed segment
+boundaries. Each kernel is compared against the dot_product reference on the
+same packed batch for both the forward output and the gradient wrt query.
+"""
+
+import sys
+import unittest
+from unittest import mock
+
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+
+from maxtext.common.common_types import MODEL_MODE_TRAIN
+from maxtext.configs import pyconfig
+from maxtext.layers import attention_op
+from maxtext.layers.attention_op import AttentionOp
+from maxtext.utils import maxtext_utils
+
+from tests.utils.test_helpers import get_test_config_path
+
+BATCH = 2
+SEQ = 512
+NUM_Q_HEADS = 8
+NUM_KV_HEADS = 4
+HEAD_DIM = 128
+# bf16 flash kernels differ from the unfused reference by ~1% of magnitude.
+RELATIVE_TOL = 5e-2
+
+
+class GpuAttentionPackingTest(parameterized.TestCase):
+  """Compares GPU attention kernels against dot_product on packed batches."""
+
+  def setUp(self):
+    """Builds a packing-enabled config and shared bf16 query/key/value tensors."""
+    super().setUp()
+    self.config = pyconfig.initialize(
+        [sys.argv[0], get_test_config_path()],
+        run_name="gpu_attention_packing_test",
+        enable_checkpointing=False,
+        max_target_length=SEQ,
+        attention="dot_product",
+        packing=True,
+        max_segments_per_seq=4,
+    )
+    # Single-device mesh: this test checks kernel masking correctness against
+    # a reference, not multi-device sharding, and must run on any GPU count.
+    devices_array = maxtext_utils.create_device_mesh(self.config, devices=[jax.devices()[0]])
+    self.mesh = Mesh(devices_array, self.config.mesh_axes)
+
+    rng_q, rng_k, rng_v = jax.random.split(jax.random.PRNGKey(0), 3)
+    # Queries are pre-scaled like the Attention layer does (kernels run with scale=1.0).
+    self.query = jax.random.normal(rng_q, (BATCH, SEQ, NUM_Q_HEADS, HEAD_DIM), dtype=jnp.bfloat16) * (HEAD_DIM**-0.5)
+    self.key = jax.random.normal(rng_k, (BATCH, SEQ, NUM_KV_HEADS, HEAD_DIM), dtype=jnp.bfloat16)
+    self.value = jax.random.normal(rng_v, (BATCH, SEQ, NUM_KV_HEADS, HEAD_DIM), dtype=jnp.bfloat16)
+
+  def build_op(self, kernel):
+    return AttentionOp(
+        config=self.config,
+        num_query_heads=NUM_Q_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        max_target_length=SEQ,
+        mesh=self.mesh,
+        attention_kernel=kernel,
+        dtype=jnp.bfloat16,
+        dropout_rate=0.0,
+    )
+
+  def packed_inputs(self, boundary):
+    """Two packed segments per row split at `boundary`, positions restarting per segment."""
+    segment_ids = jnp.concatenate(
+        [jnp.full((BATCH, boundary), 1, jnp.int32), jnp.full((BATCH, SEQ - boundary), 2, jnp.int32)], axis=1
+    )
+    positions = jnp.concatenate([jnp.arange(boundary, dtype=jnp.int32), jnp.arange(SEQ - boundary, dtype=jnp.int32)])[
+        None, :
+    ].repeat(BATCH, axis=0)
+    return segment_ids, positions
+
+  def unpacked_inputs(self):
+    segment_ids = jnp.ones((BATCH, SEQ), jnp.int32)
+    positions = jnp.arange(SEQ, dtype=jnp.int32)[None, :].repeat(BATCH, axis=0)
+    return segment_ids, positions
+
+  def fwd_and_grad(self, op, segment_ids, positions):
+    def loss(query):
+      out = op(query, self.key, self.value, segment_ids, positions, model_mode=MODEL_MODE_TRAIN)
+      return jnp.sum(out.astype(jnp.float32) ** 2)
+
+    out = op(self.query, self.key, self.value, segment_ids, positions, model_mode=MODEL_MODE_TRAIN)
+    grad = jax.grad(loss)(self.query)
+    return np.asarray(out.astype(jnp.float32)), np.asarray(grad.astype(jnp.float32))
+
+  def assert_matches_reference(self, kernel, segment_ids, positions, boundary):
+    """Asserts forward and grad outputs of `kernel` match dot_product on both sides of the boundary."""
+    if jax.local_devices()[0].platform != "gpu":
+      self.skipTest("Requires a GPU.")
+    reference_op = self.build_op("dot_product")
+    test_op = self.build_op(kernel)
+    for name, ref, out in zip(
+        ("forward", "grad_q"),
+        self.fwd_and_grad(reference_op, segment_ids, positions),
+        self.fwd_and_grad(test_op, segment_ids, positions),
+    ):
+      scale = max(np.abs(ref).max(), 1e-6)
+      # Cross-segment leaks show up specifically after the boundary, so report both halves.
+      first = np.abs(out[:, :boundary] - ref[:, :boundary]).max() / scale
+      second = (np.abs(out[:, boundary:] - ref[:, boundary:]).max() / scale) if boundary < SEQ else 0.0
+      self.assertLess(
+          max(first, second),
+          RELATIVE_TOL,
+          f"{kernel} {name} deviates from dot_product: "
+          f"rel diff before boundary={first:.4f}, after boundary={second:.4f}",
+      )
+
+  @pytest.mark.gpu_only
+  @parameterized.named_parameters(
+      ("unpacked", SEQ),
+      ("packed", SEQ // 2),
+      ("packed_unaligned", SEQ // 2 - 4),
+  )
+  def test_cudnn_flash_jax_matches_reference(self, boundary):
+    if boundary == SEQ:
+      segment_ids, positions = self.unpacked_inputs()
+    else:
+      segment_ids, positions = self.packed_inputs(boundary)
+    self.assert_matches_reference("cudnn_flash_jax", segment_ids, positions, boundary)
+
+  @pytest.mark.gpu_only
+  @parameterized.named_parameters(
+      ("unpacked", SEQ),
+      ("packed", SEQ // 2),
+      ("packed_unaligned", SEQ // 2 - 4),
+  )
+  def test_cutlass_flash_matches_reference(self, boundary):
+    if attention_op.cutlass_flash_lib is None:
+      self.skipTest("flash-attn-jax is not installed.")
+    if boundary == SEQ:
+      segment_ids, positions = self.unpacked_inputs()
+    else:
+      segment_ids, positions = self.packed_inputs(boundary)
+    self.assert_matches_reference("cutlass_flash", segment_ids, positions, boundary)
+
+  @pytest.mark.gpu_only
+  @parameterized.named_parameters(
+      ("unpacked", SEQ),
+      ("packed", SEQ // 2),
+      ("packed_unaligned", SEQ // 2 - 4),
+  )
+  def test_pallas_flash_matches_reference(self, boundary):
+    if boundary == SEQ:
+      segment_ids, positions = self.unpacked_inputs()
+    else:
+      segment_ids, positions = self.packed_inputs(boundary)
+    # The pallas backend is the last resort of the dispatch: reach it by hiding the
+    # cutlass library and pretending the GPU predates the cuDNN packed layout.
+    with (
+        mock.patch.object(attention_op, "cutlass_flash_lib", None),
+        mock.patch.object(attention_op, "_cudnn_jax_supports_packed_layout", return_value=False),
+    ):
+      self.assert_matches_reference("cudnn_flash_jax", segment_ids, positions, boundary)
+
+  def test_segment_ids_to_seqlens_offsets(self):
+    """Checks the cuDNN seqlens/offsets encoding of packed segment ids on the host."""
+    op = self.build_op("cudnn_flash_jax")
+    # Row 0: segments of 3 and 4 tokens plus one padding token; row 1: a single segment.
+    segment_ids = jnp.asarray([[1, 1, 1, 2, 2, 2, 2, 0], [1, 1, 1, 1, 1, 1, 1, 1]], dtype=jnp.int32)
+    seqlens, offsets = op._segment_ids_to_seqlens_offsets(segment_ids)  # pylint: disable=protected-access
+    np.testing.assert_array_equal(np.asarray(seqlens), [[3, 4, -1, -1], [8, -1, -1, -1]])
+    np.testing.assert_array_equal(np.asarray(offsets), [[0, 3, -1, -1, -1], [0, -1, -1, -1, -1]])
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION

# Description

This PR fixes a silent correctness bug in the `cudnn_flash_jax` attention kernel and adds `cutlass_flash`, an optional FlashAttention-2 (CUTLASS, via `flash-attn-jax`) backend for GPUs, together with a pallas kernel used for the shapes FA2 cannot run. The two changes are coupled: the fused fallback that makes the `cudnn_flash_jax` fix practical on pre-Hopper GPUs is provided by the new backend.

### Problem 1: cudnn_flash_jax ignores decoder_segment_ids

`AttentionOp.cudnn_jax_flash_attention` received `decoder_segment_ids` but its train branch called the jax cuDNN SDPA with `mask_type=MaskType.CAUSAL` only. With sequence packing enabled (the default `packing: true` with any real dataset), tokens attended across packed segment boundaries: no guard, no error, silently wrong loss and gradients. In a kernel-vs-reference test on packed batches, every token after the packing boundary diverged from the `dot_product` reference (max abs diff 5.4 vs 0.009 bf16 noise on the first segment).

Fix, in order of preference at runtime:
- On Hopper and newer, lower segment ids to the cuDNN packed layout: per-segment `q_seqlen`/`kv_seqlen` `[B, M]` plus `q_offsets`/`kv_offsets` `[B, M+1]` (absent segments filled with -1) with `MaskType.PADDING_CAUSAL`. This is the layout `jax._src.cudnn.fused_attention_stablehlo.dot_product_attention` documents for packed inputs.
- On older GPUs the cuDNN packed layout is rejected by jax (`Packed layout requires a GPU with at least Hopper architecture`), so the op falls back to a fused flash kernel that masks segment boundaries (see below) and logs the downgrade, instead of silently attending across boundaries.
- `max_segments_per_seq` is now validated at config time for `cudnn_flash_jax` (and `cutlass_flash`) with packing, matching the existing `cudnn_flash_te` validation. The check skips `dataset_type=synthetic`, which has no real segments and never takes the packed path. Not every packing implementation caps the run count at that bound (grain `best_fit` and `concat_then_split`, and the tfds pipeline, do not), so ids above it fold into the last segment rather than being left out of every segment, which is what previously handed cuDNN uninitialized memory.

### Problem 2: no fast, correct packed attention on pre-Hopper GPUs

On A100 we found no working fused path for packed sequences: the jax cuDNN packed layout is Hopper-only, and `cudnn_flash_te` (TE 2.17, cuDNN 9.24) finds no sm80 THD kernel and then crashes in its unfused fallback (`sequence_descriptor must be None or ndarray`). The remaining correct option, unfused `dot_product`, costs about 39 percent of step throughput at seq 2048 on a qwen3-4b benchmark.

### Key changes

- `attention=cutlass_flash`: FlashAttention-2 CUTLASS kernels through the optional `flash-attn-jax` package (import-guarded; the option errors clearly when the package is absent). It stays opt-in rather than a declared dependency: `flash-attn-jax` pins `jax<0.9` while MaxText needs `jax>=0.10`, and installing it downgrades jax until the package stops importing. That also means CI never exercises this backend, and its tests skip. Native GQA/MQA, sliding window (LOCAL_SLIDING), and sequence packing lowered to FA2's varlen kernel with `cu_seqlens` built inside jit. Requires bf16/fp16 and head_dim <= 256; decode falls back to unfused attention.
- `src/maxtext/kernels/attention/gpu_pallas_flash.py`: a fork of `jax.experimental.pallas.ops.gpu.attention` extended with sliding-window masking, gemma2-style logit soft cap (with the matching backward chain rule), and chunked head_dim accumulation for head_dim > 256, so every layer FA2 cannot run still has a fused kernel.

  Since `attention=flash` moved to Tokamax, the obvious question is whether this fork can just be `tokamax_pallas_triton.PallasTritonFlashAttention`. It cannot yet, for the two cases that are exactly this backend's job. Measured on A100 (sm80) against tokamax 0.0.12, the version MaxText resolves today:

  | case | tokamax 0.0.12 |
  |---|---|
  | packed masking via `Mask(k_start=..., is_causal=True)` | works, fwd rel err 0.0028 / grad 0.0058 vs unfused reference |
  | sliding window via `k_start` | works |
  | `logits_soft_cap` forward | works |
  | `logits_soft_cap` backward | `NotImplementedError: logits_soft_cap unsupported.` (`pallas_triton_vjp.py:385`) |
  | head_dim > 256 forward | works |
  | head_dim > 256 backward | `RESOURCE_EXHAUSTED: Shared memory size limit exceeded: requested 203136, available: 166912` |

  So soft-capped and large-head_dim layers have no backward pass there and cannot train. Both gaps now have fixes in review upstream (openxla/tokamax#1121 and #1122); once they land this file should be deleted, and the kernel carries a comment saying so.

  On the motivation behind #4465 — that `jax.experimental.pallas.ops.gpu` is heading for removal from JAX: this file is a vendored copy, not an import of those ops, so it does not hold MaxText to a module JAX plans to drop. It does mean MaxText owns the kernel, which is the cost being paid to keep soft-capped and large-head_dim layers trainable on GPU until Tokamax covers them.
- A single backend dispatch (`AttentionOp._gpu_flash_backend_dispatch`) serves `attention=cutlass_flash` and the pre-Hopper packed fallback of `cudnn_flash_jax`: FA2 where eligible, pallas otherwise. Eligibility covers dtype (bf16/fp16), head_dim, soft cap, and packed-metadata availability, so no configuration silently loses segment masking. `attention=flash` on GPU is left on the Tokamax path that landed in #4465 and is not touched by this PR.
- Context parallelism is explicitly rejected for these two backends (the kernels compute masks from shard-local positions); `cudnn_flash_te` remains the kernel to use with context parallelism.

### Measurements (A100-SXM4-80GB x 8, qwen3-4b, bf16, seq 2048, per-device batch 8, synthetic data)

| attention | TFLOP/s/device | notes |
|---|---|---|
| cudnn_flash_te | 177.8 | crashes with packing on sm80 (TE fallback bug) |
| cutlass_flash | 176.6 | fast and correct with packing; measured before the current `jax>=0.10` pin, and not reproducible on it (see above) |
| dot_product | 108.0 | previous only correct packed option on sm80 |

### Shortcomings / future work

- The Hopper-native packed path of `cudnn_flash_jax` (seqlens/offsets) is implemented per the jax API contract and covered by the new test, but our verification hardware is A100; a run of `tests/unit/gpu_attention_packing_test.py` on H100 or newer would exercise it directly.
- The TE unfused-fallback crash (`SequenceDescriptor` assertion) is a separate upstream issue and is not addressed here.
- `attention=cutlass_flash` is unverified end to end. Running it needs `flash-attn-jax`, which cannot coexist with the pinned jax, so the CUTLASS kernel and its shard_map specs are reviewed but not executed. Everything else here is exercised by the new test.
- `backward_pass_impl='auto'` in the pallas kernel now always takes the fused backward. The XLA fallback is the more accurate of the two (bf16 gradients agree with the reference to ~4e-3 against ~2e-2) but materializes `[b, h, q, kv]`, needing 12.5GiB against 3.3GiB at 8k tokens on an A100, so it does not scale. It remains available explicitly.
- K/V now use `activation_kv_heads` rather than the query head axis. On a training mesh the two resolve identically, since they differ only by `autoregressive`, which is size one there and dropped; this is a semantic correction, not a fix for MQA divisibility under tensor parallelism, which is unaffected.

FIXES: #4476

# Tests

New test: `tests/unit/gpu_attention_packing_test.py` (marked `gpu_only`). For each kernel (`cudnn_flash_jax`, `cutlass_flash`, and the pallas backend, reached by hiding the cutlass library and pretending the GPU predates the cuDNN packed layout), it compares the forward output and the gradient wrt query against the `dot_product` reference on an unpacked control, a packed batch, and a packed batch with a tile-unaligned boundary, reporting relative error separately before and after the packing boundary so cross-segment leaks are directly visible. A host-side test covers the segment-ids-to-seqlens/offsets encoding.

Results on A100 (seq 2048, GQA 32/8 heads, bf16): all kernels match the reference within 2 percent relative error on both forward and gradients, for all three boundary cases. Reproduce with:

```bash
PYTHONPATH=src:. python -m pytest tests/unit/gpu_attention_packing_test.py -v
```

`pre-commit` (repo `.pre-commit-config.yaml`: codespell, `pylint` 3.3.8, `pyink` 24.10.1, yamllint) passes on the changed files.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).


