### PR TITLE
DSV4 NNX support

### DIFF
--- a/src/maxtext/layers/nnx_decoders.py
+++ b/src/maxtext/layers/nnx_decoders.py
@@ -432,9 +432,17 @@ class NNXDecoder(nnx.Module):
 
     self.scanned_layers = None
     self.is_deepseek = self.config.decoder_block == DecoderBlockType.DEEPSEEK
+    self.is_deepseek4 = self.config.decoder_block == DecoderBlockType.DEEPSEEK4
     self.is_gemma3 = self.config.decoder_block == DecoderBlockType.GEMMA3
     self.is_gemma4 = self.config.decoder_block == DecoderBlockType.GEMMA4
     self.is_gemma4_small = self.config.decoder_block == DecoderBlockType.GEMMA4_SMALL
+
+    if config.mhc_expansion_rate > 1 and config.decoder_block == DecoderBlockType.DEEPSEEK4:
+      self.hc_head = mhc.DeepSeek4HyperHead(
+          config=config,
+          mesh=self.mesh,
+          rngs=self.rngs,
+      )
 
     self._init_decoder_layers(decoder_block_classes, rngs, mesh)
 
@@ -532,12 +540,37 @@ class NNXDecoder(nnx.Module):
     """Initializes decoder layers with scanning (non-pipeline)."""
     if self.is_deepseek:
       self._init_scanned_deepseek(decoder_block_classes, rngs)
+    elif self.is_deepseek4:
+      self._init_scanned_deepseek4(rngs)
     elif self.is_gemma3:
       self._init_scanned_gemma3(decoder_block_classes, rngs, mesh)
     elif self.is_gemma4:
       self._init_scanned_gemma4(decoder_block_classes, rngs, mesh)
     else:
       self._init_scanned_generic(decoder_block_classes, rngs)
+
+  def _init_scanned_deepseek4(self, rngs):
+    """Initializes DeepSeek V4 scanned layers: unrolls prefix hash layers and scans remaining full blocks."""
+    config = self.config
+    num_hash_layers = config.first_num_hash_layers
+    for layer_idx in range(num_hash_layers):
+      self._create_and_register_layer(
+          deepseek4.DeepSeek4DecoderLayer,
+          rngs,
+          "layers",
+          layer_idx,
+          layer_idx=layer_idx,
+      )
+
+    num_remaining_layers = config.num_decoder_layers - num_hash_layers
+    num_full_blocks = num_remaining_layers // 2
+    if num_full_blocks > 0:
+      self.scanned_blocks = self._create_scanned_layers(
+          deepseek4.DeepSeek4ScannableBlock,
+          length=num_full_blocks,
+          metadata_axis_name="scanned_blocks",
+          rngs=rngs,
+      )
 
   def _init_scanned_deepseek(self, decoder_block_classes, rngs):
     """Initializes scanned DeepSeek layers with optional Engram support."""
@@ -740,6 +773,7 @@ class NNXDecoder(nnx.Module):
       elif config.decoder_block in {
           DecoderBlockType.QWEN3_NEXT,
           DecoderBlockType.QWEN3_5,
+          DecoderBlockType.DEEPSEEK4,
       }:
         layer_kwargs = {"layer_idx": lyr}
       elif config.decoder_block == DecoderBlockType.GPT_OSS:
@@ -1225,6 +1259,7 @@ class NNXDecoder(nnx.Module):
         DecoderBlockType.MISTRAL,
         DecoderBlockType.MIXTRAL,
         DecoderBlockType.DEEPSEEK,
+        DecoderBlockType.DEEPSEEK4,
         DecoderBlockType.GEMMA,
         DecoderBlockType.GEMMA2,
         DecoderBlockType.GEMMA3,
@@ -1773,6 +1808,18 @@ class NNXDecoder(nnx.Module):
                   length=num_moe,
                   **layer_kwargs,
               )
+
+        elif self.is_deepseek4:
+          y = self._apply_deepseek4_scanned_blocks(
+              y,
+              decoder_segment_ids,
+              decoder_positions,
+              deterministic,
+              model_mode,
+              slot,
+              previous_chunk,
+              decoder_input_tokens,
+          )
         elif self.is_gemma3:
           y = self._apply_gemma3_scanned_blocks(
               y,
@@ -1862,6 +1909,12 @@ class NNXDecoder(nnx.Module):
           else:
             kv_cache = None
 
+          input_tokens = (
+              decoder_input_tokens if (cfg.engram_layers or cfg.decoder_block == DecoderBlockType.DEEPSEEK4) else None
+          )
+          if input_tokens is not None:
+            layer_kwargs["decoder_input_tokens"] = input_tokens
+
           if cfg.remat_policy != "none":
             y, kv_cache, new_state, new_graphdef = checkpointed_fn(graphdef, state, y, kv_cache)
           else:
@@ -1897,8 +1950,11 @@ class NNXDecoder(nnx.Module):
 
     # After the final transformer layer, `y` holds the raw, un-normalized hidden state.
     if getattr(cfg, "mhc_expansion_rate", 1) > 1:
-      # (batch, length, mhc_expansion_rate, emb_dim) --> (batch, length, emb_dim)
-      hidden_state = mhc_reduce(y)
+      if cfg.decoder_block == DecoderBlockType.DEEPSEEK4:
+        hidden_state = self.hc_head(y)
+      else:
+        # (batch, length, mhc_expansion_rate, emb_dim) --> (batch, length, emb_dim)
+        hidden_state = mhc_reduce(y)
     else:
       hidden_state = y
 
@@ -1925,6 +1981,56 @@ class NNXDecoder(nnx.Module):
       logits = self.apply_output_head(shared_embedding, hidden_state, deterministic, model_mode)
 
     return logits, hidden_state, kv_caches
+
+  def _apply_deepseek4_scanned_blocks(
+      self,
+      y,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      slot=None,
+      previous_chunk=None,
+      decoder_input_tokens=None,
+  ):
+    """Applies DeepSeek V4 scanned decoder blocks: unrolled prefix hash layers followed by scanned full blocks."""
+    cfg = self.config
+    num_hash_layers = cfg.first_num_hash_layers
+
+    layer_call_kwargs = {
+        "previous_chunk": previous_chunk,
+        "slot": slot,
+        "decoder_input_tokens": decoder_input_tokens,
+    }
+
+    # 1. Unrolled prefix layers (0, 1, 2)
+    for layer_idx in range(num_hash_layers):
+      layer = getattr(self, f"layers_{layer_idx}")
+      y, _ = layer(
+          y,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          **layer_call_kwargs,
+      )
+
+    # 2. Scanned blocks
+    num_remaining_layers = cfg.num_decoder_layers - num_hash_layers
+    num_full_blocks = num_remaining_layers // 2
+    if num_full_blocks > 0 and hasattr(self, "scanned_blocks"):
+      y, self.scanned_blocks, _ = self._apply_layers_sequentially(
+          self.scanned_blocks,
+          y,
+          decoder_segment_ids,
+          decoder_positions,
+          deterministic,
+          model_mode,
+          length=num_full_blocks,
+          **layer_call_kwargs,
+      )
+
+    return y
 
   def _apply_gemma3_scanned_blocks(
       self,

--- a/tests/unit/deepseek_v4_vs_reference_test.py
+++ b/tests/unit/deepseek_v4_vs_reference_test.py
@@ -1512,6 +1512,35 @@ class DeepSeekV4HyperHeadTest(unittest.TestCase):
     print(f"HYPER HEAD PARITY - MAX ABS DIFF: {max_diff:.6e}, MEAN ABS DIFF: {mean_diff:.6e}")
     np.testing.assert_allclose(mt_out, pt_out, rtol=5e-5, atol=5e-5)
 
+  def test_nnx_decoder_hyperhead_integration(self):
+    from maxtext.layers.nnx_decoders import NNXDecoder
+    from unittest.mock import patch
+
+    # Specifically instantiate full NNXDecoder to ensure it didn't bypass the HyperHead!
+    mt_decoder = NNXDecoder(
+        config=self.mx_config,
+        mesh=self.mesh,
+        rngs=self.rngs,
+    )
+    self.assertTrue(hasattr(mt_decoder, "hc_head"), "NNXDecoder completely missed hc_head setup! Bug in nnx_decoders.py!")
+    self.assertIsInstance(mt_decoder.hc_head, DeepSeek4HyperHead, "NNXDecoder instantiated the wrong HyperHead class!")
+
+    # Verify hc_head.__call__ is invoked during NNXDecoder forward pass
+    def dummy_embed(tokens, **kwargs):
+      return jnp.zeros((tokens.shape[0], tokens.shape[1], self.mx_config.emb_dim), dtype=jnp.float32)
+
+    dummy_tokens = jnp.zeros((2, 4), dtype=jnp.int32)
+    dummy_positions = jnp.arange(4, dtype=jnp.int32)[None, :]
+
+    with patch.object(DeepSeek4HyperHead, "__call__", wraps=mt_decoder.hc_head.__call__) as mock_call:
+      _ = mt_decoder(
+          shared_embedding=dummy_embed,
+          decoder_input_tokens=dummy_tokens,
+          decoder_positions=dummy_positions,
+          deterministic=True,
+      )
+      self.assertTrue(mock_call.called, "NNXDecoder forward pass did not invoke hc_head.__call__!")
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/unit/train_compile_test.py
+++ b/tests/unit/train_compile_test.py
@@ -863,12 +863,13 @@ class TrainCompile(parameterized.TestCase):
     )
 
   @parameterized.named_parameters(
-      {"testcase_name": "scanned", "scan_layers": "true"},
+      {"testcase_name": "linen_scanned", "scan_layers": "true", "enable_nnx": "False"},
+      {"testcase_name": "nnx_scanned", "scan_layers": "true", "enable_nnx": "True"},
   )
   @pytest.mark.cpu_only
-  def test_deepseek4(self, scan_layers):
-    # test deepseek4 compile (Linen-only: DeepSeek NNX decoder rewrite is a follow-up PR).
-    compiled_trainstep_file = f"/tmp/test_deepseek4_{scan_layers}.pickle"
+  def test_deepseek4(self, scan_layers, enable_nnx):
+    # test deepseek4 compile across Linen and NNX
+    compiled_trainstep_file = f"/tmp/test_deepseek4_{scan_layers}_{enable_nnx}.pickle"
     train_compile_main(
         (
             "",
@@ -884,9 +885,9 @@ class TrainCompile(parameterized.TestCase):
             "attention=dot_product",
             "dtype=bfloat16",
             "weight_dtype=bfloat16",
-            "enable_nnx=False",
-            "pure_nnx=False",
-            "pure_nnx_decoder=False",
+            f"enable_nnx={enable_nnx}",
+            f"pure_nnx={enable_nnx}",
+            f"pure_nnx_decoder={enable_nnx}",
         )
     )
 


### PR DESCRIPTION
# Description

This PR adds DeepSeek V4 (`DEEPSEEK4`) decoder block support and HyperHead routing integration to `NNXDecoder`.

### Context & Implementation Details
- Instantiates `DeepSeek4HyperHead` on `NNXDecoder` when `mhc_expansion_rate > 1` and `decoder_block == DecoderBlockType.DEEPSEEK4`.
- Routes the post-transformer hidden state reduction in `NNXDecoder` through `self.hc_head(y)` for `DEEPSEEK4` instead of the default `mhc_reduce(y)`.
- Added `DecoderBlockType.DEEPSEEK4` to the list of supported decoder block types in `NNXDecoder`.

# Tests

- Added unit test `test_nnx_decoder_hyperhead_integration` in `tests/unit/deepseek_v4_vs_reference_test.py` to verify `NNXDecoder` initializes `hc_head` as `DeepSeek4HyperHead`.
- Ran `pytest tests/unit/deepseek_v4_vs_reference_test.py`.
- [comparison of training loss curve over 10 steps vs linen reference](https://b.corp.google.com/issues/535324012#comment6)

# Checklist

- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
