### PR TITLE
[CI] Resolve test runner resource conflicts and add job-level concurr…

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -196,6 +196,8 @@ jobs:
     if: |
       always() &&
       needs.gate_test_run.result == 'success'
+    concurrency:
+      group: tpu-v6e-4-lock-${{ matrix.flavor }}
     uses: ./.github/workflows/run_tests_coordinator.yml
     strategy:
       fail-fast: false
@@ -227,6 +229,8 @@ jobs:
       always() &&
       needs.gate_test_run.result == 'success' &&
       github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    concurrency:
+      group: tpu-tpu7x-8-lock-${{ matrix.flavor }}
     uses: ./.github/workflows/run_tests_coordinator.yml
     strategy:
       fail-fast: false
@@ -244,6 +248,8 @@ jobs:
     if: |
       always() &&
       needs.gate_test_run.result == 'success'
+    concurrency:
+      group: gpu-a100-lock-${{ matrix.flavor }}
     strategy:
       fail-fast: false
       matrix:
@@ -277,6 +283,8 @@ jobs:
     if: |
       always() &&
       needs.gate_test_run.result == 'success'
+    concurrency:
+      group: tpu-v6e-4-lock-pathways-unit-${{ matrix.group }}
     uses: ./.github/workflows/run_pathways_tests.yml
     strategy:
         fail-fast: false
@@ -302,6 +310,8 @@ jobs:
     if: |
       always() &&
       needs.gate_test_run.result == 'success'
+    concurrency:
+      group: tpu-v6e-4-lock-pathways-integration
     uses: ./.github/workflows/run_pathways_tests.yml
     strategy:
         fail-fast: false

--- a/tests/integration/decode_tests.py
+++ b/tests/integration/decode_tests.py
@@ -22,9 +22,14 @@ import pytest
 from absl.testing import absltest
 from contextlib import redirect_stdout
 
-from maxtext.inference.decode import main as decode_main
+from maxtext.inference.decode import main as _decode_main
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
-from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
+from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory, get_config_with_unique_run_name
+
+
+def decode_main(config_list):
+  return _decode_main(get_config_with_unique_run_name(config_list, "decode_test"))
+
 
 pytestmark = [pytest.mark.tpu_only, pytest.mark.external_serving, pytest.mark.integration_test]
 

--- a/tests/integration/deepseek_scan_engram_test.py
+++ b/tests/integration/deepseek_scan_engram_test.py
@@ -28,7 +28,9 @@ from maxtext.utils.globals import MAXTEXT_PKG_DIR
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.layers.decoders import Decoder
 from maxtext.utils import maxtext_utils
+from tests.utils.test_helpers import get_config_with_unique_run_name
 import pytest
+
 
 
 class DummyEmbedding:
@@ -117,14 +119,17 @@ class TestDeepSeekScanEngram(unittest.TestCase):
 
     config_path = os.path.join(MAXTEXT_PKG_DIR, "configs", "base.yml")
     config = pyconfig.initialize(
-        [None, config_path]
-        + self._COMMON_CONFIG
-        + [
-            f"engram_layers=[{engram_layers_str}]",
-            f"first_num_dense_layers={first_num_dense_layers}",
-            f"base_num_decoder_layers={base_num_decoder_layers}",
-            f"num_decoder_layers={base_num_decoder_layers}",
-        ]
+        get_config_with_unique_run_name(
+            [None, config_path]
+            + self._COMMON_CONFIG
+            + [
+                f"engram_layers=[{engram_layers_str}]",
+                f"first_num_dense_layers={first_num_dense_layers}",
+                f"base_num_decoder_layers={base_num_decoder_layers}",
+                f"num_decoder_layers={base_num_decoder_layers}",
+            ],
+            "deepseek_scan_engram_test",
+        )
     )
 
     devices_array = maxtext_utils.create_device_mesh(config)

--- a/tests/integration/gradient_accumulation_test.py
+++ b/tests/integration/gradient_accumulation_test.py
@@ -26,11 +26,20 @@ import os
 import os.path
 
 from maxtext.common.gcloud_stub import is_decoupled
-from maxtext.trainers.pre_train.train import main as train_main
+from maxtext.trainers.pre_train.train import main as _train_main
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
-from maxtext.trainers.post_train.sft.train_sft_native import main as sft_main
+from maxtext.trainers.post_train.sft.train_sft_native import main as _sft_main
 
-from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
+from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory, get_config_with_unique_run_name
+
+
+def train_main(config_list):
+  return _train_main(get_config_with_unique_run_name(config_list))
+
+
+def sft_main(config_list):
+  return _sft_main(get_config_with_unique_run_name(config_list, "sft_grad_accumulate"))
+
 
 
 def generate_random_string(length=10):

--- a/tests/integration/pipeline_parallelism_test.py
+++ b/tests/integration/pipeline_parallelism_test.py
@@ -28,7 +28,7 @@ from flax.linen import partitioning as nn_partitioning
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh
-from maxtext.configs import pyconfig
+from maxtext.configs import pyconfig as _pyconfig
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
 from maxtext.common.common_types import MODEL_MODE_TRAIN
 from maxtext.common.gcloud_stub import is_decoupled
@@ -37,9 +37,22 @@ from maxtext.layers import pipeline
 from maxtext.models import deepseek
 from maxtext.models import simple_layer
 from maxtext.utils import maxtext_utils
-from maxtext.trainers.pre_train.train import main as train_main
-from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
+from maxtext.trainers.pre_train.train import main as _train_main
+from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory, get_config_with_unique_run_name, get_test_run_name
 import pytest
+
+
+class pyconfig:
+  @staticmethod
+  def initialize(args, **kwargs):
+    if "run_name" in kwargs:
+      kwargs["run_name"] = get_test_run_name(kwargs["run_name"])
+    return _pyconfig.initialize(get_config_with_unique_run_name(args), **kwargs)
+
+
+def train_main(config_list):
+  return _train_main(get_config_with_unique_run_name(config_list))
+
 
 
 # Helper to fix pipeline parallelism in test_full_train_fp8 and test_full_train_nanoo_fp8

--- a/tests/integration/simple_decoder_layer_test.py
+++ b/tests/integration/simple_decoder_layer_test.py
@@ -19,8 +19,11 @@ import os.path
 import pytest
 
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
-from maxtext.trainers.pre_train.train import main as train_main
-from tests.utils.test_helpers import get_test_config_path
+from maxtext.trainers.pre_train.train import main as _train_main
+from tests.utils.test_helpers import get_test_config_path, get_config_with_unique_run_name
+
+def train_main(config_list):
+  return _train_main(get_config_with_unique_run_name(config_list, "simple_decoder_layer_test"))
 
 pytestmark = pytest.mark.integration_test
 

--- a/tests/integration/smoke/train_gpu_smoke_test.py
+++ b/tests/integration/smoke/train_gpu_smoke_test.py
@@ -19,9 +19,14 @@ import unittest
 from absl.testing import absltest
 
 from maxtext.common.gcloud_stub import is_decoupled
-from maxtext.trainers.pre_train.train import main as train_main
+from maxtext.trainers.pre_train.train import main as _train_main
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
-from tests.utils.test_helpers import get_test_dataset_path, get_test_base_output_directory, get_test_config_path
+from tests.utils.test_helpers import get_test_dataset_path, get_test_base_output_directory, get_test_config_path, get_config_with_unique_run_name
+
+
+def train_main(config_list):
+  return _train_main(get_config_with_unique_run_name(config_list))
+
 
 
 class Train(unittest.TestCase):
@@ -47,7 +52,7 @@ class Train(unittest.TestCase):
             # pylint: disable=f-string-without-interpolation
             f"base_output_directory={self.base_output_directory}",
             "run_name=runner_test",
-            r"dataset_path={self.dataset_path}",
+            f"dataset_path={self.dataset_path}",
             "enable_checkpointing=False",
             rf"tokenizer_path={os.path.join(MAXTEXT_ASSETS_ROOT, 'tokenizers', 'tokenizer.llama2')}",
             "enable_goodput_recording=False",

--- a/tests/integration/smoke/train_int8_smoke_test.py
+++ b/tests/integration/smoke/train_int8_smoke_test.py
@@ -19,9 +19,14 @@ import unittest
 from absl.testing import absltest
 
 from maxtext.common.gcloud_stub import is_decoupled
-from maxtext.trainers.pre_train.train import main as train_main
+from maxtext.trainers.pre_train.train import main as _train_main
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
-from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
+from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory, get_config_with_unique_run_name
+
+
+def train_main(config_list):
+  return _train_main(get_config_with_unique_run_name(config_list))
+
 
 
 class Train(unittest.TestCase):
@@ -46,7 +51,7 @@ class Train(unittest.TestCase):
             # pylint: disable=f-string-without-interpolation
             f"base_output_directory={self.base_output_directory}",
             "run_name=runner_test",
-            r"dataset_path={self.dataset_path}",
+            f"dataset_path={self.dataset_path}",
             "base_emb_dim=8",
             "base_num_query_heads=4",
             "base_num_kv_heads=4",

--- a/tests/integration/smoke/train_smoke_test.py
+++ b/tests/integration/smoke/train_smoke_test.py
@@ -17,11 +17,16 @@ import os
 import unittest
 
 from absl.testing import absltest
-from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory
+from tests.utils.test_helpers import get_test_config_path, get_test_dataset_path, get_test_base_output_directory, get_config_with_unique_run_name
 
 from maxtext.common.gcloud_stub import is_decoupled
-from maxtext.trainers.pre_train.train import main as train_main
+from maxtext.trainers.pre_train.train import main as _train_main
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
+
+
+def train_main(config_list):
+  return _train_main(get_config_with_unique_run_name(config_list))
+
 
 
 class Train(unittest.TestCase):
@@ -46,7 +51,7 @@ class Train(unittest.TestCase):
             # pylint: disable=f-string-without-interpolation
             f"base_output_directory={self.base_output_directory}",
             "run_name=runner_test",
-            r"dataset_path={self.dataset_path}",
+            f"dataset_path={self.dataset_path}",
             "base_emb_dim=8",
             "base_num_query_heads=4",
             "base_num_kv_heads=4",
@@ -74,7 +79,7 @@ class Train(unittest.TestCase):
             # pylint: disable=f-string-without-interpolation
             f"base_output_directory={self.base_output_directory}",
             "run_name=runner_test",
-            r"dataset_path={self.dataset_path}",
+            f"dataset_path={self.dataset_path}",
             "base_emb_dim=8",
             "base_num_query_heads=4",
             "base_num_kv_heads=4",
@@ -103,7 +108,7 @@ class Train(unittest.TestCase):
             # pylint: disable=f-string-without-interpolation
             f"base_output_directory={self.base_output_directory}",
             "run_name=runner_test",
-            r"dataset_path={self.dataset_path}",
+            f"dataset_path={self.dataset_path}",
             "base_emb_dim=8",
             "base_num_query_heads=4",
             "base_num_kv_heads=4",
@@ -135,7 +140,7 @@ class Train(unittest.TestCase):
             # pylint: disable=f-string-without-interpolation
             f"base_output_directory={self.base_output_directory}",
             "run_name=runner_test",
-            r"dataset_path={self.dataset_path}",
+            f"dataset_path={self.dataset_path}",
             "base_emb_dim=256",
             "attention_output_dim=256",
             "moe_expert_input_dim=256",
@@ -169,7 +174,7 @@ class Train(unittest.TestCase):
             # pylint: disable=f-string-without-interpolation
             f"base_output_directory={self.base_output_directory}",
             "run_name=runner_test",
-            r"dataset_path={self.dataset_path}",
+            f"dataset_path={self.dataset_path}",
             "base_emb_dim=8",
             "base_num_query_heads=4",
             "base_num_kv_heads=4",
@@ -198,7 +203,7 @@ class Train(unittest.TestCase):
             # pylint: disable=f-string-without-interpolation
             f"base_output_directory={self.base_output_directory}",
             "run_name=runner_test",
-            r"dataset_path={self.dataset_path}",
+            f"dataset_path={self.dataset_path}",
             "base_emb_dim=8",
             "base_num_query_heads=4",
             "base_num_kv_heads=4",

--- a/tests/integration/smoke/train_using_ragged_dot_smoke_test.py
+++ b/tests/integration/smoke/train_using_ragged_dot_smoke_test.py
@@ -20,9 +20,11 @@ import tempfile
 from absl.testing import absltest
 from absl.testing import parameterized
 from maxtext.trainers.pre_train import train
-from tests.utils.test_helpers import get_test_config_path
+from tests.utils.test_helpers import get_test_config_path, get_config_with_unique_run_name
 
-train_main = train.main
+def train_main(config_list):
+  return train.main(get_config_with_unique_run_name(config_list, "ragged_dot_smoke_test"))
+
 gettempdir = tempfile.gettempdir
 
 

--- a/tests/integration/sparsity_test.py
+++ b/tests/integration/sparsity_test.py
@@ -20,9 +20,11 @@ from absl.testing import absltest
 from absl.testing import parameterized
 import pytest
 from maxtext.trainers.pre_train import train
-from tests.utils.test_helpers import get_test_config_path
+from tests.utils.test_helpers import get_test_config_path, get_config_with_unique_run_name
 
-train_main = train.main
+def train_main(config_list):
+  return train.main(get_config_with_unique_run_name(config_list, "sparsity_test"))
+
 gettempdir = tempfile.gettempdir
 
 

--- a/tests/integration/tokamax_test.py
+++ b/tests/integration/tokamax_test.py
@@ -20,9 +20,11 @@ from absl.testing import absltest
 from absl.testing import parameterized
 import pytest
 from maxtext.trainers.pre_train import train
-from tests.utils.test_helpers import get_test_config_path
+from tests.utils.test_helpers import get_test_config_path, get_config_with_unique_run_name
 
-train_main = train.main
+def train_main(config_list):
+  return train.main(get_config_with_unique_run_name(config_list, "tokamax_test"))
+
 gettempdir = tempfile.gettempdir
 
 

--- a/tests/integration/train_tests.py
+++ b/tests/integration/train_tests.py
@@ -20,13 +20,19 @@ import jax
 
 from absl.testing import absltest
 from maxtext.common.gcloud_stub import is_decoupled
-from maxtext.trainers.pre_train.train import main as train_main
+from maxtext.trainers.pre_train.train import main as _train_main
 from maxtext.utils.globals import MAXTEXT_ASSETS_ROOT
+
+
+def train_main(config_list):
+  return _train_main(get_config_with_unique_run_name(config_list))
+
 from tests.utils.test_helpers import (
     get_test_config_path,
     get_test_dataset_path,
     get_test_base_output_directory,
     is_rocm_backend,
+    get_config_with_unique_run_name,
 )
 
 

--- a/tests/integration/vision_encoder_test.py
+++ b/tests/integration/vision_encoder_test.py
@@ -28,9 +28,10 @@ from maxtext.inference.maxengine import maxengine
 from maxtext.models import models
 from maxtext.multimodal import processor_gemma3
 from maxtext.multimodal import utils as mm_utils
-from tests.utils.test_helpers import get_test_config_path
+from tests.utils.test_helpers import get_test_config_path, get_config_with_unique_run_name
 import numpy as np
 import pytest
+
 
 pytestmark = [pytest.mark.external_serving, pytest.mark.integration_test]
 
@@ -70,7 +71,9 @@ class VisionEncoderEmbeddingTest(unittest.TestCase):
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
     """Correctness test for the gemma3-4b image embedding."""
     # Load weights from reference checkpoint
-    config = pyconfig.initialize(VisionEncoderEmbeddingTest.CONFIGS["gemma3-4b"])
+    config = pyconfig.initialize(
+        get_config_with_unique_run_name(VisionEncoderEmbeddingTest.CONFIGS["gemma3-4b"], "vision_encoder_test")
+    )
     engine = maxengine.MaxEngine(config)
     rng = jax.random.PRNGKey(1234)
     rng, rng_load_params = jax.random.split(rng)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -90,10 +90,32 @@ def get_test_base_output_directory(cloud_path=None):
   return cloud_path or "gs://runner-maxtext-logs"
 
 
+def get_test_run_name(prefix: str) -> str:
+  """Generate a unique run name for test isolation."""
+  import random
+  import string
+  random_string = "".join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(6))
+  return f"{prefix}_{random_string}"
+
+
+def get_config_with_unique_run_name(config_list, prefix="runner_test"):
+  """Returns a copy of the config list with run_name replaced by a unique name."""
+  unique_run_name = get_test_run_name(prefix)
+  res = []
+  for arg in config_list:
+    if arg is not None and isinstance(arg, str) and arg.startswith("run_name="):
+      res.append(f"run_name={unique_run_name}")
+    else:
+      res.append(arg)
+  return res
+
+
 __all__ = [
     "get_test_base_output_directory",
     "is_rocm_backend",
     "get_test_config_path",
     "get_post_train_test_config_path",
     "get_test_dataset_path",
+    "get_config_with_unique_run_name",
 ]
+


### PR DESCRIPTION
…ency locks

This change addresses concurrent resource conflicts on MaxText CI test runners (TPU and GPU self-hosted VM instances) and eliminates output directory collisions.

Key Modifications:
1. Dynamic Test Run Isolation:
   - Introduced get_config_with_unique_run_name in test_helpers.py that appends a random suffix to config list inputs.
   - Wrapped train_main, decode_main, and pyconfig.initialize calls across integration, unit, and smoke tests to dynamically randomize the run_name property.

2. Fix Validation Typos:
   - Corrected syntax typo r"dataset_path={self.dataset_path}" to f"dataset_path={self.dataset_path}" in smoke test files.

3. Job-Level Concurrency Locks:
   - Added job-level concurrency rules in ci_pipeline.yml to lock TPU and GPU jobs per matrix flavor.

TAG=agy
CONV=1946d206-b90c-4c19-8fdc-8e39b32e4542

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

You can also provide a comma-separated list. If you don't want to close a bug but
simply to reference it, use BUGS, e.g.: 
BUGS: b/123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
