### PR TITLE
Wire padded video masks through Qwen3 decode (New)

### DIFF
--- a/src/maxtext/inference/decode.py
+++ b/src/maxtext/inference/decode.py
@@ -184,8 +184,12 @@ def main(argv: Sequence[str]) -> None:
           positions=position_ids,  # pyrefly: ignore[bad-argument-type]
           mrope_deltas=mrope_position_deltas,  # pyrefly: ignore[bad-argument-type]
           images=processor_outputs.pixel_values if config.use_multimodal else None,  # pyrefly: ignore[bad-argument-type]
-          image_masks=processor_outputs.pixel_mask if config.use_multimodal and "llama4" in config.model_name else None,  # pyrefly: ignore[bad-argument-type]
+          image_masks=processor_outputs.pixel_mask
+          if config.use_multimodal and "llama4" in config.model_name
+          else None,  # pyrefly: ignore[bad-argument-type]
           videos=getattr(processor_outputs, "video_values", None) if config.use_multimodal else None,
+          video_masks=getattr(processor_outputs, "video_mask", None) if config.use_multimodal else None,
+          video_grid_thw=getattr(processor_outputs, "video_grid_thw", None) if config.use_multimodal else None,
           audio_values=processor_outputs.audio_values if config.use_audio else None,  # pyrefly: ignore[bad-argument-type]
           audio_masks=processor_outputs.audio_mask if config.use_audio else None,  # pyrefly: ignore[bad-argument-type]
           true_length=true_length,

--- a/src/maxtext/inference/maxengine/maxengine.py
+++ b/src/maxtext/inference/maxengine/maxengine.py
@@ -212,6 +212,7 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
       encoder_image_masks=None,
       encoder_videos=None,
       encoder_video_masks=None,
+      encoder_video_grid_thw=None,
       encoder_audios=None,
   ):
     """NNX equivalent of `model.apply(..., mutable=["cache"])`. Returns (logits, new_cache_dict)."""
@@ -219,7 +220,9 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
     nnx.replace_by_pure_dict(cache_state, cache_dict)
     # copy=True avoids reusing Variable objects across traces (TraceContextError),
     # mirroring the workaround in train.py's diff_wrapper.
-    model = nnx.merge(self.graphdef, params, cache_state, self._nnx_rest_state, copy=True)  # pyrefly: ignore[no-matching-overload]
+    model = nnx.merge(
+        self.graphdef, params, cache_state, self._nnx_rest_state, copy=True
+    )  # pyrefly: ignore[no-matching-overload]
     logits = model(
         decoder_input_tokens,
         decoder_positions,
@@ -228,6 +231,7 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
         encoder_image_masks=encoder_image_masks,
         encoder_videos=encoder_videos,
         encoder_video_masks=encoder_video_masks,
+        encoder_video_grid_thw=encoder_video_grid_thw,
         encoder_audios=encoder_audios,
         enable_dropout=enable_dropout,
         model_mode=model_mode,
@@ -280,7 +284,9 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
       if x.format == l:
         return x
       # Somehow this can be None sometimes.
-      dll = (l.layout if jax.__version_info__ >= (0, 6, 3) else l.device_local_layout) if isinstance(l, Format) else l  # pyrefly: ignore[missing-attribute]
+      dll = (
+          (l.layout if jax.__version_info__ >= (0, 6, 3) else l.device_local_layout) if isinstance(l, Format) else l
+      )  # pyrefly: ignore[missing-attribute]
       f = jax.jit(self._identity, out_shardings=Format(dll, s)).lower(x).compile(compiler_options=xla_flags)
       y = f(x)
       # Achieves donation of the input argument, but allows for different memory
@@ -409,7 +415,10 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
       with nn_partitioning.axis_rules(self.config.logical_axis_rules):
         full_sharding = sharding.nnx_construct_named_sharding(full_abs, self._mesh)
       concrete_model = maxtext_utils_nnx.create_nnx_sharded_model(
-          self.model, self._create_model_fn, mesh=self._mesh, named_sharding=full_sharding  # pyrefly: ignore[bad-argument-type]
+          self.model,
+          self._create_model_fn,
+          mesh=self._mesh,
+          named_sharding=full_sharding,  # pyrefly: ignore[bad-argument-type]
       )
       graphdef, _, _, rest_state = nnx.split(concrete_model, nnx.Param, nnx.Cache, ...)
       self.graphdef = graphdef
@@ -664,7 +673,9 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
     )
 
   @functools.partial(
-      jax.jit, static_argnums=(0,), static_argnames=("return_prompt_logp", "algorithm", "topk", "nucleus_topp")
+      jax.jit,
+      static_argnums=(0,),
+      static_argnames=("video_grid_thw", "return_prompt_logp", "algorithm", "topk", "nucleus_topp"),
   )
   def _prefill_jit(
       self,
@@ -678,6 +689,7 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
       image_masks: jax.Array | None = None,
       videos: jax.Array | None = None,
       video_masks: jax.Array | None = None,
+      video_grid_thw: tuple[int, int, int] | None = None,
       audio_values: jax.Array | None = None,
       audio_masks: jax.Array | None = None,
       true_length: int,
@@ -785,6 +797,7 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
             encoder_image_masks=image_masks,
             encoder_videos=videos,
             encoder_video_masks=video_masks,
+            encoder_video_grid_thw=video_grid_thw,
             encoder_audios=audio_values,
             enable_dropout=False,
             model_mode=MODEL_MODE_PREFILL,
@@ -803,6 +816,7 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
             encoder_image_masks=image_masks,
             encoder_videos=videos,
             encoder_video_masks=video_masks,
+            encoder_video_grid_thw=video_grid_thw,
             encoder_audios=audio_values,
             decoder_segment_ids=sequence_indicator,
             enable_dropout=False,
@@ -887,6 +901,7 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
       image_masks: jax.Array | None = None,
       videos: jax.Array | None = None,
       video_masks: jax.Array | None = None,
+      video_grid_thw: jax.Array | None = None,
       audio_values: jax.Array | None = None,
       audio_masks: jax.Array | None = None,
       true_length: int,
@@ -901,6 +916,12 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
       temperature: float | None = None,
   ):  # returns (new_prefix, result_tokens)
     """Public API for prefill that updates page state outside JIT."""
+    if video_grid_thw is not None:
+      flat_video_grid = jax.device_get(video_grid_thw).reshape(-1)
+      if flat_video_grid.size != 3:
+        raise ValueError(f"Decode currently supports one video grid with 3 values, got shape {video_grid_thw.shape}.")
+      video_grid_thw = tuple(int(dim) for dim in flat_video_grid)
+
     # Update page state before JIT call
 
     # Sample rng before JIT call
@@ -920,6 +941,7 @@ class MaxEngine(_BaseEngine):  # pyrefly: ignore[invalid-inheritance]
         image_masks=image_masks,
         videos=videos,
         video_masks=video_masks,
+        video_grid_thw=video_grid_thw,
         audio_values=audio_values,
         audio_masks=audio_masks,
         sampler=sampler,

--- a/src/maxtext/layers/decoders.py
+++ b/src/maxtext/layers/decoders.py
@@ -1261,7 +1261,13 @@ class Decoder(nn.Module):
             if deepstack_visual_embeds is not None and lyr < len(deepstack_visual_embeds):
               visual_embeds = deepstack_visual_embeds[lyr]
               # Use bidirectional_mask to identify visual token positions
-              bidirectional_mask_value = multimodal_input.bidirectional_mask if multimodal_input is not None else None
+              bidirectional_mask_value = None
+              if multimodal_input is not None:
+                bidirectional_mask_value = (
+                    multimodal_input.bidirectional_mask
+                    if multimodal_input.bidirectional_mask is not None
+                    else multimodal_input.bidirectional_mask_video
+                )
               if bidirectional_mask_value is not None and visual_embeds is not None:
                 y = deepstack_process(y, bidirectional_mask_value, visual_embeds)
 

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -1597,7 +1597,13 @@ class NNXDecoder(nnx.Module):
 
     layer_kwargs = {}
     # Extract the bidirectional mask locally for layer configurations
-    bidirectional_mask = multimodal_input.bidirectional_mask if multimodal_input is not None else None
+    bidirectional_mask = None
+    if multimodal_input is not None:
+      bidirectional_mask = (
+          multimodal_input.bidirectional_mask
+          if multimodal_input.bidirectional_mask is not None
+          else multimodal_input.bidirectional_mask_video
+      )
 
     if cfg.decoder_block in {DecoderBlockType.GEMMA3, DecoderBlockType.GEMMA4}:
       layer_kwargs["bidirectional_mask"] = bidirectional_mask

--- a/src/maxtext/models/models.py
+++ b/src/maxtext/models/models.py
@@ -129,6 +129,7 @@ class TransformerLinenPure(nn.Module):
       encoder_image_masks: None | jnp.ndarray = None,
       encoder_videos: None | jnp.ndarray = None,
       encoder_video_masks: None | jnp.ndarray = None,
+      encoder_video_grid_thw: None | jnp.ndarray = None,
       encoder_audios: None | jnp.ndarray = None,
       enable_dropout=True,
       model_mode=MODEL_MODE_TRAIN,
@@ -172,8 +173,12 @@ class TransformerLinenPure(nn.Module):
 
     if self.config.use_multimodal and encoder_videos is not None:
       video_embeddings, deepstack_visual_embeds = self.vision_encoder(  # pyrefly: ignore[not-callable]
-          input_images=encoder_videos, deterministic=not enable_dropout
+          input_images=encoder_videos,
+          input_masks=encoder_video_masks,
+          video_grid_thw=encoder_video_grid_thw,
+          deterministic=not enable_dropout,
       )
+      encoder_video_masks = mm_processor.downsample_video_mask_to_tokens(encoder_video_masks, self.config)
       bidirectional_mask_video = mm_processor.get_bidirectional_mask_vision(
           self.config, decoder_input_tokens, is_video=True
       )
@@ -442,6 +447,7 @@ class Transformer(nnx.Module):
       encoder_image_masks: jax.Array | None = None,
       encoder_videos: jax.Array | None = None,
       encoder_video_masks: jax.Array | None = None,
+      encoder_video_grid_thw: jax.Array | None = None,
       encoder_audios: jax.Array | None = None,
       enable_dropout=True,
       model_mode=MODEL_MODE_TRAIN,
@@ -499,8 +505,12 @@ class Transformer(nnx.Module):
 
     if self.config.use_multimodal and encoder_videos is not None:
       video_embeddings, deepstack_visual_embeds = self.vision_encoder(  # pyrefly: ignore[not-callable]
-          input_images=encoder_videos, deterministic=not enable_dropout
+          input_images=encoder_videos,
+          input_masks=encoder_video_masks,
+          video_grid_thw=encoder_video_grid_thw,
+          deterministic=not enable_dropout,
       )
+      encoder_video_masks = mm_processor.downsample_video_mask_to_tokens(encoder_video_masks, self.config)
       bidirectional_mask_video = mm_processor.get_bidirectional_mask_vision(
           self.config, decoder_input_tokens, is_video=True
       )

--- a/src/maxtext/multimodal/processor.py
+++ b/src/maxtext/multimodal/processor.py
@@ -149,11 +149,15 @@ def prepare_text_for_image_fusion(tokens, config, processor_output=None):
   if config.model_name in ["gemma3-4b", "gemma3-12b", "gemma3-27b"]:
     from maxtext.multimodal.processor_gemma3 import add_extra_tokens_for_images_gemma3  # pylint: disable=import-outside-toplevel
 
-    return add_extra_tokens_for_images_gemma3(tokens, max_num_images=processor_output.num_images)  # pyrefly: ignore[missing-attribute]
+    return add_extra_tokens_for_images_gemma3(
+        tokens, max_num_images=processor_output.num_images
+    )  # pyrefly: ignore[missing-attribute]
   elif config.model_name in ["gemma4-26b", "gemma4-31b", "gemma4-e2b", "gemma4-e4b"]:
     from maxtext.multimodal.processor_gemma4 import add_extra_tokens_for_images_gemma4  # pylint: disable=import-outside-toplevel
 
-    return add_extra_tokens_for_images_gemma4(tokens, max_num_images=processor_output.num_images)  # pyrefly: ignore[missing-attribute]
+    return add_extra_tokens_for_images_gemma4(
+        tokens, max_num_images=processor_output.num_images
+    )  # pyrefly: ignore[missing-attribute]
   elif config.model_name in ["llama4-17b-16e", "llama4-17b-128e"]:
     from maxtext.multimodal.processor_llama4 import add_extra_tokens_for_images_llama4  # pylint: disable=import-outside-toplevel
 
@@ -245,3 +249,16 @@ def get_bidirectional_mask_audio(config, decoder_input_tokens):
     # Create bidirectional_mask for audio token merging
     bidirectional_mask_audio = decoder_input_tokens == tokens.audio_pad
   return bidirectional_mask_audio
+
+
+def downsample_video_mask_to_tokens(video_mask, config):
+  """Routes video-mask reduction to the model-specific multimodal processor."""
+  if video_mask is None:
+    return None
+  if config.model_name.startswith(("qwen3")):
+    from maxtext.multimodal.processor_qwen3_omni import (  # pylint: disable=import-outside-toplevel
+        downsample_video_mask_to_tokens as downsample_qwen3_video_mask,
+    )
+
+    return downsample_qwen3_video_mask(video_mask, config)
+  raise ValueError(f"Model {config.model_name} does not support padded video-mask reduction.")

--- a/src/maxtext/multimodal/processor_qwen3_omni.py
+++ b/src/maxtext/multimodal/processor_qwen3_omni.py
@@ -198,6 +198,27 @@ def maybe_pad_video_values_to_max_grid(
   return padded_video_values, video_grid_thw, video_mask
 
 
+def downsample_video_mask_to_tokens(video_mask, config):
+  """Reduces a Qwen3 pixel mask to the post-projector video-token mask.
+
+  Example: with patch size `(2, 16, 16)`, spatial merge size `2`, and padded
+  grid `(3, 4, 4)`, a pixel mask `[1, 1, 6, 64, 64]` becomes 48 patch-mask
+  values and then 12 projected-token-mask values. A valid grid `(2, 2, 4)`
+  marks the first `2 * 2 * 4 / 2**2 = 4` projected tokens as valid.
+  """
+  if video_mask is None:
+    return None
+
+  patch_elements = config.temporal_patch_size_for_vit * config.patch_size_for_vit**2
+  patch_mask = video_mask.reshape(video_mask.shape[0], -1, patch_elements).max(axis=-1)
+  merge_elements = config.spatial_merge_size_for_vit**2
+  if patch_mask.shape[-1] % merge_elements:
+    raise ValueError(
+        f"Video patch-mask length {patch_mask.shape[-1]} must be divisible by spatial merge area {merge_elements}."
+    )
+  return patch_mask.reshape(patch_mask.shape[0], -1, merge_elements).max(axis=-1).astype(jnp.int32)
+
+
 def smart_resize(
     height: int,
     width: int,

--- a/src/maxtext/multimodal/utils.py
+++ b/src/maxtext/multimodal/utils.py
@@ -161,9 +161,19 @@ def merge_mm_embeddings(
       # This handles cases where token_masks is already (B, ...)
       flat_tile_masks = token_masks.reshape(batch_size, -1)
 
-    # Expand the tile-level mask to a token-level mask to match the embeddings.
-    # A mask of shape (B, N*T) becomes (B, N*T*K) by repeating each element K times.
-    flat_token_masks_processed = jnp.repeat(flat_tile_masks, repeats=num_toks_per_token, axis=1)
+    if flat_tile_masks.shape[1] == flat_multimodal_embeddings.shape[1]:
+      # Qwen padded video supplies one validity value per projected token.
+      flat_token_masks_processed = flat_tile_masks
+    else:
+      # Tiled image models supply one validity value per tile. Expand each tile
+      # validity value over the tokens produced by that tile.
+      expected_tile_count = flat_multimodal_embeddings.shape[1] // num_toks_per_token
+      if flat_tile_masks.shape[1] != expected_tile_count:
+        raise ValueError(
+            "token_masks must contain either one value per multimodal token or one value per tile. "
+            f"Got {flat_tile_masks.shape[1]} mask values for {flat_multimodal_embeddings.shape[1]} embeddings."
+        )
+      flat_token_masks_processed = jnp.repeat(flat_tile_masks, repeats=num_toks_per_token, axis=1)
 
   # Vmap the inner merge function over the batch dimension
   return jax.vmap(
@@ -545,7 +555,9 @@ def hertz_to_mel(freq: Union[float, np.ndarray], mel_scale: str = "htk") -> Unio
 
   if isinstance(freq, np.ndarray):
     log_region = freq >= min_log_hertz
-    mels[log_region] = min_log_mel + np.log(freq[log_region] / min_log_hertz) * logstep  # pyrefly: ignore[unsupported-operation]
+    mels[log_region] = (
+        min_log_mel + np.log(freq[log_region] / min_log_hertz) * logstep
+    )  # pyrefly: ignore[unsupported-operation]
   elif freq >= min_log_hertz:
     mels = min_log_mel + np.log(freq / min_log_hertz) * logstep
 
@@ -603,7 +615,9 @@ def mel_to_hertz(mels: Union[float, np.ndarray], mel_scale: str = "htk") -> Unio
 
   if isinstance(mels, np.ndarray):
     log_region = mels >= min_log_mel
-    freq[log_region] = min_log_hertz * np.exp(logstep * (mels[log_region] - min_log_mel))  # pyrefly: ignore[unsupported-operation]
+    freq[log_region] = min_log_hertz * np.exp(
+        logstep * (mels[log_region] - min_log_mel)
+    )  # pyrefly: ignore[unsupported-operation]
   elif mels >= min_log_mel:
     freq = min_log_hertz * np.exp(logstep * (mels - min_log_mel))
 

--- a/tests/unit/multimodal_utils_test.py
+++ b/tests/unit/multimodal_utils_test.py
@@ -356,6 +356,24 @@ class TestLlama4PostProcessing(unittest.TestCase):
     np.testing.assert_array_equal(merged[0, 0], text_embeddings[0, 0])
     np.testing.assert_array_equal(merged_null[0, 0], text_embeddings[0, 0])
 
+  def test_merge_mm_embeddings_with_token_level_video_mask(self):
+    """A projected-token mask packs only valid padded video embeddings."""
+    text_embeddings = np.arange(1 * 8 * 2, dtype=np.float32).reshape(1, 8, 2)
+    video_embeddings = np.arange(1 * 6 * 2, dtype=np.float32).reshape(1, 6, 2) + 100.0
+    placeholder_mask = np.zeros((1, 8), dtype=np.int32)
+    placeholder_mask[:, 2:5] = 1
+    video_token_mask = np.asarray([[1, 1, 1, 0, 0, 0]], dtype=np.int32)
+
+    merged = mm_utils.merge_mm_embeddings(
+        text_embeddings,
+        video_embeddings,
+        placeholder_mask,
+        video_token_mask,
+    )
+
+    np.testing.assert_array_equal(merged[0, 2:5], video_embeddings[0, :3])
+    np.testing.assert_array_equal(merged[0, 5:], text_embeddings[0, 5:])
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/unit/qwen3_omni_layers_test.py
+++ b/tests/unit/qwen3_omni_layers_test.py
@@ -483,6 +483,30 @@ class TestQwen3OmniMoeVisionPatchEmbed(BaseVisionTestCase):
     self.assertEqual(padded_values.shape[4], cfg.video_max_grid_w * cfg.patch_size_for_vit)
     np.testing.assert_array_equal(padded_grid, video_grid_thw)  # Grid should not change
 
+  def test_video_mask_downsamples_to_projected_tokens(self):
+    """Pixel padding mask becomes one validity value per projected video token."""
+    cfg = pyconfig.initialize(
+        ["", base_config_path],
+        model_name="qwen3-vl-2b",
+        video_max_grid_t=3,
+        video_max_grid_h=4,
+        video_max_grid_w=4,
+        patch_size_for_vit=16,
+        temporal_patch_size_for_vit=2,
+        spatial_merge_size_for_vit=2,
+        scan_layers=False,
+    )
+    raw_grid = np.asarray([[2, 2, 4]], dtype=np.int32)
+    raw_video = np.ones((1, 3, 4, 32, 64), dtype=np.float32)
+    _, _, pixel_mask = maybe_pad_video_values_to_max_grid(raw_video, raw_grid, cfg)
+
+    token_mask = mm_processor.downsample_video_mask_to_tokens(jnp.asarray(pixel_mask), cfg)
+
+    self.assertEqual(token_mask.shape, (1, 12))
+    self.assertEqual(int(jnp.sum(token_mask)), 4)
+    np.testing.assert_array_equal(np.asarray(token_mask[0, :4]), np.ones(4, dtype=np.int32))
+    np.testing.assert_array_equal(np.asarray(token_mask[0, 4:]), np.zeros(8, dtype=np.int32))
+
   def test_patch_embed_is_jittable(self):
     """Test that patch embed is JIT-compilable."""
 


### PR DESCRIPTION
# Description

E2E decode now works for padded/resized video input:

- Pass `video_masks, video_grid_thw` through MaxEngine and the vision encoder.
- Convert pixel masks into post-projector token masks.
- Merge only valid video embeddings into decoder placeholders.
- Use video placeholder masks for deepstack features.
- Preserve existing tile-mask behavior for other vision models.
- Add focused mask reduction and embedding merge tests.

# Tests
**Original** video grid [5, 30, 28], tensor size [10, 480, 448]:
```
python -m maxtext.inference.decode maxtext/configs/base.yml tokenizer_type=huggingface model_name=qwen3-vl-2b tokenizer_path=Qwen/Qwen3-VL-2B-Instruct load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-vl-2b/unscanned/2026-07-01-11-55/0/items per_device_batch_size=1 run_name=ht_test scan_layers=false use_multimodal=true prompt=\'What\ is\ the\ classification\ of\ the\ single\ exhibit\ in\ this\ video\?\' video_path=\'tests/assets/test_video.mp4\' max_prefill_predict_length=1240 max_target_length=1280 ici_tensor_parallelism=4 override_model_config=true attention=\'dot_product\' hf_access_token=xxx

# Logs, video tensor shape [1, 3, 10, 480, 448]
DEBUG: vision encoder video input shape=(Array(1, dtype=int32), Array(3, dtype=int32), Array(10, dtype=int32), Array(480, dtype=int32),Array(448, dtype=int32))
` -> `The exhibit is a dinosaur, specifically a large, multi-headed creature. It is likely a model or replica of a prehistoric animal, possibly a type of theropod dinosaur, given its size and features`
```
**Padded** video [5, 30, 28] -> [32, 32, 32], tensor size [64, 512, 512]. `video_max_grid_t/h/w=32, attention_for_vit="autoselected"`
```
python -m maxtext.inference.decode maxtext/configs/base.yml tokenizer_type=huggingface model_name=qwen3-vl-2b tokenizer_path=Qwen/Qwen3-VL-2B-Instruct load_parameters_path=gs://hengtaoguo-maxtext-logs/checkpoints/qwen3-vl-2b/unscanned/2026-07-01-11-55/0/items per_device_batch_size=1 run_name=ht_test scan_layers=false use_multimodal=true prompt=\'What\ is\ the\ classification\ of\ the\ single\ exhibit\ in\ this\ video\?\' video_path=\'tests/assets/test_video.mp4\' max_prefill_predict_length=1240 max_target_length=1280 ici_tensor_parallelism=4 override_model_config=true video_max_grid_t=32 video_max_grid_h=32 video_max_grid_w=32 attention=\'dot_product\' attention_for_vit=\'autoselected\' hf_access_token=xxx

# Logs, video tensor shape [1, 3, 64, 512, 512], fixed canvas
DEBUG: vision encoder video input shape=(Array(1, dtype=int32), Array(3, dtype=int32), Array(64, dtype=int32), Array(512, dtype=int32),Array(512, dtype=int32))
` -> `The exhibit is a dinosaur, specifically a large, multi-headed creature. It is likely a model or replica of a prehistoric animal, possibly a type of theropod dinosaur, and is displayed in a`
```

The output string is basically identical, and drifted after ~35 tokens generation. This could be caused by small numerical differences in ViT attention kernel using `dot_product vs autoselected`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
