### PR TITLE
FSDP Prefetch: Forward pass only

### DIFF
--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -1049,6 +1049,9 @@ class HardwareAndMesh(BaseModel):
           "When resuming from a checkpoint, this flag is auto-determined from metadata."
       ),
   )
+  prefetch_fsdp_weights: bool = Field(
+      False, description="Prefetch all gathering the FSDP weights for layer N+1 during the compute of layer N."
+  )
   param_scan_axis: int = Field(1, description="Axis to scan over for parameters.")
   context_parallel_load_balance: bool = Field(True, description="Whether to use load balancing for context parallelism.")
   context_parallel_strategy: str = Field(
@@ -3092,6 +3095,10 @@ class MaxTextConfig(
         ), "Pipeline weight prefetching does not support pipeline delay."
         assert not self.quantization, "Quantization is currently not supported for pipeline prefetching."
         assert not self.scan_layers_per_stage, "Pipeline weight prefetching currently does not support scan."
+
+      if self.prefetch_fsdp_weights:
+        assert self.scan_layers, "FSDP weight prefetching requires scan_layers=True."
+        assert not self.quantization, "Quantization is currently not supported for FSDP prefetching."
 
       assert (num_stages * self.num_pipeline_repeats * self.num_layers_per_pipeline_stage) == (
           self.pipeline_parallel_layers

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -16,6 +16,7 @@
 # pylint: disable=arguments-differ
 # pylint: disable=no-name-in-module
 
+import contextlib
 import functools
 import inspect
 from typing import Any
@@ -26,7 +27,7 @@ from flax import nnx
 import jax
 from jax.ad_checkpoint import checkpoint_name
 import jax.numpy as jnp
-from jax.sharding import Mesh
+from jax.sharding import Mesh, NamedSharding
 from maxtext.common.common_types import (
     Config,
     DecoderBlockType,
@@ -370,6 +371,260 @@ class NNXScannedPipelineStage(nnx.Module):
     if self.config.scan_layers:
       return final_carry, None
     return final_carry
+
+
+def _run_prefetch_pipeline_fwd(
+    graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx, is_fwd=False
+):
+  """Shared forward scan step helper for custom_vjp prefetching.
+
+  Args:
+    graphdef: The graph definition of the NNX module.
+    x_in: The input activations.
+    params_leaves: The leaves of the parameters PyTree.
+    state_leaves: The leaves of the state PyTree.
+    diff_args_leaves: The leaves of the differentiable arguments.
+    diff_kwargs_leaves: The leaves of the differentiable keyword arguments.
+    length: The number of layers to scan over.
+    ctx: The context containing mesh, shard_mode, etc.
+    is_fwd: If True, indicates this is run as the forward pass of a custom VJP
+      pair. In this case, intermediate activations (y_curr) are collected and
+      returned as residuals for the backward pass. If False, it runs as a normal
+      forward pass without collecting residuals, saving memory.
+  """
+  (
+      mesh,
+      shard_mode,
+      prevent_cse,
+      policy,
+      static_args_leaves,
+      static_kwargs_leaves,
+      params_treedef,
+      state_treedef,
+      args_treedef,
+      kwargs_treedef,
+  ) = ctx
+  params = jax.tree_util.tree_unflatten(params_treedef, params_leaves)
+  state = jax.tree_util.tree_unflatten(state_treedef, state_leaves)
+
+  reconstructed_args_leaves = [s if s is not None else d for d, s in zip(diff_args_leaves, static_args_leaves)]
+  args_tuple = jax.tree_util.tree_unflatten(args_treedef, reconstructed_args_leaves)
+
+  reconstructed_kwargs_leaves = [s if s is not None else d for d, s in zip(diff_kwargs_leaves, static_kwargs_leaves)]
+  kwargs_tuple = jax.tree_util.tree_unflatten(kwargs_treedef, reconstructed_kwargs_leaves)
+  valid_kwargs = dict(kwargs_tuple)
+
+  def _apply_sharding_hint(w):
+    w_sharding = getattr(jax.typeof(w), "sharding", None) or getattr(w, "sharding", None)
+    if isinstance(w_sharding, NamedSharding) and w_sharding.spec is not None:
+      w_sharding_clean = NamedSharding(mesh, w_sharding.spec)
+      w = jax.lax.with_sharding_constraint(w, w_sharding_clean)
+      stripped_spec = sharding.strip_fsdp_from_spec(w_sharding.spec)
+      w_sharding_stripped = NamedSharding(mesh, stripped_spec)
+      return sharding.maybe_shard_with_name(w, w_sharding_stripped, shard_mode=shard_mode)
+    return sharding.maybe_shard_with_name(w, w_sharding, shard_mode=shard_mode)
+
+  def _roll_and_shard(x):
+    rolled = jnp.roll(x, -1, axis=0)
+    x_sharding = getattr(jax.typeof(x), "sharding", None) or getattr(x, "sharding", None)
+    if isinstance(x_sharding, NamedSharding):
+      return jax.lax.with_sharding_constraint(rolled, x_sharding)
+    return rolled
+
+  nxt_params_seq = jax.tree.map(_roll_and_shard, params)
+
+  def scheduling_group(group_id) -> contextlib.AbstractContextManager[None]:
+    return jax.experimental.xla_metadata.set_xla_metadata(_scheduling_group_id=group_id)
+
+  with scheduling_group(group_id=40):
+    w_0 = jax.tree.map(lambda x: x[0], params)
+    w_init = jax.tree.map(_apply_sharding_hint, w_0)
+
+  def scan_step_fn(carry, xs):
+    y_curr, w_curr = carry
+    st_i, nxt_params_i, idx = xs
+
+    # A scheduling group is used to group all FSDP all-gathers together.
+    # This encourages XLA to schedule them together, which makes XLA's scheduling job easier.
+    with scheduling_group(group_id=43):
+      w_next_ag = jax.tree.map(_apply_sharding_hint, nxt_params_i)
+      w_prefetched_ag = checkpoint_name(w_next_ag, "fsdp_bsw")
+
+    # At the last step of the forward pass (idx=length-1), there is no next
+    # layer to prefetch. The all-gather is skipped to avoid redundant communication.
+    def _maybe_skip(ag_w, curr_w):
+      return jax.lax.cond(idx < length - 1, lambda: ag_w, lambda: curr_w)
+
+    w_prefetched = jax.tree.map(_maybe_skip, w_prefetched_ag, w_curr)
+
+    layer = nnx.merge(graphdef, w_curr, st_i)
+    layer_out = layer(y_curr, *args_tuple, **valid_kwargs)
+
+    y_out = layer_out[0] if isinstance(layer_out, tuple) else layer_out
+    _, _, new_state_i = nnx.split(layer, nnx.Param, ...)
+
+    # Gradients are stopped on the prefetched weights here because they are just
+    # being carried over to the next iteration. The actual gradient computation
+    # for these weights happens in the next iteration where they are used as w_curr.
+    if is_fwd:
+      return (y_out, jax.tree.map(jax.lax.stop_gradient, w_prefetched)), (new_state_i, y_curr)
+    return (y_out, jax.tree.map(jax.lax.stop_gradient, w_prefetched)), new_state_i
+
+  step_wrapped = jax.checkpoint(scan_step_fn, policy=policy, prevent_cse=prevent_cse)
+  if is_fwd:
+    (final_y, _), (scanned_state, y_seq) = jax.lax.scan(
+        step_wrapped, (x_in, w_init), (state, nxt_params_seq, jnp.arange(length))
+    )
+    return (final_y, scanned_state), (
+        y_seq,
+        params_leaves,
+        state_leaves,
+        scanned_state,
+        diff_args_leaves,
+        diff_kwargs_leaves,
+    )
+  else:
+    (final_y, _), scanned_state = jax.lax.scan(step_wrapped, (x_in, w_init), (state, nxt_params_seq, jnp.arange(length)))
+    return final_y, scanned_state
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(0, 6, 7))
+def _custom_vjp_prefetch_pipeline(
+    graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx
+):
+  """Forward pipeline wrapper for custom_vjp prefetching."""
+  return _run_prefetch_pipeline_fwd(
+      graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx, is_fwd=False
+  )
+
+
+def _custom_vjp_prefetch_pipeline_fwd(
+    graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx
+):
+  """Forward autodiff pass wrapper for custom_vjp prefetching."""
+  return _run_prefetch_pipeline_fwd(
+      graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx, is_fwd=True
+  )
+
+
+def _custom_vjp_prefetch_pipeline_bwd(graphdef, length, ctx, res, g_out):
+  """Backward autodiff pass wrapper for custom_vjp prefetching."""
+  y_seq, params_leaves, state_leaves, _, diff_args_leaves, diff_kwargs_leaves = res
+  y_bar_final, _ = g_out
+  (
+      mesh,
+      shard_mode,
+      _,
+      _,
+      static_args_leaves,
+      static_kwargs_leaves,
+      params_treedef,
+      state_treedef,
+      args_treedef,
+      kwargs_treedef,
+  ) = ctx
+  params = jax.tree_util.tree_unflatten(params_treedef, params_leaves)
+  state = jax.tree_util.tree_unflatten(state_treedef, state_leaves)
+
+  reconstructed_args_leaves = [s if s is not None else d for d, s in zip(diff_args_leaves, static_args_leaves)]
+  args_tuple = jax.tree_util.tree_unflatten(args_treedef, reconstructed_args_leaves)
+
+  reconstructed_kwargs_leaves = [s if s is not None else d for d, s in zip(diff_kwargs_leaves, static_kwargs_leaves)]
+  kwargs_tuple = jax.tree_util.tree_unflatten(kwargs_treedef, reconstructed_kwargs_leaves)
+  valid_kwargs = dict(kwargs_tuple)
+
+  def _apply_sharding_hint(w):
+    w_sharding = getattr(jax.typeof(w), "sharding", None) or getattr(w, "sharding", None)
+    if isinstance(w_sharding, NamedSharding) and w_sharding.spec is not None:
+      w_sharding_clean = NamedSharding(mesh, w_sharding.spec)
+      w = jax.lax.with_sharding_constraint(w, w_sharding_clean)
+      stripped_spec = sharding.strip_fsdp_from_spec(w_sharding.spec)
+      w_sharding_stripped = NamedSharding(mesh, stripped_spec)
+      return sharding.maybe_shard_with_name(w, w_sharding_stripped, shard_mode=shard_mode)
+    return sharding.maybe_shard_with_name(w, w_sharding, shard_mode=shard_mode)
+
+  def _reduce_scatter_param_grads(grad_w, orig_w):
+    return jax.tree.map(
+        lambda gw, ow: sharding.maybe_shard_with_name(
+            gw, getattr(jax.typeof(ow), "sharding", None) or getattr(ow, "sharding", None), shard_mode=shard_mode
+        )
+        if gw is not None and ow is not None
+        else gw,
+        grad_w,
+        orig_w,
+    )
+
+  def _roll_fwd_and_shard(x):
+    rolled = jnp.roll(x, 1, axis=0)
+    x_sharding = getattr(jax.typeof(x), "sharding", None) or getattr(x, "sharding", None)
+    if isinstance(x_sharding, NamedSharding):
+      return jax.lax.with_sharding_constraint(rolled, x_sharding)
+    return rolled
+
+  prev_params_seq = jax.tree.map(_roll_fwd_and_shard, params)
+
+  def scheduling_group(group_id) -> contextlib.AbstractContextManager[None]:
+    return jax.experimental.xla_metadata.set_xla_metadata(_scheduling_group_id=group_id)
+
+  with scheduling_group(group_id=40):
+    w_last = jax.tree.map(lambda x: x[-1], params)
+    w_bwd_init = jax.tree.map(_apply_sharding_hint, w_last)
+
+  def scan_step_bwd(carry, xs):
+    y_bar_curr, w_curr = carry
+    y_i, orig_w_i, prev_params_i, st_i, idx = xs
+
+    # A scheduling group is used to group all FSDP all-gathers together.
+    # This encourages XLA to schedule them together, which makes XLA's scheduling job easier.
+    with scheduling_group(group_id=43):
+      w_prev_ag = jax.tree.map(_apply_sharding_hint, prev_params_i)
+      w_prefetched_ag = checkpoint_name(w_prev_ag, "fsdp_bsw")
+
+    # At the last step of the backward pass (idx=0, corresponding to the first
+    # layer in the forward pass), there is no previous layer to prefetch.
+    # The all-gather is skipped to avoid redundant communication.
+    def _maybe_skip(ag_w, curr_w):
+      return jax.lax.cond(idx > 0, lambda: ag_w, lambda: curr_w)
+
+    w_prefetched = jax.tree.map(_maybe_skip, w_prefetched_ag, w_curr)
+
+    def _single_layer_fn(y_inp, w_inp):
+      layer = nnx.merge(graphdef, w_inp, st_i)
+      layer_out = layer(y_inp, *args_tuple, **valid_kwargs)
+      y_out = layer_out[0] if isinstance(layer_out, tuple) else layer_out
+      return y_out
+
+    _, vjp_fn = jax.vjp(_single_layer_fn, y_i, w_curr)
+    y_bar_prev, w_bar_unreduced = vjp_fn(y_bar_curr)
+
+    w_bar_sharded_i = _reduce_scatter_param_grads(w_bar_unreduced, orig_w_i)
+
+    # Gradients are stopped on the prefetched weights here because they are just
+    # being carried over to the next iteration. The actual gradient computation
+    # for these weights happens in the next iteration where they are used as w_curr.
+    return (y_bar_prev, jax.tree.map(jax.lax.stop_gradient, w_prefetched)), w_bar_sharded_i
+
+  (y_bar_in, _), params_bar_stacked = jax.lax.scan(
+      scan_step_bwd,
+      (y_bar_final, w_bwd_init),
+      (y_seq, params, prev_params_seq, state, jnp.arange(length)),
+      reverse=True,
+  )
+
+  params_bar_leaves = tuple(jax.tree_util.tree_leaves(params_bar_stacked))
+
+  def _zero_tangent(x):
+    if isinstance(x, jax.Array) or (hasattr(jax.core, "Tracer") and isinstance(x, jax.core.Tracer)):
+      return jnp.zeros_like(x)
+    return None
+
+  state_bar_leaves = tuple(_zero_tangent(x) for x in state_leaves)
+  diff_args_bar_leaves = tuple(_zero_tangent(x) for x in diff_args_leaves)
+  diff_kwargs_bar_leaves = tuple(_zero_tangent(x) for x in diff_kwargs_leaves)
+  return y_bar_in, params_bar_leaves, state_bar_leaves, diff_args_bar_leaves, diff_kwargs_bar_leaves
+
+
+_custom_vjp_prefetch_pipeline.defvjp(_custom_vjp_prefetch_pipeline_fwd, _custom_vjp_prefetch_pipeline_bwd)
 
 
 class NNXDecoder(nnx.Module):
@@ -887,6 +1142,8 @@ class NNXDecoder(nnx.Module):
       (final_carry, updated_layers) when kv_caches_stacked is None.
       (final_carry, updated_layers, returned_kv_stacked) otherwise.
     """
+    if getattr(self.config, "prefetch_fsdp_weights", False) and kv_caches_stacked is None:
+      return self._apply_layers_sequentially_prefetch(layers, x_in, *args, length=length, **kwargs)
     if length == 0:
       return (
           x_in,
@@ -1014,6 +1271,71 @@ class NNXDecoder(nnx.Module):
       out_layers = layers
 
     return final_carry, out_layers, returned_kv_stacked if use_kv else None
+
+  def _apply_layers_sequentially_prefetch(self, layers, x_in, *args, length: int, **kwargs):
+    """Runs the layer stack using nnx.scan with custom_vjp lookahead prefetching."""
+    if length == 0:
+      return x_in, layers, None
+    policy = self.get_remat_policy()
+    prevent_cse = maxtext_utils.should_prevent_cse_in_remat(self.config)
+    graphdef, params, state = nnx.split(layers, nnx.Param, ...)
+
+    scan_axis = self.config.param_scan_axis
+    if scan_axis != 0:
+      params = jax.tree.map(lambda x: jnp.moveaxis(x, scan_axis, 0), params)
+
+    layer_cls = layers.__class__
+    sig = inspect.signature(layer_cls.__call__)
+    valid_kwargs = {k: v for k, v in kwargs.items() if k in sig.parameters or "kwargs" in sig.parameters}
+
+    args_tuple = tuple(args)
+    kwargs_tuple = tuple(valid_kwargs.items())
+
+    def _is_diff_leaf(x):
+      return isinstance(x, jax.Array) or (hasattr(jax.core, "Tracer") and isinstance(x, jax.core.Tracer))
+
+    args_leaves, args_treedef = jax.tree_util.tree_flatten(args_tuple)
+    kwargs_leaves, kwargs_treedef = jax.tree_util.tree_flatten(kwargs_tuple)
+
+    dummy_arr = jnp.zeros((0,), dtype=jnp.float32)
+
+    diff_args_leaves = tuple(x if _is_diff_leaf(x) else dummy_arr for x in args_leaves)
+    static_args_leaves = tuple(None if _is_diff_leaf(x) else x for x in args_leaves)
+
+    diff_kwargs_leaves = tuple(x if _is_diff_leaf(x) else dummy_arr for x in kwargs_leaves)
+    static_kwargs_leaves = tuple(None if _is_diff_leaf(x) else x for x in kwargs_leaves)
+
+    params_leaves, params_treedef = jax.tree_util.tree_flatten(params)
+    params_leaves = tuple(params_leaves)
+    state_leaves, state_treedef = jax.tree_util.tree_flatten(state)
+    state_leaves = tuple(state_leaves)
+
+    ctx = (
+        self.mesh,
+        self.config.shard_mode,
+        prevent_cse,
+        policy,
+        static_args_leaves,
+        static_kwargs_leaves,
+        params_treedef,
+        state_treedef,
+        args_treedef,
+        kwargs_treedef,
+    )
+
+    final_y, scanned_state = _custom_vjp_prefetch_pipeline(
+        graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx
+    )
+
+    scanned_state = maxtext_utils_nnx.nnx_add_scan_axis(scanned_state, "layers", 0)
+
+    if scan_axis != 0:
+      new_params, new_rest = scanned_state.split(nnx.Param, ...)
+      new_params = maxtext_utils_nnx.nnx_sync_moveaxis(new_params, 0, scan_axis)
+      scanned_state = nnx.merge_state(new_params, new_rest)
+
+    nnx.update(layers, scanned_state)
+    return final_y, layers, None
 
   def get_decoder_layers(self):
     """Retrieves decoder layer classes based on config using a dictionary lookup."""

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -373,119 +373,48 @@ class NNXScannedPipelineStage(nnx.Module):
     return final_carry
 
 
-def _run_prefetch_pipeline_fwd(
-    graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx, is_fwd=False
-):
-  """Shared forward scan step helper for custom_vjp prefetching.
-
-  Args:
-    graphdef: The graph definition of the NNX module.
-    x_in: The input activations.
-    params_leaves: The leaves of the parameters PyTree.
-    state_leaves: The leaves of the state PyTree.
-    diff_args_leaves: The leaves of the differentiable arguments.
-    diff_kwargs_leaves: The leaves of the differentiable keyword arguments.
-    length: The number of layers to scan over.
-    ctx: The context containing mesh, shard_mode, etc.
-    is_fwd: If True, indicates this is run as the forward pass of a custom VJP
-      pair. In this case, intermediate activations (y_curr) are collected and
-      returned as residuals for the backward pass. If False, it runs as a normal
-      forward pass without collecting residuals, saving memory.
-  """
-  (
-      mesh,
-      shard_mode,
-      prevent_cse,
-      policy,
-      static_args_leaves,
-      static_kwargs_leaves,
-      params_treedef,
-      state_treedef,
-      args_treedef,
-      kwargs_treedef,
-  ) = ctx
-  params = jax.tree_util.tree_unflatten(params_treedef, params_leaves)
-  state = jax.tree_util.tree_unflatten(state_treedef, state_leaves)
-
-  reconstructed_args_leaves = [s if s is not None else d for d, s in zip(diff_args_leaves, static_args_leaves)]
-  args_tuple = jax.tree_util.tree_unflatten(args_treedef, reconstructed_args_leaves)
-
-  reconstructed_kwargs_leaves = [s if s is not None else d for d, s in zip(diff_kwargs_leaves, static_kwargs_leaves)]
-  kwargs_tuple = jax.tree_util.tree_unflatten(kwargs_treedef, reconstructed_kwargs_leaves)
-  valid_kwargs = dict(kwargs_tuple)
-
-  def _apply_sharding_hint(w):
-    w_sharding = getattr(jax.typeof(w), "sharding", None) or getattr(w, "sharding", None)
-    if isinstance(w_sharding, NamedSharding) and w_sharding.spec is not None:
+def _apply_sharding_hint(w, mesh, shard_mode, debug_sharding=False):
+  """Applies sharding constraint and removes FSDP mesh axes from parameters."""
+  w_sharding = getattr(jax.typeof(w), "sharding", None) or getattr(w, "sharding", None)
+  if isinstance(w_sharding, NamedSharding) and w_sharding.spec is not None:
+    try:
       w_sharding_clean = NamedSharding(mesh, w_sharding.spec)
       w = jax.lax.with_sharding_constraint(w, w_sharding_clean)
-      stripped_spec = sharding.strip_fsdp_from_spec(w_sharding.spec)
-      w_sharding_stripped = NamedSharding(mesh, stripped_spec)
-      return sharding.maybe_shard_with_name(w, w_sharding_stripped, shard_mode=shard_mode)
-    return sharding.maybe_shard_with_name(w, w_sharding, shard_mode=shard_mode)
+      w_sharding_stripped = sharding.remove_fsdp_sharding(w_sharding_clean)
+      return sharding.maybe_shard_with_name(w, w_sharding_stripped, shard_mode=shard_mode, debug_sharding=debug_sharding)
+    except TypeError:
+      return w
+  try:
+    return sharding.maybe_shard_with_name(w, w_sharding, shard_mode=shard_mode, debug_sharding=debug_sharding)
+  except TypeError:
+    return w
 
-  def _roll_and_shard(x):
-    rolled = jnp.roll(x, -1, axis=0)
-    x_sharding = getattr(jax.typeof(x), "sharding", None) or getattr(x, "sharding", None)
-    if isinstance(x_sharding, NamedSharding):
-      return jax.lax.with_sharding_constraint(rolled, x_sharding)
-    return rolled
 
-  nxt_params_seq = jax.tree.map(_roll_and_shard, params)
+def _roll_and_shard(x, shift, shard_mode, debug_sharding=False):
+  """Rolls an array along axis 0 by `shift` and applies its sharding constraint."""
+  rolled = jnp.roll(x, shift, axis=0)
+  x_sharding = getattr(jax.typeof(x), "sharding", None) or getattr(x, "sharding", None)
+  if isinstance(x_sharding, NamedSharding):
+    try:
+      return sharding.maybe_shard_with_name(rolled, x_sharding, shard_mode=shard_mode, debug_sharding=debug_sharding)
+    except TypeError:
+      return rolled
+  return rolled
 
-  def scheduling_group(group_id) -> contextlib.AbstractContextManager[None]:
-    return jax.experimental.xla_metadata.set_xla_metadata(_scheduling_group_id=group_id)
 
-  with scheduling_group(group_id=40):
-    w_0 = jax.tree.map(lambda x: x[0], params)
-    w_init = jax.tree.map(_apply_sharding_hint, w_0)
+def _reduce_scatter_param_grads(grad_w, orig_w, shard_mode, debug_sharding=False):
+  """Applies sharding constraint to parameter gradients matching original parameter sharding."""
 
-  def scan_step_fn(carry, xs):
-    y_curr, w_curr = carry
-    st_i, nxt_params_i, idx = xs
+  def _shard(gw, ow):
+    if gw is None or ow is None:
+      return gw
+    s = getattr(jax.typeof(ow), "sharding", None) or getattr(ow, "sharding", None)
+    try:
+      return sharding.maybe_shard_with_name(gw, s, shard_mode=shard_mode, debug_sharding=debug_sharding)
+    except TypeError:
+      return gw
 
-    # A scheduling group is used to group all FSDP all-gathers together.
-    # This encourages XLA to schedule them together, which makes XLA's scheduling job easier.
-    with scheduling_group(group_id=43):
-      w_next_ag = jax.tree.map(_apply_sharding_hint, nxt_params_i)
-      w_prefetched_ag = checkpoint_name(w_next_ag, "fsdp_bsw")
-
-    # At the last step of the forward pass (idx=length-1), there is no next
-    # layer to prefetch. The all-gather is skipped to avoid redundant communication.
-    def _maybe_skip(ag_w, curr_w):
-      return jax.lax.cond(idx < length - 1, lambda: ag_w, lambda: curr_w)
-
-    w_prefetched = jax.tree.map(_maybe_skip, w_prefetched_ag, w_curr)
-
-    layer = nnx.merge(graphdef, w_curr, st_i)
-    layer_out = layer(y_curr, *args_tuple, **valid_kwargs)
-
-    y_out = layer_out[0] if isinstance(layer_out, tuple) else layer_out
-    _, _, new_state_i = nnx.split(layer, nnx.Param, ...)
-
-    # Gradients are stopped on the prefetched weights here because they are just
-    # being carried over to the next iteration. The actual gradient computation
-    # for these weights happens in the next iteration where they are used as w_curr.
-    if is_fwd:
-      return (y_out, jax.tree.map(jax.lax.stop_gradient, w_prefetched)), (new_state_i, y_curr)
-    return (y_out, jax.tree.map(jax.lax.stop_gradient, w_prefetched)), new_state_i
-
-  step_wrapped = jax.checkpoint(scan_step_fn, policy=policy, prevent_cse=prevent_cse)
-  if is_fwd:
-    (final_y, _), (scanned_state, y_seq) = jax.lax.scan(
-        step_wrapped, (x_in, w_init), (state, nxt_params_seq, jnp.arange(length))
-    )
-    return (final_y, scanned_state), (
-        y_seq,
-        params_leaves,
-        state_leaves,
-        scanned_state,
-        diff_args_leaves,
-        diff_kwargs_leaves,
-    )
-  else:
-    (final_y, _), scanned_state = jax.lax.scan(step_wrapped, (x_in, w_init), (state, nxt_params_seq, jnp.arange(length)))
-    return final_y, scanned_state
+  return jax.tree.map(_shard, grad_w, orig_w)
 
 
 @functools.partial(jax.custom_vjp, nondiff_argnums=(0, 6, 7))
@@ -493,29 +422,22 @@ def _custom_vjp_prefetch_pipeline(
     graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx
 ):
   """Forward pipeline wrapper for custom_vjp prefetching."""
-  return _run_prefetch_pipeline_fwd(
-      graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx, is_fwd=False
+  out, _ = _custom_vjp_prefetch_pipeline_fwd(
+      graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx
   )
+  return out
 
 
 def _custom_vjp_prefetch_pipeline_fwd(
     graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx
 ):
   """Forward autodiff pass wrapper for custom_vjp prefetching."""
-  return _run_prefetch_pipeline_fwd(
-      graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx, is_fwd=True
-  )
-
-
-def _custom_vjp_prefetch_pipeline_bwd(graphdef, length, ctx, res, g_out):
-  """Backward autodiff pass wrapper for custom_vjp prefetching."""
-  y_seq, params_leaves, state_leaves, _, diff_args_leaves, diff_kwargs_leaves = res
-  y_bar_final, _ = g_out
   (
       mesh,
       shard_mode,
-      _,
-      _,
+      prevent_cse,
+      policy,
+      debug_sharding,
       static_args_leaves,
       static_kwargs_leaves,
       params_treedef,
@@ -533,95 +455,123 @@ def _custom_vjp_prefetch_pipeline_bwd(graphdef, length, ctx, res, g_out):
   kwargs_tuple = jax.tree_util.tree_unflatten(kwargs_treedef, reconstructed_kwargs_leaves)
   valid_kwargs = dict(kwargs_tuple)
 
-  def _apply_sharding_hint(w):
-    w_sharding = getattr(jax.typeof(w), "sharding", None) or getattr(w, "sharding", None)
-    if isinstance(w_sharding, NamedSharding) and w_sharding.spec is not None:
-      w_sharding_clean = NamedSharding(mesh, w_sharding.spec)
-      w = jax.lax.with_sharding_constraint(w, w_sharding_clean)
-      stripped_spec = sharding.strip_fsdp_from_spec(w_sharding.spec)
-      w_sharding_stripped = NamedSharding(mesh, stripped_spec)
-      return sharding.maybe_shard_with_name(w, w_sharding_stripped, shard_mode=shard_mode)
-    return sharding.maybe_shard_with_name(w, w_sharding, shard_mode=shard_mode)
-
-  def _reduce_scatter_param_grads(grad_w, orig_w):
-    return jax.tree.map(
-        lambda gw, ow: sharding.maybe_shard_with_name(
-            gw, getattr(jax.typeof(ow), "sharding", None) or getattr(ow, "sharding", None), shard_mode=shard_mode
-        )
-        if gw is not None and ow is not None
-        else gw,
-        grad_w,
-        orig_w,
-    )
-
-  def _roll_fwd_and_shard(x):
-    rolled = jnp.roll(x, 1, axis=0)
-    x_sharding = getattr(jax.typeof(x), "sharding", None) or getattr(x, "sharding", None)
-    if isinstance(x_sharding, NamedSharding):
-      return jax.lax.with_sharding_constraint(rolled, x_sharding)
-    return rolled
-
-  prev_params_seq = jax.tree.map(_roll_fwd_and_shard, params)
+  nxt_params_seq = jax.tree.map(lambda x: _roll_and_shard(x, -1, shard_mode, debug_sharding), params)
 
   def scheduling_group(group_id) -> contextlib.AbstractContextManager[None]:
     return jax.experimental.xla_metadata.set_xla_metadata(_scheduling_group_id=group_id)
 
   with scheduling_group(group_id=40):
-    w_last = jax.tree.map(lambda x: x[-1], params)
-    w_bwd_init = jax.tree.map(_apply_sharding_hint, w_last)
+    w_0 = jax.tree.map(lambda x: x[0], params)
+    w_init = jax.tree.map(lambda x: _apply_sharding_hint(x, mesh, shard_mode, debug_sharding), w_0)
 
-  def scan_step_bwd(carry, xs):
-    y_bar_curr, w_curr = carry
-    y_i, orig_w_i, prev_params_i, st_i, idx = xs
+  def scanned_layers_fn(x_in_scan, bsw):
+    # Unpack initial layer weights and rolled next-layer parameters from the bsw tuple.
+    # Passing bsw as a differentiable argument to jax.vjp allows scan_vjp_fn to compute
+    # parameter gradients for all layers in the backward pass.
+    w_curr, nxt_params = bsw
 
-    # A scheduling group is used to group all FSDP all-gathers together.
-    # This encourages XLA to schedule them together, which makes XLA's scheduling job easier.
-    with scheduling_group(group_id=43):
-      w_prev_ag = jax.tree.map(_apply_sharding_hint, prev_params_i)
-      w_prefetched_ag = checkpoint_name(w_prev_ag, "fsdp_bsw")
+    def scan_step_fn(carry, xs):
+      y_curr, w_c = carry
+      st_i, nxt_params_i, idx = xs
 
-    # At the last step of the backward pass (idx=0, corresponding to the first
-    # layer in the forward pass), there is no previous layer to prefetch.
-    # The all-gather is skipped to avoid redundant communication.
-    def _maybe_skip(ag_w, curr_w):
-      return jax.lax.cond(idx > 0, lambda: ag_w, lambda: curr_w)
+      with scheduling_group(group_id=43):
+        w_next_ag = jax.tree.map(lambda x: _apply_sharding_hint(x, mesh, shard_mode, debug_sharding), nxt_params_i)
+        w_prefetched_ag = checkpoint_name(w_next_ag, "fsdp_bsw")
 
-    w_prefetched = jax.tree.map(_maybe_skip, w_prefetched_ag, w_curr)
+      def _maybe_skip(ag_w, curr_w):
+        return jax.lax.cond(idx < length - 1, lambda: ag_w, lambda: curr_w)
 
-    def _single_layer_fn(y_inp, w_inp):
-      layer = nnx.merge(graphdef, w_inp, st_i)
-      layer_out = layer(y_inp, *args_tuple, **valid_kwargs)
-      y_out = layer_out[0] if isinstance(layer_out, tuple) else layer_out
-      return y_out
+      w_prefetched = jax.tree.map(_maybe_skip, w_prefetched_ag, w_c)
 
-    _, vjp_fn = jax.vjp(_single_layer_fn, y_i, w_curr)
-    y_bar_prev, w_bar_unreduced = vjp_fn(y_bar_curr)
+      def _single_layer_fn(y_inp, w_inp):
+        layer = nnx.merge(graphdef, w_inp, st_i)
+        layer_out = layer(y_inp, *args_tuple, **valid_kwargs)
+        return layer_out[0] if isinstance(layer_out, tuple) else layer_out
 
-    w_bar_sharded_i = _reduce_scatter_param_grads(w_bar_unreduced, orig_w_i)
+      if policy is not None:
+        _single_layer_fn_remat = jax.checkpoint(_single_layer_fn, policy=policy, prevent_cse=prevent_cse)
+      else:
+        _single_layer_fn_remat = _single_layer_fn
 
-    # Gradients are stopped on the prefetched weights here because they are just
-    # being carried over to the next iteration. The actual gradient computation
-    # for these weights happens in the next iteration where they are used as w_curr.
-    return (y_bar_prev, jax.tree.map(jax.lax.stop_gradient, w_prefetched)), w_bar_sharded_i
+      y_out = _single_layer_fn_remat(y_curr, w_c)
+      layer = nnx.merge(graphdef, w_c, st_i)
+      _, _, new_state_i = nnx.split(layer, nnx.Param, ...)
 
-  (y_bar_in, _), params_bar_stacked = jax.lax.scan(
-      scan_step_bwd,
-      (y_bar_final, w_bwd_init),
-      (y_seq, params, prev_params_seq, state, jnp.arange(length)),
-      reverse=True,
+      # Stop gradients on the prefetched weights carried over to the next iteration.
+      # The actual gradient computation for these weights occurs in the next step when consumed as w_curr.
+      return (y_out, jax.tree.map(jax.lax.stop_gradient, w_prefetched)), new_state_i
+
+    (final_y, _), scanned_state = jax.lax.scan(scan_step_fn, (x_in_scan, w_curr), (state, nxt_params, jnp.arange(length)))
+    return final_y, scanned_state
+
+  (final_y, scanned_state), scan_vjp_fn = jax.vjp(scanned_layers_fn, x_in, (w_init, nxt_params_seq))
+  scan_vjp_fn.args_res[1] = None
+
+  return (final_y, scanned_state), (
+      scan_vjp_fn,
+      scanned_state,
+      params_leaves,
+      diff_args_leaves,
+      diff_kwargs_leaves,
   )
 
-  params_bar_leaves = tuple(jax.tree_util.tree_leaves(params_bar_stacked))
+
+def _custom_vjp_prefetch_pipeline_bwd(_graphdef, _length, ctx, res, g_out):
+  """Backward autodiff pass wrapper for custom_vjp prefetching."""
+  scan_vjp_fn, scanned_state, params_leaves, diff_args_leaves, diff_kwargs_leaves = res
+  y_bar_final, g_scanned_state = g_out
+  (
+      mesh,
+      shard_mode,
+      _,
+      _,
+      debug_sharding,
+      _,
+      _,
+      params_treedef,
+      _,
+      _,
+      _,
+  ) = ctx
+  params = jax.tree_util.tree_unflatten(params_treedef, params_leaves)
+
+  nxt_params_seq = jax.tree.map(lambda x: _roll_and_shard(x, -1, shard_mode, debug_sharding), params)
+
+  def scheduling_group(group_id) -> contextlib.AbstractContextManager[None]:
+    return jax.experimental.xla_metadata.set_xla_metadata(_scheduling_group_id=group_id)
+
+  with scheduling_group(group_id=40):
+    w_0 = jax.tree.map(lambda x: x[0], params)
+    w_init = jax.tree.map(lambda x: _apply_sharding_hint(x, mesh, shard_mode, debug_sharding), w_0)
+
+  if g_scanned_state is None:
+    g_scanned_state = jax.tree.map(
+        lambda x: jnp.zeros_like(x) if isinstance(x, jax.Array) else None,
+        scanned_state,
+    )
+
+  scan_vjp_fn.args_res[1] = (w_init, nxt_params_seq)
+  dx_in, (dw_init, d_nxt_params_seq) = scan_vjp_fn((y_bar_final, g_scanned_state))
+
+  # Roll back rolled parameter gradients to match original stacked params shape
+  d_params_seq = jax.tree.map(lambda x: _roll_and_shard(x, 1, shard_mode, debug_sharding), d_nxt_params_seq)
+
+  # Combine dw_init (gradient for layer 0 initial weights) into layer 0 of d_params_seq
+  def _add_w0(dp, w0):
+    return dp.at[0].add(w0)
+
+  params_bar_stacked = jax.tree.map(_add_w0, d_params_seq, dw_init)
+  params_bar_sharded = _reduce_scatter_param_grads(params_bar_stacked, params, shard_mode, debug_sharding)
+  params_bar_leaves = tuple(jax.tree_util.tree_leaves(params_bar_sharded))
 
   def _zero_tangent(x):
     if isinstance(x, jax.Array) or (hasattr(jax.core, "Tracer") and isinstance(x, jax.core.Tracer)):
       return jnp.zeros_like(x)
     return None
 
-  state_bar_leaves = tuple(_zero_tangent(x) for x in state_leaves)
   diff_args_bar_leaves = tuple(_zero_tangent(x) for x in diff_args_leaves)
   diff_kwargs_bar_leaves = tuple(_zero_tangent(x) for x in diff_kwargs_leaves)
-  return y_bar_in, params_bar_leaves, state_bar_leaves, diff_args_bar_leaves, diff_kwargs_bar_leaves
+  return dx_in, params_bar_leaves, None, diff_args_bar_leaves, diff_kwargs_bar_leaves
 
 
 _custom_vjp_prefetch_pipeline.defvjp(_custom_vjp_prefetch_pipeline_fwd, _custom_vjp_prefetch_pipeline_bwd)
@@ -1291,6 +1241,10 @@ class NNXDecoder(nnx.Module):
     args_tuple = tuple(args)
     kwargs_tuple = tuple(valid_kwargs.items())
 
+    # jax.custom_vjp requires positional arguments (1-5) to consist strictly of differentiable JAX arrays.
+    # We split positional (args) and keyword (kwargs) arguments into two parallel structures:
+    # 1. diff_*_leaves: Contains ONLY JAX arrays/tracers (substituting non-arrays with dummy_arr).
+    # 2. static_*_leaves: Contains non-array metadata (booleans, strings, shapes), passed via static context (ctx).
     def _is_diff_leaf(x):
       return isinstance(x, jax.Array) or (hasattr(jax.core, "Tracer") and isinstance(x, jax.core.Tracer))
 
@@ -1315,6 +1269,7 @@ class NNXDecoder(nnx.Module):
         self.config.shard_mode,
         prevent_cse,
         policy,
+        self.config.debug_sharding,
         static_args_leaves,
         static_kwargs_leaves,
         params_treedef,
@@ -1327,12 +1282,7 @@ class NNXDecoder(nnx.Module):
         graphdef, x_in, params_leaves, state_leaves, diff_args_leaves, diff_kwargs_leaves, length, ctx
     )
 
-    scanned_state = maxtext_utils_nnx.nnx_add_scan_axis(scanned_state, "layers", 0)
-
-    if scan_axis != 0:
-      new_params, new_rest = scanned_state.split(nnx.Param, ...)
-      new_params = maxtext_utils_nnx.nnx_sync_moveaxis(new_params, 0, scan_axis)
-      scanned_state = nnx.merge_state(new_params, new_rest)
+    scanned_state = maxtext_utils_nnx.nnx_add_and_sync_scan_axis(scanned_state, "layers")
 
     nnx.update(layers, scanned_state)
     return final_y, layers, None
@@ -1610,7 +1560,13 @@ class NNXDecoder(nnx.Module):
           raise ValueError(f"Unsupported model_name for multimodal: {cfg.model_name}")
 
       if video_embeddings is not None and cfg.use_multimodal:
-        if cfg.model_name in {"qwen3-omni-30b-a3b", "qwen3-vl-2b", "qwen3-vl-4b", "qwen3.5-35b-a3b", "qwen3.5-397b-a17b"}:
+        if cfg.model_name in {
+            "qwen3-omni-30b-a3b",
+            "qwen3-vl-2b",
+            "qwen3-vl-4b",
+            "qwen3.5-35b-a3b",
+            "qwen3.5-397b-a17b",
+        }:
           y = mm_utils.merge_mm_embeddings(
               text_embeddings=y,
               multimodal_embeddings=video_embeddings,

--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -390,18 +390,6 @@ def _apply_sharding_hint(w, mesh, shard_mode, debug_sharding=False):
     return w
 
 
-def _roll_and_shard(x, shift, shard_mode, debug_sharding=False):
-  """Rolls an array along axis 0 by `shift` and applies its sharding constraint."""
-  rolled = jnp.roll(x, shift, axis=0)
-  x_sharding = getattr(jax.typeof(x), "sharding", None) or getattr(x, "sharding", None)
-  if isinstance(x_sharding, NamedSharding):
-    try:
-      return sharding.maybe_shard_with_name(rolled, x_sharding, shard_mode=shard_mode, debug_sharding=debug_sharding)
-    except TypeError:
-      return rolled
-  return rolled
-
-
 def _reduce_scatter_param_grads(grad_w, orig_w, shard_mode, debug_sharding=False):
   """Applies sharding constraint to parameter gradients matching original parameter sharding."""
 
@@ -455,56 +443,46 @@ def _custom_vjp_prefetch_pipeline_fwd(
   kwargs_tuple = jax.tree_util.tree_unflatten(kwargs_treedef, reconstructed_kwargs_leaves)
   valid_kwargs = dict(kwargs_tuple)
 
-  nxt_params_seq = jax.tree.map(lambda x: _roll_and_shard(x, -1, shard_mode, debug_sharding), params)
-
   def scheduling_group(group_id) -> contextlib.AbstractContextManager[None]:
     return jax.experimental.xla_metadata.set_xla_metadata(_scheduling_group_id=group_id)
 
-  with scheduling_group(group_id=40):
-    w_0 = jax.tree.map(lambda x: x[0], params)
-    w_init = jax.tree.map(lambda x: _apply_sharding_hint(x, mesh, shard_mode, debug_sharding), w_0)
+  def scanned_layers_fn(x_in_scan, params_diff):
+    # params_diff: the original stacked SHARDED params, the only differentiable weight
+    # input. Step i's xs slice holds layer i's sharded weights; gradients reduce-scatter
+    # directly into it. The all-gather happens INSIDE the remat region, so:
+    #   - only the sharded params_i slice is saved as a scan residual (no gathered
+    #     weights are kept alive from fwd to bwd),
+    #   - the backward pass re-gathers from the sharded slice (unless the remat policy
+    #     explicitly saves "fsdp_bsw"),
+    #   - the scheduling-group metadata lets XLA's latency-hiding scheduler overlap the
+    #     gather with surrounding compute in both fwd and bwd.
 
-  def scanned_layers_fn(x_in_scan, bsw):
-    # Unpack initial layer weights and rolled next-layer parameters from the bsw tuple.
-    # Passing bsw as a differentiable argument to jax.vjp allows scan_vjp_fn to compute
-    # parameter gradients for all layers in the backward pass.
-    w_curr, nxt_params = bsw
+    def scan_step_fn(y_curr, xs):
+      st_i, params_i = xs
 
-    def scan_step_fn(carry, xs):
-      y_curr, w_c = carry
-      st_i, nxt_params_i, idx = xs
-
-      with scheduling_group(group_id=43):
-        w_next_ag = jax.tree.map(lambda x: _apply_sharding_hint(x, mesh, shard_mode, debug_sharding), nxt_params_i)
-        w_prefetched_ag = checkpoint_name(w_next_ag, "fsdp_bsw")
-
-      def _maybe_skip(ag_w, curr_w):
-        return jax.lax.cond(idx < length - 1, lambda: ag_w, lambda: curr_w)
-
-      w_prefetched = jax.tree.map(_maybe_skip, w_prefetched_ag, w_c)
-
-      def _single_layer_fn(y_inp, w_inp):
-        layer = nnx.merge(graphdef, w_inp, st_i)
+      def _single_layer_fn(y_inp, params_i_inp):
+        with scheduling_group(group_id=43):
+          w_ag = jax.tree.map(lambda x: _apply_sharding_hint(x, mesh, shard_mode, debug_sharding), params_i_inp)
+          w_ag = checkpoint_name(w_ag, "fsdp_bsw")
+        layer = nnx.merge(graphdef, w_ag, st_i)
         layer_out = layer(y_inp, *args_tuple, **valid_kwargs)
         return layer_out[0] if isinstance(layer_out, tuple) else layer_out
 
-      if policy is not None:
-        _single_layer_fn_remat = jax.checkpoint(_single_layer_fn, policy=policy, prevent_cse=prevent_cse)
-      else:
-        _single_layer_fn_remat = _single_layer_fn
+      _single_layer_fn_remat = jax.checkpoint(_single_layer_fn, policy=policy, prevent_cse=prevent_cse)
 
-      y_out = _single_layer_fn_remat(y_curr, w_c)
-      layer = nnx.merge(graphdef, w_c, st_i)
+      y_out = _single_layer_fn_remat(y_curr, params_i)
+      layer = nnx.merge(graphdef, params_i, st_i)
       _, _, new_state_i = nnx.split(layer, nnx.Param, ...)
 
-      # Stop gradients on the prefetched weights carried over to the next iteration.
-      # The actual gradient computation for these weights occurs in the next step when consumed as w_curr.
-      return (y_out, jax.tree.map(jax.lax.stop_gradient, w_prefetched)), new_state_i
+      return y_out, new_state_i
 
-    (final_y, _), scanned_state = jax.lax.scan(scan_step_fn, (x_in_scan, w_curr), (state, nxt_params, jnp.arange(length)))
+    final_y, scanned_state = jax.lax.scan(scan_step_fn, x_in_scan, (state, params_diff))
     return final_y, scanned_state
 
-  (final_y, scanned_state), scan_vjp_fn = jax.vjp(scanned_layers_fn, x_in, (w_init, nxt_params_seq))
+  (final_y, scanned_state), scan_vjp_fn = jax.vjp(scanned_layers_fn, x_in, params)
+  # Drop the stacked sharded params residual held by the vjp closure; it is re-injected
+  # in the backward pass from params_leaves (which alias the caller's live params), so
+  # no extra full-stack copy is retained between fwd and bwd.
   scan_vjp_fn.args_res[1] = None
 
   return (final_y, scanned_state), (
@@ -521,11 +499,11 @@ def _custom_vjp_prefetch_pipeline_bwd(_graphdef, _length, ctx, res, g_out):
   scan_vjp_fn, scanned_state, params_leaves, diff_args_leaves, diff_kwargs_leaves = res
   y_bar_final, g_scanned_state = g_out
   (
-      mesh,
-      shard_mode,
       _,
       _,
-      debug_sharding,
+      _,
+      _,
+      _,
       _,
       _,
       params_treedef,
@@ -533,16 +511,10 @@ def _custom_vjp_prefetch_pipeline_bwd(_graphdef, _length, ctx, res, g_out):
       _,
       _,
   ) = ctx
+  # Re-inject the stacked sharded params residual dropped in fwd. params_leaves alias the
+  # caller's live params, so this holds no extra full-stack copy across the fwd/bwd gap.
   params = jax.tree_util.tree_unflatten(params_treedef, params_leaves)
-
-  nxt_params_seq = jax.tree.map(lambda x: _roll_and_shard(x, -1, shard_mode, debug_sharding), params)
-
-  def scheduling_group(group_id) -> contextlib.AbstractContextManager[None]:
-    return jax.experimental.xla_metadata.set_xla_metadata(_scheduling_group_id=group_id)
-
-  with scheduling_group(group_id=40):
-    w_0 = jax.tree.map(lambda x: x[0], params)
-    w_init = jax.tree.map(lambda x: _apply_sharding_hint(x, mesh, shard_mode, debug_sharding), w_0)
+  scan_vjp_fn.args_res[1] = params
 
   if g_scanned_state is None:
     g_scanned_state = jax.tree.map(
@@ -550,19 +522,12 @@ def _custom_vjp_prefetch_pipeline_bwd(_graphdef, _length, ctx, res, g_out):
         scanned_state,
     )
 
-  scan_vjp_fn.args_res[1] = (w_init, nxt_params_seq)
-  dx_in, (dw_init, d_nxt_params_seq) = scan_vjp_fn((y_bar_final, g_scanned_state))
-
-  # Roll back rolled parameter gradients to match original stacked params shape
-  d_params_seq = jax.tree.map(lambda x: _roll_and_shard(x, 1, shard_mode, debug_sharding), d_nxt_params_seq)
-
-  # Combine dw_init (gradient for layer 0 initial weights) into layer 0 of d_params_seq
-  def _add_w0(dp, w0):
-    return dp.at[0].add(w0)
-
-  params_bar_stacked = jax.tree.map(_add_w0, d_params_seq, dw_init)
-  params_bar_sharded = _reduce_scatter_param_grads(params_bar_stacked, params, shard_mode, debug_sharding)
-  params_bar_leaves = tuple(jax.tree_util.tree_leaves(params_bar_sharded))
+  # Gradients flow through the in-remat gather of the sharded params, so d_params comes
+  # out of the scan VJP already sharded like the stacked sharded params (the gather's
+  # transpose is a reduce-scatter); no post-hoc resharding is needed (it would force an
+  # extra full-stack copy).
+  dx_in, d_params = scan_vjp_fn((y_bar_final, g_scanned_state))
+  params_bar_leaves = tuple(jax.tree_util.tree_leaves(d_params))
 
   def _zero_tangent(x):
     if isinstance(x, jax.Array) or (hasattr(jax.core, "Tracer") and isinstance(x, jax.core.Tracer)):

--- a/src/maxtext/utils/sharding.py
+++ b/src/maxtext/utils/sharding.py
@@ -919,3 +919,10 @@ def all_gather_over_fsdp(variables, sharding_info, mesh, logical_axis_rules, sha
   # Apply the constraint to the model's current variables. This tells JAX to
   # gather the weights into this layout.
   return maybe_shard_with_name(variables, physical_constraint_no_fsdp, shard_mode=shard_mode)
+
+
+def strip_fsdp_from_spec(spec):
+  """Strip FSDP mesh axes from partition spec."""
+  if spec is None:
+    return None
+  return P(*(None if axis in ("fsdp", "fsdp_transpose") else axis for axis in spec))

--- a/src/maxtext/utils/sharding.py
+++ b/src/maxtext/utils/sharding.py
@@ -919,10 +919,3 @@ def all_gather_over_fsdp(variables, sharding_info, mesh, logical_axis_rules, sha
   # Apply the constraint to the model's current variables. This tells JAX to
   # gather the weights into this layout.
   return maybe_shard_with_name(variables, physical_constraint_no_fsdp, shard_mode=shard_mode)
-
-
-def strip_fsdp_from_spec(spec):
-  """Strip FSDP mesh axes from partition spec."""
-  if spec is None:
-    return None
-  return P(*(None if axis in ("fsdp", "fsdp_transpose") else axis for axis in spec))

--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -32,7 +32,8 @@ import jax.numpy as jnp
 import numpy as np
 from flax import linen as nn
 from flax import nnx
-from jax.sharding import Mesh
+from jax._src.sharding_impls import GSPMDSharding  # pylint: disable=protected-access
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 from maxtext.common.common_types import (
     DECODING_ACTIVE_SEQUENCE_INDICATOR,
@@ -1049,7 +1050,10 @@ class TestGemma4SmallNNXDecoder(unittest.TestCase):
             return 0
           return gemma4_small.kv_donor_layer_idx(lyr, layer_types, num_kv_shared)
 
-        with patch("maxtext.models.gemma4_small.kv_donor_layer_idx", side_effect=mock_donor_idx):
+        with patch(
+            "maxtext.models.gemma4_small.kv_donor_layer_idx",
+            side_effect=mock_donor_idx,
+        ):
           decoder(
               shared_embedding,
               ids,
@@ -1059,3 +1063,407 @@ class TestGemma4SmallNNXDecoder(unittest.TestCase):
               model_mode=MODEL_MODE_TRAIN,
               kv_caches=kv_caches,
           )
+
+
+class TestNNXDecoderPrefetching(unittest.TestCase):
+  """Unit and integration tests for FSDP BSW dual-buffer lookahead prefetching."""
+
+  def setUp(self):
+    super().setUp()
+    self.cfg = _make_config(scan_layers=True, prefetch_fsdp_weights=True, num_decoder_layers=3)
+    self.mesh = _make_mesh(self.cfg)
+    self.rng = jax.random.PRNGKey(0)
+    self.rngs = nnx.Rngs(params=0, dropout=1)
+
+  def _make_token_inputs(self):
+    batch = self.cfg.global_batch_size_to_train_on
+    seq_len = self.cfg.max_target_length
+    ids = jax.random.randint(self.rng, (batch, seq_len), 0, self.cfg.vocab_size)
+    segment_ids = jnp.full((batch, seq_len), DECODING_ACTIVE_SEQUENCE_INDICATOR)
+    positions = jnp.broadcast_to(jnp.arange(seq_len)[None], (batch, seq_len))
+    return ids, segment_ids, positions
+
+  def _get_sharded_params_and_state(self, decoder, with_fsdp=False, use_partition_specs=False):
+    """Splits decoder and applies NamedSharding with partition specs to parameters."""
+    nnx.pop(decoder, nnx.RngState, nnx.RngCount)
+    graphdef, params, state = nnx.split(decoder, nnx.Param, ...)
+
+    def _shard_arr(arr):
+      if isinstance(arr, jax.Array):
+        if with_fsdp and arr.ndim >= 2:
+          fsdp_size = self.mesh.shape.get("fsdp", 1)
+          data_size = self.mesh.shape.get("data", 1)
+          axis_0 = "fsdp" if arr.shape[0] % fsdp_size == 0 else None
+          axis_1 = "data" if arr.ndim > 2 and arr.shape[1] % data_size == 0 else None
+          spec = PartitionSpec(axis_0, axis_1)
+        else:
+          spec = PartitionSpec()
+        if use_partition_specs:
+          # Directly return the array with sharding attribute set as PartitionSpec string/spec for testing
+          return jax.lax.with_sharding_constraint(arr, NamedSharding(self.mesh, spec))
+        return jax.lax.with_sharding_constraint(arr, NamedSharding(self.mesh, spec))
+      return arr
+
+    params = jax.tree.map(_shard_arr, params)
+    return graphdef, params, state
+
+  def test_prefetch_forward_pass_no_grad(self):
+    """Exercises _custom_vjp_prefetch_pipeline outside autodiff (is_fwd=False)."""
+    decoder = NNXDecoder(config=self.cfg, mesh=self.mesh, model_mode=MODEL_MODE_TRAIN, rngs=self.rngs)
+    shared_emb = Embed(
+        num_embeddings=self.cfg.vocab_size,
+        num_features=self.cfg.emb_dim,
+        dtype=self.cfg.dtype,
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        config=self.cfg,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    ids, segment_ids, positions = self._make_token_inputs()
+    graphdef, params, state = self._get_sharded_params_and_state(decoder, with_fsdp=False)
+    m = nnx.merge(graphdef, params, state)
+    logits, _, kv = m(
+        shared_emb,
+        ids,
+        positions,
+        decoder_segment_ids=segment_ids,
+        deterministic=True,
+        model_mode=MODEL_MODE_TRAIN,
+    )
+    self.assertEqual(
+        logits.shape,
+        (
+            self.cfg.global_batch_size_to_train_on,
+            self.cfg.max_target_length,
+            self.cfg.vocab_size,
+        ),
+    )
+    self.assertIsNone(kv)
+
+  def test_prefetch_value_and_grad(self):
+    """Exercises _custom_vjp_prefetch_pipeline_fwd and _custom_vjp_prefetch_pipeline_bwd."""
+    decoder = NNXDecoder(config=self.cfg, mesh=self.mesh, model_mode=MODEL_MODE_TRAIN, rngs=self.rngs)
+    shared_emb = Embed(
+        num_embeddings=self.cfg.vocab_size,
+        num_features=self.cfg.emb_dim,
+        dtype=self.cfg.dtype,
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        config=self.cfg,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    ids, segment_ids, positions = self._make_token_inputs()
+    graphdef, params, state = self._get_sharded_params_and_state(decoder, with_fsdp=False)
+
+    # pylint: disable=too-many-positional-arguments
+    def loss_fn(p, s, emb, token_ids, pos, seg_ids):
+      m = nnx.merge(graphdef, p, s)
+      out_logits, _, _ = m(
+          emb,
+          token_ids,
+          pos,
+          decoder_segment_ids=seg_ids,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.sum(out_logits**2)
+
+    loss_val, (grad_params, grad_emb) = jax.value_and_grad(loss_fn, argnums=(0, 2))(
+        params, state, shared_emb, ids, positions, segment_ids
+    )
+    self.assertTrue(jnp.isfinite(loss_val))
+    self.assertIsNotNone(grad_params)
+    self.assertIsNotNone(grad_emb)
+
+  def test_prefetch_sharding_hints_and_fsdp_spec(self):
+    """Exercises PartitionSpec stripping, NamedSharding branches, and reduce-scatter collective helpers."""
+    decoder = NNXDecoder(config=self.cfg, mesh=self.mesh, model_mode=MODEL_MODE_TRAIN, rngs=self.rngs)
+    shared_emb = Embed(
+        num_embeddings=self.cfg.vocab_size,
+        num_features=self.cfg.emb_dim,
+        dtype=self.cfg.dtype,
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        config=self.cfg,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    ids, segment_ids, positions = self._make_token_inputs()
+    graphdef, params_sharded, state = self._get_sharded_params_and_state(decoder, with_fsdp=True)
+
+    def loss_fn(p, s):
+      m = nnx.merge(graphdef, p, s)
+      out_logits, _, _ = m(
+          shared_emb,
+          ids,
+          positions,
+          decoder_segment_ids=segment_ids,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.sum(out_logits)
+
+    loss_val, grad_params = jax.value_and_grad(loss_fn)(params_sharded, state)
+    self.assertTrue(jnp.isfinite(loss_val))
+    self.assertIsNotNone(grad_params)
+
+  def test_prefetch_tuple_and_nontuple_layer_output(self):
+    """Exercises layer output unpacking branches for tuple and non-tuple return types in fwd and bwd."""
+    decoder = NNXDecoder(config=self.cfg, mesh=self.mesh, model_mode=MODEL_MODE_TRAIN, rngs=self.rngs)
+    shared_emb = Embed(
+        num_embeddings=self.cfg.vocab_size,
+        num_features=self.cfg.emb_dim,
+        dtype=self.cfg.dtype,
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        config=self.cfg,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    ids, segment_ids, positions = self._make_token_inputs()
+    graphdef, params, state = self._get_sharded_params_and_state(decoder, with_fsdp=False)
+
+    with unittest.mock.patch(
+        "maxtext.layers.nnx_decoders.NNXDecoderLayer.__call__",
+        return_value=jnp.zeros(
+            (
+                self.cfg.global_batch_size_to_train_on,
+                self.cfg.max_target_length,
+                self.cfg.emb_dim,
+            )
+        ),
+    ):
+
+      def loss_fn(p, s):
+        m = nnx.merge(graphdef, p, s)
+        out_logits, _, _ = m(
+            shared_emb,
+            ids,
+            positions,
+            decoder_segment_ids=segment_ids,
+            deterministic=True,
+            model_mode=MODEL_MODE_TRAIN,
+        )
+        return jnp.sum(out_logits)
+
+      loss_val, grad_params = jax.value_and_grad(loss_fn)(params, state)
+      self.assertTrue(jnp.isfinite(loss_val))
+      self.assertIsNotNone(grad_params)
+
+  def test_prefetch_zero_length(self):
+    """Exercises length == 0 fast return inside _apply_layers_sequentially_prefetch."""
+    decoder = NNXDecoder(config=self.cfg, mesh=self.mesh, model_mode=MODEL_MODE_TRAIN, rngs=self.rngs)
+    hidden = jnp.zeros(
+        (
+            self.cfg.global_batch_size_to_train_on,
+            self.cfg.max_target_length,
+            self.cfg.emb_dim,
+        )
+    )
+    # pylint: disable=protected-access
+    out, _, kv = decoder._apply_layers_sequentially_prefetch(decoder.layers, hidden, length=0)
+    self.assertEqual(out.shape, hidden.shape)
+    self.assertIsNone(kv)
+
+  def test_prefetch_unnamed_sharding_and_none_specs(self):
+    """Exercises non-NamedSharding branches and None specs inside prefetch pipeline fwd/bwd helpers."""
+    # 1) Exercise non-NamedSharding branches by mocking getattr for 'sharding' attribute on params
+    rngs1 = nnx.Rngs(params=0, dropout=1)
+    cfg_auto = _make_config(
+        scan_layers=True,
+        prefetch_fsdp_weights=True,
+        num_decoder_layers=2,
+        shard_mode="auto",
+    )
+    decoder = NNXDecoder(config=cfg_auto, mesh=self.mesh, model_mode=MODEL_MODE_TRAIN, rngs=rngs1)
+    shared_emb = Embed(
+        num_embeddings=cfg_auto.vocab_size,
+        num_features=cfg_auto.emb_dim,
+        dtype=cfg_auto.dtype,
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        config=cfg_auto,
+        mesh=self.mesh,
+        rngs=rngs1,
+    )
+    ids, segment_ids, positions = self._make_token_inputs()
+    nnx.pop(decoder, nnx.RngState, nnx.RngCount)
+    graphdef, params, state = nnx.split(decoder, nnx.Param, ...)
+
+    s_dev = GSPMDSharding.get_replicated(
+        tuple(self.mesh.devices.flat) if hasattr(self.mesh.devices, "flat") else tuple(self.mesh.devices)
+    )
+    orig_getattr = getattr
+
+    def _mock_getattr(obj, name, default=None):
+      if name == "sharding":
+        return s_dev
+      return orig_getattr(obj, name, default)
+
+    def loss_fn(p, s):
+      m = nnx.merge(graphdef, p, s)
+      out_logits, _, _ = m(
+          shared_emb,
+          ids,
+          positions,
+          decoder_segment_ids=segment_ids,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.sum(out_logits)
+
+    with unittest.mock.patch("maxtext.layers.nnx_decoders.getattr", side_effect=_mock_getattr):
+      loss_val, grad_params = jax.value_and_grad(loss_fn)(params, state)
+    self.assertTrue(jnp.isfinite(loss_val))
+    self.assertIsNotNone(grad_params)
+
+    # 2) Exercise shard_mode='auto' branches with explicit NamedSharding and PartitionSpec
+    rngs2 = nnx.Rngs(params=0, dropout=1)
+    cfg_auto_pspec = _make_config(
+        scan_layers=True,
+        prefetch_fsdp_weights=True,
+        num_decoder_layers=2,
+        shard_mode="auto",
+    )
+    decoder_pspec = NNXDecoder(
+        config=cfg_auto_pspec,
+        mesh=self.mesh,
+        model_mode=MODEL_MODE_TRAIN,
+        rngs=rngs2,
+    )
+    shared_emb_pspec = Embed(
+        num_embeddings=cfg_auto_pspec.vocab_size,
+        num_features=cfg_auto_pspec.emb_dim,
+        dtype=cfg_auto_pspec.dtype,
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        config=cfg_auto_pspec,
+        mesh=self.mesh,
+        rngs=rngs2,
+    )
+    nnx.pop(decoder_pspec, nnx.RngState, nnx.RngCount)
+    graphdef_pspec, params_pspec, state_pspec = nnx.split(decoder_pspec, nnx.Param, ...)
+
+    def _to_named_sharding_pspec(arr):
+      if isinstance(arr, jax.Array):
+        return jax.lax.with_sharding_constraint(
+            arr,
+            jax.sharding.NamedSharding(self.mesh, jax.sharding.PartitionSpec()),
+        )
+      return arr
+
+    params_pspec = jax.tree.map(_to_named_sharding_pspec, params_pspec)
+
+    def loss_fn_pspec(p, s):
+      m = nnx.merge(graphdef_pspec, p, s)
+      out_logits, _, _ = m(
+          shared_emb_pspec,
+          ids,
+          positions,
+          decoder_segment_ids=segment_ids,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.sum(out_logits)
+
+    loss_val_pspec, grad_params_pspec = jax.value_and_grad(loss_fn_pspec)(params_pspec, state_pspec)
+    self.assertTrue(jnp.isfinite(loss_val_pspec))
+    self.assertIsNotNone(grad_params_pspec)
+
+  def test_prefetch_with_param_scan_axis_nonzero(self):
+    """Exercises param_scan_axis != 0 inside _apply_layers_sequentially_prefetch."""
+    cfg_scan_1 = _make_config(
+        scan_layers=True,
+        prefetch_fsdp_weights=True,
+        num_decoder_layers=2,
+        param_scan_axis=1,
+    )
+    decoder = NNXDecoder(
+        config=cfg_scan_1,
+        mesh=self.mesh,
+        model_mode=MODEL_MODE_TRAIN,
+        rngs=self.rngs,
+    )
+    shared_emb = Embed(
+        num_embeddings=cfg_scan_1.vocab_size,
+        num_features=cfg_scan_1.emb_dim,
+        dtype=cfg_scan_1.dtype,
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        config=cfg_scan_1,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    ids, segment_ids, positions = self._make_token_inputs()
+    graphdef, params, state = self._get_sharded_params_and_state(decoder, with_fsdp=False)
+
+    def loss_fn(p, s):
+      m = nnx.merge(graphdef, p, s)
+      out_logits, _, _ = m(
+          shared_emb,
+          ids,
+          positions,
+          decoder_segment_ids=segment_ids,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.sum(out_logits)
+
+    loss_val, grad_params = jax.value_and_grad(loss_fn)(params, state)
+    self.assertTrue(jnp.isfinite(loss_val))
+    self.assertIsNotNone(grad_params)
+
+  def test_apply_layers_sequentially_zero_length_no_prefetch(self):
+    """Exercises length == 0 fast return inside _apply_layers_sequentially when prefetch_fsdp_weights is False."""
+    cfg_no_prefetch = _make_config(scan_layers=True, prefetch_fsdp_weights=False, num_decoder_layers=2)
+    decoder = NNXDecoder(
+        config=cfg_no_prefetch,
+        mesh=self.mesh,
+        model_mode=MODEL_MODE_TRAIN,
+        rngs=self.rngs,
+    )
+    hidden = jnp.zeros(
+        (
+            self.cfg.global_batch_size_to_train_on,
+            self.cfg.max_target_length,
+            self.cfg.emb_dim,
+        )
+    )
+    # pylint: disable=protected-access
+    out, _, kv = decoder._apply_layers_sequentially(decoder.layers, hidden, length=0, kv_caches_stacked=None)
+    self.assertEqual(out.shape, hidden.shape)
+    self.assertIsNone(kv)
+
+  def test_prefetch_pipeline_non_array_state_leaf(self):
+    """Exercises _zero_tangent returning None for non-array/non-tracer state leaves during backward pass."""
+    cfg_auto = _make_config(
+        scan_layers=True,
+        prefetch_fsdp_weights=True,
+        num_decoder_layers=2,
+        shard_mode="auto",
+    )
+    decoder = NNXDecoder(config=cfg_auto, mesh=self.mesh, model_mode=MODEL_MODE_TRAIN, rngs=self.rngs)
+    shared_emb = Embed(
+        num_embeddings=cfg_auto.vocab_size,
+        num_features=cfg_auto.emb_dim,
+        dtype=cfg_auto.dtype,
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        config=cfg_auto,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    ids, segment_ids, positions = self._make_token_inputs()
+
+    decoder.dummy = nnx.BatchStat(np.array([1.0, 2.0]))
+    graphdef, params, state = self._get_sharded_params_and_state(decoder, with_fsdp=False)
+
+    def loss_fn(p, s):
+      m = nnx.merge(graphdef, p, s)
+      out_logits, _, _ = m(
+          shared_emb,
+          ids,
+          positions,
+          decoder_segment_ids=segment_ids,
+          deterministic=True,
+          model_mode=MODEL_MODE_TRAIN,
+      )
+      return jnp.sum(out_logits)
+
+    loss_val, grad_params = jax.value_and_grad(loss_fn)(params, state)
+    self.assertTrue(jnp.isfinite(loss_val))
+    self.assertIsNotNone(grad_params)

--- a/tests/unit/nnx_decoders_test.py
+++ b/tests/unit/nnx_decoders_test.py
@@ -32,7 +32,6 @@ import jax.numpy as jnp
 import numpy as np
 from flax import linen as nn
 from flax import nnx
-from jax._src.sharding_impls import GSPMDSharding  # pylint: disable=protected-access
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 from maxtext.common.common_types import (
@@ -1287,9 +1286,7 @@ class TestNNXDecoderPrefetching(unittest.TestCase):
     nnx.pop(decoder, nnx.RngState, nnx.RngCount)
     graphdef, params, state = nnx.split(decoder, nnx.Param, ...)
 
-    s_dev = GSPMDSharding.get_replicated(
-        tuple(self.mesh.devices.flat) if hasattr(self.mesh.devices, "flat") else tuple(self.mesh.devices)
-    )
+    s_dev = NamedSharding(self.mesh, PartitionSpec())
     orig_getattr = getattr
 
     def _mock_getattr(obj, name, default=None):


### PR DESCRIPTION
# Description

### Overview
This PR implements **single-buffer lookahead parameter prefetching** for Fully Sharded Data Parallelism (FSDP / ZeRO-3) across `NNXDecoderLayer` and `nnx.scan` layer boundaries (`NNXScannedPipelineStage` / `NNXDecoder`). 
In standard FSDP training, parameter All-Gather collectives lie exposed on the critical execution path before every layer's forward computation, stalling TensorCores while waiting for interconnect transfers. By restructuring our scanned layers and `custom_vjp` stack to prefetch weights for layer `l+1` asynchronously while layer `l` executes, this PR decouples parameter reconstruction from immediate consumption and enables **complete communication-compute overlap**.

### Key Architectural Changes
1. **Double-Stacked `custom_vjp` Architecture for Scanned Weight Prefetching**
   - **Outer Custom VJP (`_custom_vjp_prefetch_scan`)**:
     - Decorates the full scanned decoder stack (`@functools.partial(jax.custom_vjp, nondiff_argnums=(0, 6, 7))`).
     - **Forward Pass (`_custom_vjp_prefetch_scan_fwd`)**: Executes the `jax.lax.scan` loop over layers while lookahead prefetching weights for upcoming layers (`scheduling_group(group_id=43)`). Evaluates per-layer forward autodiff passes (`_prefetch_single_layer_custom_vjp_fwd`) and collects the sequence of per-layer `vjp_fn` closures into `vjp_seq`.
     - **Primal Weight Clearing (`vjp_fn.args_res[1] = None`)**: Drops un-sharded primal weight arrays from residual memory immediately during the forward pass to minimize peak HBM footprint.
     - **Backward Pass (`_custom_vjp_prefetch_scan_bwd`)**: Scans backward (`jax.lax.scan(..., reverse=True)`), performing lookahead prefetching for reverse layer passes, restoring `vjp_fn_i.args_res[1] = w_curr` JIT right before evaluating each layer's VJP, and applying Reduce-Scatter ops (`_reduce_scatter_param_grads`) to parameter gradients.
   - **Inner Custom VJP (`_prefetch_single_layer_custom_vjp`)**:
     - Decorates single-layer execution (`@functools.partial(jax.custom_vjp, nondiff_argnums=(0, 1, 2, 3, 4, 5))`).
     - Encapsulates per-layer rematerialization policies (`jax.checkpoint(_single_layer_fn, policy=...)`) and manages single-step VJP evaluation.
2. **Scan Carry & Rematerialization Policy Separation**
   - `scan_step_fn` handles the scanned carry tuple `(y_out, w_prefetched)` and XLA scheduling groups, while `_prefetch_single_layer_custom_vjp` cleanly manages per-layer rematerialization and checkpointing.
3. **Scan Boundary All-Gather Wrap-Around Prevention**
   - Adds explicit boundary guards (`_maybe_skip` with `idx < length - 1` in forward and `idx > 0` in backward) to prevent `_apply_sharding_hint` from initiating multi-gigabyte All-Gathers on wrapped-around boundary parameters from `jnp.roll`.
   - **XLA Scheduling Group Safety**: Places conditional control flow (`jax.lax.cond`) *outside* of `scheduling_group(group_id=43)` so that the scheduling annotation wraps only pure data-flow operations (`_apply_sharding_hint` and `checkpoint_name`), completely avoiding XLA C++ `RemoveTrivialGroups()` iterator crashes on nested control flow.
4. **Array vs. Tracer Parameter Splitting (`diff_args_leaves` / `diff_kwargs_leaves`)**
   - Keeps integer/array arguments (e.g., `decoder_positions`, `decoder_segment_ids`, and attention masks) cleanly split as differentiable/non-differentiable leaves when passed into `_custom_vjp_prefetch_scan`.
   - Ensures JAX `Tracer` objects never enter `ctx` at `nondiff_argnums=(0, 6, 7)`, preventing `UnexpectedTracerError` while keeping `mesh`, `shard_mode`, and treedefs static.
5. **Unified `NNXDecoder.__call__` Layer Execution**
   - Redirects to `_apply_layers_sequentially_prefetch` when `prefetch_fsdp_weights` is enabled, unifying prefetching across scanned decoder stacks.

### Trade-offs & Best Practices

* **Ideal Use Case**: Maximum step-time savings occur when All-Gather communication duration (`T_AG`) closely matches GMM/dense compute duration (`T_GMM`).
* **Pros**: Significantly faster forward pass execution due to 100% overlap of All-Gather communication behind GMM compute blocks.
* **Cons**: Slightly higher High Bandwidth Memory (HBM) footprint since each device must hold two reconstructed layer weight matrices in memory simultaneously during the lookahead window.

#### Recommended XLA Compiler Flags
For optimal SparseCore offloading, copy elision, and latency hiding without systolic array interruption, run with:
```bash
--xla_tpu_rerun_latency_hiding_scheduler_post_sc_assignment=true \
--xla_tpu_num_sparse_cores_for_gather_offloading=1 \
--xla_tpu_enable_copy_fusion=true \
--xla_tpu_copy_elision_analysis_allowance=150000 \
--xla_tpu_copy_insertion_use_region_analysis_limit=10000 \
--xla_tpu_use_single_sparse_core_for_all_gather_offload=true
```

### Next Steps & Future Work
* **Backward Pass Reduce-Scatter Overlap**: While All-Gathers are now completely hidden in the forward pass, parameter gradient `reduce-scatter` collectives in the backward pass (`_custom_vjp_prefetch_scan_bwd`) remain exposed at the tail of each step (waiting for `A^T x dY` GMMs to finish). Future iterations will introduce lag-behind reverse scan carry pipelining to overlap backward `reduce-scatters` with TGMMs.

BUGS: b/515348405

# Tests & Verification

### XManager & XProf Benchmarks (TPU7x-64)
* **Baseline (Without Prefetching)**: `xid/271422723`
* **With Lookahead Prefetching**: `xid/273154030 `

### Results
* **Forward Pass Layer Execution**: In a balanced compute/communication regime, single sparse decoder layer duration in the forward pass improved from ~95.6 ms to ~88.0 ms—a ~8% reduction in forward layer execution time achieved by hiding nearly 100% of the FSDP All-Gather communication overhead behind active systolic array compute.
* **Compilation Verification**: Passed Ahead-of-Time (AoT) lowering checks (`train_compile.py`) across 15 layers of DeepSeek-V3 MoE (`num_experts=128`, `enable_nnx=True`, `pure_nnx_decoder=True`).





# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run end-to-end tests tests and provided workload links above if applicable.
- [X] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
