### PR TITLE
Add Hugging Face Grain streaming integration and onboarding guide

### DIFF
--- a/docs/guides/data_input_pipeline/data_input_grain.md
+++ b/docs/guides/data_input_pipeline/data_input_grain.md
@@ -49,7 +49,7 @@ MOUNT_PATH=${MOUNT_PATH?} \
 
 Note that `FILE_PATH` is optional; when provided, the script runs `ls -R` for pre-filling the metadata cache (see ["Performance tuning best practices" on the Google Cloud documentation](https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/performance)).
 
-1. Set `dataset_type=grain`, `grain_file_type={arrayrecord|parquet|tfrecord}`, `grain_train_files` in `src/maxtext/configs/base.yml` or through command line arguments to match the file pattern on the mounted local path.
+1. Set `dataset_type=grain`, `grain_file_type={arrayrecord|parquet|tfrecord}`, `grain_train_files` in `src/maxtext/configs/base.yml` or through command line arguments to match the file pattern on the mounted local path. You can also stream datasets directly from Hugging Face by providing `hf://` prefix patterns in `grain_train_files` (e.g., `hf://datasets/dvruette/lm1b/**/*.parquet`), or simply specifying `hf_path` with `grain_file_type=parquet` to automatically construct the `hf://` pattern. Note that streaming directly from Hugging Face is currently only supported for datasets in the Parquet format. For gated datasets, make sure to set the `hf_access_token` config.
 
 2. Tune `grain_worker_count` for performance. This parameter controls the number of child processes used by Grain (more details in [behind_the_scenes](https://google-grain.readthedocs.io/en/latest/behind_the_scenes.html)). If you use a large number of workers, check your config for gcsfuse in [setup_gcsfuse.sh](https://github.com/AI-Hypercomputer/maxtext/blob/main/src/dependencies/scripts/setup_gcsfuse.sh) to avoid gcsfuse throttling.
 

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -3340,10 +3340,15 @@ class MaxTextConfig(
       if self.eval_interval > 0 and not self.hf_eval_split:
         raise ValueError("Please specify hf_eval_split or set eval_interval to <=0.")
     elif self.dataset_type == DatasetType.GRAIN:
-      if not self.grain_train_files and not self.grain_train_mixture_config_path:
-        raise ValueError("When dataset_type=grain, please set grain_train_files or grain_train_mixture_config_path")
-      if self.eval_interval > 0 and not self.grain_eval_files:
-        raise ValueError("Please specify grain_eval_files or set eval_interval to <=0.")
+      use_hf_parquet = self.hf_path and self.grain_file_type == "parquet"
+
+      if not self.grain_train_files and not self.grain_train_mixture_config_path and not use_hf_parquet:
+        raise ValueError(
+            "When dataset_type=grain, set grain_train_files, "
+            "grain_train_mixture_config_path, or use hf_path with grain_file_type=parquet."
+        )
+      if self.eval_interval > 0 and not self.grain_eval_files and not use_hf_parquet:
+        raise ValueError("Please specify grain_eval_files (or hf_path with parquet) or set eval_interval to <=0.")
     elif self.dataset_type == DatasetType.TFDS:
       logger.warning(
           "tfds pipeline is deprecated. Use dataset_type=grain, grain_file_type=tfrecord, and provide grain_train_files."

--- a/src/maxtext/input_pipeline/grain_data_processing.py
+++ b/src/maxtext/input_pipeline/grain_data_processing.py
@@ -16,6 +16,7 @@
 
 import math
 import glob
+import re
 from pathlib import Path
 import functools
 import ml_collections
@@ -36,14 +37,54 @@ from maxtext.utils import gcs_utils
 from maxtext.utils import max_logging
 
 
-def find_data_files(data_file_pattern):
+def construct_hf_dataset_path(hf_path: str, hf_train_files: str | None = None, split: str = "train") -> str:
+  """
+  Constructs a robust Hugging Face fsspec (hf://) path for dataset loading.
+  """
+  hf_path = hf_path.strip().strip("/")
+
+  scheme_prefix = "hf://"
+  if hf_path.startswith("hf://"):
+    hf_path = hf_path[len("hf://") :]
+
+  if not hf_path.startswith("datasets/"):
+    hf_path = f"datasets/{hf_path}"
+
+  match = re.match(r"^([^@]+)(@.+)?$", hf_path)
+  repo_path = match.group(1) if match else hf_path
+  revision_suffix = match.group(2) if match and match.group(2) else ""
+
+  if hf_train_files:
+    file_pattern = hf_train_files.lstrip("/")
+  else:
+    if split:
+      file_pattern = f"**/*{split}*.parquet"
+    else:
+      file_pattern = "**/*.parquet"
+
+  full_path = f"{scheme_prefix}{repo_path}{revision_suffix}/{file_pattern}"
+  return full_path
+
+
+def find_data_files(data_file_pattern, hf_access_token=None):
   """Find data files matching the pattern."""
   if data_file_pattern.startswith("gs://"):
     data_files = gcs_utils.gcs_glob_pattern(data_file_pattern)
+  elif data_file_pattern.startswith("hf://"):
+    from huggingface_hub import HfFileSystem  # pylint: disable=import-outside-toplevel
+
+    fs = HfFileSystem(token=hf_access_token)
+    stripped_pattern = data_file_pattern[len("hf://") :]
+    data_files = [f"hf://{f}" for f in fs.glob(stripped_pattern)]
   else:
     # Local files
     data_files = glob.glob(str(Path(data_file_pattern).expanduser().resolve()))
   if not data_files:
+    if data_file_pattern.startswith("hf://") and "/**/*.parquet" in data_file_pattern:
+      raise FileNotFoundError(
+          f"No parquet files found for HuggingFace dataset pattern: {data_file_pattern}. "
+          "Please make sure the dataset contains parquet files."
+      )
     raise FileNotFoundError(f"No files found matching pattern: {data_file_pattern}")
   max_logging.log(f"Found {len(data_files)} files for train/eval with grain")
   return data_files
@@ -96,12 +137,13 @@ def get_datasets(
     grain_data_source_max_workers,
     mixture_config_path=None,
     elastic=False,
+    hf_access_token=None,
 ):
   """Load dataset from array_record files for using with grain"""
   if data_file_type == "arrayrecord":
     # Helper function to find files, create data source, and wrap in MapDataset
     def create_dataset_from_pattern(pattern):
-      files = find_data_files(pattern)
+      files = find_data_files(pattern, hf_access_token=hf_access_token)
       source = grain.ArrayRecordDataSource(files)
       return grain.MapDataset.source(source)
 
@@ -181,7 +223,7 @@ def get_datasets(
       )
       return dataset
   elif data_file_type in ("tfrecord", "parquet"):
-    data_files = find_data_files(data_file_pattern)
+    data_files = find_data_files(data_file_pattern, hf_access_token=hf_access_token)
     file_slice, files_per_host, row_shard = input_pipeline_utils.compute_file_sharding(
         len(data_files), dataloading_host_index, dataloading_host_count
     )
@@ -205,7 +247,9 @@ def get_datasets(
     if data_file_type == "tfrecord":
       dataset = dataset.map(input_pipeline_utils.make_tfrecord_iter_dataset)  # pyrefly: ignore[missing-attribute]
     else:
-      dataset = dataset.map(grain.experimental.ParquetIterDataset)  # pyrefly: ignore[missing-attribute]
+      dataset = dataset.map(
+          functools.partial(input_pipeline_utils.make_parquet_iter_dataset, hf_access_token=hf_access_token)
+      )  # pyrefly: ignore[missing-attribute]
     cycle_length = min(files_per_host, grain_num_threads)
     dataset = grain.experimental.InterleaveIterDataset(dataset, cycle_length=cycle_length)
     if row_shard is not None:
@@ -432,9 +476,13 @@ def make_grain_train_iterator(
 
   pipeline_fn = _get_pipeline_fn(config)
 
+  grain_train_files = config.grain_train_files
+  if not grain_train_files and not config.grain_train_mixture_config_path and config.hf_path:
+    grain_train_files = construct_hf_dataset_path(config.hf_path, split="train")
+
   get_ds_fn = functools.partial(
       get_datasets,
-      config.grain_train_files,
+      grain_train_files,
       config.grain_file_type,
       shuffle=config.enable_data_shuffling,
       shuffle_seed=config.data_shuffle_seed,
@@ -446,6 +494,7 @@ def make_grain_train_iterator(
       grain_data_source_max_workers=config.grain_data_source_max_workers,
       mixture_config_path=config.grain_train_mixture_config_path,
       elastic=config.grain_use_elastic_iterator,
+      hf_access_token=getattr(config, "hf_access_token", None),
   )
 
   preprocessing_fn = functools.partial(
@@ -533,9 +582,14 @@ def make_grain_eval_iterator(
 
   pipeline_fn = _get_pipeline_fn(config)
 
+  grain_eval_files = config.grain_eval_files
+  if not grain_eval_files and getattr(config, "hf_path", None):
+    split = getattr(config, "hf_eval_split", None) or "validation"
+    grain_eval_files = construct_hf_dataset_path(config.hf_path, split=split)
+
   get_ds_fn = functools.partial(
       get_datasets,
-      config.grain_eval_files,
+      grain_eval_files,
       config.grain_file_type,
       shuffle=False,  # No shuffle for eval
       shuffle_seed=config.data_shuffle_seed,
@@ -545,6 +599,7 @@ def make_grain_eval_iterator(
       grain_num_threads=config.grain_num_threads_eval,
       grain_prefetch_buffer_size=config.grain_prefetch_buffer_size_eval,
       grain_data_source_max_workers=config.grain_data_source_max_workers,
+      hf_access_token=getattr(config, "hf_access_token", None),
   )
 
   preprocessing_fn = functools.partial(

--- a/src/maxtext/input_pipeline/input_pipeline_utils.py
+++ b/src/maxtext/input_pipeline/input_pipeline_utils.py
@@ -172,7 +172,9 @@ def is_conversational(features, data_columns):
   for column in data_columns:
     messages = features[column]
     if isinstance(messages, datasets.Sequence):
-      if isinstance(messages.feature, dict) and "role" in messages.feature and "content" in messages.feature:  # pyrefly: ignore[missing-attribute]
+      if (
+          isinstance(messages.feature, dict) and "role" in messages.feature and "content" in messages.feature
+      ):  # pyrefly: ignore[missing-attribute]
         return True
 
   return False
@@ -494,6 +496,15 @@ def make_tfrecord_iter_dataset(path: str):
   if path.startswith("gs://"):
     return GCSTFRecordIterDataset(path)
   return TFRecordIterDataset(path)
+
+
+def make_parquet_iter_dataset(path: str, hf_access_token: str | None = None):
+  """Returns the appropriate ParquetIterDataset for local or HF paths."""
+  if path.startswith("hf://"):
+    from huggingface_hub import HfFileSystem  # pylint: disable=import-outside-toplevel
+
+    return grain.experimental.ParquetIterDataset(path, filesystem=HfFileSystem(token=hf_access_token))
+  return grain.experimental.ParquetIterDataset(path)
 
 
 def compute_file_sharding(file_count, host_index, host_count):
@@ -840,11 +851,19 @@ class PadOrTrimToMaxLength(grain.MapTransform):
         if isinstance(element[data_column], mm_utils.PreprocessorOutput):
           raise TypeError("Only 'images' column can be of type PreprocessorOutput.")
 
-        element[f"{data_column}_segmentation"] = element[data_column] != self.pad_id  # pyrefly: ignore[unsupported-operation]
-        element[f"{data_column}_segmentation"] = element[f"{data_column}_segmentation"].astype(np.int32)  # pyrefly: ignore[missing-attribute]
-        element[f"{data_column}_position"] = np.arange(element[data_column].shape[0], dtype=np.int32)  # pyrefly: ignore[missing-attribute]
+        element[f"{data_column}_segmentation"] = (
+            element[data_column] != self.pad_id
+        )  # pyrefly: ignore[unsupported-operation]
+        element[f"{data_column}_segmentation"] = element[f"{data_column}_segmentation"].astype(
+            np.int32
+        )  # pyrefly: ignore[missing-attribute]
+        element[f"{data_column}_position"] = np.arange(
+            element[data_column].shape[0], dtype=np.int32
+        )  # pyrefly: ignore[missing-attribute]
         if self.add_true_length:
-          element[f"{data_column}_true_length"] = np.array([element[data_column].shape[0]], dtype=np.int32)  # pyrefly: ignore[missing-attribute]
+          element[f"{data_column}_true_length"] = np.array(
+              [element[data_column].shape[0]], dtype=np.int32
+          )  # pyrefly: ignore[missing-attribute]
 
     for key, _ in element.items():
       if key == "images":


### PR DESCRIPTION
# Description

This PR adds native support for streaming Hugging Face datasets in MaxText's input pipeline via PyGrain and `HfFileSystem`.

Previously, users tracking datasets externally or directly on the Hugging Face hub had to download files locally/to cloud buckets before running MaxText. This PR changes that by intercepting `hf://` file patterns, natively authenticating or globbing datasets using the Hugging Face Python API, and passing those paths to Grain's `ParquetIterDataset`.

**Relevant Context & Implementation Details:**
- **Problem solved:** Eliminates the intermediate step of downloading Hugging Face datasets by taking advantage of PyArrow's HTTP Range request capabilities directly via `HfFileSystem`.
- **Implementation:** Added `make_parquet_iter_dataset` in `input_pipeline_utils.py` that conditionally imports `HfFileSystem` based on the file prefix. The `grain_data_processing.py` script was updated to resolve remote glob patterns and apply the new lazy mapping to data file iterators.

# Tests

The changes were verified on a `v4` TPU VM by streaming the `dvruette/lm1b` parquet dataset directly from Hugging Face hub while compiling the Gemma-2b model.

**Instructions / Commands to reproduce:**
https://paste.googleplex.com/5863157917679616

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
